### PR TITLE
fix(cloudwatch): keep GetLogEvents paging inside the list bounds

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -428,7 +428,10 @@ public class CloudWatchLogsService {
         if (nextToken != null && nextToken.startsWith("f/")) {
             int offset = parseTokenIndex(nextToken, 2);
             pageStart = Math.min(offset, total);
-            pageEnd = Math.min(pageStart + maxEvents, total);
+            // Take the window out of what is left rather than adding to the offset, so a
+            // max-events cap configured near Integer.MAX_VALUE cannot overflow the end
+            // index negative once pagination has moved past the first page.
+            pageEnd = pageStart + Math.min(maxEvents, total - pageStart);
         } else if (nextToken != null && nextToken.startsWith("b/")) {
             int end = parseTokenIndex(nextToken, 2);
             pageEnd = Math.min(end, total);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -525,6 +525,39 @@ class CloudWatchLogsServiceTest {
     }
 
     @Test
+    void getLogEventsPagesForwardWithAnUnboundedMaxEventsPerQuery() {
+        CloudWatchLogsService unboundedService = new CloudWatchLogsService(
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                new InMemoryStorage<>(),
+                Integer.MAX_VALUE,
+                new RegionResolver("us-east-1", "000000000000")
+        );
+
+        unboundedService.createLogGroup("/app/logs", null, null, REGION);
+        unboundedService.createLogStream("/app/logs", "stream-1", REGION);
+        long now = System.currentTimeMillis();
+        unboundedService.putLogEvents("/app/logs", "stream-1", List.of(
+                Map.of("timestamp", now, "message", "a"),
+                Map.of("timestamp", now + 1, "message", "b"),
+                Map.of("timestamp", now + 2, "message", "c")
+        ), REGION);
+
+        CloudWatchLogsService.LogEventsResult page =
+                unboundedService.getLogEvents("/app/logs", "stream-1", null, null, 0, true, null, REGION);
+        assertEquals(3, page.events().size());
+        assertEquals("f/3", page.nextForwardToken());
+
+        // GetLogEvents echoes its token at the end of the stream, so a paginator always
+        // spends one more call on the token it was just handed.
+        CloudWatchLogsService.LogEventsResult atEnd = unboundedService.getLogEvents(
+                "/app/logs", "stream-1", null, null, 0, true, page.nextForwardToken(), REGION);
+        assertEquals(0, atEnd.events().size());
+        assertEquals("f/3", atEnd.nextForwardToken());
+    }
+
+    @Test
     void getLogEventsRejectsMalformedNextToken() {
         service.createLogGroup("/app/logs", null, null, REGION);
         service.createLogStream("/app/logs", "stream-1", REGION);


### PR DESCRIPTION
`GetLogEvents` ends a page at `Math.min(pageStart + maxEvents, total)`, where `maxEvents` is `Math.min(limit > 0 ? limit : Integer.MAX_VALUE, maxEventsPerQuery)`. `FLOCI_SERVICES_CLOUDWATCHLOGS_MAX_EVENTS_PER_QUERY` has no upper bound, so setting it near `Integer.MAX_VALUE` (the natural way to express "no cap") makes `pageStart + maxEvents` overflow negative the moment a forward token moves pagination past the first page. `subList` then throws and the call fails with a 500:

```
java.lang.IllegalArgumentException: fromIndex(3) > toIndex(-2147483646)
	at CloudWatchLogsService.getLogEvents(CloudWatchLogsService.java:446)
```

The end of the stream is where a client meets this, not some deep page. `GetLogEvents` echoes its forward token when nothing is left (#90, #184), so a paginator always spends one more call on the token it was just handed. With a large cap and at least one event, that call is the one that throws.

Taking the window out of what remains keeps both operands inside the list's own bounds:

```java
pageEnd = pageStart + Math.min(maxEvents, total - pageStart);
```

`pageStart` is already clamped to `total`, so `total - pageStart` is non-negative and `pageEnd` lands in `[pageStart, total]`. Behaviour at the default cap of 10000 is unchanged.

The other three branches are unaffected: the backward and tail branches subtract and clamp with `Math.max(..., 0)`, and the initial forward branch is a plain `Math.min`.

Out of scope: a *negative* `max-events-per-query` is still unvalidated and produces an invalid range in several branches. That is a config-validation gap rather than this overflow, and the fix here neither helps nor worsens it.

## Test plan
- [x] `getLogEventsPagesForwardWithAnUnboundedMaxEventsPerQuery` drives the second paginator call under a cap of `Integer.MAX_VALUE`; it fails on `main` with the exception above and passes here
- [x] `./mvnw clean test`: 10476 tests, 0 failures, 0 errors, 9 skipped