### PR TITLE
fix: serialize GetRecords ApproximateArrivalTimestamp as a plain decimal

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -15,6 +15,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.HashMap;
@@ -297,7 +299,7 @@ public class KinesisJsonHandler {
                     .put("PartitionKey", rec.getPartitionKey())
                     .put("SequenceNumber", rec.getSequenceNumber())
                     .put("ApproximateArrivalTimestamp",
-                         rec.getApproximateArrivalTimestamp().toEpochMilli() / 1000.0);
+                         epochSeconds(rec.getApproximateArrivalTimestamp()));
         }
         if (continuationSeqNo != null) {
             eventPayload.put("ContinuationSequenceNumber", continuationSeqNo);
@@ -516,11 +518,23 @@ public class KinesisJsonHandler {
             rNode.put("Data", Base64.getEncoder().encodeToString(rec.getData()));
             rNode.put("PartitionKey", rec.getPartitionKey());
             rNode.put("SequenceNumber", rec.getSequenceNumber());
-            rNode.put("ApproximateArrivalTimestamp", rec.getApproximateArrivalTimestamp().toEpochMilli() / 1000.0);
+            rNode.put("ApproximateArrivalTimestamp", epochSeconds(rec.getApproximateArrivalTimestamp()));
         }
         response.put("NextShardIterator", (String) result.get("NextShardIterator"));
         response.put("MillisBehindLatest", ((Number) result.get("MillisBehindLatest")).longValue());
         return Response.ok(response).build();
+    }
+
+    /**
+     * Renders an {@link Instant} as an exact decimal epoch-seconds value (millisecond precision)
+     * rather than a {@code double} - {@code Instant.toEpochMilli() / 1000.0} loses precision and,
+     * for any 2020s-era timestamp, Jackson serializes the resulting large double in scientific
+     * notation (e.g. {@code 1.786959659083E9}), which AWS SDK for Java v2's timestamp unmarshaller
+     * cannot parse despite the response returning HTTP 200. See #2099 for the same defect against
+     * {@code DescribeStream}/{@code DescribeStreamSummary}'s {@code StreamCreationTimestamp}.
+     */
+    private BigDecimal epochSeconds(Instant timestamp) {
+        return BigDecimal.valueOf(timestamp.toEpochMilli(), 3);
     }
 
     private Response handleIncreaseStreamRetentionPeriod(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -294,12 +294,13 @@ public class KinesisJsonHandler {
         ObjectNode eventPayload = objectMapper.createObjectNode();
         ArrayNode recordsNode = eventPayload.putArray("Records");
         for (KinesisRecord rec : records) {
-            recordsNode.addObject()
+            ObjectNode recordNode = recordsNode.addObject()
                     .put("Data", Base64.getEncoder().encodeToString(rec.getData()))
                     .put("PartitionKey", rec.getPartitionKey())
-                    .put("SequenceNumber", rec.getSequenceNumber())
-                    .put("ApproximateArrivalTimestamp",
-                         epochSeconds(rec.getApproximateArrivalTimestamp()));
+                    .put("SequenceNumber", rec.getSequenceNumber());
+            if (rec.getApproximateArrivalTimestamp() != null) {
+                recordNode.put("ApproximateArrivalTimestamp", epochSeconds(rec.getApproximateArrivalTimestamp()));
+            }
         }
         if (continuationSeqNo != null) {
             eventPayload.put("ContinuationSequenceNumber", continuationSeqNo);
@@ -518,7 +519,9 @@ public class KinesisJsonHandler {
             rNode.put("Data", Base64.getEncoder().encodeToString(rec.getData()));
             rNode.put("PartitionKey", rec.getPartitionKey());
             rNode.put("SequenceNumber", rec.getSequenceNumber());
-            rNode.put("ApproximateArrivalTimestamp", epochSeconds(rec.getApproximateArrivalTimestamp()));
+            if (rec.getApproximateArrivalTimestamp() != null) {
+                rNode.put("ApproximateArrivalTimestamp", epochSeconds(rec.getApproximateArrivalTimestamp()));
+            }
         }
         response.put("NextShardIterator", (String) result.get("NextShardIterator"));
         response.put("MillisBehindLatest", ((Number) result.get("MillisBehindLatest")).longValue());

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -787,6 +787,39 @@ class KinesisIntegrationTest {
     }
 
     @Test
+    @Order(57)
+    void getRecordsReturnsPlainDecimalArrivalTimestamp() {
+        String stream = "at-timestamp-plain-decimal";
+        String shardId = atTimestampCreateStream(stream);
+        atTimestampPutAndGetSequence(stream, "cmVjMA==");
+
+        // Timestamp at epoch 1s (before the record) so GetRecords returns it via the same
+        // AT_TIMESTAMP resolution path exercised by the other tests in this group.
+        String iterator = atTimestampIterator(stream, shardId, 1.0);
+
+        String responseBody = given()
+            .header("X-Amz-Target", "Kinesis_20131202.GetRecords")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("{\"ShardIterator\": \"" + iterator + "\"}")
+        .when().post("/")
+        .then().statusCode(200)
+            .body("Records.size()", equalTo(1))
+            .extract().asString();
+
+        // ApproximateArrivalTimestamp must be a plain decimal lexeme - real 2020s-era epoch
+        // seconds render as a large double that Java serializes in scientific notation
+        // (e.g. "1.786959659083E9"), which AWS SDK for Java v2's timestamp unmarshaller cannot
+        // parse despite the response returning HTTP 200 (see floci-io/floci#2099 for the same
+        // defect against DescribeStream/DescribeStreamSummary's StreamCreationTimestamp).
+        var matcher = java.util.regex.Pattern
+            .compile("\"ApproximateArrivalTimestamp\"\\s*:\\s*(-?\\d+(?:\\.\\d+)?)(?=\\s*[,}])")
+            .matcher(responseBody);
+        assertTrue(matcher.find(), "timestamp must be serialized as a plain JSON decimal: " + responseBody);
+        assertFalse(matcher.group(1).contains("E"));
+        assertFalse(matcher.group(1).contains("e"));
+    }
+
+    @Test
     @Order(51)
     void atTimestampBeforeFirstRecordReturnsAll() {
         String stream = "at-timestamp-before";

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -10,12 +10,16 @@ import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Base64;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class KinesisJsonHandlerTest {
 
@@ -24,11 +28,12 @@ class KinesisJsonHandlerTest {
     private static final String STREAM_ARN = "arn:aws:kinesis:us-east-1:123456789012:stream/test-stream";
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private KinesisService service;
     private KinesisJsonHandler handler;
 
     @BeforeEach
     void setUp() {
-        KinesisService service = new KinesisService(
+        service = new KinesisService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new RegionResolver(REGION, ACCOUNT)
@@ -436,5 +441,80 @@ class KinesisJsonHandlerTest {
         AwsException ex = assertThrows(AwsException.class,
                 () -> handler.handle("PutRecords", req, REGION));
         assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void getRecordsSerializesApproximateArrivalTimestampAsPlainDecimal() throws Exception {
+        createStream("test-stream");
+
+        ObjectNode putReq = MAPPER.createObjectNode();
+        putReq.put("StreamName", "test-stream");
+        putReq.put("Data", "dGVzdA==");
+        putReq.put("PartitionKey", "pk1");
+        handler.handle("PutRecord", putReq, REGION);
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        String shardId = responseEntity(handler.handle("DescribeStream", descReq, REGION))
+                .get("StreamDescription").get("Shards").get(0).get("ShardId").asText();
+
+        // A fixed, realistic (2020s-era) arrival timestamp - Instant.now() would also trigger
+        // the bug, but a fixed value makes the expected serialized decimal assertable exactly.
+        service.describeStream("test-stream", REGION).getShards().get(0).getRecords().get(0)
+                .setApproximateArrivalTimestamp(Instant.ofEpochMilli(1_786_959_659_083L));
+
+        ObjectNode iterReq = MAPPER.createObjectNode();
+        iterReq.put("StreamName", "test-stream");
+        iterReq.put("ShardId", shardId);
+        iterReq.put("ShardIteratorType", "TRIM_HORIZON");
+        String iterator = responseEntity(handler.handle("GetShardIterator", iterReq, REGION))
+                .get("ShardIterator").asText();
+
+        ObjectNode recReq = MAPPER.createObjectNode();
+        recReq.put("ShardIterator", iterator);
+        var timestampNode = responseEntity(handler.handle("GetRecords", recReq, REGION))
+                .get("Records").get(0).get("ApproximateArrivalTimestamp");
+
+        assertTrue(timestampNode.isNumber());
+        assertEquals(new BigDecimal("1786959659.083"), timestampNode.decimalValue());
+
+        String serialized = MAPPER.writeValueAsString(timestampNode);
+        assertEquals("1786959659.083", serialized);
+        assertFalse(serialized.contains("E"));
+        assertFalse(serialized.contains("e"));
+    }
+
+    @Test
+    void getRecordsWholeSecondArrivalTimestampRemainsNumeric() throws Exception {
+        createStream("test-stream");
+
+        ObjectNode putReq = MAPPER.createObjectNode();
+        putReq.put("StreamName", "test-stream");
+        putReq.put("Data", "dGVzdA==");
+        putReq.put("PartitionKey", "pk1");
+        handler.handle("PutRecord", putReq, REGION);
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        String shardId = responseEntity(handler.handle("DescribeStream", descReq, REGION))
+                .get("StreamDescription").get("Shards").get(0).get("ShardId").asText();
+
+        service.describeStream("test-stream", REGION).getShards().get(0).getRecords().get(0)
+                .setApproximateArrivalTimestamp(Instant.ofEpochMilli(1_786_959_659_000L));
+
+        ObjectNode iterReq = MAPPER.createObjectNode();
+        iterReq.put("StreamName", "test-stream");
+        iterReq.put("ShardId", shardId);
+        iterReq.put("ShardIteratorType", "TRIM_HORIZON");
+        String iterator = responseEntity(handler.handle("GetShardIterator", iterReq, REGION))
+                .get("ShardIterator").asText();
+
+        ObjectNode recReq = MAPPER.createObjectNode();
+        recReq.put("ShardIterator", iterator);
+        var timestampNode = responseEntity(handler.handle("GetRecords", recReq, REGION))
+                .get("Records").get(0).get("ApproximateArrivalTimestamp");
+
+        assertEquals(new BigDecimal("1786959659.000"), timestampNode.decimalValue());
+        assertEquals("1786959659.000", MAPPER.writeValueAsString(timestampNode));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -517,4 +517,44 @@ class KinesisJsonHandlerTest {
         assertEquals(new BigDecimal("1786959659.000"), timestampNode.decimalValue());
         assertEquals("1786959659.000", MAPPER.writeValueAsString(timestampNode));
     }
+
+    @Test
+    void getRecordsOmitsArrivalTimestampRatherThanThrowingWhenNull() throws Exception {
+        // A record loaded back from hybrid/persistent JSON-backed storage (KinesisRecord is
+        // @RegisterForReflection with a no-arg constructor) can have a null
+        // approximateArrivalTimestamp if it was persisted by an older Floci version, or the
+        // field was otherwise dropped - GetRecords must not NPE serializing the whole response
+        // just because one record's timestamp is missing.
+        createStream("test-stream");
+
+        ObjectNode putReq = MAPPER.createObjectNode();
+        putReq.put("StreamName", "test-stream");
+        putReq.put("Data", "dGVzdA==");
+        putReq.put("PartitionKey", "pk1");
+        handler.handle("PutRecord", putReq, REGION);
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        String shardId = responseEntity(handler.handle("DescribeStream", descReq, REGION))
+                .get("StreamDescription").get("Shards").get(0).get("ShardId").asText();
+
+        service.describeStream("test-stream", REGION).getShards().get(0).getRecords().get(0)
+                .setApproximateArrivalTimestamp(null);
+
+        ObjectNode iterReq = MAPPER.createObjectNode();
+        iterReq.put("StreamName", "test-stream");
+        iterReq.put("ShardId", shardId);
+        iterReq.put("ShardIteratorType", "TRIM_HORIZON");
+        String iterator = responseEntity(handler.handle("GetShardIterator", iterReq, REGION))
+                .get("ShardIterator").asText();
+
+        ObjectNode recReq = MAPPER.createObjectNode();
+        recReq.put("ShardIterator", iterator);
+        Response resp = handler.handle("GetRecords", recReq, REGION);
+        assertThat(resp.getStatus(), is(200));
+
+        ObjectNode record = (ObjectNode) responseEntity(resp).get("Records").get(0);
+        assertFalse(record.has("ApproximateArrivalTimestamp"));
+        assertTrue(record.has("SequenceNumber"));
+    }
 }


### PR DESCRIPTION
## Summary

Apply the same fix as #2173 to a sibling occurrence of the same defect: `GetRecords` (and `SubscribeToShard`'s event payload) serialize `ApproximateArrivalTimestamp` from epoch milliseconds by dividing through a `double`, so Jackson may serialize the resulting JSON number in scientific notation, e.g. `1.786959659083E9`.

Reuses `KinesisJsonHandler`'s existing `epochSeconds(Instant)` helper (added by #2173, now merged: `BigDecimal.valueOf(millis, 3)`, exact millisecond precision, no exponent notation) at both `ApproximateArrivalTimestamp` call sites (`handleGetRecords`, `handleSubscribeToShard`), instead of adding a second copy of it.

Addressed a review comment: guarded both call sites against a null `ApproximateArrivalTimestamp` (reachable via hybrid/persistent JSON-backed storage - `KinesisRecord` is `@RegisterForReflection` with a no-arg constructor), omitting the field instead of NPEing the whole response. New test: `getRecordsOmitsArrivalTimestampRatherThanThrowingWhenNull`.

## Scope correction (updated after review)

**This PR's original description overstated its impact, and I've rewritten this section to correct that.** It claimed the scientific-notation value breaks AWS SDK for Java v2 unmarshalling, and that this was the root cause of an `AT_TIMESTAMP` client never finding an already-written record.

@pgermosen correctly showed that doesn't hold for a default client: Floci routes Kinesis responses through `AwsJsonCborController` whenever the client sends CBOR, which the real Java SDK does by default, so this JSON *text* never reaches it. Verified independently - the original reproducer raises no exception with or without this change.

So the accurate scope is narrower: this matters only for callers on the plain `application/x-amz-json-1.1` path (boto3/CLI with `AWS_CBOR_DISABLE=true`, or older SDKs), where a scientific-notation number is still a wire-format deviation from real Kinesis worth fixing, exactly as #2173 treats the same defect in `DescribeStream`.

Chasing this down did surface the *actual* cause of the behaviour originally attributed to it, a separate and more serious pre-existing bug in the CBOR timestamp units convention (both request and response directions). That was filed separately as #2368 and has since been fixed and merged via #2432; unrelated to this change either way.

Closes #2358

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real Kinesis serializes `ApproximateArrivalTimestamp` as a plain JSON decimal on the `x-amz-json-1.1` path; this aligns Floci with that.

## Checklist

- [x] targeted Kinesis handler and integration tests passed locally on the original implementation
- [x] full local suite showed no Kinesis-package regressions on the original implementation
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] full suite re-run after the rebase below

Rebased onto current `main`. #2173 merged in the meantime and already added `epochSeconds(Instant)` to this same class, so the rebase dropped this branch's own duplicate copy and repointed both call sites at the shared one, exactly as flagged. Also brought two review-scoped bits in line with the repository's explicit-type rule: a `var` in `KinesisJsonHandlerTest`/`KinesisIntegrationTest` and an inline fully-qualified `java.util.regex.Pattern` reference are now the concrete type and an import, respectively.
