### PR TITLE
docs(testcontainers-python): fix outdated import statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ pip install testcontainers-floci
 
 ```python
 import boto3
-from testcontainers_floci import FlociContainer
+from floci import FlociContainer
 
 
 def test_s3_create_bucket():

--- a/docs/testcontainers/python.md
+++ b/docs/testcontainers/python.md
@@ -20,7 +20,7 @@ uv add --dev testcontainers-floci
 
 ```python
 import boto3
-from testcontainers_floci import FlociContainer
+from floci import FlociContainer
 
 
 def test_s3_create_bucket():
@@ -46,7 +46,7 @@ Use a session-scoped fixture so the container starts once and is shared across a
 ```python
 import pytest
 import boto3
-from testcontainers_floci import FlociContainer
+from floci import FlociContainer
 
 
 @pytest.fixture(scope="session")
@@ -85,7 +85,7 @@ def test_upload_object(s3_client):
 import pytest
 import boto3
 import json
-from testcontainers_floci import FlociContainer
+from floci import FlociContainer
 
 
 @pytest.fixture(scope="session")
@@ -125,7 +125,7 @@ def test_send_and_receive_message(sqs_client):
 ```python
 import pytest
 import boto3
-from testcontainers_floci import FlociContainer
+from floci import FlociContainer
 
 
 @pytest.fixture(scope="session")
@@ -191,7 +191,7 @@ Place shared fixtures in `conftest.py` so every test module picks them up automa
 # conftest.py
 import pytest
 import boto3
-from testcontainers_floci import FlociContainer
+from floci import FlociContainer
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

The Python Testcontainer docs were outdated in comparison with the [PyPI docs page](https://pypi.org/project/testcontainers-floci/). This PR resolves the gap.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

