### PR TITLE
feat(cloudwatch): Adds support for orderBy, pagination, limit in DescribeLogStreams response

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudWatchLogsDescribeStreamsOrderingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudWatchLogsDescribeStreamsOrderingTest.java
@@ -1,0 +1,134 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.model.DescribeLogStreamsResponse;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InvalidParameterException;
+import software.amazon.awssdk.services.cloudwatchlogs.model.LogStream;
+import software.amazon.awssdk.services.cloudwatchlogs.model.OrderBy;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CloudWatch Logs DescribeLogStreams ordering and pagination")
+class CloudWatchLogsDescribeStreamsOrderingTest {
+
+    @Test
+    @DisplayName("orderBy LastEventTime descending with limit 1 returns the most recently active stream")
+    void lastEventTimeDescendingWithLimitReturnsMostRecentStream() {
+        String groupName = "/test/" + TestFixtures.uniqueName("logs-describe-streams-order");
+
+        try (CloudWatchLogsClient logs = TestFixtures.cloudWatchLogsClient()) {
+            try {
+                logs.createLogGroup(request -> request.logGroupName(groupName));
+                // Alphabetical order deliberately disagrees with event recency, so a
+                // name-sorted result (the pre-fix behavior) fails the assertion.
+                long base = System.currentTimeMillis();
+                createStreamWithEvent(logs, groupName, "a-oldest", base - 2000);
+                createStreamWithEvent(logs, groupName, "b-newest", base);
+                createStreamWithEvent(logs, groupName, "c-middle", base - 1000);
+
+                DescribeLogStreamsResponse response = logs.describeLogStreams(request -> request
+                        .logGroupName(groupName)
+                        .orderBy(OrderBy.LAST_EVENT_TIME)
+                        .descending(true)
+                        .limit(1));
+
+                assertThat(response.logStreams())
+                        .as("limit is honored on the wire")
+                        .hasSize(1);
+                assertThat(response.logStreams().get(0).logStreamName())
+                        .as("descending LastEventTime puts the most recently active stream first")
+                        .isEqualTo("b-newest");
+                assertThat(response.nextToken())
+                        .as("more streams remain, so a next page is advertised")
+                        .isNotNull();
+            } finally {
+                deleteIfPresent(logs, groupName);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("the SDK paginator walks every stream once and terminates")
+    void paginatorWalksEveryStreamOnceAndTerminates() {
+        String groupName = "/test/" + TestFixtures.uniqueName("logs-describe-streams-paging");
+
+        try (CloudWatchLogsClient logs = TestFixtures.cloudWatchLogsClient()) {
+            try {
+                logs.createLogGroup(request -> request.logGroupName(groupName));
+                for (int i = 0; i < 5; i++) {
+                    int index = i;
+                    logs.createLogStream(request -> request
+                            .logGroupName(groupName)
+                            .logStreamName("stream-" + index));
+                }
+
+                List<String> names = new ArrayList<>();
+                logs.describeLogStreamsPaginator(request -> request
+                                .logGroupName(groupName)
+                                .limit(2))
+                        .stream()
+                        .forEach(page -> page.logStreams().stream()
+                                .map(LogStream::logStreamName)
+                                .forEach(names::add));
+
+                assertThat(names)
+                        .as("every stream is seen exactly once, name-ascending by default")
+                        .containsExactly("stream-0", "stream-1", "stream-2", "stream-3", "stream-4");
+            } finally {
+                deleteIfPresent(logs, groupName);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("orderBy LastEventTime combined with a name prefix is rejected like real AWS")
+    void lastEventTimeWithPrefixIsRejected() {
+        String groupName = "/test/" + TestFixtures.uniqueName("logs-describe-streams-reject");
+
+        try (CloudWatchLogsClient logs = TestFixtures.cloudWatchLogsClient()) {
+            try {
+                logs.createLogGroup(request -> request.logGroupName(groupName));
+
+                assertThatThrownBy(() -> logs.describeLogStreams(request -> request
+                        .logGroupName(groupName)
+                        .logStreamNamePrefix("stream")
+                        .orderBy(OrderBy.LAST_EVENT_TIME)))
+                        .as("real AWS rejects LastEventTime ordering with a logStreamNamePrefix")
+                        .isInstanceOf(InvalidParameterException.class);
+            } finally {
+                deleteIfPresent(logs, groupName);
+            }
+        }
+    }
+
+    private static void createStreamWithEvent(CloudWatchLogsClient logs, String groupName,
+                                              String streamName, long timestamp) {
+        logs.createLogStream(request -> request
+                .logGroupName(groupName)
+                .logStreamName(streamName));
+        logs.putLogEvents(request -> request
+                .logGroupName(groupName)
+                .logStreamName(streamName)
+                .logEvents(InputLogEvent.builder()
+                        .timestamp(timestamp)
+                        .message("event for " + streamName)
+                        .build()));
+    }
+
+    private static void deleteIfPresent(CloudWatchLogsClient logs, String groupName) {
+        boolean present = logs.describeLogGroups(request -> request.logGroupNamePrefix(groupName))
+                .logGroups()
+                .stream()
+                .anyMatch(group -> groupName.equals(group.logGroupName()));
+        if (present) {
+            logs.deleteLogGroup(request -> request.logGroupName(groupName));
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -135,12 +135,17 @@ public class CloudWatchLogsHandler {
     private Response handleDescribeLogStreams(JsonNode request, String region) {
         String groupName = resolveLogGroupName(request);
         String prefix = request.path("logStreamNamePrefix").asText(null);
-        List<LogStream> streams = logsService.describeLogStreams(groupName, prefix, region);
+        String orderBy = request.path("orderBy").asText(null);
+        boolean descending = request.path("descending").asBoolean(false);
+        int limit = request.path("limit").asInt(0);
+        String nextToken = request.has("nextToken") ? request.path("nextToken").asText(null) : null;
+        CloudWatchLogsService.DescribeLogStreamsResult result =
+                logsService.describeLogStreams(groupName, prefix, orderBy, descending, limit, nextToken, region);
 
         String logGroupArn = logsService.buildArn(groupName, region);
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode streamsArray = objectMapper.createArrayNode();
-        for (LogStream s : streams) {
+        for (LogStream s : result.logStreams()) {
             ObjectNode node = objectMapper.createObjectNode();
             node.put("logStreamName", s.getLogStreamName());
             node.put("arn", logGroupArn + ":log-stream:" + s.getLogStreamName());
@@ -157,6 +162,9 @@ public class CloudWatchLogsHandler {
             streamsArray.add(node);
         }
         response.set("logStreams", streamsArray);
+        if (result.nextToken() != null) {
+            response.put("nextToken", result.nextToken());
+        }
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -15,7 +15,9 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -344,26 +346,74 @@ public class CloudWatchLogsService {
         });
         // Streams that never received events have no lastEventTimestamp; sort them oldest,
         // with the name as tie-break so the order stays deterministic.
-        Comparator<LogStream> comparator = byLastEventTime
+        Comparator<LogStream> base = byLastEventTime
                 ? Comparator.comparingLong((LogStream s) ->
                                 s.getLastEventTimestamp() == null ? Long.MIN_VALUE : s.getLastEventTimestamp())
                         .thenComparing(LogStream::getLogStreamName)
                 : Comparator.comparing(LogStream::getLogStreamName);
-        result.sort(descending ? comparator.reversed() : comparator);
+        Comparator<LogStream> order = descending ? base.reversed() : base;
+        result.sort(order);
 
-        int maxResults = Math.min(limit > 0 ? limit : 50, 50);
-        int offset = 0;
+        // The token is a cursor on the sort key of the last stream returned, not a positional
+        // offset: streams created, deleted or reordered between page requests must not shift
+        // the resume point, or callers see duplicates and gaps. Names are unique per group and
+        // the comparator tie-breaks on name, so "strictly after the cursor" is well-defined.
+        int start = 0;
         if (nextToken != null && !nextToken.isBlank()) {
-            try {
-                offset = Integer.parseInt(nextToken);
-            } catch (NumberFormatException e) {
-                offset = 0;
+            LogStream cursor = decodeStreamCursor(nextToken, byLastEventTime, descending);
+            while (start < result.size() && order.compare(result.get(start), cursor) <= 0) {
+                start++;
             }
         }
-        int start = Math.min(offset, result.size());
+        int maxResults = Math.min(limit > 0 ? limit : 50, 50);
         int end = Math.min(start + maxResults, result.size());
-        String token = end < result.size() ? String.valueOf(end) : null;
+        String token = end < result.size()
+                ? encodeStreamCursor(result.get(end - 1), byLastEventTime, descending)
+                : null;
         return new DescribeLogStreamsResult(result.subList(start, end), token);
+    }
+
+    // Cursor format (base64 of "v1:<order>:<direction>:<lastEventTimestamp|->:<name>").
+    // ':' cannot appear in a log stream name, and the name comes last, so the split is safe.
+    // The ordering fields are embedded so a token replayed against a query with different
+    // orderBy/descending arguments is rejected instead of resuming at a meaningless position.
+
+    private static String encodeStreamCursor(LogStream last, boolean byLastEventTime, boolean descending) {
+        String raw = "v1:" + (byLastEventTime ? "ts" : "name") + ":" + (descending ? "desc" : "asc") + ":"
+                + (last.getLastEventTimestamp() == null ? "-" : last.getLastEventTimestamp()) + ":"
+                + last.getLogStreamName();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static LogStream decodeStreamCursor(String nextToken, boolean byLastEventTime, boolean descending) {
+        String[] parts;
+        try {
+            String raw = new String(Base64.getUrlDecoder().decode(nextToken), StandardCharsets.UTF_8);
+            parts = raw.split(":", 5);
+        } catch (IllegalArgumentException e) {
+            throw invalidNextToken();
+        }
+        if (parts.length != 5
+                || !"v1".equals(parts[0])
+                || !(byLastEventTime ? "ts" : "name").equals(parts[1])
+                || !(descending ? "desc" : "asc").equals(parts[2])
+                || parts[4].isEmpty()) {
+            throw invalidNextToken();
+        }
+        LogStream cursor = new LogStream();
+        cursor.setLogStreamName(parts[4]);
+        if (!"-".equals(parts[3])) {
+            try {
+                cursor.setLastEventTimestamp(Long.parseLong(parts[3]));
+            } catch (NumberFormatException e) {
+                throw invalidNextToken();
+            }
+        }
+        return cursor;
+    }
+
+    private static AwsException invalidNextToken() {
+        return new AwsException("InvalidParameterException", "The specified nextToken is invalid.", 400);
     }
 
     // ──────────────────────────── Log Events ────────────────────────────
@@ -503,9 +553,6 @@ public class CloudWatchLogsService {
         return index;
     }
 
-    private AwsException invalidNextToken() {
-        return new AwsException("InvalidParameterException", "The specified nextToken is invalid.", 400);
-    }
     /**
      * A FilterLogEvents match paired with the stream that emitted it. FilterLogEvents is the
      * cross-stream API, so the stream is what lets a caller attribute a hit; GetLogEvents needs

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -305,7 +305,27 @@ public class CloudWatchLogsService {
         LOG.infov("Deleted log stream: {0}/{1}", groupName, streamName);
     }
 
+    public record DescribeLogStreamsResult(List<LogStream> logStreams, String nextToken) {}
+
     public List<LogStream> describeLogStreams(String groupName, String prefix, String region) {
+        return describeLogStreams(groupName, prefix, null, false, 0, null, region).logStreams();
+    }
+
+    public DescribeLogStreamsResult describeLogStreams(String groupName, String prefix, String orderBy,
+                                                       boolean descending, int limit, String nextToken,
+                                                       String region) {
+        boolean byLastEventTime = "LastEventTime".equals(orderBy);
+        if (orderBy != null && !orderBy.isBlank() && !byLastEventTime && !"LogStreamName".equals(orderBy)) {
+            throw new AwsException("InvalidParameterException",
+                    "1 validation error detected: Value '" + orderBy + "' at 'orderBy' failed to satisfy "
+                            + "constraint: Member must satisfy enum value set: [LogStreamName, LastEventTime]", 400);
+        }
+        // Matches real AWS: LastEventTime ordering cannot be combined with a name prefix.
+        if (byLastEventTime && prefix != null && !prefix.isBlank()) {
+            throw new AwsException("InvalidParameterException",
+                    "Cannot order by LastEventTime with a logStreamNamePrefix.", 400);
+        }
+
         // Verify group exists
         groupStore.get(groupKey(region, groupName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -322,8 +342,28 @@ public class CloudWatchLogsService {
             String streamName = k.substring(storagePrefix.length());
             return streamName.startsWith(prefix);
         });
-        result.sort(Comparator.comparing(LogStream::getLogStreamName));
-        return result;
+        // Streams that never received events have no lastEventTimestamp; sort them oldest,
+        // with the name as tie-break so the order stays deterministic.
+        Comparator<LogStream> comparator = byLastEventTime
+                ? Comparator.comparingLong((LogStream s) ->
+                                s.getLastEventTimestamp() == null ? Long.MIN_VALUE : s.getLastEventTimestamp())
+                        .thenComparing(LogStream::getLogStreamName)
+                : Comparator.comparing(LogStream::getLogStreamName);
+        result.sort(descending ? comparator.reversed() : comparator);
+
+        int maxResults = Math.min(limit > 0 ? limit : 50, 50);
+        int offset = 0;
+        if (nextToken != null && !nextToken.isBlank()) {
+            try {
+                offset = Integer.parseInt(nextToken);
+            } catch (NumberFormatException e) {
+                offset = 0;
+            }
+        }
+        int start = Math.min(offset, result.size());
+        int end = Math.min(start + maxResults, result.size());
+        String token = end < result.size() ? String.valueOf(end) : null;
+        return new DescribeLogStreamsResult(result.subList(start, end), token);
     }
 
     // ──────────────────────────── Log Events ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
@@ -62,6 +63,13 @@ public class CloudWatchLogsService {
     // Non-monotonic: a backward NTP step could briefly flip a Complete query back to Running — a rare,
     // self-healing emulator artifact we accept rather than complicate the injectable clock with nanoTime.
     private final LongSupplier clock;
+
+    /**
+     * DescribeLogStreams pagination snapshots keyed by the snapshot id embedded in nextToken.
+     * TTL-evicted on snapshot creation; see describeLogStreams for why pagination is
+     * snapshot-based rather than offset- or cursor-based.
+     */
+    private final ConcurrentHashMap<String, StreamPageSnapshot> streamPageSnapshots = new ConcurrentHashMap<>();
 
     /** Cached Logs Insights queries keyed by queryId, bounded with LRU-style eviction. */
     private static final int MAX_STORED_QUERIES = 100;
@@ -333,6 +341,22 @@ public class CloudWatchLogsService {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "The specified log group does not exist: " + groupName, 400));
 
+        int maxResults = Math.min(limit > 0 ? limit : 50, 50);
+
+        // Pagination works over a snapshot of the ordering taken when the first page is
+        // served: the token names a stored snapshot plus a position in it. Re-sorting the
+        // live collection on every page (whether resumed by offset or by sort-key cursor)
+        // skips or repeats streams whenever creates, deletes or PutLogEvents reorder streams
+        // across a page boundary — e.g. an unreturned stream that receives a newer event
+        // between descending LastEventTime pages jumps ahead of any cursor and is never
+        // returned. The snapshot freezes membership and order; attributes are re-read live
+        // per page and streams deleted since the snapshot are dropped, so every stream that
+        // existed when pagination started is returned at most once, with current attributes.
+        if (nextToken != null && !nextToken.isBlank()) {
+            return resumeStreamPage(nextToken, groupName, prefix, byLastEventTime, descending,
+                    maxResults, region);
+        }
+
         String storagePrefix = streamKeyPrefix(region, groupName);
         List<LogStream> result = streamStore.scan(k -> {
             if (!k.startsWith(storagePrefix)) {
@@ -351,65 +375,78 @@ public class CloudWatchLogsService {
                                 s.getLastEventTimestamp() == null ? Long.MIN_VALUE : s.getLastEventTimestamp())
                         .thenComparing(LogStream::getLogStreamName)
                 : Comparator.comparing(LogStream::getLogStreamName);
-        Comparator<LogStream> order = descending ? base.reversed() : base;
-        result.sort(order);
+        result.sort(descending ? base.reversed() : base);
 
-        // The token is a cursor on the sort key of the last stream returned, not a positional
-        // offset: streams created, deleted or reordered between page requests must not shift
-        // the resume point, or callers see duplicates and gaps. Names are unique per group and
-        // the comparator tie-breaks on name, so "strictly after the cursor" is well-defined.
-        int start = 0;
-        if (nextToken != null && !nextToken.isBlank()) {
-            LogStream cursor = decodeStreamCursor(nextToken, byLastEventTime, descending);
-            while (start < result.size() && order.compare(result.get(start), cursor) <= 0) {
-                start++;
-            }
+        int end = Math.min(maxResults, result.size());
+        String token = null;
+        if (end < result.size()) {
+            String snapshotId = UUID.randomUUID().toString();
+            streamPageSnapshots.put(snapshotId, new StreamPageSnapshot(
+                    groupKey(region, groupName), prefix == null ? "" : prefix,
+                    byLastEventTime, descending,
+                    result.stream().map(LogStream::getLogStreamName).toList(),
+                    clock.getAsLong()));
+            evictExpiredStreamPageSnapshots();
+            token = encodeStreamPageToken(snapshotId, end);
         }
-        int maxResults = Math.min(limit > 0 ? limit : 50, 50);
-        int end = Math.min(start + maxResults, result.size());
-        String token = end < result.size()
-                ? encodeStreamCursor(result.get(end - 1), byLastEventTime, descending)
-                : null;
-        return new DescribeLogStreamsResult(result.subList(start, end), token);
+        return new DescribeLogStreamsResult(result.subList(0, end), token);
     }
 
-    // Cursor format (base64 of "v1:<order>:<direction>:<lastEventTimestamp|->:<name>").
-    // ':' cannot appear in a log stream name, and the name comes last, so the split is safe.
-    // The ordering fields are embedded so a token replayed against a query with different
-    // orderBy/descending arguments is rejected instead of resuming at a meaningless position.
-
-    private static String encodeStreamCursor(LogStream last, boolean byLastEventTime, boolean descending) {
-        String raw = "v1:" + (byLastEventTime ? "ts" : "name") + ":" + (descending ? "desc" : "asc") + ":"
-                + (last.getLastEventTimestamp() == null ? "-" : last.getLastEventTimestamp()) + ":"
-                + last.getLogStreamName();
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
-    }
-
-    private static LogStream decodeStreamCursor(String nextToken, boolean byLastEventTime, boolean descending) {
+    private DescribeLogStreamsResult resumeStreamPage(String nextToken, String groupName, String prefix,
+                                                      boolean byLastEventTime, boolean descending,
+                                                      int maxResults, String region) {
         String[] parts;
         try {
             String raw = new String(Base64.getUrlDecoder().decode(nextToken), StandardCharsets.UTF_8);
-            parts = raw.split(":", 5);
+            parts = raw.split(":", 3);
         } catch (IllegalArgumentException e) {
             throw invalidNextToken();
         }
-        if (parts.length != 5
-                || !"v1".equals(parts[0])
-                || !(byLastEventTime ? "ts" : "name").equals(parts[1])
-                || !(descending ? "desc" : "asc").equals(parts[2])
-                || parts[4].isEmpty()) {
+        int position;
+        if (parts.length != 3 || !"v2".equals(parts[0])) {
             throw invalidNextToken();
         }
-        LogStream cursor = new LogStream();
-        cursor.setLogStreamName(parts[4]);
-        if (!"-".equals(parts[3])) {
-            try {
-                cursor.setLastEventTimestamp(Long.parseLong(parts[3]));
-            } catch (NumberFormatException e) {
-                throw invalidNextToken();
-            }
+        try {
+            position = Integer.parseInt(parts[2]);
+        } catch (NumberFormatException e) {
+            throw invalidNextToken();
         }
-        return cursor;
+        StreamPageSnapshot snapshot = streamPageSnapshots.get(parts[1]);
+        // A token replayed against a different group or query shape resumes at a meaningless
+        // position; reject it like an unknown or expired token.
+        if (snapshot == null
+                || position < 0
+                || !snapshot.groupKey().equals(groupKey(region, groupName))
+                || !snapshot.prefix().equals(prefix == null ? "" : prefix)
+                || snapshot.byLastEventTime() != byLastEventTime
+                || snapshot.descending() != descending) {
+            throw invalidNextToken();
+        }
+
+        List<LogStream> page = new ArrayList<>();
+        List<String> names = snapshot.streamNames();
+        int index = position;
+        while (index < names.size() && page.size() < maxResults) {
+            streamStore.get(streamKey(region, groupName, names.get(index))).ifPresent(page::add);
+            index++;
+        }
+        String token = index < names.size() ? encodeStreamPageToken(parts[1], index) : null;
+        return new DescribeLogStreamsResult(page, token);
+    }
+
+    private record StreamPageSnapshot(String groupKey, String prefix, boolean byLastEventTime,
+                                      boolean descending, List<String> streamNames, long createdAtMs) {}
+
+    private static final long STREAM_PAGE_SNAPSHOT_TTL_MS = 15 * 60 * 1000;
+
+    private void evictExpiredStreamPageSnapshots() {
+        long cutoff = clock.getAsLong() - STREAM_PAGE_SNAPSHOT_TTL_MS;
+        streamPageSnapshots.values().removeIf(s -> s.createdAtMs() < cutoff);
+    }
+
+    private static String encodeStreamPageToken(String snapshotId, int position) {
+        String raw = "v2:" + snapshotId + ":" + position;
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
     }
 
     private static AwsException invalidNextToken() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -74,6 +74,34 @@ class CloudWatchLogsHandlerTest {
         assertEquals(STREAM, streams.get(0).path("logStreamName").asText());
     }
 
+    @Test
+    void describeLogStreamsHonorsOrderByDescendingLimitAndReturnsNextToken() {
+        service.createLogStream(GROUP, "another-stream", REGION);
+        service.putLogEvents(GROUP, STREAM,
+                java.util.List.of(java.util.Map.of("timestamp", 2000L, "message", "new")), REGION);
+        service.putLogEvents(GROUP, "another-stream",
+                java.util.List.of(java.util.Map.of("timestamp", 1000L, "message", "old")), REGION);
+        ObjectNode request = MAPPER.createObjectNode()
+                .put("logGroupName", GROUP)
+                .put("orderBy", "LastEventTime")
+                .put("descending", true)
+                .put("limit", 1);
+
+        Response response = handler.handle("DescribeLogStreams", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        ObjectNode entity = (ObjectNode) response.getEntity();
+        JsonNode streams = entity.path("logStreams");
+        assertEquals(1, streams.size());
+        assertEquals(STREAM, streams.get(0).path("logStreamName").asText());
+        assertTrue(entity.has("nextToken"));
+
+        ObjectNode nextRequest = request.deepCopy().put("nextToken", entity.path("nextToken").asText());
+        ObjectNode nextEntity = (ObjectNode) handler.handle("DescribeLogStreams", nextRequest, REGION).getEntity();
+        assertEquals("another-stream", nextEntity.path("logStreams").get(0).path("logStreamName").asText());
+        assertFalse(nextEntity.has("nextToken"));
+    }
+
     // ──────────────────────────── GetDataProtectionPolicy ────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -270,6 +270,83 @@ class CloudWatchLogsServiceTest {
     }
 
     @Test
+    void describeLogStreamsRejectsMalformedNextToken() {
+        // A garbage token must fail loudly: silently restarting from the first page makes
+        // custom pagination loops duplicate results or never progress.
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.describeLogStreams("/app/logs", null, null, false, 0, "not-a-token", REGION));
+        assertEquals("InvalidParameterException", e.getErrorCode());
+    }
+
+    @Test
+    void describeLogStreamsRejectsTokenFromDifferentOrdering() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        service.createLogStream("/app/logs", "stream-2", REGION);
+
+        String nameOrderToken = service
+                .describeLogStreams("/app/logs", null, null, false, 1, null, REGION)
+                .nextToken();
+        assertNotNull(nameOrderToken);
+
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.describeLogStreams("/app/logs", null, "LastEventTime", true, 1, nameOrderToken, REGION));
+        assertEquals("InvalidParameterException", e.getErrorCode());
+    }
+
+    @Test
+    void describeLogStreamsPaginationDoesNotSkipAfterDeletionBetweenPages() {
+        // A positional offset applied to the re-scanned collection would skip stream-3 here:
+        // deleting already-returned stream-1 shifts everything left by one. The cursor keeps
+        // the resume point anchored to the last returned stream instead.
+        service.createLogGroup("/app/logs", null, null, REGION);
+        for (int i = 1; i <= 4; i++) {
+            service.createLogStream("/app/logs", "stream-" + i, REGION);
+        }
+
+        var page1 = service.describeLogStreams("/app/logs", null, null, false, 2, null, REGION);
+        assertEquals(List.of("stream-1", "stream-2"),
+                page1.logStreams().stream().map(LogStream::getLogStreamName).toList());
+
+        service.deleteLogStream("/app/logs", "stream-1", REGION);
+
+        var page2 = service.describeLogStreams("/app/logs", null, null, false, 2, page1.nextToken(), REGION);
+        assertEquals(List.of("stream-3", "stream-4"),
+                page2.logStreams().stream().map(LogStream::getLogStreamName).toList());
+        assertNull(page2.nextToken());
+    }
+
+    @Test
+    void describeLogStreamsLastEventTimePaginationDoesNotRepeatReorderedStreams() {
+        // PutLogEvents to an already-returned stream between pages moves it even further
+        // ahead in descending order. A positional offset would then re-serve the stream at
+        // the boundary; the cursor never returns anything at-or-before the last seen key.
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "a", REGION);
+        service.createLogStream("/app/logs", "b", REGION);
+        service.createLogStream("/app/logs", "c", REGION);
+        service.createLogStream("/app/logs", "d", REGION);
+        service.putLogEvents("/app/logs", "a", List.of(Map.of("timestamp", 1000L, "message", "x")), REGION);
+        service.putLogEvents("/app/logs", "b", List.of(Map.of("timestamp", 2000L, "message", "x")), REGION);
+        service.putLogEvents("/app/logs", "c", List.of(Map.of("timestamp", 3000L, "message", "x")), REGION);
+        service.putLogEvents("/app/logs", "d", List.of(Map.of("timestamp", 4000L, "message", "x")), REGION);
+
+        var page1 = service.describeLogStreams("/app/logs", null, "LastEventTime", true, 2, null, REGION);
+        assertEquals(List.of("d", "c"),
+                page1.logStreams().stream().map(LogStream::getLogStreamName).toList());
+
+        service.putLogEvents("/app/logs", "d", List.of(Map.of("timestamp", 5000L, "message", "x")), REGION);
+
+        var page2 = service.describeLogStreams("/app/logs", null, "LastEventTime", true, 2, page1.nextToken(), REGION);
+        assertEquals(List.of("b", "a"),
+                page2.logStreams().stream().map(LogStream::getLogStreamName).toList());
+        assertNull(page2.nextToken());
+    }
+
+    @Test
     void describeLogStreamsRejectsLastEventTimeWithPrefix() {
         service.createLogGroup("/app/logs", null, null, REGION);
         AwsException e = assertThrows(AwsException.class, () ->

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -347,6 +347,37 @@ class CloudWatchLogsServiceTest {
     }
 
     @Test
+    void describeLogStreamsReturnsUnseenStreamThatReorderedAcrossThePageBoundary() {
+        // An unreturned stream that receives a newer event between descending LastEventTime
+        // pages sorts ahead of any saved sort-key cursor on the next request and would be
+        // skipped forever. The snapshot freezes the ordering at page one, so the stream is
+        // still returned in its original position.
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "a", REGION);
+        service.createLogStream("/app/logs", "b", REGION);
+        service.createLogStream("/app/logs", "c", REGION);
+        service.createLogStream("/app/logs", "d", REGION);
+        service.putLogEvents("/app/logs", "a", List.of(Map.of("timestamp", 1000L, "message", "x")), REGION);
+        service.putLogEvents("/app/logs", "b", List.of(Map.of("timestamp", 2000L, "message", "x")), REGION);
+        service.putLogEvents("/app/logs", "c", List.of(Map.of("timestamp", 3000L, "message", "x")), REGION);
+        service.putLogEvents("/app/logs", "d", List.of(Map.of("timestamp", 4000L, "message", "x")), REGION);
+
+        var page1 = service.describeLogStreams("/app/logs", null, "LastEventTime", true, 2, null, REGION);
+        assertEquals(List.of("d", "c"),
+                page1.logStreams().stream().map(LogStream::getLogStreamName).toList());
+
+        // b was not returned yet; this would now sort it ahead of c, the last returned stream.
+        service.putLogEvents("/app/logs", "b", List.of(Map.of("timestamp", 9000L, "message", "x")), REGION);
+
+        var page2 = service.describeLogStreams("/app/logs", null, "LastEventTime", true, 2, page1.nextToken(), REGION);
+        assertEquals(List.of("b", "a"),
+                page2.logStreams().stream().map(LogStream::getLogStreamName).toList());
+        assertNull(page2.nextToken());
+        // Attributes are live even though the position is frozen.
+        assertEquals(9000L, page2.logStreams().getFirst().getLastEventTimestamp());
+    }
+
+    @Test
     void describeLogStreamsRejectsLastEventTimeWithPrefix() {
         service.createLogGroup("/app/logs", null, null, REGION);
         AwsException e = assertThrows(AwsException.class, () ->

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsServiceTest.java
@@ -216,6 +216,76 @@ class CloudWatchLogsServiceTest {
     }
 
     @Test
+    void describeLogStreamsOrdersByLastEventTimeDescendingWithLimit() {
+        // The SDK idiom for "find the most recently active stream":
+        // orderBy(LAST_EVENT_TIME).descending(true).limit(1). Alphabetical order is set up
+        // to disagree with event recency so a name-sorted result would fail the assertion.
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "a-oldest", REGION);
+        service.createLogStream("/app/logs", "b-newest", REGION);
+        service.createLogStream("/app/logs", "c-middle", REGION);
+        service.putLogEvents("/app/logs", "a-oldest", List.of(Map.of("timestamp", 1000L, "message", "old")), REGION);
+        service.putLogEvents("/app/logs", "b-newest", List.of(Map.of("timestamp", 3000L, "message", "new")), REGION);
+        service.putLogEvents("/app/logs", "c-middle", List.of(Map.of("timestamp", 2000L, "message", "mid")), REGION);
+
+        var result = service.describeLogStreams("/app/logs", null, "LastEventTime", true, 1, null, REGION);
+
+        assertEquals(1, result.logStreams().size());
+        assertEquals("b-newest", result.logStreams().getFirst().getLogStreamName());
+        assertNotNull(result.nextToken());
+    }
+
+    @Test
+    void describeLogStreamsSortsStreamsWithoutEventsOldestByLastEventTime() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "z-empty", REGION);
+        service.createLogStream("/app/logs", "a-active", REGION);
+        service.putLogEvents("/app/logs", "a-active", List.of(Map.of("timestamp", 1000L, "message", "x")), REGION);
+
+        var descending = service.describeLogStreams("/app/logs", null, "LastEventTime", true, 0, null, REGION);
+        assertEquals(List.of("a-active", "z-empty"),
+                descending.logStreams().stream().map(LogStream::getLogStreamName).toList());
+
+        var ascending = service.describeLogStreams("/app/logs", null, "LastEventTime", false, 0, null, REGION);
+        assertEquals(List.of("z-empty", "a-active"),
+                ascending.logStreams().stream().map(LogStream::getLogStreamName).toList());
+    }
+
+    @Test
+    void describeLogStreamsPaginatesWithNextToken() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        service.createLogStream("/app/logs", "stream-1", REGION);
+        service.createLogStream("/app/logs", "stream-2", REGION);
+        service.createLogStream("/app/logs", "stream-3", REGION);
+
+        var page1 = service.describeLogStreams("/app/logs", null, null, false, 2, null, REGION);
+        assertEquals(List.of("stream-1", "stream-2"),
+                page1.logStreams().stream().map(LogStream::getLogStreamName).toList());
+        assertNotNull(page1.nextToken());
+
+        var page2 = service.describeLogStreams("/app/logs", null, null, false, 2, page1.nextToken(), REGION);
+        assertEquals(List.of("stream-3"),
+                page2.logStreams().stream().map(LogStream::getLogStreamName).toList());
+        assertNull(page2.nextToken());
+    }
+
+    @Test
+    void describeLogStreamsRejectsLastEventTimeWithPrefix() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.describeLogStreams("/app/logs", "stream", "LastEventTime", true, 0, null, REGION));
+        assertEquals("InvalidParameterException", e.getErrorCode());
+    }
+
+    @Test
+    void describeLogStreamsRejectsUnknownOrderBy() {
+        service.createLogGroup("/app/logs", null, null, REGION);
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.describeLogStreams("/app/logs", null, "CreationTime", false, 0, null, REGION));
+        assertEquals("InvalidParameterException", e.getErrorCode());
+    }
+
+    @Test
     void deleteLogGroupCascadesStreamsAndEvents() {
         service.createLogGroup("/app/logs", null, null, REGION);
         service.createLogStream("/app/logs", "stream-1", REGION);


### PR DESCRIPTION
## Summary

Adds support when describing log streams using the orderBy and limit clauses. Adds support for pagination.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against SDK 2.52.0.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
