### PR TITLE
fix(core): stop leaked executor threads from pinning test classloaders

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLogStreamer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLogStreamer.java
@@ -25,8 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -207,12 +207,21 @@ public class ContainerLogStreamer {
      */
     static final class LogReassemblyCallback extends ResultCallback.Adapter<Frame> {
 
-        private static final ScheduledExecutorService CLOSE_DRAIN_SCHEDULER =
-                Executors.newSingleThreadScheduledExecutor(runnable -> {
-                    Thread thread = new Thread(runnable, "floci-container-log-close");
-                    thread.setDaemon(true);
-                    return thread;
-                });
+        // The idle core thread must time out. A permanent thread would keep executing-class
+        // references alive and pin the whole application classloader after shutdown, which
+        // accumulates across the many app restarts of a profile-switching test run.
+        private static final ScheduledExecutorService CLOSE_DRAIN_SCHEDULER = closeDrainScheduler();
+
+        private static ScheduledExecutorService closeDrainScheduler() {
+            var scheduler = new ScheduledThreadPoolExecutor(1, runnable -> {
+                Thread thread = new Thread(runnable, "floci-container-log-close");
+                thread.setDaemon(true);
+                return thread;
+            });
+            scheduler.setKeepAliveTime(5, TimeUnit.SECONDS);
+            scheduler.allowCoreThreadTimeOut(true);
+            return scheduler;
+        }
         private static final long DEFAULT_CLOSE_GRACE_MILLIS = 2_000;
 
         private final Map<StreamType, LogLineBuffer> buffers = new EnumMap<>(StreamType.class);

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -13,6 +13,7 @@ import io.github.hectorvent.floci.services.elbv2.model.TargetDescription;
 import io.github.hectorvent.floci.services.elbv2.model.TargetHealth;
 import io.github.hectorvent.floci.services.ssm.SsmCommandService;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
@@ -57,6 +58,11 @@ public class AutoScalingReconciler {
     @PostConstruct
     void start() {
         scheduler.scheduleAtFixedRate(this::reconcileAll, 5, 10, TimeUnit.SECONDS);
+    }
+
+    @PreDestroy
+    void stop() {
+        scheduler.shutdownNow();
     }
 
     void onStart(@Observes StartupEvent event) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -100,6 +101,11 @@ public class CloudFormationService {
             LOG.infov("Loaded {0} CloudFormation stack(s) and {1} export(s) from storage",
                     stacks.size(), exports.size());
         }
+    }
+
+    @PreDestroy
+    void stop() {
+        executor.shutdownNow();
     }
 
     private void persistStack(Stack stack) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudmap/CloudMapService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudmap/CloudMapService.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.cloudmap.model.Instance;
 import io.github.hectorvent.floci.services.cloudmap.model.Namespace;
 import io.github.hectorvent.floci.services.cloudmap.model.Operation;
 import io.github.hectorvent.floci.services.cloudmap.model.Service;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -69,6 +70,13 @@ public class CloudMapService {
                     return t;
                 })
                 : null;
+    }
+
+    @PreDestroy
+    void stop() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
     }
 
     // ──────────────────────────── Namespaces ────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -19,6 +19,7 @@ import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.Mount;
 import com.github.dockerjava.api.model.MountType;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -96,6 +97,11 @@ public class Ec2ContainerManager {
         this.config = config;
         this.metadataServer = metadataServer;
         this.portForwardManager = portForwardManager;
+    }
+
+    @PreDestroy
+    void stop() {
+        executor.shutdownNow();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/portforward/Ec2PortForwardManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/portforward/Ec2PortForwardManager.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ContainerNetwork;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -73,6 +74,11 @@ public class Ec2PortForwardManager {
         this.lifecycleManager = lifecycleManager;
         this.portAllocator = portAllocator;
         this.config = config;
+    }
+
+    @PreDestroy
+    void stop() {
+        executor.shutdownNow();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.services.sqs.model.MessageAttributeValue;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -127,6 +128,11 @@ public class SqsService implements Resettable {
         this.snsService = snsService;
         loadPersistedMessages();
         loadPersistedDedup();
+    }
+
+    @PreDestroy
+    void stop() {
+        moveTaskExecutor.shutdownNow();
     }
 
     public void clear() {

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
@@ -13,6 +13,7 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ssm.model.Command;
 import io.github.hectorvent.floci.services.ssm.model.CommandInvocation;
 import io.github.hectorvent.floci.services.ssm.model.InstanceInformation;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -77,6 +78,11 @@ public class SsmCommandService implements Resettable {
             thread.setDaemon(true);
             return thread;
         });
+    }
+
+    @PreDestroy
+    void stop() {
+        directExecutionExecutor.shutdownNow();
     }
 
     public void clear() {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -48,6 +48,7 @@ import io.vertx.mutiny.ext.web.client.WebClient;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.ManagedContext;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -187,6 +188,11 @@ public class AslExecutor {
         } else {
             webClient = null;
         }
+    }
+
+    @PreDestroy
+    void stop() {
+        executor.shutdownNow();
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
@@ -42,6 +43,25 @@ class AutoScalingReconcilerTest {
         asg.getInstances().add(instance("Detached"));
 
         assertEquals(2, AutoScalingReconciler.activeCapacity(asg));
+    }
+
+    @Test
+    void stopTerminatesReconcilerThread() throws Exception {
+        var asgService = mock(AutoScalingService.class);
+        var ec2Service = mock(Ec2Service.class);
+        var elbV2Service = mock(ElbV2Service.class);
+        var reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        var preexisting = Thread.getAllStackTraces().keySet();
+
+        reconciler.start();
+        var reconcilerThread = Thread.getAllStackTraces().keySet().stream()
+                .filter(t -> "asg-reconciler".equals(t.getName()) && !preexisting.contains(t))
+                .findFirst().orElseThrow();
+
+        reconciler.stop();
+        reconcilerThread.join(5_000);
+
+        assertFalse(reconcilerThread.isAlive());
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,6 +6,11 @@ quarkus:
       max-body-size: ${floci.max-request-size}M
   datasource:
     active: false
+  # Groovy (a REST Assured dependency) starts DFA-cache-cleaner threads that never stop.
+  # Loaded parent-first they live in the shared system classloader, so they cannot pin a
+  # per-profile application classloader across the many app restarts of a test run.
+  class-loading:
+    parent-first-artifacts: org.apache.groovy:groovy
 
 floci:
   base-url: "http://localhost:4566"


### PR DESCRIPTION
## Summary

Fixing memory leak found in https://github.com/floci-io/floci/actions/runs/32009906425/job/95391436428?pr=1941

| Metric (full `mvn test`, 4GB heap) | PR #1941 before fix | This fix |
|---|---|---|
| Test result | 10,612 run, 3 timeout errors |10,570 run, all green |
| Full GC count | 55 | 1 |
| Live set after full GC (mid run) | 3.0–3.2 GB |  2.26 GB |
| Live set at end of run | 4.05 GB, OOM on default JMX on CI | 3.4 GB after young GC, still reclaiming |
| End-of-run behavior | full GC storm | stable |

Service beans never shut down their executors. The leftover threads pinned the classloader of every stopped test application. Around 40 profile restarts per run grew retained heap past the 4GB surefire default and CI failed with OutOfMemoryError.

Add `@PreDestroy` shutdown to the owning beans. Let the close-drain scheduler thread time out when idle. Load Groovy parent-first in tests so its cleaner threads stop pinning app classloaders.


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

