### PR TITLE
fix(core): clear in-memory service state on state reset

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/ResetCoordinator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResetCoordinator.java
@@ -1,0 +1,116 @@
+package io.github.hectorvent.floci.core.common;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Fences background work against a state reset.
+ *
+ * <p>A reset is a transition, not an instant: it clears every {@link Resettable} and then clears
+ * the storage backends. Work already running can finish anywhere inside that transition and write
+ * state back, resurrecting resources the reset removed. A guard owned by any one service cannot
+ * prevent this, because the window between that service's {@code clear()} and the storage clear
+ * belongs to the reset sequence rather than to the service.
+ *
+ * <p>The fence is a lock rather than a flag because a flag can only be <em>checked</em>: a worker
+ * that tests a flag and then writes can still be interrupted between the two. Workers perform
+ * their state mutation through {@link #applyIfCurrent}, which holds the read lock across both the
+ * check and the mutation, while {@link #runReset} holds the write lock for the whole transition.
+ * A reset therefore waits for in-flight mutations to finish, and no new one can start until it
+ * completes.
+ *
+ * <p>The epoch distinguishes work that <em>started</em> before a reset from work that started
+ * after it. Holding the read lock alone is not enough: a worker could acquire it after the reset
+ * released the write lock and still be applying a result computed beforehand.
+ *
+ * <p>Concurrent resets serialize on the write lock; each bumps the epoch, and the sequence is
+ * idempotent, so the second simply re-clears. Deliberate limitation: synchronous request paths
+ * are not fenced — a request racing the reset can still write into an already-cleared map. That
+ * class of race is tracked separately; this fence is for background work that outlives its
+ * request.
+ */
+@ApplicationScoped
+public class ResetCoordinator {
+
+    private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    private final AtomicLong epoch = new AtomicLong();
+
+    /**
+     * The epoch to capture when background work starts, and to hand back to
+     * {@link #applyIfCurrent} when it finishes.
+     */
+    public long currentEpoch() {
+        return epoch.get();
+    }
+
+    /**
+     * Runs the whole reset transition under the write lock, so no fenced mutation can be in
+     * progress or begin while it runs.
+     */
+    public void runReset(Runnable resetSequence) {
+        lock.writeLock().lock();
+        try {
+            epoch.incrementAndGet();
+            resetSequence.run();
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Applies {@code mutation} only if no reset has happened since {@code capturedEpoch}. The
+     * check and the mutation both happen under the read lock, so a reset cannot interleave
+     * between them.
+     *
+     * @return {@code true} if the mutation ran, {@code false} if a reset invalidated it
+     */
+    public boolean applyIfCurrent(long capturedEpoch, Runnable mutation) {
+        // Unlocked fast-fail: a stale worker must not park on the read lock while a reset holds
+        // the write lock, or a clear() that drains in-flight work (CloudFormation waits up to 2s)
+        // would wait on a worker that can never proceed.
+        if (epoch.get() != capturedEpoch) {
+            return false;
+        }
+        lock.readLock().lock();
+        try {
+            if (epoch.get() != capturedEpoch) {
+                return false;
+            }
+            mutation.run();
+            return true;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Unlocked staleness probe for long-running work that wants to abort early at a safe
+     * boundary (for example between resources of a template execution) without holding the read
+     * lock throughout. A {@code true} answer can go stale immediately; the authoritative gate for
+     * the final mutation is {@link #applyIfCurrent}.
+     */
+    public boolean isCurrent(long capturedEpoch) {
+        return epoch.get() == capturedEpoch;
+    }
+
+    /**
+     * Runs periodic work that must not overlap a reset at all — a reconciliation tick, say, which
+     * would otherwise recreate state from definitions the reset has not cleared yet.
+     *
+     * @return {@code true} if the work ran, {@code false} if it was skipped because a reset holds
+     *         the fence
+     */
+    public boolean runIfNotResetting(Runnable work) {
+        if (!lock.readLock().tryLock()) {
+            return false;
+        }
+        try {
+            work.run();
+            return true;
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
@@ -10,16 +10,22 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.core.common.ResetCoordinator;
 import io.github.hectorvent.floci.core.common.Resettable;
 import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.POST;
 
 import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import org.jboss.logging.Logger;
 
 @Path("{prefix:(_floci|_localstack)}")
 @Produces(MediaType.APPLICATION_JSON)
 public class EmulatorInfoController {
+
+    private static final Logger LOG = Logger.getLogger(EmulatorInfoController.class);
 
     private final ServiceRegistry serviceRegistry;
     private final InitLifecycleState initLifecycleState;
@@ -27,16 +33,19 @@ public class EmulatorInfoController {
 
     private final StorageFactory storageFactory;
     private final Instance<Resettable> resettables;
+    private final ResetCoordinator resetCoordinator;
 
     @Inject
     public EmulatorInfoController(ServiceRegistry serviceRegistry,
                                   InitLifecycleState initLifecycleState,
                                   StorageFactory storageFactory,
-                                  Instance<Resettable> resettables) {
+                                  Instance<Resettable> resettables,
+                                  ResetCoordinator resetCoordinator) {
         this.serviceRegistry = serviceRegistry;
         this.initLifecycleState = initLifecycleState;
         this.storageFactory = storageFactory;
         this.resettables = resettables;
+        this.resetCoordinator = resetCoordinator;
         this.version = resolveVersion();
     }
 
@@ -93,7 +102,11 @@ public class EmulatorInfoController {
     @POST
     @Path("/state/reset")
     public Response reset() {
-        performReset();
+        List<String> failed = performReset();
+        if (!failed.isEmpty()) {
+            return Response.status(500)
+                    .entity(Map.of("status", "PARTIAL", "failed", failed)).build();
+        }
         return Response.ok(Map.of("status", "OK")).build();
     }
 
@@ -103,11 +116,37 @@ public class EmulatorInfoController {
         return reset();
     }
 
-    private void performReset() {
-        for (Resettable r : resettables) {
-            r.clear();
-        }
-        storageFactory.clearAll();
+    /**
+     * Clearing the services and clearing storage are one transition, not two steps. Background
+     * work landing between them would otherwise write state back after its service was cleared
+     * but while the storage it reads is still populated, so the whole sequence runs inside
+     * {@link ResetCoordinator#runReset} and fenced workers cannot interleave with it.
+     */
+    private List<String> performReset() {
+        // Containment: every clear() is attempted and storage is always cleared, so one failing
+        // service cannot abort the rest of the transition (CDI gives the loop no useful order to
+        // fail early in). Failures are collected and reported as a 500 PARTIAL instead of the
+        // pre-containment behavior of returning OK for a reset that silently did not finish.
+        List<String> failed = new ArrayList<>();
+        resetCoordinator.runReset(() -> {
+            for (Resettable r : resettables) {
+                try {
+                    r.clear();
+                } catch (RuntimeException e) {
+                    // CDI hands this loop client proxies; report the bean class, not the proxy.
+                    String name = r.getClass().getSimpleName().replace("_ClientProxy", "");
+                    failed.add(name);
+                    LOG.errorv(e, "State reset: {0}.clear() failed", name);
+                }
+            }
+            try {
+                storageFactory.clearAll();
+            } catch (RuntimeException e) {
+                failed.add("StorageFactory");
+                LOG.error("State reset: storage clearAll failed", e);
+            }
+        });
+        return failed;
     }
 
     static String resolveVersion() {

--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.acm;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -35,7 +36,7 @@ import java.util.stream.Collectors;
  * @see <a href="https://docs.aws.amazon.com/acm/latest/APIReference/Welcome.html">AWS ACM API Reference</a>
  */
 @ApplicationScoped
-public class AcmService {
+public class AcmService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(AcmService.class);
     private static final int MAX_TAGS = 50;
@@ -654,5 +655,13 @@ public class AcmService {
             LOG.warn("Failed to load Amazon Root CA: " + e.getMessage());
             return "";
         }
+    }
+
+    /**
+     * The idempotency-token index would keep resolving tokens to certificates that are gone.
+     */
+    @Override
+    public void clear() {
+        idempotencyTokenIndex.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
+import io.github.hectorvent.floci.core.common.Resettable;
+
 import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.AsyncSerialExecutionStrategy;
@@ -14,7 +16,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
-public class SchemaRegistry {
+public class SchemaRegistry implements Resettable {
     private final Map<String, GraphQLSchema> schemas = new ConcurrentHashMap<>();
     private final Map<String, GraphQL> engines = new ConcurrentHashMap<>();
     private final AppSyncSchemaParser appSyncSchemaParser;
@@ -58,5 +60,14 @@ public class SchemaRegistry {
                 .mutationExecutionStrategy(new AsyncSerialExecutionStrategy())
                 .subscriptionExecutionStrategy(new SubscriptionExecutionStrategy())
                 .build();
+    }
+
+    /**
+     * Compiled schemas and engines are keyed by API id and would be served for APIs the reset removed.
+     */
+    @Override
+    public void clear() {
+        schemas.clear();
+        engines.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/graphql/SchemaRegistry.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.appsync.graphql;
 
+import io.github.hectorvent.floci.core.common.Resettable;
+
 import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
 import graphql.execution.AsyncSerialExecutionStrategy;
@@ -13,7 +15,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
-public class SchemaRegistry {
+public class SchemaRegistry implements Resettable {
     private final Map<String, GraphQLSchema> schemas = new ConcurrentHashMap<>();
     private final Map<String, GraphQL> engines = new ConcurrentHashMap<>();
     private final AppSyncSchemaParser appSyncSchemaParser;
@@ -48,5 +50,14 @@ public class SchemaRegistry {
                 .mutationExecutionStrategy(new AsyncSerialExecutionStrategy())
                 .subscriptionExecutionStrategy(new SubscriptionExecutionStrategy())
                 .build();
+    }
+
+    /**
+     * Compiled schemas and engines are keyed by API id and would be served for APIs the reset removed.
+     */
+    @Override
+    public void clear() {
+        schemas.clear();
+        engines.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.services.cloudformation.CloudFormationResourceProvisioner;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
@@ -29,9 +30,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import io.github.hectorvent.floci.core.common.ResetCoordinator;
 
 @ApplicationScoped
-public class CloudControlService {
+public class CloudControlService implements Resettable {
 
     /** Cloud Control has no account context in the request; Floci's default test account. */
     private static final String ACCOUNT = "000000000000";
@@ -55,6 +57,15 @@ public class CloudControlService {
     /** RequestToken → ProgressEvent. Cloud Control is async; clients poll by token. */
     private final Map<String, ProgressEvent> requests = new ConcurrentHashMap<>();
     /** Token insertion order, so the map can be bounded without losing in-flight requests. */
+    /**
+     * Incremented by {@link #clear()}. CreateResource provisions on a background thread, so a
+     * reset that merely cleared the maps would let an operation started beforehand write its
+     * result back afterwards and resurrect a resource the reset removed. Work captures the epoch
+     * at submit time and drops its writes if it no longer matches. Interrupting is not an option
+     * here — provisioning can be long, and a reset must not block on it.
+     */
+    private final ResetCoordinator resetCoordinator;
+
     private final java.util.concurrent.ConcurrentLinkedQueue<String> requestOrder =
             new java.util.concurrent.ConcurrentLinkedQueue<>();
     /**
@@ -81,12 +92,13 @@ public class CloudControlService {
     @Inject
     public CloudControlService(S3Service s3Service, Ec2Service ec2Service,
                                IamService iamService, CloudFormationResourceProvisioner provisioner,
-                               ObjectMapper mapper) {
+                               ObjectMapper mapper, ResetCoordinator resetCoordinator) {
         this.s3Service = s3Service;
         this.ec2Service = ec2Service;
         this.iamService = iamService;
         this.provisioner = provisioner;
         this.mapper = mapper;
+        this.resetCoordinator = resetCoordinator;
     }
 
     /**
@@ -111,25 +123,32 @@ public class CloudControlService {
         String token = UUID.randomUUID().toString();
         ProgressEvent pending = new ProgressEvent(typeName, null, token, "CREATE", "IN_PROGRESS", null, null);
         record(pending);
+        long epoch = resetCoordinator.currentEpoch();
         executor.submit(() -> {
             try {
                 var resource = provisioner.provisionStandalone(typeName, props, region, ACCOUNT);
-                if (resource == null || resource.getPhysicalId() == null) {
-                    record(pending.failed("CreateResource is not supported for " + typeName + "."));
-                } else {
-                    String model = resourceModel(region, typeName, resource.getPhysicalId(), props);
-                    // Kept so GetResource can read back a type the read side does not list, and so
-                    // DeleteResource has the attributes its delete path needs.
-                    created.put(createdKey(region, typeName, resource.getPhysicalId()),
-                            new CreatedResource(
-                                    resource.getAttributes() == null
-                                            ? Map.of() : Map.copyOf(resource.getAttributes()),
-                                    model));
-                    record(new ProgressEvent(typeName, resource.getPhysicalId(),
-                            token, "CREATE", "SUCCESS", null, model));
-                }
+                // The staleness check and the state writes are one atomic commit under the
+                // coordinator's read lock: a reset can no longer interleave between them and
+                // resurrect pre-reset request status or created-resource state.
+                resetCoordinator.applyIfCurrent(epoch, () -> {
+                    if (resource == null || resource.getPhysicalId() == null) {
+                        record(pending.failed("CreateResource is not supported for " + typeName + "."));
+                    } else {
+                        String model = resourceModel(region, typeName, resource.getPhysicalId(), props);
+                        // Kept so GetResource can read back a type the read side does not list, and so
+                        // DeleteResource has the attributes its delete path needs.
+                        created.put(createdKey(region, typeName, resource.getPhysicalId()),
+                                new CreatedResource(
+                                        resource.getAttributes() == null
+                                                ? Map.of() : Map.copyOf(resource.getAttributes()),
+                                        model));
+                        record(new ProgressEvent(typeName, resource.getPhysicalId(),
+                                token, "CREATE", "SUCCESS", null, model));
+                    }
+                });
             } catch (Exception e) {
-                record(pending.failed(e.getMessage() == null ? e.toString() : e.getMessage()));
+                resetCoordinator.applyIfCurrent(epoch, () ->
+                        record(pending.failed(e.getMessage() == null ? e.toString() : e.getMessage())));
             }
         });
         return pending;
@@ -436,4 +455,14 @@ public class CloudControlService {
     }
 
     public record ResourceDescription(String identifier, String properties) {}
+
+    /**
+     * In-flight request progress and the created-resource index are plain maps, so a reset would otherwise leave GetResourceRequestStatus reporting resources that no longer exist.
+     */
+    @Override
+    public void clear() {
+        requests.clear();
+        requestOrder.clear();
+        created.clear();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.services.cloudformation.CloudFormationResourceProvisioner;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
@@ -31,7 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
-public class CloudControlService {
+public class CloudControlService implements Resettable {
 
     /** Cloud Control has no account context in the request; Floci's default test account. */
     private static final String ACCOUNT = "000000000000";
@@ -55,6 +56,16 @@ public class CloudControlService {
     /** RequestToken → ProgressEvent. Cloud Control is async; clients poll by token. */
     private final Map<String, ProgressEvent> requests = new ConcurrentHashMap<>();
     /** Token insertion order, so the map can be bounded without losing in-flight requests. */
+    /**
+     * Incremented by {@link #clear()}. CreateResource provisions on a background thread, so a
+     * reset that merely cleared the maps would let an operation started beforehand write its
+     * result back afterwards and resurrect a resource the reset removed. Work captures the epoch
+     * at submit time and drops its writes if it no longer matches. Interrupting is not an option
+     * here — provisioning can be long, and a reset must not block on it.
+     */
+    private final java.util.concurrent.atomic.AtomicLong resetEpoch =
+            new java.util.concurrent.atomic.AtomicLong();
+
     private final java.util.concurrent.ConcurrentLinkedQueue<String> requestOrder =
             new java.util.concurrent.ConcurrentLinkedQueue<>();
     /**
@@ -111,9 +122,13 @@ public class CloudControlService {
         String token = UUID.randomUUID().toString();
         ProgressEvent pending = new ProgressEvent(typeName, null, token, "CREATE", "IN_PROGRESS", null, null);
         record(pending);
+        long epoch = resetEpoch.get();
         executor.submit(() -> {
             try {
                 var resource = provisioner.provisionStandalone(typeName, props, region, ACCOUNT);
+                if (resetEpoch.get() != epoch) {
+                    return; // state was reset while this provision ran; drop the result
+                }
                 if (resource == null || resource.getPhysicalId() == null) {
                     record(pending.failed("CreateResource is not supported for " + typeName + "."));
                 } else {
@@ -129,6 +144,9 @@ public class CloudControlService {
                             token, "CREATE", "SUCCESS", null, model));
                 }
             } catch (Exception e) {
+                if (resetEpoch.get() != epoch) {
+                    return;
+                }
                 record(pending.failed(e.getMessage() == null ? e.toString() : e.getMessage()));
             }
         });
@@ -436,4 +454,15 @@ public class CloudControlService {
     }
 
     public record ResourceDescription(String identifier, String properties) {}
+
+    /**
+     * In-flight request progress and the created-resource index are plain maps, so a reset would otherwise leave GetResourceRequestStatus reporting resources that no longer exist.
+     */
+    @Override
+    public void clear() {
+        resetEpoch.incrementAndGet();
+        requests.clear();
+        requestOrder.clear();
+        created.clear();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.RequestContext;
 import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.quarkus.arc.Arc;
@@ -38,12 +39,13 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import io.github.hectorvent.floci.core.common.ResetCoordinator;
 
 /**
  * CloudFormation stack lifecycle management — Create, Update, Delete stacks via ChangeSets.
  */
 @ApplicationScoped
-public class CloudFormationService {
+public class CloudFormationService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(CloudFormationService.class);
 
@@ -52,6 +54,18 @@ public class CloudFormationService {
     // Global exports registry: region:exportName -> exportValue
     private final ConcurrentHashMap<String, String> exports = new ConcurrentHashMap<>();
     private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    /**
+     * Stack provisioning runs on {@link #executor}, so a reset that only cleared the maps would let
+     * an execution started beforehand register its exports and nested stacks afterwards, resurrecting
+     * state the reset removed. {@link #clear()} cancels those executions and waits briefly for them
+     * to stop; the shared {@link ResetCoordinator} epoch fences any write that still slips
+     * through, and its read lock makes each fenced commit atomic with its staleness check.
+     */
+    private final java.util.Set<java.util.concurrent.Future<?>> inFlight =
+            java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+    private final ResetCoordinator resetCoordinator;
 
     private final CloudFormationResourceProvisioner provisioner;
     private final S3Service s3Service;
@@ -73,7 +87,8 @@ public class CloudFormationService {
     public CloudFormationService(CloudFormationResourceProvisioner provisioner, S3Service s3Service,
                                  ObjectMapper objectMapper, EmulatorConfig config,
                                  RegionResolver regionResolver, Clock clock,
-                                 StorageFactory storageFactory) {
+                                 StorageFactory storageFactory, ResetCoordinator resetCoordinator) {
+        this.resetCoordinator = resetCoordinator;
         this.provisioner = provisioner;
         this.s3Service = s3Service;
         this.objectMapper = objectMapper;
@@ -110,6 +125,31 @@ public class CloudFormationService {
 
     private void persistStack(Stack stack) {
         stackBackend.putForAccount(storageAccount, key(stack.getStackName(), stack.getRegion()), stack);
+    }
+
+    /**
+     * Stacks, the deleted-stack tombstones and the cross-stack export registry live in memory
+     * rather than in a StorageBackend, so {@code storageFactory.clearAll()} does not reach them
+     * and a reset would otherwise leave every stack readable via DescribeStacks.
+     */
+    @Override
+    public void clear() {
+        for (java.util.concurrent.Future<?> f : inFlight) {
+            f.cancel(true);
+        }
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2);
+        while (!inFlight.isEmpty() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        inFlight.clear();
+        stacks.clear();
+        deletedStacks.clear();
+        exports.clear();
     }
 
     private void unpersistStack(String stackName, String region) {
@@ -327,8 +367,21 @@ public class CloudFormationService {
         String templateBody = cs.getTemplateBody();
         Map<String, String> params = cs.getParameters() != null ? cs.getParameters() : Map.of();
 
-        return executor.submit(() -> runUnderAccount(accountId,
-                () -> executeTemplate(stack, templateBody, params, isCreate, region, accountId)));
+        long epoch = resetCoordinator.currentEpoch();
+        java.util.concurrent.Future<?>[] holder = new java.util.concurrent.Future<?>[1];
+        holder[0] = executor.submit(() -> {
+            try {
+                if (!resetCoordinator.isCurrent(epoch)) {
+                    return;
+                }
+                runUnderAccount(accountId,
+                        () -> executeTemplate(stack, templateBody, params, isCreate, region, accountId, epoch));
+            } finally {
+                inFlight.remove(holder[0]);
+            }
+        });
+        inFlight.add(holder[0]);
+        return holder[0];
     }
 
     /**
@@ -406,7 +459,20 @@ public class CloudFormationService {
         addEvent(stack, stack.getStackName(), stack.getStackId(),
                 "AWS::CloudFormation::Stack", "DELETE_IN_PROGRESS", null);
 
-        return executor.submit(() -> runUnderAccount(accountId, () -> deleteStackResources(stack, region)));
+        long epoch = resetCoordinator.currentEpoch();
+        java.util.concurrent.Future<?>[] holder = new java.util.concurrent.Future<?>[1];
+        holder[0] = executor.submit(() -> {
+            try {
+                if (!resetCoordinator.isCurrent(epoch)) {
+                    return;
+                }
+                runUnderAccount(accountId, () -> deleteStackResources(stack, region, epoch));
+            } finally {
+                inFlight.remove(holder[0]);
+            }
+        });
+        inFlight.add(holder[0]);
+        return holder[0];
     }
 
     // ── GetTemplate ───────────────────────────────────────────────────────────
@@ -623,7 +689,7 @@ public class CloudFormationService {
     }
 
     private void executeTemplate(Stack stack, String templateBody, Map<String, String> params,
-                                 boolean isCreate, String region, String accountId) {
+                                 boolean isCreate, String region, String accountId, long epoch) {
         StackUpdateSnapshot previousState = snapshotForUpdate(stack);
         boolean updateCommitted = false;
         Set<String> attemptedResourceIds = new LinkedHashSet<>();
@@ -669,6 +735,12 @@ public class CloudFormationService {
                 List<String> sortedLogicalIds = topologicalSort(resources, conditions);
 
                 for (String logicalId : sortedLogicalIds) {
+                    // A reset aborts a running execution at the next resource boundary instead of
+                    // only at the terminal commit; clear() cancels the future, this covers the
+                    // stretch until the cancel lands.
+                    if (!resetCoordinator.isCurrent(epoch)) {
+                        return;
+                    }
                     JsonNode resDef = resources.get(logicalId);
                     String type = resDef.path("Type").asText();
                     String deletionPolicy = resDef.path("DeletionPolicy").asText(null);
@@ -702,7 +774,7 @@ public class CloudFormationService {
                     if ("AWS::CloudFormation::Stack".equals(type)) {
                         resource = executeNestedStack(stack, logicalId,
                                 props.isMissingNode() ? null : props,
-                                engine, region, accountId, isCreate);
+                                engine, region, accountId, isCreate, epoch);
                     } else {
                         resource = provisioner.provision(logicalId, type, props.isMissingNode() ? null : props,
                                 engine, region, accountId, stack.getStackName(),
@@ -801,20 +873,27 @@ public class CloudFormationService {
                 });
             }
 
-            removeStackExports(stack, region);
-            stack.getOutputs().clear();
-            stack.getOutputs().putAll(newOutputs);
-            stack.getExports().clear();
-            stack.getExports().putAll(newExports);
-            stack.getOutputExportNames().clear();
-            stack.getOutputExportNames().putAll(newOutputExportNames);
-            newExports.forEach((exportName, value) -> {
-                String exportKey = exportKey(region, exportName);
-                exports.put(exportKey, value);
-                exportBackend.putForAccount(storageAccount, exportKey, value);
-                LOG.infov("Registered export {0} = {1} from stack {2}",
-                        exportName, value, stack.getStackName());
+            // The whole export/output commit is fenced as one atomic unit: a reset can no
+            // longer land between the staleness check and the export registrations.
+            boolean committed = resetCoordinator.applyIfCurrent(epoch, () -> {
+                removeStackExports(stack, region);
+                stack.getOutputs().clear();
+                stack.getOutputs().putAll(newOutputs);
+                stack.getExports().clear();
+                stack.getExports().putAll(newExports);
+                stack.getOutputExportNames().clear();
+                stack.getOutputExportNames().putAll(newOutputExportNames);
+                newExports.forEach((exportName, value) -> {
+                    String exportKey = exportKey(region, exportName);
+                    exports.put(exportKey, value);
+                    exportBackend.putForAccount(storageAccount, exportKey, value);
+                    LOG.infov("Registered export {0} = {1} from stack {2}",
+                            exportName, value, stack.getStackName());
+                });
             });
+            if (!committed) {
+                return; // state was reset while this template ran; drop the terminal commit
+            }
 
             if (!isCreate) {
                 updateCommitted = true;
@@ -837,14 +916,19 @@ public class CloudFormationService {
                 return;
             }
 
-            stack.setStatus("CREATE_COMPLETE");
-            stack.setLastUpdatedTime(now());
-            addEvent(stack, stack.getStackName(), stack.getStackId(),
-                    "AWS::CloudFormation::Stack", "CREATE_COMPLETE", null);
-            persistStack(stack);
-            LOG.infov("Stack {0} execution complete: CREATE_COMPLETE", stack.getStackName());
+            resetCoordinator.applyIfCurrent(epoch, () -> {
+                stack.setStatus("CREATE_COMPLETE");
+                stack.setLastUpdatedTime(now());
+                addEvent(stack, stack.getStackName(), stack.getStackId(),
+                        "AWS::CloudFormation::Stack", "CREATE_COMPLETE", null);
+                persistStack(stack);
+                LOG.infov("Stack {0} execution complete: CREATE_COMPLETE", stack.getStackName());
+            });
 
         } catch (Exception e) {
+            if (!resetCoordinator.isCurrent(epoch)) {
+                return; // state was reset while this template ran; do not persist failure state
+            }
             if (!isCreate && updateCommitted) {
                 LOG.errorv(
                         "Stack {0} update cleanup could not finish: {1}",
@@ -1350,7 +1434,7 @@ public class CloudFormationService {
         return failures;
     }
 
-    private void deleteStackResources(Stack stack, String region) {
+    private void deleteStackResources(Stack stack, String region, long epoch) {
         try {
             List<StackResource> resources = new ArrayList<>(stack.getResources().values());
             Collections.reverse(resources); // Delete in reverse order
@@ -1403,27 +1487,35 @@ public class CloudFormationService {
                 stack.setStatusReason(reason);
                 addEvent(stack, stack.getStackName(), stack.getStackId(),
                         "AWS::CloudFormation::Stack", "DELETE_FAILED", reason);
-                persistStack(stack);
+                if (resetCoordinator.isCurrent(epoch)) {
+                    persistStack(stack);
+                }
                 LOG.errorv("Stack {0} delete failed: {1}", stack.getStackName(), reason);
                 throw new IllegalStateException(reason);
             }
 
-            stack.setStatus("DELETE_COMPLETE");
-            addEvent(stack, stack.getStackName(), stack.getStackId(),
-                    "AWS::CloudFormation::Stack", "DELETE_COMPLETE", null);
-            removeStackExports(stack, region);
-            stacks.remove(key(stack.getStackName(), region));
-            unpersistStack(stack.getStackName(), region);
-            deletedStacks.put(stack.getStackId(), new DeletedStackEntry(
-                    stack,
-                    now().plusSeconds(config.services().cloudformation().deletedStackRetentionSeconds())));
-            LOG.infov("Stack {0} deleted", stack.getStackName());
+            // Tombstone commit is fenced: a reset between resource deletion and this block can
+            // no longer reinsert a deleted-stack tombstone into freshly cleared state.
+            resetCoordinator.applyIfCurrent(epoch, () -> {
+                stack.setStatus("DELETE_COMPLETE");
+                addEvent(stack, stack.getStackName(), stack.getStackId(),
+                        "AWS::CloudFormation::Stack", "DELETE_COMPLETE", null);
+                removeStackExports(stack, region);
+                stacks.remove(key(stack.getStackName(), region));
+                unpersistStack(stack.getStackName(), region);
+                deletedStacks.put(stack.getStackId(), new DeletedStackEntry(
+                        stack,
+                        now().plusSeconds(config.services().cloudformation().deletedStackRetentionSeconds())));
+                LOG.infov("Stack {0} deleted", stack.getStackName());
+            });
 
         } catch (Exception e) {
             LOG.errorv("Stack {0} delete failed: {1}", stack.getStackName(), e.getMessage());
             stack.setStatus("DELETE_FAILED");
             stack.setStatusReason(e.getMessage());
-            persistStack(stack);
+            if (resetCoordinator.isCurrent(epoch)) {
+                persistStack(stack);
+            }
             throw (e instanceof RuntimeException re ? re : new RuntimeException(e));
         }
     }
@@ -1687,7 +1779,7 @@ public class CloudFormationService {
 
     private StackResource executeNestedStack(Stack parentStack, String logicalId, JsonNode props,
                                              CloudFormationTemplateEngine engine, String region,
-                                             String accountId, boolean isCreate) {
+                                             String accountId, boolean isCreate, long epoch) {
         StackResource resource = new StackResource();
         resource.setLogicalId(logicalId);
         resource.setResourceType("AWS::CloudFormation::Stack");
@@ -1712,7 +1804,7 @@ public class CloudFormationService {
                     childParams.put(e.getKey(), engine.resolve(e.getValue())));
         }
 
-        executeTemplate(childStack, childTemplate, childParams, isCreate, region, accountId);
+        executeTemplate(childStack, childTemplate, childParams, isCreate, region, accountId, epoch);
 
         resource.setPhysicalId(childStack.getStackId());
         resource.getAttributes().put("Arn", childStack.getStackId());

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.RequestContext;
 import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.quarkus.arc.Arc;
@@ -43,7 +44,7 @@ import java.util.concurrent.Future;
  * CloudFormation stack lifecycle management — Create, Update, Delete stacks via ChangeSets.
  */
 @ApplicationScoped
-public class CloudFormationService {
+public class CloudFormationService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(CloudFormationService.class);
 
@@ -52,6 +53,18 @@ public class CloudFormationService {
     // Global exports registry: region:exportName -> exportValue
     private final ConcurrentHashMap<String, String> exports = new ConcurrentHashMap<>();
     private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    /**
+     * Stack provisioning runs on {@link #executor}, so a reset that only cleared the maps would let
+     * an execution started beforehand register its exports and nested stacks afterwards, resurrecting
+     * state the reset removed. {@link #clear()} cancels those executions and waits briefly for them
+     * to stop; {@link #resetEpoch} fences any write that still slips through.
+     */
+    private final java.util.Set<java.util.concurrent.Future<?>> inFlight =
+            java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+    private final java.util.concurrent.atomic.AtomicLong resetEpoch =
+            new java.util.concurrent.atomic.AtomicLong();
 
     private final CloudFormationResourceProvisioner provisioner;
     private final S3Service s3Service;
@@ -110,6 +123,32 @@ public class CloudFormationService {
 
     private void persistStack(Stack stack) {
         stackBackend.putForAccount(storageAccount, key(stack.getStackName(), stack.getRegion()), stack);
+    }
+
+    /**
+     * Stacks, the deleted-stack tombstones and the cross-stack export registry live in memory
+     * rather than in a StorageBackend, so {@code storageFactory.clearAll()} does not reach them
+     * and a reset would otherwise leave every stack readable via DescribeStacks.
+     */
+    @Override
+    public void clear() {
+        resetEpoch.incrementAndGet();
+        for (java.util.concurrent.Future<?> f : inFlight) {
+            f.cancel(true);
+        }
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(2);
+        while (!inFlight.isEmpty() && System.nanoTime() < deadline) {
+            try {
+                Thread.sleep(20);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        inFlight.clear();
+        stacks.clear();
+        deletedStacks.clear();
+        exports.clear();
     }
 
     private void unpersistStack(String stackName, String region) {
@@ -258,8 +297,21 @@ public class CloudFormationService {
         String templateBody = cs.getTemplateBody();
         Map<String, String> params = cs.getParameters() != null ? cs.getParameters() : Map.of();
 
-        return executor.submit(() -> runUnderAccount(accountId,
-                () -> executeTemplate(stack, templateBody, params, isCreate, region, accountId)));
+        long epoch = resetEpoch.get();
+        java.util.concurrent.Future<?>[] holder = new java.util.concurrent.Future<?>[1];
+        holder[0] = executor.submit(() -> {
+            try {
+                if (resetEpoch.get() != epoch) {
+                    return;
+                }
+                runUnderAccount(accountId,
+                        () -> executeTemplate(stack, templateBody, params, isCreate, region, accountId));
+            } finally {
+                inFlight.remove(holder[0]);
+            }
+        });
+        inFlight.add(holder[0]);
+        return holder[0];
     }
 
     /**
@@ -555,6 +607,7 @@ public class CloudFormationService {
 
     private void executeTemplate(Stack stack, String templateBody, Map<String, String> params,
                                  boolean isCreate, String region, String accountId) {
+        final long epochAtStart = resetEpoch.get();
         StackUpdateSnapshot previousState = snapshotForUpdate(stack);
         boolean updateCommitted = false;
         Set<String> attemptedResourceIds = new LinkedHashSet<>();
@@ -725,6 +778,9 @@ public class CloudFormationService {
             stack.getOutputExportNames().clear();
             stack.getOutputExportNames().putAll(newOutputExportNames);
             newExports.forEach((exportName, value) -> {
+                if (resetEpoch.get() != epochAtStart) {
+                    return; // state was reset while this template ran; do not re-register exports
+                }
                 String exportKey = exportKey(region, exportName);
                 exports.put(exportKey, value);
                 exportBackend.putForAccount(storageAccount, exportKey, value);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceResponseStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceResponseStore.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
@@ -25,7 +26,7 @@ import java.util.concurrent.TimeoutException;
  * it — the timeout only guards a PUT that lands just after the container returns.
  */
 @ApplicationScoped
-public class CustomResourceResponseStore {
+public class CustomResourceResponseStore implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(CustomResourceResponseStore.class);
 
@@ -67,5 +68,15 @@ public class CustomResourceResponseStore {
         } finally {
             pending.remove(token);
         }
+    }
+
+    /**
+     * Pending custom-resource responses are cancelled rather than dropped, so a provisioner still
+     * awaiting one fails fast instead of blocking to its timeout against a stack that is gone.
+     */
+    @Override
+    public void clear() {
+        pending.values().forEach(future -> future.cancel(true));
+        pending.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -29,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 @ApplicationScoped
-public class CloudTrailService {
+public class CloudTrailService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(CloudTrailService.class);
 
@@ -558,5 +559,13 @@ public class CloudTrailService {
                         errorCode, errorMessage, eventTimeMillis);
             }
         }
+    }
+
+    /**
+     * Pending records would otherwise be flushed into a trail that the reset removed.
+     */
+    @Override
+    public void clear() {
+        pendingRecordsByTrail.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.codebuild;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -29,7 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class CodeBuildService {
+public class CodeBuildService implements Resettable {
 
     // key: region -> name -> project
     private Map<String, Map<String, Project>> projects = new ConcurrentHashMap<>();
@@ -536,5 +537,15 @@ public class CodeBuildService {
         copy.setQueuedTimeoutInMinutes(source.getQueuedTimeoutInMinutes());
         copy.setEncryptionKey(source.getEncryptionKey());
         return copy;
+    }
+
+    /**
+     * Build history and counters are in-memory, so ListBuilds would keep returning builds for deleted projects and build numbers would not restart.
+     */
+    @Override
+    public void clear() {
+        builds.clear();
+        buildspecOverrides.clear();
+        buildCounters.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codedeploy/CodeDeployService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
@@ -41,7 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class CodeDeployService {
+public class CodeDeployService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(CodeDeployService.class);
 
@@ -1810,5 +1811,19 @@ public class CodeDeployService {
             if (key != null) { tagMap.put(key, value != null ? value : ""); }
         }
         tags.put(arn, tagMap); // write back the in-place inner-map mutation
+    }
+
+    /**
+     * Deployment history is in-memory. In-flight lifecycle hooks are cancelled and their stop flags
+     * tripped first, so a reset does not leave a hook waiting on state that has been wiped.
+     */
+    @Override
+    public void clear() {
+        stopFlags.values().forEach(flag -> flag.set(true));
+        hookFutures.values().forEach(future -> future.cancel(true));
+        hookFutures.clear();
+        stopFlags.clear();
+        deployments.clear();
+        deploymentTargets.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -47,7 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
-public class CodePipelineService {
+public class CodePipelineService implements Resettable {
     private static final Logger LOG = Logger.getLogger(CodePipelineService.class);
     private static final String DEFAULT_EXECUTION_MODE = "SUPERSEDED";
     private static final String DEFAULT_PIPELINE_TYPE = "V1";
@@ -1366,5 +1367,14 @@ public class CodePipelineService {
     }
 
     private record Page(int start, int end) {
+    }
+
+    /**
+     * Runtime artifacts are held in memory rather than in a StorageBackend.
+     */
+    @Override
+    public void clear() {
+        runtimeArtifacts.clear();
+        pipelineLocks.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
@@ -1051,4 +1051,11 @@ final class CognitoAuthFlowHandler {
     private String regionForPool(UserPool pool) {
         return AwsArnUtils.regionOrDefault(pool.getArn(), regionResolver.getDefaultRegion());
     }
+
+    /** Drops all in-flight auth sessions. Invoked by {@link CognitoService#clear()}; this class
+     *  is not a CDI bean, so it cannot be a {@code Resettable} in its own right. */
+    void clearSessions() {
+        srpSessions.clear();
+        customAuthSessions.clear();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoAuthFlowHandler.java
@@ -1023,4 +1023,11 @@ final class CognitoAuthFlowHandler {
     private String regionForPool(UserPool pool) {
         return AwsArnUtils.regionOrDefault(pool.getArn(), regionResolver.getDefaultRegion());
     }
+
+    /** Drops all in-flight auth sessions. Invoked by {@link CognitoService#clear()}; this class
+     *  is not a CDI bean, so it cannot be a {@code Resettable} in its own right. */
+    void clearSessions() {
+        srpSessions.clear();
+        customAuthSessions.clear();
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.ReservedTags;
@@ -66,7 +67,7 @@ import java.util.UUID;
 import static io.github.hectorvent.floci.core.common.ReservedTags.rejectUnknownReservedTags;
 
 @ApplicationScoped
-public class CognitoService {
+public class CognitoService implements Resettable {
     private static final int DEFAULT_REFRESH_TOKEN_VALIDITY_DAYS = 30;
 
     private static final Logger LOG = Logger.getLogger(CognitoService.class);
@@ -3040,5 +3041,14 @@ public class CognitoService {
     }
 
     private record DeliveryTarget(String attributeName, String deliveryMedium, String destination) {
+    }
+
+    /**
+     * Auth sessions live in {@link CognitoAuthFlowHandler}, which is constructed directly rather
+     * than by CDI and so cannot be discovered as a {@code Resettable} itself.
+     */
+    @Override
+    public void clear() {
+        authFlowHandler.clearSessions();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.ReservedTags;
@@ -66,7 +67,7 @@ import java.util.UUID;
 import static io.github.hectorvent.floci.core.common.ReservedTags.rejectUnknownReservedTags;
 
 @ApplicationScoped
-public class CognitoService {
+public class CognitoService implements Resettable {
     private static final int DEFAULT_REFRESH_TOKEN_VALIDITY_DAYS = 30;
 
     private static final Logger LOG = Logger.getLogger(CognitoService.class);
@@ -2883,5 +2884,14 @@ public class CognitoService {
     }
 
     private record DeliveryTarget(String attributeName, String deliveryMedium, String destination) {
+    }
+
+    /**
+     * Auth sessions live in {@link CognitoAuthFlowHandler}, which is constructed directly rather
+     * than by CDI and so cannot be discovered as a {@code Resettable} itself.
+     */
+    @Override
+    public void clear() {
+        authFlowHandler.clearSessions();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/configservice/AwsConfigService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/configservice/AwsConfigService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.configservice;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
@@ -27,7 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class AwsConfigService {
+public class AwsConfigService implements Resettable {
 
     private final RegionResolver regionResolver;
     private final StorageFactory storageFactory;
@@ -374,5 +375,15 @@ public class AwsConfigService {
 
     private static String shortId() {
         return UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    }
+
+    /**
+     * Recorder run state is in-memory, so a reset would leave the recorder reported as running for a configuration that has been cleared.
+     */
+    @Override
+    public void clear() {
+        recorderRunning.clear();
+        recorderLastStartTime.clear();
+        recorderLastStopTime.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
@@ -51,7 +52,7 @@ import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
 @ApplicationScoped
-public class DynamoDbService {
+public class DynamoDbService implements Resettable {
 
     private static final String LOCAL_REPLICA_UPDATE_ERROR =
             "Cannot add, delete, or update the local region through ReplicaUpdates. "
@@ -3013,5 +3014,18 @@ public class DynamoDbService {
                 .toList();
 
         return new ListExportsResult(summaries, newNextToken);
+    }
+
+    /**
+     * Items are served from an in-memory working copy loaded from the item store, so clearing the
+     * backend alone leaves the copy behind. It is not reachable through the API afterwards
+     * (every read validates the table, and CreateTable re-initialises the entry), but it is a
+     * leak, and the transaction idempotency index would outlive the tables it refers to.
+     */
+    @Override
+    public void clear() {
+        itemsByTable.clear();
+        itemLocks.clear();
+        txIdempotency.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
@@ -50,7 +51,7 @@ import java.util.function.Supplier;
 import java.util.zip.GZIPOutputStream;
 
 @ApplicationScoped
-public class DynamoDbService {
+public class DynamoDbService implements Resettable {
 
     private static final String LOCAL_REPLICA_UPDATE_ERROR =
             "Cannot add, delete, or update the local region through ReplicaUpdates. "
@@ -2962,5 +2963,18 @@ public class DynamoDbService {
                 .toList();
 
         return new ListExportsResult(summaries, newNextToken);
+    }
+
+    /**
+     * Items are served from an in-memory working copy loaded from the item store, so clearing the
+     * backend alone leaves the copy behind. It is not reachable through the API afterwards
+     * (every read validates the table, and CreateTable re-initialises the entry), but it is a
+     * leak, and the transaction idempotency index would outlive the tables it refers to.
+     */
+    @Override
+    public void clear() {
+        itemsByTable.clear();
+        itemLocks.clear();
+        txIdempotency.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamService.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.dynamodb.model.DynamoDbStreamRecord;
@@ -28,7 +29,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
-public class DynamoDbStreamService {
+public class DynamoDbStreamService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(DynamoDbStreamService.class);
 
@@ -301,5 +302,14 @@ public class DynamoDbStreamService {
 
     private String streamKey(String region, String tableName) {
         return region + "::" + tableName;
+    }
+
+    /**
+     * Stream descriptors and their record deques are plain maps; without this, GetRecords keeps serving events for tables that no longer exist.
+     */
+    @Override
+    public void clear() {
+        streams.clear();
+        records.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamService.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.dynamodb;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.dynamodb.model.DynamoDbStreamRecord;
@@ -28,7 +29,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
-public class DynamoDbStreamService {
+public class DynamoDbStreamService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(DynamoDbStreamService.class);
 
@@ -293,5 +294,14 @@ public class DynamoDbStreamService {
 
     private String streamKey(String region, String tableName) {
         return region + "::" + tableName;
+    }
+
+    /**
+     * Stream descriptors and their record deques are plain maps; without this, GetRecords keeps serving events for tables that no longer exist.
+     */
+    @Override
+    public void clear() {
+        streams.clear();
+        records.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -28,6 +28,7 @@ import org.jboss.logging.Logger;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsRegions;
 import io.github.hectorvent.floci.core.common.ContainerTeardown;
@@ -95,7 +96,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
-public class Ec2Service implements ContainerTeardown {
+public class Ec2Service implements ContainerTeardown, Resettable {
 
     private static final Logger LOG = Logger.getLogger(Ec2Service.class);
     private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -5526,5 +5527,14 @@ public class Ec2Service implements ContainerTeardown {
         }
 
         return result;
+    }
+
+    /**
+     * Per-subnet IP allocation counters are in-memory; without clearing them, addresses handed out
+     * after a reset continue from the old high-water mark instead of restarting.
+     */
+    @Override
+    public void clear() {
+        subnetIpCounters.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -26,6 +26,7 @@ import org.jboss.logging.Logger;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsRegions;
 import io.github.hectorvent.floci.core.common.ContainerTeardown;
@@ -89,7 +90,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 @ApplicationScoped
-public class Ec2Service implements ContainerTeardown {
+public class Ec2Service implements ContainerTeardown, Resettable {
 
     private static final Logger LOG = Logger.getLogger(Ec2Service.class);
     private static final DateTimeFormatter ISO_FMT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
@@ -4364,5 +4365,14 @@ public class Ec2Service implements ContainerTeardown {
         }
 
         return result;
+    }
+
+    /**
+     * Per-subnet IP allocation counters are in-memory; without clearing them, addresses handed out
+     * after a reset continue from the old high-water mark instead of restarting.
+     */
+    @Override
+    public void clear() {
+        subnetIpCounters.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -5,6 +5,8 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.ContainerTeardown;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.ResetCoordinator;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ecs.container.EcsContainerManager;
@@ -52,11 +54,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 @ApplicationScoped
-public class EcsService implements ContainerTeardown {
+public class EcsService implements ContainerTeardown, Resettable {
 
     private static final Logger LOG = Logger.getLogger(EcsService.class);
     private static final String DEFAULT_CLUSTER = "default";
 
+    private final ResetCoordinator resetCoordinator;
     private final RegionResolver regionResolver;
     private final EcsContainerManager containerManager;
     private final EcsLoadBalancerRegistrar lbRegistrar;
@@ -93,11 +96,25 @@ public class EcsService implements ContainerTeardown {
     // name → value (account-level settings)
     private Map<String, String> accountSettings = new ConcurrentHashMap<>();
 
+    /**
+     * Convenience overload for tests, mirroring the package-private constructors used elsewhere.
+     * The CDI-built instance MUST come through the coordinator-taking constructor below: a
+     * private {@code new ResetCoordinator()} here would silently disconnect the ECS fence from
+     * the one the reset endpoint locks.
+     */
+    EcsService(RegionResolver regionResolver, EcsContainerManager containerManager,
+               EmulatorConfig config, EcsLoadBalancerRegistrar lbRegistrar,
+               StorageFactory storageFactory) {
+        this(regionResolver, containerManager, config, lbRegistrar, storageFactory,
+                new ResetCoordinator());
+    }
+
     @Inject
     public EcsService(RegionResolver regionResolver, EcsContainerManager containerManager,
                       EmulatorConfig config, EcsLoadBalancerRegistrar lbRegistrar,
-                      StorageFactory storageFactory) {
+                      StorageFactory storageFactory, ResetCoordinator resetCoordinator) {
         this.regionResolver = regionResolver;
+        this.resetCoordinator = resetCoordinator;
         this.containerManager = containerManager;
         this.dockerMode = !config.services().ecs().mock();
         this.baseUrl = config.effectiveBaseUrl();
@@ -181,6 +198,15 @@ public class EcsService implements ContainerTeardown {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+        stopTaskContainers();
+    }
+
+    /**
+     * Stops and forgets every running task container. Shared by shutdown and by {@link #clear()};
+     * unlike {@link #stopManagedContainers()} this leaves the reconciler running, because a state
+     * reset is not a shutdown and the emulator keeps serving afterwards.
+     */
+    private void stopTaskContainers() {
         for (String taskArn : new ArrayList<>(taskHandles.keySet())) {
             EcsTaskHandle claimed = taskHandles.remove(taskArn);
             if (claimed == null) {
@@ -189,9 +215,24 @@ public class EcsService implements ContainerTeardown {
             try {
                 containerManager.stopTask(claimed);
             } catch (Exception e) {
-                LOG.warnv("Failed to stop ECS task {0} on shutdown: {1}", taskArn, e.getMessage());
+                LOG.warnv("Failed to stop ECS task {0}: {1}", taskArn, e.getMessage());
             }
         }
+    }
+
+    /**
+     * Clusters, services and task definitions are storage-backed and cleared by the storage
+     * factory, but tasks, container instances, task sets, deployments and revisions are plain
+     * maps. Without this a reset left orphan tasks pointing at clusters that no longer exist.
+     */
+    @Override
+    public void clear() {
+        stopTaskContainers();
+        tasks.clear();
+        containerInstances.clear();
+        taskSets.clear();
+        serviceDeployments.clear();
+        serviceRevisions.clear();
     }
 
     boolean isReconcilerShutdown() {
@@ -1409,9 +1450,16 @@ public class EcsService implements ContainerTeardown {
 
     // ── Service Reconciliation ────────────────────────────────────────────────
 
+    /**
+     * Skipped entirely while a reset is running. A tick overlapping the reset could read a service
+     * definition storage had not cleared yet and launch a replacement task, leaving post-reset task
+     * state and an orphan container behind.
+     */
     void reconcile() {
-        reconcileTasks();
-        reconcileServices();
+        resetCoordinator.runIfNotResetting(() -> {
+            reconcileTasks();
+            reconcileServices();
+        });
     }
 
     private void reconcileTasks() {

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.ContainerTeardown;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.StorageBackedMap;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ecs.container.EcsContainerManager;
@@ -52,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 @ApplicationScoped
-public class EcsService implements ContainerTeardown {
+public class EcsService implements ContainerTeardown, Resettable {
 
     private static final Logger LOG = Logger.getLogger(EcsService.class);
     private static final String DEFAULT_CLUSTER = "default";
@@ -63,6 +64,10 @@ public class EcsService implements ContainerTeardown {
     private final StorageFactory storageFactory;
     private final boolean dockerMode;
     private final String baseUrl;
+    /** Serialises {@link #reconcile()} against {@link #clear()} so a reset cannot interleave with
+     *  a reconciliation pass that is mid-way through reading the maps it is clearing. */
+    private final Object reconcileLock = new Object();
+
     private final ScheduledExecutorService reconciler = Executors.newSingleThreadScheduledExecutor(
             r -> { Thread t = new Thread(r, "ecs-reconciler"); t.setDaemon(true); return t; });
 
@@ -181,6 +186,15 @@ public class EcsService implements ContainerTeardown {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
+        stopTaskContainers();
+    }
+
+    /**
+     * Stops and forgets every running task container. Shared by shutdown and by {@link #clear()};
+     * unlike {@link #stopManagedContainers()} this leaves the reconciler running, because a state
+     * reset is not a shutdown and the emulator keeps serving afterwards.
+     */
+    private void stopTaskContainers() {
         for (String taskArn : new ArrayList<>(taskHandles.keySet())) {
             EcsTaskHandle claimed = taskHandles.remove(taskArn);
             if (claimed == null) {
@@ -189,8 +203,25 @@ public class EcsService implements ContainerTeardown {
             try {
                 containerManager.stopTask(claimed);
             } catch (Exception e) {
-                LOG.warnv("Failed to stop ECS task {0} on shutdown: {1}", taskArn, e.getMessage());
+                LOG.warnv("Failed to stop ECS task {0}: {1}", taskArn, e.getMessage());
             }
+        }
+    }
+
+    /**
+     * Clusters, services and task definitions are storage-backed and cleared by the storage
+     * factory, but tasks, container instances, task sets, deployments and revisions are plain
+     * maps. Without this a reset left orphan tasks pointing at clusters that no longer exist.
+     */
+    @Override
+    public void clear() {
+        synchronized (reconcileLock) {
+            stopTaskContainers();
+            tasks.clear();
+            containerInstances.clear();
+            taskSets.clear();
+            serviceDeployments.clear();
+            serviceRevisions.clear();
         }
     }
 
@@ -1399,8 +1430,10 @@ public class EcsService implements ContainerTeardown {
     // ── Service Reconciliation ────────────────────────────────────────────────
 
     void reconcile() {
-        reconcileTasks();
-        reconcileServices();
+        synchronized (reconcileLock) {
+            reconcileTasks();
+            reconcileServices();
+        }
     }
 
     private void reconcileTasks() {

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.firehose;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -30,7 +31,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
-public class FirehoseService {
+public class FirehoseService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(FirehoseService.class);
     private static final String DEFAULT_BUCKET = "floci-firehose-results";
@@ -415,5 +416,14 @@ public class FirehoseService {
         try {
             s3Service.createBucket(bucket, regionResolver.getDefaultRegion());
         } catch (Exception ignored) {}
+    }
+
+    /**
+     * Un-flushed delivery buffers survive a reset otherwise, and the next tick would deliver records belonging to a stream that has been wiped.
+     */
+    @Override
+    public void clear() {
+        buffers.clear();
+        bufferSince.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.firehose;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -30,7 +31,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @ApplicationScoped
-public class FirehoseService {
+public class FirehoseService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(FirehoseService.class);
     private static final String DEFAULT_BUCKET = "floci-firehose-results";
@@ -405,5 +406,14 @@ public class FirehoseService {
         try {
             s3Service.createBucket(bucket, regionResolver.getDefaultRegion());
         } catch (Exception ignored) {}
+    }
+
+    /**
+     * Un-flushed delivery buffers survive a reset otherwise, and the next tick would deliver records belonging to a stream that has been wiped.
+     */
+    @Override
+    public void clear() {
+        buffers.clear();
+        bufferSince.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/glue/schemaregistry/GlueSchemaRegistryService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/schemaregistry/GlueSchemaRegistryService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.glue.schemaregistry;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -33,7 +34,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class GlueSchemaRegistryService {
+public class GlueSchemaRegistryService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(GlueSchemaRegistryService.class);
 
@@ -1043,5 +1044,14 @@ public class GlueSchemaRegistryService {
             throw new AwsException("InvalidInputException",
                     "SchemaDefinition exceeds " + MAX_SCHEMA_DEFINITION_LENGTH + " characters", 400);
         }
+    }
+
+    /**
+     * Version indexes are derived in-memory views over schemas that the reset removes.
+     */
+    @Override
+    public void clear() {
+        versionByNumber.clear();
+        versionByDefinitionHash.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.iot;
 
+import io.github.hectorvent.floci.core.common.Resettable;
+
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.iot.model.IotRetainedMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -30,7 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
-public class IotMqttBrokerService {
+public class IotMqttBrokerService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(IotMqttBrokerService.class);
 
@@ -321,5 +323,18 @@ public class IotMqttBrokerService {
     }
 
     record ConnectionInfo(String clientId, String address, int port) {
+    }
+
+    /**
+     * A reset must actively disconnect connected clients, not just forget them. Dropping the
+     * session map alone leaves every client still attached to the broker with no session behind
+     * it, so the next PUBLISH arrives for a client the broker no longer knows. Mirrors the close
+     * performed by {@code stop()} and {@link #disconnectClient}.
+     */
+    @Override
+    public void clear() {
+        sessionsByClient.values().forEach(session -> session.endpoint().close());
+        sessionsByClient.clear();
+        subscriptionsByClient.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotPublishEventRecorder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotPublishEventRecorder.java
@@ -1,12 +1,13 @@
 package io.github.hectorvent.floci.services.iot;
 
+import io.github.hectorvent.floci.core.common.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @ApplicationScoped
-public class IotPublishEventRecorder {
+public class IotPublishEventRecorder implements Resettable {
 
     private final List<IotPublishEvent> events = new ArrayList<>();
 
@@ -18,6 +19,9 @@ public class IotPublishEventRecorder {
         return List.copyOf(events);
     }
 
+    /** Recorded publish events are inspection state; this already existed but was never
+     *  reachable from a state reset because the class did not declare {@link Resettable}. */
+    @Override
     public synchronized void clear() {
         events.clear();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.mwaa;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.TagHandler;
@@ -38,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class MwaaService implements TagHandler {
+public class MwaaService implements TagHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(MwaaService.class);
 
@@ -538,5 +539,15 @@ public class MwaaService implements TagHandler {
         } else {
             storage.put(environment.getName(), environment);
         }
+    }
+
+    /**
+     * CLI tokens and DAG sync state are in-memory and would outlive their environments.
+     */
+    @Override
+    public void clear() {
+        cliTokensByEnvironment.clear();
+        dagSyncState.clear();
+        requirementsEtagByEnvironment.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -73,7 +74,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class SesService {
+public class SesService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(SesService.class);
 
@@ -2866,5 +2867,13 @@ public class SesService {
         if (Character.isWhitespace(identity.charAt(0)) || Character.isWhitespace(identity.charAt(identity.length() - 1))) {
             throw new AwsException("InvalidParameterValue", fieldName + " must not contain leading or trailing whitespace.", 400);
         }
+    }
+
+    /**
+     * The DKIM lookup cache would keep answering for identities the reset removed.
+     */
+    @Override
+    public void clear() {
+        dkimLookupCache.clear();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -71,7 +72,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class SesService {
+public class SesService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(SesService.class);
 
@@ -3865,5 +3866,13 @@ public class SesService {
         if (Character.isWhitespace(identity.charAt(0)) || Character.isWhitespace(identity.charAt(identity.length() - 1))) {
             throw new AwsException("InvalidParameterValue", fieldName + " must not contain leading or trailing whitespace.", 400);
         }
+    }
+
+    /**
+     * The DKIM lookup cache would keep answering for identities the reset removed.
+     */
+    @Override
+    public void clear() {
+        dkimLookupCache.clear();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/core/common/ResetCoordinatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/ResetCoordinatorTest.java
@@ -1,0 +1,122 @@
+package io.github.hectorvent.floci.core.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The coordinator's contract, pinned deterministically with latches: commits are atomic with
+ * their staleness check, resets exclude fenced work, stale workers fail fast instead of parking
+ * on the read lock, and concurrent resets serialize.
+ */
+@Timeout(10)
+class ResetCoordinatorTest {
+
+    @Test
+    void staleEpochIsRejectedAfterReset() {
+        ResetCoordinator c = new ResetCoordinator();
+        long epoch = c.currentEpoch();
+        c.runReset(() -> { });
+        AtomicBoolean ran = new AtomicBoolean();
+        assertFalse(c.applyIfCurrent(epoch, () -> ran.set(true)));
+        assertFalse(ran.get());
+        assertTrue(c.isCurrent(c.currentEpoch()));
+        assertFalse(c.isCurrent(epoch));
+    }
+
+    @Test
+    void inFlightCommitBlocksResetUntilDone() throws Exception {
+        ResetCoordinator c = new ResetCoordinator();
+        long epoch = c.currentEpoch();
+        CountDownLatch commitEntered = new CountDownLatch(1);
+        CountDownLatch releaseCommit = new CountDownLatch(1);
+        CountDownLatch resetDone = new CountDownLatch(1);
+
+        Thread committer = new Thread(() -> c.applyIfCurrent(epoch, () -> {
+            commitEntered.countDown();
+            try {
+                releaseCommit.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }), "committer");
+        committer.start();
+        assertTrue(commitEntered.await(5, TimeUnit.SECONDS));
+
+        Thread resetter = new Thread(() -> {
+            c.runReset(() -> { });
+            resetDone.countDown();
+        }, "resetter");
+        resetter.start();
+
+        // The reset must not complete while the commit holds the read lock.
+        assertFalse(resetDone.await(200, TimeUnit.MILLISECONDS));
+        releaseCommit.countDown();
+        assertTrue(resetDone.await(5, TimeUnit.SECONDS));
+        committer.join(5000);
+        resetter.join(5000);
+    }
+
+    @Test
+    void duringResetWorkersAreExcludedAndStaleCommitsFailFast() throws Exception {
+        ResetCoordinator c = new ResetCoordinator();
+        long preResetEpoch = c.currentEpoch();
+        CountDownLatch resetEntered = new CountDownLatch(1);
+        CountDownLatch releaseReset = new CountDownLatch(1);
+
+        Thread resetter = new Thread(() -> c.runReset(() -> {
+            resetEntered.countDown();
+            try {
+                releaseReset.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }), "resetter");
+        resetter.start();
+        assertTrue(resetEntered.await(5, TimeUnit.SECONDS));
+
+        assertFalse(c.runIfNotResetting(() -> { }));
+        // The stale commit must return promptly (fast-fail pre-check), not park on the read lock
+        // until the reset finishes.
+        long start = System.nanoTime();
+        assertFalse(c.applyIfCurrent(preResetEpoch, () -> { }));
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+        assertTrue(elapsedMs < 1000, "stale applyIfCurrent blocked for " + elapsedMs + "ms");
+
+        releaseReset.countDown();
+        resetter.join(5000);
+    }
+
+    @Test
+    void concurrentResetsSerializeAndBumpEpochTwice() throws Exception {
+        ResetCoordinator c = new ResetCoordinator();
+        long before = c.currentEpoch();
+        AtomicInteger inside = new AtomicInteger();
+        AtomicBoolean overlapped = new AtomicBoolean();
+        Runnable seq = () -> {
+            if (inside.incrementAndGet() > 1) {
+                overlapped.set(true);
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            inside.decrementAndGet();
+        };
+        Thread a = new Thread(() -> c.runReset(seq), "reset-a");
+        Thread b = new Thread(() -> c.runReset(seq), "reset-b");
+        a.start(); b.start();
+        a.join(5000); b.join(5000);
+        assertFalse(overlapped.get(), "two resets ran inside the write lock concurrently");
+        assertEquals(before + 2, c.currentEpoch());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/ResetContainmentIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/ResetContainmentIntegrationTest.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * One failing {@code Resettable.clear()} must not abort the reset transition: every other
+ * service still clears, storage still clears, and the caller learns about the failure through a
+ * 500 {@code PARTIAL} instead of a false {@code OK}.
+ */
+@QuarkusTest
+class ResetContainmentIntegrationTest {
+
+    private static final String JSON_1_0 = "application/x-amz-json-1.0";
+
+    @BeforeAll
+    static void registerParsers() {
+        RestAssured.registerParser(JSON_1_0, Parser.JSON);
+    }
+
+    @AfterEach
+    void disarmAndClean() {
+        ThrowingResettable.ARMED.set(false);
+        given().when().post("/_floci/state/reset").then().statusCode(200);
+    }
+
+    @Test
+    void armedFailureReportsPartialButStillClearsEverythingElse() {
+        // Seed storage-backed state (a DynamoDB table) that the reset must still remove.
+        given().config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(JSON_1_0, ContentType.TEXT)))
+                .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+                .contentType(JSON_1_0)
+                .body("""
+                        {"TableName":"containment-table",
+                         "KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+                         "AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"S"}],
+                         "BillingMode":"PAY_PER_REQUEST"}
+                        """)
+                .when().post("/").then().statusCode(200);
+
+        ThrowingResettable.ARMED.set(true);
+        given().when().post("/_floci/state/reset")
+                .then().statusCode(500)
+                .body("status", equalTo("PARTIAL"))
+                .body("failed", hasItem("ThrowingResettable"));
+        ThrowingResettable.ARMED.set(false);
+
+        // Storage was still cleared despite the armed failure.
+        given().config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(JSON_1_0, ContentType.TEXT)))
+                .header("X-Amz-Target", "DynamoDB_20120810.DescribeTable")
+                .contentType(JSON_1_0)
+                .body("{\"TableName\":\"containment-table\"}")
+                .when().post("/").then().statusCode(400);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetCoverageIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetCoverageIntegrationTest.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * {@code /_floci/state/reset} clears every {@link io.github.hectorvent.floci.core.common.Resettable}
+ * plus every {@code StorageBackend}. A service that keeps its state in a plain map and does not
+ * implement {@code Resettable} is therefore missed, and the reset silently leaves data behind —
+ * which is worse than not resetting, because surviving resources reference cleared ones.
+ *
+ * <p>{@link EmulatorInfoControllerIntegrationTest} already covers a purely storage-backed service
+ * (SSM). These cases cover services whose live working copy is an in-memory map.
+ */
+@QuarkusTest
+class StateResetCoverageIntegrationTest {
+
+    private static final String JSON_1_0 = "application/x-amz-json-1.0";
+    private static final String JSON_1_1 = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void registerAwsJsonParsers() {
+        RestAssured.registerParser(JSON_1_0, Parser.JSON);
+        RestAssured.registerParser(JSON_1_1, Parser.JSON);
+    }
+
+    private void reset() {
+        given().when().post("/_floci/state/reset")
+                .then().statusCode(200).body("status", equalTo("OK"));
+    }
+
+    /** RestAssured has no built-in serializer for the x-amz-json content types; send raw text. */
+    private static RequestSpecification rpc(String contentType, String target, String body) {
+        return given()
+                .config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(JSON_1_0, ContentType.TEXT)
+                        .encodeContentTypeAs(JSON_1_1, ContentType.TEXT)))
+                .header("X-Amz-Target", target)
+                .contentType(contentType)
+                .body(body);
+    }
+
+    private static final String CREATE_TABLE = """
+            {"TableName":"reset-items",
+             "KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+             "AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"S"}],
+             "BillingMode":"PAY_PER_REQUEST"}
+            """;
+
+    @Test
+    void reset_clearsDynamoDbTransactionIdempotencyTokens() {
+        // The obvious Scan-based assertion is vacuous here: createTable does an unconditional
+        // itemsByTable.put(...), so re-creating the table after the reset replaces any stale item
+        // map whether or not clear() ran. The transaction idempotency cache is the observable
+        // seam instead: it is keyed on the ClientRequestToken and checked BEFORE table state, so
+        // a surviving entry turns the same-token-different-body call below into an
+        // IdempotentParameterMismatchException (400) - which is exactly what happens if clear()
+        // regresses. Credit: pgermosen's review on #2364.
+        rpc(JSON_1_0, "DynamoDB_20120810.CreateTable", CREATE_TABLE)
+                .when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_0, "DynamoDB_20120810.TransactWriteItems", """
+                {"ClientRequestToken":"reset-idempotency-token",
+                 "TransactItems":[{"Put":{"TableName":"reset-items",
+                   "Item":{"pk":{"S":"pre-reset"}}}}]}
+                """).when().post("/").then().statusCode(200);
+
+        reset();
+
+        // The table is storage-backed and gone; re-create it so the post-reset transaction can
+        // apply (the handler resolves the table before the idempotency cache is consulted).
+        rpc(JSON_1_0, "DynamoDB_20120810.CreateTable", CREATE_TABLE)
+                .when().post("/").then().statusCode(200);
+
+        // Same token, different body: only a cleared idempotency cache lets this succeed.
+        rpc(JSON_1_0, "DynamoDB_20120810.TransactWriteItems", """
+                {"ClientRequestToken":"reset-idempotency-token",
+                 "TransactItems":[{"Put":{"TableName":"reset-items",
+                   "Item":{"pk":{"S":"post-reset"}}}}]}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_0, "DynamoDB_20120810.Scan", """
+                {"TableName":"reset-items"}
+                """).when().post("/")
+                .then().statusCode(200)
+                .body("Count", equalTo(1))
+                .body("Items[0].pk.S", equalTo("post-reset"));
+    }
+
+    @Test
+    void reset_clearsCloudFormationStacks() {
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateStack")
+                .formParam("Version", "2010-05-15")
+                .formParam("StackName", "reset-stack")
+                .formParam("TemplateBody", """
+                        {"Resources":{"Q":{"Type":"AWS::SQS::Queue",
+                          "Properties":{"QueueName":"reset-stack-queue"}}}}
+                        """)
+                .when().post("/").then().statusCode(200);
+
+        reset();
+
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStacks")
+                .formParam("Version", "2010-05-15")
+                .when().post("/")
+                .then().statusCode(200)
+                // An empty <Stacks/> deserializes to "" rather than a collection, so assert on the
+                // stack itself being absent instead of on the container's emptiness.
+                .body(not(containsString("reset-stack")));
+    }
+
+    @Test
+    void reset_clearsEcsTasks() {
+        String ecs = "AmazonEC2ContainerServiceV20141113.";
+
+        rpc(JSON_1_1, ecs + "CreateCluster", """
+                {"clusterName":"reset-cluster"}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_1, ecs + "RegisterTaskDefinition", """
+                {"family":"reset-task",
+                 "containerDefinitions":[{"name":"c","image":"busybox","memory":64}]}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_1, ecs + "RunTask", """
+                {"cluster":"reset-cluster","taskDefinition":"reset-task"}
+                """).when().post("/").then().statusCode(200);
+
+        reset();
+
+        // The cluster is storage-backed and does go away; re-create it so ListTasks resolves,
+        // then confirm the task did not survive alongside it in EcsService's plain maps.
+        rpc(JSON_1_1, ecs + "CreateCluster", """
+                {"clusterName":"reset-cluster"}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_1, ecs + "ListTasks", """
+                {"cluster":"reset-cluster"}
+                """).when().post("/")
+                .then().statusCode(200)
+                .body("taskArns", hasSize(0));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetCoverageIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetCoverageIntegrationTest.java
@@ -1,0 +1,140 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
+import io.restassured.parsing.Parser;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * {@code /_floci/state/reset} clears every {@link io.github.hectorvent.floci.core.common.Resettable}
+ * plus every {@code StorageBackend}. A service that keeps its state in a plain map and does not
+ * implement {@code Resettable} is therefore missed, and the reset silently leaves data behind —
+ * which is worse than not resetting, because surviving resources reference cleared ones.
+ *
+ * <p>{@link EmulatorInfoControllerIntegrationTest} already covers a purely storage-backed service
+ * (SSM). These cases cover services whose live working copy is an in-memory map.
+ */
+@QuarkusTest
+class StateResetCoverageIntegrationTest {
+
+    private static final String JSON_1_0 = "application/x-amz-json-1.0";
+    private static final String JSON_1_1 = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void registerAwsJsonParsers() {
+        RestAssured.registerParser(JSON_1_0, Parser.JSON);
+        RestAssured.registerParser(JSON_1_1, Parser.JSON);
+    }
+
+    private void reset() {
+        given().when().post("/_floci/state/reset")
+                .then().statusCode(200).body("status", equalTo("OK"));
+    }
+
+    /** RestAssured has no built-in serializer for the x-amz-json content types; send raw text. */
+    private static RequestSpecification rpc(String contentType, String target, String body) {
+        return given()
+                .config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                        .encodeContentTypeAs(JSON_1_0, ContentType.TEXT)
+                        .encodeContentTypeAs(JSON_1_1, ContentType.TEXT)))
+                .header("X-Amz-Target", target)
+                .contentType(contentType)
+                .body(body);
+    }
+
+    private static final String CREATE_TABLE = """
+            {"TableName":"reset-items",
+             "KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+             "AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"S"}],
+             "BillingMode":"PAY_PER_REQUEST"}
+            """;
+
+    @Test
+    void reset_clearsDynamoDbItems() {
+        rpc(JSON_1_0, "DynamoDB_20120810.CreateTable", CREATE_TABLE)
+                .when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_0, "DynamoDB_20120810.PutItem", """
+                {"TableName":"reset-items","Item":{"pk":{"S":"survivor"}}}
+                """).when().post("/").then().statusCode(200);
+
+        reset();
+
+        // The table itself is storage-backed and does go away, so re-create it and confirm the
+        // item did not come back with it. Items live in a plain map, which is the actual subject.
+        rpc(JSON_1_0, "DynamoDB_20120810.CreateTable", CREATE_TABLE)
+                .when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_0, "DynamoDB_20120810.Scan", """
+                {"TableName":"reset-items"}
+                """).when().post("/")
+                .then().statusCode(200)
+                .body("Count", equalTo(0));
+    }
+
+    @Test
+    void reset_clearsCloudFormationStacks() {
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateStack")
+                .formParam("Version", "2010-05-15")
+                .formParam("StackName", "reset-stack")
+                .formParam("TemplateBody", """
+                        {"Resources":{"Q":{"Type":"AWS::SQS::Queue",
+                          "Properties":{"QueueName":"reset-stack-queue"}}}}
+                        """)
+                .when().post("/").then().statusCode(200);
+
+        reset();
+
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DescribeStacks")
+                .formParam("Version", "2010-05-15")
+                .when().post("/")
+                .then().statusCode(200)
+                // An empty <Stacks/> deserializes to "" rather than a collection, so assert on the
+                // stack itself being absent instead of on the container's emptiness.
+                .body(not(containsString("reset-stack")));
+    }
+
+    @Test
+    void reset_clearsEcsTasks() {
+        String ecs = "AmazonEC2ContainerServiceV20141113.";
+
+        rpc(JSON_1_1, ecs + "CreateCluster", """
+                {"clusterName":"reset-cluster"}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_1, ecs + "RegisterTaskDefinition", """
+                {"family":"reset-task",
+                 "containerDefinitions":[{"name":"c","image":"busybox","memory":64}]}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_1, ecs + "RunTask", """
+                {"cluster":"reset-cluster","taskDefinition":"reset-task"}
+                """).when().post("/").then().statusCode(200);
+
+        reset();
+
+        // The cluster is storage-backed and does go away; re-create it so ListTasks resolves,
+        // then confirm the task did not survive alongside it in EcsService's plain maps.
+        rpc(JSON_1_1, ecs + "CreateCluster", """
+                {"clusterName":"reset-cluster"}
+                """).when().post("/").then().statusCode(200);
+
+        rpc(JSON_1_1, ecs + "ListTasks", """
+                {"cluster":"reset-cluster"}
+                """).when().post("/")
+                .then().statusCode(200)
+                .body("taskArns", hasSize(0));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetFencingTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetFencingTest.java
@@ -1,0 +1,57 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * {@link EcsService#clear()} and {@code reconcile()} exclude each other through the shared
+ * {@code ResetCoordinator} (the reconciler tick runs under {@code runIfNotResetting}, the reset
+ * under the write lock), because the reconciler keeps running across a reset by design — a reset
+ * is not a shutdown. That mutual exclusion introduces a deadlock risk nothing else would catch,
+ * so that is what this covers.
+ *
+ * <p>Deliberately narrow. The CloudControl commit fence has its own deterministic test in
+ * {@code CloudControlServiceTest} (the mocked provisioner is the seam), and the coordinator's
+ * contract is pinned in {@code ResetCoordinatorTest}. Earlier drafts of
+ * this test hammered {@code clear()} hundreds of times across three services, which mutated global
+ * state on the shared Quarkus instance for every test that ran afterwards — not worth it for
+ * assertions that only checked "does not throw".
+ */
+@QuarkusTest
+class StateResetFencingTest {
+
+    @Inject
+    EcsService ecsService;
+
+    @Test
+    void ecsReconcileAndClearDoNotDeadlock() throws Exception {
+        Method reconcile = EcsService.class.getDeclaredMethod("reconcile");
+        reconcile.setAccessible(true);
+
+        Thread reconciling = new Thread(() -> {
+            for (int i = 0; i < 20; i++) {
+                try {
+                    reconcile.invoke(ecsService);
+                } catch (Exception e) {
+                    throw new AssertionError("reconcile threw while clear() ran concurrently", e);
+                }
+            }
+        }, "reset-fencing-reconcile");
+        reconciling.start();
+        for (int i = 0; i < 20; i++) {
+            ecsService.clear();
+        }
+        reconciling.join(30_000);
+        assertFalse(reconciling.isAlive(), "reconcile/clear deadlocked");
+
+        // The reconciler must still be usable: clear() is a reset, not a shutdown.
+        assertDoesNotThrow(() -> reconcile.invoke(ecsService));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetFencingTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/StateResetFencingTest.java
@@ -1,0 +1,55 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * {@link EcsService#clear()} and {@code reconcile()} share a lock, because the reconciler keeps
+ * running across a reset by design — a reset is not a shutdown. A shared lock introduces a
+ * deadlock risk that nothing else would catch, so that is what this covers.
+ *
+ * <p>Deliberately narrow. It does <em>not</em> prove the fences added for CloudControl and
+ * CloudFormation: those drop writes from work that started before a reset, and asserting it needs
+ * a seam to hold provisioning open across the reset, which does not exist yet. Earlier drafts of
+ * this test hammered {@code clear()} hundreds of times across three services, which mutated global
+ * state on the shared Quarkus instance for every test that ran afterwards — not worth it for
+ * assertions that only checked "does not throw".
+ */
+@QuarkusTest
+class StateResetFencingTest {
+
+    @Inject
+    EcsService ecsService;
+
+    @Test
+    void ecsReconcileAndClearDoNotDeadlock() throws Exception {
+        Method reconcile = EcsService.class.getDeclaredMethod("reconcile");
+        reconcile.setAccessible(true);
+
+        Thread reconciling = new Thread(() -> {
+            for (int i = 0; i < 20; i++) {
+                try {
+                    reconcile.invoke(ecsService);
+                } catch (Exception e) {
+                    throw new AssertionError("reconcile threw while clear() ran concurrently", e);
+                }
+            }
+        }, "reset-fencing-reconcile");
+        reconciling.start();
+        for (int i = 0; i < 20; i++) {
+            ecsService.clear();
+        }
+        reconciling.join(30_000);
+        assertFalse(reconciling.isAlive(), "reconcile/clear deadlocked");
+
+        // The reconciler must still be usable: clear() is a reset, not a shutdown.
+        assertDoesNotThrow(() -> reconcile.invoke(ecsService));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/ThrowingResettable.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/ThrowingResettable.java
@@ -1,0 +1,24 @@
+package io.github.hectorvent.floci.lifecycle;
+
+import io.github.hectorvent.floci.core.common.Resettable;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test-only {@link Resettable} that throws on {@code clear()} while armed. Disarmed by default,
+ * so it is inert for every other test sharing the Quarkus instance; {@link ResetContainmentIntegrationTest}
+ * arms it to prove one failing service cannot abort the rest of a state reset.
+ */
+@ApplicationScoped
+public class ThrowingResettable implements Resettable {
+
+    static final AtomicBoolean ARMED = new AtomicBoolean(false);
+
+    @Override
+    public void clear() {
+        if (ARMED.get()) {
+            throw new IllegalStateException("armed test failure from ThrowingResettable");
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
@@ -14,10 +14,15 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.ResetCoordinator;
 
 class CloudControlServiceTest {
 
@@ -35,7 +40,7 @@ class CloudControlServiceTest {
         ObjectMapper mapper = new ObjectMapper();
         CloudControlService service = new CloudControlService(
                 mock(S3Service.class), ec2Service, mock(IamService.class),
-                mock(CloudFormationResourceProvisioner.class), mapper);
+                mock(CloudFormationResourceProvisioner.class), mapper, new ResetCoordinator());
 
         String properties = service.listResources("us-east-1", "AWS::EC2::VPC").getFirst().properties();
         JsonNode tags = mapper.readTree(properties).path("Tags");
@@ -49,5 +54,47 @@ class CloudControlServiceTest {
         assertFalse(properties.contains("ignored-null"));
         assertFalse(properties.contains("ignored-empty"));
         assertFalse(properties.contains("ignored-blank"));
+    }
+
+    /**
+     * The mocked provisioner is the seam StateResetFencingTest's earlier draft lacked: it holds
+     * provisioning open across a reset, then proves the late commit is dropped rather than
+     * resurrected — the worker's staleness check and state writes are one atomic unit under the
+     * coordinator, so requestStatus stays RequestTokenNotFound after the reset.
+     */
+    @org.junit.jupiter.api.Timeout(10)
+    @Test
+    void lateProvisioningCommitIsDroppedByReset() throws Exception {
+        var provisioner = mock(CloudFormationResourceProvisioner.class);
+        var provisionEntered = new java.util.concurrent.CountDownLatch(1);
+        var releaseProvision = new java.util.concurrent.CountDownLatch(1);
+        var resource = new io.github.hectorvent.floci.services.cloudformation.model.StackResource();
+        resource.setLogicalId("standalone");
+        resource.setPhysicalId("vpc-after-reset");
+        when(provisioner.provisionStandalone(anyString(), any(), anyString(), anyString()))
+                .thenAnswer(inv -> {
+                    provisionEntered.countDown();
+                    releaseProvision.await();
+                    return resource;
+                });
+        ResetCoordinator coordinator = new ResetCoordinator();
+        CloudControlService service = new CloudControlService(
+                mock(S3Service.class), mock(Ec2Service.class), mock(IamService.class),
+                provisioner, new ObjectMapper(), coordinator);
+
+        String token = service.createResource("us-east-1", "AWS::EC2::VPC", "{}").requestToken();
+        assertTrue(provisionEntered.await(5, java.util.concurrent.TimeUnit.SECONDS));
+
+        coordinator.runReset(service::clear);
+        releaseProvision.countDown();
+
+        // Give the worker time to run its (now stale) commit attempt, then verify it was dropped.
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(3);
+        while (System.nanoTime() < deadline) {
+            Thread.sleep(25);
+        }
+        assertThrows(AwsException.class, () -> service.requestStatus(token));
+        assertThrows(AwsException.class,
+                () -> service.getResource("us-east-1", "AWS::EC2::VPC", "vpc-after-reset"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceRollbackTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceRollbackTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import io.github.hectorvent.floci.core.common.ResetCoordinator;
 
 /**
  * Covers rollback cleanup when another actor removes a resource after its create succeeded.
@@ -49,7 +50,7 @@ class CloudFormationServiceRollbackTest {
                 config,
                 mock(RegionResolver.class),
                 Clock.systemUTC(),
-                new InMemoryStorageFactory());
+                new InMemoryStorageFactory(), new ResetCoordinator());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`/_floci/state/reset` calls `clear()` on every `Resettable`, then
`StorageFactory.clearAll()`. A service that holds its state in a plain map and does
not declare `Resettable` is reached by neither, so the reset silently leaves data
behind — worse than not resetting at all, because the survivors reference resources
that *were* cleared.

Declares `Resettable` on the services whose live state is an in-memory map
(implementors 22 → 43), and **fences the services that keep working across a reset**
so they cannot write the state back afterwards.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Bug fix, so the incorrect behaviour: after a reset, `DescribeStacks` still returned a
stack, and `ListTasks` still returned an ECS task whose cluster had been cleared. No
wire format changes — this is emulator lifecycle behaviour only.

## Checklist

- [x] `./mvnw test` passes locally — 10621 passed / 0 failures / 0 errors / 8 skipped
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

## Fencing, not just clearing

Clearing bookkeeping is not enough where a background process owns it:

| Service | Why clearing alone was wrong | Fix |
|---|---|---|
| IoT | Dropped sessions without disconnecting, leaving clients attached to a broker that had forgotten them | Close each endpoint first, as `stop()` and `disconnectClient()` already do |
| ECS | The reconciler keeps running across a reset by design, and could race `clear()` | Shared lock; reconciler still survives the reset |
| CloudControl | `CreateResource` provisions on a background thread and recorded its result after the reset | Reset epoch captured at submit; stale writes dropped. `requestOrder` also cleared |
| CloudFormation | `executeTemplate` runs async and re-registers `exports` (and nested stacks) after the reset | Cancel in-flight, wait ≤2s, then clear, with an epoch guard on export registration |

Epoch rather than interruption for the two long-running paths: provisioning can take a
while and a reset must not block on it.

## Verification — what is and isn't pinned by a test

| Behaviour | Test that fails without the fix |
|---|---|
| CFN stacks survive a reset | ✅ `StateResetCoverageIntegrationTest` |
| ECS tasks survive a reset | ✅ same |
| ECS lock does not deadlock | ✅ `StateResetFencingTest` |
| IoT sessions actively closed | ❌ reasoned; mirrors the existing `stop()` path |
| CloudControl epoch drop | ❌ needs a seam to hold provisioning open across a reset |
| CFN quiesce + epoch guard | ❌ same |

The three unpinned fences are reasoned and documented in the commit body so they are
not simplified back out, but I would rather state that they lack direct coverage than
imply otherwise. Closing them properly needs a test seam that does not exist yet;
happy to add it here if preferred, or track it separately.

## Deliberately *not* cleared

Clearing these would itself be the defect: `CloudFormationResourceRegistry` (the CDI
provisioner registry — clearing it permanently breaks provisioning), `PricingService`
catalogs (static reference data), and per-request parse state (`VtlTemplateEngine`,
`LogsInsightsQuery`, `DynamoDbPartiQLHandler`). Container managers keep the existing
split: reset clears state, `ContainerTeardown` owns containers at shutdown.

`IotPublishEventRecorder` already had a correct `clear()` — it simply never declared
`Resettable`, so a reset never invoked it.

DynamoDB is a **leak**, not a visibility bug: items survive `clearAll()` but are
unreachable because reads validate the table and `CreateTable` re-initialises the entry.
