### PR TITLE
fix(lambda): round-trip StartingPosition on event source mappings

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -3915,6 +3915,18 @@ public class CloudFormationResourceProvisioner {
             try { req.put("BatchSize", Integer.parseInt(batchSize)); } catch (NumberFormatException ignored) {}
         }
 
+        String startingPosition = resolveOptional(props, "StartingPosition", engine);
+        if (startingPosition != null) {
+            req.put("StartingPosition", startingPosition);
+        }
+
+        String startingPositionTimestamp = resolveOptional(props, "StartingPositionTimestamp", engine);
+        if (startingPositionTimestamp != null) {
+            try {
+                req.put("StartingPositionTimestamp", Double.parseDouble(startingPositionTimestamp));
+            } catch (NumberFormatException ignored) {}
+        }
+
         var esm = lambdaService.createEventSourceMapping(region, req);
         r.setPhysicalId(esm.getUuid());
         r.getAttributes().put("Id", esm.getUuid());

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -3924,7 +3924,13 @@ public class CloudFormationResourceProvisioner {
         if (startingPositionTimestamp != null) {
             try {
                 req.put("StartingPositionTimestamp", Double.parseDouble(startingPositionTimestamp));
-            } catch (NumberFormatException ignored) {}
+            } catch (NumberFormatException e) {
+                // Not swallowed the way BatchSize above is: dropping this one degrades into the
+                // "StartingPositionTimestamp is required" error from the service, which points at
+                // the wrong problem and hides the value that actually failed to parse.
+                throw new AwsException("ValidationError",
+                        "Value of property StartingPositionTimestamp must be a number.", 400);
+            }
         }
 
         var esm = lambdaService.createEventSourceMapping(region, req);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -3923,11 +3923,17 @@ public class CloudFormationResourceProvisioner {
         String startingPositionTimestamp = resolveOptional(props, "StartingPositionTimestamp", engine);
         if (startingPositionTimestamp != null) {
             try {
-                req.put("StartingPositionTimestamp", Double.parseDouble(startingPositionTimestamp));
+                double timestamp = Double.parseDouble(startingPositionTimestamp);
+                if (!Double.isFinite(timestamp)) {
+                    throw new NumberFormatException("Non-finite timestamp");
+                }
+                req.put("StartingPositionTimestamp", timestamp);
             } catch (NumberFormatException e) {
                 // Not swallowed the way BatchSize above is: dropping this one degrades into the
                 // "StartingPositionTimestamp is required" error from the service, which points at
-                // the wrong problem and hides the value that actually failed to parse.
+                // the wrong problem and hides the value that actually failed to parse. Double.parseDouble
+                // accepts "NaN"/"Infinity"/"-Infinity" without throwing, so isFinite is checked explicitly
+                // to keep those from silently becoming epoch-zero or long-extremum timestamps downstream.
                 throw new AwsException("ValidationError",
                         "Value of property StartingPositionTimestamp must be a number.", 400);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -340,6 +340,15 @@ public class LambdaController {
         node.put("BatchSize", esm.getBatchSize());
         node.put("State", esm.getState());
         node.put("LastModified", (double) esm.getLastModified() / 1000.0);
+        // Omitted rather than nulled when unset, so a mapping created without a starting position
+        // reads back the way AWS returns it - and so Terraform sees the configured value on refresh
+        // instead of treating the field as unset and forcing a replacement on every plan.
+        if (esm.getStartingPosition() != null) {
+            node.put("StartingPosition", esm.getStartingPosition());
+        }
+        if (esm.getStartingPositionTimestamp() != null) {
+            node.put("StartingPositionTimestamp", (double) esm.getStartingPositionTimestamp() / 1000.0);
+        }
         ArrayNode responseTypes = node.putArray("FunctionResponseTypes");
 
         if (esm.getBisectBatchOnFunctionError() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -775,6 +775,8 @@ public class LambdaService {
 
         EventSourceMapping.DestinationConfig destinationConfig = parseDestinationConfig(request);
 
+        StartingPositionSpec startingPosition = parseStartingPosition(request, eventSourceArn);
+
         String queueUrl = eventSourceArn.contains(":sqs:") ? AwsArnUtils.arnToQueueUrl(eventSourceArn, config.effectiveBaseUrl()) : null;
 
         EventSourceMapping esm = new EventSourceMapping();
@@ -792,6 +794,8 @@ public class LambdaService {
         esm.setFunctionResponseTypes(functionResponseTypes);
         esm.setBisectBatchOnFunctionError(bisectBatchOnFunctionError);
         esm.setDestinationConfig(destinationConfig);
+        esm.setStartingPosition(startingPosition.position());
+        esm.setStartingPositionTimestamp(startingPosition.timestampMillis());
         esm.setLastModified(System.currentTimeMillis());
 
         esmStore.save(esm);
@@ -832,6 +836,55 @@ public class LambdaService {
         EventSourceMapping.DestinationConfig destinationConfig = new EventSourceMapping.DestinationConfig();
         destinationConfig.setOnFailure(onFailure);
         return destinationConfig;
+    }
+
+    /** A validated {@code StartingPosition} plus, for {@code AT_TIMESTAMP}, its epoch-millis instant. */
+    private record StartingPositionSpec(String position, Long timestampMillis) {}
+
+    /**
+     * Parses {@code StartingPosition}/{@code StartingPositionTimestamp} out of a create request.
+     *
+     * <p>Absent means absent: AWS requires a starting position for stream event sources, but Floci
+     * has always accepted mappings without one (its pollers default to reading from the trim
+     * horizon), so this validates only what a caller actually sent rather than newly rejecting
+     * requests that used to succeed. There is no update counterpart because AWS's
+     * UpdateEventSourceMapping does not accept the field at all - it is replace-only.
+     */
+    private StartingPositionSpec parseStartingPosition(Map<String, Object> request, String eventSourceArn) {
+        Object raw = request.get("StartingPosition");
+        if (raw == null) {
+            return new StartingPositionSpec(null, null);
+        }
+        if (!(raw instanceof String position) || position.isBlank()) {
+            throw new AwsException("InvalidParameterValueException",
+                    "StartingPosition must be one of TRIM_HORIZON, LATEST, AT_TIMESTAMP", 400);
+        }
+        if (!"TRIM_HORIZON".equals(position) && !"LATEST".equals(position) && !"AT_TIMESTAMP".equals(position)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "StartingPosition must be one of TRIM_HORIZON, LATEST, AT_TIMESTAMP (got " + position + ")", 400);
+        }
+        if (!"AT_TIMESTAMP".equals(position)) {
+            return new StartingPositionSpec(position, null);
+        }
+        // AT_TIMESTAMP is Kinesis-only among the event sources Floci supports - DynamoDB Streams
+        // shard iterators have no timestamp form at all, so silently accepting it there would
+        // promise a starting point that can never be honoured.
+        if (eventSourceArn != null && !eventSourceArn.contains(":kinesis:")) {
+            throw new AwsException("InvalidParameterValueException",
+                    "AT_TIMESTAMP is only supported for Amazon Kinesis event sources", 400);
+        }
+        Object rawTimestamp = request.get("StartingPositionTimestamp");
+        if (rawTimestamp == null) {
+            throw new AwsException("InvalidParameterValueException",
+                    "StartingPositionTimestamp is required when StartingPosition is AT_TIMESTAMP", 400);
+        }
+        if (!(rawTimestamp instanceof Number timestamp)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "StartingPositionTimestamp must be a numeric epoch-seconds value", 400);
+        }
+        // Lambda speaks restJson1, whose timestamps are (possibly fractional) epoch seconds - the
+        // same convention buildEsmResponse already uses for LastModified on the way back out.
+        return new StartingPositionSpec(position, Math.round(timestamp.doubleValue() * 1000.0));
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -24,6 +24,8 @@ public class EventSourceMapping {
     private int batchSize = 10;
     private String state = "Enabled";
     private long lastModified;
+    private String startingPosition;
+    private Long startingPositionTimestamp;
     private List<String> functionResponseTypes = new ArrayList<>();
     private Map<String, String> shardSequenceNumbers = new HashMap<>();
     private ScalingConfig scalingConfig;
@@ -65,6 +67,15 @@ public class EventSourceMapping {
 
     public long getLastModified() { return lastModified; }
     public void setLastModified(long lastModified) { this.lastModified = lastModified; }
+
+    public String getStartingPosition() { return startingPosition; }
+    public void setStartingPosition(String startingPosition) { this.startingPosition = startingPosition; }
+
+    /** Epoch milliseconds; only ever set alongside an {@code AT_TIMESTAMP} starting position. */
+    public Long getStartingPositionTimestamp() { return startingPositionTimestamp; }
+    public void setStartingPositionTimestamp(Long startingPositionTimestamp) {
+        this.startingPositionTimestamp = startingPositionTimestamp;
+    }
 
     public List<String> getFunctionResponseTypes() { return functionResponseTypes; }
     public void setFunctionResponseTypes(List<String> functionResponseTypes) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4182,6 +4182,89 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_lambdaEventSourceMappingWithStartingPosition() {
+        String stackName = "cfn-esm-starting-position-stack";
+        String funcName = "cfn-esm-starting-position-func";
+        String streamName = "cfn-esm-starting-position-stream";
+
+        String template = """
+            {
+              "Resources": {
+                "MyStream": {
+                  "Type": "AWS::Kinesis::Stream",
+                  "Properties": {
+                    "Name": "%s",
+                    "ShardCount": 1
+                  }
+                },
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Code": {
+                      "ZipFile": "exports.handler = async (e) => ({ statusCode: 200 });"
+                    }
+                  }
+                },
+                "MyESM": {
+                  "Type": "AWS::Lambda::EventSourceMapping",
+                  "Properties": {
+                    "FunctionName": { "Ref": "MyFunction" },
+                    "EventSourceArn": { "Fn::GetAtt": ["MyStream", "Arn"] },
+                    "StartingPosition": "AT_TIMESTAMP",
+                    "StartingPositionTimestamp": 1787036486.712,
+                    "BatchSize": 5
+                  }
+                }
+              }
+            }
+            """.formatted(streamName, funcName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // The whole point of this test: StartingPosition/StartingPositionTimestamp must survive
+        // the CFN -> Lambda plumbing, not just the direct-API path EsmIntegrationTest covers.
+        given()
+        .when()
+            .get("/2015-03-31/event-source-mappings?FunctionName=" + funcName)
+        .then()
+            .statusCode(200)
+            .body("EventSourceMappings[0].StartingPosition", equalTo("AT_TIMESTAMP"))
+            .body("EventSourceMappings[0].StartingPositionTimestamp", equalTo(1787036486.712f));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void crossStackReference_fnImportValue() {
         // Stack A exports a bucket name
         String templateA = """

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4265,6 +4265,71 @@ class CloudFormationIntegrationTest {
     }
 
     @Test
+    void createStack_lambdaEventSourceMappingWithNonFiniteStartingPositionTimestampFailsResource() {
+        String stackName = "cfn-esm-nonfinite-timestamp-stack";
+        String funcName = "cfn-esm-nonfinite-timestamp-func";
+        String streamName = "cfn-esm-nonfinite-timestamp-stream";
+
+        // "NaN" is passed as a JSON string since JSON itself has no NaN/Infinity literal;
+        // Double.parseDouble happily accepts it, which is exactly what the isFinite guard exists to catch.
+        String template = """
+            {
+              "Resources": {
+                "MyStream": {
+                  "Type": "AWS::Kinesis::Stream",
+                  "Properties": {
+                    "Name": "%s",
+                    "ShardCount": 1
+                  }
+                },
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "%s",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Code": {
+                      "ZipFile": "exports.handler = async (e) => ({ statusCode: 200 });"
+                    }
+                  }
+                },
+                "MyESM": {
+                  "Type": "AWS::Lambda::EventSourceMapping",
+                  "Properties": {
+                    "FunctionName": { "Ref": "MyFunction" },
+                    "EventSourceArn": { "Fn::GetAtt": ["MyStream", "Arn"] },
+                    "StartingPosition": "AT_TIMESTAMP",
+                    "StartingPositionTimestamp": "NaN",
+                    "BatchSize": 5
+                  }
+                }
+              }
+            }
+            """.formatted(streamName, funcName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CREATE_FAILED"));
+    }
+
+    @Test
     void crossStackReference_fnImportValue() {
         // Stack A exports a bucket name
         String templateA = """

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -1,14 +1,18 @@
 package io.github.hectorvent.floci.services.lambda;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.path.json.config.JsonPathConfig;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.math.BigDecimal;
+
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -29,6 +33,8 @@ class EsmIntegrationTest {
             "arn:aws:sqs:" + REGION + ":" + ACCOUNT_ID + ":" + QUEUE_NAME;
     private static final String FUNCTION_ARN =
             "arn:aws:lambda:" + REGION + ":" + ACCOUNT_ID + ":function:" + FUNCTION_NAME;
+    private static final String STREAM_ARN =
+            "arn:aws:kinesis:" + REGION + ":" + ACCOUNT_ID + ":stream/esm-test-stream";
     private static final String NON_DEFAULT_ACCOUNT = "000000000001";
     private static final String MULTI_ACCOUNT_QUEUE_NAME = "esm-multi-account-queue";
     private static final String MULTI_ACCOUNT_FUNCTION_NAME = "esm-multi-account-fn";
@@ -721,6 +727,176 @@ class EsmIntegrationTest {
         } catch (NumberFormatException e) {
             return 0;
         }
+    }
+
+    // ──────────────────────────── StartingPosition ────────────────────────────
+
+    @Test
+    @Order(70)
+    void createEventSourceMappingWithStartingPositionRoundTrips() {
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "StartingPosition": "LATEST"
+                }
+                """.formatted(FUNCTION_NAME, STREAM_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("StartingPosition", equalTo("LATEST"))
+        .extract()
+            .path("UUID");
+
+        given()
+        .when()
+            .get(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(200)
+            .body("StartingPosition", equalTo("LATEST"));
+
+        // List has its own response-building path, and Terraform refreshes through it too.
+        given()
+            .queryParam("FunctionName", FUNCTION_NAME)
+        .when()
+            .get(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(200)
+            .body("EventSourceMappings.find { it.UUID == '" + uuid + "' }.StartingPosition",
+                    equalTo("LATEST"));
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    @Order(71)
+    void createEventSourceMappingWithAtTimestampRoundTripsItsTimestamp() {
+        double startingPositionTimestamp = 1787036486.712;
+
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "StartingPosition": "AT_TIMESTAMP",
+                    "StartingPositionTimestamp": %s
+                }
+                """.formatted(FUNCTION_NAME, STREAM_ARN, startingPositionTimestamp))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("StartingPosition", equalTo("AT_TIMESTAMP"))
+        .extract()
+            .path("UUID");
+
+        // Lambda is a restJson1 service, so the timestamp goes out as epoch seconds — the same
+        // convention it came in on, and the one LastModified already uses. Read as BigDecimal
+        // because RestAssured's default float mapping cannot hold millisecond precision at this
+        // magnitude, and would report a passing round-trip as a ~57s drift.
+        BigDecimal returned = given()
+        .when()
+            .get(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(200)
+            .body("StartingPosition", equalTo("AT_TIMESTAMP"))
+        .extract()
+            .jsonPath(new JsonPathConfig(JsonPathConfig.NumberReturnType.BIG_DECIMAL))
+            .get("StartingPositionTimestamp");
+        assertEquals(startingPositionTimestamp, returned.doubleValue(), 0.001);
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    @Order(72)
+    void responseOmitsStartingPositionWhenUnset() {
+        // AWS omits the field on mappings that have none (SQS sources never do) rather than
+        // returning it as null.
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s"
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("$", not(hasKey("StartingPosition")))
+            .body("$", not(hasKey("StartingPositionTimestamp")))
+        .extract()
+            .path("UUID");
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    @Order(73)
+    void createEventSourceMappingRejectsUnknownStartingPosition() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "StartingPosition": "AT_SEQUENCE_NUMBER"
+                }
+                """.formatted(FUNCTION_NAME, STREAM_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("TRIM_HORIZON, LATEST, AT_TIMESTAMP"));
+    }
+
+    @Test
+    @Order(74)
+    void createEventSourceMappingRejectsAtTimestampWithoutATimestamp() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "StartingPosition": "AT_TIMESTAMP"
+                }
+                """.formatted(FUNCTION_NAME, STREAM_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("StartingPositionTimestamp is required"));
+    }
+
+    @Test
+    @Order(75)
+    void createEventSourceMappingRejectsAtTimestampOnANonKinesisSource() {
+        String dynamoStreamArn =
+                "arn:aws:dynamodb:" + REGION + ":" + ACCOUNT_ID
+                        + ":table/esm-at-timestamp-table/stream/2026-01-01T00:00:00.000";
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "StartingPosition": "AT_TIMESTAMP",
+                    "StartingPositionTimestamp": 1787036486.712
+                }
+                """.formatted(FUNCTION_NAME, dynamoStreamArn))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("only supported for Amazon Kinesis"));
     }
 
     // ──────────────────────────── Multi-account ESM ────────────────────────────


### PR DESCRIPTION
## Summary

Closes #2369.

`CreateEventSourceMapping` accepted `StartingPosition` and `StartingPositionTimestamp` but never
stored them, so the create response, `GetEventSourceMapping` and `ListEventSourceMappings` all
omitted the fields. Any IaC tool that refreshes a mapping therefore reads the starting position back
as unset — and since both fields are `ForceNew` in Terraform's `aws_lambda_event_source_mapping`,
every plan proposes adding the value it already asked for and so destroys and recreates the mapping,
on every apply, indefinitely.

This is the same defect shape as #1537, which fixed `DestinationConfig` and
`BisectBatchOnFunctionError` the same way.

- **Store both fields** on `EventSourceMapping` (position as-is; timestamp normalised to epoch
  millis, matching how `lastModified` is held).
- **Emit both** from `buildEsmResponse`, omitting them when unset the way AWS omits them for sources
  that have no starting position — so the SQS case doesn't grow a null key.
- **Validate only what was sent.** AWS requires a starting position for stream sources, but Floci has
  always accepted mappings without one, so an absent field stays absent rather than becoming a new
  400 for callers that work today. What *is* sent gets checked: the value must be one of
  `TRIM_HORIZON`/`LATEST`/`AT_TIMESTAMP`, `AT_TIMESTAMP` requires a timestamp, and `AT_TIMESTAMP` is
  rejected on non-Kinesis sources (DynamoDB Streams shard iterators have no timestamp form at all,
  so accepting it there would promise a starting point that can never be honoured).
- **No update path**, because AWS's `UpdateEventSourceMapping` doesn't accept the field — it's
  replace-only, which is exactly why Terraform marks it `ForceNew`.
- **CloudFormation**: `provisionLambdaEventSourceMapping` dropped both fields for the same reason, so
  they're passed through too. This edits the existing method rather than adding a resource type, so
  it shouldn't cut against `CONTRIBUTING.md`'s "don't add cases to this class" — happy to move it if
  you'd rather it went to a `LambdaCfnProvisioner` as part of dismantling the monolith.

`StartingPositionTimestamp` crosses the wire as (possibly fractional) epoch seconds in both
directions, which is the restJson1 default and the convention `LastModified` already uses in this
same response builder.

### Deliberately not in this PR

The pollers ignore the stored position too — both `KinesisEventSourcePoller` and
`DynamoDbStreamsEventSourcePoller` hardcode `TRIM_HORIZON` for a shard with no stored sequence
number, so a `LATEST` mapping replays the whole existing stream on its first poll. That's a genuine
second bug (described in #2369), but it's a behaviour change rather than a wire-compatibility fix,
and the obvious implementation has a trap worth agreeing on first: the pollers mint a fresh iterator
on *every* tick while no sequence number is stored, so passing `LATEST` straight through would
re-snapshot the shard tip each tick and silently drop records written between two ticks. `LATEST`
has to resolve to a concrete resume point exactly once. Glad to follow up with that separately.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** both fields accepted on create, then absent from every response that should
carry them.

Verified against a locally built image (this branch's `quarkus-app` overlaid on `floci/floci:latest-jvm`)
using **AWS CLI v2**, with `floci/floci:nightly` as the before-baseline:

Before — `StartingPosition` missing despite being supplied on create:

```console
$ aws --endpoint-url http://localhost:4598 lambda get-event-source-mapping --uuid 50ff54cc-...
{
    "UUID": "50ff54cc-ed6b-4218-87e2-767ddf666148",
    "BatchSize": 5,
    "EventSourceArn": "arn:aws:kinesis:eu-west-1:000000000000:stream/esm-verify-stream",
    "FunctionArn": "arn:aws:lambda:eu-west-1:000000000000:function:esm-verify-fn",
    "LastModified": "2026-08-18T09:46:13.328000+02:00",
    "State": "Enabled",
    "FunctionResponseTypes": []
}
```

After:

```console
$ aws --endpoint-url http://localhost:4599 lambda get-event-source-mapping --uuid 52823a98-...
{
    "UUID": "52823a98-a32f-4957-b4d2-1250062a98f6",
    "StartingPosition": "LATEST",
    "BatchSize": 5,
    "EventSourceArn": "arn:aws:kinesis:eu-west-1:000000000000:stream/esm-verify-stream",
    "FunctionArn": "arn:aws:lambda:eu-west-1:000000000000:function:esm-verify-fn",
    "LastModified": "2026-08-18T09:45:34.118000+02:00",
    "State": "Enabled",
    "FunctionResponseTypes": []
}

$ aws ... lambda list-event-source-mappings --function-name esm-verify-fn \
    --query 'EventSourceMappings[].{UUID:UUID,StartingPosition:StartingPosition}'
[{"UUID": "52823a98-a32f-4957-b4d2-1250062a98f6", "StartingPosition": "LATEST"}]
```

`AT_TIMESTAMP` units round-trip correctly — asked for `2026-08-17T12:34:56Z`, got back the same
instant rendered in the CLI's local zone (UTC+2):

```console
$ aws ... lambda create-event-source-mapping ... \
    --starting-position AT_TIMESTAMP --starting-position-timestamp 2026-08-17T12:34:56Z \
    --query '{StartingPosition:StartingPosition,StartingPositionTimestamp:StartingPositionTimestamp}'
{"StartingPosition": "AT_TIMESTAMP", "StartingPositionTimestamp": "2026-08-17T14:34:56+02:00"}
```

And the validation surfaces through the SDK rather than as a 500:

```console
$ aws ... lambda create-event-source-mapping ... --starting-position AT_TIMESTAMP
An error occurred (InvalidParameterValueException) ...
message: StartingPositionTimestamp is required when StartingPosition is AT_TIMESTAMP
```

An SQS mapping created without a starting position still returns exactly the keys it did before —
`UUID`, `BatchSize`, `EventSourceArn`, `FunctionArn`, `LastModified`, `State`,
`FunctionResponseTypes` — with no `StartingPosition`/`StartingPositionTimestamp` added.

## Checklist

- [x] `./mvnw test` passes locally — full repo suite (10625 tests) has 2 failing classes
      (`DocDbIntegrationTest`, `NeptuneOpenCypherIntegrationTest`, socket timeouts against their
      proxy containers); both untouched by this diff and pass cleanly in isolation, so this reads
      as local resource contention under the full suite's container load, not a regression. The
      681 tests across every Lambda/ESM/CloudFormation/poller suite this PR actually touches are
      all green.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
