### PR TITLE
fix(cloudwatch): gzipped decompression is bounded, added tests

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
@@ -307,13 +307,22 @@ public class AwsJsonCborController {
     }
 
     private byte[] decodeBody(byte[] compressed) throws IOException {
+        int buffSize = 64 * 1024;
+        byte[] buffer = new byte[buffSize]; // 10 MB limit max over all aws services, to avoid OOM. AWS services should not send more than 10 MB in a single request.
+        int totalRead = 0;
+        int maxRead = 10 * 1024 * 1024; // 10 MB limit max over all aws services, to avoid OOM. AWS services should not send more than 10 MB in a single request.
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (GZIPInputStream gis = new GZIPInputStream(new java.io.ByteArrayInputStream(compressed))) {
-            byte[] buffer = gis.readNBytes(10*1024*1024); // 10 MB limit max over all aws services, to avoid OOM. AWS services should not send more than 10 MB in a single request.
-            int check = gis.read();
-            if (check != -1) {
-                throw new AwsException("PayloadTooLargeException", "Payload Too Large", 413);
+            int read;
+            while ((read = gis.read(buffer)) != -1) {
+                totalRead += read;
+                if (totalRead >= maxRead) {
+                    throw new AwsException("PayloadTooLargeException", "Payload Too Large", 413);
+                }
+                baos.write(buffer, 0, read);
             }
-            return buffer;
+
+            return baos.toByteArray();
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
@@ -229,7 +229,7 @@ public class AwsJsonCborController {
             return false;
         }
         for (String header : contentEncodingHeaders) {
-            if (header != null &&  header.toLowerCase().contains("gzip")) {
+            if (header != null && header.toLowerCase(java.util.Locale.ROOT).contains("gzip")) {
                 return true;
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
@@ -19,8 +19,11 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPInputStream;
 
 /**
  * Generic dispatcher for all AWS services that use the application/cbor protocol,
@@ -182,9 +185,7 @@ public class AwsJsonCborController {
         LOG.debugv("Smithy RPC v2 CBOR: service={0}, operation={1}", serviceId, operation);
 
         try {
-            JsonNode request = (body != null && body.length > 0)
-                    ? CBOR_MAPPER.readTree(body)
-                    : objectMapper.createObjectNode();
+            JsonNode request = bodyToJson(httpHeaders, body);
             String region = regionResolver.resolveRegion(httpHeaders);
 
             Response delegated = dispatchCbor(serviceId, operation, request, region);
@@ -208,6 +209,32 @@ public class AwsJsonCborController {
             LOG.error("Error processing Smithy CBOR request: " + serviceId + "." + operation, e);
             return Response.status(500).build();
         }
+    }
+
+    JsonNode bodyToJson(HttpHeaders httpHeaders, byte[] body) throws IOException {
+        JsonNode request;
+        if (body != null && body.length > 0) {
+            if( httpHeaders.getRequestHeader("Content-encoding") != null && isGZipped(httpHeaders.getRequestHeader("Content-encoding"))) {
+                body = decodeBody(body);
+            }
+            request = CBOR_MAPPER.readTree(body);
+        } else {
+            request = objectMapper.createObjectNode();
+        }
+        return request;
+    }
+
+    private boolean isGZipped(List<String> contentEncodingHeaders) {
+        if (contentEncodingHeaders == null) {
+            return false;
+        }
+        for (String header : contentEncodingHeaders) {
+            if (header != null &&  header.toLowerCase().contains("gzip")) {
+                return true;
+            }
+        }
+        return false;
+
     }
 
     /**
@@ -240,9 +267,7 @@ public class AwsJsonCborController {
         LOG.debugv("{0} CBOR action: {1}", serviceKey, action);
 
         try {
-            JsonNode request = (body != null && body.length > 0)
-                    ? CBOR_MAPPER.readTree(body)
-                    : objectMapper.createObjectNode();
+            JsonNode request = bodyToJson(httpHeaders, body);
             String region = regionResolver.resolveRegion(httpHeaders);
 
             Response delegated = switch (serviceKey) {
@@ -278,6 +303,17 @@ public class AwsJsonCborController {
         } catch (Exception e) {
             LOG.error("Error processing CBOR request: " + serviceKey + "." + action, e);
             return Response.status(500).build();
+        }
+    }
+
+    private byte[] decodeBody(byte[] compressed) throws IOException {
+        try (GZIPInputStream gis = new GZIPInputStream(new java.io.ByteArrayInputStream(compressed))) {
+            byte[] buffer = gis.readNBytes(10*1024*1024); // 10 MB limit max over all aws services, to avoid OOM. AWS services should not send more than 10 MB in a single request.
+            int check = gis.read();
+            if (check != -1) {
+                throw new AwsException("PayloadTooLargeException", "Payload Too Large", 413);
+            }
+            return buffer;
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborIncomingRequestTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborIncomingRequestTest.java
@@ -9,17 +9,27 @@ import jakarta.inject.Inject;
 
 import java.io.ByteArrayOutputStream;
 import java.util.Map;
-import java.util.UUID;
 import java.util.zip.GZIPOutputStream;
 
 import org.jboss.resteasy.reactive.server.jaxrs.HttpHeadersImpl;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 
-
-/** */
+/**
+ * Integration test for {@link AwsJsonCborController#bodyToJson(HttpHeaders, byte[])}.
+ * <p>
+ * Verifies handling of incoming smithy-rpc-v2-cbor request bodies: a gzip-encoded body
+ * (as signalled by a {@code Content-Encoding: gzip} header) must be transparently
+ * decompressed and decoded back into the original {@link JsonNode}, and a decompressed
+ * body that exceeds the 10 MB safety limit enforced in {@code decodeBody} must fail fast
+ * with an {@link AwsException} (413 Payload Too Large) rather than risk an OOM from an
+ * unbounded gzip bomb.
+ * <p>
+ * Boots Quarkus ({@code @QuarkusTest}) since the controller is injected and exercises the
+ * real request-decoding path used by CloudWatch Metrics and other smithy-rpc-v2-cbor
+ * services.
+ */
 @QuarkusTest
 class AwsJsonCborIncomingRequestTest {
 
@@ -42,13 +52,16 @@ class AwsJsonCborIncomingRequestTest {
         o.put("Value", 9344221);
         o.put("Unit", "Seconds");
 
+        // Encode the metrics payload to CBOR and gzip it, simulating what a real AWS SDK
+        // client sends when it compresses a smithy-rpc-v2-cbor request body.
         byte[] compressedNode = AwsJsonCborController.nodeToSmithyCbor(metrics);
         ByteArrayOutputStream gzipped = new ByteArrayOutputStream();
         try (GZIPOutputStream gon = new GZIPOutputStream(gzipped)) {
             gon.write(compressedNode);
         }
 
-
+        // bodyToJson must detect the Content-Encoding header, gunzip the body, and decode
+        // the resulting CBOR bytes back into the original JsonNode.
         JsonNode node =
                 awsJsonCborController.bodyToJson(
                         new HttpHeadersImpl(Map.of("Content-Encoding", "gzip").entrySet()),
@@ -58,26 +71,24 @@ class AwsJsonCborIncomingRequestTest {
     }
 
     @Test
-    void payloadToLargeExceptionThrown() throws Exception {
+    void payloadTooLargeExceptionThrown() throws Exception {
 
-        ObjectMapper jsonMapper = new ObjectMapper();
-        ObjectNode metrics = jsonMapper.createObjectNode();
-        metrics.put("Namespace", "Test");
-        ArrayNode metricData = metrics.putArray("MetricData");
-
-        ObjectNode o = metricData.addObject();
-        o.put("UUID", UUID.randomUUID().toString());
-
-        for(int i = 0; i < 1000000; i++) {
-            metricData.add(o);
+        // No need for a valid CBOR structure here — decodeBody's 10 MB limit is enforced
+        // purely on decompressed byte count, so raw pseudo-random bytes are enough to
+        // exceed it. The varying pattern (instead of all-zero bytes) also keeps gzip from
+        // trivially collapsing the payload via run-length compression.
+        int elevenMB = 11 * 1024 * 1024;
+        byte[] rawBytes = new byte[elevenMB];
+        for (int i = 0,j = 37; i < elevenMB; i++, j+=19) {
+            rawBytes[i] = (byte) (i+j & 0xFF);
         }
-
-        byte[] compressedNode = AwsJsonCborController.nodeToSmithyCbor(metrics);
         ByteArrayOutputStream gzipped = new ByteArrayOutputStream();
         try (GZIPOutputStream gon = new GZIPOutputStream(gzipped)) {
-            gon.write(compressedNode);
+            gon.write(rawBytes);
         }
 
+        // Exceeding the decompressed size limit must surface as a 413 Payload Too Large
+        // AwsException, not an OutOfMemoryError or a silently truncated body.
         Assertions.assertThrows(AwsException.class, () -> {
             awsJsonCborController.bodyToJson(
                     new HttpHeadersImpl(Map.of("Content-Encoding", "gzip").entrySet()),

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborIncomingRequestTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsJsonCborIncomingRequestTest.java
@@ -1,0 +1,87 @@
+package io.github.hectorvent.floci.core.common;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Map;
+import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
+
+import org.jboss.resteasy.reactive.server.jaxrs.HttpHeadersImpl;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+
+/** */
+@QuarkusTest
+class AwsJsonCborIncomingRequestTest {
+
+    @Inject AwsJsonCborController awsJsonCborController;
+
+    @Test
+    void gzippedRequestIsDecompressed() throws Exception {
+
+        ObjectMapper jsonMapper = new ObjectMapper();
+        ObjectNode metrics = jsonMapper.createObjectNode();
+        metrics.put("Namespace", "Test");
+        ArrayNode metricData = metrics.putArray("MetricData");
+
+        ObjectNode o = metricData.addObject();
+        o.put("MetricName", "SYSTEM_NORMALIZED_CPU_STEAL");
+        ArrayNode dimensions = o.putArray("Dimensions");
+        ObjectNode dimension = dimensions.addObject();
+        dimension.put("Name","clusterName");
+        dimension.put("Value", "test");
+        o.put("Value", 9344221);
+        o.put("Unit", "Seconds");
+
+        byte[] compressedNode = AwsJsonCborController.nodeToSmithyCbor(metrics);
+        ByteArrayOutputStream gzipped = new ByteArrayOutputStream();
+        try (GZIPOutputStream gon = new GZIPOutputStream(gzipped)) {
+            gon.write(compressedNode);
+        }
+
+
+        JsonNode node =
+                awsJsonCborController.bodyToJson(
+                        new HttpHeadersImpl(Map.of("Content-Encoding", "gzip").entrySet()),
+                        gzipped.toByteArray());
+
+        Assertions.assertEquals(metrics, node);
+    }
+
+    @Test
+    void payloadToLargeExceptionThrown() throws Exception {
+
+        ObjectMapper jsonMapper = new ObjectMapper();
+        ObjectNode metrics = jsonMapper.createObjectNode();
+        metrics.put("Namespace", "Test");
+        ArrayNode metricData = metrics.putArray("MetricData");
+
+        ObjectNode o = metricData.addObject();
+        o.put("UUID", UUID.randomUUID().toString());
+
+        for(int i = 0; i < 1000000; i++) {
+            metricData.add(o);
+        }
+
+        byte[] compressedNode = AwsJsonCborController.nodeToSmithyCbor(metrics);
+        ByteArrayOutputStream gzipped = new ByteArrayOutputStream();
+        try (GZIPOutputStream gon = new GZIPOutputStream(gzipped)) {
+            gon.write(compressedNode);
+        }
+
+        Assertions.assertThrows(AwsException.class, () -> {
+            awsJsonCborController.bodyToJson(
+                    new HttpHeadersImpl(Map.of("Content-Encoding", "gzip").entrySet()),
+                    gzipped.toByteArray());
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Closes https://github.com/floci-io/floci/issues/2277

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

GZipped CBOR requests were not handled.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

