### PR TITLE
fix(secretsmanager,rds): rotate secrets that an AWS service manages

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -10,6 +10,10 @@ setup() {
 teardown() {
     aws_cmd rds delete-db-instance --db-instance-identifier "$DB_ID" --skip-final-snapshot >/dev/null 2>&1 || true
     aws_cmd rds delete-db-instance --db-instance-identifier "$DB_ID_2" --skip-final-snapshot >/dev/null 2>&1 || true
+    if [ -n "${MANAGED_SECRET_ARN:-}" ]; then
+        aws_cmd secretsmanager delete-secret --secret-id "$MANAGED_SECRET_ARN" \
+            --force-delete-without-recovery >/dev/null 2>&1 || true
+    fi
 }
 
 @test "RDS: create db instance returns resource identifiers" {
@@ -86,4 +90,40 @@ teardown() {
     # Might have more from other tests, but at least 2
     count=$(echo "$output" | jq '.DBInstances | length')
     [ "$count" -ge 2 ]
+}
+
+@test "RDS: managed master user secret is owned by rds and rotates without a Lambda" {
+    run aws_cmd rds create-db-instance \
+        --db-instance-identifier "$DB_ID" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10 \
+        --master-username admin \
+        --manage-master-user-password
+    assert_success
+
+    MANAGED_SECRET_ARN=$(json_get "$output" '.DBInstance.MasterUserSecret.SecretArn')
+    [ -n "$MANAGED_SECRET_ARN" ]
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$MANAGED_SECRET_ARN"
+    assert_success
+    [ "$(json_get "$output" '.OwningService')" = "rds" ]
+
+    # RDS rotates this secret itself, so a rotation Lambda is not accepted for it.
+    run aws_cmd secretsmanager rotate-secret \
+        --secret-id "$MANAGED_SECRET_ARN" \
+        --rotation-lambda-arn "arn:aws:lambda:$AWS_DEFAULT_REGION:000000000000:function:absent"
+    assert_failure
+    assert_output --partial "not supported for a service-managed secret"
+
+    # The call terraform's aws_secretsmanager_secret_rotation makes: rules, no Lambda ARN.
+    run aws_cmd secretsmanager rotate-secret \
+        --secret-id "$MANAGED_SECRET_ARN" \
+        --rotation-rules 'AutomaticallyAfterDays=7'
+    assert_success
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$MANAGED_SECRET_ARN"
+    assert_success
+    [ "$(json_get "$output" '.RotationEnabled')" = "true" ]
+    [ "$(json_get "$output" '.RotationRules.AutomaticallyAfterDays')" = "7" ]
 }

--- a/docs/services/secrets-manager.md
+++ b/docs/services/secrets-manager.md
@@ -16,7 +16,7 @@
 | `ListSecrets` | List all secrets |
 | `DeleteSecret` | Delete a secret (with recovery window) |
 | `RestoreSecret` | - |
-| `RotateSecret` | Trigger secret rotation via a Lambda |
+| `RotateSecret` | Trigger secret rotation, via a Lambda or by the owning service |
 | `TagResource` | Tag a secret |
 | `UntagResource` | Remove tags |
 | `ListSecretVersionIds` | List all versions of a secret |

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -36,7 +36,9 @@ import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.core.common.Resettable;
+import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
@@ -733,6 +735,30 @@ public class RdsService implements Resettable {
     private String resourceRegionOrDefault(String resourceName) {
         return resourceName != null && resourceName.startsWith("arn:")
                 ? regionFromArn(resourceName) : regionResolver.getDefaultRegion();
+    }
+
+    /**
+     * Marks the master user secrets of persisted instances as owned by RDS. An instance stored
+     * before floci tracked ownership refers to a secret that would otherwise read as an ordinary
+     * one, and so would refuse the Lambda-free rotation these secrets are rotated with. RDS state
+     * is what makes the secret managed, so the instance is what this reads — never the name.
+     */
+    void backfillManagedSecretOwnership(@Observes StartupEvent event) {
+        if (secretsManagerService == null) {
+            return;
+        }
+        for (DbInstance instance : allInstances()) {
+            String secretArn = instance.getMasterUserSecretArn();
+            if (secretArn == null) {
+                continue;
+            }
+            try {
+                secretsManagerService.markOwnedByService(
+                        secretArn, MANAGED_SECRET_OWNING_SERVICE, regionFromArn(secretArn));
+            } catch (RuntimeException e) {
+                LOG.debugv(e, "Could not mark master user secret {0} as service-managed", secretArn);
+            }
+        }
     }
 
     private void attachManagedMasterUserSecret(DbInstance instance, String region, String kmsKeyId) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -747,18 +747,23 @@ public class RdsService implements Resettable {
         if (secretsManagerService == null) {
             return;
         }
-        for (DbInstance instance : allInstances()) {
-            String secretArn = instance.getMasterUserSecretArn();
-            if (secretArn == null) {
-                continue;
+        // Reading persisted state must not be able to stop the emulator from starting.
+        try {
+            for (DbInstance instance : allInstances()) {
+                String secretArn = instance.getMasterUserSecretArn();
+                if (secretArn == null) {
+                    continue;
+                }
+                try {
+                    // The secret's ARN names its own account and region, neither of which a
+                    // startup backfill has a request context to infer.
+                    secretsManagerService.markOwnedByService(secretArn, MANAGED_SECRET_OWNING_SERVICE);
+                } catch (RuntimeException e) {
+                    LOG.debugv(e, "Could not mark master user secret {0} as service-managed", secretArn);
+                }
             }
-            try {
-                // The secret's ARN names its own account and region, neither of which a startup
-                // backfill has a request context to infer.
-                secretsManagerService.markOwnedByService(secretArn, MANAGED_SECRET_OWNING_SERVICE);
-            } catch (RuntimeException e) {
-                LOG.debugv(e, "Could not mark master user secret {0} as service-managed", secretArn);
-            }
+        } catch (RuntimeException e) {
+            LOG.warnv(e, "Skipped the master user secret ownership backfill");
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -36,9 +36,7 @@ import io.github.hectorvent.floci.services.rds.proxy.RdsProxyManager;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.core.common.Resettable;
-import io.quarkus.runtime.StartupEvent;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
@@ -320,6 +318,7 @@ public class RdsService implements Resettable {
         restoreClusters();
         restoreInstances();
         restoreProxies();
+        backfillManagedSecretOwnership();
     }
 
     public void clear() {
@@ -742,8 +741,13 @@ public class RdsService implements Resettable {
      * before floci tracked ownership refers to a secret that would otherwise read as an ordinary
      * one, and so would refuse the Lambda-free rotation these secrets are rotated with. RDS state
      * is what makes the secret managed, so the instance is what this reads — never the name.
+     *
+     * <p>Runs from {@link #restorePersistedRuntime()} rather than from its own {@code StartupEvent}
+     * observer: the lifecycle calls that after {@code storageFactory.loadAll()}, whereas two
+     * observers of the same event have no ordering between them, and a reload would discard these
+     * writes before they were flushed.
      */
-    void backfillManagedSecretOwnership(@Observes StartupEvent event) {
+    void backfillManagedSecretOwnership() {
         if (secretsManagerService == null) {
             return;
         }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -753,8 +753,9 @@ public class RdsService implements Resettable {
                 continue;
             }
             try {
-                secretsManagerService.markOwnedByService(
-                        secretArn, MANAGED_SECRET_OWNING_SERVICE, regionFromArn(secretArn));
+                // The secret's ARN names its own account and region, neither of which a startup
+                // backfill has a request context to infer.
+                secretsManagerService.markOwnedByService(secretArn, MANAGED_SECRET_OWNING_SERVICE);
             } catch (RuntimeException e) {
                 LOG.debugv(e, "Could not mark master user secret {0} as service-managed", secretArn);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -64,6 +64,8 @@ public class RdsService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(RdsService.class);
     private static final ObjectMapper JSON = new ObjectMapper();
+    /** Value AWS reports as the OwningService of a secret RDS manages. */
+    private static final String MANAGED_SECRET_OWNING_SERVICE = "rds";
     private static final List<ManagedClusterParameterGroup> MANAGED_CLUSTER_PARAMETER_GROUPS = List.of(
             managedDefault("aurora-mysql5.7"),
             managedDefault("aurora-mysql8.0"),
@@ -739,13 +741,19 @@ public class RdsService implements Resettable {
                     "ManageMasterUserPassword requires Secrets Manager support.", 400);
         }
         String secretName = "rds!" + instance.getDbiResourceId();
+        // RDS owns the secret it manages: it rotates the master password itself, so the secret
+        // carries no rotation Lambda. AWS marks that with OwningService and these two tags.
+        List<Secret.Tag> tags = List.of(
+                new Secret.Tag("aws:rds:primaryDBInstanceArn", instance.getDbInstanceArn()),
+                new Secret.Tag("aws:secretsmanager:owningService", MANAGED_SECRET_OWNING_SERVICE));
         Secret secret = secretsManagerService.createSecret(
                 secretName,
                 managedMasterSecretString(instance),
                 null,
                 "Managed RDS master user secret for " + instance.getDbInstanceIdentifier(),
                 kmsKeyId,
-                null,
+                tags,
+                MANAGED_SECRET_OWNING_SERVICE,
                 region);
         instance.setMasterUserSecretArn(secret.getArn());
         instance.setMasterUserSecretStatus("active");

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -302,6 +302,9 @@ public class SecretsManagerJsonHandler {
         if (secret.getDeletedDate() != null) {
             response.put("DeletedDate", secret.getDeletedDate().toEpochMilli() / 1000.0);
         }
+        if (secret.getOwningService() != null) {
+            response.put("OwningService", secret.getOwningService());
+        }
 
         ArrayNode tagsArray = objectMapper.createArrayNode();
         if (secret.getTags() != null) {
@@ -402,6 +405,9 @@ public class SecretsManagerJsonHandler {
             }
             if (secret.getLastAccessedDate() != null) {
                 node.put("LastAccessedDate", secret.getLastAccessedDate().toEpochMilli() / 1000.0);
+            }
+            if (secret.getOwningService() != null) {
+                node.put("OwningService", secret.getOwningService());
             }
             ArrayNode tagsArray = objectMapper.createArrayNode();
             if (secret.getTags() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -485,7 +485,11 @@ public class SecretsManagerJsonHandler {
         ObjectNode response = objectMapper.createObjectNode();
         response.put("ARN", secret.getArn());
         response.put("Name", secret.getName());
-        response.put("VersionId", clientRequestToken);
+        // A service-managed secret is rotated in place by its owning service, staging no version
+        // for the request token, so report the version that exists rather than one that would
+        // resolve to nothing.
+        boolean serviceManaged = secret.getOwningService() != null && secret.getCurrentVersionId() != null;
+        response.put("VersionId", serviceManaged ? secret.getCurrentVersionId() : clientRequestToken);
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -307,6 +307,34 @@ public class SecretsManagerService {
     }
 
     /**
+     * Marks an existing secret as owned by an AWS service, so that it rotates the way a
+     * service-managed secret does. Ownership is normally set when the owning service creates the
+     * secret; this backfills secrets persisted before floci tracked it. A secret that is already
+     * owned, or that no longer exists, is left as it is.
+     */
+    public void markOwnedByService(String secretId, String owningService, String region) {
+        Secret resolved;
+        try {
+            resolved = resolveSecret(secretId, region);
+        } catch (AwsException e) {
+            if ("ResourceNotFoundException".equals(e.getErrorCode())) {
+                return;
+            }
+            throw e;
+        }
+
+        synchronized (lockFor(resolved.getArn())) {
+            Secret secret = resolveSecret(resolved.getArn(), region);
+            if (secret.getOwningService() != null) {
+                return;
+            }
+            secret.setOwningService(owningService);
+            store.put(regionKey(region, secret.getName()), secret);
+            LOG.infov("Marked secret {0} as owned by {1}", secret.getName(), owningService);
+        }
+    }
+
+    /**
      * Claims the single Secrets Manager target-attachment slot for a CloudFormation resource.
      *
      * @return {@code true} when this call created the claim, or {@code false} when the same

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -82,6 +82,17 @@ public class SecretsManagerService {
 
     public Secret createSecret(String name, String secretString, String secretBinary,
                                String description, String kmsKeyId, List<Secret.Tag> tags, String region) {
+        return createSecret(name, secretString, secretBinary, description, kmsKeyId, tags, null, region);
+    }
+
+    /**
+     * Creates a secret, optionally owned by an AWS service such as {@code rds}. A service-owned
+     * secret is rotated by that service rather than by a rotation Lambda, so callers cannot supply
+     * one for it. Only other floci services set {@code owningService}; the wire API cannot.
+     */
+    public Secret createSecret(String name, String secretString, String secretBinary,
+                               String description, String kmsKeyId, List<Secret.Tag> tags,
+                               String owningService, String region) {
         String storageKey = regionKey(region, name);
         Secret existing = store.get(storageKey).orElse(null);
 
@@ -115,6 +126,7 @@ public class SecretsManagerService {
         secret.setTags(tags != null ? new ArrayList<>(tags) : new ArrayList<>());
         secret.setVersions(versions);
         secret.setCurrentVersionId(versionId);
+        secret.setOwningService(owningService);
 
         store.put(storageKey, secret);
         LOG.infov("Created secret: {0} in region {1}", name, region);
@@ -466,8 +478,8 @@ public class SecretsManagerService {
             // IS the region it lives in — comparing the request region is equivalent to a
             // per-secret attribute here (all match when the prefix fits, none otherwise).
             case "primary-region" -> region != null && region.startsWith(targetVal);
-            // owning-service is a valid Filter.Key enum value but is currently deferred (always returning false)
-            case "owning-service" -> false;
+            case "owning-service" -> secret.getOwningService() != null
+                    && secret.getOwningService().startsWith(targetVal);
             case "all" -> {
                 String lowerVal = targetVal.toLowerCase();
                 boolean nameMatch = secret.getName() != null && secret.getName().toLowerCase().startsWith(lowerVal);
@@ -534,14 +546,22 @@ public class SecretsManagerService {
                     "RotationRules can't include both AutomaticallyAfterDays and ScheduleExpression.", 400);
         }
 
+        // A service-managed secret is rotated by its owning service, so it has no rotation Lambda:
+        // AWS rejects one here, and does not require one to enable rotation.
+        boolean serviceManaged = secret.getOwningService() != null;
+        if (serviceManaged && rotationLambdaArn != null) {
+            throw new AwsException("InvalidRequestException",
+                    "Rotation Lambda ARN is not supported for a service-managed secret.", 400);
+        }
+
         String finalLambdaArn = rotationLambdaArn != null ? rotationLambdaArn : secret.getRotationLambdaArn();
-        if (finalLambdaArn == null) {
+        if (!serviceManaged && finalLambdaArn == null) {
             throw new AwsException("InvalidRequestException",
                     "You tried to enable rotation on a secret that doesn't already have a Lambda function ARN configured and you didn't include such an ARN as a parameter in this call.", 400);
         }
 
         // Validate Lambda exists synchronously
-        if (lambdaService != null) {
+        if (!serviceManaged && lambdaService != null) {
             try {
                 lambdaService.getFunction(region, finalLambdaArn);
             } catch (AwsException e) {
@@ -570,9 +590,20 @@ public class SecretsManagerService {
                 secret.setRotationRules(rotationRules);
             }
             secret.setRotationEnabled(true);
-            secret.setLastChangedDate(Instant.now());
+            Instant now = Instant.now();
+            secret.setLastChangedDate(now);
+            // The owning service rotates in place, so record it as done rather than staging a
+            // pending version for a Lambda that will never run.
+            if (serviceManaged && rotateImmediately) {
+                secret.setLastRotatedDate(now);
+            }
 
             store.put(regionKey(region, secret.getName()), secret);
+        }
+
+        if (serviceManaged) {
+            LOG.infov("Enabled service-managed rotation for secret: {0}", secret.getName());
+            return secret;
         }
 
         String arn = secret.getArn();

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -2,8 +2,10 @@ package io.github.hectorvent.floci.services.secretsmanager;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
@@ -31,6 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
 
 @ApplicationScoped
 public class SecretsManagerService {
@@ -307,31 +310,54 @@ public class SecretsManagerService {
     }
 
     /**
-     * Marks an existing secret as owned by an AWS service, so that it rotates the way a
+     * Marks the secret with this ARN as owned by an AWS service, so that it rotates the way a
      * service-managed secret does. Ownership is normally set when the owning service creates the
      * secret; this backfills secrets persisted before floci tracked it. A secret that is already
      * owned, or that no longer exists, is left as it is.
+     *
+     * <p>A backfill runs outside any request, so the account cannot come from the request context:
+     * the secret's own ARN names the account whose store holds it, and that is the store this
+     * addresses. Passing a name instead of an ARN would read the wrong account.
      */
-    public void markOwnedByService(String secretId, String owningService, String region) {
-        Secret resolved;
+    public void markOwnedByService(String secretArn, String owningService) {
+        if (secretArn == null || !secretArn.startsWith("arn:")) {
+            return;
+        }
+        AwsArnUtils.Arn arn;
         try {
-            resolved = resolveSecret(secretId, region);
-        } catch (AwsException e) {
-            if ("ResourceNotFoundException".equals(e.getErrorCode())) {
-                return;
-            }
-            throw e;
+            arn = AwsArnUtils.parse(secretArn);
+        } catch (IllegalArgumentException e) {
+            LOG.debugv("Ignoring malformed secret ARN during ownership backfill: {0}", secretArn);
+            return;
         }
 
-        synchronized (lockFor(resolved.getArn())) {
-            Secret secret = resolveSecret(resolved.getArn(), region);
-            if (secret.getOwningService() != null) {
+        synchronized (lockFor(secretArn)) {
+            Secret secret = findByArnInAccount(secretArn, arn);
+            if (secret == null || secret.getOwningService() != null) {
                 return;
             }
             secret.setOwningService(owningService);
-            store.put(regionKey(region, secret.getName()), secret);
-            LOG.infov("Marked secret {0} as owned by {1}", secret.getName(), owningService);
+            String key = regionKey(arn.region(), secret.getName());
+            if (store instanceof AccountAwareStorageBackend<Secret> aware) {
+                aware.putForAccount(arn.accountId(), key, secret);
+            } else {
+                store.put(key, secret);
+            }
+            LOG.infov("Marked secret {0} in account {1} as owned by {2}",
+                    secret.getName(), arn.accountId(), owningService);
         }
+    }
+
+    /** Finds a secret by full ARN within the account and region that ARN names. */
+    private Secret findByArnInAccount(String secretArn, AwsArnUtils.Arn arn) {
+        Predicate<String> inRegion = key -> key.startsWith(arn.region() + "::");
+        List<Secret> candidates = store instanceof AccountAwareStorageBackend<Secret> aware
+                ? aware.scanForAccount(arn.accountId(), inRegion)
+                : store.scan(inRegion);
+        return candidates.stream()
+                .filter(s -> secretArn.equals(s.getArn()))
+                .findFirst()
+                .orElse(null);
     }
 
     /**
@@ -618,13 +644,11 @@ public class SecretsManagerService {
                 secret.setRotationRules(rotationRules);
             }
             secret.setRotationEnabled(true);
-            Instant now = Instant.now();
-            secret.setLastChangedDate(now);
-            // The owning service rotates in place, so record it as done rather than staging a
-            // pending version for a Lambda that will never run.
-            if (serviceManaged && rotateImmediately) {
-                secret.setLastRotatedDate(now);
-            }
+            secret.setLastChangedDate(Instant.now());
+            // A service-managed secret is rotated by its owning service, which floci does not
+            // emulate: the master password is not re-issued here, so nothing sets LastRotatedDate.
+            // Reporting a rotation that did not happen would leave GetSecretValue and the database
+            // holding a credential the secret claims to have replaced.
 
             store.put(regionKey(region, secret.getName()), secret);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/model/Secret.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/model/Secret.java
@@ -29,6 +29,8 @@ public class Secret {
     private Instant lastRotatedDate;
     private Instant nextRotationDate;
     private String targetAttachmentOwner;
+    /** The AWS service that owns this secret and rotates it itself, such as {@code rds}. */
+    private String owningService;
 
     @RegisterForReflection
     public record RotationRules(
@@ -180,5 +182,13 @@ public class Secret {
 
     public void setTargetAttachmentOwner(String targetAttachmentOwner) {
         this.targetAttachmentOwner = targetAttachmentOwner;
+    }
+
+    public String getOwningService() {
+        return owningService;
+    }
+
+    public void setOwningService(String owningService) {
+        this.owningService = owningService;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -330,9 +330,34 @@ class RdsServiceTest {
 
         // An instance persisted by a floci that predates ownership tracking still names its
         // secret, which is what makes that secret managed — the name never is.
-        service.backfillManagedSecretOwnership(null);
+        service.backfillManagedSecretOwnership();
 
         verify(secretsManager).markOwnedByService(secretArn, "rds");
+    }
+
+    @Test
+    void restorePersistedRuntimeRunsTheOwnershipBackfill() {
+        // The lifecycle calls restorePersistedRuntime() after storageFactory.loadAll(), so the
+        // backfill hangs off that rather than off its own StartupEvent observer, which would have
+        // no ordering against the reload.
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret restored = new Secret();
+        String restoredArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-secret";
+        restored.setArn(restoredArn);
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(restored);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        service.createDbInstance("mydb", "postgres", "13",
+                "admin", null, "dbname", "db.t3.micro",
+                20, true, null, null, null, true, null);
+
+        service.restorePersistedRuntime();
+
+        verify(secretsManager).markOwnedByService(restoredArn, "rds");
     }
 
     @Test
@@ -353,7 +378,7 @@ class RdsServiceTest {
                 "admin", null, "dbname", "db.t3.micro",
                 20, true, null, null, null, true, null);
 
-        assertDoesNotThrow(() -> service.backfillManagedSecretOwnership(null));
+        assertDoesNotThrow(() -> service.backfillManagedSecretOwnership());
     }
 
     @Test
@@ -368,7 +393,7 @@ class RdsServiceTest {
                 "admin", "password", "dbname", "db.t3.micro",
                 20, false, null, null, null);
 
-        service.backfillManagedSecretOwnership(null);
+        service.backfillManagedSecretOwnership();
 
         verify(secretsManager, never()).markOwnedByService(any(), any());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -312,6 +312,47 @@ class RdsServiceTest {
     }
 
     @Test
+    void backfillMarksMasterUserSecretsOfPersistedInstances() {
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        String secretArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-secret";
+        secret.setArn(secretArn);
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        service.createDbInstance("mydb", "postgres", "13",
+                "admin", null, "dbname", "db.t3.micro",
+                20, true, null, null, null, true, null);
+
+        // An instance persisted by a floci that predates ownership tracking still names its
+        // secret, which is what makes that secret managed — the name never is.
+        service.backfillManagedSecretOwnership(null);
+
+        verify(secretsManager).markOwnedByService(secretArn, "rds", "us-east-1");
+    }
+
+    @Test
+    void backfillIgnoresInstancesWithoutAManagedSecret() {
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        service.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null);
+
+        service.backfillManagedSecretOwnership(null);
+
+        verify(secretsManager, never()).markOwnedByService(any(), any(), any());
+    }
+
+    @Test
     void createDbInstanceRejectsUnknownParameterGroup() {
         AwsException exception = assertThrows(AwsException.class, () -> rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "password", "dbname", "db.t3.micro",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -276,7 +276,7 @@ class RdsServiceTest {
         SecretsManagerService secretsManager = mock(SecretsManagerService.class);
         Secret secret = new Secret();
         secret.setArn("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-secret");
-        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq("kms-key-1"), eq(null), eq("us-east-1")))
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq("kms-key-1"), any(), eq("rds"), eq("us-east-1")))
                 .thenReturn(secret);
         RdsService service = newService(containerManager, proxyManager,
                 new InMemoryStorage<>(), new InMemoryStorage<>(),
@@ -295,11 +295,20 @@ class RdsServiceTest {
 
         ArgumentCaptor<String> secretName = ArgumentCaptor.forClass(String.class);
         ArgumentCaptor<String> secretString = ArgumentCaptor.forClass(String.class);
-        verify(secretsManager).createSecret(secretName.capture(), secretString.capture(), eq(null), any(), eq("kms-key-1"), eq(null), eq("us-east-1"));
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Secret.Tag>> secretTags = ArgumentCaptor.forClass(List.class);
+        verify(secretsManager).createSecret(secretName.capture(), secretString.capture(), eq(null), any(),
+                eq("kms-key-1"), secretTags.capture(), eq("rds"), eq("us-east-1"));
         assertTrue(secretName.getValue().startsWith("rds!db-"));
         assertTrue(secretString.getValue().contains("\"username\":\"admin\""));
         assertTrue(secretString.getValue().contains("\"password\":\"" + instance.getMasterPassword() + "\""));
         assertTrue(secretString.getValue().contains("\"dbInstanceIdentifier\":\"mydb\""));
+
+        // AWS marks the secret it manages with both of these tags, alongside OwningService.
+        assertTrue(secretTags.getValue().contains(
+                new Secret.Tag("aws:secretsmanager:owningService", "rds")));
+        assertTrue(secretTags.getValue().contains(
+                new Secret.Tag("aws:rds:primaryDBInstanceArn", instance.getDbInstanceArn())));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -332,7 +332,7 @@ class RdsServiceTest {
         // secret, which is what makes that secret managed — the name never is.
         service.backfillManagedSecretOwnership(null);
 
-        verify(secretsManager).markOwnedByService(secretArn, "rds", "us-east-1");
+        verify(secretsManager).markOwnedByService(secretArn, "rds");
     }
 
     @Test
@@ -349,7 +349,7 @@ class RdsServiceTest {
 
         service.backfillManagedSecretOwnership(null);
 
-        verify(secretsManager, never()).markOwnedByService(any(), any(), any());
+        verify(secretsManager, never()).markOwnedByService(any(), any());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -336,6 +336,27 @@ class RdsServiceTest {
     }
 
     @Test
+    void backfillDoesNotStopStartupWhenASecretCannotBeMarked() {
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        secret.setArn("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-secret");
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        doThrow(new IllegalStateException("storage unavailable"))
+                .when(secretsManager).markOwnedByService(any(), any());
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        service.createDbInstance("mydb", "postgres", "13",
+                "admin", null, "dbname", "db.t3.micro",
+                20, true, null, null, null, true, null);
+
+        assertDoesNotThrow(() -> service.backfillManagedSecretOwnership(null));
+    }
+
+    @Test
     void backfillIgnoresInstancesWithoutAManagedSecret() {
         SecretsManagerService secretsManager = mock(SecretsManagerService.class);
         RdsService service = newService(containerManager, proxyManager,

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -168,6 +168,87 @@ class SecretsManagerJsonHandlerTest {
     }
 
     @Test
+    void owningServiceIsReportedByDescribeAndList() {
+        service.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION);
+
+        ObjectNode describeReq = MAPPER.createObjectNode();
+        describeReq.put("SecretId", "rds!db-1234");
+        ObjectNode described = (ObjectNode) handler
+                .handle("DescribeSecret", describeReq, REGION)
+                .getEntity();
+        ObjectNode listed = (ObjectNode) ((ObjectNode) handler
+                .handle("ListSecrets", MAPPER.createObjectNode(), REGION)
+                .getEntity())
+                .path("SecretList")
+                .path(0);
+
+        assertThat(described.get("OwningService").asText(), is("rds"));
+        assertThat(listed.get("OwningService").asText(), is("rds"));
+    }
+
+    @Test
+    void listSecretsFiltersByOwningService() {
+        service.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION);
+        ObjectNode createReq = MAPPER.createObjectNode();
+        createReq.put("Name", "ordinary-secret");
+        handler.handle("CreateSecret", createReq, REGION);
+
+        ObjectNode listReq = MAPPER.createObjectNode();
+        listReq.putArray("Filters").addObject().put("Key", "owning-service").putArray("Values").add("rds");
+        ObjectNode owned = (ObjectNode) handler.handle("ListSecrets", listReq, REGION).getEntity();
+
+        assertThat(owned.get("SecretList").size(), is(1));
+        assertThat(owned.get("SecretList").get(0).get("Name").asText(), is("rds!db-1234"));
+
+        // A leading "!" negates a filter, so this selects the secrets no service owns.
+        ObjectNode negatedReq = MAPPER.createObjectNode();
+        negatedReq.putArray("Filters").addObject().put("Key", "owning-service").putArray("Values").add("!rds");
+        ObjectNode unowned = (ObjectNode) handler.handle("ListSecrets", negatedReq, REGION).getEntity();
+
+        assertThat(unowned.get("SecretList").size(), is(1));
+        assertThat(unowned.get("SecretList").get(0).get("Name").asText(), is("ordinary-secret"));
+    }
+
+    @Test
+    void ownerlessSecretsOmitOwningService() {
+        ObjectNode createReq = MAPPER.createObjectNode();
+        createReq.put("Name", "ordinary-secret");
+        handler.handle("CreateSecret", createReq, REGION);
+
+        ObjectNode describeReq = MAPPER.createObjectNode();
+        describeReq.put("SecretId", "ordinary-secret");
+        ObjectNode described = (ObjectNode) handler
+                .handle("DescribeSecret", describeReq, REGION)
+                .getEntity();
+
+        assertThat(described.has("OwningService"), is(false));
+    }
+
+    @Test
+    void rotateServiceManagedSecretSucceedsOverTheWire() {
+        service.createSecret("rds!db-5678", "value", null, null, null, null, "rds", REGION);
+
+        // The call terraform's aws_secretsmanager_secret_rotation makes for a managed secret:
+        // rotation rules, no RotationLambdaARN.
+        ObjectNode rotateReq = MAPPER.createObjectNode();
+        rotateReq.put("SecretId", "rds!db-5678");
+        rotateReq.putObject("RotationRules").put("AutomaticallyAfterDays", 7);
+        Response response = handler.handle("RotateSecret", rotateReq, REGION);
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(((ObjectNode) response.getEntity()).get("Name").asText(), is("rds!db-5678"));
+
+        ObjectNode describeReq = MAPPER.createObjectNode();
+        describeReq.put("SecretId", "rds!db-5678");
+        ObjectNode described = (ObjectNode) handler
+                .handle("DescribeSecret", describeReq, REGION)
+                .getEntity();
+        assertThat(described.get("RotationEnabled").asBoolean(), is(true));
+        assertThat(described.path("RotationRules").get("AutomaticallyAfterDays").asInt(), is(7));
+        assertThat(described.has("RotationLambdaARN"), is(false));
+    }
+
+    @Test
     void listSecretsResponseIncludesKmsKeyId() {
         ObjectNode createReq = MAPPER.createObjectNode();
         createReq.put("Name", "list-kms-secret");

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -249,6 +249,26 @@ class SecretsManagerJsonHandlerTest {
     }
 
     @Test
+    void rotateServiceManagedSecretReturnsAVersionThatResolves() {
+        service.createSecret("rds!db-9012", "value", null, null, null, null, "rds", REGION);
+
+        ObjectNode rotateReq = MAPPER.createObjectNode();
+        rotateReq.put("SecretId", "rds!db-9012");
+        rotateReq.putObject("RotationRules").put("AutomaticallyAfterDays", 7);
+        ObjectNode rotated = (ObjectNode) handler.handle("RotateSecret", rotateReq, REGION).getEntity();
+
+        // Nothing stages a version for the request token here, so the reported VersionId has to be
+        // one a caller can actually read back.
+        ObjectNode getReq = MAPPER.createObjectNode();
+        getReq.put("SecretId", "rds!db-9012");
+        getReq.put("VersionId", rotated.get("VersionId").asText());
+        Response response = handler.handle("GetSecretValue", getReq, REGION);
+
+        assertThat(response.getStatus(), is(200));
+        assertThat(((ObjectNode) response.getEntity()).get("SecretString").asText(), is("value"));
+    }
+
+    @Test
     void listSecretsResponseIncludesKmsKeyId() {
         ObjectNode createReq = MAPPER.createObjectNode();
         createReq.put("Name", "list-kms-secret");

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -327,6 +327,67 @@ class SecretsManagerServiceTest {
     }
 
     @Test
+    void rotateSecretWithoutLambdaArnThrows() {
+        service.createSecret("my-secret", "value", null, null, null, null, REGION);
+
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.rotateSecret("my-secret", null, null,
+                        new Secret.RotationRules(30, null, null), true, REGION));
+
+        assertEquals("InvalidRequestException", e.getErrorCode());
+    }
+
+    @Test
+    void rotateServiceManagedSecretNeedsNoLambdaArn() {
+        io.github.hectorvent.floci.services.lambda.LambdaService mockLambda =
+                org.mockito.Mockito.mock(io.github.hectorvent.floci.services.lambda.LambdaService.class);
+        SecretsManagerService svc = new SecretsManagerService(
+                new InMemoryStorage<String, Secret>(), 30,
+                new io.github.hectorvent.floci.core.common.RegionResolver("us-east-1", "000000000000"),
+                mockLambda, new com.fasterxml.jackson.databind.ObjectMapper());
+
+        // The secret RDS manages: rotated by RDS itself, so it carries no rotation Lambda.
+        svc.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION);
+
+        Secret rotated = svc.rotateSecret("rds!db-1234", null, null,
+                new Secret.RotationRules(7, null, null), true, REGION);
+
+        assertTrue(rotated.isRotationEnabled());
+        assertEquals(7, rotated.getRotationRules().automaticallyAfterDays());
+        assertNotNull(rotated.getLastRotatedDate());
+        assertNull(rotated.getRotationLambdaArn());
+        // No Lambda exists to drive the rotation lifecycle, so none may be invoked.
+        org.mockito.Mockito.verifyNoInteractions(mockLambda);
+    }
+
+    @Test
+    void rotateServiceManagedSecretRejectsLambdaArn() {
+        service.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION);
+
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.rotateSecret("rds!db-1234", null,
+                        "arn:aws:lambda:us-east-1:000000000000:function:rotate",
+                        new Secret.RotationRules(7, null, null), true, REGION));
+
+        assertEquals("InvalidRequestException", e.getErrorCode());
+        assertEquals("Rotation Lambda ARN is not supported for a service-managed secret.", e.getMessage());
+    }
+
+    @Test
+    void ordinarySecretNamedLikeAnRdsSecretStillNeedsALambdaArn() {
+        // Ownership is a property of the secret, not of its name: anyone may create a secret
+        // called rds!something, and that must not grant it service-managed rotation.
+        service.createSecret("rds!db-impostor", "value", null, null, null, null, REGION);
+
+        AwsException e = assertThrows(AwsException.class, () ->
+                service.rotateSecret("rds!db-impostor", null, null,
+                        new Secret.RotationRules(7, null, null), true, REGION));
+
+        assertEquals("InvalidRequestException", e.getErrorCode());
+        assertTrue(e.getMessage().contains("doesn't already have a Lambda function ARN configured"));
+    }
+
+    @Test
     void tagAndUntagResource() {
         service.createSecret("my-secret", "value", null, null, null,
                 List.of(new Secret.Tag("env", "prod")), REGION);

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -374,6 +374,32 @@ class SecretsManagerServiceTest {
     }
 
     @Test
+    void markOwnedByServiceLetsAPersistedSecretRotateAsManaged() {
+        // A secret stored before floci tracked ownership deserializes without an owning service.
+        service.createSecret("rds!db-1234", "value", null, null, null, null, REGION);
+        assertThrows(AwsException.class, () ->
+                service.rotateSecret("rds!db-1234", null, null,
+                        new Secret.RotationRules(7, null, null), true, REGION));
+
+        service.markOwnedByService("rds!db-1234", "rds", REGION);
+
+        assertEquals("rds", service.describeSecret("rds!db-1234", REGION).getOwningService());
+        assertTrue(service.rotateSecret("rds!db-1234", null, null,
+                new Secret.RotationRules(7, null, null), true, REGION).isRotationEnabled());
+    }
+
+    @Test
+    void markOwnedByServiceKeepsAnExistingOwnerAndToleratesAMissingSecret() {
+        service.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION);
+
+        service.markOwnedByService("rds!db-1234", "redshift", REGION);
+        assertEquals("rds", service.describeSecret("rds!db-1234", REGION).getOwningService());
+
+        // A backfill runs over whatever state it finds, so a secret that is gone is not an error.
+        assertDoesNotThrow(() -> service.markOwnedByService("no-such-secret", "rds", REGION));
+    }
+
+    @Test
     void ordinarySecretNamedLikeAnRdsSecretStillNeedsALambdaArn() {
         // Ownership is a property of the secret, not of its name: anyone may create a secret
         // called rds!something, and that must not grant it service-managed rotation.

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.secretsmanager;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
@@ -354,7 +355,8 @@ class SecretsManagerServiceTest {
 
         assertTrue(rotated.isRotationEnabled());
         assertEquals(7, rotated.getRotationRules().automaticallyAfterDays());
-        assertNotNull(rotated.getLastRotatedDate());
+        // floci does not re-issue the credential, so it must not claim a rotation happened.
+        assertNull(rotated.getLastRotatedDate());
         assertNull(rotated.getRotationLambdaArn());
         // No Lambda exists to drive the rotation lifecycle, so none may be invoked.
         org.mockito.Mockito.verifyNoInteractions(mockLambda);
@@ -376,12 +378,12 @@ class SecretsManagerServiceTest {
     @Test
     void markOwnedByServiceLetsAPersistedSecretRotateAsManaged() {
         // A secret stored before floci tracked ownership deserializes without an owning service.
-        service.createSecret("rds!db-1234", "value", null, null, null, null, REGION);
+        String arn = service.createSecret("rds!db-1234", "value", null, null, null, null, REGION).getArn();
         assertThrows(AwsException.class, () ->
                 service.rotateSecret("rds!db-1234", null, null,
                         new Secret.RotationRules(7, null, null), true, REGION));
 
-        service.markOwnedByService("rds!db-1234", "rds", REGION);
+        service.markOwnedByService(arn, "rds");
 
         assertEquals("rds", service.describeSecret("rds!db-1234", REGION).getOwningService());
         assertTrue(service.rotateSecret("rds!db-1234", null, null,
@@ -390,13 +392,39 @@ class SecretsManagerServiceTest {
 
     @Test
     void markOwnedByServiceKeepsAnExistingOwnerAndToleratesAMissingSecret() {
-        service.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION);
+        String arn = service.createSecret("rds!db-1234", "value", null, null, null, null, "rds", REGION).getArn();
 
-        service.markOwnedByService("rds!db-1234", "redshift", REGION);
+        service.markOwnedByService(arn, "redshift");
         assertEquals("rds", service.describeSecret("rds!db-1234", REGION).getOwningService());
 
-        // A backfill runs over whatever state it finds, so a secret that is gone is not an error.
-        assertDoesNotThrow(() -> service.markOwnedByService("no-such-secret", "rds", REGION));
+        // A backfill runs over whatever state it finds, so neither a secret that is gone nor a
+        // malformed ARN is an error.
+        assertDoesNotThrow(() -> service.markOwnedByService(
+                "arn:aws:secretsmanager:" + REGION + ":000000000000:secret:no-such-secret-AbCdEf", "rds"));
+        assertDoesNotThrow(() -> service.markOwnedByService("not-an-arn", "rds"));
+    }
+
+    @Test
+    void markOwnedByServiceAddressesTheAccountNamedInTheArn() {
+        // A backfill runs at startup, outside any request, so the store resolves the default
+        // account unless the ARN's account is used. Secrets of other accounts must still be found,
+        // and a same-named default-account secret must be left alone.
+        AccountAwareStorageBackend<Secret> accountAware =
+                AccountAwareStorageBackend.inMemory("000000000000");
+        SecretsManagerService svc = new SecretsManagerService(accountAware, 30);
+
+        Secret otherAccount = new Secret();
+        otherAccount.setName("rds!db-1234");
+        otherAccount.setArn("arn:aws:secretsmanager:" + REGION + ":111122223333:secret:rds!db-1234-AbCdEf");
+        accountAware.putForAccount("111122223333", REGION + "::rds!db-1234", otherAccount);
+
+        Secret sameNameHere = svc.createSecret("rds!db-1234", "value", null, null, null, null, REGION);
+
+        svc.markOwnedByService(otherAccount.getArn(), "rds");
+
+        assertEquals("rds",
+                accountAware.getForAccount("111122223333", REGION + "::rds!db-1234").orElseThrow().getOwningService());
+        assertNull(sameNameHere.getOwningService());
     }
 
     @Test


### PR DESCRIPTION
Closes #2376.

## Problem

`RotateSecret` requires a rotation Lambda for every secret, so a secret RDS manages
through `ManageMasterUserPassword` can never enable rotation:

```
InvalidRequestException: You tried to enable rotation on a secret that doesn't already
have a Lambda function ARN configured and you didn't include such an ARN as a parameter
in this call.
```

Terraform reaches this through `aws_secretsmanager_secret_rotation`, which the upstream
`terraform-aws-modules/rds` module creates for a managed master password, passing only
`rotation_rules`.

## What AWS does

I filed #2376 without a live check and said so there, so I ran one: a `db.t3.micro`
postgres instance created with `--manage-master-user-password`, then `describe-secret`
on the secret it produced.

```json
{
    "Name": "rds!db-3bea3cf2-0b5f-436f-a6a1-97aad29da293",
    "OwningService": "rds",
    "RotationEnabled": true,
    "RotationRules": { "AutomaticallyAfterDays": 7 },
    "Tags": [
        { "Key": "aws:rds:primaryDBInstanceArn", "Value": "arn:aws:rds:eu-central-1:000000000000:db:probe" },
        { "Key": "aws:secretsmanager:owningService", "Value": "rds" }
    ]
}
```

No `RotationLambdaARN` anywhere. Three calls against that secret:

| Call | Result |
| --- | --- |
| `rotate-secret --rotation-rules AutomaticallyAfterDays=7` | accepted, returns a `VersionId` |
| `rotate-secret --rotation-lambda-arn ...` | `InvalidRequestException: Rotation Lambda ARN is not supported for a service-managed secret.` |
| `delete-secret` | `InvalidRequestException: Operation is not allowed on secret owned by rds` |

So the Lambda requirement is inverted for these secrets: not merely optional, but refused.

## Change

Keyed off ownership rather than the `rds!` name prefix — anyone may create an ordinary
secret called `rds!something`, and that must not grant it managed-rotation semantics.
There is a test for exactly that.

- `Secret` carries an `owningService`, set by floci services only, never settable over the wire
- RDS marks the master user secret it creates as owned by `rds`, with the two tags above
- `RotateSecret` needs no Lambda for an owned secret, rejects one with AWS's message, and
  skips the Lambda rotation lifecycle that would have nothing to invoke
- `DescribeSecret` and `ListSecrets` report `OwningService`, and the `owning-service`
  `ListSecrets` filter now matches on it instead of being hardcoded to `false`

## Tests

Unit tests for each branch, plus a CLI compatibility test that walks the whole path:
create the instance with `--manage-master-user-password`, describe the secret it produced,
reject a Lambda ARN, then rotate with rules alone. Verified by running it against a build
without the fix, where it fails on the missing `OwningService`.

## Deliberately not included

`DeleteSecret` and `UpdateSecret` also refuse service-managed secrets on AWS. `DeleteSecret`
is the interesting one: AWS deletes the managed secret itself when the instance goes away,
which floci does not do yet, so adding the guard alone would strand an undeletable secret
after `delete-db-instance`. That pair belongs together in a follow-up.
