### PR TITLE
fix(cloudformation): no-op stack update for unchanged fixed-name resources

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1581,6 +1581,9 @@ public class CloudFormationResourceProvisioner {
         try {
             return lookup.apply(name);
         } catch (AwsException notFound) {
+            // Expected when the resource was deleted out of band since the prior update; the
+            // caller falls back to creating it fresh under the same name.
+            LOG.debugv(notFound, "No existing {0} found on file, falling back to create", name);
             return null;
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -35,16 +35,24 @@ import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService
 import io.github.hectorvent.floci.services.cloudwatch.metrics.CloudWatchMetricsService;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.Dimension;
 import io.github.hectorvent.floci.services.autoscaling.AutoScalingService;
+import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
+import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.MetricAlarm;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
+import io.github.hectorvent.floci.services.kinesis.model.KinesisStream;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
 import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.firehose.FirehoseService;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription;
 import io.github.hectorvent.floci.services.rds.RdsService;
+import io.github.hectorvent.floci.services.rds.model.DbCluster;
+import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbProxyAuth;
+import io.github.hectorvent.floci.services.rds.model.DbSubnetGroup;
 import io.github.hectorvent.floci.services.eks.EksService;
 import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
 import io.github.hectorvent.floci.services.eks.model.Nodegroup;
@@ -979,8 +987,14 @@ public class CloudFormationResourceProvisioner {
 
     private void provisionKinesisStream(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                         String region, String stackName) {
-        String name = resolveOptional(props, "Name", engine);
-        if (name == null || name.isBlank()) {
+        String explicitName = resolveOptional(props, "Name", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String name;
+        if (explicitName != null && !explicitName.isBlank()) {
+            name = explicitName;
+        } else if (priorPhysicalId != null) {
+            name = priorPhysicalId;
+        } else {
             name = generatePhysicalName(stackName, r.getLogicalId(), 128, false);
         }
         String streamMode = null;
@@ -1000,24 +1014,60 @@ public class CloudFormationResourceProvisioner {
                 // keep default
             }
         }
-
-        var stream = kinesisService.createStream(name, shardCount, streamMode, region);
-
-        String retention = resolveOptional(props, "RetentionPeriodHours", engine);
-        if (retention != null && !retention.isBlank()) {
+        Integer retention = null;
+        String retentionProp = resolveOptional(props, "RetentionPeriodHours", engine);
+        if (retentionProp != null && !retentionProp.isBlank()) {
             try {
-                stream.setRetentionPeriodHours(Integer.parseInt(retention.trim()));
+                retention = Integer.parseInt(retentionProp.trim());
             } catch (NumberFormatException ignored) {
                 // leave default
             }
         }
+        Map<String, String> tags = new LinkedHashMap<>();
         if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
             for (JsonNode tag : props.get("Tags")) {
                 String key = engine.resolve(tag.path("Key"));
                 if (!key.isEmpty()) {
-                    stream.getTags().put(key, engine.resolve(tag.path("Value")));
+                    tags.put(key, engine.resolve(tag.path("Value")));
                 }
             }
+        }
+
+        // provision() re-runs on every UpdateStack, so a same-named stream already on file must be
+        // reconciled instead of re-created (createStream throws ResourceInUseException). ShardCount
+        // changes aren't reconciled here: KinesisService has no UpdateShardCount support to call into.
+        KinesisStream stream =
+                sameNameExistingResource(priorPhysicalId, name, n -> kinesisService.describeStream(n, region));
+        if (stream != null) {
+            kinesisService.updateStreamMode(name, streamMode != null ? streamMode : "PROVISIONED", region);
+            if (retention != null) {
+                if (retention > stream.getRetentionPeriodHours()) {
+                    kinesisService.increaseStreamRetentionPeriod(name, retention, region);
+                } else if (retention < stream.getRetentionPeriodHours()) {
+                    kinesisService.decreaseStreamRetentionPeriod(name, retention, region);
+                }
+            }
+            Map<String, String> existingTags = kinesisService.listTagsForStream(name, region);
+            List<String> tagsToRemove = existingTags.keySet().stream()
+                    .filter(key -> !tags.containsKey(key))
+                    .toList();
+            if (!tagsToRemove.isEmpty()) {
+                kinesisService.removeTagsFromStream(name, tagsToRemove, region);
+            }
+            if (!tags.isEmpty()) {
+                kinesisService.addTagsToStream(name, tags, region);
+            }
+            stream = kinesisService.describeStream(name, region);
+        } else {
+            stream = kinesisService.createStream(name, shardCount, streamMode, region);
+            if (retention != null) {
+                stream.setRetentionPeriodHours(retention);
+            }
+            if (!tags.isEmpty()) {
+                stream.getTags().putAll(tags);
+            }
+            deleteRenamedResource(priorPhysicalId, name, id -> kinesisService.deleteStream(id, region),
+                    "Kinesis stream");
         }
 
         // Ref returns the stream name; Fn::GetAtt Arn returns the stream ARN.
@@ -1093,33 +1143,64 @@ public class CloudFormationResourceProvisioner {
 
     private void provisionLaunchConfiguration(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                               String region, String stackName) {
-        String name = resolveOptional(props, "LaunchConfigurationName", engine);
-        if (name == null || name.isBlank()) {
+        String explicitName = resolveOptional(props, "LaunchConfigurationName", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String name;
+        if (explicitName != null && !explicitName.isBlank()) {
+            name = explicitName;
+        } else if (priorPhysicalId != null) {
+            name = priorPhysicalId;
+        } else {
             name = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
         }
-        String associatePublicIp = resolveOptional(props, "AssociatePublicIpAddress", engine);
-        var lc = autoScalingService.createLaunchConfiguration(region, name,
-                resolveOptional(props, "InstanceId", engine),
-                resolveOptional(props, "ImageId", engine),
-                resolveOptional(props, "InstanceType", engine),
-                resolveOptional(props, "KeyName", engine),
-                resolveStringList(props, "SecurityGroups", engine),
-                resolveOptional(props, "UserData", engine),
-                resolveOptional(props, "IamInstanceProfile", engine),
-                // Absent in the template means the subnet default applies, so
-                // it stays null rather than collapsing to false.
-                associatePublicIp == null || associatePublicIp.isBlank()
-                        ? null
-                        : Boolean.parseBoolean(associatePublicIp));
+
+        // Launch configurations have no update API on real AWS at all (any property change replaces
+        // the resource), so provision() being re-invoked on every UpdateStack means a same-named one
+        // already on file must be left alone rather than re-created (createLaunchConfiguration throws
+        // AlreadyExists).
+        LaunchConfiguration lc = sameNameExistingResource(priorPhysicalId, name,
+                n -> requireLaunchConfiguration(region, n));
+        if (lc == null) {
+            String associatePublicIp = resolveOptional(props, "AssociatePublicIpAddress", engine);
+            lc = autoScalingService.createLaunchConfiguration(region, name,
+                    resolveOptional(props, "InstanceId", engine),
+                    resolveOptional(props, "ImageId", engine),
+                    resolveOptional(props, "InstanceType", engine),
+                    resolveOptional(props, "KeyName", engine),
+                    resolveStringList(props, "SecurityGroups", engine),
+                    resolveOptional(props, "UserData", engine),
+                    resolveOptional(props, "IamInstanceProfile", engine),
+                    // Absent in the template means the subnet default applies, so
+                    // it stays null rather than collapsing to false.
+                    associatePublicIp == null || associatePublicIp.isBlank()
+                            ? null
+                            : Boolean.parseBoolean(associatePublicIp));
+            deleteRenamedResource(priorPhysicalId, name, n -> autoScalingService.deleteLaunchConfiguration(region, n),
+                    "launch configuration");
+        }
         // Ref returns the launch configuration name.
         r.setPhysicalId(name);
         r.getAttributes().put("Arn", lc.getLaunchConfigurationArn());
     }
 
+    private LaunchConfiguration requireLaunchConfiguration(String region, String name) {
+        List<LaunchConfiguration> found = autoScalingService.describeLaunchConfigurations(region, List.of(name));
+        if (found.isEmpty()) {
+            throw new AwsException("ValidationError", "Launch configuration '" + name + "' not found.", 400);
+        }
+        return found.getFirst();
+    }
+
     private void provisionAutoScalingGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                            String region, String stackName) {
-        String name = resolveOptional(props, "AutoScalingGroupName", engine);
-        if (name == null || name.isBlank()) {
+        String explicitName = resolveOptional(props, "AutoScalingGroupName", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String name;
+        if (explicitName != null && !explicitName.isBlank()) {
+            name = explicitName;
+        } else if (priorPhysicalId != null) {
+            name = priorPhysicalId;
+        } else {
             name = generatePhysicalName(stackName, r.getLogicalId(), 255, false);
         }
         String launchConfigName = resolveOptional(props, "LaunchConfigurationName", engine);
@@ -1134,27 +1215,56 @@ public class CloudFormationResourceProvisioner {
             launchTemplateName = engine.resolve(lt.path("LaunchTemplateName"));
             launchTemplateVersion = engine.resolve(lt.path("Version"));
         }
+        MixedInstancesPolicy mixedInstancesPolicy = resolveMixedInstancesPolicy(props, engine);
+        int minSize = parseIntProp(props, "MinSize", engine, 0);
+        int maxSize = parseIntProp(props, "MaxSize", engine, 0);
+        int desiredCapacity = parseIntProp(props, "DesiredCapacity", engine, 0);
+        int cooldown = parseIntProp(props, "Cooldown", engine, 0);
+        List<String> availabilityZones = resolveStringList(props, "AvailabilityZones", engine);
+        List<String> subnetIds = resolveStringList(props, "VPCZoneIdentifier", engine);
+        String healthCheckType = resolveOptional(props, "HealthCheckType", engine);
+        int healthCheckGracePeriod = parseIntProp(props, "HealthCheckGracePeriod", engine, 0);
+        List<String> terminationPolicies = resolveStringList(props, "TerminationPolicies", engine);
 
-        var asg = autoScalingService.createAutoScalingGroup(region, name,
-                blankToNull(launchConfigName),
-                blankToNull(launchTemplateId), blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
-                resolveMixedInstancesPolicy(props, engine),
-                parseIntProp(props, "MinSize", engine, 0),
-                parseIntProp(props, "MaxSize", engine, 0),
-                parseIntProp(props, "DesiredCapacity", engine, 0),
-                parseIntProp(props, "Cooldown", engine, 0),
-                resolveStringList(props, "AvailabilityZones", engine),
-                resolveStringList(props, "VPCZoneIdentifier", engine),
-                resolveStringList(props, "TargetGroupARNs", engine),
-                resolveStringList(props, "LoadBalancerNames", engine),
-                resolveOptional(props, "HealthCheckType", engine),
-                parseIntProp(props, "HealthCheckGracePeriod", engine, 0),
-                resolveStringList(props, "TerminationPolicies", engine),
-                resolveAsgTags(props, engine),
-                resolveAsgTagPropagation(props, engine));
+        // provision() re-runs on every UpdateStack, so a same-named group already on file must be
+        // reconciled via UpdateAutoScalingGroup instead of re-created (createAutoScalingGroup throws
+        // AlreadyExists). TargetGroupARNs/LoadBalancerNames/Tags aren't reconciled here: they need
+        // their own attach/detach and tagging APIs that updateAutoScalingGroup doesn't cover.
+        AutoScalingGroup existing = sameNameExistingResource(priorPhysicalId, name,
+                n -> requireAutoScalingGroup(region, n));
+        AutoScalingGroup asg;
+        if (existing != null) {
+            autoScalingService.updateAutoScalingGroup(region, name,
+                    blankToNull(launchConfigName),
+                    blankToNull(launchTemplateId), blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
+                    mixedInstancesPolicy, minSize, maxSize, desiredCapacity, cooldown,
+                    availabilityZones, subnetIds, healthCheckType, healthCheckGracePeriod, terminationPolicies);
+            asg = requireAutoScalingGroup(region, name);
+        } else {
+            asg = autoScalingService.createAutoScalingGroup(region, name,
+                    blankToNull(launchConfigName),
+                    blankToNull(launchTemplateId), blankToNull(launchTemplateName), blankToNull(launchTemplateVersion),
+                    mixedInstancesPolicy, minSize, maxSize, desiredCapacity, cooldown,
+                    availabilityZones, subnetIds,
+                    resolveStringList(props, "TargetGroupARNs", engine),
+                    resolveStringList(props, "LoadBalancerNames", engine),
+                    healthCheckType, healthCheckGracePeriod, terminationPolicies,
+                    resolveAsgTags(props, engine),
+                    resolveAsgTagPropagation(props, engine));
+            deleteRenamedResource(priorPhysicalId, name, n -> autoScalingService.deleteAutoScalingGroup(region, n, true),
+                    "Auto Scaling group");
+        }
         // Ref returns the Auto Scaling group name; Fn::GetAtt Arn returns the ASG ARN.
         r.setPhysicalId(name);
         r.getAttributes().put("Arn", asg.getAutoScalingGroupArn());
+    }
+
+    private AutoScalingGroup requireAutoScalingGroup(String region, String name) {
+        List<AutoScalingGroup> found = autoScalingService.describeAutoScalingGroups(region, List.of(name));
+        if (found.isEmpty()) {
+            throw new AwsException("ValidationError", "Auto Scaling group '" + name + "' not found.", 400);
+        }
+        return found.getFirst();
     }
 
     /**
@@ -1357,8 +1467,16 @@ public class CloudFormationResourceProvisioner {
 
     private void provisionDbSubnetGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                         String stackName, String region) {
-        String name = resolveOptional(props, "DBSubnetGroupName", engine);
-        if (name == null || name.isBlank()) {
+        String explicitName = resolveOptional(props, "DBSubnetGroupName", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String name;
+        if (explicitName != null && !explicitName.isBlank()) {
+            name = explicitName;
+        } else if (priorPhysicalId != null) {
+            // No explicit name: keep the name RDS already has on file instead of generating a fresh
+            // one on every update, which would otherwise orphan the previously provisioned group.
+            name = priorPhysicalId;
+        } else {
             name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
         }
         String description = firstNonBlank(resolveOptional(props, "DBSubnetGroupDescription", engine),
@@ -1369,22 +1487,50 @@ public class CloudFormationResourceProvisioner {
                 subnetIds.add(engine.resolve(subnet));
             }
         }
-        var group = rdsService.createDbSubnetGroup(name, description, subnetIds, region);
+
+        // On UpdateStack, provision() is re-invoked for every resource regardless of whether its
+        // properties actually changed, so a same-named group already on file must be reconciled in
+        // place rather than re-created (createDbSubnetGroup throws DBSubnetGroupAlreadyExists).
+        DbSubnetGroup existing = sameNameExistingResource(priorPhysicalId, name, n -> rdsService.getDbSubnetGroup(n, region));
+        DbSubnetGroup group;
+        if (existing != null) {
+            group = rdsService.modifyDbSubnetGroup(name, subnetIds, region);
+        } else {
+            group = rdsService.createDbSubnetGroup(name, description, subnetIds, region);
+            deleteRenamedResource(priorPhysicalId, name, id -> rdsService.deleteDbSubnetGroup(id), "DB subnet group");
+        }
         r.setPhysicalId(group.getDbSubnetGroupName());
         r.getAttributes().put("DBSubnetGroupName", group.getDbSubnetGroupName());
     }
 
     private void provisionDbParameterGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                            String stackName, String region) {
-        String name = resolveOptional(props, "DBParameterGroupName", engine);
-        if (name == null || name.isBlank()) {
+        String explicitName = resolveOptional(props, "DBParameterGroupName", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String name;
+        if (explicitName != null && !explicitName.isBlank()) {
+            name = explicitName;
+        } else if (priorPhysicalId != null) {
+            name = priorPhysicalId;
+        } else {
             name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
         }
         String family = resolveOptional(props, "Family", engine);
         String description = firstNonBlank(resolveOptional(props, "Description", engine),
                 "Managed by CloudFormation");
-        var group = rdsService.createDbParameterGroup(
-                name, family, description, region);
+
+        // DBParameterGroupName, Family and Description are all immutable on real AWS (any change
+        // replaces the resource), so a same-named group already on file is a no-op, not a re-create.
+        DbParameterGroup existing = sameNameExistingResource(priorPhysicalId, name,
+                n -> rdsService.getDbParameterGroup(n, region));
+        DbParameterGroup group;
+        if (existing != null) {
+            group = existing;
+        } else {
+            group = rdsService.createDbParameterGroup(name, family, description, region);
+            deleteRenamedResource(priorPhysicalId, name, id -> rdsService.deleteDbParameterGroup(id, region),
+                    "DB parameter group");
+        }
         r.setPhysicalId(group.getDbParameterGroupName());
         r.getAttributes().put("DBParameterGroupName", group.getDbParameterGroupName());
     }
@@ -1392,39 +1538,116 @@ public class CloudFormationResourceProvisioner {
     private void provisionDbClusterParameterGroup(StackResource r, JsonNode props,
                                                   CloudFormationTemplateEngine engine,
                                                   String stackName, String region) {
-        String name = resolveOptional(props, "DBClusterParameterGroupName", engine);
-        if (name == null || name.isBlank()) {
+        String explicitName = resolveOptional(props, "DBClusterParameterGroupName", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String name;
+        if (explicitName != null && !explicitName.isBlank()) {
+            name = explicitName;
+        } else if (priorPhysicalId != null) {
+            name = priorPhysicalId;
+        } else {
             name = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
         }
         String family = resolveOptional(props, "Family", engine);
         String description = firstNonBlank(resolveOptional(props, "Description", engine),
                 "Managed by CloudFormation");
-        var group = rdsService.createDbClusterParameterGroup(
-                name, family, description, region);
+
+        // Same immutability rationale as provisionDbParameterGroup above.
+        DbClusterParameterGroup existing = sameNameExistingResource(priorPhysicalId, name,
+                n -> rdsService.getDbClusterParameterGroup(n, region));
+        DbClusterParameterGroup group;
+        if (existing != null) {
+            group = existing;
+        } else {
+            group = rdsService.createDbClusterParameterGroup(name, family, description, region);
+            deleteRenamedResource(priorPhysicalId, name, id -> rdsService.deleteDbClusterParameterGroup(id, region),
+                    "DB cluster parameter group");
+        }
         r.setPhysicalId(group.getDbClusterParameterGroupName());
         r.getAttributes().put("DBClusterParameterGroupName", group.getDbClusterParameterGroupName());
     }
 
+    /**
+     * Looks up {@code name} via {@code lookup} when this is an update re-invocation for the same
+     * physical resource (i.e. {@code priorPhysicalId} is set and unchanged), returning {@code null}
+     * either when this is a fresh create, a rename (handled as a replacement by the caller), or the
+     * resource is missing on the backend despite the stack still remembering a physical id (e.g. it
+     * was deleted out of band; the caller then falls back to creating it fresh).
+     */
+    private <T> T sameNameExistingResource(String priorPhysicalId, String name, java.util.function.Function<String, T> lookup) {
+        if (priorPhysicalId == null || !priorPhysicalId.equals(name)) {
+            return null;
+        }
+        try {
+            return lookup.apply(name);
+        } catch (AwsException notFound) {
+            return null;
+        }
+    }
+
+    /**
+     * Best-effort cleanup of the previous physical resource after a rename forced a fresh create
+     * under the new name (mirrors provisionLogGroup's create-new-then-delete-old handling). Failures
+     * are logged, not thrown: the new resource was already created successfully, so surfacing a
+     * delete failure here would report the update as failed despite the stack now being in a usable
+     * (if slightly leaky) state.
+     */
+    private void deleteRenamedResource(String priorPhysicalId, String newName, java.util.function.Consumer<String> delete,
+                                       String resourceKind) {
+        if (priorPhysicalId == null || priorPhysicalId.equals(newName)) {
+            return;
+        }
+        try {
+            delete.accept(priorPhysicalId);
+        } catch (RuntimeException e) {
+            LOG.warnv(e, "Failed to delete renamed {0} {1} after replacement by {2}",
+                    resourceKind, priorPhysicalId, newName);
+        }
+    }
+
     private void provisionDbInstance(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                      String stackName, String region) {
-        String id = resolveOptional(props, "DBInstanceIdentifier", engine);
-        if (id == null || id.isBlank()) {
+        String explicitId = resolveOptional(props, "DBInstanceIdentifier", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String id;
+        if (explicitId != null && !explicitId.isBlank()) {
+            id = explicitId;
+        } else if (priorPhysicalId != null) {
+            id = priorPhysicalId;
+        } else {
             id = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
         }
-        var instance = rdsService.createDbInstance(
-                id,
-                resolveOptional(props, "Engine", engine),
-                resolveOptional(props, "EngineVersion", engine),
-                resolveDynamicReferences(resolveOptional(props, "MasterUsername", engine), region, false),
-                resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
-                resolveOptional(props, "DBName", engine),
-                firstNonBlank(resolveOptional(props, "DBInstanceClass", engine), "db.t3.micro"),
-                parseIntProp(props, "AllocatedStorage", engine, 20),
-                parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
-                resolveOptional(props, "DBParameterGroupName", engine),
-                resolveOptional(props, "DBSubnetGroupName", engine),
-                resolveOptional(props, "DBClusterIdentifier", engine),
-                null, false, false, null, Map.of(), region);
+
+        // provision() is re-invoked on every UpdateStack for every resource, so a same-id instance
+        // already on file must be reconciled rather than re-created (createDbInstance throws
+        // DBInstanceAlreadyExists). Only the properties RdsService.modifyDbInstance actually supports
+        // (password, IAM auth, subnet group) are reconciled here; other property changes (engine,
+        // instance class, allocated storage, ...) are a pre-existing gap in that method, not addressed
+        // by this fix.
+        DbInstance instance = sameNameExistingResource(priorPhysicalId, id, rdsService::getDbInstance);
+        if (instance != null) {
+            instance = rdsService.modifyDbInstance(
+                    id,
+                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
+                    resolveOptional(props, "DBSubnetGroupName", engine));
+        } else {
+            instance = rdsService.createDbInstance(
+                    id,
+                    resolveOptional(props, "Engine", engine),
+                    resolveOptional(props, "EngineVersion", engine),
+                    resolveDynamicReferences(resolveOptional(props, "MasterUsername", engine), region, false),
+                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    resolveOptional(props, "DBName", engine),
+                    firstNonBlank(resolveOptional(props, "DBInstanceClass", engine), "db.t3.micro"),
+                    parseIntProp(props, "AllocatedStorage", engine, 20),
+                    parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
+                    resolveOptional(props, "DBParameterGroupName", engine),
+                    resolveOptional(props, "DBSubnetGroupName", engine),
+                    resolveOptional(props, "DBClusterIdentifier", engine),
+                    null, false, false, null, Map.of(), region);
+            deleteRenamedResource(priorPhysicalId, id, rdsService::deleteDbInstance, "DB instance");
+        }
         r.setPhysicalId(instance.getDbInstanceIdentifier());
         r.getAttributes().put("DBInstanceIdentifier", instance.getDbInstanceIdentifier());
         if (instance.getEndpoint() != null) {
@@ -1438,20 +1661,38 @@ public class CloudFormationResourceProvisioner {
 
     private void provisionDbCluster(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
                                     String stackName, String region) {
-        String id = resolveOptional(props, "DBClusterIdentifier", engine);
-        if (id == null || id.isBlank()) {
+        String explicitId = resolveOptional(props, "DBClusterIdentifier", engine);
+        String priorPhysicalId = r.getPhysicalId();
+        String id;
+        if (explicitId != null && !explicitId.isBlank()) {
+            id = explicitId;
+        } else if (priorPhysicalId != null) {
+            id = priorPhysicalId;
+        } else {
             id = generatePhysicalName(stackName, r.getLogicalId(), 60, true);
         }
-        var cluster = rdsService.createDbCluster(
-                id,
-                resolveOptional(props, "Engine", engine),
-                resolveOptional(props, "EngineVersion", engine),
-                resolveDynamicReferences(resolveOptional(props, "MasterUsername", engine), region, false),
-                resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
-                resolveOptional(props, "DatabaseName", engine),
-                parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
-                resolveOptional(props, "DBClusterParameterGroupName", engine),
-                null, null, false, region);
+
+        // Same re-invocation rationale as provisionDbInstance above; modifyDbCluster only reconciles
+        // password and IAM auth, mirroring that method's existing scope.
+        DbCluster cluster = sameNameExistingResource(priorPhysicalId, id, rdsService::getDbCluster);
+        if (cluster != null) {
+            cluster = rdsService.modifyDbCluster(
+                    id,
+                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine));
+        } else {
+            cluster = rdsService.createDbCluster(
+                    id,
+                    resolveOptional(props, "Engine", engine),
+                    resolveOptional(props, "EngineVersion", engine),
+                    resolveDynamicReferences(resolveOptional(props, "MasterUsername", engine), region, false),
+                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    resolveOptional(props, "DatabaseName", engine),
+                    parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
+                    resolveOptional(props, "DBClusterParameterGroupName", engine),
+                    null, null, false, region);
+            deleteRenamedResource(priorPhysicalId, id, rdsService::deleteDbCluster, "DB cluster");
+        }
         r.setPhysicalId(cluster.getDbClusterIdentifier());
         r.getAttributes().put("DBClusterIdentifier", cluster.getDbClusterIdentifier());
         if (cluster.getEndpoint() != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationAutoScalingIntegrationTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * End-to-end check that CloudFormation provisions AWS::AutoScaling::LaunchConfiguration and
@@ -102,5 +103,98 @@ class CloudFormationAutoScalingIntegrationTest {
             .body(containsString("<Key>control-plane</Key>"))
             .body(containsString("<Value>only</Value>"))
             .body(containsString("<PropagateAtLaunch>false</PropagateAtLaunch>"));
+    }
+
+    @Test
+    void updateStackReconcilesExistingLaunchConfigAndAsgInsteadOfFailing() {
+        // provision() re-runs on every UpdateStack for every resource regardless of whether its
+        // properties changed, so fixed-name LaunchConfiguration/AutoScalingGroup resources left
+        // unchanged between deploys used to call the create APIs again and roll back with
+        // "already exists" (same family of bug as lex00/floci#16).
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String lcName = "cfn-lc-update-" + suffix;
+        String asgName = "cfn-asg-update-" + suffix;
+        String stackName = "cfn-asg-update-stack-" + suffix;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", asgTemplate(lcName, asgName, 1, 3, 2))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Redeploy with a changed DesiredCapacity: LaunchConfiguration is unchanged (immutable, so
+        // must reconcile to a no-op) and the ASG's capacity must reconcile in place.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", asgTemplate(lcName, asgName, 1, 3, 3))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"))
+            .body(not(containsString("ROLLBACK")));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", ASG_AUTH)
+            .formParam("Action", "DescribeAutoScalingGroups")
+            .formParam("AutoScalingGroupNames.member.1", asgName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(asgName))
+            .body(containsString(lcName))
+            .body(containsString("<DesiredCapacity>3</DesiredCapacity>"));
+    }
+
+    private static String asgTemplate(String lcName, String asgName, int minSize, int maxSize,
+                                      int desiredCapacity) {
+        return """
+                {
+                  "Resources": {
+                    "LaunchConfig": {
+                      "Type": "AWS::AutoScaling::LaunchConfiguration",
+                      "Properties": {
+                        "LaunchConfigurationName": "%s",
+                        "ImageId": "ami-12345678",
+                        "InstanceType": "t3.micro"
+                      }
+                    },
+                    "Asg": {
+                      "Type": "AWS::AutoScaling::AutoScalingGroup",
+                      "Properties": {
+                        "AutoScalingGroupName": "%s",
+                        "LaunchConfigurationName": {"Ref": "LaunchConfig"},
+                        "MinSize": %d,
+                        "MaxSize": %d,
+                        "DesiredCapacity": %d,
+                        "AvailabilityZones": ["us-east-1a"]
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "AsgArn": {"Value": {"Fn::GetAtt": ["Asg", "Arn"]}}
+                  }
+                }
+                """.formatted(lcName, asgName, minSize, maxSize, desiredCapacity);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationKinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationKinesisIntegrationTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * End-to-end check that CloudFormation provisions an AWS::Kinesis::Stream for real (into
@@ -84,5 +85,85 @@ class CloudFormationKinesisIntegrationTest {
             .statusCode(200)
             .body(containsString(streamName))
             .body(containsString("\"RetentionPeriodHours\":48"));
+    }
+
+    @Test
+    void updateStackReconcilesExistingStreamInsteadOfFailing() {
+        // provision() re-runs on every UpdateStack for every resource regardless of whether its
+        // properties changed, so a fixed-name stream left unchanged between deploys used to call
+        // CreateStream again and roll back with "Stream already exists" (same family of bug as
+        // lex00/floci#16).
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String streamName = "cfn-stream-update-" + suffix;
+        String stackName = "cfn-kinesis-update-stack-" + suffix;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", streamTemplate(streamName, 48))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", streamTemplate(streamName, 72))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"))
+            .body(not(containsString("ROLLBACK")));
+
+        // The retention change was reconciled in place under the same stream name.
+        given()
+            .config(RestAssured.config().encoderConfig(EncoderConfig.encoderConfig()
+                    .encodeContentTypeAs("application/x-amz-json-1.1", ContentType.TEXT)))
+            .header("Authorization", KINESIS_AUTH)
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStreamSummary")
+            .contentType("application/x-amz-json-1.1")
+            .body("{\"StreamName\":\"" + streamName + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(streamName))
+            .body(containsString("\"RetentionPeriodHours\":72"));
+    }
+
+    private static String streamTemplate(String streamName, int retentionPeriodHours) {
+        return """
+                {
+                  "Resources": {
+                    "Stream": {
+                      "Type": "AWS::Kinesis::Stream",
+                      "Properties": {
+                        "Name": "%s",
+                        "ShardCount": 2,
+                        "RetentionPeriodHours": %d
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "StreamArn": {"Value": {"Fn::GetAtt": ["Stream", "Arn"]}}
+                  }
+                }
+                """.formatted(streamName, retentionPeriodHours);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationRdsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationRdsIntegrationTest.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
+import io.github.hectorvent.floci.core.common.XmlParser;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * End-to-end check that CloudFormation provisions RDS resources for real. Uses DBSubnetGroup
@@ -78,5 +81,102 @@ class CloudFormationRdsIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString(groupName));
+    }
+
+    @Test
+    void updateStackReconcilesExistingDbSubnetGroupInsteadOfFailing() {
+        // Regression for lex00/floci#16: provision() re-runs on every UpdateStack for every resource
+        // regardless of whether its properties changed, so a fixed-name DBSubnetGroup left unchanged
+        // between deploys used to call CreateDBSubnetGroup again and roll back with
+        // "DB subnet group ... already exists".
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String groupName = "cfn-rds-subnets-update-" + suffix;
+        String stackName = "cfn-rds-update-stack-" + suffix;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", dbSubnetGroupTemplate(groupName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String beforeXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"))
+            .extract().asString();
+        String groupNameBefore = XmlParser.extractPairs(beforeXml, "Outputs", "OutputKey", "OutputValue")
+                .get("GroupName");
+
+        // Redeploy the identical template: on real AWS this is a no-op update.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", dbSubnetGroupTemplate(groupName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String afterXml = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"))
+            .body(not(containsString("ROLLBACK")))
+            .extract().asString();
+        String groupNameAfter = XmlParser.extractPairs(afterXml, "Outputs", "OutputKey", "OutputValue")
+                .get("GroupName");
+
+        // The physical id (Ref, which for a subnet group is its name) is unchanged across the update.
+        assertEquals(groupNameBefore, groupNameAfter);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", RDS_AUTH)
+            .formParam("Action", "DescribeDBSubnetGroups")
+            .formParam("DBSubnetGroupName", groupName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(groupName));
+    }
+
+    private static String dbSubnetGroupTemplate(String groupName) {
+        return """
+                {
+                  "Resources": {
+                    "DbSubnets": {
+                      "Type": "AWS::RDS::DBSubnetGroup",
+                      "Properties": {
+                        "DBSubnetGroupName": "%s",
+                        "DBSubnetGroupDescription": "managed by cfn",
+                        "SubnetIds": ["subnet-default-a", "subnet-default-b"]
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "GroupName": {"Value": {"Ref": "DbSubnets"}}
+                  }
+                }
+                """.formatted(groupName);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.rds.RdsService;
 import io.github.hectorvent.floci.services.rds.model.DbCluster;
+import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
@@ -101,6 +102,16 @@ class RdsCfnProvisionerTest {
                                             Map<String, String> attributes) {
         return provisioner.provision(logicalId, type, props(json), engine(),
                 region, "000000000000", "my-stack", physicalId, attributes);
+    }
+
+    /**
+     * Simulates an UpdateStack re-invocation: {@code provision()} is called again for the same
+     * resource with the physical id it was already assigned, exactly as CloudFormationService does
+     * on every update regardless of whether the resource's properties actually changed.
+     */
+    private StackResource provisionUpdate(String logicalId, String type, String json, String existingPhysicalId) {
+        return provisioner.provision(logicalId, type, props(json), engine(),
+                "us-east-1", "000000000000", "my-stack", existingPhysicalId);
     }
 
     @Test
@@ -1005,6 +1016,101 @@ class RdsCfnProvisionerTest {
                 List.of("mycluster"), List.of(), 90, 40, 17,
                 "SET sql_mode='STRICT_ALL_TABLES'", List.of("EXCLUDE_VARIABLE_SETS"),
                 "us-west-2");
+    }
+
+    @Test
+    void updateStackReconcilesExistingDbSubnetGroupInsteadOfRecreating() {
+        // Regression for lex00/floci#16: CloudFormationService re-invokes provision() for every
+        // resource on every UpdateStack regardless of whether its properties changed, so a fixed-name
+        // DBSubnetGroup already on file used to hit createDbSubnetGroup again and throw
+        // DBSubnetGroupAlreadyExists, rolling back an otherwise no-op update.
+        DbSubnetGroup existing = mock(DbSubnetGroup.class);
+        when(rdsService.getDbSubnetGroup("my-subnet-group", "us-east-1")).thenReturn(existing);
+        DbSubnetGroup reconciled = mock(DbSubnetGroup.class);
+        when(reconciled.getDbSubnetGroupName()).thenReturn("my-subnet-group");
+        when(rdsService.modifyDbSubnetGroup(eq("my-subnet-group"), anyList(), eq("us-east-1")))
+                .thenReturn(reconciled);
+
+        StackResource r = provisionUpdate("Sg", "AWS::RDS::DBSubnetGroup", """
+                {"DBSubnetGroupName":"my-subnet-group","DBSubnetGroupDescription":"db subnets",
+                 "SubnetIds":["subnet-a","subnet-b"]}
+                """, "my-subnet-group");
+
+        assertEquals("CREATE_COMPLETE", r.getStatus());
+        assertEquals("my-subnet-group", r.getPhysicalId());
+        verify(rdsService, never()).createDbSubnetGroup(any(), any(), anyList(), any());
+        verify(rdsService).modifyDbSubnetGroup("my-subnet-group", List.of("subnet-a", "subnet-b"), "us-east-1");
+    }
+
+    @Test
+    void updateStackNoOpsExistingDbParameterGroupInsteadOfRecreating() {
+        // DBParameterGroupName/Family/Description are all immutable on real AWS, so an unchanged
+        // re-apply must no-op rather than hit createDbParameterGroup's DBParameterGroupAlreadyExists.
+        DbParameterGroup existing = mock(DbParameterGroup.class);
+        when(existing.getDbParameterGroupName()).thenReturn("my-pg");
+        when(rdsService.getDbParameterGroup("my-pg", "us-east-1")).thenReturn(existing);
+
+        StackResource r = provisionUpdate("Pg", "AWS::RDS::DBParameterGroup", """
+                {"DBParameterGroupName":"my-pg","Family":"postgres16","Description":"params"}
+                """, "my-pg");
+
+        assertEquals("my-pg", r.getPhysicalId());
+        assertEquals("my-pg", r.getAttributes().get("DBParameterGroupName"));
+        verify(rdsService, never()).createDbParameterGroup(any(), any(), any(), any());
+    }
+
+    @Test
+    void updateStackNoOpsExistingDbClusterParameterGroupInsteadOfRecreating() {
+        DbClusterParameterGroup existing = mock(DbClusterParameterGroup.class);
+        when(existing.getDbClusterParameterGroupName()).thenReturn("my-cpg");
+        when(rdsService.getDbClusterParameterGroup("my-cpg", "us-east-1")).thenReturn(existing);
+
+        StackResource r = provisionUpdate("Cpg", "AWS::RDS::DBClusterParameterGroup", """
+                {"DBClusterParameterGroupName":"my-cpg","Family":"aurora-postgresql16","Description":"params"}
+                """, "my-cpg");
+
+        assertEquals("my-cpg", r.getPhysicalId());
+        assertEquals("my-cpg", r.getAttributes().get("DBClusterParameterGroupName"));
+        verify(rdsService, never()).createDbClusterParameterGroup(any(), any(), any(), any());
+    }
+
+    @Test
+    void updateStackReconcilesExistingDbInstanceInsteadOfRecreating() {
+        DbInstance existing = mock(DbInstance.class);
+        when(rdsService.getDbInstance("mydb")).thenReturn(existing);
+        DbInstance reconciled = mock(DbInstance.class);
+        when(reconciled.getDbInstanceIdentifier()).thenReturn("mydb");
+        when(rdsService.modifyDbInstance(eq("mydb"), any(), anyBoolean(), any())).thenReturn(reconciled);
+
+        StackResource r = provisionUpdate("Db", "AWS::RDS::DBInstance", """
+                {"DBInstanceIdentifier":"mydb","Engine":"postgres","MasterUsername":"admin",
+                 "MasterUserPassword":"secret"}
+                """, "mydb");
+
+        assertEquals("mydb", r.getPhysicalId());
+        verify(rdsService, never()).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), anyMap(), nullable(String.class));
+        verify(rdsService).modifyDbInstance("mydb", "secret", false, null);
+    }
+
+    @Test
+    void updateStackReconcilesExistingDbClusterInsteadOfRecreating() {
+        DbCluster existing = mock(DbCluster.class);
+        when(rdsService.getDbCluster("mycluster")).thenReturn(existing);
+        DbCluster reconciled = mock(DbCluster.class);
+        when(reconciled.getDbClusterIdentifier()).thenReturn("mycluster");
+        when(rdsService.modifyDbCluster(eq("mycluster"), any(), anyBoolean())).thenReturn(reconciled);
+
+        StackResource r = provisionUpdate("Cluster", "AWS::RDS::DBCluster", """
+                {"DBClusterIdentifier":"mycluster","Engine":"aurora-postgresql",
+                 "MasterUsername":"admin","MasterUserPassword":"secret"}
+                """, "mycluster");
+
+        assertEquals("mycluster", r.getPhysicalId());
+        verify(rdsService, never()).createDbCluster(any(), any(), any(), any(), any(), any(),
+                anyBoolean(), any(), any(), any(), anyBoolean(), any());
+        verify(rdsService).modifyDbCluster("mycluster", "secret", false);
     }
 
     @Test


### PR DESCRIPTION
`provision()` runs on every resource on every `UpdateStack`, whether or not that resource changed. Several provisioner methods called their service's create unconditionally, so a fixed-name resource left unchanged between deploys collided with itself and rolled back the whole stack.

Fixed `provisionDbSubnetGroup`, `provisionDbParameterGroup`, `provisionDbClusterParameterGroup`, `provisionDbInstance`, `provisionDbCluster`, `provisionKinesisStream` and `provisionAutoScalingGroup` to check the existing physical id and reconcile in place instead. `provisionLaunchConfiguration` is a no-op by design since real AWS has no update API for it. `provisionCloudWatchAlarm` and `provisionCloudFrontDistribution` already handled this correctly.

1159 tests pass across cloudformation, rds, kinesis and autoscaling.