### PR TITLE
fix(apigateway): project HTTP API v2 cookies

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -401,7 +401,7 @@ public class ApiGatewayExecuteController {
         try {
             InvokeResult result = lambdaService.invoke(region, functionName, eventJson.getBytes(),
                     InvocationType.RequestResponse);
-            return buildProxyResponse(result);
+            return buildProxyResponse(result, false);
         } catch (AwsException e) {
             if (e.getHttpStatus() == 404) {
                 return Response.status(404)
@@ -839,7 +839,7 @@ public class ApiGatewayExecuteController {
         }
     }
 
-    Response buildProxyResponse(InvokeResult result) {
+    Response buildProxyResponse(InvokeResult result, boolean httpApiV2) {
         if (result.getPayload() == null || result.getPayload().length == 0) {
             return Response.status(result.getFunctionError() != null ? 502 : result.getStatusCode()).build();
         }
@@ -859,6 +859,12 @@ public class ApiGatewayExecuteController {
                 multiHeaders.fields().forEachRemaining(e -> {
                     if (e.getValue().isArray()) e.getValue().forEach(v -> builder.header(e.getKey(), v.asText()));
                 });
+            }
+            if (httpApiV2) {
+                JsonNode cookies = node.get("cookies");
+                if (cookies != null && cookies.isArray()) {
+                    cookies.forEach(cookie -> builder.header(HttpHeaders.SET_COOKIE, cookie.asText()));
+                }
             }
 
             JsonNode bodyNode = node.get("body");
@@ -1419,7 +1425,7 @@ public class ApiGatewayExecuteController {
         try {
             InvokeResult result = lambdaService.invoke(region, functionName,
                     eventJson.getBytes(), InvocationType.RequestResponse);
-            return buildProxyResponse(result);
+            return buildProxyResponse(result, true);
         } catch (AwsException e) {
             if (e.getHttpStatus() == 404) {
                 return Response.status(404)

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -132,7 +132,7 @@ class ApiGatewayExecuteControllerTest {
         ApiGatewayExecuteController controller = controller(new ObjectMapper());
         Response response = controller.buildProxyResponse(proxyPayload("""
                 {"statusCode":404,"headers":{"content-type":"application/problem+json"},"body":"{}"}
-                """));
+                """), false);
         assertEquals("application/problem+json", response.getMediaType().toString());
     }
 
@@ -143,7 +143,7 @@ class ApiGatewayExecuteControllerTest {
         ApiGatewayExecuteController controller = controller(new ObjectMapper());
         Response response = controller.buildProxyResponse(proxyPayload("""
                 {"statusCode":200,"headers":{"Content-Type":"text/plain"},"body":"hi"}
-                """));
+                """), false);
         assertEquals("text/plain", response.getMediaType().toString());
     }
 
@@ -152,7 +152,7 @@ class ApiGatewayExecuteControllerTest {
         ApiGatewayExecuteController controller = controller(new ObjectMapper());
         Response response = controller.buildProxyResponse(proxyPayload("""
                 {"statusCode":200,"headers":{"CONTENT-TYPE":"application/xml"},"body":"<a/>"}
-                """));
+                """), false);
         assertEquals("application/xml", response.getMediaType().toString());
     }
 
@@ -161,7 +161,7 @@ class ApiGatewayExecuteControllerTest {
         ApiGatewayExecuteController controller = controller(new ObjectMapper());
         Response response = controller.buildProxyResponse(proxyPayload("""
                 {"statusCode":200,"headers":{"X-Other":"value"},"body":"{}"}
-                """));
+                """), false);
         assertEquals("application/json", response.getMediaType().toString());
     }
 
@@ -172,7 +172,7 @@ class ApiGatewayExecuteControllerTest {
         ApiGatewayExecuteController controller = controller(new ObjectMapper());
         Response response = controller.buildProxyResponse(proxyPayload("""
                 {"statusCode":200,"headers":{"content-type":null},"body":"{}"}
-                """));
+                """), false);
         assertEquals("application/json", response.getMediaType().toString());
     }
 
@@ -183,7 +183,7 @@ class ApiGatewayExecuteControllerTest {
         ApiGatewayExecuteController controller = controller(new ObjectMapper());
         Response response = controller.buildProxyResponse(proxyPayload("""
                 {"statusCode":200,"multiValueHeaders":{"content-type":["application/xml"]},"body":"<a/>"}
-                """));
+                """), false);
         assertEquals("application/xml", response.getMediaType().toString());
     }
 
@@ -197,7 +197,7 @@ class ApiGatewayExecuteControllerTest {
                 "headers":{"Content-Type":"text/plain"},\
                 "multiValueHeaders":{"Content-Type":["application/xml"]},\
                 "body":"<a/>"}
-                """));
+                """), false);
         assertEquals("application/xml", response.getMediaType().toString());
     }
 
@@ -305,5 +305,52 @@ class ApiGatewayExecuteControllerTest {
 
         verify(apiGatewayService).resolveRestApiRegion("us-east-1", "restapi1");
         verify(apiGatewayService).getRestApi("ap-southeast-2", "restapi1");
+    }
+
+    @Test
+    void projectsHttpApiV2CookiesAsRepeatedSetCookieHeaders() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ApiGatewayExecuteController controller = controller(objectMapper);
+        InvokeResult result = new InvokeResult(
+                200,
+                null,
+                """
+                {
+                  "statusCode": 200,
+                  "cookies": [
+                    "session=one; Path=/; HttpOnly",
+                    "csrf=two; Path=/; Secure"
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8),
+                null,
+                "request-id");
+
+        try (Response response = controller.buildProxyResponse(result, true)) {
+            assertEquals(
+                    List.of("session=one; Path=/; HttpOnly", "csrf=two; Path=/; Secure"),
+                    response.getStringHeaders().get(HttpHeaders.SET_COOKIE));
+        }
+    }
+
+    @Test
+    void ignoresHttpApiV2CookiesForRestApiV1Responses() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        ApiGatewayExecuteController controller = controller(objectMapper);
+        InvokeResult result = new InvokeResult(
+                200,
+                null,
+                """
+                {
+                  "statusCode": 200,
+                  "cookies": ["session=one; Path=/; HttpOnly"]
+                }
+                """.getBytes(StandardCharsets.UTF_8),
+                null,
+                "request-id");
+
+        try (Response response = controller.buildProxyResponse(result, false)) {
+            assertTrue(response.getStringHeaders().getOrDefault(HttpHeaders.SET_COOKIE, List.of()).isEmpty());
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -308,7 +308,7 @@ class ApiGatewayExecuteControllerTest {
     }
 
     @Test
-    void projectsHttpApiV2CookiesAsRepeatedSetCookieHeaders() {
+    void projectsHttpApiV2CookiesAsRepeatedSetCookieHeadersAlongsideResponseHeaders() {
         ObjectMapper objectMapper = new ObjectMapper();
         ApiGatewayExecuteController controller = controller(objectMapper);
         InvokeResult result = new InvokeResult(
@@ -317,6 +317,9 @@ class ApiGatewayExecuteControllerTest {
                 """
                 {
                   "statusCode": 200,
+                  "headers": {
+                    "X-Trace": "cookie-projection"
+                  },
                   "cookies": [
                     "session=one; Path=/; HttpOnly",
                     "csrf=two; Path=/; Secure"
@@ -330,6 +333,7 @@ class ApiGatewayExecuteControllerTest {
             assertEquals(
                     List.of("session=one; Path=/; HttpOnly", "csrf=two; Path=/; Secure"),
                     response.getStringHeaders().get(HttpHeaders.SET_COOKIE));
+            assertEquals("cookie-projection", response.getHeaderString("X-Trace"));
         }
     }
 
@@ -343,14 +347,26 @@ class ApiGatewayExecuteControllerTest {
                 """
                 {
                   "statusCode": 200,
-                  "cookies": ["session=one; Path=/; HttpOnly"]
+                  "headers": {
+                    "X-Trace": "rest-v1"
+                  },
+                  "multiValueHeaders": {
+                    "Set-Cookie": [
+                      "legacy=one; Path=/; HttpOnly",
+                      "legacy=two; Path=/; Secure"
+                    ]
+                  },
+                  "cookies": ["http-api-v2=ignored; Path=/"]
                 }
                 """.getBytes(StandardCharsets.UTF_8),
                 null,
                 "request-id");
 
         try (Response response = controller.buildProxyResponse(result, false)) {
-            assertTrue(response.getStringHeaders().getOrDefault(HttpHeaders.SET_COOKIE, List.of()).isEmpty());
+            assertEquals(
+                    List.of("legacy=one; Path=/; HttpOnly", "legacy=two; Path=/; Secure"),
+                    response.getStringHeaders().get(HttpHeaders.SET_COOKIE));
+            assertEquals("rest-v1", response.getHeaderString("X-Trace"));
         }
     }
 }


### PR DESCRIPTION
## Summary

Project Lambda proxy response cookies from API Gateway HTTP API payload format v2 as repeated `Set-Cookie` headers, without changing REST API v1 response handling.

## Behavior

| Lambda proxy response | Projected HTTP response |
| --- | --- |
| HTTP API v2 `cookies: ["session=one", "csrf=two"]` | Two separate `Set-Cookie` headers |
| HTTP API v2 `headers` alongside `cookies` | Ordinary headers and cookies are both preserved |
| REST API v1 `cookies` field | Ignored; existing `headers` and `multiValueHeaders` behavior is unchanged |

## Validation

- Focused API Gateway, JWT, and account-routing suite: 51 tests passed.
- `./mvnw test`: 10,845 tests passed, 9 skipped.
