### PR TITLE
feat(elasticache): support cache parameter groups

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/elasticache.bats
+++ b/compatibility-tests/sdk-test-awscli/test/elasticache.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# ElastiCache tests
+
+setup() {
+    load 'test_helper/common-setup'
+    PG="bats-pg-$(unique_name)"
+}
+
+teardown() {
+    aws_cmd elasticache delete-cache-parameter-group --cache-parameter-group-name "$PG" >/dev/null 2>&1 || true
+}
+
+@test "ElastiCache: create, describe, modify and delete a cache parameter group" {
+    run aws_cmd elasticache create-cache-parameter-group \
+        --cache-parameter-group-name "$PG" \
+        --cache-parameter-group-family redis7 \
+        --description "bats parameter group"
+    assert_success
+    [ "$(json_get "$output" '.CacheParameterGroup.CacheParameterGroupName')" = "$PG" ]
+    [ "$(json_get "$output" '.CacheParameterGroup.CacheParameterGroupFamily')" = "redis7" ]
+    [ "$(json_get "$output" '.CacheParameterGroup.Description')" = "bats parameter group" ]
+    [ "$(json_get "$output" '.CacheParameterGroup.IsGlobal')" = "false" ]
+    arn=$(json_get "$output" '.CacheParameterGroup.ARN')
+    [[ "$arn" == *":parametergroup:$PG" ]]
+
+    run aws_cmd elasticache describe-cache-parameter-groups --cache-parameter-group-name "$PG"
+    assert_success
+    [ "$(json_get "$output" '.CacheParameterGroups | length')" = "1" ]
+
+    run aws_cmd elasticache modify-cache-parameter-group \
+        --cache-parameter-group-name "$PG" \
+        --parameter-name-values 'ParameterName=maxmemory-policy,ParameterValue=allkeys-lru'
+    assert_success
+    [ "$(json_get "$output" '.CacheParameterGroupName')" = "$PG" ]
+
+    run aws_cmd elasticache describe-cache-parameters --cache-parameter-group-name "$PG"
+    assert_success
+    [ "$(json_get "$output" '.Parameters[0].ParameterName')" = "maxmemory-policy" ]
+    [ "$(json_get "$output" '.Parameters[0].ParameterValue')" = "allkeys-lru" ]
+    [ "$(json_get "$output" '.Parameters[0].Source')" = "user" ]
+
+    run aws_cmd elasticache delete-cache-parameter-group --cache-parameter-group-name "$PG"
+    assert_success
+
+    run aws_cmd elasticache describe-cache-parameter-groups --cache-parameter-group-name "$PG"
+    assert_failure
+    assert_output --partial "CacheParameterGroupNotFound"
+}
+
+@test "ElastiCache: the default parameter groups AWS publishes are listed" {
+    run aws_cmd elasticache describe-cache-parameter-groups
+    assert_success
+    names=$(json_get "$output" '.CacheParameterGroups[].CacheParameterGroupName')
+    echo "$names" | grep -q '^default\.redis7$'
+    echo "$names" | grep -q '^default\.redis7\.cluster\.on$'
+    echo "$names" | grep -q '^default\.valkey8$'
+
+    run aws_cmd elasticache describe-cache-parameter-groups --cache-parameter-group-name default.redis7
+    assert_success
+    [ "$(json_get "$output" '.CacheParameterGroups[0].CacheParameterGroupFamily')" = "redis7" ]
+}
+
+@test "ElastiCache: a duplicate parameter group is rejected" {
+    aws_cmd elasticache create-cache-parameter-group --cache-parameter-group-name "$PG" \
+        --cache-parameter-group-family redis7 --description first >/dev/null
+
+    run aws_cmd elasticache create-cache-parameter-group --cache-parameter-group-name "$PG" \
+        --cache-parameter-group-family redis7 --description second
+    assert_failure
+    assert_output --partial "CacheParameterGroupAlreadyExists"
+}
+
+@test "ElastiCache: an unknown family is rejected" {
+    run aws_cmd elasticache create-cache-parameter-group \
+        --cache-parameter-group-name "$PG" \
+        --cache-parameter-group-family redis99 --description x
+    assert_failure
+    assert_output --partial "not a valid parameter group family"
+}
+
+@test "ElastiCache: a default parameter group cannot be deleted" {
+    # AWS rejects it on the identifier rule, since a user-supplied name cannot contain dots.
+    run aws_cmd elasticache delete-cache-parameter-group --cache-parameter-group-name default.redis7
+    assert_failure
+    assert_output --partial "not a valid identifier"
+}

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -24,8 +24,24 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
 | `DescribeCacheSubnetGroups` | - |
-| `DescribeCacheParameterGroups` | - |
+| `CreateCacheParameterGroup` | Create a cache parameter group |
+| `DescribeCacheParameterGroups` | List parameter groups, including the AWS defaults |
+| `ModifyCacheParameterGroup` | Set parameters on a group |
+| `DescribeCacheParameters` | List the parameters set on a group |
+| `DeleteCacheParameterGroup` | Delete a cache parameter group |
+| `ListTagsForResource` | Tags on a parameter group ARN |
 <!-- floci:actions:end -->
+
+### Cache Parameter Groups
+
+The `default.*` groups AWS publishes are listed for every family it supports, and cannot be modified
+or deleted — AWS refuses those by the identifier rule, since a name it accepts cannot contain a dot.
+
+floci does not carry AWS's per-family catalogue of parameter names, which runs to dozens per family.
+It therefore stores whatever parameters a caller sets and reports them with source `user`, rather
+than rejecting names a partial catalogue happens to be missing, which would refuse configurations
+AWS accepts. `DescribeCacheParameters` returns those parameters; a request for `system` or
+`engine-default` parameters returns none, and listings are unpaged.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -376,8 +376,16 @@ public class ElastiCacheQueryHandler {
             if (arn.length != 7 || !"arn".equals(arn[0])) {
                 throw new AwsException("InvalidARN", "Input ARN string does not have 7 components.", 400);
             }
-            // The ARN names the resource, so its region and account decide what is being asked
-            // about — reading the trailing name alone would answer for a different resource.
+            // Every component names part of the resource, so each is checked before the name is
+            // used: a partition, service, region or account that is not this one asks about a
+            // different resource, and answering from the trailing name would describe the wrong.
+            if (!"aws".equals(arn[1])) {
+                throw new AwsException("InvalidARN", "partition field is wrong. Expected value is aws", 400);
+            }
+            if (!"elasticache".equals(arn[2])) {
+                throw new AwsException("InvalidARN",
+                        "service field is wrong. Expected value is elasticache", 400);
+            }
             if (!regionResolver.getRegion().equals(arn[3])) {
                 throw new AwsException("InvalidParameterValue",
                         "Unauthorized call. Please check the region or customer id", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.AwsQueryResponse;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.elasticache.model.AuthMode;
 import io.github.hectorvent.floci.services.elasticache.model.CacheCluster;
+import io.github.hectorvent.floci.services.elasticache.model.CacheParameterGroup;
 import io.github.hectorvent.floci.services.elasticache.model.ElastiCacheUser;
 import io.github.hectorvent.floci.services.elasticache.model.Endpoint;
 import io.github.hectorvent.floci.services.elasticache.model.ReplicationGroup;
@@ -20,7 +21,9 @@ import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Query-protocol handler for all ElastiCache actions (form-encoded POST, XML response).
@@ -63,7 +66,12 @@ public class ElastiCacheQueryHandler {
             case "DescribeCacheClusters"      -> handleDescribeCacheClusters(params);
             case "DeleteCacheCluster"         -> handleDeleteCacheCluster(params);
             case "DescribeCacheSubnetGroups"  -> handleDescribeCacheSubnetGroups(params);
+            case "CreateCacheParameterGroup" -> handleCreateCacheParameterGroup(params);
             case "DescribeCacheParameterGroups" -> handleDescribeCacheParameterGroups(params);
+            case "ModifyCacheParameterGroup" -> handleModifyCacheParameterGroup(params);
+            case "DescribeCacheParameters" -> handleDescribeCacheParameters(params);
+            case "DeleteCacheParameterGroup" -> handleDeleteCacheParameterGroup(params);
+            case "ListTagsForResource" -> handleListTagsForResource(params);
             default -> AwsQueryResponse.error("UnsupportedOperation",
                     "Operation " + action + " is not supported.", AwsNamespaces.EC, 400);
         };
@@ -292,11 +300,147 @@ public class ElastiCacheQueryHandler {
         return Response.ok(AwsQueryResponse.envelope("DescribeCacheSubnetGroups", AwsNamespaces.EC, xml.build())).build();
     }
 
+    private Response handleCreateCacheParameterGroup(MultivaluedMap<String, String> params) {
+        try {
+            CacheParameterGroup group = service.createCacheParameterGroup(
+                    params.getFirst("CacheParameterGroupName"),
+                    params.getFirst("CacheParameterGroupFamily"),
+                    params.getFirst("Description"),
+                    parseTags(params));
+            var xml = new XmlBuilder();
+            appendParameterGroup(xml, group);
+            return Response.ok(AwsQueryResponse.envelope("CreateCacheParameterGroup", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
     private Response handleDescribeCacheParameterGroups(MultivaluedMap<String, String> params) {
-        // Cache parameter groups are not modeled by the emulator; return the wire-accurate
-        // empty result so SDK clients get a valid 200 instead of an unsupported-action 400.
-        var xml = new XmlBuilder().start("CacheParameterGroups").end("CacheParameterGroups");
-        return Response.ok(AwsQueryResponse.envelope("DescribeCacheParameterGroups", AwsNamespaces.EC, xml.build())).build();
+        try {
+            List<CacheParameterGroup> groups =
+                    service.describeCacheParameterGroups(params.getFirst("CacheParameterGroupName"));
+            var xml = new XmlBuilder().start("CacheParameterGroups");
+            groups.forEach(group -> appendParameterGroup(xml, group));
+            xml.end("CacheParameterGroups");
+            return Response.ok(AwsQueryResponse.envelope("DescribeCacheParameterGroups", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private Response handleModifyCacheParameterGroup(MultivaluedMap<String, String> params) {
+        try {
+            String name = params.getFirst("CacheParameterGroupName");
+            service.modifyCacheParameterGroup(name, parseParameterNameValues(params));
+            var xml = new XmlBuilder().elem("CacheParameterGroupName", name);
+            return Response.ok(AwsQueryResponse.envelope("ModifyCacheParameterGroup", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private Response handleDescribeCacheParameters(MultivaluedMap<String, String> params) {
+        try {
+            CacheParameterGroup group = service.requireParameterGroup(params.getFirst("CacheParameterGroupName"));
+            // floci stores only what a caller set, so every parameter it can report has source "user".
+            // A request for another source gets the empty list rather than invented defaults.
+            String source = params.getFirst("Source");
+            boolean includeUserParameters = source == null || source.isBlank() || "user".equals(source);
+
+            var xml = new XmlBuilder().start("Parameters");
+            if (includeUserParameters) {
+                group.getParameters().forEach((name, value) -> xml
+                        .start("Parameter")
+                        .elem("ParameterName", name)
+                        .elem("ParameterValue", value)
+                        .elem("Source", "user")
+                        .elem("IsModifiable", true)
+                        .end("Parameter"));
+            }
+            xml.end("Parameters")
+                    .start("CacheNodeTypeSpecificParameters").end("CacheNodeTypeSpecificParameters");
+            return Response.ok(AwsQueryResponse.envelope("DescribeCacheParameters", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    /**
+     * Tags for a resource ARN. Only parameter groups carry tags in floci, so any other ARN reports
+     * none — which is what floci knows, rather than a guess at what AWS would hold.
+     */
+    private Response handleListTagsForResource(MultivaluedMap<String, String> params) {
+        try {
+            String resourceName = params.getFirst("ResourceName");
+            Map<String, String> tags = Map.of();
+            if (resourceName != null && resourceName.contains(":parametergroup:")) {
+                String name = resourceName.substring(resourceName.lastIndexOf(':') + 1);
+                tags = service.requireParameterGroup(name).getTags();
+            }
+            var xml = new XmlBuilder().start("TagList");
+            tags.forEach((key, value) -> xml.start("Tag")
+                    .elem("Key", key)
+                    .elem("Value", value)
+                    .end("Tag"));
+            xml.end("TagList");
+            return Response.ok(AwsQueryResponse.envelope("ListTagsForResource", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private Response handleDeleteCacheParameterGroup(MultivaluedMap<String, String> params) {
+        try {
+            service.deleteCacheParameterGroup(params.getFirst("CacheParameterGroupName"));
+            return Response.ok(AwsQueryResponse.envelope("DeleteCacheParameterGroup", AwsNamespaces.EC, "")).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private void appendParameterGroup(XmlBuilder xml, CacheParameterGroup group) {
+        xml.start("CacheParameterGroup")
+                .elem("CacheParameterGroupName", group.getName())
+                .elem("CacheParameterGroupFamily", group.getFamily())
+                .elem("Description", group.getDescription())
+                .elem("IsGlobal", false)
+                .elem("ARN", parameterGroupArn(group.getName()))
+                .end("CacheParameterGroup");
+    }
+
+    private String parameterGroupArn(String name) {
+        return "arn:aws:elasticache:" + regionResolver.getRegion() + ":"
+                + regionResolver.getAccountId() + ":parametergroup:" + name;
+    }
+
+    /**
+     * Reads a Query-protocol list of pairs under every spelling it arrives in. The member element
+     * takes its name from the shape's {@code locationName} — {@code Tag} and
+     * {@code ParameterNameValue} here, not {@code member} — and SDKs differ, so each is tried.
+     */
+    private static Map<String, String> parsePairs(MultivaluedMap<String, String> params,
+                                                  List<String> prefixes, String keyName, String valueName) {
+        Map<String, String> pairs = new LinkedHashMap<>();
+        for (String prefix : prefixes) {
+            for (int i = 1; ; i++) {
+                String key = params.getFirst(prefix + "." + i + "." + keyName);
+                if (key == null) {
+                    break;
+                }
+                pairs.put(key, params.getFirst(prefix + "." + i + "." + valueName));
+            }
+        }
+        return pairs;
+    }
+
+    private static Map<String, String> parseTags(MultivaluedMap<String, String> params) {
+        return parsePairs(params, List.of("Tags.Tag", "Tags.member", "Tag"), "Key", "Value");
+    }
+
+    private static Map<String, String> parseParameterNameValues(MultivaluedMap<String, String> params) {
+        return parsePairs(params,
+                List.of("ParameterNameValues.ParameterNameValue", "ParameterNameValues.member"),
+                "ParameterName", "ParameterValue");
     }
 
     // ── IAM Token Validation ──────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -372,10 +372,27 @@ public class ElastiCacheQueryHandler {
     private Response handleListTagsForResource(MultivaluedMap<String, String> params) {
         try {
             String resourceName = params.getFirst("ResourceName");
+            String[] arn = resourceName == null ? new String[0] : resourceName.split(":", -1);
+            if (arn.length != 7 || !"arn".equals(arn[0])) {
+                throw new AwsException("InvalidARN", "Input ARN string does not have 7 components.", 400);
+            }
+            // The ARN names the resource, so its region and account decide what is being asked
+            // about — reading the trailing name alone would answer for a different resource.
+            if (!regionResolver.getRegion().equals(arn[3])) {
+                throw new AwsException("InvalidParameterValue",
+                        "Unauthorized call. Please check the region or customer id", 400);
+            }
+            if (!regionResolver.getAccountId().equals(arn[4])) {
+                throw new AwsException("InvalidParameterValue",
+                        "The resource ARN does not belong to the caller's account.", 400);
+            }
+
             Map<String, String> tags = Map.of();
-            if (resourceName != null && resourceName.contains(":parametergroup:")) {
-                String name = resourceName.substring(resourceName.lastIndexOf(':') + 1);
-                tags = service.requireParameterGroup(name).getTags();
+            if ("parametergroup".equals(arn[5])) {
+                tags = service.findParameterGroup(arn[6])
+                        .orElseThrow(() -> new AwsException("CacheParameterGroupNotFound",
+                                arn[6] + " is not present", 404))
+                        .getTags();
             }
             var xml = new XmlBuilder().start("TagList");
             tags.forEach((key, value) -> xml.start("Tag")

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -411,11 +411,20 @@ public class ElastiCacheService {
         return List.of(requireParameterGroup(name));
     }
 
-    public CacheParameterGroup requireParameterGroup(String name) {
+    private static boolean isDefaultParameterGroup(String name) {
+        return defaultParameterGroups().stream().anyMatch(group -> group.getName().equals(name));
+    }
+
+    /** The group by that name, whether stored or one of the published defaults. */
+    public java.util.Optional<CacheParameterGroup> findParameterGroup(String name) {
         return parameterGroups.get(name)
                 .or(() -> defaultParameterGroups().stream()
                         .filter(group -> group.getName().equals(name))
-                        .findFirst())
+                        .findFirst());
+    }
+
+    public CacheParameterGroup requireParameterGroup(String name) {
+        return findParameterGroup(name)
                 .orElseThrow(() -> new AwsException("CacheParameterGroupNotFound",
                         "CacheParameterGroup " + name + " not found.", 404));
     }
@@ -426,13 +435,20 @@ public class ElastiCacheService {
      * missing from a partial catalogue would refuse configurations AWS accepts.
      */
     public void modifyCacheParameterGroup(String name, Map<String, String> parameters) {
-        requireParameterGroup(name);
         synchronized (lockFor(name)) {
             // Read inside the lock: a record resolved before it could have been deleted since, and
             // writing it back would restore the group the delete removed.
-            CacheParameterGroup group = parameterGroups.get(name)
-                    .orElseThrow(() -> new AwsException("InvalidParameterValue",
-                            "The parameter group " + name + " is a default group and cannot be modified.", 400));
+            CacheParameterGroup group = parameterGroups.get(name).orElse(null);
+            if (group == null) {
+                // Absent from the store means one of two different things, and they do not share
+                // an error: a published default was never stored, whereas anything else is gone.
+                if (isDefaultParameterGroup(name)) {
+                    throw new AwsException("InvalidParameterValue",
+                            "The parameter group " + name + " is a default group and cannot be modified.", 400);
+                }
+                throw new AwsException("CacheParameterGroupNotFound",
+                        "CacheParameterGroup " + name + " not found.", 404);
+            }
             Map<String, String> updated = new LinkedHashMap<>(group.getParameters());
             updated.putAll(parameters);
             group.setParameters(updated);

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.model.AuthMode;
+import io.github.hectorvent.floci.services.elasticache.model.CacheParameterGroup;
 import io.github.hectorvent.floci.services.elasticache.model.Endpoint;
 import io.github.hectorvent.floci.services.elasticache.model.ElastiCacheUser;
 import io.github.hectorvent.floci.services.elasticache.model.ReplicationGroup;
@@ -18,12 +19,15 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 
 /**
  * Core ElastiCache business logic — replication groups and users.
@@ -36,11 +40,13 @@ public class ElastiCacheService {
 
     private final StorageBackend<String, ReplicationGroup> groups;
     private final StorageBackend<String, ElastiCacheUser> users;
+    private final StorageBackend<String, CacheParameterGroup> parameterGroups;
     private final ElastiCacheContainerManager containerManager;
     private final ElastiCacheProxyManager proxyManager;
     private final EmulatorConfig config;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
     private final Set<String> provisioningGroupIds = ConcurrentHashMap.newKeySet();
+    private final ConcurrentHashMap<String, Object> parameterGroupLocks = new ConcurrentHashMap<>();
 
     @Inject
     public ElastiCacheService(ElastiCacheContainerManager containerManager,
@@ -54,6 +60,8 @@ public class ElastiCacheService {
                 new TypeReference<Map<String, ReplicationGroup>>() {});
         this.users = storageFactory.create("elasticache", "elasticache-users.json",
                 new TypeReference<Map<String, ElastiCacheUser>>() {});
+        this.parameterGroups = storageFactory.create("elasticache", "elasticache-parameter-groups.json",
+                new TypeReference<Map<String, CacheParameterGroup>>() {});
     }
 
     public ReplicationGroup createReplicationGroup(String groupId, String description,
@@ -311,5 +319,137 @@ public class ElastiCacheService {
 
     private void releaseProxyPort(int port) {
         usedPorts.remove(port);
+    }
+
+    // ── Cache Parameter Groups ────────────────────────────────────────────────
+
+    /** The families AWS accepts, and validates a create against. */
+    private static final List<String> PARAMETER_GROUP_FAMILIES = List.of(
+            "memcached1.4", "memcached1.5", "memcached1.6",
+            "redis2.6", "redis2.8", "redis3.2", "redis4.0", "redis5.0", "redis6.x", "redis7",
+            "valkey7", "valkey8", "valkey9");
+
+    /** The families AWS also publishes a cluster-mode default for. */
+    private static final List<String> CLUSTER_MODE_FAMILIES = List.of(
+            "redis3.2", "redis4.0", "redis5.0", "redis6.x", "redis7", "valkey7", "valkey8", "valkey9");
+
+    /**
+     * Names begin with a letter and hold only letters, digits and single interior hyphens. AWS
+     * applies this to deletes as well as creates, which is why a {@code default.*} group cannot be
+     * deleted: the dot fails this rule before anything looks the group up.
+     */
+    private static final Pattern PARAMETER_GROUP_NAME =
+            Pattern.compile("^[a-zA-Z][a-zA-Z0-9]*(-[a-zA-Z0-9]+)*$");
+
+    /**
+     * The {@code default.*} groups AWS publishes. Derived rather than stored: nothing can modify or
+     * delete them, so persisting them would only add records to migrate, a writer to race, and an
+     * install predating this that needs backfilling.
+     */
+    private static List<CacheParameterGroup> defaultParameterGroups() {
+        List<CacheParameterGroup> defaults = new ArrayList<>();
+        for (String family : PARAMETER_GROUP_FAMILIES) {
+            defaults.add(new CacheParameterGroup("default." + family, family,
+                    "Default parameter group for " + family));
+            if (CLUSTER_MODE_FAMILIES.contains(family)) {
+                defaults.add(new CacheParameterGroup("default." + family + ".cluster.on", family,
+                        "Customized default parameter group for " + family + " with cluster mode on"));
+            }
+        }
+        return defaults;
+    }
+
+    private static void validateParameterGroupName(String name) {
+        if (name == null || name.isBlank() || !PARAMETER_GROUP_NAME.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "The parameter CacheParameterGroupName is not a valid identifier. Identifiers must "
+                            + "begin with a letter; must contain only ASCII letters, digits, and hyphens; "
+                            + "and must not end with a hyphen or contain two consecutive hyphens.", 400);
+        }
+    }
+
+    /**
+     * One monitor per group name, taken by every writer before it reads. Guarding the record itself
+     * would be too late: a create has no record yet, so two of them could both pass the existence
+     * check, and a modify that resolved its record before locking would write back one a concurrent
+     * delete had already removed.
+     */
+    private Object lockFor(String parameterGroupName) {
+        return parameterGroupLocks.computeIfAbsent(parameterGroupName, key -> new Object());
+    }
+
+    public CacheParameterGroup createCacheParameterGroup(String name, String family,
+                                                         String description, Map<String, String> tags) {
+        validateParameterGroupName(name);
+        if (family == null || !PARAMETER_GROUP_FAMILIES.contains(family)) {
+            throw new AwsException("InvalidParameterValue",
+                    "CacheParameterGroupFamily " + family + " is not a valid parameter group family.", 400);
+        }
+
+        synchronized (lockFor(name)) {
+            if (parameterGroups.get(name).isPresent()) {
+                throw new AwsException("CacheParameterGroupAlreadyExists",
+                        "Parameter group " + name + " already exists", 400);
+            }
+            CacheParameterGroup group = new CacheParameterGroup(name, family, description);
+            if (tags != null) {
+                group.setTags(new LinkedHashMap<>(tags));
+            }
+            parameterGroups.put(name, group);
+            LOG.infov("Created cache parameter group {0} ({1})", name, family);
+            return group;
+        }
+    }
+
+    /** Every group, or the one named. The published defaults are listed, as AWS lists them. */
+    public List<CacheParameterGroup> describeCacheParameterGroups(String name) {
+        if (name == null || name.isBlank()) {
+            List<CacheParameterGroup> all = new ArrayList<>(defaultParameterGroups());
+            all.addAll(parameterGroups.scan(key -> true));
+            return all;
+        }
+        return List.of(requireParameterGroup(name));
+    }
+
+    public CacheParameterGroup requireParameterGroup(String name) {
+        return parameterGroups.get(name)
+                .or(() -> defaultParameterGroups().stream()
+                        .filter(group -> group.getName().equals(name))
+                        .findFirst())
+                .orElseThrow(() -> new AwsException("CacheParameterGroupNotFound",
+                        "CacheParameterGroup " + name + " not found.", 404));
+    }
+
+    /**
+     * Records the parameters a caller sets. floci does not carry AWS's per-family catalogue of
+     * parameter names, so it cannot tell a real name from a typo and does not try: rejecting names
+     * missing from a partial catalogue would refuse configurations AWS accepts.
+     */
+    public void modifyCacheParameterGroup(String name, Map<String, String> parameters) {
+        requireParameterGroup(name);
+        synchronized (lockFor(name)) {
+            // Read inside the lock: a record resolved before it could have been deleted since, and
+            // writing it back would restore the group the delete removed.
+            CacheParameterGroup group = parameterGroups.get(name)
+                    .orElseThrow(() -> new AwsException("InvalidParameterValue",
+                            "The parameter group " + name + " is a default group and cannot be modified.", 400));
+            Map<String, String> updated = new LinkedHashMap<>(group.getParameters());
+            updated.putAll(parameters);
+            group.setParameters(updated);
+            parameterGroups.put(name, group);
+        }
+        LOG.debugv("Modified {0} parameter(s) on cache parameter group {1}", parameters.size(), name);
+    }
+
+    public void deleteCacheParameterGroup(String name) {
+        validateParameterGroupName(name);
+        synchronized (lockFor(name)) {
+            if (parameterGroups.get(name).isEmpty()) {
+                throw new AwsException("CacheParameterGroupNotFound",
+                        "CacheParameterGroupnot found: " + name, 404);
+            }
+            parameterGroups.delete(name);
+        }
+        LOG.infov("Deleted cache parameter group {0}", name);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -447,7 +447,7 @@ public class ElastiCacheService {
                             "The parameter group " + name + " is a default group and cannot be modified.", 400);
                 }
                 throw new AwsException("CacheParameterGroupNotFound",
-                        "CacheParameterGroup " + name + " not found.", 404);
+                        "CacheParameterGroup not found: " + name, 404);
             }
             Map<String, String> updated = new LinkedHashMap<>(group.getParameters());
             updated.putAll(parameters);
@@ -461,6 +461,10 @@ public class ElastiCacheService {
         validateParameterGroupName(name);
         synchronized (lockFor(name)) {
             if (parameterGroups.get(name).isEmpty()) {
+                // AWS emits this without the space after the type name. Deliberately not
+                // corrected: matching it is the point, and each action words this differently —
+                // describe says "CacheParameterGroup <name> not found." and modify says
+                // "CacheParameterGroup not found: <name>".
                 throw new AwsException("CacheParameterGroupNotFound",
                         "CacheParameterGroupnot found: " + name, 404);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/CacheParameterGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/CacheParameterGroup.java
@@ -1,0 +1,47 @@
+package io.github.hectorvent.floci.services.elasticache.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CacheParameterGroup {
+
+    private String name;
+    private String family;
+    private String description;
+    /** Only the parameters a caller set; floci does not carry AWS's per-family defaults. */
+    private Map<String, String> parameters = new LinkedHashMap<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    public CacheParameterGroup() {
+    }
+
+    public CacheParameterGroup(String name, String family, String description) {
+        this.name = name;
+        this.family = family;
+        this.description = description;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getFamily() { return family; }
+    public void setFamily(String family) { this.family = family; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public Map<String, String> getParameters() { return parameters; }
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters == null ? new LinkedHashMap<>() : parameters;
+    }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : tags;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/CacheParameterGroupConcurrencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/CacheParameterGroupConcurrencyTest.java
@@ -1,0 +1,135 @@
+package io.github.hectorvent.floci.services.elasticache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.elasticache.model.CacheParameterGroup;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The write paths of a cache parameter group: only one create of a name can win, a modify cannot
+ * restore a group deleted alongside it, and a stored group survives being written and read back.
+ */
+@QuarkusTest
+class CacheParameterGroupConcurrencyTest {
+
+    @Inject
+    ElastiCacheService service;
+
+    @Test
+    void onlyOneConcurrentCreateOfANameSucceeds() {
+        // Without a lock held across the existence check and the write, both creates see no group
+        // and both succeed, so a duplicate never reports one.
+        String name = "concurrent-create-pg";
+        var pool = Executors.newFixedThreadPool(8);
+        var start = new CountDownLatch(1);
+        var created = new AtomicInteger();
+        var rejected = new AtomicInteger();
+        try {
+            List<Future<Object>> attempts = java.util.stream.IntStream.range(0, 8)
+                    .mapToObj(i -> pool.submit(() -> {
+                        start.await();
+                        try {
+                            service.createCacheParameterGroup(name, "redis7", "concurrent", Map.of());
+                            created.incrementAndGet();
+                        } catch (AwsException e) {
+                            assertEquals("CacheParameterGroupAlreadyExists", e.getErrorCode());
+                            rejected.incrementAndGet();
+                        }
+                        return null;
+                    }))
+                    .toList();
+            start.countDown();
+            for (Future<Object> attempt : attempts) {
+                attempt.get(30, TimeUnit.SECONDS);
+            }
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertEquals(1, created.get(), "more than one create of the same name was accepted");
+        assertEquals(7, rejected.get());
+        service.deleteCacheParameterGroup(name);
+    }
+
+    @Test
+    void aModifyCannotRestoreAGroupThatWasDeleted() throws Exception {
+        // The modify reads its record inside the lock, so a delete that got there first leaves it
+        // with nothing to write back.
+        String name = "modify-delete-race-pg";
+        var pool = Executors.newFixedThreadPool(2);
+        try {
+            for (int attempt = 0; attempt < 40; attempt++) {
+                service.createCacheParameterGroup(name, "redis7", "race", Map.of());
+                var start = new CountDownLatch(1);
+
+                Future<?> modify = pool.submit(() -> {
+                    start.await();
+                    try {
+                        service.modifyCacheParameterGroup(name, Map.of("maxmemory-policy", "allkeys-lru"));
+                    } catch (AwsException expectedWhenDeleteWon) {
+                        // The delete got there first, which is a legitimate outcome.
+                    }
+                    return null;
+                });
+                Future<?> delete = pool.submit(() -> {
+                    start.await();
+                    service.deleteCacheParameterGroup(name);
+                    return null;
+                });
+
+                start.countDown();
+                modify.get(30, TimeUnit.SECONDS);
+                delete.get(30, TimeUnit.SECONDS);
+
+                AwsException gone = assertThrows(AwsException.class,
+                        () -> service.requireParameterGroup(name),
+                        "the deleted parameter group was restored by a concurrent modify");
+                assertEquals("CacheParameterGroupNotFound", gone.getErrorCode());
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void aGroupSurvivesBeingWrittenAndReadBack() throws Exception {
+        // The records are persisted as JSON, so what a restart reloads has to carry the parameters
+        // and tags that were set — and a record written before either field existed still has to
+        // load.
+        ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+        CacheParameterGroup group = new CacheParameterGroup("persisted-pg", "redis7", "persisted");
+        group.setParameters(new java.util.LinkedHashMap<>(Map.of("maxmemory-policy", "allkeys-lru")));
+        group.setTags(new java.util.LinkedHashMap<>(Map.of("env", "prod")));
+
+        Map<String, CacheParameterGroup> reloaded = mapper.readValue(
+                mapper.writeValueAsString(Map.of("persisted-pg", group)),
+                new TypeReference<Map<String, CacheParameterGroup>>() {});
+
+        CacheParameterGroup restored = reloaded.get("persisted-pg");
+        assertEquals("redis7", restored.getFamily());
+        assertEquals("allkeys-lru", restored.getParameters().get("maxmemory-policy"));
+        assertEquals("prod", restored.getTags().get("env"));
+
+        CacheParameterGroup legacy = mapper.readValue(
+                "{\"name\":\"old-pg\",\"family\":\"redis7\"}", CacheParameterGroup.class);
+        assertTrue(legacy.getParameters().isEmpty(), "a record without parameters must load with none");
+        assertTrue(legacy.getTags().isEmpty(), "a record without tags must load with none");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/CacheParameterGroupConcurrencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/CacheParameterGroupConcurrencyTest.java
@@ -83,8 +83,12 @@ class CacheParameterGroupConcurrencyTest {
                     start.await();
                     try {
                         service.modifyCacheParameterGroup(name, Map.of("maxmemory-policy", "allkeys-lru"));
-                    } catch (AwsException expectedWhenDeleteWon) {
-                        // The delete got there first, which is a legitimate outcome.
+                    } catch (AwsException e) {
+                        // Losing the race is a legitimate outcome, but only with this error: any
+                        // other one would be a real failure hiding inside the tolerated case.
+                        assertEquals("CacheParameterGroupNotFound", e.getErrorCode(),
+                                "modify losing the race to delete reported " + e.getErrorCode()
+                                        + ": " + e.getMessage());
                     }
                     return null;
                 });
@@ -106,6 +110,24 @@ class CacheParameterGroupConcurrencyTest {
         } finally {
             pool.shutdownNow();
         }
+    }
+
+    @Test
+    void modifyReportsWhichThingIsActuallyWrong() {
+        // Absent from the store covers two different situations, and the race test only sees the
+        // second one when it happens to lose the race, so both are asserted directly here.
+        service.createCacheParameterGroup("gone-pg", "redis7", "deleted below", Map.of());
+        service.deleteCacheParameterGroup("gone-pg");
+
+        AwsException deleted = assertThrows(AwsException.class,
+                () -> service.modifyCacheParameterGroup("gone-pg", Map.of("maxmemory-policy", "noeviction")));
+        assertEquals("CacheParameterGroupNotFound", deleted.getErrorCode(),
+                "a group that was deleted must not be reported as a default group");
+
+        AwsException published = assertThrows(AwsException.class,
+                () -> service.modifyCacheParameterGroup("default.redis7", Map.of("maxmemory-policy", "noeviction")));
+        assertEquals("InvalidParameterValue", published.getErrorCode());
+        assertTrue(published.getMessage().contains("default group"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
@@ -239,6 +239,36 @@ class ElastiCacheParameterGroupIntegrationTest {
     }
 
     @Test
+    @Order(4)
+    void eachActionWordsItsNotFoundTheWayAwsWordsIt() {
+        // Three actions, three different sentences on a live account — including a delete that
+        // omits the space after the type name. They are pinned here so the odd one cannot be
+        // tidied into the others by someone reading it as a typo.
+        query("DescribeCacheParameterGroups")
+                .formParam("CacheParameterGroupName", "absent-pg")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("CacheParameterGroup absent-pg not found."));
+
+        query("ModifyCacheParameterGroup")
+                .formParam("CacheParameterGroupName", "absent-pg")
+                .formParam("ParameterNameValues.ParameterNameValue.1.ParameterName", "maxmemory-policy")
+                .formParam("ParameterNameValues.ParameterNameValue.1.ParameterValue", "noeviction")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("CacheParameterGroup not found: absent-pg"));
+
+        query("DeleteCacheParameterGroup")
+                .formParam("CacheParameterGroupName", "absent-pg")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("CacheParameterGroupnot found: absent-pg"));
+    }
+
+    @Test
     @Order(5)
     void deleteRemovesItAndTheSecondDeleteReportsItMissing() {
         query("DeleteCacheParameterGroup")

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
@@ -1,0 +1,217 @@
+package io.github.hectorvent.floci.services.elasticache;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Cache parameter groups over the Query protocol.
+ *
+ * <p>Behaviour follows a live account: the create response and its ARN, the error each rejection
+ * carries, and the {@code default.*} groups AWS publishes. What floci does not carry is AWS's
+ * per-family catalogue of parameter names, so it stores what a caller sets and reports it as
+ * {@code user} — rejecting names absent from a partial catalogue would refuse configurations AWS
+ * accepts.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ElastiCacheParameterGroupIntegrationTest {
+
+    private static final String GROUP = "int-test-pg";
+    // The router picks the service out of the credential scope, so every request carries it.
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/elasticache/aws4_request";
+
+    private static io.restassured.specification.RequestSpecification query(String action) {
+        return given()
+                .header("Authorization", AUTH_HEADER)
+                .formParam("Action", action)
+                .formParam("Version", "2015-02-02");
+    }
+
+    @Test
+    @Order(1)
+    void createReturnsTheGroupAndItsArn() {
+        query("CreateCacheParameterGroup")
+                .formParam("CacheParameterGroupName", GROUP)
+                .formParam("CacheParameterGroupFamily", "redis7")
+                .formParam("Description", "integration test")
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "prod")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CacheParameterGroupName>" + GROUP + "</CacheParameterGroupName>"))
+            .body(containsString("<CacheParameterGroupFamily>redis7</CacheParameterGroupFamily>"))
+            .body(containsString("<IsGlobal>false</IsGlobal>"))
+            .body(containsString(":parametergroup:" + GROUP + "</ARN>"));
+    }
+
+    @Test
+    @Order(2)
+    void duplicateIsRejected() {
+        query("CreateCacheParameterGroup")
+                .formParam("CacheParameterGroupName", GROUP)
+                .formParam("CacheParameterGroupFamily", "redis7")
+                .formParam("Description", "again")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("CacheParameterGroupAlreadyExists"))
+            // The Query protocol answers in XML; a JSON error here would be unparseable to an SDK.
+            .body(containsString("<Error>"));
+    }
+
+    @Test
+    @Order(2)
+    void anUnknownFamilyIsRejected() {
+        query("CreateCacheParameterGroup")
+                .formParam("CacheParameterGroupName", "bad-family-pg")
+                .formParam("CacheParameterGroupFamily", "redis99")
+                .formParam("Description", "x")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("not a valid parameter group family"));
+    }
+
+    @Test
+    @Order(2)
+    void anInvalidNameIsRejected() {
+        for (String invalid : new String[]{"1leading-digit", "trailing-", "double--hyphen", "has.dot"}) {
+            query("CreateCacheParameterGroup")
+                    .formParam("CacheParameterGroupName", invalid)
+                    .formParam("CacheParameterGroupFamily", "redis7")
+                    .formParam("Description", "x")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("not a valid identifier"));
+        }
+    }
+
+    @Test
+    @Order(3)
+    void modifyStoresTheParametersAndDescribeReportsThem() {
+        query("ModifyCacheParameterGroup")
+                .formParam("CacheParameterGroupName", GROUP)
+                .formParam("ParameterNameValues.ParameterNameValue.1.ParameterName", "maxmemory-policy")
+                .formParam("ParameterNameValues.ParameterNameValue.1.ParameterValue", "allkeys-lru")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CacheParameterGroupName>" + GROUP + "</CacheParameterGroupName>"));
+
+        query("DescribeCacheParameters")
+                .formParam("CacheParameterGroupName", GROUP)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ParameterName>maxmemory-policy</ParameterName>"))
+            .body(containsString("<ParameterValue>allkeys-lru</ParameterValue>"))
+            .body(containsString("<Source>user</Source>"));
+    }
+
+    @Test
+    @Order(3)
+    void describeParametersHonoursTheSourceFilter() {
+        // floci holds no system defaults, so a request for them reports none rather than
+        // returning the user's parameters under the wrong source.
+        query("DescribeCacheParameters")
+                .formParam("CacheParameterGroupName", GROUP)
+                .formParam("Source", "system")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<ParameterName>")));
+    }
+
+    @Test
+    @Order(3)
+    void tagsSurviveTheCreateAndAreListed() {
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:elasticache:us-east-1:000000000000:parametergroup:" + GROUP)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"))
+            .body(containsString("<Value>prod</Value>"));
+    }
+
+    @Test
+    @Order(4)
+    void theDefaultGroupsArePublished() {
+        query("DescribeCacheParameterGroups")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CacheParameterGroupName>default.redis7</CacheParameterGroupName>"))
+            .body(containsString("<CacheParameterGroupName>default.redis7.cluster.on</CacheParameterGroupName>"))
+            .body(containsString("<CacheParameterGroupName>default.valkey8</CacheParameterGroupName>"))
+            .body(containsString("<CacheParameterGroupName>" + GROUP + "</CacheParameterGroupName>"));
+    }
+
+    @Test
+    @Order(4)
+    void aDefaultGroupCannotBeModifiedOrDeleted() {
+        query("ModifyCacheParameterGroup")
+                .formParam("CacheParameterGroupName", "default.redis7")
+                .formParam("ParameterNameValues.ParameterNameValue.1.ParameterName", "maxmemory-policy")
+                .formParam("ParameterNameValues.ParameterNameValue.1.ParameterValue", "noeviction")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400);
+
+        // AWS rejects the delete on the identifier rule, since a name cannot contain dots.
+        query("DeleteCacheParameterGroup")
+                .formParam("CacheParameterGroupName", "default.redis7")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("not a valid identifier"));
+    }
+
+    @Test
+    @Order(5)
+    void deleteRemovesItAndTheSecondDeleteReportsItMissing() {
+        query("DeleteCacheParameterGroup")
+                .formParam("CacheParameterGroupName", GROUP)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        query("DescribeCacheParameterGroups")
+                .formParam("CacheParameterGroupName", GROUP)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("CacheParameterGroupNotFound"));
+
+        query("DeleteCacheParameterGroup")
+                .formParam("CacheParameterGroupName", GROUP)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("CacheParameterGroupNotFound"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
@@ -153,6 +153,40 @@ class ElastiCacheParameterGroupIntegrationTest {
     }
 
     @Test
+    @Order(3)
+    void tagsAreAnsweredForTheArnThatWasAskedAbout() {
+        // Reading the trailing name alone would answer with this caller's group for an ARN naming
+        // another account or region. Each rejection is the one AWS gives.
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:elasticache:eu-west-1:000000000000:parametergroup:" + GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("Please check the region"));
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:elasticache:us-east-1:111122223333:parametergroup:" + GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("does not belong to the caller"));
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", "not-an-arn")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("does not have 7 components"));
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:elasticache:us-east-1:000000000000:parametergroup:no-such-pg")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("no-such-pg is not present"));
+    }
+
+    @Test
     @Order(4)
     void theDefaultGroupsArePublished() {
         query("DescribeCacheParameterGroups")

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
@@ -178,6 +178,22 @@ class ElastiCacheParameterGroupIntegrationTest {
             .statusCode(400)
             .body(containsString("does not have 7 components"));
 
+        // An ARN in another service's namespace names another resource, however familiar the
+        // trailing name looks.
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:rds:us-east-1:000000000000:parametergroup:" + GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("service field is wrong"));
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws-cn:elasticache:us-east-1:000000000000:parametergroup:" + GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("partition field is wrong"));
+
         query("ListTagsForResource")
                 .formParam("ResourceName", "arn:aws:elasticache:us-east-1:000000000000:parametergroup:no-such-pg")
         .when().post("/")


### PR DESCRIPTION
Closes #2375.

## Problem

`CreateCacheParameterGroup` is unsupported, so `aws_elasticache_parameter_group` cannot be
created at all — and most Redis modules set at least `maxmemory-policy`. `DescribeCacheParameterGroups`
existed as a stub that returned an empty list whatever was asked of it, so the `default.*`
groups a module references were invisible too.

## Change

The group surface over the Query protocol: `CreateCacheParameterGroup`,
`DescribeCacheParameterGroups`, `ModifyCacheParameterGroup`, `DescribeCacheParameters`,
`DeleteCacheParameterGroup`, plus `ListTagsForResource` for a parameter group ARN —
without it the tags a create carries would be stored and never readable.

The `default.*` groups are derived rather than stored. Nothing can modify or delete them, so
persisting them would only add records to migrate and a writer to race.

## Verified against AWS

| | AWS |
| --- | --- |
| Create response | name, family, description, `IsGlobal: false`, `…:parametergroup:<name>` |
| Duplicate | `CacheParameterGroupAlreadyExists` — *Parameter group X already exists* |
| Unknown group | `CacheParameterGroupNotFound` — *CacheParameterGroup X not found.* |
| Second delete | `CacheParameterGroupNotFound` — *CacheParameterGroupnot found: X* (AWS's own wording, and it differs from describe's) |
| Unknown family | `InvalidParameterValue` — *…redis99 is not a valid parameter group family.* |
| `default.*` name | rejected by the identifier rule — a name cannot contain a dot, which is also how AWS refuses to delete a default group |
| Modify | returns `{CacheParameterGroupName}`; the parameter reads back with `Source: user` |
| 21 default groups | across 13 families, including the `.cluster.on` variants |

## Concurrency

Every writer takes one monitor keyed by the group name **before it reads**. Guarding the record
cannot serve a create, which has no record yet — two of them would both pass the existence check.
And a modify that resolved its record before locking would write back a group a concurrent delete
had already removed. Both are covered by tests that fail when the lock is moved or dropped.

## Deliberate deviations

floci does not carry AWS's per-family catalogue of parameter names, which runs to dozens per
family. It stores what a caller sets and reports it with `Source: user`; rejecting names missing
from a partial catalogue would refuse configurations AWS accepts. A request for `system`
parameters therefore returns none rather than reporting user parameters under another source,
and listings are unpaged. Documented in `docs/services/elasticache.md`.

Group names are keyed per account and not per region, matching how this service already stores
replication groups and users rather than giving one resource its own scoping.

## Not verified

Whether `CreateCacheCluster` validates a referenced parameter group. floci ignores the field
today, so this PR does not change it.
