### PR TITLE
fix(apigateway): compile the trailing-slash tests against the current controller

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2AuthorizerEventTrailingSlashTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2AuthorizerEventTrailingSlashTest.java
@@ -46,7 +46,7 @@ class BuildV2AuthorizerEventTrailingSlashTest {
         controller = new ApiGatewayExecuteController(
                 null, null, null,
                 regionResolver, new ObjectMapper(), null,
-                null, null, null, null, new ApiGatewayExecuteRouteContext(), null
+                null, null, null, null, new ApiGatewayExecuteRouteContext(), null, null
         );
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventTrailingSlashTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventTrailingSlashTest.java
@@ -45,7 +45,7 @@ class BuildV2ProxyEventTrailingSlashTest {
         controller = new ApiGatewayExecuteController(
                 null, null, null,
                 regionResolver, new ObjectMapper(), null,
-                null, null, null, null, new ApiGatewayExecuteRouteContext(), null
+                null, null, null, null, new ApiGatewayExecuteRouteContext(), null, null
         );
     }
 


### PR DESCRIPTION
`main` does not compile its test sources, so CI is red on `main` itself and on every open PR.

`ApiGatewayExecuteController` gained a `RequestContext` parameter in #2377. The two tests added by
#2367 were written before that change and merged after it, so they construct the controller with
one argument too few:

```
[ERROR] BuildV2ProxyEventTrailingSlashTest.java:[45,22] constructor ApiGatewayExecuteController
        cannot be applied to given types;
[ERROR]   reason: actual and formal argument lists differ in length
```

This adds the missing argument to both, exactly as #2377 did for the sibling tests
(`BuildV2ProxyEventJwtClaimsTest` and the others already pass `…, new ApiGatewayExecuteRouteContext(), null, null`).

No behaviour changes — test sources only. `./mvnw test-compile` passes on this branch, where it
fails on `main`.
