### PR TITLE
fix(apigateway): pass RequestContext to ApiGatewayExecuteController in trailing-slash tests

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2AuthorizerEventTrailingSlashTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2AuthorizerEventTrailingSlashTest.java
@@ -46,7 +46,8 @@ class BuildV2AuthorizerEventTrailingSlashTest {
         controller = new ApiGatewayExecuteController(
                 null, null, null,
                 regionResolver, new ObjectMapper(), null,
-                null, null, null, null, new ApiGatewayExecuteRouteContext(), null
+                null, null, null, null, new ApiGatewayExecuteRouteContext(), null,
+                null
         );
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventTrailingSlashTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventTrailingSlashTest.java
@@ -45,7 +45,8 @@ class BuildV2ProxyEventTrailingSlashTest {
         controller = new ApiGatewayExecuteController(
                 null, null, null,
                 regionResolver, new ObjectMapper(), null,
-                null, null, null, null, new ApiGatewayExecuteRouteContext(), null
+                null, null, null, null, new ApiGatewayExecuteRouteContext(), null,
+                null
         );
     }
 


### PR DESCRIPTION
## Problem

CI has been failing on `main` since 64696375 (#2367). Build error:

```
[ERROR] BuildV2AuthorizerEventTrailingSlashTest.java:[46,22] constructor ApiGatewayExecuteController
in class io.github.hectorvent.floci.services.apigateway.ApiGatewayExecuteController cannot be applied
to given types; reason: actual and formal argument lists differ in length
```

#2377 added a trailing `RequestContext requestContext` parameter to `ApiGatewayExecuteController`'s
constructor. #2367's branch was opened before that and never rebased, so its two new test files
(`BuildV2AuthorizerEventTrailingSlashTest`, `BuildV2ProxyEventTrailingSlashTest`) still call the
constructor with the old 12-argument list. Neither PR touched the same line of the constructor
declaration, so git's merge produced no conflict marker on either side — the break only shows up at
compile time.

## Fix

Pass `null` as the 13th argument in both files, matching the existing pattern of nulling out
dependencies these tests don't exercise (`requestContext` is only read by `execute()`'s dispatch
path, never by `buildRequestAuthorizerEventV1`/`buildV2ProxyEvent`, which is all these tests call).

## Verification

```
./mvnw test-compile          # now succeeds
./mvnw test -Dtest='io.github.hectorvent.floci.services.apigateway.**,io.github.hectorvent.floci.services.apigatewayv2.**'
Tests run: 868, Failures: 0, Errors: 0
```