### PR TITLE
feat(elasticache): support cache subnet groups

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/elasticache.bats
+++ b/compatibility-tests/sdk-test-awscli/test/elasticache.bats
@@ -84,3 +84,34 @@ teardown() {
     assert_failure
     assert_output --partial "not a valid identifier"
 }
+
+@test "ElastiCache: cache subnet group takes its VPC and zones from the subnets" {
+    vpc=$(aws_cmd ec2 create-vpc --cidr-block 10.30.0.0/16 --query 'Vpc.VpcId' --output text)
+    a=$(aws_cmd ec2 create-subnet --vpc-id "$vpc" --cidr-block 10.30.1.0/24 \
+        --availability-zone us-east-1a --query 'Subnet.SubnetId' --output text)
+    b=$(aws_cmd ec2 create-subnet --vpc-id "$vpc" --cidr-block 10.30.2.0/24 \
+        --availability-zone us-east-1b --query 'Subnet.SubnetId' --output text)
+    SNG="bats-sng-$(unique_name)"
+
+    run aws_cmd elasticache create-cache-subnet-group \
+        --cache-subnet-group-name "$SNG" \
+        --cache-subnet-group-description "bats subnet group" \
+        --subnet-ids "$a" "$b"
+    assert_success
+    [ "$(json_get "$output" '.CacheSubnetGroup.VpcId')" = "$vpc" ]
+    [ "$(json_get "$output" '.CacheSubnetGroup.Subnets | length')" = "2" ]
+    [ "$(json_get "$output" '.CacheSubnetGroup.Subnets[0].SubnetAvailabilityZone.Name')" = "us-east-1a" ]
+
+    run aws_cmd elasticache describe-cache-subnet-groups --cache-subnet-group-name "$SNG"
+    assert_success
+    [ "$(json_get "$output" '.CacheSubnetGroups[0].CacheSubnetGroupName')" = "$SNG" ]
+
+    run aws_cmd elasticache create-cache-subnet-group \
+        --cache-subnet-group-name "bats-absent-$(unique_name)" \
+        --cache-subnet-group-description x --subnet-ids subnet-00000000000000000
+    assert_failure
+    assert_output --partial "are invalid"
+
+    run aws_cmd elasticache delete-cache-subnet-group --cache-subnet-group-name "$SNG"
+    assert_success
+}

--- a/compatibility-tests/sdk-test-awscli/test/elasticache.bats
+++ b/compatibility-tests/sdk-test-awscli/test/elasticache.bats
@@ -115,3 +115,25 @@ teardown() {
     run aws_cmd elasticache delete-cache-subnet-group --cache-subnet-group-name "$SNG"
     assert_success
 }
+
+@test "ElastiCache: a cache subnet group is built from subnets in the caller's region" {
+    # Subnets exist in the region they were created in. Resolving them in the configured default
+    # region instead rejects a caller's own subnets as invalid.
+    export AWS_DEFAULT_REGION=eu-west-1
+    vpc=$(aws_cmd ec2 create-vpc --cidr-block 10.31.0.0/16 --query 'Vpc.VpcId' --output text)
+    s=$(aws_cmd ec2 create-subnet --vpc-id "$vpc" --cidr-block 10.31.1.0/24 \
+        --availability-zone eu-west-1a --query 'Subnet.SubnetId' --output text)
+    SNG_EU="bats-sng-eu-$(unique_name)"
+
+    run aws_cmd elasticache create-cache-subnet-group \
+        --cache-subnet-group-name "$SNG_EU" \
+        --cache-subnet-group-description "bats other region" \
+        --subnet-ids "$s"
+    assert_success
+    [ "$(json_get "$output" '.CacheSubnetGroup.VpcId')" = "$vpc" ]
+    [ "$(json_get "$output" '.CacheSubnetGroup.Subnets[0].SubnetAvailabilityZone.Name')" = "eu-west-1a" ]
+    [[ "$(json_get "$output" '.CacheSubnetGroup.ARN')" == arn:aws:elasticache:eu-west-1:* ]]
+
+    run aws_cmd elasticache delete-cache-subnet-group --cache-subnet-group-name "$SNG_EU"
+    assert_success
+}

--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -23,7 +23,10 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `CreateCacheCluster` | - |
 | `DescribeCacheClusters` | - |
 | `DeleteCacheCluster` | - |
-| `DescribeCacheSubnetGroups` | - |
+| `CreateCacheSubnetGroup` | Create a cache subnet group |
+| `DescribeCacheSubnetGroups` | List cache subnet groups |
+| `ModifyCacheSubnetGroup` | Replace a group's description or subnets |
+| `DeleteCacheSubnetGroup` | Delete a cache subnet group |
 | `CreateCacheParameterGroup` | Create a cache parameter group |
 | `DescribeCacheParameterGroups` | List parameter groups, including the AWS defaults |
 | `ModifyCacheParameterGroup` | Set parameters on a group |
@@ -31,6 +34,12 @@ Floci manages real Valkey/Redis Docker containers and proxies TCP connections to
 | `DeleteCacheParameterGroup` | Delete a cache parameter group |
 | `ListTagsForResource` | Tags on a parameter group ARN |
 <!-- floci:actions:end -->
+
+### Cache Subnet Groups
+
+A subnet group's VPC and each subnet's availability zone are read from the subnets themselves, as
+AWS reads them, so the subnets have to exist in the emulator's EC2 first. Subnets that are unknown,
+or that span more than one VPC, are refused the way AWS refuses them.
 
 ### Cache Parameter Groups
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.elasticache.model.AuthMode;
 import io.github.hectorvent.floci.services.elasticache.model.CacheCluster;
 import io.github.hectorvent.floci.services.elasticache.model.CacheParameterGroup;
+import io.github.hectorvent.floci.services.elasticache.model.CacheSubnetGroup;
 import io.github.hectorvent.floci.services.elasticache.model.ElastiCacheUser;
 import io.github.hectorvent.floci.services.elasticache.model.Endpoint;
 import io.github.hectorvent.floci.services.elasticache.model.ReplicationGroup;
@@ -65,7 +66,10 @@ public class ElastiCacheQueryHandler {
             case "CreateCacheCluster"         -> handleCreateCacheCluster(params);
             case "DescribeCacheClusters"      -> handleDescribeCacheClusters(params);
             case "DeleteCacheCluster"         -> handleDeleteCacheCluster(params);
+            case "CreateCacheSubnetGroup"     -> handleCreateCacheSubnetGroup(params);
             case "DescribeCacheSubnetGroups"  -> handleDescribeCacheSubnetGroups(params);
+            case "ModifyCacheSubnetGroup"     -> handleModifyCacheSubnetGroup(params);
+            case "DeleteCacheSubnetGroup"     -> handleDeleteCacheSubnetGroup(params);
             case "CreateCacheParameterGroup" -> handleCreateCacheParameterGroup(params);
             case "DescribeCacheParameterGroups" -> handleDescribeCacheParameterGroups(params);
             case "ModifyCacheParameterGroup" -> handleModifyCacheParameterGroup(params);
@@ -293,14 +297,92 @@ public class ElastiCacheQueryHandler {
 
     // ── Subnet / Parameter Groups (read-only describes for resources not modeled) ────
 
-    private Response handleDescribeCacheSubnetGroups(MultivaluedMap<String, String> params) {
-        // Cache subnet groups are not modeled by the emulator; return the wire-accurate
-        // empty result so SDK clients get a valid 200 instead of an unsupported-action 400.
-        var xml = new XmlBuilder().start("CacheSubnetGroups").end("CacheSubnetGroups");
-        return Response.ok(AwsQueryResponse.envelope("DescribeCacheSubnetGroups", AwsNamespaces.EC, xml.build())).build();
+    private Response handleCreateCacheSubnetGroup(MultivaluedMap<String, String> params) {
+        try {
+            CacheSubnetGroup group = service.createCacheSubnetGroup(
+                    params.getFirst("CacheSubnetGroupName"),
+                    params.getFirst("CacheSubnetGroupDescription"),
+                    parseSubnetIds(params),
+                    parseTags(params));
+            var xml = new XmlBuilder();
+            appendSubnetGroup(xml, group);
+            return Response.ok(AwsQueryResponse.envelope("CreateCacheSubnetGroup", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
     }
 
-    private Response handleCreateCacheParameterGroup(MultivaluedMap<String, String> params) {
+    private Response handleDescribeCacheSubnetGroups(MultivaluedMap<String, String> params) {
+        try {
+            List<CacheSubnetGroup> groups =
+                    service.describeCacheSubnetGroups(params.getFirst("CacheSubnetGroupName"));
+            var xml = new XmlBuilder().start("CacheSubnetGroups");
+            groups.forEach(group -> appendSubnetGroup(xml, group));
+            xml.end("CacheSubnetGroups");
+            return Response.ok(AwsQueryResponse.envelope("DescribeCacheSubnetGroups", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private Response handleModifyCacheSubnetGroup(MultivaluedMap<String, String> params) {
+        try {
+            CacheSubnetGroup group = service.modifyCacheSubnetGroup(
+                    params.getFirst("CacheSubnetGroupName"),
+                    params.getFirst("CacheSubnetGroupDescription"),
+                    parseSubnetIds(params));
+            var xml = new XmlBuilder();
+            appendSubnetGroup(xml, group);
+            return Response.ok(AwsQueryResponse.envelope("ModifyCacheSubnetGroup", AwsNamespaces.EC, xml.build())).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private Response handleDeleteCacheSubnetGroup(MultivaluedMap<String, String> params) {
+        try {
+            service.deleteCacheSubnetGroup(params.getFirst("CacheSubnetGroupName"));
+            return Response.ok(AwsQueryResponse.envelope("DeleteCacheSubnetGroup", AwsNamespaces.EC, "")).build();
+        } catch (AwsException e) {
+            return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.EC, e.getHttpStatus());
+        }
+    }
+
+    private void appendSubnetGroup(XmlBuilder xml, CacheSubnetGroup group) {
+        xml.start("CacheSubnetGroup")
+                .elem("CacheSubnetGroupName", group.getName())
+                .elem("CacheSubnetGroupDescription", group.getDescription())
+                .elem("VpcId", group.getVpcId())
+                .start("Subnets");
+        group.getSubnetAvailabilityZones().forEach((subnetId, availabilityZone) -> xml
+                .start("Subnet")
+                .elem("SubnetIdentifier", subnetId)
+                .start("SubnetAvailabilityZone").elem("Name", availabilityZone).end("SubnetAvailabilityZone")
+                .start("SupportedNetworkTypes").elem("member", "ipv4").end("SupportedNetworkTypes")
+                .end("Subnet"));
+        xml.end("Subnets")
+                .start("SupportedNetworkTypes").elem("member", "ipv4").end("SupportedNetworkTypes")
+                .elem("ARN", "arn:aws:elasticache:" + regionResolver.getRegion() + ":"
+                        + regionResolver.getAccountId() + ":subnetgroup:" + group.getName())
+                .end("CacheSubnetGroup");
+    }
+
+    /** Reads the SubnetIds list under every spelling the Query protocol sends it in. */
+    private static List<String> parseSubnetIds(MultivaluedMap<String, String> params) {
+        List<String> subnetIds = new ArrayList<>();
+        for (String prefix : List.of("SubnetIds.SubnetIdentifier", "SubnetIds.member")) {
+            for (int i = 1; ; i++) {
+                String subnetId = params.getFirst(prefix + "." + i);
+                if (subnetId == null) {
+                    break;
+                }
+                subnetIds.add(subnetId);
+            }
+        }
+        return subnetIds;
+    }
+
+private Response handleCreateCacheParameterGroup(MultivaluedMap<String, String> params) {
         try {
             CacheParameterGroup group = service.createCacheParameterGroup(
                     params.getFirst("CacheParameterGroupName"),
@@ -396,6 +478,9 @@ public class ElastiCacheQueryHandler {
             }
 
             Map<String, String> tags = Map.of();
+            if ("subnetgroup".equals(arn[5])) {
+                tags = service.describeCacheSubnetGroups(arn[6]).getFirst().getTags();
+            }
             if ("parametergroup".equals(arn[5])) {
                 tags = service.findParameterGroup(arn[6])
                         .orElseThrow(() -> new AwsException("CacheParameterGroupNotFound",

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -3,16 +3,20 @@ package io.github.hectorvent.floci.services.elasticache;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.model.AuthMode;
 import io.github.hectorvent.floci.services.elasticache.model.CacheParameterGroup;
+import io.github.hectorvent.floci.services.elasticache.model.CacheSubnetGroup;
 import io.github.hectorvent.floci.services.elasticache.model.Endpoint;
 import io.github.hectorvent.floci.services.elasticache.model.ElastiCacheUser;
 import io.github.hectorvent.floci.services.elasticache.model.ReplicationGroup;
 import io.github.hectorvent.floci.services.elasticache.model.ReplicationGroupStatus;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Subnet;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -41,9 +45,12 @@ public class ElastiCacheService {
     private final StorageBackend<String, ReplicationGroup> groups;
     private final StorageBackend<String, ElastiCacheUser> users;
     private final StorageBackend<String, CacheParameterGroup> parameterGroups;
+    private final StorageBackend<String, CacheSubnetGroup> subnetGroups;
     private final ElastiCacheContainerManager containerManager;
     private final ElastiCacheProxyManager proxyManager;
     private final EmulatorConfig config;
+    private final Ec2Service ec2Service;
+    private final RegionResolver regionResolver;
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
     private final Set<String> provisioningGroupIds = ConcurrentHashMap.newKeySet();
     private final ConcurrentHashMap<String, Object> parameterGroupLocks = new ConcurrentHashMap<>();
@@ -52,16 +59,22 @@ public class ElastiCacheService {
     public ElastiCacheService(ElastiCacheContainerManager containerManager,
                               ElastiCacheProxyManager proxyManager,
                               StorageFactory storageFactory,
-                              EmulatorConfig config) {
+                              EmulatorConfig config,
+                              Ec2Service ec2Service,
+                              RegionResolver regionResolver) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.config = config;
+        this.ec2Service = ec2Service;
+        this.regionResolver = regionResolver;
         this.groups = storageFactory.create("elasticache", "elasticache-groups.json",
                 new TypeReference<Map<String, ReplicationGroup>>() {});
         this.users = storageFactory.create("elasticache", "elasticache-users.json",
                 new TypeReference<Map<String, ElastiCacheUser>>() {});
         this.parameterGroups = storageFactory.create("elasticache", "elasticache-parameter-groups.json",
                 new TypeReference<Map<String, CacheParameterGroup>>() {});
+        this.subnetGroups = storageFactory.create("elasticache", "elasticache-subnet-groups.json",
+                new TypeReference<Map<String, CacheSubnetGroup>>() {});
     }
 
     public ReplicationGroup createReplicationGroup(String groupId, String description,
@@ -319,6 +332,113 @@ public class ElastiCacheService {
 
     private void releaseProxyPort(int port) {
         usedPorts.remove(port);
+    }
+
+    // ── Cache Subnet Groups ───────────────────────────────────────────────────
+
+    /**
+     * Creates a subnet group. The VPC and each subnet's availability zone are read from the
+     * subnets rather than the request, because that is where AWS takes them from — which makes
+     * resolving them against EC2 part of answering, not an optional check.
+     */
+    public CacheSubnetGroup createCacheSubnetGroup(String name, String description,
+                                                   List<String> subnetIds, Map<String, String> tags) {
+        validateSubnetGroupName(name);
+        synchronized (lockFor("sng:" + name)) {
+            if (subnetGroups.get(name).isPresent()) {
+                throw new AwsException("CacheSubnetGroupAlreadyExists",
+                        "Cache subnet group " + name + " already exists.", 400);
+            }
+            CacheSubnetGroup group = buildSubnetGroup(name, description, subnetIds);
+            if (tags != null && !tags.isEmpty()) {
+                group.setTags(tags);
+            }
+            subnetGroups.put(name, group);
+            LOG.infov("Created cache subnet group {0} in {1}", name, group.getVpcId());
+            return group;
+        }
+    }
+
+    public List<CacheSubnetGroup> describeCacheSubnetGroups(String name) {
+        if (name == null || name.isBlank()) {
+            return subnetGroups.scan(key -> true);
+        }
+        return List.of(subnetGroups.get(name)
+                .orElseThrow(() -> new AwsException("CacheSubnetGroupNotFoundFault",
+                        "Cache subnet group " + name + " not found.", 404)));
+    }
+
+    /** Replaces the description and, when subnets are given, the whole subnet set. */
+    public CacheSubnetGroup modifyCacheSubnetGroup(String name, String description, List<String> subnetIds) {
+        validateSubnetGroupName(name);
+        synchronized (lockFor("sng:" + name)) {
+            CacheSubnetGroup existing = subnetGroups.get(name)
+                    .orElseThrow(() -> new AwsException("CacheSubnetGroupNotFoundFault",
+                            "Cache subnet group " + name + " not found.", 404));
+            String effectiveDescription = description == null ? existing.getDescription() : description;
+            CacheSubnetGroup updated;
+            if (subnetIds == null || subnetIds.isEmpty()) {
+                // No subnets given means none change, so the stored ones are kept as they are:
+                // re-resolving them would fail a description-only change if a subnet had since
+                // been deleted from EC2.
+                updated = new CacheSubnetGroup(name, effectiveDescription, existing.getVpcId(),
+                        existing.getSubnetAvailabilityZones());
+            } else {
+                updated = buildSubnetGroup(name, effectiveDescription, subnetIds);
+            }
+            updated.setTags(existing.getTags());
+            subnetGroups.put(name, updated);
+            return updated;
+        }
+    }
+
+    public void deleteCacheSubnetGroup(String name) {
+        validateSubnetGroupName(name);
+        synchronized (lockFor("sng:" + name)) {
+            if (subnetGroups.get(name).isEmpty()) {
+                throw new AwsException("CacheSubnetGroupNotFoundFault",
+                        "Cache Subnet Group " + name + " does not exist.", 404);
+            }
+            subnetGroups.delete(name);
+        }
+        LOG.infov("Deleted cache subnet group {0}", name);
+    }
+
+    private CacheSubnetGroup buildSubnetGroup(String name, String description, List<String> subnetIds) {
+        if (subnetIds == null || subnetIds.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "The parameter SubnetIds must be provided.", 400);
+        }
+        String region = regionResolver.getDefaultRegion();
+        List<Subnet> resolved = ec2Service.describeSubnets(region, subnetIds, Map.of());
+        if (resolved.size() != subnetIds.size()) {
+            throw new AwsException("InvalidParameterValue",
+                    "Some input subnets in :[" + String.join(", ", subnetIds) + "] are invalid.", 400);
+        }
+
+        String vpcId = resolved.getFirst().getVpcId();
+        List<String> foreign = resolved.stream()
+                .filter(subnet -> subnet.getVpcId() != null && !vpcId.equals(subnet.getVpcId()))
+                .map(Subnet::getSubnetId)
+                .toList();
+        if (!foreign.isEmpty()) {
+            throw new AwsException("InvalidSubnet", "Subnets " + resolved.getFirst().getSubnetId()
+                    + " and " + foreign.getFirst() + " are not in the same VPC.", 400);
+        }
+
+        Map<String, String> availabilityZones = new LinkedHashMap<>();
+        resolved.forEach(subnet -> availabilityZones.put(subnet.getSubnetId(), subnet.getAvailabilityZone()));
+        return new CacheSubnetGroup(name, description, vpcId, availabilityZones);
+    }
+
+    /** Subnet group names take the same identifier rule as parameter group names. */
+    private static void validateSubnetGroupName(String name) {
+        if (name == null || name.isBlank() || !PARAMETER_GROUP_NAME.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "The parameter CacheSubnetGroupName is not a valid identifier. Identifiers must "
+                            + "begin with a letter; must contain only ASCII letters, digits, and hyphens; "
+                            + "and must not end with a hyphen or contain two consecutive hyphens.", 400);
+        }
     }
 
     // ── Cache Parameter Groups ────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -365,7 +365,7 @@ public class ElastiCacheService {
         }
         return List.of(subnetGroups.get(name)
                 .orElseThrow(() -> new AwsException("CacheSubnetGroupNotFoundFault",
-                        "Cache subnet group " + name + " not found.", 404)));
+                        "Cache subnet group " + name + " not found.", 400)));
     }
 
     /** Replaces the description and, when subnets are given, the whole subnet set. */
@@ -374,7 +374,7 @@ public class ElastiCacheService {
         synchronized (lockFor("sng:" + name)) {
             CacheSubnetGroup existing = subnetGroups.get(name)
                     .orElseThrow(() -> new AwsException("CacheSubnetGroupNotFoundFault",
-                            "Cache subnet group " + name + " not found.", 404));
+                            "Cache subnet group " + name + " not found.", 400));
             String effectiveDescription = description == null ? existing.getDescription() : description;
             CacheSubnetGroup updated;
             if (subnetIds == null || subnetIds.isEmpty()) {
@@ -397,7 +397,7 @@ public class ElastiCacheService {
         synchronized (lockFor("sng:" + name)) {
             if (subnetGroups.get(name).isEmpty()) {
                 throw new AwsException("CacheSubnetGroupNotFoundFault",
-                        "Cache Subnet Group " + name + " does not exist.", 404);
+                        "Cache Subnet Group " + name + " does not exist.", 400);
             }
             subnetGroups.delete(name);
         }
@@ -437,7 +437,13 @@ public class ElastiCacheService {
         return new CacheSubnetGroup(name, description, vpcId, availabilityZones);
     }
 
-    /** Subnet group names take the same identifier rule as parameter group names. */
+    /**
+     * Subnet group names take the same identifier rule as parameter group names.
+     *
+     * <p>The not-found faults do not match, though, and the difference is AWS's: the subnet-group
+     * fault keeps its {@code Fault} suffix on the wire and is a 400, while the parameter-group one
+     * drops the suffix and is a 404. Both are declared that way in the service model.
+     */
     private static void validateSubnetGroupName(String name) {
         if (name == null || name.isBlank() || !PARAMETER_GROUP_NAME.matcher(name).matches()) {
             throw new AwsException("InvalidParameterValue",

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -428,8 +428,12 @@ public class ElastiCacheService {
                     + " and " + foreign.getFirst() + " are not in the same VPC.", 400);
         }
 
+        // In the order the caller gave them: describeSubnets answers in the store's scan order,
+        // which would make the reported order of a group's subnets arbitrary between calls.
+        Map<String, String> zoneBySubnet = new LinkedHashMap<>();
+        resolved.forEach(subnet -> zoneBySubnet.put(subnet.getSubnetId(), subnet.getAvailabilityZone()));
         Map<String, String> availabilityZones = new LinkedHashMap<>();
-        resolved.forEach(subnet -> availabilityZones.put(subnet.getSubnetId(), subnet.getAvailabilityZone()));
+        subnetIds.forEach(id -> availabilityZones.put(id, zoneBySubnet.get(id)));
         return new CacheSubnetGroup(name, description, vpcId, availabilityZones);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -409,7 +409,9 @@ public class ElastiCacheService {
             throw new AwsException("InvalidParameterValue",
                     "The parameter SubnetIds must be provided.", 400);
         }
-        String region = regionResolver.getDefaultRegion();
+        // The caller's region, not the configured default: subnets exist in the region they were
+        // created in, and the ARN this group is reported under is built from that same region.
+        String region = regionResolver.getRegion();
         List<Subnet> resolved = ec2Service.describeSubnets(region, subnetIds, Map.of());
         if (resolved.size() != subnetIds.size()) {
             throw new AwsException("InvalidParameterValue",

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/model/CacheSubnetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/model/CacheSubnetGroup.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.services.elasticache.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CacheSubnetGroup {
+
+    private String name;
+    private String description;
+    /** Taken from the subnets, which is where AWS gets it: a group cannot span VPCs. */
+    private String vpcId;
+    /** Subnet id to availability zone, in the order the subnets were given. */
+    private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
+
+    public CacheSubnetGroup() {
+    }
+
+    public CacheSubnetGroup(String name, String description, String vpcId,
+                            Map<String, String> subnetAvailabilityZones) {
+        this.name = name;
+        this.description = description;
+        this.vpcId = vpcId;
+        setSubnetAvailabilityZones(subnetAvailabilityZones);
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getVpcId() { return vpcId; }
+    public void setVpcId(String vpcId) { this.vpcId = vpcId; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags);
+    }
+
+    public Map<String, String> getSubnetAvailabilityZones() { return subnetAvailabilityZones; }
+    public void setSubnetAvailabilityZones(Map<String, String> subnetAvailabilityZones) {
+        this.subnetAvailabilityZones = subnetAvailabilityZones == null
+                ? new LinkedHashMap<>() : new LinkedHashMap<>(subnetAvailabilityZones);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -4,6 +4,8 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerHandle;
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheContainerManager;
 import io.github.hectorvent.floci.services.elasticache.model.AuthMode;
@@ -58,7 +60,9 @@ class ElastiCacheServiceTest {
                 .thenReturn(new ElastiCacheContainerHandle("cid", "grp", "localhost", 6379));
         doNothing().when(proxyManager).startProxy(anyString(), any(), anyInt(), anyString(), anyInt(), any());
 
-        service = new ElastiCacheService(containerManager, proxyManager, storageFactory, config);
+        Ec2Service ec2Service = org.mockito.Mockito.mock(Ec2Service.class);
+        service = new ElastiCacheService(containerManager, proxyManager, storageFactory, config,
+                ec2Service, new RegionResolver("us-east-1", "000000000000"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
@@ -1,0 +1,225 @@
+package io.github.hectorvent.floci.services.elasticache;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * Cache subnet groups over the Query protocol.
+ *
+ * <p>The VPC and each subnet's availability zone are read from the subnets, as AWS reads them, so
+ * these tests create real subnets in the emulator's EC2 first: a group cannot be answered for
+ * subnets that do not exist.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ElastiCacheSubnetGroupIntegrationTest {
+
+    private static final String GROUP = "int-test-sng";
+    private static final String EC_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/elasticache/aws4_request";
+    private static final String EC2_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/ec2/aws4_request";
+
+    private static String firstSubnet;
+    private static String secondSubnet;
+    private static String vpcId;
+
+    private static io.restassured.specification.RequestSpecification elasticache(String action) {
+        return given().header("Authorization", EC_AUTH)
+                .formParam("Action", action)
+                .formParam("Version", "2015-02-02");
+    }
+
+    private static String ec2(String action, String... formParams) {
+        var request = given().header("Authorization", EC2_AUTH)
+                .formParam("Action", action)
+                .formParam("Version", "2016-11-15");
+        for (int i = 0; i < formParams.length; i += 2) {
+            request = request.formParam(formParams[i], formParams[i + 1]);
+        }
+        return request.when().post("/").then().statusCode(200).extract().body().asString();
+    }
+
+    private static String between(String xml, String tag) {
+        int start = xml.indexOf("<" + tag + ">") + tag.length() + 2;
+        return xml.substring(start, xml.indexOf("</" + tag + ">", start));
+    }
+
+    @Test
+    @Order(1)
+    void createSubnetsToPlaceTheGroupIn() {
+        vpcId = between(ec2("CreateVpc", "CidrBlock", "10.20.0.0/16"), "vpcId");
+        firstSubnet = between(ec2("CreateSubnet", "VpcId", vpcId, "CidrBlock", "10.20.1.0/24",
+                "AvailabilityZone", "us-east-1a"), "subnetId");
+        secondSubnet = between(ec2("CreateSubnet", "VpcId", vpcId, "CidrBlock", "10.20.2.0/24",
+                "AvailabilityZone", "us-east-1b"), "subnetId");
+    }
+
+    @Test
+    @Order(2)
+    void createReportsTheVpcAndZonesTakenFromTheSubnets() {
+        elasticache("CreateCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", GROUP)
+                .formParam("CacheSubnetGroupDescription", "integration test")
+                .formParam("SubnetIds.SubnetIdentifier.1", firstSubnet)
+                .formParam("SubnetIds.SubnetIdentifier.2", secondSubnet)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CacheSubnetGroupName>" + GROUP + "</CacheSubnetGroupName>"))
+            .body(containsString("<VpcId>" + vpcId + "</VpcId>"))
+            .body(containsString("<SubnetIdentifier>" + firstSubnet + "</SubnetIdentifier>"))
+            .body(containsString("<Name>us-east-1a</Name>"))
+            .body(containsString("<Name>us-east-1b</Name>"))
+            .body(containsString(":subnetgroup:" + GROUP + "</ARN>"));
+    }
+
+    @Test
+    @Order(3)
+    void aSubnetThatDoesNotExistIsRejected() {
+        elasticache("CreateCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", "absent-subnet-sng")
+                .formParam("CacheSubnetGroupDescription", "x")
+                .formParam("SubnetIds.SubnetIdentifier.1", "subnet-00000000000000000")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("are invalid"));
+    }
+
+    @Test
+    @Order(3)
+    void subnetsFromTwoVpcsAreRejected() {
+        String otherVpc = between(ec2("CreateVpc", "CidrBlock", "10.21.0.0/16"), "vpcId");
+        String otherSubnet = between(ec2("CreateSubnet", "VpcId", otherVpc, "CidrBlock", "10.21.1.0/24",
+                "AvailabilityZone", "us-east-1a"), "subnetId");
+
+        elasticache("CreateCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", "cross-vpc-sng")
+                .formParam("CacheSubnetGroupDescription", "x")
+                .formParam("SubnetIds.SubnetIdentifier.1", firstSubnet)
+                .formParam("SubnetIds.SubnetIdentifier.2", otherSubnet)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("are not in the same VPC"));
+    }
+
+    @Test
+    @Order(3)
+    void duplicateAndUnknownGroupsCarryTheirOwnErrors() {
+        elasticache("CreateCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", GROUP)
+                .formParam("CacheSubnetGroupDescription", "again")
+                .formParam("SubnetIds.SubnetIdentifier.1", firstSubnet)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("CacheSubnetGroupAlreadyExists"));
+
+        elasticache("DescribeCacheSubnetGroups")
+                .formParam("CacheSubnetGroupName", "no-such-sng")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("Cache subnet group no-such-sng not found"));
+    }
+
+    @Test
+    @Order(4)
+    void modifyReplacesTheDescriptionAndSubnets() {
+        elasticache("ModifyCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", GROUP)
+                .formParam("CacheSubnetGroupDescription", "changed")
+                .formParam("SubnetIds.SubnetIdentifier.1", firstSubnet)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CacheSubnetGroupDescription>changed</CacheSubnetGroupDescription>"))
+            .body(containsString("<SubnetIdentifier>" + firstSubnet + "</SubnetIdentifier>"));
+
+        // The subnet dropped by the modify is gone from the group.
+        elasticache("DescribeCacheSubnetGroups")
+                .formParam("CacheSubnetGroupName", GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(org.hamcrest.Matchers.not(containsString(secondSubnet)));
+    }
+
+    @Test
+    @Order(4)
+    void tagsGivenAtCreateAreKeptAndListed() {
+        // Dropping them would leave terraform with a diff it can never settle.
+        elasticache("CreateCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", "tagged-sng")
+                .formParam("CacheSubnetGroupDescription", "tagged")
+                .formParam("SubnetIds.SubnetIdentifier.1", firstSubnet)
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "prod")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        elasticache("ListTagsForResource")
+                .formParam("ResourceName",
+                        "arn:aws:elasticache:us-east-1:000000000000:subnetgroup:tagged-sng")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"))
+            .body(containsString("<Value>prod</Value>"));
+    }
+
+    @Test
+    @Order(4)
+    void aDescriptionOnlyModifyLeavesTheSubnetsAlone() {
+        // Nothing is said about subnets, so none change — and the stored ones are not re-resolved,
+        // which would fail this call if one of them had since been deleted from EC2.
+        elasticache("ModifyCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", "tagged-sng")
+                .formParam("CacheSubnetGroupDescription", "description only")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<CacheSubnetGroupDescription>description only</CacheSubnetGroupDescription>"))
+            .body(containsString("<SubnetIdentifier>" + firstSubnet + "</SubnetIdentifier>"));
+
+        // And the tags survive a modify.
+        elasticache("ListTagsForResource")
+                .formParam("ResourceName",
+                        "arn:aws:elasticache:us-east-1:000000000000:subnetgroup:tagged-sng")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"));
+
+        elasticache("DeleteCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", "tagged-sng")
+        .when().post("/").then().statusCode(200);
+    }
+
+    @Test
+    @Order(5)
+    void deleteRemovesItAndSaysSoDifferentlyTheSecondTime() {
+        elasticache("DeleteCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        // AWS words the delete's not-found differently from the describe's.
+        elasticache("DeleteCacheSubnetGroup")
+                .formParam("CacheSubnetGroupName", GROUP)
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("Cache Subnet Group " + GROUP + " does not exist"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
@@ -77,7 +77,12 @@ class ElastiCacheSubnetGroupIntegrationTest {
             .body(containsString("<SubnetIdentifier>" + firstSubnet + "</SubnetIdentifier>"))
             .body(containsString("<Name>us-east-1a</Name>"))
             .body(containsString("<Name>us-east-1b</Name>"))
-            .body(containsString(":subnetgroup:" + GROUP + "</ARN>"));
+            .body(containsString(":subnetgroup:" + GROUP + "</ARN>"))
+            // In the order they were given: the subnets are read back from a store whose scan
+            // order is its own, so the group would otherwise report them in an arbitrary order.
+            .body(org.hamcrest.Matchers.matchesPattern(
+                    "(?s).*<SubnetIdentifier>" + firstSubnet + "</SubnetIdentifier>.*"
+                            + "<SubnetIdentifier>" + secondSubnet + "</SubnetIdentifier>.*"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
@@ -24,7 +24,7 @@ class ElastiCacheSubnetGroupIntegrationTest {
     private static final String EC_AUTH =
             "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/elasticache/aws4_request";
     private static final String EC2_AUTH =
-            "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/ec2/aws4_request";
+            "AWS4-HMAC-SHA256 Credential=test/20260412/%s/ec2/aws4_request";
 
     private static String firstSubnet;
     private static String secondSubnet;
@@ -36,8 +36,8 @@ class ElastiCacheSubnetGroupIntegrationTest {
                 .formParam("Version", "2015-02-02");
     }
 
-    private static String ec2(String action, String... formParams) {
-        var request = given().header("Authorization", EC2_AUTH)
+    private static String ec2(String region, String action, String... formParams) {
+        var request = given().header("Authorization", EC2_AUTH.formatted(region))
                 .formParam("Action", action)
                 .formParam("Version", "2016-11-15");
         for (int i = 0; i < formParams.length; i += 2) {
@@ -54,10 +54,10 @@ class ElastiCacheSubnetGroupIntegrationTest {
     @Test
     @Order(1)
     void createSubnetsToPlaceTheGroupIn() {
-        vpcId = between(ec2("CreateVpc", "CidrBlock", "10.20.0.0/16"), "vpcId");
-        firstSubnet = between(ec2("CreateSubnet", "VpcId", vpcId, "CidrBlock", "10.20.1.0/24",
+        vpcId = between(ec2("us-east-1", "CreateVpc", "CidrBlock", "10.20.0.0/16"), "vpcId");
+        firstSubnet = between(ec2("us-east-1", "CreateSubnet", "VpcId", vpcId, "CidrBlock", "10.20.1.0/24",
                 "AvailabilityZone", "us-east-1a"), "subnetId");
-        secondSubnet = between(ec2("CreateSubnet", "VpcId", vpcId, "CidrBlock", "10.20.2.0/24",
+        secondSubnet = between(ec2("us-east-1", "CreateSubnet", "VpcId", vpcId, "CidrBlock", "10.20.2.0/24",
                 "AvailabilityZone", "us-east-1b"), "subnetId");
     }
 
@@ -96,8 +96,8 @@ class ElastiCacheSubnetGroupIntegrationTest {
     @Test
     @Order(3)
     void subnetsFromTwoVpcsAreRejected() {
-        String otherVpc = between(ec2("CreateVpc", "CidrBlock", "10.21.0.0/16"), "vpcId");
-        String otherSubnet = between(ec2("CreateSubnet", "VpcId", otherVpc, "CidrBlock", "10.21.1.0/24",
+        String otherVpc = between(ec2("us-east-1", "CreateVpc", "CidrBlock", "10.21.0.0/16"), "vpcId");
+        String otherSubnet = between(ec2("us-east-1", "CreateSubnet", "VpcId", otherVpc, "CidrBlock", "10.21.1.0/24",
                 "AvailabilityZone", "us-east-1a"), "subnetId");
 
         elasticache("CreateCacheSubnetGroup")
@@ -203,6 +203,31 @@ class ElastiCacheSubnetGroupIntegrationTest {
         elasticache("DeleteCacheSubnetGroup")
                 .formParam("CacheSubnetGroupName", "tagged-sng")
         .when().post("/").then().statusCode(200);
+    }
+
+    @Test
+    @Order(4)
+    void subnetsAreResolvedInTheCallersRegion() {
+        // Subnets exist in the region they were created in. Resolving against the configured
+        // default region instead would reject these as invalid, and would report the group under
+        // an eu-west-1 ARN built from subnets read somewhere else.
+        String euVpc = between(ec2("eu-west-1", "CreateVpc", "CidrBlock", "10.30.0.0/16"), "vpcId");
+        String euSubnet = between(ec2("eu-west-1", "CreateSubnet", "VpcId", euVpc,
+                "CidrBlock", "10.30.1.0/24", "AvailabilityZone", "eu-west-1a"), "subnetId");
+
+        given().header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260412/eu-west-1/elasticache/aws4_request")
+                .formParam("Action", "CreateCacheSubnetGroup")
+                .formParam("Version", "2015-02-02")
+                .formParam("CacheSubnetGroupName", "eu-west-sng")
+                .formParam("CacheSubnetGroupDescription", "other region")
+                .formParam("SubnetIds.SubnetIdentifier.1", euSubnet)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<VpcId>" + euVpc + "</VpcId>"))
+            .body(containsString("<Name>eu-west-1a</Name>"))
+            .body(containsString("arn:aws:elasticache:eu-west-1:"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheSubnetGroupIntegrationTest.java
@@ -128,11 +128,13 @@ class ElastiCacheSubnetGroupIntegrationTest {
             .statusCode(400)
             .body(containsString("CacheSubnetGroupAlreadyExists"));
 
+        // 400, not 404: the subnet-group fault is declared that way, unlike the parameter-group
+        // one a few hundred lines up, which really is a 404.
         elasticache("DescribeCacheSubnetGroups")
                 .formParam("CacheSubnetGroupName", "no-such-sng")
         .when().post("/")
         .then()
-            .statusCode(404)
+            .statusCode(400)
             .body(containsString("Cache subnet group no-such-sng not found"));
     }
 
@@ -249,7 +251,7 @@ class ElastiCacheSubnetGroupIntegrationTest {
                 .formParam("CacheSubnetGroupName", GROUP)
         .when().post("/")
         .then()
-            .statusCode(404)
+            .statusCode(400)
             .body(containsString("Cache Subnet Group " + GROUP + " does not exist"));
     }
 }


### PR DESCRIPTION
Closes #2398.

## Problem

`CreateCacheSubnetGroup` is unsupported, so `aws_elasticache_subnet_group` cannot be created and no
Redis or Valkey module that places a cluster in a VPC can apply — the usual arrangement.
`DescribeCacheSubnetGroups` already answered with an empty list, so the read half existed with
nothing behind it, the same shape cache parameter groups had.

## Change

`CreateCacheSubnetGroup`, `ModifyCacheSubnetGroup`, `DeleteCacheSubnetGroup`, and a
`DescribeCacheSubnetGroups` that returns what was created.

A group's `VpcId` and each subnet's availability zone come from the subnets rather than from the
request, because that is where AWS reads them — so resolving the subnets against EC2 is part of
answering, not an optional check. `RdsService` faces the same problem for DB subnet groups, and
this follows it.

## Verified against AWS

| Case | AWS |
| --- | --- |
| Create | `VpcId` and per-subnet AZ derived from the subnets, `SupportedNetworkTypes: [ipv4]` on both group and subnets, `…:subnetgroup:<name>` ARN |
| Subnet that does not exist | `InvalidParameterValue` — *Some input subnets in :[…] are invalid.* |
| Subnets across two VPCs | `InvalidSubnet` — *Subnets X and Y are not in the same VPC.* |
| Duplicate | `CacheSubnetGroupAlreadyExists` — *Cache subnet group X already exists.* |
| Describe unknown | `CacheSubnetGroupNotFoundFault` — *Cache subnet group X not found.* |
| Delete unknown | `CacheSubnetGroupNotFoundFault` — *Cache Subnet Group X does not exist.* |
| Invalid name | the same identifier rule as parameter groups |

The two not-found messages differ from each other in wording and capitalisation; both are
reproduced as AWS words them.

## Deliberately handled

Tags given at create are stored and readable through `ListTagsForResource` on a `subnetgroup` ARN,
rather than accepted and dropped. A modify naming no subnets keeps the stored ones rather than
resolving them again, which would otherwise fail a description-only change if a subnet had since
been deleted from EC2. Listings are unpaged.

## Known, not addressed here

Deleting an EC2 subnet leaves a group referring to it. RDS's DB subnet groups behave the same way,
so this matches the neighbour rather than giving one resource its own cascade; worth its own change
if wanted. AWS refuses to delete a subnet group that a cluster uses — floci models no reference
from a cluster to a subnet group, so there is nothing here to guard.


