### PR TITLE
feat(rds,docdb): answer DescribeGlobalClusters

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -127,3 +127,21 @@ teardown() {
     [ "$(json_get "$output" '.RotationEnabled')" = "true" ]
     [ "$(json_get "$output" '.RotationRules.AutomaticallyAfterDays')" = "7" ]
 }
+
+@test "RDS: describe global clusters returns an empty list" {
+    run aws_cmd rds describe-global-clusters
+    assert_success
+    [ "$(json_get "$output" '.GlobalClusters | length')" = "0" ]
+}
+
+@test "DocDB: describe global clusters answers the read every cluster read makes" {
+    # DocumentDB signs with the rds scope, so this is the same handler the CLI reaches
+    # for either service. Without an answer here a created cluster cannot be read back.
+    run aws_cmd docdb describe-global-clusters
+    assert_success
+    [ "$(json_get "$output" '.GlobalClusters | length')" = "0" ]
+
+    run aws_cmd docdb describe-global-clusters --global-cluster-identifier "bats-absent-gc"
+    assert_failure
+    assert_output --partial "GlobalClusterNotFoundFault"
+}

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -22,6 +22,7 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | `CreateDBCluster` | Create a DocumentDB cluster and start a MongoDB container |
 | `DescribeDBClusters` | List clusters and their connection details |
 | `DescribeDBClusterSnapshots` | - |
+| `DescribeGlobalClusters` | List global clusters — always empty, as none are modeled |
 | `DeleteDBCluster` | Stop and remove a cluster (must have no instances) |
 | `ModifyDBCluster` | Update engine version or IAM auth setting |
 | `CreateDBInstance` | Add an instance to a cluster |

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -52,6 +52,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `ModifyDBProxyTargetGroup` | Update target-group connection-pool configuration |
 | `DescribeDBProxyTargets` | List a proxy target group's registered targets |
 | `DescribeDBClusterSnapshots` | - |
+| `DescribeGlobalClusters` | List global clusters — always empty, as none are modeled |
 | `AddTagsToResource` | Add tags to a DB resource |
 | `ListTagsForResource` | List tags for a DB resource |
 | `RemoveTagsFromResource` | Remove tags from a DB resource |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -372,7 +372,12 @@ public class AwsQueryController {
             "DeleteDBParameterGroup", "ModifyDBParameterGroup", "DescribeDBParameters",
             "DescribeDBProxies", "CreateDBProxy", "ModifyDBProxy", "DeleteDBProxy",
             "RegisterDBProxyTargets", "DeregisterDBProxyTargets",
-            "DescribeDBProxyTargetGroups", "ModifyDBProxyTargetGroup", "DescribeDBProxyTargets"
+            "DescribeDBProxyTargetGroups", "ModifyDBProxyTargetGroup", "DescribeDBProxyTargets",
+            "CreateDBClusterParameterGroup", "DescribeDBClusterParameterGroups",
+            "ModifyDBClusterParameterGroup", "DeleteDBClusterParameterGroup",
+            "DescribeDBClusterParameters",
+            "CreateOptionGroup", "DescribeOptionGroups", "ModifyOptionGroup", "DeleteOptionGroup",
+            "DescribeDBSnapshots", "DescribeDBClusterSnapshots"
     );
 
     private static final Set<String> CLOUDFORMATION_ACTIONS = Set.of(

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -367,6 +367,7 @@ public class AwsQueryController {
             "CreateDBSubnetGroup", "DescribeDBSubnetGroups", "ModifyDBSubnetGroup", "DeleteDBSubnetGroup",
             "AddTagsToResource", "ListTagsForResource", "RemoveTagsFromResource",
             "CreateDBCluster", "DescribeDBClusters", "DeleteDBCluster", "ModifyDBCluster",
+            "DescribeGlobalClusters",
             "CreateDBParameterGroup", "DescribeDBParameterGroups",
             "DeleteDBParameterGroup", "ModifyDBParameterGroup", "DescribeDBParameters",
             "DescribeDBProxies", "CreateDBProxy", "ModifyDBProxy", "DeleteDBProxy",

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
@@ -36,6 +36,7 @@ public class DocDbQueryHandler {
                 case "CreateDBCluster"    -> handleCreateDbCluster(params);
                 case "DescribeDBClusters" -> handleDescribeDbClusters(params);
                 case "DescribeDBClusterSnapshots" -> handleDescribeDbClusterSnapshots(params);
+                case "DescribeGlobalClusters" -> handleDescribeGlobalClusters(params);
                 case "DeleteDBCluster"    -> handleDeleteDbCluster(params);
                 case "ModifyDBCluster"    -> handleModifyDbCluster(params);
                 case "CreateDBInstance"   -> handleCreateDbInstance(params);
@@ -96,6 +97,42 @@ public class DocDbQueryHandler {
         }
         xml.end("DBClusters").start("Marker").end("Marker");
         return Response.ok(AwsQueryResponse.envelope("DescribeDBClusters", AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    private Response handleDescribeGlobalClusters(MultivaluedMap<String, String> params) {
+        // Global clusters are not modeled; an empty list is what completes the provider's read.
+        // Real SDKs sign DocumentDB with the "rds" scope and land on RdsQueryHandler instead;
+        // this serves the "docdb" scope Floci also accepts, and must answer the same way.
+        // MaxRecords is rejected before the identifier is looked up, and a marker after it —
+        // the order a live account applies them in.
+        String maxRecords = params.getFirst("MaxRecords");
+        if (maxRecords != null && !maxRecords.isBlank()) {
+            int max = -1;
+            try {
+                max = Integer.parseInt(maxRecords.trim());
+            } catch (NumberFormatException e) {
+                LOG.debugv("Non-numeric MaxRecords {0} on DescribeGlobalClusters", maxRecords);
+            }
+            if (max < 20 || max > 100) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid value " + maxRecords + " for MaxRecords. Must be between 20 and 100", 400);
+            }
+        }
+        String identifier = params.getFirst("GlobalClusterIdentifier");
+        if (identifier != null && !identifier.isBlank()) {
+            // Naming one is a different question from listing none, and AWS errors on it.
+            throw new AwsException("GlobalClusterNotFoundFault",
+                    "Global cluster '" + identifier + "' not found", 404);
+        }
+        // No page is ever handed out, so any marker a caller presents came from somewhere else.
+        String marker = params.getFirst("Marker");
+        if (marker != null && !marker.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "The request token is invalid.", 400);
+        }
+        // Filters are not validated: the answer is empty for every name AWS accepts, and a partial
+        // list of accepted names would reject filters a live account allows.
+        XmlBuilder xml = new XmlBuilder().start("GlobalClusters").end("GlobalClusters");
+        return Response.ok(AwsQueryResponse.envelope("DescribeGlobalClusters", AwsNamespaces.RDS, xml.build())).build();
     }
 
     private Response handleDescribeDbClusterSnapshots(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -95,6 +95,7 @@ public class RdsQueryHandler {
                 case "ModifyDBProxyTargetGroup" -> handleModifyDbProxyTargetGroup(params, region);
                 case "DescribeDBProxyTargets" -> handleDescribeDbProxyTargets(params, region);
                 case "DescribeDBClusterSnapshots" -> handleDescribeDbClusterSnapshots(params);
+                case "DescribeGlobalClusters" -> handleDescribeGlobalClusters(params);
                 case "AddTagsToResource" -> handleAddTagsToResource(params, region);
                 case "ListTagsForResource" -> handleListTagsForResource(params, region);
                 case "RemoveTagsFromResource" -> handleRemoveTagsFromResource(params, region);
@@ -1094,6 +1095,41 @@ public class RdsQueryHandler {
             xml.elem("TargetArn", t.getTargetArn());
         }
         return xml.build();
+    }
+
+    private Response handleDescribeGlobalClusters(MultivaluedMap<String, String> params) {
+        // Global clusters are not modeled. Both providers read this on every cluster read, and
+        // DocumentDB signs with the "rds" scope, so this handler answers for either service.
+        // MaxRecords is rejected before the identifier is looked up, and a marker after it —
+        // the order a live account applies them in.
+        String maxRecords = params.getFirst("MaxRecords");
+        if (maxRecords != null && !maxRecords.isBlank()) {
+            int max = -1;
+            try {
+                max = Integer.parseInt(maxRecords.trim());
+            } catch (NumberFormatException e) {
+                LOG.debugv("Non-numeric MaxRecords {0} on DescribeGlobalClusters", maxRecords);
+            }
+            if (max < 20 || max > 100) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid value " + maxRecords + " for MaxRecords. Must be between 20 and 100", 400);
+            }
+        }
+        String identifier = params.getFirst("GlobalClusterIdentifier");
+        if (identifier != null && !identifier.isBlank()) {
+            // Naming one is a different question from listing none, and AWS errors on it.
+            throw new AwsException("GlobalClusterNotFoundFault",
+                    "Global cluster '" + identifier + "' not found", 404);
+        }
+        // No page is ever handed out, so any marker a caller presents came from somewhere else.
+        String marker = params.getFirst("Marker");
+        if (marker != null && !marker.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "The request token is invalid.", 400);
+        }
+        // Filters are not validated: the answer is empty for every name AWS accepts, and a partial
+        // list of accepted names would reject filters a live account allows.
+        String result = new XmlBuilder().start("GlobalClusters").end("GlobalClusters").build();
+        return Response.ok(AwsQueryResponse.envelope("DescribeGlobalClusters", AwsNamespaces.RDS, result)).build();
     }
 
     private Response handleDescribeDbClusterSnapshots(MultivaluedMap<String, String> params) {

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsQueryControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsQueryControllerIntegrationTest.java
@@ -2,10 +2,14 @@ package io.github.hectorvent.floci.core.common;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
 class AwsQueryControllerIntegrationTest {
@@ -38,6 +42,26 @@ class AwsQueryControllerIntegrationTest {
             .contentType("application/xml")
             .body("DescribeGlobalClustersResponse.DescribeGlobalClustersResult.GlobalClusters",
                     equalTo(""));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"DescribeDBClusterSnapshots", "DescribeDBSnapshots",
+            "DescribeDBClusterParameterGroups", "DescribeDBClusterParameters", "DescribeOptionGroups",
+            "CreateDBClusterParameterGroup", "ModifyDBClusterParameterGroup",
+            "DeleteDBClusterParameterGroup", "CreateOptionGroup", "ModifyOptionGroup",
+            "DeleteOptionGroup"})
+    void everyRdsActionIsInferredWithoutAnAuthorizationHeader(String action) {
+        // Whatever each answers — a result or a validation error for the parameters left out here —
+        // RDS has to be the one answering. An action the handler serves but the inference list does
+        // not name is dispatched to SQS instead.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", action)
+        .when()
+            .post("/")
+        .then()
+            .body(not(containsString("sqs.amazonaws.com")))
+            .body(not(containsString("is not supported by SQS")));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsQueryControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsQueryControllerIntegrationTest.java
@@ -24,6 +24,23 @@ class AwsQueryControllerIntegrationTest {
     }
 
     @Test
+    void globalClusterActionFallbackWithoutAuthorizationHeader() {
+        // Without a credential scope the service is inferred from the action. An action the RDS
+        // handler serves but the inference list does not name is dispatched to SQS, which answers
+        // UnsupportedOperation for it.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeGlobalClusters")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeGlobalClustersResponse.DescribeGlobalClustersResult.GlobalClusters",
+                    equalTo(""));
+    }
+
+    @Test
     void ec2ActionFallbackWithoutAuthorizationHeader() {
         given()
             .contentType("application/x-www-form-urlencoded")

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbGlobalClusterIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbGlobalClusterIntegrationTest.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * DescribeGlobalClusters on the path the DocumentDB SDK actually takes.
+ *
+ * <p>DocumentDB's signing name is {@code rds}, and this action carries no engine or cluster
+ * identifier to route on, so the request reaches the RDS handler however the caller thinks of it.
+ * The provider reads it as part of every {@code aws_docdb_cluster} read: without an answer the
+ * cluster is created and then cannot be read back, which fails the apply after the fact.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DocDbGlobalClusterIntegrationTest {
+
+    private static final String CLUSTER_ID = "gc-read-back-cluster";
+
+    /** What the DocumentDB SDK signs with. */
+    private static final String RDS_SCOPE =
+            "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/rds/aws4_request, "
+            + "SignedHeaders=content-type;host, Signature=test";
+    /** The scope floci also accepts for DocumentDB. */
+    private static final String DOCDB_SCOPE =
+            "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/docdb/aws4_request, "
+            + "SignedHeaders=content-type;host, Signature=test";
+
+    private static io.restassured.specification.RequestSpecification query(String scope, String action) {
+        return given().header("Authorization", scope)
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    @Test
+    @Order(1)
+    void createTheClusterTheProviderWouldCreate() {
+        query(RDS_SCOPE, "CreateDBCluster")
+                .formParam("DBClusterIdentifier", CLUSTER_ID)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(CLUSTER_ID));
+    }
+
+    @Test
+    @Order(2)
+    void theReadThatFollowsTheCreateReportsNoGlobalClusters() {
+        // No engine or cluster id on this request, so it lands on the RDS handler — the same
+        // place the provider's call lands.
+        query(RDS_SCOPE, "DescribeGlobalClusters")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<GlobalClusters></GlobalClusters>"))
+            .body(containsString("rds.amazonaws.com/doc/2014-10-31"));
+    }
+
+    @Test
+    @Order(2)
+    void theDocDbScopeAnswersTheSameWay() {
+        query(DOCDB_SCOPE, "DescribeGlobalClusters")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<GlobalClusters></GlobalClusters>"));
+
+        query(DOCDB_SCOPE, "DescribeGlobalClusters")
+                .formParam("GlobalClusterIdentifier", "no-such-gc")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("GlobalClusterNotFoundFault"))
+            .body(containsString("Global cluster &apos;no-such-gc&apos; not found"));
+    }
+
+    @Test
+    @Order(3)
+    void theClusterIsStillReadableAfterwards() {
+        query(RDS_SCOPE, "DescribeDBClusters")
+                .formParam("DBClusterIdentifier", CLUSTER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(CLUSTER_ID))
+            .body(containsString("docdb"));
+    }
+
+    @Test
+    @Order(4)
+    void cleanUp() {
+        query(RDS_SCOPE, "DeleteDBCluster")
+                .formParam("DBClusterIdentifier", CLUSTER_ID)
+                .formParam("SkipFinalSnapshot", "true")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -907,6 +907,108 @@ class RdsQueryHandlerTest {
         assertFalse(body.contains("<Marker>"));
     }
 
+    // ─────────────────────────── Global clusters ───────────────────────────────
+
+    @Test
+    void describeGlobalClusters_returnsEmptyListWith200() {
+        // The RDS and DocumentDB providers both read this on every cluster read, and DocumentDB
+        // signs with the "rds" scope, so this handler answers for both. A live account with no
+        // global clusters answers with an empty list, not an error.
+        Response response = handler.handle("DescribeGlobalClusters", params());
+
+        String body = (String) response.getEntity();
+        assertEquals(200, response.getStatus());
+        assertTrue(body.contains("<DescribeGlobalClustersResult>"));
+        assertTrue(body.contains("<GlobalClusters></GlobalClusters>"));
+        assertTrue(body.contains("rds.amazonaws.com/doc/2014-10-31"));
+    }
+
+    @Test
+    void describeGlobalClusters_unknownIdentifierIsNotFound() {
+        // Naming one that does not exist is a different question from listing none, and AWS
+        // answers it with GlobalClusterNotFoundFault rather than an empty list.
+        MultivaluedMap<String, String> params = params();
+        params.putSingle("GlobalClusterIdentifier", "no-such-gc");
+
+        Response response = handler.handle("DescribeGlobalClusters", params);
+
+        String body = (String) response.getEntity();
+        assertEquals(404, response.getStatus());
+        assertTrue(body.contains("<Code>GlobalClusterNotFoundFault</Code>"));
+        assertTrue(body.contains("Global cluster &apos;no-such-gc&apos; not found"));
+    }
+
+    @Test
+    void describeGlobalClusters_blankIdentifierListsRatherThanFailing() {
+        // An empty form field is the SDK omitting the filter, not a request for a cluster named "".
+        MultivaluedMap<String, String> params = params();
+        params.putSingle("GlobalClusterIdentifier", "");
+
+        Response response = handler.handle("DescribeGlobalClusters", params);
+
+        assertEquals(200, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("<GlobalClusters></GlobalClusters>"));
+    }
+
+    @Test
+    void describeGlobalClusters_rejectsMaxRecordsOutsideTheAllowedRange() {
+        // A live account rejects this before it looks the identifier up, so an empty model is no
+        // reason to accept a value AWS refuses.
+        for (String value : new String[]{"5", "101", "abc"}) {
+            MultivaluedMap<String, String> params = params();
+            params.putSingle("MaxRecords", value);
+            params.putSingle("GlobalClusterIdentifier", "no-such-gc");
+
+            Response response = handler.handle("DescribeGlobalClusters", params);
+
+            assertEquals(400, response.getStatus(), "MaxRecords=" + value);
+            String body = (String) response.getEntity();
+            assertTrue(body.contains("Invalid value " + value + " for MaxRecords"), body);
+        }
+    }
+
+    @Test
+    void describeGlobalClusters_acceptsMaxRecordsInsideTheAllowedRange() {
+        MultivaluedMap<String, String> params = params();
+        params.putSingle("MaxRecords", "20");
+
+        Response response = handler.handle("DescribeGlobalClusters", params);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    void describeGlobalClusters_rejectsAMarkerItNeverIssued() {
+        // No page is ever handed out, so a marker cannot have come from here. AWS checks this
+        // after the identifier, which is why the not-found wins when both are present.
+        MultivaluedMap<String, String> params = params();
+        params.putSingle("Marker", "bogus");
+
+        Response response = handler.handle("DescribeGlobalClusters", params);
+
+        assertEquals(400, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("The request token is invalid."));
+
+        params.putSingle("GlobalClusterIdentifier", "no-such-gc");
+        Response withBoth = handler.handle("DescribeGlobalClusters", params);
+        assertEquals(404, withBoth.getStatus());
+        assertTrue(((String) withBoth.getEntity()).contains("GlobalClusterNotFoundFault"));
+    }
+
+    @Test
+    void describeGlobalClusters_acceptsFiltersWithoutValidatingThem() {
+        // Every filter name AWS accepts answers empty here, and Floci carries no list of the
+        // accepted names — rejecting one would refuse a filter a live account allows.
+        MultivaluedMap<String, String> params = params();
+        params.putSingle("Filters.Filter.1.Name", "db-cluster-id");
+        params.putSingle("Filters.Filter.1.Values.Value.1", "anything");
+
+        Response response = handler.handle("DescribeGlobalClusters", params);
+
+        assertEquals(200, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("<GlobalClusters></GlobalClusters>"));
+    }
+
     // ──────────────────────────── DBProxy wire shapes ──────────────────────────
 
     @Test


### PR DESCRIPTION
Closes #2400.

## What

`aws_docdb_cluster` reads global cluster information as part of every cluster read, so a DocumentDB cluster created against Floci fails its apply on `UnsupportedOperation` — created, but not readable:

```
Error: reading DocumentDB Global Cluster information for DocumentDB Cluster (...):
operation error DocDB: DescribeGlobalClusters, https response error StatusCode: 400,
api error UnsupportedOperation: Operation DescribeGlobalClusters is not supported.
```

## Where the action actually lands

DocumentDB's signing name is `rds`, and `DescribeGlobalClusters` carries no engine or cluster identifier for `AwsQueryController` to route on, so the request reaches `RdsQueryHandler` whichever service the caller has in mind — the quoted error is that handler's wording. The implementation lives there, and the `docdb` credential scope Floci also accepts answers identically through `DocDbQueryHandler`.

Global clusters are not modelled, so the list is empty — which is what a live account with none answers, rather than an error.

## Behaviour, checked against a live account

| Request | Answer |
|---|---|
| no parameters | `200`, empty `<GlobalClusters>` |
| `GlobalClusterIdentifier` naming one that does not exist | `404 GlobalClusterNotFoundFault` — `Global cluster 'x' not found` |
| `MaxRecords` outside 20–100 | `400 InvalidParameterValue`, applied *before* the identifier lookup |
| `Marker` | `400 InvalidParameterValue` — `The request token is invalid.`, applied *after* the identifier |

Both services answer identically, and both answer in the RDS namespace (`http://rds.amazonaws.com/doc/2014-10-31/`).

Filters are accepted without validation. A live account rejects an unrecognised filter name, but accepts at least `db-cluster-id` and `engine`, and every name it accepts answers empty here — a partial list of accepted names would refuse filters that are valid.

## Unsigned requests

Without a credential scope the service is inferred from the action name, and the inference list named 31 of the 43 actions `RdsQueryHandler` dispatches — so `DescribeGlobalClusters` was answered by SQS with `UnsupportedOperation`. The other eleven were in the same state: the five cluster parameter group actions, the four option group actions, and both snapshot describes. All twelve are added, so every action the handler dispatches is now inferable and nothing inferable is undispatched — both directions empty. None of the twelve appears in another service's inference list, so no existing routing changes.

These two fixes are in their own commits, separate from the feature commit.

## Tests

- `RdsQueryHandlerTest` — wire shape, namespace, the not-found error, the `MaxRecords` range and its precedence, the marker, filters
- `DocDbGlobalClusterIntegrationTest` — the provider's sequence over HTTP: create a docdb cluster on the rds scope, read global clusters, read the cluster back; plus the docdb scope
- `compatibility-tests/sdk-test-awscli/test/rds.bats` — `aws rds describe-global-clusters` and `aws docdb describe-global-clusters`, so the CLI's own parser checks the wire shape
- `AwsQueryControllerIntegrationTest` — the unsigned path: `DescribeGlobalClusters` answering an empty list, and a parameterized case over the eleven actions asserting RDS answers them rather than SQS

Each was proved by reverting the change and watching the test fail: the dispatch case in each handler, the not-found guard, and both new validations.

