### PR TITLE
fix: preserve Firehose compression format in CloudFormation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -1981,6 +1981,10 @@ public class CloudFormationResourceProvisioner {
                 : (props != null ? props.get("S3DestinationConfiguration") : null);
         if (s3Node != null && !s3Node.isNull()) {
             s3 = new DeliveryStreamDescription.S3Destination();
+
+            s3.setCompressionFormat(
+                blankToNull(engine.resolve(s3Node.path("CompressionFormat")))
+            );
             s3.setBucketArn(blankToNull(engine.resolve(s3Node.path("BucketARN"))));
             s3.setPrefix(blankToNull(engine.resolve(s3Node.path("Prefix"))));
             if (s3Node.has("BufferingHints")) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationFirehoseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationFirehoseIntegrationTest.java
@@ -39,7 +39,8 @@ class CloudFormationFirehoseIntegrationTest {
                         "S3DestinationConfiguration": {
                           "BucketARN": "arn:aws:s3:::my-firehose-bucket",
                           "RoleARN": "arn:aws:iam::000000000000:role/firehose-role",
-                          "Prefix": "logs/"
+                          "Prefix": "logs/",
+                          "CompressionFormat": "GZIP"
                         }
                       }
                     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationFirehoseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationFirehoseIntegrationTest.java
@@ -88,5 +88,6 @@ class CloudFormationFirehoseIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString(streamName));
+            .body(containsString("GZIP"))
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationFirehoseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationFirehoseIntegrationTest.java
@@ -1,13 +1,13 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
-import io.quarkus.test.junit.QuarkusTest;
-import io.restassured.RestAssured;
-import io.restassured.config.EncoderConfig;
-import io.restassured.http.ContentType;
+import static org.hamcrest.Matchers.containsString;
 import org.junit.jupiter.api.Test;
 
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
 import static io.restassured.RestAssured.given;
-import static org.hamcrest.Matchers.containsString;
+import io.restassured.config.EncoderConfig;
+import io.restassured.http.ContentType;
 
 /**
  * End-to-end check that CloudFormation provisions an AWS::KinesisFirehose::DeliveryStream for real
@@ -87,7 +87,7 @@ class CloudFormationFirehoseIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body(containsString(streamName));
-            .body(containsString("GZIP"))
+            .body(containsString(streamName))
+            .body(containsString("GZIP"));
     }
 }


### PR DESCRIPTION
Fixes an issue where the CompressionFormat configured for an AWS Kinesis Data Firehose delivery stream was not propagated when the stream was created through CloudFormation.

Problem

When a Firehose delivery stream was provisioned using CloudFormation with S3DestinationConfiguration or ExtendedS3DestinationConfiguration, the CompressionFormat property was not copied to the internal S3Destination model.

For example:

{
  "S3DestinationConfiguration": {
    "BucketARN": "arn:aws:s3:::my-firehose-bucket",
    "RoleARN": "arn:aws:iam::000000000000:role/firehose-role",
    "Prefix": "logs/",
    "CompressionFormat": "GZIP"
  }
}

The CompressionFormat value was therefore lost during CloudFormation provisioning.

Solution

Updated CloudFormationResourceProvisioner to read and propagate CompressionFormat from the CloudFormation destination configuration:

s3.setCompressionFormat(
    blankToNull(engine.resolve(s3Node.path("CompressionFormat")))
);

This works for both:

S3DestinationConfiguration
ExtendedS3DestinationConfiguration
Tests

Added a regression case to CloudFormationFirehoseIntegrationTest using:

"CompressionFormat": "GZIP"
Verification
CloudFormationFirehoseIntegrationTest — 1 passed, 0 failures
git diff --check — passed
Maven build — BUILD SUCCESS
Related

This ensures CloudFormation-created Firehose delivery streams correctly preserve the requested S3 compression format.