### PR TITLE
feat(rds,docdb): tag DocumentDB clusters and parameter groups

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -162,3 +162,33 @@ teardown() {
 
     aws_cmd rds delete-db-cluster-parameter-group --db-cluster-parameter-group-name "$CPG" >/dev/null 2>&1 || true
 }
+
+@test "DocDB: cluster tags survive create and can be added and removed" {
+    # The tag actions carry only the resource ARN, so this is also the check that they reach
+    # DocumentDB at all rather than the RDS handler, which does not hold its records.
+    CLUSTER_ID="bats-docdb-$(unique_name)"
+    run aws_cmd docdb create-db-cluster --db-cluster-identifier "$CLUSTER_ID" \
+        --engine docdb --master-username docdbadmin --master-user-password "secret99password" \
+        --tags Key=env,Value=bats
+    assert_success
+    arn=$(json_get "$output" '.DBCluster.DBClusterArn')
+
+    run aws_cmd docdb list-tags-for-resource --resource-name "$arn"
+    assert_success
+    assert_output --partial '"Key": "env"'
+
+    run aws_cmd docdb add-tags-to-resource --resource-name "$arn" --tags Key=env,Value=changed Key=extra,Value=yes
+    assert_success
+    run aws_cmd docdb list-tags-for-resource --resource-name "$arn"
+    assert_success
+    assert_output --partial '"Value": "changed"'
+
+    # Removing a key that is not there is not an error on a live account.
+    run aws_cmd docdb remove-tags-from-resource --resource-name "$arn" --tag-keys extra absent
+    assert_success
+    run aws_cmd docdb list-tags-for-resource --resource-name "$arn"
+    assert_success
+    refute_output --partial '"Key": "extra"'
+
+    aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
+}

--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -145,3 +145,20 @@ teardown() {
     assert_failure
     assert_output --partial "GlobalClusterNotFoundFault"
 }
+
+@test "RDS: cluster parameter group reports its ARN and carries tags" {
+    CPG="bats-cpg-$(unique_name)"
+    run aws_cmd rds create-db-cluster-parameter-group --db-cluster-parameter-group-name "$CPG" \
+        --db-parameter-group-family aurora-postgresql15 --description "bats" \
+        --tags Key=team,Value=data
+    assert_success
+    arn=$(json_get "$output" '.DBClusterParameterGroup.DBClusterParameterGroupArn')
+    [ -n "$arn" ]
+    [[ "$arn" == *":cluster-pg:$CPG" ]]
+
+    run aws_cmd rds list-tags-for-resource --resource-name "$arn"
+    assert_success
+    assert_output --partial '"Key": "team"'
+
+    aws_cmd rds delete-db-cluster-parameter-group --db-cluster-parameter-group-name "$CPG" >/dev/null 2>&1 || true
+}

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -29,6 +29,9 @@ The management API shares the RDS Query endpoint (`POST /` with an `Action=` par
 | `DescribeDBInstances` | List instances |
 | `DeleteDBInstance` | Remove an instance from a cluster |
 | `ModifyDBInstance` | Update instance class or IAM auth setting |
+| `ListTagsForResource` | List a cluster's or instance's tags |
+| `AddTagsToResource` | Add or overwrite tags on a cluster or instance |
+| `RemoveTagsFromResource` | Remove tags by key from a cluster or instance |
 <!-- floci:actions:end -->
 
 ## Configuration

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -299,7 +299,8 @@ public class AwsQueryController {
 
                 if ("docdb".equalsIgnoreCase(engine)
                        || docDbService.hasCluster(clusterId)
-                       || docDbService.hasInstance(instanceId)) {
+                       || docDbService.hasInstance(instanceId)
+                       || namesDocDbResource(formParams.getFirst("ResourceName"))) {
                         yield docDbQueryHandler.handle(action, formParams);
                 }
                 yield rdsQueryHandler.handle(action, formParams, region);
@@ -317,6 +318,25 @@ public class AwsQueryController {
             default -> xmlErrorResponse("UnknownService",
                     "Unknown or unsupported service: " + service, 400);
         };
+    }
+
+    /**
+     * Whether a tagging {@code ResourceName} names a DocumentDB cluster or instance.
+     *
+     * <p>The tag actions carry no engine or identifier to route on — only the ARN of the resource
+     * they address — so without reading it they reach the RDS handler, which does not hold
+     * DocumentDB's records. An ARN naming something DocumentDB does not have stays with RDS.
+     */
+    private boolean namesDocDbResource(String resourceName) {
+        if (resourceName == null || !resourceName.startsWith("arn:")) {
+            return false;
+        }
+        int lastSeparator = resourceName.lastIndexOf(':');
+        if (lastSeparator < 0 || lastSeparator == resourceName.length() - 1) {
+            return false;
+        }
+        String identifier = resourceName.substring(lastSeparator + 1);
+        return docDbService.hasCluster(identifier) || docDbService.hasInstance(identifier);
     }
 
     private Response handleCognitoQuery(String action, MultivaluedMap<String, String> formParams, String region) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -183,6 +183,8 @@ public class AwsQueryController {
     private final DocDbQueryHandler docDbQueryHandler;
     private final DocDbService docDbService;
     private final RdsService rdsService;
+    /** ARNs already reported as held by both services, so the warning is logged once each. */
+    private final java.util.Set<String> reportedArnCollisions = java.util.concurrent.ConcurrentHashMap.newKeySet();
     private final SqsQueryHandler sqsQueryHandler;
     private final SnsQueryHandler snsQueryHandler;
     private final SesQueryHandler sesQueryHandler;
@@ -314,7 +316,7 @@ public class AwsQueryController {
                 if ("docdb".equalsIgnoreCase(engine)
                        || docDbService.hasCluster(clusterId)
                        || docDbService.hasInstance(instanceId)
-                       || namesDocDbResource(formParams.getFirst("ResourceName"))) {
+                       || namesDocDbResource(formParams.getFirst("ResourceName"), region)) {
                         yield docDbQueryHandler.handle(action, formParams);
                 }
                 yield rdsQueryHandler.handle(action, formParams, region);
@@ -343,9 +345,25 @@ public class AwsQueryController {
      * share one ARN space, so a name both services use would otherwise be answered from the wrong
      * store, and an RDS parameter group or option group could be resolved as a cluster. Anything
      * DocumentDB does not hold under that exact ARN stays with RDS.
+     *
+     * <p>State persisted before creates were made to share one identifier space can still hold the
+     * same identifier in both stores. DocumentDB answers it, which is what the identifier checks
+     * above already do for every other action on that record — describe, modify and delete
+     * included — so one identifier keeps one answer. The collision is logged once, because the
+     * RDS record behind it is unreachable on this scope and only deleting one of the two fixes it.
      */
-    private boolean namesDocDbResource(String resourceName) {
-        return docDbService.hasResourceWithArn(resourceName);
+    private boolean namesDocDbResource(String resourceName, String region) {
+        if (!docDbService.hasResourceWithArn(resourceName)) {
+            return false;
+        }
+        String identifier = resourceName.substring(resourceName.lastIndexOf(':') + 1);
+        if (rdsService.hasClusterOrInstance(identifier, identifier, region)
+                && reportedArnCollisions.add(resourceName)) {
+            LOG.warnv("RDS and DocumentDB both hold {0}; DocumentDB answers for it, as it does for "
+                    + "every other action on that identifier. Delete one of the two records.",
+                    resourceName);
+        }
+        return true;
     }
 
     private Response handleCognitoQuery(String action, MultivaluedMap<String, String> formParams, String region) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -322,8 +322,8 @@ public class AwsQueryController {
                 }
 
                 if ("docdb".equalsIgnoreCase(engine)
-                       || docDbService.hasCluster(clusterId)
-                       || docDbService.hasInstance(instanceId)
+                       || docDbService.hasCluster(clusterId, region)
+                       || docDbService.hasInstance(instanceId, region)
                        || namesDocDbResource(formParams.getFirst("ResourceName"), region)) {
                         yield docDbQueryHandler.handle(action, formParams);
                 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -302,9 +302,17 @@ public class AwsQueryController {
                 // create an Aurora cluster named like an existing DocumentDB one. Sending a create
                 // to whoever already holds the identifier is what answers AlreadyExists — and it
                 // stops two services holding one identifier, which no ARN could then tell apart.
-                boolean creating = "CreateDBCluster".equals(action) || "CreateDBInstance".equals(action);
-                if (creating && rdsService.hasClusterOrInstance(clusterId, instanceId, region)) {
-                    yield rdsQueryHandler.handle(action, formParams, region);
+                // Only the identifier being created is checked: CreateDBInstance names the parent
+                // cluster too, and that one existing in RDS is the normal case, not a clash.
+                if ("CreateDBCluster".equals(action)
+                        && rdsService.hasClusterOrInstance(clusterId, null, region)) {
+                    yield xmlErrorResponse("DBClusterAlreadyExistsFault",
+                            "DB Cluster already exists", 400);
+                }
+                if ("CreateDBInstance".equals(action)
+                        && rdsService.hasClusterOrInstance(null, instanceId, region)) {
+                    yield xmlErrorResponse("DBInstanceAlreadyExists",
+                            "DB Instance already exists", 400);
                 }
 
                 if ("neptune".equalsIgnoreCase(engine)

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.elasticache.ElastiCacheQueryHandler;
 import io.github.hectorvent.floci.services.iam.IamQueryHandler;
 import io.github.hectorvent.floci.services.iam.StsQueryHandler;
 import io.github.hectorvent.floci.services.rds.RdsQueryHandler;
+import io.github.hectorvent.floci.services.rds.RdsService;
 import io.github.hectorvent.floci.services.sns.SnsQueryHandler;
 import io.github.hectorvent.floci.services.ses.SesQueryHandler;
 import io.github.hectorvent.floci.services.sqs.SqsQueryHandler;
@@ -181,6 +182,7 @@ public class AwsQueryController {
     private final NeptuneService neptuneService;
     private final DocDbQueryHandler docDbQueryHandler;
     private final DocDbService docDbService;
+    private final RdsService rdsService;
     private final SqsQueryHandler sqsQueryHandler;
     private final SnsQueryHandler snsQueryHandler;
     private final SesQueryHandler sesQueryHandler;
@@ -203,6 +205,7 @@ public class AwsQueryController {
                               NeptuneService neptuneService,
                               DocDbQueryHandler docDbQueryHandler,
                               DocDbService docDbService,
+                              RdsService rdsService,
                               SqsQueryHandler sqsQueryHandler, SnsQueryHandler snsQueryHandler,
                               SesQueryHandler sesQueryHandler,
                               IamQueryHandler iamQueryHandler, StsQueryHandler stsQueryHandler,
@@ -221,6 +224,7 @@ public class AwsQueryController {
         this.neptuneService = neptuneService;
         this.docDbQueryHandler = docDbQueryHandler;
         this.docDbService = docDbService;
+        this.rdsService = rdsService;
         this.sqsQueryHandler = sqsQueryHandler;
         this.snsQueryHandler = snsQueryHandler;
         this.sesQueryHandler = sesQueryHandler;
@@ -291,6 +295,16 @@ public class AwsQueryController {
                 String engine = formParams.getFirst("Engine");
                 String clusterId = formParams.getFirst("DBClusterIdentifier");
                 String instanceId = formParams.getFirst("DBInstanceIdentifier");
+
+                // One identifier space covers the whole RDS family: a live account refuses to
+                // create an Aurora cluster named like an existing DocumentDB one. Sending a create
+                // to whoever already holds the identifier is what answers AlreadyExists — and it
+                // stops two services holding one identifier, which no ARN could then tell apart.
+                boolean creating = "CreateDBCluster".equals(action) || "CreateDBInstance".equals(action);
+                if (creating && rdsService.hasClusterOrInstance(clusterId, instanceId, region)) {
+                    yield rdsQueryHandler.handle(action, formParams, region);
+                }
+
                 if ("neptune".equalsIgnoreCase(engine)
                         || neptuneService.hasCluster(clusterId)
                         || neptuneService.hasInstance(instanceId)) {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -298,21 +298,9 @@ public class AwsQueryController {
                 String clusterId = formParams.getFirst("DBClusterIdentifier");
                 String instanceId = formParams.getFirst("DBInstanceIdentifier");
 
-                // One identifier space covers the whole RDS family: a live account refuses to
-                // create an Aurora cluster named like an existing DocumentDB one. Sending a create
-                // to whoever already holds the identifier is what answers AlreadyExists — and it
-                // stops two services holding one identifier, which no ARN could then tell apart.
-                // Only the identifier being created is checked: CreateDBInstance names the parent
-                // cluster too, and that one existing in RDS is the normal case, not a clash.
-                if ("CreateDBCluster".equals(action)
-                        && rdsService.hasClusterOrInstance(clusterId, null, region)) {
-                    yield xmlErrorResponse("DBClusterAlreadyExistsFault",
-                            "DB Cluster already exists", 400);
-                }
-                if ("CreateDBInstance".equals(action)
-                        && rdsService.hasClusterOrInstance(null, instanceId, region)) {
-                    yield xmlErrorResponse("DBInstanceAlreadyExists",
-                            "DB Instance already exists", 400);
+                Response identifierClash = rdsAlreadyHoldsIdentifier(action, formParams, region);
+                if (identifierClash != null) {
+                    yield identifierClash;
                 }
 
                 if ("neptune".equalsIgnoreCase(engine)
@@ -330,7 +318,12 @@ public class AwsQueryController {
                 yield rdsQueryHandler.handle(action, formParams, region);
             }
             case "neptune" -> neptuneQueryHandler.handle(action, formParams);
-            case "docdb" -> docDbQueryHandler.handle(action, formParams);
+            case "docdb" -> {
+                // The same check as on the rds scope: DocumentDB is reachable under either, and a
+                // create that skipped it here would put a second record under an ARN RDS owns.
+                Response clash = rdsAlreadyHoldsIdentifier(action, formParams, region);
+                yield clash != null ? clash : docDbQueryHandler.handle(action, formParams);
+            }
             case "email" -> sesQueryHandler.handle(action, formParams, region);
             case "monitoring" -> cloudWatchMetricsQueryHandler.handle(action, formParams, region);
             case "cloudformation" -> cloudFormationQueryHandler.handle(action, formParams, region);
@@ -342,6 +335,31 @@ public class AwsQueryController {
             default -> xmlErrorResponse("UnknownService",
                     "Unknown or unsupported service: " + service, 400);
         };
+    }
+
+    /**
+     * The AlreadyExists answer when a create names an identifier RDS already holds here, or null.
+     *
+     * <p>One identifier space covers the whole RDS family: a live account refuses to create an
+     * Aurora cluster named like an existing DocumentDB one. Answering that way is what stops two
+     * services holding one identifier in one region, which no ARN could then tell apart — so the
+     * check has to run on every route that reaches DocumentDB, not only the {@code rds} scope.
+     *
+     * <p>Only the identifier being created is checked: {@code CreateDBInstance} names its parent
+     * cluster too, and that cluster existing in RDS is the normal case rather than a clash.
+     */
+    private Response rdsAlreadyHoldsIdentifier(String action,
+                                               MultivaluedMap<String, String> formParams,
+                                               String region) {
+        if ("CreateDBCluster".equals(action) && rdsService.hasClusterOrInstance(
+                formParams.getFirst("DBClusterIdentifier"), null, region)) {
+            return xmlErrorResponse("DBClusterAlreadyExistsFault", "DB Cluster already exists", 400);
+        }
+        if ("CreateDBInstance".equals(action) && rdsService.hasClusterOrInstance(
+                null, formParams.getFirst("DBInstanceIdentifier"), region)) {
+            return xmlErrorResponse("DBInstanceAlreadyExists", "DB Instance already exists", 400);
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -325,18 +325,13 @@ public class AwsQueryController {
      *
      * <p>The tag actions carry no engine or identifier to route on — only the ARN of the resource
      * they address — so without reading it they reach the RDS handler, which does not hold
-     * DocumentDB's records. An ARN naming something DocumentDB does not have stays with RDS.
+     * DocumentDB's records. The whole ARN is matched, not its trailing name: RDS and DocumentDB
+     * share one ARN space, so a name both services use would otherwise be answered from the wrong
+     * store, and an RDS parameter group or option group could be resolved as a cluster. Anything
+     * DocumentDB does not hold under that exact ARN stays with RDS.
      */
     private boolean namesDocDbResource(String resourceName) {
-        if (resourceName == null || !resourceName.startsWith("arn:")) {
-            return false;
-        }
-        int lastSeparator = resourceName.lastIndexOf(':');
-        if (lastSeparator < 0 || lastSeparator == resourceName.length() - 1) {
-            return false;
-        }
-        String identifier = resourceName.substring(lastSeparator + 1);
-        return docDbService.hasCluster(identifier) || docDbService.hasInstance(identifier);
+        return docDbService.hasResourceWithArn(resourceName);
     }
 
     private Response handleCognitoQuery(String action, MultivaluedMap<String, String> formParams, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
@@ -366,7 +366,10 @@ public class DocDbQueryHandler {
                 if (key == null) {
                     break;
                 }
-                tags.put(key, params.getFirst(prefix + "." + i + ".Value"));
+                // A key given without a value is stored as an empty value, as AWS stores it —
+                // a null would also break the immutable copy the read hands back.
+                String value = params.getFirst(prefix + "." + i + ".Value");
+                tags.put(key, value == null ? "" : value);
             }
         }
         return tags;

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
@@ -13,7 +13,11 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 @ApplicationScoped
 public class DocDbQueryHandler {
@@ -43,6 +47,9 @@ public class DocDbQueryHandler {
                 case "DescribeDBInstances"-> handleDescribeDbInstances(params);
                 case "DeleteDBInstance"   -> handleDeleteDbInstance(params);
                 case "ModifyDBInstance"   -> handleModifyDbInstance(params);
+                case "ListTagsForResource" -> handleListTagsForResource(params);
+                case "AddTagsToResource"   -> handleAddTagsToResource(params);
+                case "RemoveTagsFromResource" -> handleRemoveTagsFromResource(params);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by DocDB.", AwsNamespaces.RDS, 400);
             };
@@ -71,6 +78,11 @@ public class DocDbQueryHandler {
 
         DocDbCluster cluster = service.createDbCluster(id, engineVersion,
                 masterUsername, masterPassword, iamEnabled);
+        // Tags given at create are readable back on a live account, so they must not be dropped.
+        Map<String, String> tags = parseTags(params);
+        if (!tags.isEmpty()) {
+            service.addTagsToResource(cluster.getDbClusterArn(), tags);
+        }
         return Response.ok(AwsQueryResponse.envelope("CreateDBCluster", AwsNamespaces.RDS,
                 clusterXml(cluster))).build();
     }
@@ -315,5 +327,62 @@ public class DocDbQueryHandler {
             }
         }
         return null;
+    }
+
+    // ── Tags ──────────────────────────────────────────────────────────────────
+
+    private Response handleListTagsForResource(MultivaluedMap<String, String> params) {
+        // Filters are accepted without validation: a live account rejects an unrecognised filter
+        // name, but Floci carries no list of the names it accepts, and the tags of one named
+        // resource are the same answer either way.
+        Map<String, String> tags = service.listTagsForResource(params.getFirst("ResourceName"));
+        XmlBuilder xml = new XmlBuilder().start("TagList");
+        tags.forEach((key, value) -> xml.start("Tag")
+                .elem("Key", key)
+                .elem("Value", value == null ? "" : value)
+                .end("Tag"));
+        xml.end("TagList");
+        return Response.ok(AwsQueryResponse.envelope("ListTagsForResource",
+                AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    private Response handleAddTagsToResource(MultivaluedMap<String, String> params) {
+        service.addTagsToResource(params.getFirst("ResourceName"), parseTags(params));
+        return Response.ok(AwsQueryResponse.envelope("AddTagsToResource", AwsNamespaces.RDS, "")).build();
+    }
+
+    private Response handleRemoveTagsFromResource(MultivaluedMap<String, String> params) {
+        service.removeTagsFromResource(params.getFirst("ResourceName"), tagKeys(params));
+        return Response.ok(AwsQueryResponse.envelope("RemoveTagsFromResource",
+                AwsNamespaces.RDS, "")).build();
+    }
+
+    /** Every spelling the SDKs and the CLI use for a tag list, as RdsQueryHandler reads them. */
+    private static Map<String, String> parseTags(MultivaluedMap<String, String> params) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        for (String prefix : List.of("Tags.member", "Tags.Tag", "Tag")) {
+            for (int i = 1; ; i++) {
+                String key = params.getFirst(prefix + "." + i + ".Key");
+                if (key == null) {
+                    break;
+                }
+                tags.put(key, params.getFirst(prefix + "." + i + ".Value"));
+            }
+        }
+        return tags;
+    }
+
+    private static List<String> tagKeys(MultivaluedMap<String, String> params) {
+        List<String> keys = new ArrayList<>();
+        for (String prefix : List.of("TagKeys.member", "TagKeys.TagKey", "TagKeys")) {
+            for (int i = 1; ; i++) {
+                String key = params.getFirst(prefix + "." + i);
+                if (key == null) {
+                    break;
+                }
+                keys.add(key);
+            }
+        }
+        return keys;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -67,7 +67,10 @@ public class DocDbService {
                         "DocDB cluster " + id + " already exists.", 400);
             }
 
-            String region = regionResolver.getDefaultRegion();
+            // The caller's region, not the configured default: the ARN this create answers with is
+            // the one the caller tags by, and a tag call is checked against the region it is made
+            // from — an ARN naming somewhere else is one its own creator cannot use.
+            String region = regionResolver.getRegion();
 
             DocDbCluster cluster = new DocDbCluster();
             cluster.setDbClusterIdentifier(id);
@@ -225,7 +228,7 @@ public class DocDbService {
                 }
 
                 DocDbCluster cluster = getDbCluster(dbClusterIdentifier);
-                String region = regionResolver.getDefaultRegion();
+                String region = regionResolver.getRegion();
 
                 DocDbInstance instance = new DocDbInstance();
                 instance.setDbInstanceIdentifier(id);

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -127,10 +127,27 @@ public class DocDbService {
     }
 
     public boolean hasCluster(String id) {
+        return hasCluster(id, regionResolver.getRegion());
+    }
+
+    /**
+     * Whether DocumentDB holds this cluster <em>in this region</em>.
+     *
+     * <p>The records are keyed by identifier alone, so the region has to come from the one place
+     * that carries it — the stored ARN. Without that, an RDS request naming a cluster DocumentDB
+     * holds somewhere else is answered from here, and a name RDS is free to reuse in another
+     * region stops being usable.
+     */
+    public boolean hasCluster(String id, String region) {
         if (id == null || id.isBlank()) {
             return false;
         }
-        return clusters.get(id).isPresent();
+        return clusters.get(id).filter(c -> regionOf(c.getDbClusterArn()).equals(region)).isPresent();
+    }
+
+    /** The region a record was created in, taken from its ARN; older records carry the default. */
+    private String regionOf(String arn) {
+        return AwsArnUtils.regionOrDefault(arn, regionResolver.getDefaultRegion());
     }
 
     /**
@@ -152,10 +169,14 @@ public class DocDbService {
     }
 
     public boolean hasInstance(String id) {
+        return hasInstance(id, regionResolver.getRegion());
+    }
+
+    public boolean hasInstance(String id, String region) {
         if (id == null || id.isBlank()) {
             return false;
         }
-        return instances.get(id).isPresent();
+        return instances.get(id).filter(i -> regionOf(i.getDbInstanceArn()).equals(region)).isPresent();
     }
 
     public Collection<DocDbCluster> listDbClusters(String filterId) {

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -130,6 +130,24 @@ public class DocDbService {
         return clusters.get(id).isPresent();
     }
 
+    /**
+     * Whether an ARN names a DocumentDB cluster or instance, matched against the stored ARN.
+     *
+     * <p>RDS and DocumentDB share the {@code arn:aws:rds:...} space, so the trailing identifier
+     * alone does not identify a service: an RDS resource whose name a DocumentDB record happens to
+     * share would be answered from the wrong store. The full ARN settles region, account, type and
+     * name in one comparison, as the db-cluster-id filter already does.
+     */
+    public boolean hasResourceWithArn(String arn) {
+        if (arn == null || !arn.startsWith("arn:")) {
+            return false;
+        }
+        return clusters.scan(k -> true).stream()
+                        .anyMatch(c -> arn.equalsIgnoreCase(c.getDbClusterArn()))
+                || instances.scan(k -> true).stream()
+                        .anyMatch(i -> arn.equalsIgnoreCase(i.getDbInstanceArn()));
+    }
+
     public boolean hasInstance(String id) {
         if (id == null || id.isBlank()) {
             return false;

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.docdb;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -17,8 +18,11 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ApplicationScoped
 public class DocDbService {
@@ -32,6 +36,11 @@ public class DocDbService {
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
     private final DocDbContainerManager containerManager;
+    /**
+     * One monitor per stored record, taken by everything that writes it. A tag update is a
+     * read-modify-write, so without a lock shared with delete it can put a deleted cluster back.
+     */
+    private final ConcurrentHashMap<String, Object> writeLocks = new ConcurrentHashMap<>();
 
     @Inject
     public DocDbService(EmulatorConfig config,
@@ -52,58 +61,60 @@ public class DocDbService {
     public DocDbCluster createDbCluster(String id, String engineVersion,
                                         String masterUsername, String masterPassword,
                                         boolean iamEnabled) {
-        if (clusters.get(id).isPresent()) {
-            throw new AwsException("DBClusterAlreadyExistsFault",
-                    "DocDB cluster " + id + " already exists.", 400);
-        }
-
-        String region = regionResolver.getDefaultRegion();
-
-        DocDbCluster cluster = new DocDbCluster();
-        cluster.setDbClusterIdentifier(id);
-        cluster.setStatus("available");
-        cluster.setEngineVersion(engineVersion != null ? engineVersion : ENGINE_VERSION_DEFAULT);
-        cluster.setMasterUsername(masterUsername);
-        cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
-        cluster.setDbClusterArn(regionResolver.buildArn("rds", region, "cluster:" + id));
-        cluster.setDbClusterResourceId("cluster-" + UUID.randomUUID().toString()
-                .replace("-", "").substring(0, 24).toUpperCase());
-        cluster.setCreatedAt(Instant.now());
-        cluster.setDbClusterMembers(new ArrayList<>());
-
-        if (config.services().docdb().mock()) {
-            LOG.infov("Creating DocDB cluster {0} in mock mode (no container)", id);
-            cluster.setEndpoint("localhost");
-            cluster.setReaderEndpoint("localhost");
-            cluster.setPort(MONGO_PORT);
-        } else {
-            String image = config.services().docdb().defaultImage();
-            LOG.infov("Creating DocDB cluster {0}, image={1}", id, image);
-            // A cluster record is metadata: its identifier, ARN and tags need no Docker, so the
-            // cluster is created and reaches 'available' even when no daemon is reachable. Only
-            // connecting to the database needs the container.
-            DocDbContainerHandle handle = containerManager.tryStart(id, image, masterUsername, masterPassword);
-            if (handle != null) {
-                cluster.setEndpoint(handle.getHost());
-                cluster.setReaderEndpoint(handle.getHost());
-                cluster.setPort(handle.getPort());
-                cluster.setContainerId(handle.getContainerId());
-                cluster.setContainerHost(handle.getHost());
-                cluster.setContainerPort(handle.getPort());
-            } else {
-                cluster.setEndpoint(resolveEndpointHost());
-                cluster.setReaderEndpoint(resolveEndpointHost());
-                cluster.setPort(MONGO_PORT);
-                LOG.warnv("DocDB cluster {0} created without a backing MongoDB container: no "
-                        + "Docker daemon is reachable. Metadata operations work; connections to "
-                        + "the cluster do not until a daemon appears.", id);
+        synchronized (lockFor("cluster:" + id)) {
+            if (clusters.get(id).isPresent()) {
+                throw new AwsException("DBClusterAlreadyExistsFault",
+                        "DocDB cluster " + id + " already exists.", 400);
             }
-        }
 
-        clusters.put(id, cluster);
-        LOG.infov("DocDB cluster {0} created, endpoint={1}:{2}",
-                id, cluster.getEndpoint(), String.valueOf(cluster.getPort()));
-        return cluster;
+            String region = regionResolver.getDefaultRegion();
+
+            DocDbCluster cluster = new DocDbCluster();
+            cluster.setDbClusterIdentifier(id);
+            cluster.setStatus("available");
+            cluster.setEngineVersion(engineVersion != null ? engineVersion : ENGINE_VERSION_DEFAULT);
+            cluster.setMasterUsername(masterUsername);
+            cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
+            cluster.setDbClusterArn(regionResolver.buildArn("rds", region, "cluster:" + id));
+            cluster.setDbClusterResourceId("cluster-" + UUID.randomUUID().toString()
+                    .replace("-", "").substring(0, 24).toUpperCase());
+            cluster.setCreatedAt(Instant.now());
+            cluster.setDbClusterMembers(new ArrayList<>());
+
+            if (config.services().docdb().mock()) {
+                LOG.infov("Creating DocDB cluster {0} in mock mode (no container)", id);
+                cluster.setEndpoint("localhost");
+                cluster.setReaderEndpoint("localhost");
+                cluster.setPort(MONGO_PORT);
+            } else {
+                String image = config.services().docdb().defaultImage();
+                LOG.infov("Creating DocDB cluster {0}, image={1}", id, image);
+                // A cluster record is metadata: its identifier, ARN and tags need no Docker, so the
+                // cluster is created and reaches 'available' even when no daemon is reachable. Only
+                // connecting to the database needs the container.
+                DocDbContainerHandle handle = containerManager.tryStart(id, image, masterUsername, masterPassword);
+                if (handle != null) {
+                    cluster.setEndpoint(handle.getHost());
+                    cluster.setReaderEndpoint(handle.getHost());
+                    cluster.setPort(handle.getPort());
+                    cluster.setContainerId(handle.getContainerId());
+                    cluster.setContainerHost(handle.getHost());
+                    cluster.setContainerPort(handle.getPort());
+                } else {
+                    cluster.setEndpoint(resolveEndpointHost());
+                    cluster.setReaderEndpoint(resolveEndpointHost());
+                    cluster.setPort(MONGO_PORT);
+                    LOG.warnv("DocDB cluster {0} created without a backing MongoDB container: no "
+                            + "Docker daemon is reachable. Metadata operations work; connections to "
+                            + "the cluster do not until a daemon appears.", id);
+                }
+            }
+
+            clusters.put(id, cluster);
+            LOG.infov("DocDB cluster {0} created, endpoint={1}:{2}",
+                    id, cluster.getEndpoint(), String.valueOf(cluster.getPort()));
+            return cluster;
+        }
     }
 
     public DocDbCluster getDbCluster(String id) {
@@ -143,39 +154,43 @@ public class DocDbService {
     }
 
     public DocDbCluster modifyDbCluster(String id, String engineVersion, Boolean iamEnabled) {
-        DocDbCluster cluster = getDbCluster(id);
-        if (engineVersion != null && !engineVersion.isBlank()) {
-            cluster.setEngineVersion(engineVersion);
+        synchronized (lockFor("cluster:" + id)) {
+            DocDbCluster cluster = getDbCluster(id);
+            if (engineVersion != null && !engineVersion.isBlank()) {
+                cluster.setEngineVersion(engineVersion);
+            }
+            if (iamEnabled != null) {
+                cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
+            }
+            clusters.put(id, cluster);
+            LOG.infov("DocDB cluster {0} modified", id);
+            return cluster;
         }
-        if (iamEnabled != null) {
-            cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
-        }
-        clusters.put(id, cluster);
-        LOG.infov("DocDB cluster {0} modified", id);
-        return cluster;
     }
 
     public void deleteDbCluster(String id) {
-        DocDbCluster cluster = clusters.get(id).orElseThrow(() ->
-                new AwsException("DBClusterNotFoundFault",
-                        "DocDB cluster " + id + " not found.", 404));
+        synchronized (lockFor("cluster:" + id)) {
+            DocDbCluster cluster = clusters.get(id).orElseThrow(() ->
+                    new AwsException("DBClusterNotFoundFault",
+                            "DocDB cluster " + id + " not found.", 404));
 
-        if (cluster.getDbClusterMembers() != null && !cluster.getDbClusterMembers().isEmpty()) {
-            throw new AwsException("InvalidDBClusterStateFault",
-                    "Cannot delete DocDB cluster " + id + " — it still has DB instances.", 400);
+            if (cluster.getDbClusterMembers() != null && !cluster.getDbClusterMembers().isEmpty()) {
+                throw new AwsException("InvalidDBClusterStateFault",
+                        "Cannot delete DocDB cluster " + id + " — it still has DB instances.", 400);
+            }
+
+            cluster.setStatus("deleting");
+            clusters.put(id, cluster);
+
+            if (cluster.getContainerId() != null) {
+                containerManager.stop(new DocDbContainerHandle(
+                        cluster.getContainerId(), id,
+                        cluster.getContainerHost(), cluster.getContainerPort()));
+            }
+
+            clusters.delete(id);
+            LOG.infov("DocDB cluster {0} deleted", id);
         }
-
-        cluster.setStatus("deleting");
-        clusters.put(id, cluster);
-
-        if (cluster.getContainerId() != null) {
-            containerManager.stop(new DocDbContainerHandle(
-                    cluster.getContainerId(), id,
-                    cluster.getContainerHost(), cluster.getContainerPort()));
-        }
-
-        clusters.delete(id);
-        LOG.infov("DocDB cluster {0} deleted", id);
     }
 
     // ── Instances ─────────────────────────────────────────────────────────────
@@ -183,34 +198,39 @@ public class DocDbService {
     public DocDbInstance createDbInstance(String id, String dbClusterIdentifier,
                                           String dbInstanceClass, String engineVersion,
                                           boolean iamEnabled) {
-        if (instances.get(id).isPresent()) {
-            throw new AwsException("DBInstanceAlreadyExists",
-                    "DocDB instance " + id + " already exists.", 400);
+        // Instance monitor before cluster monitor, the one order every path that holds both uses.
+        synchronized (lockFor("instance:" + id)) {
+            synchronized (lockFor("cluster:" + dbClusterIdentifier)) {
+                if (instances.get(id).isPresent()) {
+                    throw new AwsException("DBInstanceAlreadyExists",
+                            "DocDB instance " + id + " already exists.", 400);
+                }
+
+                DocDbCluster cluster = getDbCluster(dbClusterIdentifier);
+                String region = regionResolver.getDefaultRegion();
+
+                DocDbInstance instance = new DocDbInstance();
+                instance.setDbInstanceIdentifier(id);
+                instance.setDbClusterIdentifier(dbClusterIdentifier);
+                instance.setDbInstanceClass(dbInstanceClass != null ? dbInstanceClass : "db.r5.large");
+                instance.setEngineVersion(engineVersion != null ? engineVersion : cluster.getEngineVersion());
+                instance.setStatus("available");
+                instance.setEndpoint(cluster.getEndpoint());
+                instance.setPort(cluster.getPort());
+                instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
+                instance.setDbInstanceArn(regionResolver.buildArn("rds", region, "db:" + id));
+                instance.setDbiResourceId("db-" + UUID.randomUUID().toString()
+                        .replace("-", "").substring(0, 24).toUpperCase());
+                instance.setCreatedAt(Instant.now());
+
+                cluster.getDbClusterMembers().add(id);
+                clusters.put(dbClusterIdentifier, cluster);
+
+                instances.put(id, instance);
+                LOG.infov("DocDB instance {0} created in cluster {1}", id, dbClusterIdentifier);
+                        return instance;
+            }
         }
-
-        DocDbCluster cluster = getDbCluster(dbClusterIdentifier);
-        String region = regionResolver.getDefaultRegion();
-
-        DocDbInstance instance = new DocDbInstance();
-        instance.setDbInstanceIdentifier(id);
-        instance.setDbClusterIdentifier(dbClusterIdentifier);
-        instance.setDbInstanceClass(dbInstanceClass != null ? dbInstanceClass : "db.r5.large");
-        instance.setEngineVersion(engineVersion != null ? engineVersion : cluster.getEngineVersion());
-        instance.setStatus("available");
-        instance.setEndpoint(cluster.getEndpoint());
-        instance.setPort(cluster.getPort());
-        instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
-        instance.setDbInstanceArn(regionResolver.buildArn("rds", region, "db:" + id));
-        instance.setDbiResourceId("db-" + UUID.randomUUID().toString()
-                .replace("-", "").substring(0, 24).toUpperCase());
-        instance.setCreatedAt(Instant.now());
-
-        cluster.getDbClusterMembers().add(id);
-        clusters.put(dbClusterIdentifier, cluster);
-
-        instances.put(id, instance);
-        LOG.infov("DocDB instance {0} created in cluster {1}", id, dbClusterIdentifier);
-        return instance;
     }
 
     public DocDbInstance getDbInstance(String id) {
@@ -234,37 +254,133 @@ public class DocDbService {
     }
 
     public DocDbInstance modifyDbInstance(String id, String dbInstanceClass, Boolean iamEnabled) {
-        DocDbInstance instance = getDbInstance(id);
-        if (dbInstanceClass != null && !dbInstanceClass.isBlank()) {
-            instance.setDbInstanceClass(dbInstanceClass);
+        synchronized (lockFor("instance:" + id)) {
+            DocDbInstance instance = getDbInstance(id);
+            if (dbInstanceClass != null && !dbInstanceClass.isBlank()) {
+                instance.setDbInstanceClass(dbInstanceClass);
+            }
+            if (iamEnabled != null) {
+                instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
+            }
+            instances.put(id, instance);
+            LOG.infov("DocDB instance {0} modified", id);
+            return instance;
         }
-        if (iamEnabled != null) {
-            instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
-        }
-        instances.put(id, instance);
-        LOG.infov("DocDB instance {0} modified", id);
-        return instance;
     }
 
     public void deleteDbInstance(String id) {
-        DocDbInstance instance = instances.get(id).orElseThrow(() ->
-                new AwsException("DBInstanceNotFound",
-                        "DocDB instance " + id + " not found.", 404));
+        synchronized (lockFor("instance:" + id)) {
+            DocDbInstance instance = instances.get(id).orElseThrow(() ->
+                    new AwsException("DBInstanceNotFound",
+                            "DocDB instance " + id + " not found.", 404));
 
-        String clusterId = instance.getDbClusterIdentifier();
-        DocDbCluster cluster = clusters.get(clusterId).orElse(null);
-        if (cluster != null) {
-            cluster.getDbClusterMembers().remove(id);
-            clusters.put(clusterId, cluster);
+            String clusterId = instance.getDbClusterIdentifier();
+            synchronized (lockFor("cluster:" + clusterId)) {
+                DocDbCluster cluster = clusters.get(clusterId).orElse(null);
+                if (cluster != null) {
+                    cluster.getDbClusterMembers().remove(id);
+                    clusters.put(clusterId, cluster);
+                }
+            }
+
+            instances.delete(id);
+            LOG.infov("DocDB instance {0} deleted", id);
         }
-
-        instances.delete(id);
-        LOG.infov("DocDB instance {0} deleted", id);
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private String resolveEndpointHost() {
         return config.hostname().orElse("localhost");
+    }
+
+    // ── Tags ──────────────────────────────────────────────────────────────────
+
+    /** A resolved tag target: the record's key, its tags, and a sink that persists an update. */
+    private record TagTarget(String lockKey, Map<String, String> tags,
+                             java.util.function.Consumer<Map<String, String>> save) {}
+
+    public Map<String, String> listTagsForResource(String resourceName) {
+        return Map.copyOf(resolveTagTarget(resourceName).tags());
+    }
+
+    public void addTagsToResource(String resourceName, Map<String, String> tags) {
+        updateTags(resourceName, current -> current.putAll(tags));
+    }
+
+    public void removeTagsFromResource(String resourceName, Collection<String> tagKeys) {
+        // A key that is not present is not an error on a live account; the ones that are get removed.
+        updateTags(resourceName, current -> tagKeys.forEach(current::remove));
+    }
+
+    private void updateTags(String resourceName, java.util.function.Consumer<Map<String, String>> change) {
+        // Resolve once to learn which record is meant, then do the read-modify-write under that
+        // record's monitor and resolve again inside it: the record can be deleted in between, and
+        // saving what the first read returned would put it back.
+        String lockKey = resolveTagTarget(resourceName).lockKey();
+        synchronized (lockFor(lockKey)) {
+            TagTarget target = resolveTagTarget(resourceName);
+            Map<String, String> updated = new LinkedHashMap<>(target.tags());
+            change.accept(updated);
+            target.save().accept(updated);
+        }
+    }
+
+    private Object lockFor(String key) {
+        return writeLocks.computeIfAbsent(key, k -> new Object());
+    }
+
+    /**
+     * Resolves a tagging {@code ResourceName} to the DocumentDB record it names.
+     *
+     * <p>Only ARNs reach here: the router picks this service by looking the ARN's identifier up in
+     * DocumentDB storage, so a bare name stays with RDS. The region and account are checked before
+     * the identifier, as a live account checks them — storage is keyed by identifier alone, so an
+     * ARN naming another region would otherwise resolve this caller's cluster.
+     */
+    private TagTarget resolveTagTarget(String resourceName) {
+        if (resourceName == null || resourceName.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ResourceName is required.", 400);
+        }
+        AwsArnUtils.Arn arn;
+        try {
+            arn = AwsArnUtils.parse(resourceName);
+        } catch (IllegalArgumentException malformed) {
+            throw new AwsException("InvalidParameterValue", "Invalid resource name:  " + resourceName, 400);
+        }
+        if (!"rds".equals(arn.service())
+                || !regionResolver.getRegion().equals(arn.region())
+                || !Objects.equals(regionResolver.getAccountId(), arn.accountId())) {
+            // One message for both, which is what a live account answers.
+            throw new AwsException("InvalidParameterValue",
+                    "The specified resource name does not match an RDS resource in this region.", 400);
+        }
+
+        String resource = arn.resource();
+        int separator = resource.indexOf(':');
+        if (separator < 0) {
+            throw new AwsException("InvalidParameterValue", "Invalid resource name:  " + resourceName, 400);
+        }
+        String type = resource.substring(0, separator);
+        String id = resource.substring(separator + 1);
+
+        return switch (type) {
+            case "cluster" -> {
+                DocDbCluster cluster = getDbCluster(id);
+                yield new TagTarget("cluster:" + id, cluster.getTags(), updated -> {
+                    cluster.setTags(updated);
+                    clusters.put(id, cluster);
+                });
+            }
+            case "db" -> {
+                DocDbInstance instance = getDbInstance(id);
+                yield new TagTarget("instance:" + id, instance.getTags(), updated -> {
+                    instance.setTags(updated);
+                    instances.put(id, instance);
+                });
+            }
+            default -> throw new AwsException("InvalidParameterValue",
+                    "Tagging for resource type '" + type + "' is not yet implemented by Floci: " + resourceName, 400);
+        };
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -145,6 +145,14 @@ public class DocDbService {
         return clusters.get(id).filter(c -> regionOf(c.getDbClusterArn()).equals(region)).isPresent();
     }
 
+    /** Refuses a record whose own ARN is not the one that was asked for. */
+    private static void requireArnNamesRecord(String requested, String stored,
+                                              String errorCode, String message) {
+        if (stored != null && !stored.equalsIgnoreCase(requested)) {
+            throw new AwsException(errorCode, message, 404);
+        }
+    }
+
     /** The region a record was created in, taken from its ARN; older records carry the default. */
     private String regionOf(String arn) {
         return AwsArnUtils.regionOrDefault(arn, regionResolver.getDefaultRegion());
@@ -406,9 +414,16 @@ public class DocDbService {
         String type = resource.substring(0, separator);
         String id = resource.substring(separator + 1);
 
+        // The record has to be the one this ARN names, not merely one of that identifier: records
+        // are keyed by identifier alone, so an ARN whose region matches the caller but not the
+        // stored record would otherwise be answered — and mutated — from another region's
+        // resource. Reachable on the docdb credential scope, which dispatches here directly
+        // rather than through the routing that matches the whole ARN.
         return switch (type) {
             case "cluster" -> {
                 DocDbCluster cluster = getDbCluster(id);
+                requireArnNamesRecord(resourceName, cluster.getDbClusterArn(),
+                        "DBClusterNotFoundFault", "DocDB cluster " + id + " not found.");
                 yield new TagTarget("cluster:" + id, cluster.getTags(), updated -> {
                     cluster.setTags(updated);
                     clusters.put(id, cluster);
@@ -416,6 +431,8 @@ public class DocDbService {
             }
             case "db" -> {
                 DocDbInstance instance = getDbInstance(id);
+                requireArnNamesRecord(resourceName, instance.getDbInstanceArn(),
+                        "DBInstanceNotFound", "DocDB instance " + id + " not found.");
                 yield new TagTarget("instance:" + id, instance.getTags(), updated -> {
                     instance.setTags(updated);
                     instances.put(id, instance);

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/model/DocDbCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/model/DocDbCluster.java
@@ -4,11 +4,14 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @RegisterForReflection
 public class DocDbCluster {
     private String masterUsername;
+    private Map<String, String> tags = new LinkedHashMap<>();
 
     private String dbClusterIdentifier;
     private String status;
@@ -77,6 +80,13 @@ public class DocDbCluster {
 
     public int getContainerPort() { return containerPort; }
     public void setContainerPort(int containerPort) { this.containerPort = containerPort; }
+
+    public Map<String, String> getTags() { return tags; }
+
+    /** Normalizes null: a record persisted before tags were stored deserializes without them. */
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags);
+    }
 
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/model/DocDbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/model/DocDbInstance.java
@@ -2,10 +2,13 @@ package io.github.hectorvent.floci.services.docdb.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 @RegisterForReflection
 public class DocDbInstance {
 
     private String dbInstanceIdentifier;
+    private Map<String, String> tags = new LinkedHashMap<>();
     private String dbClusterIdentifier;
     private String dbInstanceClass;
     private String engineVersion;
@@ -55,4 +58,11 @@ public class DocDbInstance {
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
 
 
+
+    public Map<String, String> getTags() { return tags; }
+
+    /** Normalizes null: a record persisted before tags were stored deserializes without them. */
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags);
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -475,6 +475,11 @@ public class RdsQueryHandler {
         try {
             DbParameterGroup group = service.createDbParameterGroup(
                     name, family, description, region);
+            // Tags given at create are readable back on a live account.
+            Map<String, String> tags = parseTags(params);
+            if (!tags.isEmpty()) {
+                service.addTagsToResource(group.getDbParameterGroupArn(), tags, region);
+            }
             String result = paramGroupXml(group);
             return Response.ok(AwsQueryResponse.envelope("CreateDBParameterGroup", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -576,6 +581,10 @@ public class RdsQueryHandler {
         try {
             DbClusterParameterGroup group = service.createDbClusterParameterGroup(
                     name, family, description, region);
+            Map<String, String> tags = parseTags(params);
+            if (!tags.isEmpty()) {
+                service.addTagsToResource(group.getDbClusterParameterGroupArn(), tags, region);
+            }
             String result = clusterParamGroupXml(group);
             return Response.ok(AwsQueryResponse.envelope("CreateDBClusterParameterGroup", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -1407,6 +1416,7 @@ public class RdsQueryHandler {
                 .elem("DBParameterGroupName", g.getDbParameterGroupName())
                 .elem("DBParameterGroupFamily", g.getDbParameterGroupFamily())
                 .elem("Description", g.getDescription())
+                .elem("DBParameterGroupArn", g.getDbParameterGroupArn())
                 .build();
     }
 
@@ -1509,6 +1519,7 @@ public class RdsQueryHandler {
                 .elem("DBClusterParameterGroupName", g.getDbClusterParameterGroupName())
                 .elem("DBParameterGroupFamily", g.getDbParameterGroupFamily())
                 .elem("Description", g.getDescription())
+                .elem("DBClusterParameterGroupArn", g.getDbClusterParameterGroupArn())
                 .build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -1686,7 +1686,10 @@ public class RdsQueryHandler {
             if (key == null) {
                 break;
             }
-            tags.put(key, params.getFirst(prefix + "." + i + ".Value"));
+            // A key given without a value is stored as an empty value, as AWS stores it —
+            // a null would also break the immutable copy the read hands back.
+            String value = params.getFirst(prefix + "." + i + ".Value");
+            tags.put(key, value == null ? "" : value);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1176,16 +1176,15 @@ public class RdsService implements Resettable {
      * names.
      */
     public boolean hasClusterOrInstance(String clusterId, String instanceId, String region) {
-        // Any region, not only the request's: DocumentDB keys its records by bare identifier, so
-        // one name there shadows that name in RDS wherever RDS holds it. Refusing the create is a
-        // narrower answer than AWS gives — it allows one name per region — but Floci cannot hold
-        // both and answer either correctly.
+        // The request's region, and only it: RDS scopes these names by region — the same name in
+        // two regions is two resources, which the SDK compatibility suite pins — and two records
+        // in different regions carry different ARNs, so there is nothing for a tag call to
+        // confuse. What must not exist is one identifier in both services in one region.
+        String effectiveRegion = effectiveRegion(region);
         boolean cluster = clusterId != null && !clusterId.isBlank()
-                && clusters.scan(k -> true).stream()
-                        .anyMatch(c -> clusterId.equalsIgnoreCase(c.getDbClusterIdentifier()));
+                && findClusterForScope(currentAccountId(), effectiveRegion, clusterId) != null;
         boolean instance = instanceId != null && !instanceId.isBlank()
-                && instances.scan(k -> true).stream()
-                        .anyMatch(i -> instanceId.equalsIgnoreCase(i.getDbInstanceIdentifier()));
+                && findInstanceForScope(currentAccountId(), effectiveRegion, instanceId) != null;
         return cluster || instance;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -713,6 +713,21 @@ public class RdsService implements Resettable {
                     proxies.put(dbProxyKey(effectiveRegion, resolvedProxy.getDbProxyName()), updatedProxy);
                 });
             }
+            case "pg" -> {
+                DbParameterGroup group = getDbParameterGroup(resourceId, effectiveRegion);
+                yield new TagHandle(group.getTags(), updated -> {
+                    group.setTags(updated);
+                    putParameterGroupForRegion(resourceId, effectiveRegion, group);
+                });
+            }
+            case "cluster-pg" -> {
+                DbClusterParameterGroup group =
+                        getDbClusterParameterGroup(resourceId, effectiveRegion);
+                yield new TagHandle(group.getTags(), updated -> {
+                    group.setTags(updated);
+                    putClusterParameterGroupForRegion(resourceId, effectiveRegion, group);
+                });
+            }
             case "og" -> {
                 if (managedOptionGroup(resourceId) != null) {
                     throw new AwsException("InvalidOptionGroupStateFault",
@@ -724,7 +739,7 @@ public class RdsService implements Resettable {
                     putOptionGroupForRegion(resourceId, effectiveRegion, group);
                 });
             }
-            // Valid RDS resource types Floci does not model yet (pg, snapshot, ...) — taggable
+            // Valid RDS resource types Floci does not model yet (snapshot, ri, ...) — taggable
             // on real AWS, so the message states the Floci limitation rather than AWS semantics.
             default -> throw new AwsException("InvalidParameterValue",
                     "Tagging for resource type '" + type + "' is not yet implemented by Floci: " + resourceName, 400);
@@ -2091,6 +2106,7 @@ public class RdsService implements Resettable {
         }
         DbParameterGroup group = new DbParameterGroup(name, family, description);
         group.setRegion(effectiveRegion);
+        group.setDbParameterGroupArn(regionResolver.buildArn("rds", effectiveRegion, "pg:" + name));
         putParameterGroupForRegion(name, effectiveRegion, group);
         return group;
     }
@@ -2239,6 +2255,7 @@ public class RdsService implements Resettable {
         }
         DbClusterParameterGroup group = new DbClusterParameterGroup(name, family, description);
         group.setRegion(effectiveRegion);
+        group.setDbClusterParameterGroupArn(regionResolver.buildArn("rds", effectiveRegion, "cluster-pg:" + name));
         putClusterParameterGroupForRegion(name, effectiveRegion, group);
         return group;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1167,6 +1167,23 @@ public class RdsService implements Resettable {
         return cluster;
     }
 
+    /**
+     * Whether RDS holds a cluster or instance under this identifier.
+     *
+     * <p>The RDS-family services share one identifier space — a live account refuses to create an
+     * Aurora cluster named like an existing DocumentDB one with {@code DBClusterAlreadyExistsFault}
+     * — so a create naming an identifier RDS already holds belongs to RDS, whichever engine it
+     * names.
+     */
+    public boolean hasClusterOrInstance(String clusterId, String instanceId, String region) {
+        String effectiveRegion = effectiveRegion(region);
+        boolean cluster = clusterId != null && !clusterId.isBlank()
+                && findClusterForScope(currentAccountId(), effectiveRegion, clusterId) != null;
+        boolean instance = instanceId != null && !instanceId.isBlank()
+                && findInstanceForScope(currentAccountId(), effectiveRegion, instanceId) != null;
+        return cluster || instance;
+    }
+
     public DbCluster getDbCluster(String id) {
         return getDbCluster(id, regionResolver.getDefaultRegion());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -4230,8 +4230,19 @@ public class RdsService implements Resettable {
             }
         }
         resolved.ifPresent(group -> {
-            if (group.getRegion() == null || group.getRegion().isBlank()) {
-                group.setRegion(effectiveRegion);
+            // A group persisted before either field existed reads back without them. The ARN is
+            // what a caller tags by, so a group that never gets one cannot be tagged at all.
+            boolean regionMissing = group.getRegion() == null || group.getRegion().isBlank();
+            boolean arnMissing = group.getDbParameterGroupArn() == null
+                    || group.getDbParameterGroupArn().isBlank();
+            if (regionMissing || arnMissing) {
+                if (regionMissing) {
+                    group.setRegion(effectiveRegion);
+                }
+                if (arnMissing) {
+                    group.setDbParameterGroupArn(
+                            regionResolver.buildArn("rds", group.getRegion(), "pg:" + groupName));
+                }
                 putParameterGroupForRegion(groupName, effectiveRegion, group);
             }
         });
@@ -4303,8 +4314,17 @@ public class RdsService implements Resettable {
             }
         }
         resolved.ifPresent(group -> {
-            if (group.getRegion() == null || group.getRegion().isBlank()) {
-                group.setRegion(effectiveRegion);
+            boolean regionMissing = group.getRegion() == null || group.getRegion().isBlank();
+            boolean arnMissing = group.getDbClusterParameterGroupArn() == null
+                    || group.getDbClusterParameterGroupArn().isBlank();
+            if (regionMissing || arnMissing) {
+                if (regionMissing) {
+                    group.setRegion(effectiveRegion);
+                }
+                if (arnMissing) {
+                    group.setDbClusterParameterGroupArn(regionResolver.buildArn(
+                            "rds", group.getRegion(), "cluster-pg:" + groupName));
+                }
                 putClusterParameterGroupForRegion(groupName, effectiveRegion, group);
             }
         });

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1176,11 +1176,16 @@ public class RdsService implements Resettable {
      * names.
      */
     public boolean hasClusterOrInstance(String clusterId, String instanceId, String region) {
-        String effectiveRegion = effectiveRegion(region);
+        // Any region, not only the request's: DocumentDB keys its records by bare identifier, so
+        // one name there shadows that name in RDS wherever RDS holds it. Refusing the create is a
+        // narrower answer than AWS gives — it allows one name per region — but Floci cannot hold
+        // both and answer either correctly.
         boolean cluster = clusterId != null && !clusterId.isBlank()
-                && findClusterForScope(currentAccountId(), effectiveRegion, clusterId) != null;
+                && clusters.scan(k -> true).stream()
+                        .anyMatch(c -> clusterId.equalsIgnoreCase(c.getDbClusterIdentifier()));
         boolean instance = instanceId != null && !instanceId.isBlank()
-                && findInstanceForScope(currentAccountId(), effectiveRegion, instanceId) != null;
+                && instances.scan(k -> true).stream()
+                        .anyMatch(i -> instanceId.equalsIgnoreCase(i.getDbInstanceIdentifier()));
         return cluster || instance;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbClusterParameterGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbClusterParameterGroup.java
@@ -3,11 +3,14 @@ package io.github.hectorvent.floci.services.rds.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RegisterForReflection
 public class DbClusterParameterGroup {
 
+    private String dbClusterParameterGroupArn;
+    private Map<String, String> tags = new LinkedHashMap<>();
     private String dbClusterParameterGroupName;
     private String dbParameterGroupFamily;
     private String description;
@@ -37,4 +40,14 @@ public class DbClusterParameterGroup {
 
     public Map<String, String> getParameters() { return parameters; }
     public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
+
+    public Map<String, String> getTags() { return tags; }
+
+    /** Normalizes null: a record persisted before tags were stored deserializes without them. */
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags);
+    }
+
+    public String getDbClusterParameterGroupArn() { return dbClusterParameterGroupArn; }
+    public void setDbClusterParameterGroupArn(String dbClusterParameterGroupArn) { this.dbClusterParameterGroupArn = dbClusterParameterGroupArn; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbParameterGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbParameterGroup.java
@@ -3,11 +3,14 @@ package io.github.hectorvent.floci.services.rds.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RegisterForReflection
 public class DbParameterGroup {
 
+    private String dbParameterGroupArn;
+    private Map<String, String> tags = new LinkedHashMap<>();
     private String dbParameterGroupName;
     private String dbParameterGroupFamily;
     private String description;
@@ -37,4 +40,14 @@ public class DbParameterGroup {
 
     public Map<String, String> getParameters() { return parameters; }
     public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
+
+    public Map<String, String> getTags() { return tags; }
+
+    /** Normalizes null: a record persisted before tags were stored deserializes without them. */
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags == null ? new LinkedHashMap<>() : new LinkedHashMap<>(tags);
+    }
+
+    public String getDbParameterGroupArn() { return dbParameterGroupArn; }
+    public void setDbParameterGroupArn(String dbParameterGroupArn) { this.dbParameterGroupArn = dbParameterGroupArn; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.docdb;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -13,6 +14,7 @@ import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -155,5 +157,30 @@ class DocDbServiceTest {
         // Delete must not reach for a container that was never created.
         noDaemonService.deleteDbCluster("no-docker-cluster");
         verify(noDaemonContainerManager, never()).stop(any());
+    }
+
+    @Test
+    void tagsAreAnsweredOnlyForAnArnInThisRegionAndAccount() {
+        // The router reaches this service only for an ARN it already matched, so these checks
+        // guard the service's own contract: storage is keyed by identifier alone, and answering
+        // by name would hand this caller's cluster to an ARN naming somewhere else. The message
+        // is the one a live account gives, which is the same for both cases.
+        docDbService.createDbCluster("scoped-cluster", null, "admin", "secret", false);
+        String arn = docDbService.getDbCluster("scoped-cluster").getDbClusterArn();
+        docDbService.addTagsToResource(arn, java.util.Map.of("env", "test"));
+        assertEquals(java.util.Map.of("env", "test"), docDbService.listTagsForResource(arn));
+
+        for (String foreign : new String[]{
+                "arn:aws:rds:eu-west-1:000000000000:cluster:scoped-cluster",
+                "arn:aws:rds:us-east-1:111122223333:cluster:scoped-cluster"}) {
+            AwsException rejected = assertThrows(AwsException.class,
+                    () -> docDbService.listTagsForResource(foreign));
+            assertEquals("InvalidParameterValue", rejected.getErrorCode());
+            assertTrue(rejected.getMessage().contains("does not match an RDS resource in this region"));
+        }
+
+        AwsException notAnArn = assertThrows(AwsException.class,
+                () -> docDbService.listTagsForResource("scoped-cluster"));
+        assertTrue(notAnArn.getMessage().contains("Invalid resource name"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagConcurrencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagConcurrencyTest.java
@@ -1,0 +1,129 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tagging a cluster while it is being deleted must not put it back.
+ *
+ * <p>A tag update is a read-modify-write. Without a monitor shared with delete, the read can see a
+ * live cluster, the delete can remove it, and the write then stores the record again — a cluster
+ * that no describe created and no delete can remove.
+ */
+@QuarkusTest
+@TestProfile(DocDbTagConcurrencyTest.NoContainersProfile.class)
+class DocDbTagConcurrencyTest {
+
+    /** The race is in storage, not in the container: starting one per attempt only adds seconds. */
+    public static class NoContainersProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.docdb.mock", "true");
+        }
+    }
+
+    @Inject
+    DocDbService service;
+
+    @Test
+    void taggingDuringADeleteDoesNotReviveTheCluster() throws Exception {
+        for (int attempt = 0; attempt < 25; attempt++) {
+            String id = "race-cluster-" + attempt;
+            service.createDbCluster(id, "5.0.0", "admin", "secret99password", false);
+            String arn = service.getDbCluster(id).getDbClusterArn();
+
+            CountDownLatch start = new CountDownLatch(1);
+            AtomicReference<Throwable> unexpected = new AtomicReference<>();
+
+            Thread tagger = new Thread(() -> {
+                await(start);
+                try {
+                    service.addTagsToResource(arn, Map.of("env", "race"));
+                } catch (AwsException expected) {
+                    // Losing to the delete is a legitimate outcome; being answered is not.
+                    if (!"DBClusterNotFoundFault".equals(expected.getErrorCode())) {
+                        unexpected.set(expected);
+                    }
+                } catch (Throwable t) {
+                    unexpected.set(t);
+                }
+            });
+            Thread deleter = new Thread(() -> {
+                await(start);
+                try {
+                    service.deleteDbCluster(id);
+                } catch (Throwable t) {
+                    unexpected.set(t);
+                }
+            });
+
+            tagger.start();
+            deleter.start();
+            start.countDown();
+            tagger.join(TimeUnit.SECONDS.toMillis(10));
+            deleter.join(TimeUnit.SECONDS.toMillis(10));
+            assertFalse(tagger.isAlive(), "tagger did not finish — deadlock between the monitors");
+            assertFalse(deleter.isAlive(), "deleter did not finish — deadlock between the monitors");
+
+            assertNull(unexpected.get(), () -> "unexpected failure: " + unexpected.get());
+            assertFalse(service.hasCluster(id),
+                    "cluster " + id + " came back after being deleted (attempt " + attempt + ")");
+        }
+    }
+
+    @Test
+    void anInstanceAndItsClusterCanBeTaggedAtTheSameTime() throws Exception {
+        // The two paths take the monitors in one order everywhere; taking them in opposite
+        // orders would hang here rather than fail an assertion.
+        String clusterId = "lock-order-cluster";
+        String instanceId = "lock-order-instance";
+        service.createDbCluster(clusterId, "5.0.0", "admin", "secret99password", false);
+        service.createDbInstance(instanceId, clusterId, "db.r5.large", "5.0.0", false);
+        String clusterArn = service.getDbCluster(clusterId).getDbClusterArn();
+        String instanceArn = service.getDbInstance(instanceId).getDbInstanceArn();
+
+        CountDownLatch start = new CountDownLatch(1);
+        Thread one = new Thread(() -> {
+            await(start);
+            service.addTagsToResource(clusterArn, Map.of("a", "1"));
+        });
+        Thread two = new Thread(() -> {
+            await(start);
+            service.addTagsToResource(instanceArn, Map.of("b", "2"));
+        });
+        one.start();
+        two.start();
+        start.countDown();
+        one.join(TimeUnit.SECONDS.toMillis(10));
+        two.join(TimeUnit.SECONDS.toMillis(10));
+
+        assertFalse(one.isAlive() || two.isAlive(), "a tag update never finished");
+        assertTrue(service.listTagsForResource(clusterArn).containsKey("a"));
+        assertTrue(service.listTagsForResource(instanceArn).containsKey("b"));
+
+        service.deleteDbInstance(instanceId);
+        service.deleteDbCluster(clusterId);
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagIntegrationTest.java
@@ -112,6 +112,25 @@ class DocDbTagIntegrationTest {
     }
 
     @Test
+    @Order(4)
+    void aKeyWithNoValueReadsBackAsAnEmptyValue() {
+        // AWS stores an empty value for it. Carrying a null instead breaks the read for every
+        // tag on the resource, not just this one.
+        query("AddTagsToResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+                .formParam("Tags.Tag.1.Key", "novalue")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>novalue</Key><Value></Value>"));
+    }
+
+    @Test
     @Order(5)
     void anInstanceCarriesItsOwnTags() {
         query("CreateDBInstance")

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagIntegrationTest.java
@@ -159,10 +159,10 @@ class DocDbTagIntegrationTest {
 
     @Test
     @Order(6)
-    void anArnInAnotherRegionOrAccountIsRejected() {
-        // Storage is keyed by identifier alone, so without this check an ARN naming another
-        // region would be answered with this caller's cluster. A live account gives one message
-        // for both cases.
+    void anArnInAnotherRegionOrAccountIsNotThisCluster() {
+        // Routing matches the whole stored ARN, so neither of these is a DocumentDB record and
+        // RDS answers them — the point being that this caller's cluster is never what comes back
+        // for an ARN naming another region or account.
         for (String foreign : new String[]{
                 "arn:aws:rds:eu-west-1:000000000000:cluster:" + CLUSTER,
                 "arn:aws:rds:us-east-1:111122223333:cluster:" + CLUSTER}) {
@@ -171,7 +171,8 @@ class DocDbTagIntegrationTest {
             .when().post("/")
             .then()
                 .statusCode(400)
-                .body(containsString("does not match an RDS resource in this region"));
+                .body(containsString("InvalidParameterValue"))
+                .body(not(containsString("<Key>env</Key>")));
         }
     }
 
@@ -185,6 +186,49 @@ class DocDbTagIntegrationTest {
             // Not a DocumentDB record, so this one stays with RDS, which owns the ARN space.
             .statusCode(404)
             .body(containsString("DBClusterNotFoundFault"));
+    }
+
+    @Test
+    @Order(6)
+    void anRdsResourceOfTheSameNameKeepsItsOwnTags() {
+        // RDS and DocumentDB share one ARN space. A parameter group named like this cluster is a
+        // different resource, and routing on the trailing name alone would answer it, or mutate
+        // it, out of DocumentDB's store.
+        query("CreateDBParameterGroup")
+                .formParam("DBParameterGroupName", CLUSTER)
+                .formParam("DBParameterGroupFamily", "postgres15")
+                .formParam("Description", "same name, different service")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("AddTagsToResource")
+                .formParam("ResourceName", "arn:aws:rds:us-east-1:000000000000:pg:" + CLUSTER)
+                .formParam("Tags.Tag.1.Key", "owner")
+                .formParam("Tags.Tag.1.Value", "rds")
+        .when().post("/")
+        .then().statusCode(200);
+
+        // The parameter group has only its own tag...
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:rds:us-east-1:000000000000:pg:" + CLUSTER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>rds</Value>"))
+            .body(not(containsString("<Key>env</Key>")));
+
+        // ...and the cluster is untouched by it.
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"))
+            .body(not(containsString("<Value>rds</Value>")));
+
+        query("DeleteDBParameterGroup")
+                .formParam("DBParameterGroupName", CLUSTER)
+        .when().post("/").then().statusCode(200);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbTagIntegrationTest.java
@@ -1,0 +1,220 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tags on DocumentDB clusters and instances.
+ *
+ * <p>The tag actions carry no engine or identifier, only the ARN of the resource they address, so
+ * on the {@code rds} credential scope DocumentDB signs with they reach the RDS handler unless the
+ * router reads that ARN. Behaviour follows a live account: tags given at create are readable back,
+ * an existing key is overwritten, removing a key that is not there is not an error, and a key
+ * given without a value reads back as an empty value.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DocDbTagIntegrationTest {
+
+    private static final String CLUSTER = "tag-test-cluster";
+    private static final String INSTANCE = "tag-test-instance";
+    private static final String CLUSTER_ARN =
+            "arn:aws:rds:us-east-1:000000000000:cluster:" + CLUSTER;
+    private static final String INSTANCE_ARN =
+            "arn:aws:rds:us-east-1:000000000000:db:" + INSTANCE;
+
+    /** What the DocumentDB SDK signs with — the path that used to reach RDS and 404. */
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/rds/aws4_request, "
+            + "SignedHeaders=content-type;host, Signature=test";
+
+    private static io.restassured.specification.RequestSpecification query(String action) {
+        return given().header("Authorization", AUTH)
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    @Test
+    @Order(1)
+    void tagsGivenAtCreateAreReadableBack() {
+        query("CreateDBCluster")
+                .formParam("DBClusterIdentifier", CLUSTER)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "demo")
+                .formParam("Tags.Tag.2.Key", "owner")
+                .formParam("Tags.Tag.2.Value", "me")
+        .when().post("/")
+        .then().statusCode(200);
+
+        // Order is arbitrary on a live account, so only membership is asserted.
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"))
+            .body(containsString("<Value>demo</Value>"))
+            .body(containsString("<Key>owner</Key>"))
+            .body(containsString("<Value>me</Value>"));
+    }
+
+    @Test
+    @Order(2)
+    void addOverwritesAnExistingKeyAndAddsNewOnes() {
+        query("AddTagsToResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "changed")
+                .formParam("Tags.Tag.2.Key", "zzz")
+                .formParam("Tags.Tag.2.Value", "last")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>changed</Value>"))
+            .body(not(containsString("<Value>demo</Value>")))
+            .body(containsString("<Key>zzz</Key>"));
+    }
+
+    @Test
+    @Order(3)
+    void removingAKeyThatIsNotThereIsNotAnError() {
+        query("RemoveTagsFromResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+                .formParam("TagKeys.member.1", "owner")
+                .formParam("TagKeys.member.2", "absent-key")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Key>owner</Key>")))
+            .body(containsString("<Key>env</Key>"));
+    }
+
+    @Test
+    @Order(5)
+    void anInstanceCarriesItsOwnTags() {
+        query("CreateDBInstance")
+                .formParam("DBInstanceIdentifier", INSTANCE)
+                .formParam("DBClusterIdentifier", CLUSTER)
+                .formParam("Engine", "docdb")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("AddTagsToResource")
+                .formParam("ResourceName", INSTANCE_ARN)
+                .formParam("Tags.Tag.1.Key", "role")
+                .formParam("Tags.Tag.1.Value", "primary")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", INSTANCE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>role</Key>"))
+            // The cluster's tags are not the instance's.
+            .body(not(containsString("<Key>env</Key>")));
+    }
+
+    @Test
+    @Order(6)
+    void anArnInAnotherRegionOrAccountIsRejected() {
+        // Storage is keyed by identifier alone, so without this check an ARN naming another
+        // region would be answered with this caller's cluster. A live account gives one message
+        // for both cases.
+        for (String foreign : new String[]{
+                "arn:aws:rds:eu-west-1:000000000000:cluster:" + CLUSTER,
+                "arn:aws:rds:us-east-1:111122223333:cluster:" + CLUSTER}) {
+            query("ListTagsForResource")
+                    .formParam("ResourceName", foreign)
+            .when().post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("does not match an RDS resource in this region"));
+        }
+    }
+
+    @Test
+    @Order(6)
+    void anArnForAClusterThatDoesNotExistIsNotFound() {
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:rds:us-east-1:000000000000:cluster:no-such-cluster")
+        .when().post("/")
+        .then()
+            // Not a DocumentDB record, so this one stays with RDS, which owns the ARN space.
+            .statusCode(404)
+            .body(containsString("DBClusterNotFoundFault"));
+    }
+
+    @Test
+    @Order(7)
+    void tagsSurviveAModifyOfTheCluster() {
+        query("ModifyDBCluster")
+                .formParam("DBClusterIdentifier", CLUSTER)
+                .formParam("EngineVersion", "5.0.0")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"));
+    }
+
+    @Test
+    @Order(8)
+    void aDeletedClusterHasNoTagsToRead() {
+        query("DeleteDBInstance")
+                .formParam("DBInstanceIdentifier", INSTANCE)
+        .when().post("/").then().statusCode(200);
+
+        query("DeleteDBCluster")
+                .formParam("DBClusterIdentifier", CLUSTER)
+                .formParam("SkipFinalSnapshot", "true")
+        .when().post("/").then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("DBClusterNotFoundFault"));
+
+        // And tagging it does not bring it back.
+        query("AddTagsToResource")
+                .formParam("ResourceName", CLUSTER_ARN)
+                .formParam("Tags.Tag.1.Key", "revived")
+                .formParam("Tags.Tag.1.Value", "no")
+        .when().post("/")
+        .then().statusCode(404);
+
+        query("DescribeDBClusters")
+                .formParam("DBClusterIdentifier", CLUSTER)
+        .when().post("/")
+        .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -145,23 +145,48 @@ class SharedClusterIdentifierIntegrationTest {
     }
 
     @Test
-    void aCreateInAnotherRegionCannotTakeAnIdentifierRdsHolds() {
-        // DocumentDB keys records by bare identifier, so signing the create for another region
-        // does not make it a different record — it would shadow the RDS one everywhere.
+    void anotherRegionIsAnotherResource() {
+        // RDS scopes these names by region, so the same name elsewhere is a different resource —
+        // the SDK compatibility suite pins that for instances. Since each ARN carries the region
+        // it was created in, the two never share one ARN and no tag call has to choose.
         String id = "cross-region-identifier";
         rdsService.createDbCluster(id, "aurora-postgresql", null, "admin", "secret99password",
                 null, false, null);
 
-        queryIn("eu-west-1", "CreateDBCluster")
+        String docDbArn = queryIn("eu-west-1", "CreateDBCluster")
                 .formParam("DBClusterIdentifier", id)
                 .formParam("Engine", "docdb")
                 .formParam("MasterUsername", "docdbadmin")
                 .formParam("MasterUserPassword", "secret99password")
         .when().post("/")
-        .then()
-            .statusCode(400)
-            .body(containsString("AlreadyExists"));
+        .then().statusCode(200)
+        .extract().path("CreateDBClusterResponse.CreateDBClusterResult.DBCluster.DBClusterArn");
 
+        assertEquals("arn:aws:rds:eu-west-1:000000000000:cluster:" + id, docDbArn);
+        assertEquals("arn:aws:rds:us-east-1:000000000000:cluster:" + id,
+                rdsService.getDbCluster(id, "us-east-1").getDbClusterArn());
+
+        // Each ARN answers from its own service, so tagging one leaves the other alone.
+        queryIn("eu-west-1", "AddTagsToResource")
+                .formParam("ResourceName", docDbArn)
+                .formParam("Tags.Tag.1.Key", "owner")
+                .formParam("Tags.Tag.1.Value", "docdb")
+        .when().post("/")
+        .then().statusCode(200);
+
+        // Read back over the endpoint: the service checks the ARN against the caller's region, and
+        // a direct call from the test thread has no request to take one from.
+        queryIn("eu-west-1", "ListTagsForResource")
+                .formParam("ResourceName", docDbArn)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>docdb</Value>"));
+
+        assertTrue(rdsService.listTagsForResource(
+                "arn:aws:rds:us-east-1:000000000000:cluster:" + id, "us-east-1").isEmpty());
+
+        docDbService.deleteDbCluster(id);
         rdsService.deleteDbCluster(id, "us-east-1");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.URLENC;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -225,5 +226,56 @@ class SharedClusterIdentifierIntegrationTest {
                 .formParam("DBClusterIdentifier", id)
                 .formParam("SkipFinalSnapshot", "true")
         .when().post("/").then().statusCode(200);
+    }
+
+    @Test
+    void anRdsRequestIsNotAnsweredByADocumentDbClusterInAnotherRegion() {
+        // DocumentDB records are keyed by identifier alone, so the region has to be read from the
+        // record. Otherwise a name DocumentDB holds in one region is taken away from RDS in every
+        // other region: the create is refused as existing, and describes answer the wrong record.
+        String id = "region-routing-clash";
+
+        queryIn("eu-west-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then().statusCode(200);
+
+        // Same name, different region, ordinary RDS engine: RDS has to answer this.
+        queryIn("us-east-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            // Floci reports the aurora-postgresql request as its postgres engine; what matters
+            // here is that RDS answered at all rather than DocumentDB refusing it as existing.
+            .body(containsString("<Engine>postgres</Engine>"));
+
+        // And each region's describe answers from the service that owns the record there.
+        queryIn("us-east-1", "DescribeDBClusters")
+                .formParam("DBClusterIdentifier", id)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Engine>postgres</Engine>"))
+            .body(not(containsString("docdb")));
+
+        queryIn("eu-west-1", "DescribeDBClusters")
+                .formParam("DBClusterIdentifier", id)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("docdb"));
+
+        queryIn("eu-west-1", "DeleteDBCluster")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("SkipFinalSnapshot", "true")
+        .when().post("/").then().statusCode(200);
+        rdsService.deleteDbCluster(id, "us-east-1");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -313,4 +313,69 @@ class SharedClusterIdentifierIntegrationTest {
 
         rdsService.deleteDbCluster(id, "us-east-1");
     }
+
+    @Test
+    void theDocDbScopeCannotTagAnotherRegionsRecordThroughAMatchingArn() {
+        // On the docdb scope the request goes straight to the service, skipping the routing that
+        // matches the whole ARN. An ARN whose region matches the caller but names a record stored
+        // in another region must not resolve: the identifier alone is not the resource.
+        String id = "arn-identity-clash";
+        String docdbAuth = "AWS4-HMAC-SHA256 Credential=test/20260615/%s/docdb/aws4_request, "
+                + "SignedHeaders=content-type;host, Signature=test";
+
+        given().header("Authorization", docdbAuth.formatted("us-east-1"))
+                .contentType(URLENC)
+                .formParam("Action", "CreateDBCluster")
+                .formParam("Version", "2014-10-31")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+                .formParam("Tags.Tag.1.Key", "region")
+                .formParam("Tags.Tag.1.Value", "us-east-1")
+        .when().post("/")
+        .then().statusCode(200);
+
+        // Same identifier, eu-west-1 ARN, signed for eu-west-1: the region check passes, and only
+        // comparing the stored ARN stops this reaching the us-east-1 record.
+        given().header("Authorization", docdbAuth.formatted("eu-west-1"))
+                .contentType(URLENC)
+                .formParam("Action", "ListTagsForResource")
+                .formParam("Version", "2014-10-31")
+                .formParam("ResourceName", "arn:aws:rds:eu-west-1:000000000000:cluster:" + id)
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("DBClusterNotFoundFault"));
+
+        given().header("Authorization", docdbAuth.formatted("eu-west-1"))
+                .contentType(URLENC)
+                .formParam("Action", "AddTagsToResource")
+                .formParam("Version", "2014-10-31")
+                .formParam("ResourceName", "arn:aws:rds:eu-west-1:000000000000:cluster:" + id)
+                .formParam("Tags.Tag.1.Key", "region")
+                .formParam("Tags.Tag.1.Value", "eu-west-1")
+        .when().post("/")
+        .then().statusCode(404);
+
+        // The us-east-1 record still carries only its own tag.
+        given().header("Authorization", docdbAuth.formatted("us-east-1"))
+                .contentType(URLENC)
+                .formParam("Action", "ListTagsForResource")
+                .formParam("Version", "2014-10-31")
+                .formParam("ResourceName", "arn:aws:rds:us-east-1:000000000000:cluster:" + id)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>us-east-1</Value>"))
+            .body(not(containsString("<Value>eu-west-1</Value>")));
+
+        given().header("Authorization", docdbAuth.formatted("us-east-1"))
+                .contentType(URLENC)
+                .formParam("Action", "DeleteDBCluster")
+                .formParam("Version", "2014-10-31")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("SkipFinalSnapshot", "true")
+        .when().post("/").then().statusCode(200);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -1,0 +1,87 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * One identifier space covers the RDS family.
+ *
+ * <p>A live account refuses to create an Aurora cluster named like an existing DocumentDB one with
+ * {@code DBClusterAlreadyExistsFault}, and the reverse has to be refused too: two clusters of that
+ * name in different stores would share one ARN, and no tag call could say which was meant.
+ */
+@QuarkusTest
+@TestProfile(SharedClusterIdentifierIntegrationTest.NoContainersProfile.class)
+class SharedClusterIdentifierIntegrationTest {
+
+    /** Neither engine's container is what this is about, and starting one costs the test 30s. */
+    public static class NoContainersProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.rds.mock", "true",
+                          "floci.services.docdb.mock", "true");
+        }
+    }
+
+    private static final String ID = "shared-identifier";
+    private static final String ARN = "arn:aws:rds:us-east-1:000000000000:cluster:" + ID;
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/rds/aws4_request, "
+            + "SignedHeaders=content-type;host, Signature=test";
+
+    private static io.restassured.specification.RequestSpecification query(String action) {
+        return given().header("Authorization", AUTH)
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    @Test
+    void docDbCannotTakeAnIdentifierRdsAlreadyHolds() {
+        query("CreateDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("CreateDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("AlreadyExists"));
+
+        // The RDS cluster owns the ARN, and tagging reaches it rather than a DocumentDB record.
+        query("AddTagsToResource")
+                .formParam("ResourceName", ARN)
+                .formParam("Tags.Tag.1.Key", "owner")
+                .formParam("Tags.Tag.1.Value", "rds")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>rds</Value>"));
+
+        query("DeleteDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("SkipFinalSnapshot", "true")
+        .when().post("/").then().statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -48,7 +48,13 @@ class SharedClusterIdentifierIntegrationTest {
             + "SignedHeaders=content-type;host, Signature=test";
 
     private static io.restassured.specification.RequestSpecification query(String action) {
-        return given().header("Authorization", AUTH)
+        return queryIn("us-east-1", action);
+    }
+
+    private static io.restassured.specification.RequestSpecification queryIn(String region, String action) {
+        return given().header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260615/" + region + "/rds/aws4_request, "
+                        + "SignedHeaders=content-type;host, Signature=test")
                 .contentType(URLENC)
                 .formParam("Action", action)
                 .formParam("Version", "2014-10-31");
@@ -136,5 +142,63 @@ class SharedClusterIdentifierIntegrationTest {
 
         docDbService.deleteDbCluster(id);
         rdsService.deleteDbCluster(id, "us-east-1");
+    }
+
+    @Test
+    void aCreateInAnotherRegionCannotTakeAnIdentifierRdsHolds() {
+        // DocumentDB keys records by bare identifier, so signing the create for another region
+        // does not make it a different record — it would shadow the RDS one everywhere.
+        String id = "cross-region-identifier";
+        rdsService.createDbCluster(id, "aurora-postgresql", null, "admin", "secret99password",
+                null, false, null);
+
+        queryIn("eu-west-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("AlreadyExists"));
+
+        rdsService.deleteDbCluster(id, "us-east-1");
+    }
+
+    @Test
+    void aClusterCreatedOutsideTheDefaultRegionIsTaggableFromThere() {
+        // The ARN a create answers with is the one the caller tags by, and a tag call is checked
+        // against the region it is made from — an ARN naming the configured default region would
+        // be one its own creator could not use.
+        String id = "eu-west-cluster";
+        String arn = queryIn("eu-west-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then().statusCode(200)
+        .extract().path("CreateDBClusterResponse.CreateDBClusterResult.DBCluster.DBClusterArn");
+
+        assertTrue(arn.contains(":eu-west-1:"), "ARN should name the caller's region: " + arn);
+
+        queryIn("eu-west-1", "AddTagsToResource")
+                .formParam("ResourceName", arn)
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "eu")
+        .when().post("/")
+        .then().statusCode(200);
+
+        queryIn("eu-west-1", "ListTagsForResource")
+                .formParam("ResourceName", arn)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>eu</Value>"));
+
+        queryIn("eu-west-1", "DeleteDBCluster")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("SkipFinalSnapshot", "true")
+        .when().post("/").then().statusCode(200);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -1,8 +1,10 @@
 package io.github.hectorvent.floci.services.docdb;
 
+import io.github.hectorvent.floci.services.rds.RdsService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
@@ -10,6 +12,8 @@ import java.util.Map;
 import static io.restassured.RestAssured.given;
 import static io.restassured.http.ContentType.URLENC;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * One identifier space covers the RDS family.
@@ -30,6 +34,12 @@ class SharedClusterIdentifierIntegrationTest {
                           "floci.services.docdb.mock", "true");
         }
     }
+
+    @Inject
+    DocDbService docDbService;
+
+    @Inject
+    RdsService rdsService;
 
     private static final String ID = "shared-identifier";
     private static final String ARN = "arn:aws:rds:us-east-1:000000000000:cluster:" + ID;
@@ -83,5 +93,48 @@ class SharedClusterIdentifierIntegrationTest {
                 .formParam("DBClusterIdentifier", ID)
                 .formParam("SkipFinalSnapshot", "true")
         .when().post("/").then().statusCode(200);
+    }
+
+    @Test
+    void aPersistedCollisionAnswersFromOneStoreForEveryAction() {
+        // State written before creates shared one identifier space can still hold the name twice.
+        // Both records are seeded through the services, as a restart would load them, since the
+        // endpoint now refuses to create the second one.
+        String id = "persisted-collision";
+        String arn = "arn:aws:rds:us-east-1:000000000000:cluster:" + id;
+        rdsService.createDbCluster(id, "aurora-postgresql", null, "admin", "secret99password",
+                null, false, null);
+        docDbService.createDbCluster(id, "5.0.0", "docdbadmin", "secret99password", false);
+
+        // Describe already answers from DocumentDB for such a record, and has since long before
+        // tags existed. Tagging has to agree with it: one identifier, one answer.
+        query("DescribeDBClusters")
+                .formParam("DBClusterIdentifier", id)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("docdb"));
+
+        query("AddTagsToResource")
+                .formParam("ResourceName", arn)
+                .formParam("Tags.Tag.1.Key", "answered-by")
+                .formParam("Tags.Tag.1.Value", "docdb")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", arn)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>docdb</Value>"));
+
+        // The write went to the record that answers for the identifier, not to the other one.
+        assertEquals(java.util.Map.of("answered-by", "docdb"),
+                docDbService.listTagsForResource(arn));
+        assertTrue(rdsService.listTagsForResource(arn, "us-east-1").isEmpty());
+
+        docDbService.deleteDbCluster(id);
+        rdsService.deleteDbCluster(id, "us-east-1");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/SharedClusterIdentifierIntegrationTest.java
@@ -278,4 +278,39 @@ class SharedClusterIdentifierIntegrationTest {
         .when().post("/").then().statusCode(200);
         rdsService.deleteDbCluster(id, "us-east-1");
     }
+
+    @Test
+    void theDocDbScopeIsCheckedTheSameWayAsTheRdsScope() {
+        // DocumentDB is reachable under either credential scope. A create signed for the docdb
+        // scope dispatches straight to its handler, which only knows its own store — so without
+        // the same check there, this is the way to put two records under one ARN.
+        String id = "docdb-scope-clash";
+        rdsService.createDbCluster(id, "aurora-postgresql", null, "admin", "secret99password",
+                null, false, null);
+
+        given().header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/docdb/aws4_request, "
+                        + "SignedHeaders=content-type;host, Signature=test")
+                .contentType(URLENC)
+                .formParam("Action", "CreateDBCluster")
+                .formParam("Version", "2014-10-31")
+                .formParam("DBClusterIdentifier", id)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("DBClusterAlreadyExistsFault"));
+
+        // The RDS record is still the only one under that ARN, and still RDS's.
+        query("DescribeDBClusters")
+                .formParam("DBClusterIdentifier", id)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Engine>postgres</Engine>"));
+
+        rdsService.deleteDbCluster(id, "us-east-1");
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/TaggedRecordUpgradeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/TaggedRecordUpgradeTest.java
@@ -1,0 +1,58 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.docdb.model.DocDbCluster;
+import io.github.hectorvent.floci.services.docdb.model.DocDbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
+import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Records written before tags were stored have to keep working after an upgrade.
+ *
+ * <p>Floci persists these, so the first read after an upgrade deserializes JSON with no
+ * {@code tags} entry — and an explicit null is what Jackson writes back for a null field. Either
+ * way a caller listing tags must get an empty list, not a failure.
+ */
+class TaggedRecordUpgradeTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void aClusterPersistedWithoutTagsReadsAsUntagged() throws Exception {
+        DocDbCluster cluster = MAPPER.readValue(
+                "{\"dbClusterIdentifier\":\"legacy\",\"status\":\"available\"}", DocDbCluster.class);
+
+        assertNotNull(cluster.getTags());
+        assertTrue(cluster.getTags().isEmpty());
+
+        cluster.getTags().put("env", "added-after-upgrade");
+        assertEquals(Map.of("env", "added-after-upgrade"), cluster.getTags());
+    }
+
+    @Test
+    void anExplicitNullIsToleratedByEveryNewlyTaggedRecord() throws Exception {
+        assertTrue(MAPPER.readValue("{\"tags\":null}", DocDbCluster.class).getTags().isEmpty());
+        assertTrue(MAPPER.readValue("{\"tags\":null}", DocDbInstance.class).getTags().isEmpty());
+        assertTrue(MAPPER.readValue("{\"tags\":null}", DbParameterGroup.class).getTags().isEmpty());
+        assertTrue(MAPPER.readValue("{\"tags\":null}", DbClusterParameterGroup.class).getTags().isEmpty());
+    }
+
+    @Test
+    void tagsSurviveARoundTripThroughStorage() throws Exception {
+        DocDbInstance instance = new DocDbInstance();
+        instance.setDbInstanceIdentifier("round-trip");
+        instance.setTags(Map.of("env", "prod"));
+
+        DocDbInstance restored =
+                MAPPER.readValue(MAPPER.writeValueAsString(instance), DocDbInstance.class);
+
+        assertEquals(Map.of("env", "prod"), restored.getTags());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsParameterGroupTagIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsParameterGroupTagIntegrationTest.java
@@ -94,6 +94,7 @@ class RdsParameterGroupTagIntegrationTest {
                 .formParam("ResourceName", CLUSTER_PG_ARN)
                 .formParam("Tags.Tag.1.Key", "env")
                 .formParam("Tags.Tag.1.Value", "changed")
+                .formParam("Tags.Tag.2.Key", "novalue")
         .when().post("/")
         .then().statusCode(200);
 
@@ -102,11 +103,13 @@ class RdsParameterGroupTagIntegrationTest {
         .when().post("/")
         .then()
             .statusCode(200)
-            .body(containsString("<Value>changed</Value>"));
+            .body(containsString("<Value>changed</Value>"))
+            // A key given without a value reads back empty, as it does on a live account.
+            .body(containsString("<Key>novalue</Key><Value></Value>"));
 
         query("RemoveTagsFromResource")
                 .formParam("ResourceName", CLUSTER_PG_ARN)
-                .formParam("TagKeys.member.1", "team")
+                .formParam("TagKeys.member.1", "novalue")
         .when().post("/")
         .then().statusCode(200);
 
@@ -115,6 +118,7 @@ class RdsParameterGroupTagIntegrationTest {
         .when().post("/")
         .then()
             .statusCode(200)
+            .body(not(containsString("<Key>novalue</Key>")))
             .body(containsString("<Key>env</Key>"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsParameterGroupTagIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsParameterGroupTagIntegrationTest.java
@@ -1,0 +1,143 @@
+package io.github.hectorvent.floci.services.rds;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Tags on DB parameter groups and DB cluster parameter groups.
+ *
+ * <p>Both types are taggable on a live account, and both are read by the terraform provider as
+ * part of the group's own read — including for DocumentDB, whose cluster parameter groups are
+ * these records. The ARN is what a caller tags by, so the create response has to carry it.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class RdsParameterGroupTagIntegrationTest {
+
+    private static final String PG = "tag-test-pg";
+    private static final String CLUSTER_PG = "tag-test-cluster-pg";
+    private static final String PG_ARN = "arn:aws:rds:us-east-1:000000000000:pg:" + PG;
+    private static final String CLUSTER_PG_ARN =
+            "arn:aws:rds:us-east-1:000000000000:cluster-pg:" + CLUSTER_PG;
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/rds/aws4_request, "
+            + "SignedHeaders=content-type;host, Signature=test";
+
+    private static io.restassured.specification.RequestSpecification query(String action) {
+        return given().header("Authorization", AUTH)
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    @Test
+    @Order(1)
+    void createReportsTheArnAndKeepsTheTagsItWasGiven() {
+        query("CreateDBParameterGroup")
+                .formParam("DBParameterGroupName", PG)
+                .formParam("DBParameterGroupFamily", "postgres15")
+                .formParam("Description", "tag test")
+                .formParam("Tags.Tag.1.Key", "team")
+                .formParam("Tags.Tag.1.Value", "data")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            // Without the ARN in the response a caller has nothing to tag by.
+            .body(containsString("<DBParameterGroupArn>" + PG_ARN + "</DBParameterGroupArn>"));
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", PG_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>team</Key>"))
+            .body(containsString("<Value>data</Value>"));
+    }
+
+    @Test
+    @Order(1)
+    void aClusterParameterGroupIsTaggableTheSameWay() {
+        query("CreateDBClusterParameterGroup")
+                .formParam("DBClusterParameterGroupName", CLUSTER_PG)
+                .formParam("DBParameterGroupFamily", "docdb5.0")
+                .formParam("Description", "tag test")
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "test")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusterParameterGroupArn>" + CLUSTER_PG_ARN
+                    + "</DBClusterParameterGroupArn>"));
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_PG_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"))
+            .body(containsString("<Value>test</Value>"));
+    }
+
+    @Test
+    @Order(2)
+    void tagsCanBeAddedAndRemovedAfterwards() {
+        query("AddTagsToResource")
+                .formParam("ResourceName", CLUSTER_PG_ARN)
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "changed")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_PG_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>changed</Value>"));
+
+        query("RemoveTagsFromResource")
+                .formParam("ResourceName", CLUSTER_PG_ARN)
+                .formParam("TagKeys.member.1", "team")
+        .when().post("/")
+        .then().statusCode(200);
+
+        query("ListTagsForResource")
+                .formParam("ResourceName", CLUSTER_PG_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>env</Key>"));
+    }
+
+    @Test
+    @Order(3)
+    void aGroupThatDoesNotExistIsReportedAsMissing() {
+        query("ListTagsForResource")
+                .formParam("ResourceName", "arn:aws:rds:us-east-1:000000000000:cluster-pg:no-such-pg")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("NotFound"));
+    }
+
+    @Test
+    @Order(4)
+    void cleanUp() {
+        query("DeleteDBParameterGroup")
+                .formParam("DBParameterGroupName", PG)
+        .when().post("/").then().statusCode(200);
+
+        query("DeleteDBClusterParameterGroup")
+                .formParam("DBClusterParameterGroupName", CLUSTER_PG)
+        .when().post("/").then().statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -658,12 +658,17 @@ class RdsServiceTest {
 
     @Test
     void tagOperationsRejectUnsupportedResourceArn() {
-        AwsException exception = assertThrows(AwsException.class, () ->
+        // Parameter groups are tagged now, so an absent one is a missing resource rather than a
+        // missing feature. A type Floci still does not model keeps the limitation message.
+        AwsException absentGroup = assertThrows(AwsException.class, () ->
                 rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:pg:some-parameter-group"));
+        assertEquals("DBParameterGroupNotFound", absentGroup.getErrorCode());
 
-        assertEquals("InvalidParameterValue", exception.getErrorCode());
+        AwsException unsupportedType = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource("arn:aws:rds:us-east-1:123456789012:snapshot:some-snapshot"));
+        assertEquals("InvalidParameterValue", unsupportedType.getErrorCode());
         // The type is valid on real AWS; the message must present this as a Floci limitation.
-        assertTrue(exception.getMessage().contains("not yet implemented by Floci"));
+        assertTrue(unsupportedType.getMessage().contains("not yet implemented by Floci"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -1119,6 +1119,40 @@ class RdsServiceTest {
     }
 
     @Test
+    void aParameterGroupPersistedWithoutAnArnGetsOneOnFirstRead() {
+        // Only creation assigned the ARN, so a group written by an earlier version would never
+        // get one — and the ARN is what a caller tags by, so the group could not be tagged at all.
+        String accountId = "123456789012";
+        InMemoryStorage<String, DbParameterGroup> rawParameterGroups = new InMemoryStorage<>();
+        InMemoryStorage<String, DbClusterParameterGroup> rawClusterParameterGroups =
+                new InMemoryStorage<>();
+        rawParameterGroups.put("legacy-pg", new DbParameterGroup(
+                "legacy-pg", "postgres16", "legacy"));
+        rawClusterParameterGroups.put("legacy-cpg", new DbClusterParameterGroup(
+                "legacy-cpg", "aurora-postgresql16", "legacy"));
+        RdsService service = new RdsService(
+                containerManager, proxyManager, ec2Service,
+                new RegionResolver("us-east-1", accountId), config,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new AccountAwareStorageBackend<>(rawParameterGroups, null, accountId),
+                new AccountAwareStorageBackend<>(rawClusterParameterGroups, null, accountId),
+                new InMemoryStorage<>());
+
+        assertEquals("arn:aws:rds:us-east-1:" + accountId + ":pg:legacy-pg",
+                service.getDbParameterGroup("legacy-pg", "us-east-1").getDbParameterGroupArn());
+        assertEquals("arn:aws:rds:us-east-1:" + accountId + ":cluster-pg:legacy-cpg",
+                service.getDbClusterParameterGroup("legacy-cpg", "us-east-1")
+                        .getDbClusterParameterGroupArn());
+
+        // And with an ARN it can be tagged, which is the point of backfilling it.
+        service.addTagsToResource(
+                "arn:aws:rds:us-east-1:" + accountId + ":cluster-pg:legacy-cpg",
+                Map.of("env", "upgraded"), "us-east-1");
+        assertEquals(Map.of("env", "upgraded"), service.listTagsForResource(
+                "arn:aws:rds:us-east-1:" + accountId + ":cluster-pg:legacy-cpg", "us-east-1"));
+    }
+
+    @Test
     void rawLegacyParameterGroupsCannotBeClaimedByANonDefaultAccount() {
         String defaultAccount = "123456789012";
         String otherAccount = "222222222222";


### PR DESCRIPTION
Closes #2405.

## What

`aws_docdb_cluster` reads a cluster's tags as part of every read, so a cluster that created fine failed its apply on `DBClusterNotFoundFault` — created, but not readable. `aws_docdb_cluster_parameter_group`, `aws_rds_cluster_parameter_group` and `aws_db_parameter_group` failed the same read one step later.

## Three causes

**Routing.** DocumentDB signs with the `rds` credential scope, where it is told apart by `Engine` or a cluster/instance identifier. The tag actions carry neither — only the ARN of the resource they address — so they reached `RdsQueryHandler`, which does not hold DocumentDB's records. The router matches that ARN now, whole rather than by its trailing name: RDS and DocumentDB share one ARN space, so a name both services use would otherwise be answered from the wrong store, and an RDS parameter group could be resolved as a cluster. Same shape as #2400.

**Parameter groups.** The RDS tag resolver handled `db`, `cluster`, `subgrp`, `db-proxy` and `og`, but not `pg` or `cluster-pg` — and those records carried neither tags nor the ARN a caller tags by, since the create response omitted it.

**Which service owns an identifier.** Matching the whole ARN only helps if one ARN means one record. Two things had to hold for that, and neither did. A DocumentDB create could take an identifier RDS already held in that region, putting two records under one ARN — a live account refuses that, because the RDS family shares one identifier space, and Floci now answers `AlreadyExists` the same way. And DocumentDB built its ARNs from the configured default region while keying records by bare identifier, so a caller outside that region got an ARN naming somewhere they were not — one their own tag call then rejected — while the identifier they used was taken away from RDS in every other region. Both cluster and instance ARNs come from the caller's region now, and ownership of an identifier is decided per region, read from the ARN the record carries.

## Behaviour, checked against a live DocumentDB cluster and cluster parameter group

| | |
|---|---|
| tags given at create | readable back |
| order of the returned list | arbitrary — `env,owner` came back `owner,env`, so nothing asserts order |
| `AddTagsToResource` on an existing key | overwrites it |
| `RemoveTagsFromResource` naming an absent key | not an error; the present keys are removed |
| a key given with no value | reads back as an empty value |
| ARN in another region, or another account | `InvalidParameterValue` — *The specified resource name does not match an RDS resource in this region*, the one message AWS gives for both |
| an Aurora cluster named like an existing DocumentDB one | `DBClusterAlreadyExistsFault` — the RDS family shares one identifier space |

An ARN naming another region or account reaches RDS rather than DocumentDB, since it matches no DocumentDB record, and RDS rejects it — this caller's cluster is never what comes back. DocumentDB's own check on that is covered directly in `DocDbServiceTest`, where it guards the service's contract rather than the endpoint's.

The valueless-tag case was its own defect (third commit): the value was stored as null, and the read hands tags back as an immutable copy, which rejects nulls — so one such tag broke *every* subsequent read of that resource. Both handlers parse tags the same way and both had it.

## Locking

A tag update is a read-modify-write, so it takes the record's monitor, and the other writers now take the same one — otherwise tagging a cluster while it is being deleted stores the record again, leaving a cluster no describe created and no delete can remove. Paths holding both monitors take the instance's before the cluster's.

## Tests

- `DocDbTagIntegrationTest` — the full story over the `rds` scope: create with tags, overwrite, remove, valueless, instance tags, cross-region and cross-account ARNs, tags surviving a modify, and a deleted cluster staying deleted
- `DocDbTagConcurrencyTest` — the delete/tag race (fails on attempt 0 without the monitor) and a lock-order check that hangs rather than passing if the two paths ever disagree
- `RdsParameterGroupTagIntegrationTest` — ARN in the create response, tags on both group types, add/remove
- `SharedClusterIdentifierIntegrationTest` — one identifier cannot land in both services in one region; another region is another resource, with its own ARN and its own tags; and an RDS request is never answered by a DocumentDB record from a different region
- `TaggedRecordUpgradeTest` — a record persisted before tags existed reads as untagged
- `rds.bats` — the DocumentDB cluster tag lifecycle and the cluster parameter group ARN, through the CLI's own parser

Each was proved by reverting the change and watching it fail: the routing, the `cluster-pg` resolver, tags-at-create, the monitor, the null normalisation, the identifier check, the ARN region, and per-region ownership.

`RdsControlPlaneTest` from the SDK compatibility suite was run against a local emulator as well — `sdkScopesTheSameDbInstanceNameBySignedRegion` pins that RDS names are scoped by region, which is the rule the identifier check has to respect.

`RdsServiceTest.tagOperationsRejectUnsupportedResourceArn` asserted that `pg` tagging was unimplemented; it now asserts the missing group is reported as missing, and keeps the limitation check on a type Floci still does not model (`snapshot`).

## Deliberately not done

`Filters` on `ListTagsForResource` is accepted without validation. A live account rejects an unrecognised filter name, but Floci carries no list of the names it accepts, and a partial list would refuse filters that are valid.


