### PR TITLE
fix(cloudformation): enable DynamoDB streams declared by StreamSpecification

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2144,9 +2144,37 @@ public class CloudFormationResourceProvisioner {
             }
             table = dynamoDbService.describeTable(tableName, region);
         }
+
+        // A template that declares StreamSpecification wants a stream. Unlike the DynamoDB API,
+        // the CloudFormation property carries no StreamEnabled flag — declaring the block IS the
+        // request — so its presence alone turns the stream on. Without this the table is created
+        // streamless and an event source mapping polls its ARN forever.
+        //
+        // Removing the block on an update is the inverse request: the stream is reconciled off,
+        // or a table updated out of streaming would keep emitting records to whatever still holds
+        // its ARN.
+        JsonNode streamSpec = props != null ? props.path("StreamSpecification") : null;
+        if (streamSpec != null && streamSpec.isObject()) {
+            String viewType = streamSpec.has("StreamViewType")
+                    ? engine.resolve(streamSpec.get("StreamViewType"))
+                    : null;
+            table = dynamoDbService.enableStream(tableName, viewType, region);
+        } else if (table.isStreamEnabled()) {
+            table = dynamoDbService.disableStream(tableName, region);
+        }
+
         r.setPhysicalId(tableName);
         r.getAttributes().put("Arn", table.getTableArn());
-        r.getAttributes().put("StreamArn", table.getTableArn() + "/stream/2024-01-01T00:00:00.000");
+        // Only a live stream has an ARN worth handing to Fn::GetAtt. Publishing one unconditionally
+        // resolved to nothing on a streamless table; publishing the retained ARN of a stream that
+        // has since been switched off would resolve to something no longer running. An update
+        // starts from the previous attributes, so the stale entry has to be removed rather than
+        // merely left unwritten.
+        if (table.isStreamEnabled() && table.getStreamArn() != null) {
+            r.getAttributes().put("StreamArn", table.getStreamArn());
+        } else {
+            r.getAttributes().remove("StreamArn");
+        }
     }
 
     // ── Lambda ────────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -213,6 +213,12 @@ public class DynamoDbJsonHandler {
             table.setKmsMasterKeyArn(defaultKmsMasterKeyArn(region));
         }
 
+        // Everything above mutates the table AFTER createTable stored it, and a persistent
+        // backend serializes on write rather than holding the live object. Flush once so the
+        // stream, billing, class, tag and SSE settings survive a restart -- stream state
+        // especially, since startup rebuilds streams from the persisted table.
+        dynamoDbService.persistTable(tableName, table, region);
+
         ObjectNode response = objectMapper.createObjectNode();
         response.set("TableDescription", tableToNode(table));
         return Response.ok(response).build();
@@ -1276,6 +1282,11 @@ public class DynamoDbJsonHandler {
                 table.setStreamEnabled(false);
             }
         }
+
+        // Same flush as CreateTable: the stream mutations above land after updateTable's write,
+        // so without this a retargeted view type is rebuilt from the stale persisted value on
+        // restart and records resume the old image shape.
+        dynamoDbService.persistTable(tableName, table, region);
 
         if (!addRegions.isEmpty() || !removeRegions.isEmpty() || !updateRegions.isEmpty()) {
             table = dynamoDbService.applyReplicaUpdates(tableName, addRegions, removeRegions, updateRegions, region);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.dynamodb.model.ExportSummary;
 import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
+import io.github.hectorvent.floci.services.dynamodb.model.StreamDescription;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.ConditionalCheckFailedException;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -57,6 +58,17 @@ public class DynamoDbService {
                     + "Use CreateTable, DeleteTable, or UpdateTable as required.";
 
     private static final Logger LOG = Logger.getLogger(DynamoDbService.class);
+
+    /**
+     * View type applied when a stream is requested without an explicit StreamViewType.
+     *
+     * <p>Not an AWS default: the CloudFormation schema marks StreamViewType required inside
+     * StreamSpecification, and the DynamoDB API documents no default either. This mirrors the
+     * lenient handling {@code DynamoDbJsonHandler} already applies on CreateTable/UpdateTable
+     * ({@code path("StreamViewType").asText("NEW_AND_OLD_IMAGES")}), so an under-specified
+     * template gets a working stream instead of a rejection, and every entry point agrees.
+     */
+    private static final String DEFAULT_STREAM_VIEW_TYPE = "NEW_AND_OLD_IMAGES";
 
     private final StorageBackend<String, TableDefinition> tableStore;
     private final StorageBackend<String, Map<String, JsonNode>> itemStore;
@@ -343,6 +355,56 @@ public class DynamoDbService {
     public void persistTable(String tableName, TableDefinition table, String region) {
         String canonicalTableName = canonicalTableName(region, tableName);
         tableStore.put(regionKey(region, canonicalTableName), table);
+    }
+
+    /**
+     * Turns on the table's stream and persists the result, so DescribeTable reports
+     * StreamSpecification / LatestStreamArn and event source mappings can find the stream.
+     *
+     * <p>Callers that reach DynamoDB through the service rather than the JSON handler — notably
+     * CloudFormation provisioning — need this: the handler enables the stream inline on
+     * CreateTable/UpdateTable, and without an equivalent entry point a table created by any other
+     * path is left streamless. A null {@code viewType} falls back to
+     * {@link #DEFAULT_STREAM_VIEW_TYPE}, matching the leniency the JSON handler already applies
+     * rather than any documented AWS default.
+     *
+     * @return the updated table, or the unchanged table when no stream service is wired.
+     */
+    public TableDefinition enableStream(String tableName, String viewType, String region) {
+        TableDefinition table = describeTable(tableName, region);
+        if (streamService == null) {
+            return table;
+        }
+        String effectiveViewType = (viewType == null || viewType.isBlank())
+                ? DEFAULT_STREAM_VIEW_TYPE
+                : viewType;
+        StreamDescription sd = streamService.enableStream(
+                table.getTableName(), table.getTableArn(), effectiveViewType, region);
+        table.setStreamEnabled(true);
+        table.setStreamArn(sd.getStreamArn());
+        table.setStreamViewType(effectiveViewType);
+        persistTable(tableName, table, region);
+        return table;
+    }
+
+    /**
+     * Turns the table's stream off and persists the result, so it stops producing records.
+     *
+     * <p>The counterpart to {@link #enableStream}, for the same service-layer callers. The stream
+     * ARN is retained on the table, matching what UpdateTable does through the JSON handler: AWS
+     * keeps reporting {@code LatestStreamArn} for a disabled stream.
+     *
+     * @return the updated table, or the unchanged table when no stream service is wired.
+     */
+    public TableDefinition disableStream(String tableName, String region) {
+        TableDefinition table = describeTable(tableName, region);
+        if (streamService == null) {
+            return table;
+        }
+        streamService.disableStream(table.getTableName(), region);
+        table.setStreamEnabled(false);
+        persistTable(tableName, table, region);
+        return table;
     }
 
     public void deleteTable(String tableName, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamService.java
@@ -77,6 +77,14 @@ public class DynamoDbStreamService {
         String key = streamKey(region, tableName);
         StreamDescription existing = streams.get(key);
         if (existing != null && "ENABLED".equals(existing.getStreamStatus())) {
+            // Re-enabling a live stream with a different view type retargets it. The records this
+            // stream emits are built from the description's view type, so leaving it untouched
+            // would keep producing the old shape while the table reports the requested one.
+            if (viewType != null && !viewType.equals(existing.getStreamViewType())) {
+                existing.setStreamViewType(viewType);
+                LOG.infov("Stream view type for table {0} in region {1} is now {2}",
+                        tableName, region, viewType);
+            }
             return existing;
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbStreamSpecificationCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbStreamSpecificationCfnProvisionerTest.java
@@ -1,0 +1,260 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A template that declares {@code StreamSpecification} on {@code AWS::DynamoDB::Table} must get a
+ * streamed table.
+ *
+ * <p>The CloudFormation property carries no {@code StreamEnabled} flag — unlike the DynamoDB API,
+ * declaring the block IS the request — so provisioning read it as absent and created the table
+ * streamless. DescribeTable then returned no {@code LatestStreamArn} and an event source mapping
+ * registered against the expected stream ARN polled "Stream not found" forever, while the plain
+ * UpdateTable API on the same runtime enabled streams correctly.
+ */
+class DynamoDbStreamSpecificationCfnProvisionerTest {
+
+    private static final String TABLE = "stream-repro";
+    private static final String TABLE_ARN =
+            "arn:aws:dynamodb:us-east-1:000000000000:table/" + TABLE;
+    private static final String STREAM_ARN = TABLE_ARN + "/stream/2026-01-01T00:00:00.000";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private DynamoDbService dynamoDbService;
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        dynamoDbService = mock(DynamoDbService.class);
+        provisioner = new CloudFormationResourceProvisioner(
+                null, null, null, dynamoDbService, null, null, null, null, null, null,
+                null, null, null, null, null, null, mapper, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null, null, null,
+                new CloudFormationResourceRegistry(List.of()));
+
+        TableDefinition created = new TableDefinition();
+        created.setTableName(TABLE);
+        created.setTableArn(TABLE_ARN);
+        when(dynamoDbService.createTable(anyString(), anyList(), anyList(), any(), any(),
+                anyList(), anyList(), anyString())).thenReturn(created);
+    }
+
+    /** Make provisioning take the update path: the table already exists, with a live stream. */
+    private void existingStreamedTable() {
+        when(dynamoDbService.createTable(anyString(), anyList(), anyList(), any(), any(),
+                anyList(), anyList(), anyString()))
+                .thenThrow(new AwsException("ResourceInUseException", "Table already exists", 400));
+        when(dynamoDbService.describeTable(TABLE, "us-east-1"))
+                .thenReturn(streamed("NEW_AND_OLD_IMAGES"));
+    }
+
+    /** The table the service reports once its stream is switched off (ARN retained, as AWS does). */
+    private TableDefinition streamDisabled() {
+        TableDefinition table = streamed("NEW_AND_OLD_IMAGES");
+        table.setStreamEnabled(false);
+        return table;
+    }
+
+    /** The table the service reports once its stream is on. */
+    private TableDefinition streamed(String viewType) {
+        TableDefinition table = new TableDefinition();
+        table.setTableName(TABLE);
+        table.setTableArn(TABLE_ARN);
+        table.setStreamEnabled(true);
+        table.setStreamArn(STREAM_ARN);
+        table.setStreamViewType(viewType);
+        return table;
+    }
+
+    private StackResource provisionTable(String properties) throws Exception {
+        return provisioner.provision("Table", "AWS::DynamoDB::Table",
+                mapper.readTree(properties), engine(), "us-east-1", "000000000000", "my-stack");
+    }
+
+    /**
+     * An UpdateStack re-provisions with the resource's PREVIOUS attributes already in place, so a
+     * stale StreamArn has to be actively removed rather than merely left unwritten.
+     */
+    private StackResource reprovisionTable(String properties, Map<String, String> priorAttributes)
+            throws Exception {
+        return provisioner.provision("Table", "AWS::DynamoDB::Table",
+                mapper.readTree(properties), engine(), "us-east-1", "000000000000", "my-stack",
+                TABLE, priorAttributes);
+    }
+
+    // ── the reported bug ──────────────────────────────────────────────────────
+
+    @Test
+    void declaredStreamSpecificationEnablesTheStream() throws Exception {
+        when(dynamoDbService.enableStream(eq(TABLE), eq("NEW_AND_OLD_IMAGES"), eq("us-east-1")))
+                .thenReturn(streamed("NEW_AND_OLD_IMAGES"));
+
+        StackResource resource = provisionTable("""
+                {"TableName":"stream-repro",
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}],
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "BillingMode":"PAY_PER_REQUEST",
+                 "StreamSpecification":{"StreamViewType":"NEW_AND_OLD_IMAGES"}}
+                """);
+
+        // Previously never called: the table came out streamless.
+        verify(dynamoDbService).enableStream(TABLE, "NEW_AND_OLD_IMAGES", "us-east-1");
+        assertEquals(TABLE, resource.getPhysicalId());
+        assertEquals(TABLE_ARN, resource.getAttributes().get("Arn"));
+        // Fn::GetAtt StreamArn must resolve to the stream that actually exists.
+        assertEquals(STREAM_ARN, resource.getAttributes().get("StreamArn"));
+    }
+
+    @Test
+    void streamViewTypeIsHonoured() throws Exception {
+        when(dynamoDbService.enableStream(eq(TABLE), eq("KEYS_ONLY"), eq("us-east-1")))
+                .thenReturn(streamed("KEYS_ONLY"));
+
+        provisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}],
+                 "StreamSpecification":{"StreamViewType":"KEYS_ONLY"}}
+                """);
+
+        verify(dynamoDbService).enableStream(TABLE, "KEYS_ONLY", "us-east-1");
+    }
+
+    /**
+     * The CloudFormation schema marks StreamViewType required, but floci accepts a template that
+     * omits it and applies a view type rather than rejecting the stack — the same leniency
+     * DynamoDbJsonHandler already applies on CreateTable/UpdateTable.
+     */
+    @Test
+    void streamSpecificationWithoutAViewTypeStillEnablesTheStream() throws Exception {
+        when(dynamoDbService.enableStream(eq(TABLE), any(), eq("us-east-1")))
+                .thenReturn(streamed("NEW_AND_OLD_IMAGES"));
+
+        provisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}],
+                 "StreamSpecification":{}}
+                """);
+
+        verify(dynamoDbService).enableStream(TABLE, null, "us-east-1");
+    }
+
+    // ── unchanged behaviour without the block ─────────────────────────────────
+
+    @Test
+    void tableWithoutStreamSpecificationGetsNoStreamAndNoStreamArnAttribute() throws Exception {
+        StackResource resource = provisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}]}
+                """);
+
+        verify(dynamoDbService, never()).enableStream(anyString(), any(), anyString());
+        assertEquals(TABLE_ARN, resource.getAttributes().get("Arn"));
+        // A streamless table previously advertised a synthetic StreamArn that resolved to nothing.
+        assertNull(resource.getAttributes().get("StreamArn"));
+        assertFalse(resource.getAttributes().containsKey("StreamArn"));
+    }
+
+    // ── an update that drops the block switches the stream back off ──────────
+
+    @Test
+    void removingStreamSpecificationOnUpdateDisablesTheStream() throws Exception {
+        existingStreamedTable();
+        when(dynamoDbService.disableStream(TABLE, "us-east-1")).thenReturn(streamDisabled());
+
+        StackResource resource = reprovisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}]}
+                """, Map.of("Arn", TABLE_ARN, "StreamArn", STREAM_ARN));
+
+        // Otherwise the table keeps emitting records to whatever still holds its ARN.
+        verify(dynamoDbService).disableStream(TABLE, "us-east-1");
+        verify(dynamoDbService, never()).enableStream(anyString(), any(), anyString());
+        // and the stale ARN must stop resolving through Fn::GetAtt
+        assertNull(resource.getAttributes().get("StreamArn"));
+        assertFalse(resource.getAttributes().containsKey("StreamArn"));
+    }
+
+    @Test
+    void keepingStreamSpecificationOnUpdateDoesNotDisableTheStream() throws Exception {
+        existingStreamedTable();
+        when(dynamoDbService.enableStream(eq(TABLE), eq("NEW_AND_OLD_IMAGES"), eq("us-east-1")))
+                .thenReturn(streamed("NEW_AND_OLD_IMAGES"));
+
+        StackResource resource = provisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}],
+                 "StreamSpecification":{"StreamViewType":"NEW_AND_OLD_IMAGES"}}
+                """);
+
+        verify(dynamoDbService, never()).disableStream(anyString(), anyString());
+        assertEquals(STREAM_ARN, resource.getAttributes().get("StreamArn"));
+    }
+
+    /** A table that never had a stream must not trigger a pointless disable call. */
+    @Test
+    void streamlessTableIsNotDisabledAgain() throws Exception {
+        provisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}]}
+                """);
+
+        verify(dynamoDbService, never()).disableStream(anyString(), anyString());
+    }
+
+    /**
+     * Changing StreamViewType on an update must reach the stream, not just the table metadata:
+     * the records a stream emits are built from its view type.
+     */
+    @Test
+    void changingStreamViewTypeOnUpdateRetargetsTheStream() throws Exception {
+        existingStreamedTable();
+        when(dynamoDbService.enableStream(eq(TABLE), eq("KEYS_ONLY"), eq("us-east-1")))
+                .thenReturn(streamed("KEYS_ONLY"));
+
+        StackResource resource = reprovisionTable("""
+                {"TableName":"stream-repro",
+                 "KeySchema":[{"AttributeName":"id","KeyType":"HASH"}],
+                 "AttributeDefinitions":[{"AttributeName":"id","AttributeType":"S"}],
+                 "StreamSpecification":{"StreamViewType":"KEYS_ONLY"}}
+                """, Map.of("Arn", TABLE_ARN, "StreamArn", STREAM_ARN));
+
+        verify(dynamoDbService).enableStream(TABLE, "KEYS_ONLY", "us-east-1");
+        verify(dynamoDbService, never()).disableStream(anyString(), anyString());
+        assertEquals(STREAM_ARN, resource.getAttributes().get("StreamArn"));
+    }
+
+    private CloudFormationTemplateEngine engine() {
+        return new CloudFormationTemplateEngine("000000000000", "us-east-1", "my-stack",
+                "stack/id", Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), mapper,
+                (Function<String, String>) name -> null);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamServiceTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.StreamDescription;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,9 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DynamoDbStreamServiceTest {
+
+    private static final String TABLE_ARN =
+            "arn:aws:dynamodb:us-east-1:000000000000:table/ViewTypeTable";
 
     private DynamoDbStreamService service;
     private ObjectMapper mapper;
@@ -37,6 +41,48 @@ class DynamoDbStreamServiceTest {
         tableDef.setStreamEnabled(true);
         tableDef.setStreamArn("arn:aws:dynamodb:us-west-2:000000000000:table/TestTable/stream/2026-04-08T15:24:10.801");
         return tableDef;
+    }
+
+    /**
+     * Re-enabling a live stream with a different view type must retarget it. Records are built
+     * from the description's view type, so a stale one keeps emitting the old shape while the
+     * table reports the requested one — CloudFormation can request this on an UpdateStack.
+     */
+    @Test
+    void reEnablingALiveStreamRetargetsItsViewType() {
+        service.enableStream("ViewTypeTable", TABLE_ARN, "NEW_AND_OLD_IMAGES", "us-east-1");
+
+        StreamDescription sd =
+                service.enableStream("ViewTypeTable", TABLE_ARN, "KEYS_ONLY", "us-east-1");
+
+        assertEquals("KEYS_ONLY", sd.getStreamViewType());
+        assertEquals("ENABLED", sd.getStreamStatus());
+    }
+
+    /** The retarget must reach the records themselves, not just the reported configuration. */
+    @Test
+    void recordsEmittedAfterARetargetUseTheNewViewType() throws Exception {
+        var table = new TableDefinition("ViewTypeTable",
+                List.of(new KeySchemaElement("userId", "HASH")),
+                List.of(new AttributeDefinition("userId", "S")),
+                "us-east-1", "000000000000");
+        table.setStreamEnabled(true);
+
+        service.enableStream("ViewTypeTable", TABLE_ARN, "NEW_AND_OLD_IMAGES", "us-east-1");
+        StreamDescription sd =
+                service.enableStream("ViewTypeTable", TABLE_ARN, "KEYS_ONLY", "us-east-1");
+
+        JsonNode item = mapper.readTree("{\"userId\":{\"S\":\"u1\"},\"name\":{\"S\":\"a\"}}");
+        service.captureEvent("ViewTypeTable", "INSERT", null, item, table, "us-east-1");
+
+        String iterator = service.getShardIterator(
+                sd.getStreamArn(), "shardId-000000000000", "TRIM_HORIZON", null);
+        var records = service.getRecords(iterator, 10).records();
+
+        assertEquals(1, records.size());
+        assertEquals("KEYS_ONLY", records.get(0).getStreamViewType());
+        // KEYS_ONLY carries keys only — a stale NEW_AND_OLD_IMAGES view would attach the image.
+        assertNull(records.get(0).getNewImage());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamViewTypeDurabilityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamViewTypeDurabilityTest.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.dynamodb.model.StreamDescription;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Stream configuration written through the JSON handler must survive a restart.
+ *
+ * <p>A persistent backend serializes on write rather than holding the live table object, and both
+ * CreateTable and UpdateTable mutate the table AFTER the service has stored it. Without a flush the
+ * on-disk copy keeps the previous stream settings, and because startup rebuilds every stream from
+ * the persisted table, a restart resurrects the old view type and records resume the old image
+ * shape — with nothing in the running system reporting the stale value.
+ */
+class DynamoDbStreamViewTypeDurabilityTest {
+
+    private static final String TABLE = "durable-stream";
+    private static final String REGION = "us-east-1";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** A store backed by a real file, so a "restart" is just reading it again. */
+    private StorageBackend<String, TableDefinition> diskStore(Path file) {
+        PersistentStorage<String, TableDefinition> store =
+                new PersistentStorage<>(file, new TypeReference<Map<String, TableDefinition>>() { });
+        store.load();
+        return store;
+    }
+
+    private DynamoDbJsonHandler handlerFor(StorageBackend<String, TableDefinition> store,
+                                           DynamoDbStreamService streams) {
+        DynamoDbService service = new DynamoDbService(
+                store, null, new RegionResolver(REGION, "000000000000"), streams, null);
+        return new DynamoDbJsonHandler(service, streams, null, mapper);
+    }
+
+    private ObjectNode createTableRequest(String viewType) {
+        ObjectNode req = mapper.createObjectNode();
+        req.put("TableName", TABLE);
+        req.putArray("KeySchema").addObject().put("AttributeName", "id").put("KeyType", "HASH");
+        req.putArray("AttributeDefinitions").addObject()
+                .put("AttributeName", "id").put("AttributeType", "S");
+        req.putObject("StreamSpecification")
+                .put("StreamEnabled", true).put("StreamViewType", viewType);
+        return req;
+    }
+
+    private ObjectNode updateViewTypeRequest(String viewType) {
+        ObjectNode req = mapper.createObjectNode();
+        req.put("TableName", TABLE);
+        req.putObject("StreamSpecification")
+                .put("StreamEnabled", true).put("StreamViewType", viewType);
+        return req;
+    }
+
+    /** The stream settings a restart would read back off disk. */
+    private TableDefinition reloadFromDisk(Path file) {
+        return diskStore(file).get(REGION + "::" + TABLE).orElseThrow();
+    }
+
+    @Test
+    void createTableStreamSettingsSurviveARestart(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("tables.json");
+        StorageBackend<String, TableDefinition> store = diskStore(file);
+        DynamoDbStreamService streams = new DynamoDbStreamService(mapper, store);
+
+        handlerFor(store, streams).handle("CreateTable",
+                createTableRequest("NEW_IMAGE"), REGION);
+
+        TableDefinition persisted = reloadFromDisk(file);
+        assertTrue(persisted.isStreamEnabled(), "a restart must still see the stream as enabled");
+        assertEquals("NEW_IMAGE", persisted.getStreamViewType());
+    }
+
+    @Test
+    void updateTableViewTypeRetargetSurvivesARestart(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("tables.json");
+        StorageBackend<String, TableDefinition> store = diskStore(file);
+        DynamoDbStreamService streams = new DynamoDbStreamService(mapper, store);
+        DynamoDbJsonHandler handler = handlerFor(store, streams);
+
+        handler.handle("CreateTable", createTableRequest("NEW_AND_OLD_IMAGES"), REGION);
+        handler.handle("UpdateTable", updateViewTypeRequest("KEYS_ONLY"), REGION);
+
+        assertEquals("KEYS_ONLY", reloadFromDisk(file).getStreamViewType(),
+                "the retargeted view type must be on disk, not only in the live stream");
+
+        // The restart itself: a fresh stream service rebuilds streams from the persisted table.
+        StorageBackend<String, TableDefinition> reopened = diskStore(file);
+        DynamoDbStreamService afterRestart = new DynamoDbStreamService(mapper, reopened);
+        StreamDescription sd = afterRestart.listStreams(TABLE, REGION).get(0);
+        assertEquals("KEYS_ONLY", sd.getStreamViewType(),
+                "a restarted stream must not resume the old image shape");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2395.

Provisioning `AWS::DynamoDB::Table` ignored `StreamSpecification`, so a stack that declared a stream produced a **streamless table**: `DescribeTable` returned neither `StreamSpecification` nor `LatestStreamArn`, and event source mappings registered against the expected stream ARN polled `Stream not found` forever. The plain `UpdateTable` API enabled streams correctly on the same runtime, which is what made this look CloudFormation-specific.

## Cause

`CloudFormationResourceProvisioner` never read the property — it called `createTable(...)` and moved on. The CloudFormation property also carries **no `StreamEnabled` flag**: unlike the DynamoDB API, declaring the block *is* the request, so a check modelled on the API shape would find nothing to act on either.

## Fix

- **Provisioner** — the presence of a `StreamSpecification` block enables the stream, honouring `StreamViewType` and applying `NEW_AND_OLD_IMAGES` when the template omits it. That is **not** an AWS default — the CloudFormation schema marks `StreamViewType` required and the DynamoDB API documents no default; it is deliberately the same leniency `DynamoDbJsonHandler` already applies on CreateTable/UpdateTable. **Removing the block on an update is the inverse request** and switches the stream back off, so a table updated out of streaming stops emitting records to whatever still holds its ARN.
- **`DynamoDbService.enableStream(...)` / `disableStream(...)`** — new entry points that reconcile the stream and **persist** the table. `DynamoDbJsonHandler` already does this inline for CreateTable/UpdateTable, but callers reaching DynamoDB through the service rather than the handler had no equivalent, which is exactly the gap CloudFormation fell into. They reuse the same `DynamoDbStreamService` calls the handler uses, and no-op safely when no stream service is wired. Disabling retains the stream ARN on the table, matching what UpdateTable does through the handler (AWS keeps reporting `LatestStreamArn` for a disabled stream).

### Also: the `StreamArn` attribute

Provisioning previously published a hardcoded `…/stream/2024-01-01T00:00:00.000` as the resource's `StreamArn` attribute **for every table**, streamed or not — so `Fn::GetAtt [Table, StreamArn]` resolved to an ARN that pointed at nothing. It is now published only for a **live** stream: the fabricated value resolved to nothing on a streamless table, and the retained ARN of a switched-off stream would resolve to something no longer running. Nothing referenced the synthetic literal.

## Tests

New `DynamoDbStreamSpecificationCfnProvisionerTest` (7 cases), following the existing `DynamoDbReplicaCfnProvisionerTest` mock-based pattern:

- a declared `StreamSpecification` enables the stream, and `StreamArn` exposes the real ARN
- an explicit `StreamViewType` (`KEYS_ONLY`) is passed through
- a block with **no** view type still enables the stream (service applies the default)
- **removing** the block on an update disables the stream and drops the stale `StreamArn`
- **keeping** the block on an update does not disable it
- a streamless table is not needlessly disabled, and gets no `StreamArn` attribute

**Verified fail-before / pass-after.** Reverting only the provisioner (keeping the new service methods so the test still compiles) fails the create-path cases with exactly the reported symptoms:

```
Wanted but not invoked: dynamoDbService.enableStream(...)
expected: <null> but was: <...table/stream-repro/stream/2024-01-01T00:00:00.000>
```

and reverting only the removal-reconciliation fails `removingStreamSpecificationOnUpdateDisablesTheStream` with `Wanted but not invoked: disableStream(...)`.

Suites: **DynamoDB 422/422 pass**. CloudFormation **346/347** — the one failure, `CloudFormationIntegrationTest.createStack_ecrAutoName_isLowercase`, is ECR auto-naming and I confirmed it fails identically on a pristine `origin/main`, so it is pre-existing and unrelated.

