### PR TITLE
fix(apigatewayv2): return stage tags across protocols

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ApiGatewayV2ManagementTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/ApiGatewayV2ManagementTest.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.apigatewayv2.model.NotFoundException;
 import software.amazon.awssdk.services.apigatewayv2.model.ProtocolType;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -311,6 +312,7 @@ class ApiGatewayV2ManagementTest {
                 .stageName(stageName)
                 .deploymentId(deploymentId)
                 .autoDeploy(false)
+                .tags(Map.of("environment", "test", "owner", "platform"))
                 .build());
 
         assertThat(response.stageName()).isEqualTo(stageName);
@@ -318,6 +320,9 @@ class ApiGatewayV2ManagementTest {
         assertThat(response.autoDeploy()).isFalse();
         assertThat(response.createdDate()).isNotNull();
         assertThat(response.lastUpdatedDate()).isNotNull();
+        assertThat(response.tags())
+                .containsEntry("environment", "test")
+                .containsEntry("owner", "platform");
         stageCreated = true;
     }
 
@@ -333,6 +338,9 @@ class ApiGatewayV2ManagementTest {
 
         assertThat(getResponse.stageName()).isEqualTo(stageName);
         assertThat(getResponse.deploymentId()).isEqualTo(deploymentId);
+        assertThat(getResponse.tags())
+                .containsEntry("environment", "test")
+                .containsEntry("owner", "platform");
 
         var listResponse = apigwv2.getStages(GetStagesRequest.builder()
                 .apiId(apiId)
@@ -347,6 +355,13 @@ class ApiGatewayV2ManagementTest {
                 .first()
                 .extracting(item -> item.deploymentId())
                 .isEqualTo(deploymentId);
+        assertThat(listResponse.items())
+                .filteredOn(item -> stageName.equals(item.stageName()))
+                .first()
+                .extracting(item -> item.tags())
+                .satisfies(tags -> assertThat(tags)
+                        .containsEntry("environment", "test")
+                        .containsEntry("owner", "platform"));
     }
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -2177,6 +2177,10 @@ public class ApiGatewayController {
             ObjectNode stageVariables = node.putObject("stageVariables");
             s.getStageVariables().forEach(stageVariables::put);
         }
+        if (s.getTags() != null && !s.getTags().isEmpty()) {
+            ObjectNode tags = node.putObject("tags");
+            s.getTags().forEach(tags::put);
+        }
         return node;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java
@@ -628,6 +628,10 @@ public class ApiGatewayV2JsonHandler {
             ObjectNode stageVariables = node.putObject("StageVariables");
             s.getStageVariables().forEach(stageVariables::put);
         }
+        if (s.getTags() != null && !s.getTags().isEmpty()) {
+            ObjectNode tags = node.putObject("Tags");
+            s.getTags().forEach(tags::put);
+        }
         return node;
     }
 
@@ -707,7 +711,8 @@ public class ApiGatewayV2JsonHandler {
             if (!key.isEmpty() && Character.isUpperCase(key.charAt(0))) {
                 key = Character.toLowerCase(key.charAt(0)) + key.substring(1);
             }
-            result.put(key, normalizeValue(entry.getValue()));
+            Object value = "tags".equals(key) ? entry.getValue() : normalizeValue(entry.getValue());
+            result.put(key, value);
         }
         return result;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -585,6 +585,12 @@ public class ApiGatewayV2Service {
         Map<String, String> stageVariables = (Map<String, String>) request.get("stageVariables");
         stage.setStageVariables(stageVariables);
 
+        @SuppressWarnings("unchecked")
+        Map<String, String> tags = (Map<String, String>) request.get("tags");
+        if (tags != null) {
+            stage.setTags(ReservedTags.stripApiGatewayReservedTags(tags));
+        }
+
         stageStore.put(stageKey(region, apiId, stage.getStageName()), stage);
         LOG.infov("Created stage: {0} for API {1}", stage.getStageName(), apiId);
         return stage;

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Stage.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/model/Stage.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.apigatewayv2.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RegisterForReflection
@@ -14,6 +15,7 @@ public class Stage {
     private long createdDate;
     private long lastUpdatedDate;
     private Map<String, String> stageVariables;
+    private Map<String, String> tags = new HashMap<>();
 
     public Stage() {}
 
@@ -34,4 +36,7 @@ public class Stage {
 
     public Map<String, String> getStageVariables() { return stageVariables; }
     public void setStageVariables(Map<String, String> stageVariables) { this.stageVariables = stageVariables; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) { this.tags = tags; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -243,14 +243,16 @@ class ApiGatewayV2IntegrationTest {
         given()
                 .contentType(ContentType.JSON)
                 .body("""
-                        {"stageName":"prod","deploymentId":"%s","autoDeploy":false}
+                        {"stageName":"prod","deploymentId":"%s","autoDeploy":false,"tags":{"environment":"test","owner":"platform"}}
                         """.formatted(deploymentId))
                 .when().post("/v2/apis/" + apiId + "/stages")
                 .then()
                 .statusCode(201)
                 .body("stageName", equalTo("prod"))
                 .body("autoDeploy", equalTo(false))
-                .body("deploymentId", equalTo(deploymentId));
+                .body("deploymentId", equalTo(deploymentId))
+                .body("tags.environment", equalTo("test"))
+                .body("tags.owner", equalTo("platform"));
     }
 
     @Test @Order(51)
@@ -261,7 +263,9 @@ class ApiGatewayV2IntegrationTest {
                 .statusCode(200)
                 .body("stageName", equalTo("prod"))
                 .body("deploymentId", equalTo(deploymentId))
-                .body("autoDeploy", equalTo(false));
+                .body("autoDeploy", equalTo(false))
+                .body("tags.environment", equalTo("test"))
+                .body("tags.owner", equalTo("platform"));
     }
 
     @Test @Order(52)
@@ -270,7 +274,24 @@ class ApiGatewayV2IntegrationTest {
                 .when().get("/v2/apis/" + apiId + "/stages")
                 .then()
                 .statusCode(200)
-                .body("items.stageName", hasItem("prod"));
+                .body("items.stageName", hasItem("prod"))
+                .body("items.find { it.stageName == 'prod' }.tags.environment", equalTo("test"))
+                .body("items.find { it.stageName == 'prod' }.tags.owner", equalTo("platform"));
+    }
+
+    @Test @Order(53)
+    void updateStageReturnsTags() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"autoDeploy":true}
+                        """)
+                .when().patch("/v2/apis/" + apiId + "/stages/prod")
+                .then()
+                .statusCode(200)
+                .body("autoDeploy", equalTo(true))
+                .body("tags.environment", equalTo("test"))
+                .body("tags.owner", equalTo("platform"));
     }
 
     // ──────────────────────────── Cleanup ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -243,7 +243,7 @@ class ApiGatewayV2IntegrationTest {
         given()
                 .contentType(ContentType.JSON)
                 .body("""
-                        {"stageName":"prod","deploymentId":"%s","autoDeploy":false,"tags":{"environment":"test","owner":"platform"}}
+                        {"stageName":"prod","deploymentId":"%s","autoDeploy":false,"tags":{"environment":"test","owner":"platform","floci:internal":"hidden"}}
                         """.formatted(deploymentId))
                 .when().post("/v2/apis/" + apiId + "/stages")
                 .then()
@@ -252,7 +252,8 @@ class ApiGatewayV2IntegrationTest {
                 .body("autoDeploy", equalTo(false))
                 .body("deploymentId", equalTo(deploymentId))
                 .body("tags.environment", equalTo("test"))
-                .body("tags.owner", equalTo("platform"));
+                .body("tags.owner", equalTo("platform"))
+                .body("tags", not(hasKey("floci:internal")));
     }
 
     @Test @Order(51)

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandlerTest.java
@@ -98,7 +98,7 @@ class ApiGatewayV2JsonHandlerTest {
 
     @Test
     @Order(3)
-    void json11CreateDeploymentAndStage() {
+    void json11StageResponsesReturnTags() {
         deploymentId = given()
                 .contentType(AMZ_JSON)
                 .header("X-Amz-Target", TARGET_PREFIX + "CreateDeployment")
@@ -117,13 +117,55 @@ class ApiGatewayV2JsonHandlerTest {
                 .header("X-Amz-Target", TARGET_PREFIX + "CreateStage")
                 .header("Authorization", AUTH_HEADER)
                 .body("""
-                        {"ApiId":"%s","StageName":"prod","DeploymentId":"%s"}
+                        {"ApiId":"%s","StageName":"prod","DeploymentId":"%s","Tags":{"Environment":"test","Owner":"platform"}}
                         """.formatted(apiId, deploymentId))
                 .when().post("/")
                 .then()
                 .statusCode(201)
                 .body("StageName", equalTo("prod"))
-                .body("DeploymentId", equalTo(deploymentId));
+                .body("DeploymentId", equalTo(deploymentId))
+                .body("Tags.Environment", equalTo("test"))
+                .body("Tags.Owner", equalTo("platform"));
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetStage")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","StageName":"prod"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Tags.Environment", equalTo("test"))
+                .body("Tags.Owner", equalTo("platform"));
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "GetStages")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s"}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("Items.find { it.StageName == 'prod' }.Tags.Environment", equalTo("test"))
+                .body("Items.find { it.StageName == 'prod' }.Tags.Owner", equalTo("platform"));
+
+        given()
+                .contentType(AMZ_JSON)
+                .header("X-Amz-Target", TARGET_PREFIX + "UpdateStage")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                        {"ApiId":"%s","StageName":"prod","AutoDeploy":true}
+                        """.formatted(apiId))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("AutoDeploy", equalTo(true))
+                .body("Tags.Environment", equalTo("test"))
+                .body("Tags.Owner", equalTo("platform"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Return create-time API Gateway v2 stage tags from every Stage response while preserving case-sensitive tag keys. The JSON 1.1 normalization fix preserves tag-key casing for every API Gateway v2 resource handled through that path, not only stages.

No linked issue; this was found while exercising API Gateway v2 through the AWS SDK in a local integration.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Create-time stage tags were persisted but omitted from Stage responses, and JSON 1.1 request normalization lowercased case-sensitive tag keys. Stage responses now preserve the protocol-specific field shape and original tag keys across create, get, list, and update operations. Reserved `floci:` tags remain internal and are not returned.

Verified with AWS SDK for Java v2 2.52.0.

## Response coverage

| Surface | Stage responses | Tag shape |
| --- | --- | --- |
| REST JSON | CreateStage, GetStage, GetStages, UpdateStage | `tags` with original keys |
| JSON 1.1 | CreateStage, GetStage, GetStages, UpdateStage | `Tags` with original keys |
| AWS SDK for Java v2 | create, get, and list models | populated `tags()` map |

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Validation

- Focused REST JSON and JSON 1.1 Stage suite: 46 tests passed.
- Reserved-tag mutation check: bypassing `stripApiGatewayReservedTags` fails `ApiGatewayV2IntegrationTest#createStage`.
- AWS SDK for Java v2 management suite: 19 tests passed.
- `./mvnw test`: 11,072 tests passed, 9 skipped.
