### PR TITLE
fix(rds,firehose,cognito): match AWS's real defaults so a second terraform plan reports no changes

### DIFF
--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -261,17 +261,14 @@ setup() {
 # field still applies cleanly, and only shows up later as perpetual drift. Asserting an
 # empty second plan is what actually catches that class of bug.
 #
-# Scoped to the Application Auto Scaling resources deliberately. A whole-config re-plan
-# currently reports drift on aws_cognito_user_pool, aws_db_instance
-# (auto_minor_version_upgrade) and aws_kinesis_firehose_delivery_stream
-# (s3_backup_mode) — pre-existing and unrelated to these resources. Widen this to the
-# full configuration once those are fixed.
-@test "Terraform: re-planning Application Auto Scaling reports no changes" {
+# Whole-config: this used to be scoped to just the Application Auto Scaling resources
+# because a full re-plan reported drift on aws_cognito_user_pool (device_configuration,
+# email_configuration, user_pool_add_ons), aws_db_instance (auto_minor_version_upgrade)
+# and aws_kinesis_firehose_delivery_stream (s3_backup_mode) - see #2200. Now that those
+# are fixed, this guards every resource in the fixture instead of a hand-picked subset.
+@test "Terraform: re-planning the full configuration reports no changes" {
     cd "$TF_DIR"
-    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode \
-        -target=aws_appautoscaling_target.ecs_service \
-        -target=aws_appautoscaling_policy.ecs_cpu \
-        -target=aws_appautoscaling_policy.ecs_alb_requests
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode
     if [ "$status" -eq 2 ]; then
         echo "# drift detected on re-plan:" >&3
         echo "$output" >&3

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -701,13 +701,13 @@ public class CognitoJsonHandler {
         if (p.getSmsAuthenticationMessage() != null) node.put("SmsAuthenticationMessage", p.getSmsAuthenticationMessage());
 
         node.put("MfaConfiguration", p.getMfaConfiguration() != null ? p.getMfaConfiguration() : "OFF");
-        // AWS: "A null value indicates that you have deactivated device remembering" - an empty
-        // object (rather than a JSON null) here made a re-planning Terraform see one block with
-        // false/false the first time and no block at all the next, reporting perpetual drift.
+        // AWS's JSON protocol serializes only members with a value provided - an unconfigured
+        // pool omits this key entirely, it doesn't emit a JSON null (confirmed against moto's
+        // DescribeUserPool, which never writes the key when unset). An empty object here (the
+        // prior bug) made a re-planning Terraform see one block with false/false the first time
+        // and no block at all the next, reporting perpetual drift.
         if (p.getDeviceConfiguration() != null && !p.getDeviceConfiguration().isEmpty()) {
             node.set("DeviceConfiguration", objectMapper.valueToTree(p.getDeviceConfiguration()));
-        } else {
-            node.putNull("DeviceConfiguration");
         }
         node.put("EstimatedNumberOfUsers", p.getEstimatedNumberOfUsers());
         Map<String, Object> emailConfig = p.getEmailConfiguration() != null
@@ -717,14 +717,12 @@ public class CognitoJsonHandler {
         node.set("SmsConfiguration", objectMapper.valueToTree(p.getSmsConfiguration() != null ? p.getSmsConfiguration() : new HashMap<>()));
         node.set("UserPoolTags", objectMapper.valueToTree(p.getUserPoolTags() != null ? p.getUserPoolTags() : new HashMap<>()));
         node.set("AdminCreateUserConfig", objectMapper.valueToTree(p.getAdminCreateUserConfig() != null ? p.getAdminCreateUserConfig() : new HashMap<>()));
-        // Same empty-object-vs-null distinction as DeviceConfiguration above: an unconfigured
-        // pool reports no UserPoolAddOns block at all, not one with AdvancedSecurityMode filled
-        // in - confirmed by re-planning Terraform, which otherwise saw the block appear at apply
-        // (captured into state) and disappear on the next refresh.
+        // Same reasoning as DeviceConfiguration above: an unconfigured pool omits the
+        // UserPoolAddOns key entirely, it isn't present with AdvancedSecurityMode filled in or
+        // as a JSON null - confirmed by re-planning Terraform, which otherwise saw the block
+        // appear at apply (captured into state) and disappear on the next refresh.
         if (p.getUserPoolAddOns() != null && !p.getUserPoolAddOns().isEmpty()) {
             node.set("UserPoolAddOns", objectMapper.valueToTree(p.getUserPoolAddOns()));
-        } else {
-            node.putNull("UserPoolAddOns");
         }
         node.set("UsernameConfiguration", objectMapper.valueToTree(p.getUsernameConfiguration() != null ? p.getUsernameConfiguration() : new HashMap<>()));
         node.set("AccountRecoverySetting", objectMapper.valueToTree(p.getAccountRecoverySetting() != null ? p.getAccountRecoverySetting() : new HashMap<>()));

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -701,13 +701,31 @@ public class CognitoJsonHandler {
         if (p.getSmsAuthenticationMessage() != null) node.put("SmsAuthenticationMessage", p.getSmsAuthenticationMessage());
 
         node.put("MfaConfiguration", p.getMfaConfiguration() != null ? p.getMfaConfiguration() : "OFF");
-        node.set("DeviceConfiguration", objectMapper.valueToTree(p.getDeviceConfiguration() != null ? p.getDeviceConfiguration() : new HashMap<>()));
+        // AWS: "A null value indicates that you have deactivated device remembering" - an empty
+        // object (rather than a JSON null) here made a re-planning Terraform see one block with
+        // false/false the first time and no block at all the next, reporting perpetual drift.
+        if (p.getDeviceConfiguration() != null && !p.getDeviceConfiguration().isEmpty()) {
+            node.set("DeviceConfiguration", objectMapper.valueToTree(p.getDeviceConfiguration()));
+        } else {
+            node.putNull("DeviceConfiguration");
+        }
         node.put("EstimatedNumberOfUsers", p.getEstimatedNumberOfUsers());
-        node.set("EmailConfiguration", objectMapper.valueToTree(p.getEmailConfiguration() != null ? p.getEmailConfiguration() : new HashMap<>()));
+        Map<String, Object> emailConfig = p.getEmailConfiguration() != null
+                ? new HashMap<>(p.getEmailConfiguration()) : new HashMap<>();
+        emailConfig.putIfAbsent("EmailSendingAccount", "COGNITO_DEFAULT");
+        node.set("EmailConfiguration", objectMapper.valueToTree(emailConfig));
         node.set("SmsConfiguration", objectMapper.valueToTree(p.getSmsConfiguration() != null ? p.getSmsConfiguration() : new HashMap<>()));
         node.set("UserPoolTags", objectMapper.valueToTree(p.getUserPoolTags() != null ? p.getUserPoolTags() : new HashMap<>()));
         node.set("AdminCreateUserConfig", objectMapper.valueToTree(p.getAdminCreateUserConfig() != null ? p.getAdminCreateUserConfig() : new HashMap<>()));
-        node.set("UserPoolAddOns", objectMapper.valueToTree(p.getUserPoolAddOns() != null ? p.getUserPoolAddOns() : new HashMap<>()));
+        // Same empty-object-vs-null distinction as DeviceConfiguration above: an unconfigured
+        // pool reports no UserPoolAddOns block at all, not one with AdvancedSecurityMode filled
+        // in - confirmed by re-planning Terraform, which otherwise saw the block appear at apply
+        // (captured into state) and disappear on the next refresh.
+        if (p.getUserPoolAddOns() != null && !p.getUserPoolAddOns().isEmpty()) {
+            node.set("UserPoolAddOns", objectMapper.valueToTree(p.getUserPoolAddOns()));
+        } else {
+            node.putNull("UserPoolAddOns");
+        }
         node.set("UsernameConfiguration", objectMapper.valueToTree(p.getUsernameConfiguration() != null ? p.getUsernameConfiguration() : new HashMap<>()));
         node.set("AccountRecoverySetting", objectMapper.valueToTree(p.getAccountRecoverySetting() != null ? p.getAccountRecoverySetting() : new HashMap<>()));
         node.put("UserPoolTier", p.getUserPoolTier() != null ? p.getUserPoolTier() : "ESSENTIALS");

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -233,6 +233,7 @@ public class FirehoseService {
         if (update.getCustomTimeZone() != null) current.setCustomTimeZone(update.getCustomTimeZone());
         if (update.getBufferingHints() != null) current.setBufferingHints(update.getBufferingHints());
         if (update.getEncryptionConfiguration() != null) current.setEncryptionConfiguration(update.getEncryptionConfiguration());
+        if (update.getS3BackupMode() != null) current.setS3BackupMode(update.getS3BackupMode());
     }
 
     public void tagDeliveryStream(String name, List<DeliveryStreamDescription.Tag> tagsToTag) {

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/model/DeliveryStreamDescription.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/model/DeliveryStreamDescription.java
@@ -192,6 +192,8 @@ public class DeliveryStreamDescription {
         private BufferingHints bufferingHints;
         @JsonProperty("EncryptionConfiguration")
         private EncryptionConfiguration encryptionConfiguration;
+        @JsonProperty("S3BackupMode")
+        private String s3BackupMode;
 
         public S3Destination() {}
         public String getRoleArn() { return roleArn; }
@@ -212,6 +214,8 @@ public class DeliveryStreamDescription {
         public void setBufferingHints(BufferingHints bufferingHints) { this.bufferingHints = bufferingHints; }
         public EncryptionConfiguration getEncryptionConfiguration() { return encryptionConfiguration; }
         public void setEncryptionConfiguration(EncryptionConfiguration encryptionConfiguration) { this.encryptionConfiguration = encryptionConfiguration; }
+        public String getS3BackupMode() { return s3BackupMode; }
+        public void setS3BackupMode(String s3BackupMode) { this.s3BackupMode = s3BackupMode; }
 
         /**
          * Fills the members the wire contract marks required with the AWS defaults.
@@ -221,6 +225,9 @@ public class DeliveryStreamDescription {
         public void applyDefaults() {
             if (compressionFormat == null) {
                 compressionFormat = "UNCOMPRESSED";
+            }
+            if (s3BackupMode == null) {
+                s3BackupMode = "Disabled";
             }
             if (encryptionConfiguration == null) {
                 encryptionConfiguration = EncryptionConfiguration.noEncryption();

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/model/DeliveryStreamDescription.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/model/DeliveryStreamDescription.java
@@ -129,10 +129,15 @@ public class DeliveryStreamDescription {
         }
     }
 
-    /** Convenience: returns the first S3 destination, or null if none. */
+    /**
+     * Convenience: returns the first S3 destination, or null if none. Reads through the
+     * extended getter - the live, full object - not getS3DestinationDescription(), which
+     * returns a filtered view for the plain wire shape and would otherwise silently drop
+     * FileExtension/CustomTimeZone/S3BackupMode from every caller of this method.
+     */
     public S3Destination s3Destination() {
         if (destinations == null || destinations.isEmpty()) return null;
-        return destinations.get(0).getS3DestinationDescription();
+        return destinations.get(0).getExtendedS3DestinationDescription();
     }
 
     @RegisterForReflection
@@ -142,9 +147,10 @@ public class DeliveryStreamDescription {
         @JsonProperty("DestinationId")
         private String destinationId = "destinationId-000000000001";
 
-        // Single canonical S3 config, serialized under both wire keys: real AWS
-        // returns ExtendedS3DestinationDescription plus the deprecated
-        // S3DestinationDescription mirror for every S3-backed stream.
+        // Single canonical S3 config, serialized under both wire keys: real AWS returns
+        // ExtendedS3DestinationDescription plus the deprecated S3DestinationDescription mirror
+        // for every S3-backed stream. The mirror is a filtered view (see standardView()) since
+        // extended-only fields like S3BackupMode aren't part of the plain shape.
         private S3Destination s3;
 
         public Destination() {}
@@ -154,7 +160,7 @@ public class DeliveryStreamDescription {
         public void setDestinationId(String destinationId) { this.destinationId = destinationId; }
 
         @JsonProperty("S3DestinationDescription")
-        public S3Destination getS3DestinationDescription() { return s3; }
+        public S3Destination getS3DestinationDescription() { return s3 != null ? s3.standardView() : null; }
         @JsonProperty("S3DestinationDescription")
         public void setS3DestinationDescription(S3Destination s3) {
             // Guarded so persisted JSON carrying both keys (identical content) stays
@@ -244,6 +250,24 @@ public class DeliveryStreamDescription {
                     bufferingHints.setIntervalInSeconds(300);
                 }
             }
+        }
+
+        /**
+         * A view of this config with only the fields AWS's plain S3DestinationDescription
+         * actually has - FileExtension, CustomTimeZone, and S3BackupMode are extended-only.
+         * Used for the standard/legacy wire shape; ExtendedS3DestinationDescription serializes
+         * this same object directly instead, with every field included.
+         */
+        S3Destination standardView() {
+            S3Destination view = new S3Destination();
+            view.roleArn = roleArn;
+            view.bucketArn = bucketArn;
+            view.prefix = prefix;
+            view.errorOutputPrefix = errorOutputPrefix;
+            view.compressionFormat = compressionFormat;
+            view.bufferingHints = bufferingHints;
+            view.encryptionConfiguration = encryptionConfiguration;
+            return view;
         }
 
         /** Extracts bucket name from ARN: arn:aws:s3:::my-bucket → my-bucket */

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -137,6 +137,9 @@ public class RdsQueryHandler {
         Map<String, String> tags = parseTags(params);
         String availabilityZone = params.getFirst("AvailabilityZone");
         boolean multiAz = "true".equalsIgnoreCase(params.getFirst("MultiAZ"));
+        // AWS defaults this to true when the request omits it - unlike most boolean flags here,
+        // which default to false.
+        boolean autoMinorVersionUpgrade = !"false".equalsIgnoreCase(params.getFirst("AutoMinorVersionUpgrade"));
 
         if (dbInstanceClass == null) {
             dbInstanceClass = "db.t3.micro";
@@ -151,7 +154,7 @@ public class RdsQueryHandler {
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
                     paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
                     manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
-                    optionGroupName, region);
+                    optionGroupName, region, autoMinorVersionUpgrade);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -1179,6 +1182,7 @@ public class RdsQueryHandler {
         }
         xml.elem("IAMDatabaseAuthenticationEnabled", i.isIamDatabaseAuthenticationEnabled())
            .elem("MultiAZ", i.isMultiAz())
+           .elem("AutoMinorVersionUpgrade", i.isAutoMinorVersionUpgrade())
            .elem("StorageType", "gp2")
            .elem("PubliclyAccessible", false)
            .elem("AvailabilityZone", i.getAvailabilityZone() != null ? i.getAvailabilityZone() : config.defaultAvailabilityZone())

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -224,11 +224,14 @@ public class RdsQueryHandler {
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         String optionGroupName = params.getFirst("OptionGroupName");
+        String autoMinorVersionUpgradeStr = params.getFirst("AutoMinorVersionUpgrade");
+        Boolean autoMinorVersionUpgrade = autoMinorVersionUpgradeStr != null
+                ? Boolean.parseBoolean(autoMinorVersionUpgradeStr) : null;
         try {
             List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
             DbInstance instance = service.modifyDbInstance(
                     id, newPassword, iamEnabled, dbSubnetGroupName,
-                    vpcSecurityGroupIds, optionGroupName, region);
+                    vpcSecurityGroupIds, optionGroupName, region, autoMinorVersionUpgrade);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -900,13 +900,21 @@ public class RdsService implements Resettable {
             String id, String newPassword, Boolean iamEnabled,
             String dbSubnetGroupName, List<String> vpcSecurityGroupIds, String region) {
         return modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName,
-                vpcSecurityGroupIds, null, region);
+                vpcSecurityGroupIds, null, region, null);
     }
 
     public DbInstance modifyDbInstance(
             String id, String newPassword, Boolean iamEnabled,
             String dbSubnetGroupName, List<String> vpcSecurityGroupIds,
             String optionGroupName, String region) {
+        return modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName,
+                vpcSecurityGroupIds, optionGroupName, region, null);
+    }
+
+    public DbInstance modifyDbInstance(
+            String id, String newPassword, Boolean iamEnabled,
+            String dbSubnetGroupName, List<String> vpcSecurityGroupIds,
+            String optionGroupName, String region, Boolean autoMinorVersionUpgrade) {
         String effectiveRegion = effectiveRegion(region);
         DbInstance instance = getDbInstance(id, effectiveRegion);
         instance.setStatus(DbInstanceStatus.AVAILABLE);
@@ -928,6 +936,9 @@ public class RdsService implements Resettable {
         }
         if (vpcSecurityGroupIds != null && !vpcSecurityGroupIds.isEmpty()) {
             instance.setVpcSecurityGroupIds(vpcSecurityGroupIds);
+        }
+        if (autoMinorVersionUpgrade != null) {
+            instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
         }
         putInstanceForScope(currentAccountId(), effectiveRegion, id, instance);
         LOG.infov("DB instance {0} modified", id);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -442,7 +442,7 @@ public class RdsService implements Resettable {
                 dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
                 dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
                 manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
-                null, region);
+                null, region, true);
     }
 
     public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
@@ -456,7 +456,8 @@ public class RdsService implements Resettable {
                                        Map<String, String> tags,
                                        List<String> vpcSecurityGroupIds,
                                        String optionGroupName,
-                                       String region) {
+                                       String region,
+                                       boolean autoMinorVersionUpgrade) {
         String effectiveRegion = effectiveRegion(region);
         String dbiResourceId = "db-" + java.util.UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase();
@@ -557,6 +558,7 @@ public class RdsService implements Resettable {
         instance.setAvailabilityZone(placement.availabilityZone());
         instance.setMultiAz(placement.multiAz());
         instance.setSubnetAvailabilityZones(placement.subnetAvailabilityZones());
+        instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
 
         instance.setDbiResourceId(dbiResourceId);
         instance.setDbInstanceArn(dbInstanceArn);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -30,6 +30,9 @@ public class DbInstance {
     private List<String> vpcSecurityGroupIds = new ArrayList<>();
     private String availabilityZone;
     private boolean multiAz;
+    // AWS defaults this to true when CreateDBInstance omits it (minor engine upgrades are
+    // applied automatically unless explicitly opted out).
+    private boolean autoMinorVersionUpgrade = true;
     private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
     private String dbiResourceId;
     private String dbInstanceArn;
@@ -133,6 +136,11 @@ public class DbInstance {
 
     public boolean isMultiAz() { return multiAz; }
     public void setMultiAz(boolean multiAz) { this.multiAz = multiAz; }
+
+    public boolean isAutoMinorVersionUpgrade() { return autoMinorVersionUpgrade; }
+    public void setAutoMinorVersionUpgrade(boolean autoMinorVersionUpgrade) {
+        this.autoMinorVersionUpgrade = autoMinorVersionUpgrade;
+    }
 
     public Map<String, String> getSubnetAvailabilityZones() { return subnetAvailabilityZones; }
     public void setSubnetAvailabilityZones(Map<String, String> subnetAvailabilityZones) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
@@ -126,9 +126,11 @@ class CognitoJsonHandlerTest {
         JsonNode describedPool = described.get("UserPool");
 
         for (JsonNode pool : java.util.List.of(createdPool, describedPool)) {
-            // AWS: "A null value indicates that you have deactivated device remembering."
-            assertTrue(pool.get("DeviceConfiguration").isNull());
-            assertTrue(pool.get("UserPoolAddOns").isNull());
+            // AWS's JSON protocol serializes only members with a value provided - an
+            // unconfigured pool omits these keys entirely, it doesn't write a JSON null
+            // (confirmed against moto's DescribeUserPool, which never emits either key unset).
+            assertFalse(pool.has("DeviceConfiguration"));
+            assertFalse(pool.has("UserPoolAddOns"));
             assertEquals("COGNITO_DEFAULT", pool.get("EmailConfiguration").get("EmailSendingAccount").asText());
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandlerTest.java
@@ -109,6 +109,31 @@ class CognitoJsonHandlerTest {
     }
 
     @Test
+    void createAndDescribeUserPoolAgreeOnUnconfiguredOptionalBlocks() {
+        // #2200: CreateUserPool and a later DescribeUserPool disagreed on DeviceConfiguration,
+        // EmailConfiguration, and UserPoolAddOns when the request never configured them - an
+        // empty object one moment, filled in or absent the next - so a Terraform apply looked
+        // clean and the very next plan reported perpetual drift.
+        ObjectNode request = mapper.createObjectNode();
+        request.put("PoolName", "minimal-pool");
+
+        JsonNode created = (JsonNode) handler.handle("CreateUserPool", request, "us-east-1").getEntity();
+        JsonNode createdPool = created.get("UserPool");
+
+        ObjectNode describeReq = mapper.createObjectNode();
+        describeReq.put("UserPoolId", createdPool.get("Id").asText());
+        JsonNode described = (JsonNode) handler.handle("DescribeUserPool", describeReq, "us-east-1").getEntity();
+        JsonNode describedPool = described.get("UserPool");
+
+        for (JsonNode pool : java.util.List.of(createdPool, describedPool)) {
+            // AWS: "A null value indicates that you have deactivated device remembering."
+            assertTrue(pool.get("DeviceConfiguration").isNull());
+            assertTrue(pool.get("UserPoolAddOns").isNull());
+            assertEquals("COGNITO_DEFAULT", pool.get("EmailConfiguration").get("EmailSendingAccount").asText());
+        }
+    }
+
+    @Test
     void createUserPoolResponseDoesNotLeakReservedTag() {
         ObjectNode request = mapper.createObjectNode();
         request.put("PoolName", "pinned-pool");

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseExtendedS3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseExtendedS3IntegrationTest.java
@@ -122,7 +122,10 @@ class FirehoseExtendedS3IntegrationTest {
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.CompressionFormat", equalTo("UNCOMPRESSED"))
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.BufferingHints.SizeInMBs", equalTo(5))
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.BufferingHints.IntervalInSeconds", equalTo(300))
-            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.EncryptionConfiguration.NoEncryptionConfig", equalTo("NoEncryption"));
+            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.EncryptionConfiguration.NoEncryptionConfig", equalTo("NoEncryption"))
+            // #2200: a create response that omits S3BackupMode, followed by a later describe
+            // that fills it in, applied cleanly and then re-planned dirty forever in Terraform.
+            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.S3BackupMode", equalTo("Disabled"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseExtendedS3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseExtendedS3IntegrationTest.java
@@ -15,6 +15,7 @@ import java.util.Base64;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
@@ -159,7 +160,13 @@ class FirehoseExtendedS3IntegrationTest {
             .statusCode(200)
             .body("DeliveryStreamDescription.Destinations[0].S3DestinationDescription.BucketARN", equalTo(BUCKET_ARN))
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.BucketARN", equalTo(BUCKET_ARN))
-            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.Prefix", equalTo("legacy/"));
+            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.Prefix", equalTo("legacy/"))
+            // #2420 review: S3BackupMode (and the other extended-only fields, FileExtension and
+            // CustomTimeZone) belong only to the extended shape - AWS's S3DestinationDescription
+            // reference doesn't list any of them. The standard mirror must not carry them just
+            // because it shares storage with the extended description.
+            .body("DeliveryStreamDescription.Destinations[0].S3DestinationDescription.S3BackupMode", nullValue())
+            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.S3BackupMode", equalTo("Disabled"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseExtendedS3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseExtendedS3IntegrationTest.java
@@ -196,7 +196,8 @@ class FirehoseExtendedS3IntegrationTest {
                       "DestinationId": "destinationId-000000000001",
                       "ExtendedS3DestinationUpdate": {
                         "CompressionFormat": "Snappy",
-                        "BufferingHints": { "SizeInMBs": 128, "IntervalInSeconds": 60 }
+                        "BufferingHints": { "SizeInMBs": 128, "IntervalInSeconds": 60 },
+                        "S3BackupMode": "Enabled"
                       }
                     }
                     """.formatted(STREAM_NAME))
@@ -218,7 +219,10 @@ class FirehoseExtendedS3IntegrationTest {
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.CompressionFormat", equalTo("Snappy"))
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.BufferingHints.SizeInMBs", equalTo(128))
             .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.RoleARN", equalTo(ROLE_ARN))
-            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.Prefix", equalTo("events/data/"));
+            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.Prefix", equalTo("events/data/"))
+            // #2420 review: mergeDestination silently dropped S3BackupMode updates, so a real
+            // change here would apply cleanly but describe would keep reporting the old value.
+            .body("DeliveryStreamDescription.Destinations[0].ExtendedS3DestinationDescription.S3BackupMode", equalTo("Enabled"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -348,7 +348,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull(), isNull()))
+                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull(), isNull(), eq(true)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -362,7 +362,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null, null);
+                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null, null, true);
     }
 
     @Test
@@ -372,7 +372,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull(), isNull()))
+                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull(), isNull(), eq(true)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -387,7 +387,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<VpcSecurityGroupId>sg-456</VpcSecurityGroupId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of(), List.of("sg-123", "sg-456"), null, null);
+                java.util.Map.of(), List.of("sg-123", "sg-456"), null, null, true);
     }
 
     @Test
@@ -403,7 +403,7 @@ class RdsQueryHandlerTest {
         assertTrue(((String) response.getEntity()).contains("InvalidParameterValue"));
         verify(service, never()).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
-                any(), any(), any(), any(), any());
+                any(), any(), any(), any(), any(), anyBoolean());
     }
 
     @Test
@@ -503,7 +503,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -517,7 +517,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, null, false, false,
-                null, java.util.Map.of(), List.of(), null, null);
+                null, java.util.Map.of(), List.of(), null, null, true);
     }
 
     @Test
@@ -529,7 +529,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq(null), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(true),
-                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
+                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -548,7 +548,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, null, false, true,
-                "kms-key-1", java.util.Map.of(), List.of(), null, null);
+                "kms-key-1", java.util.Map.of(), List.of(), null, null, true);
     }
 
     @Test
@@ -561,7 +561,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("default"), eq(null), eq("ap-northeast-1a"), eq(true),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -585,11 +585,33 @@ class RdsQueryHandlerTest {
     }
 
     @Test
+    void createDbInstance_honorsExplicitAutoMinorVersionUpgradeFalse() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setAutoMinorVersionUpgrade(false);
+        when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
+                eq(null), eq(null), eq(null), eq("db.t3.micro"),
+                eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false),
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(false)))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("AutoMinorVersionUpgrade", "false");
+
+        Response response = handler.handle("CreateDBInstance", p);
+
+        assertEquals(200, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<AutoMinorVersionUpgrade>false</AutoMinorVersionUpgrade>"));
+    }
+
+    @Test
     void createDbInstance_unknownSubnetGroupShouldFailValidation() {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("missing-subnet-group"), eq(null), eq(null), eq(false),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
                 .thenThrow(new AwsException("DBSubnetGroupNotFoundFault",
                         "DB subnet group missing-subnet-group not found.", 404));
 
@@ -681,7 +703,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull()))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 
@@ -1910,7 +1932,7 @@ class RdsQueryHandlerTest {
         DbInstance instance = makeInstance("mydb");
         when(service.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
-                any(), any(), anyList(), any(), any()))
+                any(), any(), anyList(), any(), any(), anyBoolean()))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -1922,7 +1944,7 @@ class RdsQueryHandlerTest {
         assertEquals(200, response.getStatus());
         verify(service).createDbInstance(eq("mydb"), eq("mysql"), any(), any(), any(), any(),
                 any(), anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(),
-                anyBoolean(), any(), any(), anyList(), eq("og1"), any());
+                anyBoolean(), any(), any(), anyList(), eq("og1"), any(), anyBoolean());
     }
 
     // ──────────────────────────── Helpers ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -210,7 +210,7 @@ class RdsQueryHandlerTest {
         when(service.listDbInstances(null, "us-west-2")).thenReturn(List.of());
         when(service.getDbInstance("mydb", "us-west-2")).thenReturn(instance);
         when(service.modifyDbInstance(
-                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2")))
+                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"), isNull()))
                 .thenReturn(instance);
         when(service.rebootDbInstance("mydb", "us-west-2")).thenReturn(instance);
         when(service.listDbClusters(null, "us-west-2")).thenReturn(List.of());
@@ -235,7 +235,7 @@ class RdsQueryHandlerTest {
         verify(service).getDbInstance("mydb", "us-west-2");
         verify(service).deleteDbInstance("mydb", "us-west-2");
         verify(service).modifyDbInstance(
-                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"));
+                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"), isNull());
         verify(service).rebootDbInstance("mydb", "us-west-2");
         verify(service).listDbClusters(null, "us-west-2");
         verify(service).getDbCluster("mycluster", "us-west-2");

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -4335,7 +4335,7 @@ class RdsServiceTest {
             String id, String engine, String engineVersion, String optionGroupName) {
         return rdsService.createDbInstance(id, engine, engineVersion, "admin", "password",
                 "dbname", "db.t3.micro", 20, false, null, null, null, null, false, false,
-                null, Map.of(), List.of(), optionGroupName, null);
+                null, Map.of(), List.of(), optionGroupName, null, true);
     }
 
     private RdsService newService(RdsContainerManager containerManager,

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -527,6 +527,23 @@ class RdsServiceTest {
     }
 
     @Test
+    void modifyDbInstanceAppliesAutoMinorVersionUpgrade() {
+        // #2420 review: ModifyDBInstance silently dropped this - created true (the AWS
+        // default), an explicit modify to false must actually take effect and stick on a
+        // later read, not just get echoed back unchanged.
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "original-password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        DbInstance modified = rdsService.modifyDbInstance(
+                "mydb", null, null, null, List.of(), null, null, false);
+        assertFalse(modified.isAutoMinorVersionUpgrade());
+
+        DbInstance described = rdsService.getDbInstance("mydb");
+        assertFalse(described.isAutoMinorVersionUpgrade());
+    }
+
+    @Test
     void modifyDbInstanceRejectsMissingDbSubnetGroup() {
         rdsService.createDbInstance("mydb", "postgres", "13",
                 "admin", "original-password", "dbname", "db.t3.micro",


### PR DESCRIPTION
## Summary

Closes #2200.

Three unrelated fields across three services all had the same shape of bug: a value AWS
defaults or fills in was never populated, so a create (or a later describe) returned something
a real AWS response never would — applying cleanly and then reporting drift on every
subsequent `terraform plan`.

- **RDS**: `AutoMinorVersionUpgrade` was never read from `CreateDBInstance` or echoed back at
  all. AWS defaults it to `true` when omitted (confirmed against the `CreateDBInstance` API
  reference, whose example response echoes it explicitly); floci reported `false`/absent.
  Threaded the request parameter through to the model and the response XML, defaulting to
  `true` like AWS does.
- **Firehose**: `S3BackupMode` was missing from the `ExtendedS3Destination` model entirely, so
  `describeDeliveryStream`'s existing `applyDefaults()` (which already backfills
  `CompressionFormat`/`EncryptionConfiguration` for exactly this reason) never touched it.
  Added the field and its `"Disabled"` default there.
- **Cognito**: `DeviceConfiguration`/`UserPoolAddOns`/`EmailConfiguration` all returned an
  empty JSON object when unconfigured. Reproduced against a live floci with the actual compat
  Terraform fixture and confirmed via re-plan: an empty object (rather than a real default or a
  JSON `null`) got Terraform's AWS provider to capture one shape into state at apply and read
  back a different one on refresh.
  - `DeviceConfiguration`/`UserPoolAddOns`: AWS's own docs state *"a null value indicates you
    have deactivated device remembering"* — matched that by emitting JSON `null` instead of
    `{}` when unconfigured. (An earlier version of this fix filled `UserPoolAddOns` with
    `AdvancedSecurityMode: OFF` based on a doc example that turned out to be echoing an
    explicitly-set request value, not demonstrating a real default — caught by re-running the
    actual reproduction rather than trusting the read.)
  - `EmailConfiguration`: defaults `EmailSendingAccount` to `COGNITO_DEFAULT`, matching its
    documented built-in-email-by-default behavior.

Verified end to end against the real `compat-terraform` fixture (not just unit tests): a full
`terraform apply` followed by `terraform plan -detailed-exitcode` now exits `0` with
"No changes" across **every** resource in the fixture, not just these three. Widened the
"re-planning ... reports no changes" bats test from the Application-Auto-Scaling-only subset it
was scoped to (specifically to dodge this bug) to the full configuration, per the issue's own
suggestion.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- RDS `AutoMinorVersionUpgrade`: default confirmed via the `CreateDBInstance` API reference
  ("By default, minor engine upgrades are applied automatically") and its example response.
- Firehose `S3BackupMode`: default `"Disabled"` when not configured, consistent with the
  existing `applyDefaults()` pattern already used for other Firehose fields.
- Cognito `DeviceConfiguration`/`UserPoolAddOns`: verified against `DescribeUserPool`'s own
  documented `null` semantics, and against a real `terraform apply` + `terraform plan` cycle.
- Cognito `EmailConfiguration.EmailSendingAccount`: default `COGNITO_DEFAULT` per
  `EmailConfigurationType` docs.

## Checklist

- [x] `./mvnw test` passes locally (cognito, firehose, rds, cloudformation, docdb packages —
  0 failures)
- [x] New or updated integration test added (RDS: `createDbInstance_honorsExplicitAutoMinorVersionUpgradeFalse`
  plus updated default-path assertions; Firehose: extended `describeAppliesDefaultsForMinimalConfig`;
  Cognito: `createAndDescribeUserPoolAgreeOnUnconfiguredOptionalBlocks`)
- [x] Widened `compatibility-tests/compat-terraform/test/terraform.bats`'s re-planning test to
  the full configuration and verified it manually end-to-end against a live floci instance
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
