### PR TITLE
chore(deps): bump 15 of the 16 maven-minor-patch updates from #2083

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,10 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.platform.version>3.36.3</quarkus.platform.version>
-        <jackson.version>2.21.4</jackson.version>
+        <quarkus.platform.version>3.37.4</quarkus.platform.version>
+        <jackson.version>2.22.1</jackson.version>
         <apicurio.version>2.6.13.Final</apicurio.version>
-        <wire.version>6.3.0</wire.version>
+        <wire.version>6.4.5</wire.version>
     </properties>
 
     <dependencyManagement>
@@ -40,12 +40,12 @@
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java-util</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.api.grpc</groupId>
@@ -55,7 +55,7 @@
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2-mvstore</artifactId>
-                <version>2.3.232</version>
+                <version>2.4.240</version>
             </dependency>
             <dependency>
                 <groupId>com.squareup.wire</groupId>
@@ -136,7 +136,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>4.3.0</version>
+            <version>4.3.1</version>
         </dependency>
 
         <!-- Snappy for Firehose Snappy/HADOOP_SNAPPY delivery to S3: the only Java
@@ -190,12 +190,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.84</version>
+            <version>1.85</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.84</version>
+            <version>1.85</version>
         </dependency>
 
         <!-- JSONata expression engine (Step Functions) -->
@@ -230,7 +230,7 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.1.43</version>
+            <version>2.1.45</version>
         </dependency>
 
         <!-- Glue Schema Registry: Apicurio format utilities (parsing, canonicalization, compatibility) -->
@@ -278,7 +278,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.2.2</version>
+            <version>4.3.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -308,14 +308,14 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>2.3.232</version>
+            <version>2.4.240</version>
             <scope>test</scope>
         </dependency>
         <!-- openCypher/Bolt client for the Neptune neo4j db-type integration test -->
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
-            <version>6.1.0</version>
+            <version>6.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 quarkus:
+  jackson:
+    # Quarkus 3.37 stopped tolerating empty response beans; AWS StartApplication/
+    # StopApplication legitimately return {}, so keep the pre-3.37 behaviour.
+    fail-on-empty-beans: false
   log:
     console:
       format: "%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c{3.}] %s%e%n"


### PR DESCRIPTION
## Summary

#2083 bumps 16 dependencies as a single group and fails `Build native floci image`.
Bisecting it locally isolates **two independent breakers**, so this takes the 15 updates
that are safe and holds back the one that is not.

Supersedes #2083 (open since 1 August; its CI still builds `floci-1.5.34-runner`, a long
superseded base).

### Held back — `proto-google-common-protos` 2.49.0 → 2.73.0

A 24-minor jump against a `dependencyManagement` pin that exists to hold a protobuf set
`apicurio-registry-schema-util-protobuf` 2.6.13 can work with.

Verified in both directions with a local native build using CI's own flags
(`-Dnative -DskipTests -Dquarkus.native.additional-build-args-append="-Ob"`):

| Set | Native build |
|-----|--------------|
| These 15 updates | ✅ `floci-1.7.0-runner` in 2m39s |
| Same 15 **+** `proto-google-common-protos` 2.73.0 | ❌ reproduces #2083 exactly |

The negative control fails identically to #2083: class initialization of
`io.apicurio.registry.utils.protobuf.schema.FileDescriptorUtils` →
`NoClassDefFoundError: com/google/protobuf/GeneratedFile`.

GraalVM suggests `--initialize-at-run-time` for that class. **Deliberately not taken**: it
would defer the missing class from build time to run time, converting a loud build failure
into a crash the first time the Glue schema registry path is exercised. Upgrading apicurio
past 2.6.13 is the real fix and belongs in its own change.

### Quarkus 3.36.3 → 3.37.4 — included, with a one-line fix

Quarkus 3.37 stopped tolerating empty response beans, so EMR Serverless
`StartApplication`/`StopApplication` started returning 500 with `FAIL_ON_EMPTY_BEANS`.
Those two are the **only** empty response beans in the repo, and AWS genuinely returns `{}`
for both operations, so `quarkus.jackson.fail-on-empty-beans` restores the pre-3.37
behaviour rather than reshaping the response.

Bisected specifically rather than assumed: Jackson 2.22.1 on its own is fine; Quarkus
3.37.4 on its own reproduces it.

### Security-relevant item

`bcprov-jdk18on` / `bcpkix-jdk18on` 1.84 → 1.85. Bouncy Castle backs six real crypto paths
here: TLS certificate generation, KMS, CloudHSM, ACM certificate generation and the RDS
Postgres SCRAM handler.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — dependency versions only. The single behavioural line
(`quarkus.jackson.fail-on-empty-beans`) *preserves* an existing wire shape rather than
changing one: EMR Serverless `StartApplication`/`StopApplication` return `{}`, matching AWS.

## Checklist

- [x] `./mvnw test` passes locally — **11276 passed / 0 failures / 0 errors / 8 skipped**
- [x] New or updated integration test added — n/a for a dependency bump; the existing
      `EmrServerlessIntegrationTest` is what caught the Quarkus regression and now covers it
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Note for whoever reviews

The native image build was run locally with CI's exact flags, because `Build and Test` alone
does not exercise it — that is precisely how #2083 went green on the JVM suite while the
native job failed. Worth keeping in mind for future dependency groups: the JVM suite and the
native build fail on different bumps here, and each caught one of the two breakers.
