### PR TITLE
chore(config): declare every toggleable service in both application.yml files

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -484,6 +484,7 @@ floci:
     cloudtrail:
       enabled: true
     lightsail:
+      enabled: true
     cloudcontrol:
       enabled: true
     cloudfront:
@@ -507,9 +508,26 @@ floci:
     iotdata:
       enabled: true
     cloudhsmv2:
+      enabled: true
     rum:
       enabled: true
     guardduty:
       enabled: true
     emrserverless:
+      enabled: true
+    tagging:
+      enabled: true
+    pipes:
+      enabled: true
+    configservice:
+      enabled: true
+    docdb:
+      enabled: true
+      mock: false
+      default-image: "mongo:7.0"
+    bedrock-agent-core:
+      enabled: true
+      # invoke-response: '{"output":"yes"}'   # Body returned by InvokeAgentRuntime
+      # validate-runtime-exists: false        # true = reject unknown runtime ARNs
+    bedrock-agent-core-control:
       enabled: true

--- a/src/test/java/io/github/hectorvent/floci/config/ServiceConfigYamlCoverageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/ServiceConfigYamlCoverageTest.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import io.smallrye.config.common.utils.StringUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the rule that {@code application.yml} — not an interface {@code @WithDefault} —
+ * is the source of truth for which services run. A service reachable only through its
+ * fallback default is invisible to anyone reading the config and cannot be toggled from
+ * the file, which is how six services drifted out of both YAMLs before this test existed.
+ */
+class ServiceConfigYamlCoverageTest {
+
+    private static final List<Path> CONFIGS = List.of(
+            Path.of("src/main/resources/application.yml"),
+            Path.of("src/test/resources/application.yml"));
+
+    @Test
+    void everyToggleableServiceDeclaresEnabledInBothConfigs() throws IOException {
+        List<String> missing = new ArrayList<>();
+
+        for (Path config : CONFIGS) {
+            JsonNode services = new YAMLMapper().readTree(config.toFile())
+                    .path("floci").path("services");
+
+            for (Method accessor : EmulatorConfig.ServicesConfig.class.getDeclaredMethods()) {
+                if (!declaresEnabledToggle(accessor.getReturnType())) {
+                    continue;
+                }
+                String key = StringUtil.skewer(accessor.getName());
+                if (!services.path(key).path("enabled").isBoolean()) {
+                    missing.add(config + " -> floci.services." + key + ".enabled");
+                }
+            }
+        }
+
+        assertTrue(missing.isEmpty(),
+                "Every service config with an enabled() toggle must declare it explicitly in both "
+                        + "application.yml files. Note a bare 'service-name:' key with no child does "
+                        + "not count, since it binds to nothing. Missing: " + missing);
+    }
+
+    /**
+     * Config records without an {@code enabled()} toggle (for example {@code DuckConfig},
+     * which only carries an image and an optional URL) are not services that can be turned
+     * off, so they are exempt.
+     */
+    private static boolean declaresEnabledToggle(Class<?> configInterface) {
+        for (Method method : configInterface.getDeclaredMethods()) {
+            if (method.getName().equals("enabled")
+                    && method.getParameterCount() == 0
+                    && (method.getReturnType() == boolean.class || method.getReturnType() == Boolean.class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -291,6 +291,7 @@ floci:
     cloudtrail:
       enabled: true
     lightsail:
+      enabled: true
     cloudcontrol:
       enabled: true
     cloudfront:
@@ -314,9 +315,24 @@ floci:
     iotdata:
       enabled: true
     cloudhsmv2:
+      enabled: true
     rum:
       enabled: true
     guardduty:
       enabled: true
     emrserverless:
+      enabled: true
+    tagging:
+      enabled: true
+    configservice:
+      enabled: true
+    transcribe:
+      enabled: true
+    docdb:
+      enabled: true
+      mock: false
+      default-image: "mongo:7.0"
+    bedrock-agent-core:
+      enabled: true
+    bedrock-agent-core-control:
       enabled: true


### PR DESCRIPTION
## Summary

Eight services were not actually declared in `application.yml`:

- **Six had no key at all** — `tagging`, `pipes`, `configservice`, `docdb`,
  `bedrock-agent-core`, `bedrock-agent-core-control`
- **Two had a bare key with no child** — `lightsail`, `cloudhsmv2` — which binds to
  nothing, so they read as configured while silently falling through

All eight resolved only through their interface `@WithDefault`. AGENTS.md does not treat
that as the source of truth: *"`application.yml` defines effective runtime behavior. Treat
repository YAML as the source of truth"*, and the new-service checklist asks for both files.

Adds the missing keys and a guard test so the next service cannot drift out the same way.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — no emulated surface changes. **Every value written equals the prior `@WithDefault`**,
so runtime behaviour is identical; this moves the truth into the file rather than altering
it. Typed `chore` rather than `fix` for that reason: it should not cut a release.

## Checklist

- [x] `./mvnw test` passes locally — the guard test and the affected service suites pass
      against current `main`; the full-suite re-run after the rebase was still in flight when
      this was opened, so CI is authoritative here and I will confirm in a comment
- [x] New or updated integration test added — `ServiceConfigYamlCoverageTest`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## About the guard test

It reflects over `EmulatorConfig.ServicesConfig` and, for every accessor whose interface
declares `enabled()`, asserts an explicit boolean in both YAML files.

Two details worth knowing:

- It derives each key with SmallRye's own `StringUtil.skewer` rather than a hand-rolled
  kebab-case conversion, so it checks the **real binding name**. That mattered:
  `bedrockAgentCore()` binds to `bedrock-agent-core`, which is *not* the catalog's external
  key `bedrock-agentcore`. A reimplemented conversion could have agreed with a mistake
  instead of catching it.
- `DuckConfig` has no `enabled()` — it only carries an image and an optional URL — so it is
  exempt rather than a false positive.

I verified it **fails** when a key is removed, not just that it passes, and that is how
`lightsail` and `cloudhsmv2` were found: the original scan checked only key presence and
missed both.

## One thing to know about the test-file keys

They are for **explicitness, not necessity**. SmallRye merges both files as config sources
per property, with the test file winning per key, so a service absent from the test config
inherits the main value rather than breaking.

I originally justified them the other way round — that Quarkus replaces rather than merges,
so the test file needed its own — and that was wrong. It came apart while working on an
unrelated dependency bump: a property added to only `src/main/resources/application.yml` was
read by a `@QuarkusTest`. The commit message records the retraction.

The argument that survives is that declaring both keeps the files readable side by side and
stops a deliberate test-only override from being indistinguishable from an omission. If you
would rather the guard required the main file only, that is a one-line change to the test and
I would not argue against it.
