### PR TITLE
fix(elasticache): return the modeled capacity fault on proxy-port exhaustion

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -326,8 +326,14 @@ public class ElastiCacheService {
                 return port;
             }
         }
-        throw new AwsException("InsufficientReplicationGroupCapacity",
-                "No available proxy ports in range " + base + "-" + max, 503);
+        // Proxy-port exhaustion is a Floci-side limit, but on the wire it must look like the
+        // modeled capacity fault. botocore/smithy declare InsufficientCacheClusterCapacityFault
+        // for CreateReplicationGroup: awsQueryError code InsufficientCacheClusterCapacity,
+        // HTTP 400, Sender fault. The old InsufficientReplicationGroupCapacity/503 is invented —
+        // no such shape exists, so SDK clients cannot map it. Keep the real cause in the log.
+        LOG.warnv("ElastiCache proxy port range {0}-{1} exhausted; returning InsufficientCacheClusterCapacity", base, max);
+        throw new AwsException("InsufficientCacheClusterCapacity",
+                "The requested cache node type is not available in the specified Availability Zone.", 400);
     }
 
     private void releaseProxyPort(int port) {

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -66,6 +66,40 @@ class ElastiCacheServiceTest {
     }
 
     @Test
+    void proxyPortExhaustionSurfacesModeledCapacityFault() {
+        // A one-port range: the first replication group claims it, so the second must fail with
+        // the botocore/smithy-modeled fault for CreateReplicationGroup — wire code
+        // InsufficientCacheClusterCapacity at HTTP 400 (Sender) — not the invented
+        // InsufficientReplicationGroupCapacity/503 that no SDK can map.
+        ElastiCacheContainerManager cm = mock(ElastiCacheContainerManager.class);
+        ElastiCacheProxyManager pm = mock(ElastiCacheProxyManager.class);
+        StorageFactory sf = mock(StorageFactory.class);
+        EmulatorConfig cfg = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig sc = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ElastiCacheServiceConfig ec = mock(EmulatorConfig.ElastiCacheServiceConfig.class);
+        when(cfg.services()).thenReturn(sc);
+        when(sc.elasticache()).thenReturn(ec);
+        when(ec.proxyBasePort()).thenReturn(17000);
+        when(ec.proxyMaxPort()).thenReturn(17000);
+        when(ec.defaultImage()).thenReturn("valkey/valkey:8");
+        when(cfg.hostname()).thenReturn(java.util.Optional.of("localhost"));
+        when(sf.create(anyString(), anyString(), any())).thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
+        when(cm.start(anyString(), anyString()))
+                .thenReturn(new ElastiCacheContainerHandle("cid", "grp", "localhost", 6379));
+        doNothing().when(pm).startProxy(anyString(), any(), anyInt(), anyString(), anyInt(), any());
+        ElastiCacheService svc = new ElastiCacheService(cm, pm, sf, cfg,
+                org.mockito.Mockito.mock(Ec2Service.class),
+                new RegionResolver("us-east-1", "000000000000"));
+
+        svc.createReplicationGroup("g1", "d", AuthMode.PASSWORD, null);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> svc.createReplicationGroup("g2", "d", AuthMode.PASSWORD, null));
+        assertEquals("InsufficientCacheClusterCapacity", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
     void singleArgAuthMatchesDefaultUserOnly() {
         service.createReplicationGroup("grp", "test", AuthMode.PASSWORD, null);
 


### PR DESCRIPTION
## Summary

Proxy-port exhaustion threw `InsufficientReplicationGroupCapacity` with HTTP 503.
**No such shape exists in the elasticache model**, so SDK clients cannot map it to a typed
exception — it arrives as a generic service error.

`CreateReplicationGroup` declares `InsufficientCacheClusterCapacityFault`
([elasticache service-2.json](https://github.com/boto/botocore/blob/develop/botocore/data/elasticache/2015-02-02/service-2.json)),
whose wire code is `InsufficientCacheClusterCapacity` at HTTP 400 with `senderFault` set.
This returns that instead.

| | Before | After |
|---|--------|-------|
| Wire code | `InsufficientReplicationGroupCapacity` (not modeled) | `InsufficientCacheClusterCapacity` |
| Status | 503 | 400 |
| SDK mapping | none possible | typed exception |

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behaviour: an error code that does not exist in the model, at a status the
model does not use for it. Verified against botocore `elasticache/2015-02-02` —
`InsufficientCacheClusterCapacityFault` is declared on `CreateReplicationGroup` (and on
`CreateCacheCluster`), and its `error` block is
`{"code": "InsufficientCacheClusterCapacity", "httpStatusCode": 400, "senderFault": true}`.
Note the shape name and the wire code differ, which is why this is checked against
`error.code` rather than the shape name.

## Checklist

- [x] `./mvnw test` passes locally — all 10 ElastiCache suites (74 tests) pass on the
      rebased branch. The full-suite run on this consolidated commit was still in flight when
      this was opened; CI is authoritative and I will confirm in a comment
- [x] New or updated integration test added — `proxyPortExhaustionSurfacesModeledCapacityFault`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Two deliberate trade-offs worth reviewing

**The message shown to callers is now AWS's, not ours.** The response carries
*"The requested cache node type is not available in the specified Availability Zone."*,
which is faithful to the wire contract but misleading for a Floci user, whose actual problem
is a narrow `proxy-base-port`/`proxy-max-port` range. The real cause is preserved in a
`WARN` log line rather than lost. I think wire fidelity is the right call here, but the
diagnostic cost is real and worth a second opinion.

**503 → 400 changes retry semantics.** A 503 invites a retry; a 400 is a sender fault and
should not be retried. That follows the model, and the previous 503 was inviting retries
against a condition that cannot clear on its own — but any caller currently backing off on
the 503 will now fail fast.

## Note on the branch

This was rebased across 99 commits of drift. The rebase was textually clean and the build
then failed: `ElastiCacheService`'s constructor had gained `Ec2Service` and `RegionResolver`
on `main`, and the new test still used the old 4-arg form. Repaired here and covered by the
suites above — flagging it because a conflict-free rebase was not sufficient evidence of
correctness in this case.
