### PR TITLE
fix(docdb): give a record without an ARN the one it should have had

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -121,9 +121,27 @@ public class DocDbService {
     }
 
     public DocDbCluster getDbCluster(String id) {
-        return clusters.get(id).orElseThrow(() ->
+        DocDbCluster cluster = clusters.get(id).orElseThrow(() ->
                 new AwsException("DBClusterNotFoundFault",
                         "DocDB cluster " + id + " not found.", 404));
+        if (cluster.getDbClusterArn() == null || cluster.getDbClusterArn().isBlank()) {
+            cluster.setDbClusterArn(legacyArn("cluster:" + id));
+            clusters.put(id, cluster);
+        }
+        return cluster;
+    }
+
+    /**
+     * The ARN a record written before ARNs were stored should have had.
+     *
+     * <p>The default region rather than the caller's: such a record was created when every ARN was
+     * built from the default, so that is the region it is in — and giving it the region of whoever
+     * happens to read it first would let a caller elsewhere claim it. Without an ARN a record
+     * cannot be told apart from another region's of the same identifier, and cannot be tagged
+     * through an ARN at all.
+     */
+    private String legacyArn(String resource) {
+        return regionResolver.buildArn("rds", regionResolver.getDefaultRegion(), resource);
     }
 
     public boolean hasCluster(String id) {
@@ -148,7 +166,9 @@ public class DocDbService {
     /** Refuses a record whose own ARN is not the one that was asked for. */
     private static void requireArnNamesRecord(String requested, String stored,
                                               String errorCode, String message) {
-        if (stored != null && !stored.equalsIgnoreCase(requested)) {
+        // No null allowance: a record read through getDbCluster or getDbInstance has been given
+        // its ARN if it lacked one, so anything reaching here can be compared.
+        if (!requested.equalsIgnoreCase(stored)) {
             throw new AwsException(errorCode, message, 404);
         }
     }
@@ -239,6 +259,7 @@ public class DocDbService {
             }
 
             clusters.delete(id);
+            writeLocks.remove("cluster:" + id);
             LOG.infov("DocDB cluster {0} deleted", id);
         }
     }
@@ -284,9 +305,14 @@ public class DocDbService {
     }
 
     public DocDbInstance getDbInstance(String id) {
-        return instances.get(id).orElseThrow(() ->
+        DocDbInstance instance = instances.get(id).orElseThrow(() ->
                 new AwsException("DBInstanceNotFound",
                         "DocDB instance " + id + " not found.", 404));
+        if (instance.getDbInstanceArn() == null || instance.getDbInstanceArn().isBlank()) {
+            instance.setDbInstanceArn(legacyArn("db:" + id));
+            instances.put(id, instance);
+        }
+        return instance;
     }
 
     public Collection<DocDbInstance> listDbInstances(String filterId) {
@@ -334,6 +360,7 @@ public class DocDbService {
             }
 
             instances.delete(id);
+            writeLocks.remove("instance:" + id);
             LOG.infov("DocDB instance {0} deleted", id);
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbLegacyRecordArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbLegacyRecordArnIntegrationTest.java
@@ -1,0 +1,112 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Records written before ARNs were stored still have to resolve to themselves.
+ *
+ * <p>A tag call is answered for the record its ARN names, which needs the record to have one. A
+ * cluster persisted by an earlier Floci has none, so the comparison had nothing to compare and the
+ * call resolved by identifier alone — the hole that check closes, left open for exactly the records
+ * that predate it. The region such a record belongs to is the configured default, which is the
+ * region it was in fact created under.
+ */
+@QuarkusTest
+@TestProfile(DocDbLegacyRecordArnIntegrationTest.NoContainersProfile.class)
+class DocDbLegacyRecordArnIntegrationTest {
+
+    public static class NoContainersProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.docdb.mock", "true");
+        }
+    }
+
+    @Inject
+    DocDbService service;
+
+    private static final String ID = "legacy-arnless-cluster";
+    private static final String HOME_ARN = "arn:aws:rds:us-east-1:000000000000:cluster:" + ID;
+    private static final String FOREIGN_ARN = "arn:aws:rds:eu-west-1:000000000000:cluster:" + ID;
+
+    private static io.restassured.specification.RequestSpecification docdb(String region, String action) {
+        return given().header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260615/" + region + "/docdb/aws4_request, "
+                        + "SignedHeaders=content-type;host, Signature=test")
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    /** A record as an earlier Floci wrote it: identifier and status, no ARN. */
+    private void seedLegacyCluster() {
+        service.createDbCluster(ID, "5.0.0", "admin", "secret99password", false);
+        service.getDbCluster(ID).setDbClusterArn(null);
+    }
+
+    @Test
+    void aLegacyRecordIsNotTaggedThroughAnotherRegionsArn() {
+        seedLegacyCluster();
+
+        docdb("eu-west-1", "AddTagsToResource")
+                .formParam("ResourceName", FOREIGN_ARN)
+                .formParam("Tags.Tag.1.Key", "reached")
+                .formParam("Tags.Tag.1.Value", "wrong-region")
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("DBClusterNotFoundFault"));
+
+        docdb("eu-west-1", "ListTagsForResource")
+                .formParam("ResourceName", FOREIGN_ARN)
+        .when().post("/")
+        .then().statusCode(404);
+
+        // The record kept its own tags, and gained the ARN it should always have had — the
+        // default region's, not the region of whoever happened to read it first.
+        docdb("us-east-1", "ListTagsForResource")
+                .formParam("ResourceName", HOME_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("wrong-region")));
+
+        assertEquals(HOME_ARN, service.getDbCluster(ID).getDbClusterArn());
+
+        service.deleteDbCluster(ID);
+    }
+
+    @Test
+    void aLegacyRecordCanBeTaggedThroughItsOwnArn() {
+        // The backfill has to make the record usable, not merely refuse the wrong ARN.
+        seedLegacyCluster();
+
+        docdb("us-east-1", "AddTagsToResource")
+                .formParam("ResourceName", HOME_ARN)
+                .formParam("Tags.Tag.1.Key", "env")
+                .formParam("Tags.Tag.1.Value", "upgraded")
+        .when().post("/")
+        .then().statusCode(200);
+
+        docdb("us-east-1", "ListTagsForResource")
+                .formParam("ResourceName", HOME_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Value>upgraded</Value>"));
+
+        service.deleteDbCluster(ID);
+    }
+}


### PR DESCRIPTION
Closes #2424.

## What

#2408 made a tag call resolve to the record its ARN names rather than to any record of that identifier. The comparison was skipped when the stored ARN was null, and `DocDbCluster.dbClusterArn` defaults to null with no backfill on read — so a cluster or instance written by an earlier Floci resolved by identifier alone. The hole that check closed, still open for exactly the records that predate it.

Reachable on the `docdb` credential scope, which addresses this service directly. The `rds` scope routes by matching the whole stored ARN, so a record without one never matches another region's ARN there and the request goes to RDS, which rejects it.

## Change

The ARN is filled in on read, which is the pattern already on the RDS side — `getDbParameterGroup` fills a missing region and ARN because a group that never gets one cannot be tagged at all.

It comes from the **default region, not the caller's**. Such a record was created when every DocumentDB ARN was built from the default, so that is the region it is in; taking the reader's region would let a caller elsewhere claim it, which is the original bug wearing a fix's clothes. It is also the assumption `hasCluster(id, region)` already makes when a record has no ARN.

With every record carrying an ARN by the time it is compared, the `null` allowance in `requireArnNamesRecord` goes away rather than staying as a standing exception.

Also, as noted on #2408: a deleted record's monitor is dropped. What stops a tag from reviving a deleted record is the re-resolve inside the lock rather than the identity of the monitor, so retiring one with its record is safe — `DocDbTagConcurrencyTest` still passes across repeated runs.

## Tests

`DocDbLegacyRecordArnIntegrationTest` seeds a record in exactly the shape `TaggedRecordUpgradeTest`'s legacy fixture describes, then:

- another region's ARN for that identifier is **not found**, for both the read and the write, and the record keeps its own tags
- the record's own ARN tags it normally — the backfill has to make the record usable, not merely refuse the wrong ARN
- the ARN it gains is the default region's

Both halves are break-tested, and the second break is the one worth naming: making the backfill use the caller's region instead of the default turns the foreign-region call back into a `200`. The region choice is load-bearing, not incidental.

616 tests green, on a branch cut from current `main` (`5744082c`).
