### PR TITLE
fix(lifecycle): run start/ready hooks when FLOCI_PORT is non-default

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -49,7 +49,6 @@ import java.util.Optional;
 public class EmulatorLifecycle {
 
     private static final Logger LOG = Logger.getLogger(EmulatorLifecycle.class);
-    private static final int HTTP_PORT = 4566;
     private static final int TLS_HTTP_BACKEND_PORT = 4510;
 
     @ConfigProperty(name = "quarkus.application.version", defaultValue = "")
@@ -211,7 +210,11 @@ public class EmulatorLifecycle {
     }
 
     void onHttpStart(@ObservesAsync HttpServerStart event) {
-        int expectedPort = config.tls().enabled() ? TLS_HTTP_BACKEND_PORT : HTTP_PORT;
+        // Non-TLS: Quarkus listens on floci.port (quarkus.http.port: ${floci.port} in
+        // application.yml). TLS mode: TlsConfigSource pins the HTTP backend to 4510 and the
+        // public port is served by TlsProxyServer. Comparing against a hardcoded 4566 here
+        // made start/ready hooks never run when FLOCI_PORT was non-default (#2437).
+        int expectedPort = config.tls().enabled() ? TLS_HTTP_BACKEND_PORT : config.port();
         if (event.options().getPort() != expectedPort) {
             return;
         }

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -99,6 +99,7 @@ class EmulatorLifecycleTest {
         Mockito.lenient().when(elbv2ServiceConfig.enabled()).thenReturn(false);
         Mockito.lenient().when(config.tls()).thenReturn(tlsConfig);
         Mockito.lenient().when(tlsConfig.enabled()).thenReturn(false);
+        Mockito.lenient().when(config.port()).thenReturn(4566);
 
         emulatorLifecycle = new EmulatorLifecycle(
                 storageFactory, serviceRegistry, config,
@@ -252,6 +253,22 @@ class EmulatorLifecycleTest {
 
         verify(initializationHooksRunner).run(InitializationHook.START);
         verify(initLifecycleState).markStartCompleted();
+    }
+
+    @Test
+    @DisplayName("onHttpStart on a non-default floci.port (non-TLS) triggers hook execution (#2437)")
+    void onHttpStart_nonTls_triggersHooksOnCustomPort() throws IOException, InterruptedException {
+        Mockito.lenient().when(config.port()).thenReturn(4577);
+        when(tlsConfig.enabled()).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(true);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(true);
+
+        emulatorLifecycle.onHttpStart(new HttpServerStart(new HttpServerOptions().setPort(4577)));
+
+        verify(initializationHooksRunner).run(InitializationHook.START);
+        verify(initializationHooksRunner).run(InitializationHook.READY);
+        verify(initLifecycleState).markStartCompleted();
+        verify(initLifecycleState).markReadyCompleted();
     }
 
     @Test


### PR DESCRIPTION
Fixes #2437

## Root cause

`EmulatorLifecycle.onHttpStart()` filtered `HttpServerStart` events against a hardcoded `HTTP_PORT = 4566`, but the Quarkus HTTP server actually listens on `floci.port` (`quarkus.http.port: ${floci.port}` in `application.yml`). With any non-default `FLOCI_PORT` the guard never matched, so the deferred start/ready hook path (#159) never fired:

- `/_floci/init` stayed at `start:false, ready:false` forever
- no scripts in `ready.d`/`start.d` were discovered or executed
- `/_floci/health` still returned 200, so containers looked healthy (the silent-failure mode from the issue)

## Fix

Compare against `config.port()` instead of the hardcoded constant. TLS mode is unchanged: `TlsConfigSource` pins the HTTP backend to 4510 regardless of `floci.port`, and that branch already used its own constant.

## Testing

- New unit test `onHttpStart_nonTls_triggersHooksOnCustomPort`: with `floci.port=4577`, a server-start event on port 4577 runs START and READY hooks and marks both phases completed. Full `EmulatorLifecycleTest` suite passes (23 tests).
- End-to-end verified on JDK 25: booted the emulator with `FLOCI_PORT=4577` and a script in `/etc/floci/init/ready.d`. `/_floci/init` now reports `start:true, ready:true` with the script listed as `successful`, the script executes exactly once, and the `=== AWS Local Emulator Ready ===` banner appears.

## Side note (not in this PR)

The issue also mentions the image `HEALTHCHECK` being hardcoded to port 4566. That's a Dockerfile-level concern (`docker/Dockerfile*`) — happy to follow up separately if maintainers want it changed.