### PR TITLE
fix(ecs): round-trip command and entryPoint on container definitions

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -1018,6 +1018,18 @@ public class EcsJsonHandler {
             n.set("portMappings", pms);
         }
 
+        if (def.getEntryPoint() != null && !def.getEntryPoint().isEmpty()) {
+            ArrayNode entryPoint = objectMapper.createArrayNode();
+            def.getEntryPoint().forEach(entryPoint::add);
+            n.set("entryPoint", entryPoint);
+        }
+
+        if (def.getCommand() != null && !def.getCommand().isEmpty()) {
+            ArrayNode command = objectMapper.createArrayNode();
+            def.getCommand().forEach(command::add);
+            n.set("command", command);
+        }
+
         if (def.getEnvironment() != null && !def.getEnvironment().isEmpty()) {
             ArrayNode envArr = objectMapper.createArrayNode();
             for (KeyValuePair kv : def.getEnvironment()) {

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsIntegrationTest.java
@@ -1110,4 +1110,57 @@ class EcsIntegrationTest {
         .then()
             .statusCode(200);
     }
+
+    /**
+     * A container definition registered with {@code entryPoint} and {@code command} must echo
+     * both back on DescribeTaskDefinition. Without this, re-registering a task definition from
+     * describe output silently drops the overrides and the new revision falls back to the
+     * image's default entrypoint.
+     */
+    @Test
+    @Order(70)
+    void registerAndDescribeTaskDefinitionRoundTripsCommandAndEntryPoint() {
+        String arn = ecs("RegisterTaskDefinition")
+            .body("""
+                {
+                    "family": "entrypoint-roundtrip",
+                    "containerDefinitions": [
+                        {
+                            "name": "app",
+                            "image": "alpine:latest",
+                            "essential": true,
+                            "entryPoint": ["/bin/sh", "-c"],
+                            "command": ["fetch-ca && exec agent --serve"]
+                        },
+                        {
+                            "name": "sidecar",
+                            "image": "alpine:latest",
+                            "essential": false
+                        }
+                    ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.containerDefinitions[0].entryPoint", contains("/bin/sh", "-c"))
+            .body("taskDefinition.containerDefinitions[0].command", contains("fetch-ca && exec agent --serve"))
+        .extract()
+            .path("taskDefinition.taskDefinitionArn");
+
+        ecs("DescribeTaskDefinition")
+            .body("""
+                {"taskDefinition": "%s"}
+                """.formatted(arn))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("taskDefinition.containerDefinitions[0].entryPoint", contains("/bin/sh", "-c"))
+            .body("taskDefinition.containerDefinitions[0].command", contains("fetch-ca && exec agent --serve"))
+            // A container that set neither keeps both keys absent, as real AWS does.
+            .body("taskDefinition.containerDefinitions[1]", not(hasKey("entryPoint")))
+            .body("taskDefinition.containerDefinitions[1]", not(hasKey("command")));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerCommandEntryPointTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandlerCommandEntryPointTest.java
@@ -1,0 +1,107 @@
+package io.github.hectorvent.floci.services.ecs;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the RegisterTaskDefinition JSON wire path in {@link EcsJsonHandler}:
+ * per-container {@code command} and {@code entryPoint} must be parsed from the request,
+ * stored on the container definition, and serialized back in the response.
+ *
+ * <p>Both fields were already parsed and honoured when launching the container
+ * ({@code EcsContainerManager}), but never rendered by {@code containerDefinitionNode} — so
+ * re-registering a task definition from DescribeTaskDefinition output silently dropped them
+ * and the new revision fell back to the image's default entrypoint.
+ *
+ * <p>{@link EcsService} is mocked to echo the parsed container definitions back inside a
+ * task definition, so the test exercises parse + serialize without any Docker/Quarkus context.
+ */
+class EcsJsonHandlerCommandEntryPointTest {
+
+    private EcsService service;
+    private ObjectMapper objectMapper;
+    private EcsJsonHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+        service = mock(EcsService.class);
+        // Echo the parsed container definitions (arg index 1) back inside a task definition.
+        when(service.registerTaskDefinition(anyString(), any(), any(), any(), any(), any(), any(), any(), any(), anyString()))
+                .thenAnswer(inv -> {
+                    TaskDefinition td = new TaskDefinition();
+                    td.setFamily(inv.getArgument(0));
+                    td.setRevision(1);
+                    td.setStatus("ACTIVE");
+                    td.setContainerDefinitions(inv.getArgument(1, List.class));
+                    return td;
+                });
+
+        handler = new EcsJsonHandler(service, objectMapper);
+    }
+
+    @Test
+    void registerTaskDefinitionRoundTripsCommandAndEntryPoint() throws Exception {
+        String requestJson = """
+                {
+                  "family": "entrypoint-family",
+                  "containerDefinitions": [
+                    {
+                      "name": "app",
+                      "image": "alpine:latest",
+                      "entryPoint": ["/bin/sh", "-c"],
+                      "command": ["fetch-ca && exec agent --serve"]
+                    }
+                  ]
+                }
+                """;
+        JsonNode request = objectMapper.readTree(requestJson);
+
+        Response response = handler.handle("RegisterTaskDefinition", request, "us-east-1");
+        JsonNode container = objectMapper.valueToTree(response.getEntity())
+                .path("taskDefinition").path("containerDefinitions").get(0);
+
+        JsonNode entryPoint = container.path("entryPoint");
+        assertTrue(entryPoint.isArray() && entryPoint.size() == 2, "entryPoint expected with two elements");
+        assertEquals("/bin/sh", entryPoint.get(0).asText());
+        assertEquals("-c", entryPoint.get(1).asText());
+
+        JsonNode command = container.path("command");
+        assertTrue(command.isArray() && command.size() == 1, "command expected with one element");
+        assertEquals("fetch-ca && exec agent --serve", command.get(0).asText());
+    }
+
+    @Test
+    void containerDefinitionOmitsCommandAndEntryPointWhenNotProvided() throws Exception {
+        String requestJson = """
+                {
+                  "family": "plain-family",
+                  "containerDefinitions": [
+                    {"name": "app", "image": "alpine:latest"}
+                  ]
+                }
+                """;
+        JsonNode request = objectMapper.readTree(requestJson);
+
+        Response response = handler.handle("RegisterTaskDefinition", request, "us-east-1");
+        JsonNode container = objectMapper.valueToTree(response.getEntity())
+                .path("taskDefinition").path("containerDefinitions").get(0);
+
+        // Sparse serialization: absent input stays absent on the response, as real AWS does.
+        assertTrue(container.path("entryPoint").isMissingNode(), "entryPoint must stay absent");
+        assertTrue(container.path("command").isMissingNode(), "command must stay absent");
+    }
+}


### PR DESCRIPTION
Fixes #2445.

## Problem

`RegisterTaskDefinition` already parses `containerDefinitions[].command` and `.entryPoint` (`parseContainerDefinitions` calls `setCommand`/`setEntryPoint`), and `EcsContainerManager` honours both when launching the container. But `containerDefinitionNode` never rendered them, so `DescribeTaskDefinition` silently omitted both keys — `grep -n 'getCommand()\|getEntryPoint()' EcsJsonHandler.java` returned zero hits before this change.

The bite is on the describe → register round trip that tooling uses to cut a new revision. Verified against stock `floci/floci:latest` (1.7.0):

* Revision 1, registered with `entryPoint: ["/bin/sh","-c"]` plus a command — launches correctly, `docker inspect` shows `["/bin/sh","-c"] ["echo hello from the override; sleep 120"]`.
* Revision 2, registered by piping revision 1's `describe-task-definition` output straight back in — both keys are gone from the JSON, and the container comes up as `null ["/bin/sh"]`, the image default.

The container still *starts*, which is what makes this one unpleasant to track down: nothing errors, the setup work the entrypoint was supposed to do just silently doesn't happen.

## Fix

Twelve lines in `containerDefinitionNode`, serializing both sparsely in the same style as the surrounding `portMappings` / `mountPoints` blocks — a container definition that sets neither still serializes byte-identically, so nothing changes for existing task definitions.

## Tests

* `EcsJsonHandlerCommandEntryPointTest` — parse + serialize round trip through the JSON wire path, written in the `EcsJsonHandlerVolumesTest` style (mocked `EcsService`, no Docker/Quarkus context). Two cases: the round trip itself, and an absent-stays-absent guard for the sparse behaviour.
* `EcsIntegrationTest#registerAndDescribeTaskDefinitionRoundTripsCommandAndEntryPoint` — end-to-end `RegisterTaskDefinition` → `DescribeTaskDefinition` over the real wire protocol, with a second container in the same task definition asserting both keys stay absent when unset.

Both were watched failing before the fix went in (the integration test fails on the describe assertion; the unit test on `entryPoint expected with two elements`). Full ECS suite: **120 tests, 0 failures, 0 errors** — 117 pre-existing plus the 3 added here.

```
./mvnw test -Dtest='Ecs*Test'
```

## Notes

* This is the same class of round-trip omission as #2443 (`runtimePlatform` + `logConfiguration`), which is still open. Kept as a separate branch off `main` rather than folded into that PR, since the project prefers focused PRs — the two don't touch the same lines, so they should merge in either order.
* No docs change: `docs/services/ecs.md` documents ECS at the operation level and doesn't enumerate container-definition fields, and this restores AWS-correct behaviour rather than changing any documented contract. Happy to add a note if you'd prefer one.
