### PR TITLE
fix(ec2): install packages with yum on Amazon Linux 2 guests

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -488,37 +488,10 @@ public class Ec2ContainerManager {
 
     private void startSshd(String containerId, String instanceId) {
         try {
-            // Install openssh-server if absent. The trailing "command -v sshd" makes the script's
-            // own exit code the source of truth for whether sshd is actually available afterward -
-            // without it, a shell if/elif chain with no matching branch (no dnf/apt-get/apk found) or
-            // whose install command itself failed (e.g. no network yet, apt lock held) still exits 0
-            // by bash convention, so every later step here would silently no-op against a daemon that
-            // was never installed while still logging success.
-            // The client package is installed alongside the server because provisioning tools
-            // need scp *on the instance*: Packer's default file transfer for a shell
-            // provisioner uploads the script with scp, and real AMIs carry it. Installing only
-            // openssh-server leaves sftp-server present but /usr/bin/scp absent, so the upload
-            // fails with "SCP failed to start. This usually means that SCP is not properly
-            // installed on the remote system." The guard tests for scp too: keying it on sshd
-            // alone would skip the install entirely on an image that already has the server but
-            // no client. Package names differ -- openssh-clients on rpm distributions,
-            // openssh-client on Debian; apk's openssh already contains both.
-            // The two are not equally fatal, so the script separates them: exit 1 means no sshd
-            // and there is nothing to start, while exit 2 means sshd is there but the client
-            // package did not land. A guest that can serve SSH but cannot scp is still worth
-            // starting - it just cannot run a Packer shell provisioner - so that case warns and
-            // continues rather than leaving the instance unreachable. Checking only sshd at the
-            // end would report that state as outright success, which is the silent failure this
-            // probe exists to prevent.
-            ContainerExecResult install = execInContainerForResult(containerId, new String[]{"sh", "-c",
-                    "if ! command -v sshd >/dev/null 2>&1 || ! command -v scp >/dev/null 2>&1; then" +
-                            "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server openssh-clients >/dev/null 2>&1;" +
-                            "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server openssh-client >/dev/null 2>&1;" +
-                            "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;" +
-                            "  fi;" +
-                            "fi;" +
-                            "command -v sshd >/dev/null 2>&1 || exit 1;" +
-                            "command -v scp >/dev/null 2>&1 || exit 2"}, 120);
+            // Exit 1 means sshd is absent and there is nothing to start; exit 2 means sshd is
+            // there but the client package did not land. Only the first is fatal - see
+            // sshdInstallProbeCommand() for why the probe distinguishes them.
+            ContainerExecResult install = execInContainerForResult(containerId, sshdInstallProbeCommand(), 120);
             if (install.exitCode() == SSH_CLIENT_MISSING_EXIT_CODE) {
                 LOG.warnv("sshd is available on EC2 instance {0} but the OpenSSH client package is not:"
                         + " scp is missing, so provisioners that upload files over scp will fail: {1}",
@@ -694,6 +667,52 @@ public class Ec2ContainerManager {
         return new String[]{USER_DATA_SCRIPT_PATH};
     }
 
+    /**
+     * The install-and-verify probe {@link #startSshd} execs in the guest. Extracted so tests can
+     * assert against the string production actually issues rather than against a copy of it.
+     *
+     * <p>Installs openssh-server if absent. The trailing "command -v" checks make the script's own
+     * exit code the source of truth for whether sshd is actually available afterward - without
+     * them, a shell if/elif chain with no matching branch (no dnf/yum/apt-get/apk found) or whose
+     * install command itself failed (e.g. no network yet, apt lock held) still exits 0 by bash
+     * convention, so every later step in startSshd would silently no-op against a daemon that was
+     * never installed while still logging success.
+     *
+     * <p>The client package is installed alongside the server because provisioning tools need scp
+     * <em>on the instance</em>: Packer's default file transfer for a shell provisioner uploads the
+     * script with scp, and real AMIs carry it. Installing only openssh-server leaves sftp-server
+     * present but /usr/bin/scp absent, so the upload fails with "SCP failed to start. This usually
+     * means that SCP is not properly installed on the remote system." The guard tests for scp too:
+     * keying it on sshd alone would skip the install entirely on an image that already has the
+     * server but no client. Package names differ - openssh-clients on rpm distributions,
+     * openssh-client on Debian; apk's openssh already contains both.
+     *
+     * <p>The two failures are not equally fatal, so the script separates them: exit 1 means no sshd
+     * and there is nothing to start, while exit 2 means sshd is there but the client package did
+     * not land. A guest that can serve SSH but cannot scp is still worth starting - it just cannot
+     * run a Packer shell provisioner - so that case warns and continues rather than leaving the
+     * instance unreachable. Checking only sshd at the end would report that state as outright
+     * success, which is the silent failure this probe exists to prevent.
+     */
+    static String[] sshdInstallProbeCommand() {
+        return new String[]{"sh", "-c",
+            "if ! command -v sshd >/dev/null 2>&1 || ! command -v scp >/dev/null 2>&1; then" +
+                    "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server openssh-clients >/dev/null 2>&1;" +
+                    // yum is probed after dnf, and the order is load-bearing: Amazon Linux
+                    // 2023 and modern Fedora/RHEL ship both, and there dnf is the supported
+                    // front end while yum is only a compatibility shim over it. Amazon Linux
+                    // 2 -- reached by explicitly requesting ami-amazonlinux2, not the default
+                    // image -- ships only yum, so without this branch the chain falls through
+                    // and sshd is never installed.
+                    "  elif command -v yum >/dev/null 2>&1; then yum install -y openssh-server openssh-clients >/dev/null 2>&1;" +
+                    "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server openssh-client >/dev/null 2>&1;" +
+                    "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;" +
+                    "  fi;" +
+                    "fi;" +
+                    "command -v sshd >/dev/null 2>&1 || exit 1;" +
+                    "command -v scp >/dev/null 2>&1 || exit 2"};
+    }
+
     static String[] metadataProxyInstallCommand() {
         return new String[]{"sh", "-c", String.join("\n",
                 "set -eu",
@@ -703,6 +722,12 @@ public class Ec2ContainerManager {
                 "  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends iproute2 socat curl ca-certificates >/dev/null",
                 "elif command -v dnf >/dev/null 2>&1; then",
                 "  dnf install -y iproute socat curl ca-certificates >/dev/null",
+                // Same gap as the sshd probe: Amazon Linux 2 has only yum, so on an instance
+                // launched from ami-amazonlinux2 this chain reached its else branch and exited 1
+                // with "No supported package manager found for IMDS proxy dependencies" --
+                // leaving the instance without a link-local IMDS endpoint.
+                "elif command -v yum >/dev/null 2>&1; then",
+                "  yum install -y iproute socat curl ca-certificates >/dev/null",
                 "elif command -v apk >/dev/null 2>&1; then",
                 "  apk add --no-cache iproute2 socat curl ca-certificates >/dev/null",
                 "else",

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -269,6 +269,40 @@ class Ec2ContainerManagerTest {
     }
 
     @Test
+    void sshdInstallProbeHandlesYumForAmazonLinux2() {
+        // public.ecr.aws/amazonlinux/amazonlinux:2 ships only yum -- no dnf, no apt-get, no
+        // apk. It is NOT the default image (image-catalog.yaml pins that to amazonlinux:2023,
+        // which has dnf); it is reached by explicitly requesting ami-amazonlinux2. Without a
+        // yum branch the if/elif chain falls through, the trailing "command -v sshd" fails,
+        // and startSshd() returns early, so such an instance is never reachable over SSH.
+        //
+        // Asserted against the production accessor, not the SSHD_INSTALL_PROBE_CMD copy below,
+        // so removing the yum branch fails THIS test rather than only the withCmd verify.
+        String script = Ec2ContainerManager.sshdInstallProbeCommand()[2];
+
+        assertTrue(script.contains("command -v yum"), script);
+        // The yum branch installs the client package alongside the server, exactly as the dnf
+        // branch does -- an AL2 guest needs scp for the same reason every other guest does.
+        assertTrue(script.contains("yum install -y openssh-server openssh-clients"), script);
+        // dnf must still win where both exist (Amazon Linux 2023, modern Fedora/RHEL), where
+        // yum is only a compatibility shim over dnf.
+        assertTrue(script.indexOf("command -v dnf") < script.indexOf("command -v yum"),
+                "dnf must be probed before yum");
+    }
+
+    @Test
+    void metadataProxyInstallCommandHandlesYumForAmazonLinux2() {
+        // The IMDS proxy dependency install had the same gap, and unlike the sshd probe it
+        // ends in an explicit failure: on an ami-amazonlinux2 instance it reached the else
+        // branch and exited 1 with "No supported package manager found for IMDS proxy
+        // dependencies", leaving the instance without a link-local metadata endpoint.
+        String script = Ec2ContainerManager.metadataProxyInstallCommand()[2];
+
+        assertTrue(script.contains("command -v yum"), script);
+        assertTrue(script.contains("yum install -y iproute socat curl ca-certificates"), script);
+    }
+
+    @Test
     void metadataProxyStartCommandBindsAwsLinkLocalMetadataAddress() {
         String[] command = Ec2ContainerManager.metadataProxyStartCommand("floci", 9169);
 
@@ -467,6 +501,7 @@ class Ec2ContainerManagerTest {
     private static final String[] SSHD_INSTALL_PROBE_CMD = {"sh", "-c",
             "if ! command -v sshd >/dev/null 2>&1 || ! command -v scp >/dev/null 2>&1; then"
             + "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server openssh-clients >/dev/null 2>&1;"
+            + "  elif command -v yum >/dev/null 2>&1; then yum install -y openssh-server openssh-clients >/dev/null 2>&1;"
             + "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server openssh-client >/dev/null 2>&1;"
             + "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;"
             + "  fi;"


### PR DESCRIPTION
## Summary

Two package-manager probes in `Ec2ContainerManager` try `dnf`, `apt-get` and `apk`. `public.ecr.aws/amazonlinux/amazonlinux:2` ships **`yum`** and none of those three, so both chains fall through on an Amazon Linux 2 guest.

**`startSshd()`** — the trailing `command -v sshd` fails, the method returns early, and the instance is never reachable over SSH, despite Floci having allocated a host port for it and injected `authorized_keys`.

**`metadataProxyInstallCommand()`** — reaches its `else` branch and exits 1 with `No supported package manager found for IMDS proxy dependencies`, leaving the instance without a link-local IMDS endpoint.

### Scope (corrected)

An earlier revision of this description claimed `amazonlinux:2` was "Floci's own default EC2 image" and that "no instance launched from the default image is ever reachable over SSH". **That was wrong**, and @pgermosen was right to hold the PR over it. `src/main/resources/ec2/image-catalog.yaml:1` reads:

```yaml
defaultDockerImage: public.ecr.aws/amazonlinux/amazonlinux:2023
```

and `git log -L1,1` on that file confirms it has been `:2023` since the catalog was introduced in #1252 — it was never `:2`. AL2023 has `dnf` and already works.

So this affects instances launched **explicitly** from `ami-amazonlinux2` (or its ID `ami-0abcdef1234567890`). A missing `ImageId` and unrecognised IDs both fall back to the default.

The claim was corrected everywhere it had been copied — both test comments, **both production comments** in `Ec2ContainerManager.java` (which the review didn't flag but carried the same wording), and the commit message.

## Reproduction

```
$ docker run --rm public.ecr.aws/amazonlinux/amazonlinux:2 sh -c \
    'command -v yum; for m in apt-get dnf apk; do command -v $m; done'
/usr/bin/yum          # and nothing else
```

Both package sets install cleanly under yum:

```
$ yum install -y openssh-server openssh-clients      -> /usr/sbin/sshd, /usr/bin/scp
$ yum install -y iproute socat curl ca-certificates  -> ip, socat, curl
```

## Fix

A `yum` branch in both chains, probed **after** `dnf` so that `dnf` still wins on Amazon Linux 2023 and modern Fedora/RHEL, where both exist and `yum` is only a compatibility shim over `dnf`.

**Rebased onto current `main` now that #2449 has merged.** That changed the sshd probe under this branch, so the `yum` branch installs `openssh-server openssh-clients` — matching what the `dnf` and `apt-get` branches now do. An AL2 guest needs `scp` for the same reason every other guest does; without this the rebase would have quietly reintroduced the exact gap #2449 closed, for AL2 only.

## Test change (addressing the review)

@pgermosen noted that of the two new tests, `metadataProxyInstallCommandHandlesYumForAmazonLinux2` was load-bearing but `sshdInstallProbeHandlesYumForAmazonLinux2` asserted against the *test-local* copy of `SSHD_INSTALL_PROBE_CMD`, so on its own it only confirmed the test file agreed with itself.

Fixed by giving the sshd probe the same treatment `metadataProxyInstallCommand()` already had: extracted into `static String[] sshdInstallProbeCommand()`, and the test now asserts against that. The long rationale comment moved with the script it describes; the call site keeps a short note on the exit-code handling, which is genuinely about `startSshd`.

The test-local literal and its `verify(execCreate).withCmd(eq(SSHD_INSTALL_PROBE_CMD))` are deliberately **kept** — pointing that constant at the accessor would have made the verify tautological and lost the drift protection. So the two now do different jobs: the literal pins production's exact output, and the new test detects the branch directly.

Re-ran the mutation matrix; rows 1 and 3 are now caught by the new test itself, not only by the pre-existing verify:

| mutation | before | now |
|---|---|---|
| drop the `yum` branch from the sshd probe | caught only by the `withCmd` verify | **`sshdInstallProbeHandlesYumForAmazonLinux2` fails directly** |
| move `yum` **before** `dnf` | caught only by the `withCmd` verify | **fails directly** — `dnf must be probed before yum` |
| drop the `yum` branch from the IMDS install | caught | caught |

A new assertion pins that the yum branch installs the client package too, so the #2449 parity cannot silently regress.

## Tests

`Ec2ContainerManagerTest`: **25 tests, 0 failures, 0 errors.**
All `Ec2*Test` on the rebased branch: **491 tests, 0 failures, 0 errors.**

## Context

Found while checking whether Packer's `amazon-ebs` builder can run against Floci. The remaining piece is the addressing question in #2447, deliberately kept separate.
