### PR TITLE
fix(ec2): install the SSH client package in guests, not just the server

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -492,10 +492,19 @@ public class Ec2ContainerManager {
             // whose install command itself failed (e.g. no network yet, apt lock held) still exits 0
             // by bash convention, so every later step here would silently no-op against a daemon that
             // was never installed while still logging success.
+            // The client package is installed alongside the server because provisioning tools
+            // need scp *on the instance*: Packer's default file transfer for a shell
+            // provisioner uploads the script with scp, and real AMIs carry it. Installing only
+            // openssh-server leaves sftp-server present but /usr/bin/scp absent, so the upload
+            // fails with "SCP failed to start. This usually means that SCP is not properly
+            // installed on the remote system." The guard tests for scp too: keying it on sshd
+            // alone would skip the install entirely on an image that already has the server but
+            // no client. Package names differ -- openssh-clients on rpm distributions,
+            // openssh-client on Debian; apk's openssh already contains both.
             ContainerExecResult install = execInContainerForResult(containerId, new String[]{"sh", "-c",
-                    "if ! command -v sshd >/dev/null 2>&1; then" +
-                            "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server >/dev/null 2>&1;" +
-                            "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server >/dev/null 2>&1;" +
+                    "if ! command -v sshd >/dev/null 2>&1 || ! command -v scp >/dev/null 2>&1; then" +
+                            "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server openssh-clients >/dev/null 2>&1;" +
+                            "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server openssh-client >/dev/null 2>&1;" +
                             "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;" +
                             "  fi;" +
                             "fi;" +

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -55,6 +55,8 @@ public class Ec2ContainerManager {
     private static final String USER_DATA_SCRIPT_PATH = "/tmp/user-data.sh";
     private static final Pattern MIME_BOUNDARY = Pattern.compile("(?im)^content-type:\\s*multipart/[^;]+;\\s*boundary=\"?([^\";\\n\\r]+)\"?.*$");
     private static final List<String> ALLOWED_SSHD_PATHS = List.of("/usr/sbin/sshd", "/usr/local/sbin/sshd", "/sbin/sshd");
+    /** Exit code the sshd install probe uses for "sshd is present but scp is not". See startSshd. */
+    static final int SSH_CLIENT_MISSING_EXIT_CODE = 2;
 
     static int containerBridgeIpAttempts = 30;
     static long containerBridgeIpPollMillis = 500;
@@ -501,6 +503,13 @@ public class Ec2ContainerManager {
             // alone would skip the install entirely on an image that already has the server but
             // no client. Package names differ -- openssh-clients on rpm distributions,
             // openssh-client on Debian; apk's openssh already contains both.
+            // The two are not equally fatal, so the script separates them: exit 1 means no sshd
+            // and there is nothing to start, while exit 2 means sshd is there but the client
+            // package did not land. A guest that can serve SSH but cannot scp is still worth
+            // starting - it just cannot run a Packer shell provisioner - so that case warns and
+            // continues rather than leaving the instance unreachable. Checking only sshd at the
+            // end would report that state as outright success, which is the silent failure this
+            // probe exists to prevent.
             ContainerExecResult install = execInContainerForResult(containerId, new String[]{"sh", "-c",
                     "if ! command -v sshd >/dev/null 2>&1 || ! command -v scp >/dev/null 2>&1; then" +
                             "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server openssh-clients >/dev/null 2>&1;" +
@@ -508,8 +517,13 @@ public class Ec2ContainerManager {
                             "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;" +
                             "  fi;" +
                             "fi;" +
-                            "command -v sshd >/dev/null 2>&1"}, 120);
-            if (install.exitCode() != 0) {
+                            "command -v sshd >/dev/null 2>&1 || exit 1;" +
+                            "command -v scp >/dev/null 2>&1 || exit 2"}, 120);
+            if (install.exitCode() == SSH_CLIENT_MISSING_EXIT_CODE) {
+                LOG.warnv("sshd is available on EC2 instance {0} but the OpenSSH client package is not:"
+                        + " scp is missing, so provisioners that upload files over scp will fail: {1}",
+                        instanceId, install.summary());
+            } else if (install.exitCode() != 0) {
                 LOG.warnv("Could not install openssh-server for EC2 instance {0}: {1}",
                         instanceId, install.summary());
                 return;

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -260,6 +260,12 @@ class Ec2ContainerManagerTest {
         // The guard has to consider scp as well, or an image that already has sshd but no
         // client skips the install and provisioning still fails with nothing in the logs.
         assertTrue(script.contains("! command -v scp"), script);
+        // ...and so does the trailing status check, on its own exit code. Ending the script on
+        // "command -v sshd" alone would report a guest that has the server but whose client
+        // install failed as a success, which is the state this guard was widened to catch.
+        assertTrue(script.endsWith("command -v sshd >/dev/null 2>&1 || exit 1;"
+                + "command -v scp >/dev/null 2>&1 || exit "
+                + Ec2ContainerManager.SSH_CLIENT_MISSING_EXIT_CODE), script);
     }
 
     @Test
@@ -465,7 +471,8 @@ class Ec2ContainerManagerTest {
             + "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;"
             + "  fi;"
             + "fi;"
-            + "command -v sshd >/dev/null 2>&1"};
+            + "command -v sshd >/dev/null 2>&1 || exit 1;"
+            + "command -v scp >/dev/null 2>&1 || exit 2"};
 
     @Test
     void launchWhenSshdInstallFails_doesNotAttemptKeygenOrStart() throws Exception {
@@ -477,6 +484,35 @@ class Ec2ContainerManagerTest {
         // logged success. This forces the install probe to report failure and asserts the later
         // steps are never even attempted, rather than running against a daemon that was never
         // installed.
+        ExecCreateCmd execCreate = launchWithSshdInstallProbeExitCode(1, "i-sshdinstallfail");
+
+        verify(execCreate, timeout(2000)).withCmd(eq(SSHD_INSTALL_PROBE_CMD));
+        verify(execCreate, never()).withCmd(eq(new String[]{"ssh-keygen", "-A"}));
+        verify(execCreate, never()).withCmd(eq(new String[]{"/usr/sbin/sshd"}));
+    }
+
+    @Test
+    void launchWhenOnlySshClientInstallFails_stillStartsSshd() throws Exception {
+        // The probe's guard now also fires when scp is missing, so a guest that already has sshd
+        // but whose client-package install fails must not be reported as a plain success - that is
+        // exactly the state where Packer's default scp-based file transfer breaks. It is not fatal
+        // either: sshd is present and the instance is worth making reachable. The script separates
+        // the two with exit 2, which warns and carries on rather than returning early.
+        ExecCreateCmd execCreate = launchWithSshdInstallProbeExitCode(
+                Ec2ContainerManager.SSH_CLIENT_MISSING_EXIT_CODE, "i-scpinstallfail");
+
+        verify(execCreate, timeout(2000)).withCmd(eq(SSHD_INSTALL_PROBE_CMD));
+        verify(execCreate, timeout(2000)).withCmd(eq(new String[]{"ssh-keygen", "-A"}));
+        verify(execCreate, timeout(2000)).withCmd(eq(new String[]{"/usr/sbin/sshd"}));
+    }
+
+    /**
+     * Launches an instance where every exec succeeds except the sshd install probe, which reports
+     * {@code probeExitCode}. Returns the {@link ExecCreateCmd} the launch issued its commands
+     * through so callers can assert on which steps were attempted.
+     */
+    private ExecCreateCmd launchWithSshdInstallProbeExitCode(int probeExitCode, String instanceId)
+            throws Exception {
         LaunchHarness harness = launchHarness();
         InspectContainerCmd inspect = mock(InspectContainerCmd.class);
         InspectContainerResponse withIp = inspectResponse("172.18.0.21");
@@ -514,7 +550,7 @@ class Ec2ContainerManagerTest {
         when(inspectExec.exec()).thenAnswer(invocation -> {
             InspectExecResponse response = mock(InspectExecResponse.class);
             boolean isSshdInstallProbe = Arrays.equals(currentCommand.get(), SSHD_INSTALL_PROBE_CMD);
-            when(response.getExitCodeLong()).thenReturn(isSshdInstallProbe ? 1L : 0L);
+            when(response.getExitCodeLong()).thenReturn(isSshdInstallProbe ? (long) probeExitCode : 0L);
             return response;
         });
 
@@ -522,14 +558,12 @@ class Ec2ContainerManagerTest {
         when(harness.dockerClient.copyArchiveToContainerCmd(TEST_CONTAINER_ID)).thenReturn(copy);
         when(copy.withTarInputStream(any(InputStream.class))).thenReturn(copy);
 
-        Instance instance = instance("i-sshdinstallfail");
+        Instance instance = instance(instanceId);
 
         harness.manager.launch(instance, "ubuntu:24.04", "ssh-ed25519 AAAAtest", "us-west-2");
 
         awaitUntil(() -> "running".equals(instance.getState().getName()), Duration.ofSeconds(2));
-        verify(execCreate, timeout(2000)).withCmd(eq(SSHD_INSTALL_PROBE_CMD));
-        verify(execCreate, never()).withCmd(eq(new String[]{"ssh-keygen", "-A"}));
-        verify(execCreate, never()).withCmd(eq(new String[]{"/usr/sbin/sshd"}));
+        return execCreate;
     }
 
     private static LaunchHarness launchHarness() {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -246,6 +246,23 @@ class Ec2ContainerManagerTest {
     }
 
     @Test
+    void sshdInstallProbeAlsoInstallsTheSshClientPackage() {
+        // Packer's default file transfer runs scp *on the instance*, so a guest with only
+        // openssh-server fails the shell provisioner with "SCP failed to start. This usually
+        // means that SCP is not properly installed on the remote system." Real AMIs ship the
+        // client; installing only the server leaves sftp-server present but /usr/bin/scp
+        // absent. Package names verified against the images themselves: openssh-clients on
+        // rpm distributions, openssh-client on Debian, and apk's openssh already has both.
+        String script = SSHD_INSTALL_PROBE_CMD[2];
+
+        assertTrue(script.contains("openssh-server openssh-clients"), script);
+        assertTrue(script.contains("openssh-server openssh-client >"), script);
+        // The guard has to consider scp as well, or an image that already has sshd but no
+        // client skips the install and provisioning still fails with nothing in the logs.
+        assertTrue(script.contains("! command -v scp"), script);
+    }
+
+    @Test
     void metadataProxyStartCommandBindsAwsLinkLocalMetadataAddress() {
         String[] command = Ec2ContainerManager.metadataProxyStartCommand("floci", 9169);
 
@@ -442,9 +459,9 @@ class Ec2ContainerManagerTest {
     }
 
     private static final String[] SSHD_INSTALL_PROBE_CMD = {"sh", "-c",
-            "if ! command -v sshd >/dev/null 2>&1; then"
-            + "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server >/dev/null 2>&1;"
-            + "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server >/dev/null 2>&1;"
+            "if ! command -v sshd >/dev/null 2>&1 || ! command -v scp >/dev/null 2>&1; then"
+            + "  if command -v dnf >/dev/null 2>&1; then dnf install -y openssh-server openssh-clients >/dev/null 2>&1;"
+            + "  elif command -v apt-get >/dev/null 2>&1; then DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server openssh-client >/dev/null 2>&1;"
             + "  elif command -v apk >/dev/null 2>&1; then apk add --no-cache openssh >/dev/null 2>&1;"
             + "  fi;"
             + "fi;"


### PR DESCRIPTION
## Summary

EC2 guests get `openssh-server` but no client package, so the instance ends up with `sshd` and `sftp-server` but no `/usr/bin/scp`. Real AMIs carry both — Amazon Linux 2 ships `openssh-clients` in the base image.

Provisioning tools need `scp` **on the instance**. Packer's default file transfer for a `shell` provisioner uploads the script with `scp`, so a build against Floci fails immediately *after* connecting successfully:

```
==> amazon-ebs.floci: Connected to SSH!
Error uploading script: SCP failed to start. This usually means that
SCP is not properly installed on the remote system.
```

Confirmed on a guest: `/usr/libexec/openssh/sftp-server` is present (it comes with `openssh-server`), but `/usr/bin/scp` and `/usr/bin/sftp` are not.

## Fix

Install the client package alongside the server. Names were verified against the images rather than assumed:

```
amazonlinux:2   yum install -y openssh-clients    -> /usr/bin/scp, /usr/bin/sftp
ubuntu:24.04    apt-get install -y openssh-client -> /usr/bin/scp, /usr/bin/sftp
alpine:3        apk add openssh                   -> /usr/bin/scp, /usr/bin/sftp
```

So `apk` needs no change — its `openssh` package already contains both — and only the rpm and deb branches gain a package.

The install guard now also tests for `scp`. Keying it on `sshd` alone would skip the install on an image that already has the server but no client, leaving provisioning broken with nothing in the logs to explain it.

## Why it matters

Without this, a Packer build needs `ssh_file_transfer_method = "sftp"` as a workaround, which would not appear in a real template written against AWS. With it (plus #2448 for Amazon Linux 2 guests), a full `amazon-ebs` build runs unmodified against Floci apart from the address question in #2447.

## Tests

`sshdInstallProbeAlsoInstallsTheSshClientPackage` in `Ec2ContainerManagerTest`, asserting on the constant that the existing `verify(execCreate).withCmd(eq(SSHD_INSTALL_PROBE_CMD))` already binds to what the manager actually execs, so it cannot drift from production.

`Ec2ContainerManagerTest`: 22 tests, 0 failures, 0 errors.

## Note on overlap

This is independent of #2448 (yum) — Debian-based guests hit the missing-client problem too — but the two together are what make a stock Packer `shell` provisioner work on the default image.
