### PR TITLE
fix(appsync): wait for schema creation in SDK test

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppSyncTest.java
@@ -623,6 +623,8 @@ class AppSyncTest {
                         .build());
 
         assertThat(resp.status()).isNotNull();
+        SchemaStatus terminal = pollSchemaStatusToTerminal();
+        assertThat(terminal).isEqualTo(SchemaStatus.SUCCESS);
     }
 
     // ── Channel Namespaces ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- wait for the AWS-scalars schema creation request to reach a terminal state before the ordered channel-namespace tests begin
- assert SUCCESS for the valid schema so an unexpected terminal failure remains visible
- reuse the compatibility suite polling helper already used by the neighboring invalid-schema test

Closes #2453

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

The ordered Java SDK AppSync suite could call CreateChannelNamespace while StartSchemaCreation was still PROCESSING, producing an intermittent ConcurrentModificationException and cascading failures. The test now waits for schema creation to finish successfully before advancing.

## Testing

- ../../mvnw -f pom.xml test -Dtest=AppSyncTest (80 tests passed against a local Floci server)
- ../../mvnw -f pom.xml test -DskipTests (all Java SDK compatibility test sources compiled)
- git diff --check

## Checklist

- [ ] ./mvnw test passes locally (root full suite not run)
- [x] Updated Java SDK compatibility test
- [x] Commit messages follow Conventional Commits