### PR TITLE
fix(appsync): honor configured base URL in API URIs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -126,11 +126,7 @@ public class AppSyncService {
 
         api.setArn(buildApiArn(apiId, region));
 
-        String graphqlPath = "/v1/apis/" + apiId + "/graphql";
-        Map<String, String> uris = new HashMap<>();
-        uris.put("GRAPHQL", baseUrl + graphqlPath);
-        uris.put("REALTIME", toWebSocketBaseUrl(baseUrl) + graphqlPath + "/realtime");
-        api.setUris(uris);
+        api.setUris(graphqlApiUris(apiId));
 
         Map<String, Object> tags = castMap(request.get("tags"));
         if (tags != null) {
@@ -146,11 +142,14 @@ public class AppSyncService {
 
     public GraphqlApi getGraphqlApi(String apiId) {
         return apiStore.get(apiId)
+                .map(this::refreshGraphqlApiUris)
                 .orElseThrow(() -> new AwsException("NotFoundException", "GraphQL API not found: " + apiId, 404));
     }
 
     public Page<GraphqlApi> listGraphqlApis(Integer maxResults, String nextToken) {
-        return paginate(apiStore.scan(k -> true), nextToken, maxResults);
+        List<GraphqlApi> apis = apiStore.scan(k -> true);
+        apis.forEach(this::refreshGraphqlApiUris);
+        return paginate(apis, nextToken, maxResults);
     }
 
     @SuppressWarnings("unchecked")
@@ -1136,6 +1135,23 @@ public class AppSyncService {
 
     private static String toWebSocketBaseUrl(String value) {
         return value.replaceFirst("^http", "ws");
+    }
+
+    private Map<String, String> graphqlApiUris(String apiId) {
+        String graphqlPath = "/v1/apis/" + apiId + "/graphql";
+        Map<String, String> uris = new HashMap<>();
+        uris.put("GRAPHQL", baseUrl + graphqlPath);
+        uris.put("REALTIME", toWebSocketBaseUrl(baseUrl) + graphqlPath + "/realtime");
+        return uris;
+    }
+
+    private GraphqlApi refreshGraphqlApiUris(GraphqlApi api) {
+        Map<String, String> expectedUris = graphqlApiUris(api.getApiId());
+        if (!expectedUris.equals(api.getUris())) {
+            api.setUris(expectedUris);
+            apiStore.put(api.getApiId(), api);
+        }
+        return api;
     }
 
     private Integer castInt(Object value) {

--- a/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appsync/AppSyncService.java
@@ -44,6 +44,7 @@ public class AppSyncService {
     private final Instance<RequestContext> requestContextInstance;
     private final ObjectMapper objectMapper;
     private final Clock clock;
+    private final String baseUrl;
 
     @Inject
     public AppSyncService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver,
@@ -70,6 +71,7 @@ public class AppSyncService {
         this.requestContextInstance = requestContextInstance;
         this.objectMapper = objectMapper;
         this.clock = clock;
+        this.baseUrl = trimTrailingSlash(config.effectiveBaseUrl());
     }
 
     // ──────────────────────────── GraphQL API ────────────────────────────
@@ -124,10 +126,10 @@ public class AppSyncService {
 
         api.setArn(buildApiArn(apiId, region));
 
+        String graphqlPath = "/v1/apis/" + apiId + "/graphql";
         Map<String, String> uris = new HashMap<>();
-        String baseUri = "http://localhost:4566";
-        uris.put("GRAPHQL", baseUri + "/v1/apis/" + apiId + "/graphql");
-        uris.put("REALTIME", "ws://localhost:4566/v1/apis/" + apiId + "/graphql/realtime");
+        uris.put("GRAPHQL", baseUrl + graphqlPath);
+        uris.put("REALTIME", toWebSocketBaseUrl(baseUrl) + graphqlPath + "/realtime");
         api.setUris(uris);
 
         Map<String, Object> tags = castMap(request.get("tags"));
@@ -1126,6 +1128,14 @@ public class AppSyncService {
     private String coerceString(Object value, String defaultValue) {
         String result = coerceString(value);
         return result != null ? result : defaultValue;
+    }
+
+    private static String trimTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static String toWebSocketBaseUrl(String value) {
+        return value.replaceFirst("^http", "ws");
     }
 
     private Integer castInt(Object value) {

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncServiceTest.java
@@ -34,6 +34,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AppSyncServiceTest {
 
@@ -201,6 +202,38 @@ class AppSyncServiceTest {
     }
 
     @Test
+    void graphqlApiUrisUseConfiguredBaseUrlAndPersist() {
+        AppSyncService configuredService = newService(
+                Clock.fixed(NOW, ZoneOffset.UTC), "http://floci.example:4577/");
+
+        GraphqlApi api = configuredService.createGraphqlApi(
+                Map.of("name", "configured-url", "authenticationType", "API_KEY"), "us-east-1");
+        Map<String, String> expectedUris = Map.of(
+                "GRAPHQL", "http://floci.example:4577/v1/apis/" + api.getApiId() + "/graphql",
+                "REALTIME", "ws://floci.example:4577/v1/apis/" + api.getApiId() + "/graphql/realtime");
+
+        assertEquals(expectedUris, api.getUris());
+        assertEquals(expectedUris, configuredService.getGraphqlApi(api.getApiId()).getUris());
+        assertEquals(expectedUris, configuredService.listGraphqlApis(null, null).items().getFirst().getUris());
+    }
+
+    @Test
+    void graphqlApiRealtimeUriUsesSecureWebSocketForHttpsBaseUrl() {
+        AppSyncService configuredService = newService(
+                Clock.fixed(NOW, ZoneOffset.UTC), "https://floci.example:8443");
+
+        GraphqlApi api = configuredService.createGraphqlApi(
+                Map.of("name", "secure-url", "authenticationType", "API_KEY"), "us-east-1");
+
+        assertEquals(
+                "https://floci.example:8443/v1/apis/" + api.getApiId() + "/graphql",
+                api.getUris().get("GRAPHQL"));
+        assertEquals(
+                "wss://floci.example:8443/v1/apis/" + api.getApiId() + "/graphql/realtime",
+                api.getUris().get("REALTIME"));
+    }
+
+    @Test
     void createResolverDoesNotReregisterSchema() {
         GraphqlApi api = service.createGraphqlApi(Map.of("name", "r", "authenticationType", "API_KEY"), "us-east-1");
         service.createDataSource(api.getApiId(), Map.of("name", "none", "type", "NONE"), "us-east-1");
@@ -216,6 +249,11 @@ class AppSyncServiceTest {
 
     @SuppressWarnings("unchecked")
     private AppSyncService newService(Clock clock) {
+        return newService(clock, "http://localhost:4566");
+    }
+
+    @SuppressWarnings("unchecked")
+    private AppSyncService newService(Clock clock, String baseUrl) {
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
             public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
@@ -225,9 +263,11 @@ class AppSyncServiceTest {
         };
         Instance<RequestContext> requestContext = mock(Instance.class);
         schemaRegistry = mock(SchemaRegistry.class);
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        when(config.effectiveBaseUrl()).thenReturn(baseUrl);
         return new AppSyncService(
                 storageFactory,
-                mock(EmulatorConfig.class),
+                config,
                 new RegionResolver("us-east-1", "000000000000"),
                 schemaRegistry,
                 mock(SchemaCreationWorker.class),

--- a/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appsync/AppSyncServiceTest.java
@@ -31,8 +31,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -234,6 +237,43 @@ class AppSyncServiceTest {
     }
 
     @Test
+    void persistedGraphqlApiUrisAreRepairedOnGetListAndUpdate() {
+        AccountAwareStorageBackend<GraphqlApi> apiStore = spy(
+                AccountAwareStorageBackend.inMemory("000000000000"));
+        AppSyncService legacyService = newService(
+                Clock.fixed(NOW, ZoneOffset.UTC), "http://localhost:4566", apiStore);
+        GraphqlApi api = legacyService.createGraphqlApi(
+                Map.of("name", "persisted-api", "authenticationType", "API_KEY"), "us-east-1");
+        String apiId = api.getApiId();
+        Map<String, String> staleUris = api.getUris();
+
+        AppSyncService configuredService = newService(
+                Clock.fixed(NOW, ZoneOffset.UTC), "https://floci.example:8443/", apiStore);
+        Map<String, String> expectedUris = Map.of(
+                "GRAPHQL", "https://floci.example:8443/v1/apis/" + apiId + "/graphql",
+                "REALTIME", "wss://floci.example:8443/v1/apis/" + apiId + "/graphql/realtime");
+
+        clearInvocations(apiStore);
+        assertEquals(expectedUris, configuredService.getGraphqlApi(apiId).getUris());
+        verify(apiStore).put(apiId, api);
+
+        api.setUris(staleUris);
+        apiStore.put(apiId, api);
+        clearInvocations(apiStore);
+        assertEquals(expectedUris, configuredService.listGraphqlApis(null, null).items().getFirst().getUris());
+        verify(apiStore).put(apiId, api);
+
+        api.setUris(staleUris);
+        apiStore.put(apiId, api);
+        clearInvocations(apiStore);
+        GraphqlApi updated = configuredService.updateGraphqlApi(
+                apiId, Map.of("name", "updated-api"), "us-east-1");
+        assertEquals("updated-api", updated.getName());
+        assertEquals(expectedUris, updated.getUris());
+        verify(apiStore, times(2)).put(apiId, api);
+    }
+
+    @Test
     void createResolverDoesNotReregisterSchema() {
         GraphqlApi api = service.createGraphqlApi(Map.of("name", "r", "authenticationType", "API_KEY"), "us-east-1");
         service.createDataSource(api.getApiId(), Map.of("name", "none", "type", "NONE"), "us-east-1");
@@ -254,10 +294,19 @@ class AppSyncServiceTest {
 
     @SuppressWarnings("unchecked")
     private AppSyncService newService(Clock clock, String baseUrl) {
+        return newService(clock, baseUrl, AccountAwareStorageBackend.inMemory("000000000000"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private AppSyncService newService(Clock clock, String baseUrl,
+            AccountAwareStorageBackend<GraphqlApi> apiStore) {
         StorageFactory storageFactory = new StorageFactory(null, null) {
             @Override
             public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
+                if ("appsync-apis.json".equals(fileName)) {
+                    return (AccountAwareStorageBackend<V>) apiStore;
+                }
                 return AccountAwareStorageBackend.inMemory("000000000000");
             }
         };


### PR DESCRIPTION
## Summary

- build AppSync GRAPHQL URIs from EmulatorConfig.effectiveBaseUrl() instead of a hardcoded localhost:4566 address
- derive REALTIME URIs with ws:// or wss:// to preserve the configured transport security
- repair and persist stale URI maps when existing GraphQL APIs are read, listed, or updated after an upgrade or base URL change
- cover configured ports, trailing slashes, HTTPS, persistence, and migration of pre-existing records

Closes #2451

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

CreateGraphqlApi previously persisted GRAPHQL and REALTIME URIs pointing to localhost:4566 regardless of the externally visible Floci base URL. New APIs now honor effectiveBaseUrl(), including hostname and TLS configuration. Existing persisted APIs are lazily repaired and saved when GetGraphqlApi, ListGraphqlApis, or UpdateGraphqlApi encounters a stale URI map.

## Testing

- ./mvnw test -Dtest=AppSyncServiceTest (18 tests passed)
- git diff --check

## Checklist

- [ ] ./mvnw test passes locally (focused AppSync suite run locally; full suite runs in CI)
- [x] New or updated test added
- [x] Commit messages follow Conventional Commits