### PR TITLE
refactor(ses): add a test builder for SesService

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceDkimLookupCacheTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceDkimLookupCacheTest.java
@@ -1,23 +1,11 @@
 package io.github.hectorvent.floci.services.ses;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.route53.Route53Service;
 import io.github.hectorvent.floci.services.route53.model.HostedZone;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
-import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
-import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
-import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
-import io.github.hectorvent.floci.services.ses.model.ContactList;
-import io.github.hectorvent.floci.services.ses.model.Contact;
-import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
-import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
-import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
-import io.github.hectorvent.floci.services.ses.model.SentEmail;
-import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.testing.MutableClock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,26 +33,14 @@ class SesServiceDkimLookupCacheTest {
 
     @BeforeEach
     void setUp() {
-        identityStore = new InMemoryStorage<>();
         route53Service = mock(Route53Service.class);
         clock = new MutableClock();
         clock.reset();
-        service = new SesService(
-                identityStore,
-                new SesSentEmailService(new InMemoryStorage<String, SentEmail>()),
-                new SesAccountService(new InMemoryStorage<String, Boolean>(), new InMemoryStorage<String, AccountVdmAttributes>()),
-                new SesTemplateService(new InMemoryStorage<String, EmailTemplate>()),
-                new InMemoryStorage<String, ConfigurationSet>(),
-                new SesSuppressionService(new InMemoryStorage<String, SuppressedDestination>(), new InMemoryStorage<String, AccountSuppressionAttributes>()),
-                new SesDedicatedIpService(new InMemoryStorage<String, DedicatedIpPool>()),
-                new SesContactService(new InMemoryStorage<String, ContactList>(), new InMemoryStorage<String, Contact>(), clock),
-                new SesPolicyService(new InMemoryStorage<String, String>(), new ObjectMapper()),
-                new SesReceiptRuleService(new InMemoryStorage<String, ReceiptRuleSet>(), clock),
-                new SesCvetService(new InMemoryStorage<String, CustomVerificationEmailTemplate>()),
-                mock(SmtpRelay.class),
-                new ObjectMapper(),
-                route53Service,
-                clock);
+        SesServiceTestBuilder builder = SesServiceTestBuilder.create()
+                .route53Service(route53Service)
+                .clock(clock);
+        identityStore = builder.identityStore();
+        service = builder.build();
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceLegacyDkimTokensTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceLegacyDkimTokensTest.java
@@ -1,23 +1,10 @@
 package io.github.hectorvent.floci.services.ses;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
-import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
-import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
-import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
-import io.github.hectorvent.floci.services.ses.model.ContactList;
-import io.github.hectorvent.floci.services.ses.model.Contact;
-import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
-import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
-import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
 import io.github.hectorvent.floci.services.ses.model.Identity;
-import io.github.hectorvent.floci.services.ses.model.SentEmail;
-import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Clock;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 class SesServiceLegacyDkimTokensTest {
 
@@ -37,22 +23,9 @@ class SesServiceLegacyDkimTokensTest {
 
     @BeforeEach
     void setUp() {
-        identityStore = new InMemoryStorage<>();
-        service = new SesService(
-                identityStore,
-                new SesSentEmailService(new InMemoryStorage<String, SentEmail>()),
-                new SesAccountService(new InMemoryStorage<String, Boolean>(), new InMemoryStorage<String, AccountVdmAttributes>()),
-                new SesTemplateService(new InMemoryStorage<String, EmailTemplate>()),
-                new InMemoryStorage<String, ConfigurationSet>(),
-                new SesSuppressionService(new InMemoryStorage<String, SuppressedDestination>(), new InMemoryStorage<String, AccountSuppressionAttributes>()),
-                new SesDedicatedIpService(new InMemoryStorage<String, DedicatedIpPool>()),
-                new SesContactService(new InMemoryStorage<String, ContactList>(), new InMemoryStorage<String, Contact>(), Clock.systemUTC()),
-                new SesPolicyService(new InMemoryStorage<String, String>(), new ObjectMapper()),
-                new SesReceiptRuleService(new InMemoryStorage<String, ReceiptRuleSet>(), Clock.systemUTC()),
-                new SesCvetService(new InMemoryStorage<String, CustomVerificationEmailTemplate>()),
-                mock(SmtpRelay.class),
-                new ObjectMapper(),
-                Clock.systemUTC());
+        SesServiceTestBuilder builder = SesServiceTestBuilder.create();
+        identityStore = builder.identityStore();
+        service = builder.build();
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceListManagementTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceListManagementTest.java
@@ -3,20 +3,9 @@ package io.github.hectorvent.floci.services.ses;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
-import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
-import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
-import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.Contact;
-import io.github.hectorvent.floci.services.ses.model.ContactList;
-import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
-import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.ListManagementOptions;
 import io.github.hectorvent.floci.services.ses.model.MessageHeader;
-import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
-import io.github.hectorvent.floci.services.ses.model.SentEmail;
-import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.Topic;
 import io.github.hectorvent.floci.services.ses.model.TopicPreference;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +15,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Clock;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -57,22 +45,9 @@ class SesServiceListManagementTest {
 
     @BeforeEach
     void setUp() {
-        contactStore = new InMemoryStorage<>();
-        service = new SesService(
-                new InMemoryStorage<String, Identity>(),
-                new SesSentEmailService(new InMemoryStorage<String, SentEmail>()),
-                new SesAccountService(new InMemoryStorage<String, Boolean>(), new InMemoryStorage<String, AccountVdmAttributes>()),
-                new SesTemplateService(new InMemoryStorage<String, EmailTemplate>()),
-                new InMemoryStorage<String, ConfigurationSet>(),
-                new SesSuppressionService(new InMemoryStorage<String, SuppressedDestination>(), new InMemoryStorage<String, AccountSuppressionAttributes>()),
-                new SesDedicatedIpService(new InMemoryStorage<String, DedicatedIpPool>()),
-                new SesContactService(new InMemoryStorage<String, ContactList>(), contactStore, Clock.systemUTC()),
-                new SesPolicyService(new InMemoryStorage<String, String>(), new ObjectMapper()),
-                new SesReceiptRuleService(new InMemoryStorage<String, ReceiptRuleSet>(), Clock.systemUTC()),
-                new SesCvetService(new InMemoryStorage<String, CustomVerificationEmailTemplate>()),
-                smtpRelay,
-                new ObjectMapper(),
-                Clock.systemUTC());
+        SesServiceTestBuilder builder = SesServiceTestBuilder.create().smtpRelay(smtpRelay);
+        contactStore = builder.contactStore();
+        service = builder.build();
 
         // Sports defaults OPT_IN, Promos defaults OPT_OUT.
         service.createContactList(LIST, "desc", List.of(

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSmtpTest.java
@@ -1,26 +1,14 @@
 package io.github.hectorvent.floci.services.ses;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
-import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
-import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
-import io.github.hectorvent.floci.services.ses.model.ContactList;
-import io.github.hectorvent.floci.services.ses.model.Contact;
-import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
-import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
-import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.Identity;
 import io.github.hectorvent.floci.services.ses.model.SentEmail;
-import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Clock;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -36,22 +24,9 @@ class SesServiceSmtpTest {
 
     @BeforeEach
     void setUp() {
-        emailStore = new InMemoryStorage<>();
-        service = new SesService(
-                new InMemoryStorage<String, Identity>(),
-                new SesSentEmailService(emailStore),
-                new SesAccountService(new InMemoryStorage<String, Boolean>(), new InMemoryStorage<String, AccountVdmAttributes>()),
-                new SesTemplateService(new InMemoryStorage<String, EmailTemplate>()),
-                new InMemoryStorage<String, ConfigurationSet>(),
-                new SesSuppressionService(new InMemoryStorage<String, SuppressedDestination>(), new InMemoryStorage<String, AccountSuppressionAttributes>()),
-                new SesDedicatedIpService(new InMemoryStorage<String, DedicatedIpPool>()),
-                new SesContactService(new InMemoryStorage<String, ContactList>(), new InMemoryStorage<String, Contact>(), Clock.systemUTC()),
-                new SesPolicyService(new InMemoryStorage<String, String>(), new ObjectMapper()),
-                new SesReceiptRuleService(new InMemoryStorage<String, ReceiptRuleSet>(), Clock.systemUTC()),
-                new SesCvetService(new InMemoryStorage<String, CustomVerificationEmailTemplate>()),
-                smtpRelay,
-                new ObjectMapper(),
-                Clock.systemUTC());
+        SesServiceTestBuilder builder = SesServiceTestBuilder.create().smtpRelay(smtpRelay);
+        emailStore = builder.emailStore();
+        service = builder.build();
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionLegacyKeyTest.java
@@ -1,28 +1,13 @@
 package io.github.hectorvent.floci.services.ses;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
-import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
-import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
-import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
-import io.github.hectorvent.floci.services.ses.model.ContactList;
-import io.github.hectorvent.floci.services.ses.model.Contact;
-import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
-import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
-import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.Identity;
-import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Clock;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 /**
  * Backward-compat for suppression entries persisted by a pre-canonicalization Floci,
@@ -44,22 +29,9 @@ class SesServiceSuppressionLegacyKeyTest {
 
     @BeforeEach
     void setUp() {
-        suppressionStore = new InMemoryStorage<>();
-        service = new SesService(
-                new InMemoryStorage<String, Identity>(),
-                new SesSentEmailService(new InMemoryStorage<String, SentEmail>()),
-                new SesAccountService(new InMemoryStorage<String, Boolean>(), new InMemoryStorage<String, AccountVdmAttributes>()),
-                new SesTemplateService(new InMemoryStorage<String, EmailTemplate>()),
-                new InMemoryStorage<String, ConfigurationSet>(),
-                new SesSuppressionService(suppressionStore, new InMemoryStorage<String, AccountSuppressionAttributes>()),
-                new SesDedicatedIpService(new InMemoryStorage<String, DedicatedIpPool>()),
-                new SesContactService(new InMemoryStorage<String, ContactList>(), new InMemoryStorage<String, Contact>(), Clock.systemUTC()),
-                new SesPolicyService(new InMemoryStorage<String, String>(), new ObjectMapper()),
-                new SesReceiptRuleService(new InMemoryStorage<String, ReceiptRuleSet>(), Clock.systemUTC()),
-                new SesCvetService(new InMemoryStorage<String, CustomVerificationEmailTemplate>()),
-                mock(SmtpRelay.class),
-                new ObjectMapper(),
-                Clock.systemUTC());
+        SesServiceTestBuilder builder = SesServiceTestBuilder.create();
+        suppressionStore = builder.suppressionStore();
+        service = builder.build();
     }
 
     private void seedLegacyEntry() {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceSuppressionReasonTest.java
@@ -1,29 +1,16 @@
 package io.github.hectorvent.floci.services.ses;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
-import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
-import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
-import io.github.hectorvent.floci.services.ses.model.ContactList;
-import io.github.hectorvent.floci.services.ses.model.Contact;
-import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
-import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
-import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
-import io.github.hectorvent.floci.services.ses.model.Identity;
-import io.github.hectorvent.floci.services.ses.model.SentEmail;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.mock;
 
 /**
  * Covers {@link SesService#resolveSuppressionReason(String, String)} — the per-recipient
@@ -43,23 +30,10 @@ class SesServiceSuppressionReasonTest {
 
     @BeforeEach
     void setUp() {
-        suppressionStore = new InMemoryStorage<>();
-        accountSuppressionStore = new InMemoryStorage<>();
-        service = new SesService(
-                new InMemoryStorage<String, Identity>(),
-                new SesSentEmailService(new InMemoryStorage<String, SentEmail>()),
-                new SesAccountService(new InMemoryStorage<String, Boolean>(), new InMemoryStorage<String, AccountVdmAttributes>()),
-                new SesTemplateService(new InMemoryStorage<String, EmailTemplate>()),
-                new InMemoryStorage<String, ConfigurationSet>(),
-                new SesSuppressionService(suppressionStore, accountSuppressionStore),
-                new SesDedicatedIpService(new InMemoryStorage<String, DedicatedIpPool>()),
-                new SesContactService(new InMemoryStorage<String, ContactList>(), new InMemoryStorage<String, Contact>(), Clock.systemUTC()),
-                new SesPolicyService(new InMemoryStorage<String, String>(), new ObjectMapper()),
-                new SesReceiptRuleService(new InMemoryStorage<String, ReceiptRuleSet>(), Clock.systemUTC()),
-                new SesCvetService(new InMemoryStorage<String, CustomVerificationEmailTemplate>()),
-                mock(SmtpRelay.class),
-                new ObjectMapper(),
-                Clock.systemUTC());
+        SesServiceTestBuilder builder = SesServiceTestBuilder.create();
+        suppressionStore = builder.suppressionStore();
+        accountSuppressionStore = builder.accountSuppressionStore();
+        service = builder.build();
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
+import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.Contact;
+import io.github.hectorvent.floci.services.ses.model.ContactList;
+import io.github.hectorvent.floci.services.ses.model.CustomVerificationEmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.DedicatedIpPool;
+import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.ReceiptRuleSet;
+import io.github.hectorvent.floci.services.ses.model.SentEmail;
+import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
+import io.github.hectorvent.floci.services.route53.Route53Service;
+
+import java.time.Clock;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Builds a {@link SesService} for unit tests without the fourteen-argument constructor. Every domain
+ * is backed by an in-memory store by default; tests override only the collaborators they care about
+ * ({@link #smtpRelay}, {@link #clock}, {@link #route53Service}) and reach the underlying stores they
+ * need to seed or inspect through the getters. Adding a store to a domain service only touches this
+ * builder rather than every facade test.
+ */
+final class SesServiceTestBuilder {
+
+    private final InMemoryStorage<String, Identity> identityStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, SentEmail> emailStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, Boolean> accountSettingsStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, AccountVdmAttributes> accountVdmStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, EmailTemplate> templateStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, ConfigurationSet> configSetStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, SuppressedDestination> suppressionStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, AccountSuppressionAttributes> accountSuppressionStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, DedicatedIpPool> dedicatedIpPoolStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, ContactList> contactListStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, Contact> contactStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, String> policyStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, ReceiptRuleSet> receiptRuleStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, CustomVerificationEmailTemplate> cvetStore = new InMemoryStorage<>();
+
+    private SmtpRelay smtpRelay = mock(SmtpRelay.class);
+    // Default null, matching the production null-Route53 case: SesService treats a null Route53Service
+    // as "DNS lookup disabled" for DKIM record checks. Tests that exercise the lookup opt in via
+    // route53Service(...).
+    private Route53Service route53Service = null;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private Clock clock = Clock.systemUTC();
+
+    static SesServiceTestBuilder create() {
+        return new SesServiceTestBuilder();
+    }
+
+    SesServiceTestBuilder smtpRelay(SmtpRelay smtpRelay) {
+        this.smtpRelay = smtpRelay;
+        return this;
+    }
+
+    SesServiceTestBuilder route53Service(Route53Service route53Service) {
+        this.route53Service = route53Service;
+        return this;
+    }
+
+    SesServiceTestBuilder objectMapper(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+        return this;
+    }
+
+    // Shared by the contact, receipt-rule, and facade timestamps — pass a MutableClock to drive
+    // time-dependent behavior (e.g. the DKIM lookup cache TTL).
+    SesServiceTestBuilder clock(Clock clock) {
+        this.clock = clock;
+        return this;
+    }
+
+    InMemoryStorage<String, Identity> identityStore() {
+        return identityStore;
+    }
+
+    InMemoryStorage<String, SentEmail> emailStore() {
+        return emailStore;
+    }
+
+    InMemoryStorage<String, ConfigurationSet> configSetStore() {
+        return configSetStore;
+    }
+
+    InMemoryStorage<String, SuppressedDestination> suppressionStore() {
+        return suppressionStore;
+    }
+
+    InMemoryStorage<String, AccountSuppressionAttributes> accountSuppressionStore() {
+        return accountSuppressionStore;
+    }
+
+    InMemoryStorage<String, Contact> contactStore() {
+        return contactStore;
+    }
+
+    InMemoryStorage<String, ContactList> contactListStore() {
+        return contactListStore;
+    }
+
+    SesService build() {
+        return new SesService(
+                identityStore,
+                new SesSentEmailService(emailStore),
+                new SesAccountService(accountSettingsStore, accountVdmStore),
+                new SesTemplateService(templateStore),
+                configSetStore,
+                new SesSuppressionService(suppressionStore, accountSuppressionStore),
+                new SesDedicatedIpService(dedicatedIpPoolStore),
+                new SesContactService(contactListStore, contactStore, clock),
+                new SesPolicyService(policyStore, objectMapper),
+                new SesReceiptRuleService(receiptRuleStore, clock),
+                new SesCvetService(cvetStore),
+                smtpRelay,
+                objectMapper,
+                route53Service,
+                clock);
+    }
+}


### PR DESCRIPTION
## Summary

Add a test-scope `SesServiceTestBuilder` so unit tests construct `SesService` without its
fourteen-argument constructor. After the SES facade was split into per-domain services, six facade
unit tests (`SesServiceSmtpTest`, `SesServiceListManagementTest`, `SesServiceDkimLookupCacheTest`,
`SesServiceSuppressionLegacyKeyTest`, `SesServiceSuppressionReasonTest`, `SesServiceLegacyDkimTokensTest`)
each hand-wrote the full constructor, so adding a store to any domain service forced identical edits
across all of them. The builder defaults every domain to an in-memory store and exposes only the
collaborators a test overrides (`smtpRelay`, `clock`, `route53Service`) and the stores it seeds or
inspects, so a future store change touches one place instead of six.

The `route53Service` default is `null`, matching the production null-Route53 path (`SesService` treats
a null `Route53Service` as "DKIM DNS lookup disabled"); the cache test opts in explicitly. No
production code and no test behavior change.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire-protocol or behavior change — this is a test-only refactor. The six refactored SES unit tests
pass unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
