### PR TITLE
fix(dynamodb): stop getSortKeyNames() corrupting persisted tables

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.dynamodb.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -82,7 +83,13 @@ public class GlobalSecondaryIndex {
     /**
      * Returns all sort key attribute names in key-schema order. For a composite sort key this
      * contains more than one element; ordering must consider all of them, not just the first.
+     *
+     * <p>{@code @JsonIgnore}d: it is derived from {@code keySchema} (redundant with
+     * {@link #getSortKeyName()}), and without a backing setter Jackson's getter-as-setter
+     * fallback tries to append into the immutable list this method returns, throwing
+     * {@code UnsupportedOperationException} on deserialization whenever the index has a sort key.
      */
+    @JsonIgnore
     public List<String> getSortKeyNames() {
         return keySchema.stream()
                 .filter(k -> "RANGE".equals(k.getKeyType()))

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.dynamodb.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
@@ -81,7 +82,13 @@ public class LocalSecondaryIndex {
     /**
      * Returns all sort key attribute names in key-schema order. For a composite sort key this
      * contains more than one element; ordering must consider all of them, not just the first.
+     *
+     * <p>{@code @JsonIgnore}d: it is derived from {@code keySchema} (redundant with
+     * {@link #getSortKeyName()}), and without a backing setter Jackson's getter-as-setter
+     * fallback tries to append into the immutable list this method returns, throwing
+     * {@code UnsupportedOperationException} on deserialization whenever the index has a sort key.
      */
+    @JsonIgnore
     public List<String> getSortKeyNames() {
         return keySchema.stream()
                 .filter(k -> "RANGE".equals(k.getKeyType()))

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.dynamodb.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.quarkus.runtime.annotations.RegisterForReflection;
@@ -226,7 +227,13 @@ public class TableDefinition {
     /**
      * Returns all sort key attribute names in key-schema order. For a composite sort key this
      * contains more than one element; ordering must consider all of them, not just the first.
+     *
+     * <p>{@code @JsonIgnore}d: it is derived from {@code keySchema} (redundant with
+     * {@link #getSortKeyName()}), and without a backing setter Jackson's getter-as-setter
+     * fallback tries to append into the immutable list this method returns, throwing
+     * {@code UnsupportedOperationException} on deserialization whenever the table has a sort key.
      */
+    @JsonIgnore
     public List<String> getSortKeyNames() {
         return keySchema.stream()
                 .filter(k -> "RANGE".equals(k.getKeyType()))

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbGsiSortKeyRestartTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbGsiSortKeyRestartTest.java
@@ -1,0 +1,99 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Wire-protocol reproduction for floci-io/floci#2415: a table whose GSI (or LSI, or own primary
+ * key) has a RANGE key must survive a restart. Before the fix, {@code TableDefinition}'s Jackson
+ * round-trip threw on any such table; {@code PersistentStorage.load()} swallows that as an IOException,
+ * quarantines the file, and comes back up with zero tables in the whole store, not just the
+ * offending one.
+ *
+ * <p>The GSI case here matches the issue's own reproduction (base table HASH-only, GSI with a
+ * HASH+RANGE key schema). The LSI and base-table-composite-key cases share the identical root
+ * cause (getSortKeyNames() added to all three model classes together in #2114) and are covered at
+ * the model level by {@code SortKeyNamesJacksonRoundTripTest}.
+ */
+class DynamoDbGsiSortKeyRestartTest {
+
+    private static final String TABLE = "con-gsi";
+    private static final String REGION = "us-east-1";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    /** A store backed by a real file, so a "restart" is just reading it again. */
+    private StorageBackend<String, TableDefinition> diskStore(Path file) {
+        PersistentStorage<String, TableDefinition> store =
+                new PersistentStorage<>(file, new TypeReference<Map<String, TableDefinition>>() { });
+        store.load();
+        return store;
+    }
+
+    private DynamoDbJsonHandler handlerFor(StorageBackend<String, TableDefinition> store) {
+        DynamoDbService service = new DynamoDbService(
+                store, null, new RegionResolver(REGION, "000000000000"), null, null);
+        return new DynamoDbJsonHandler(service, null, null, mapper);
+    }
+
+    private ObjectNode createTableWithGsiSortKeyRequest() {
+        ObjectNode req = mapper.createObjectNode();
+        req.put("TableName", TABLE);
+        req.putArray("KeySchema").addObject().put("AttributeName", "PK").put("KeyType", "HASH");
+        var attrDefs = req.putArray("AttributeDefinitions");
+        attrDefs.addObject().put("AttributeName", "PK").put("AttributeType", "S");
+        attrDefs.addObject().put("AttributeName", "GSI1PK").put("AttributeType", "S");
+        attrDefs.addObject().put("AttributeName", "GSI1SK").put("AttributeType", "S");
+        req.put("BillingMode", "PAY_PER_REQUEST");
+        ObjectNode gsi = req.putArray("GlobalSecondaryIndexes").addObject();
+        gsi.put("IndexName", "GSI1");
+        var gsiKeySchema = gsi.putArray("KeySchema");
+        gsiKeySchema.addObject().put("AttributeName", "GSI1PK").put("KeyType", "HASH");
+        gsiKeySchema.addObject().put("AttributeName", "GSI1SK").put("KeyType", "RANGE");
+        gsi.putObject("Projection").put("ProjectionType", "ALL");
+        return req;
+    }
+
+    @Test
+    void tableWithGsiRangeKeySurvivesARestart(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("dynamodb-tables.json");
+        StorageBackend<String, TableDefinition> store = diskStore(file);
+
+        handlerFor(store).handle("CreateTable", createTableWithGsiSortKeyRequest(), REGION);
+
+        StorageBackend<String, TableDefinition> reopened = diskStore(file);
+        assertTrue(reopened.get(REGION + "::" + TABLE).isPresent(),
+                "a table with a GSI sort key must still be there after a restart");
+    }
+
+    @Test
+    void otherTablesSurviveEvenWhenOneHasAGsiRangeKey(@TempDir Path tmp) throws Exception {
+        Path file = tmp.resolve("dynamodb-tables.json");
+        StorageBackend<String, TableDefinition> store = diskStore(file);
+        DynamoDbJsonHandler handler = handlerFor(store);
+
+        handler.handle("CreateTable", createTableWithGsiSortKeyRequest(), REGION);
+        ObjectNode plainTable = mapper.createObjectNode();
+        plainTable.put("TableName", "plain-table");
+        plainTable.putArray("KeySchema").addObject().put("AttributeName", "id").put("KeyType", "HASH");
+        plainTable.putArray("AttributeDefinitions").addObject()
+                .put("AttributeName", "id").put("AttributeType", "S");
+        handler.handle("CreateTable", plainTable, REGION);
+
+        StorageBackend<String, TableDefinition> reopened = diskStore(file);
+        assertTrue(reopened.get(REGION + "::" + "plain-table").isPresent(),
+                "an unrelated table must not be wiped out by a sibling table's GSI sort key");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/model/SortKeyNamesJacksonRoundTripTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/model/SortKeyNamesJacksonRoundTripTest.java
@@ -1,0 +1,79 @@
+package io.github.hectorvent.floci.services.dynamodb.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Regression for floci-io/floci#2415: any {@code List<String>}-returning derived getter with no
+ * backing setter (here {@code getSortKeyNames()}) is a Jackson trap. On deserialization Jackson
+ * finds no setter, falls back to "getter as setter", calls the getter, and appends into the list
+ * it returned. {@code getSortKeyNames()} builds that list with {@code Stream.toList()}, which is
+ * immutable, so the append throws {@code UnsupportedOperationException} for every RANGE-keyed
+ * schema and is swallowed as {@code []} only when there is no sort key to append.
+ *
+ * <p>{@code getSortKeyNames()} was added to all three classes in the same commit (#2114), so the
+ * trap is identical on {@link GlobalSecondaryIndex}, {@link LocalSecondaryIndex} and
+ * {@link TableDefinition} itself (a table with its own composite primary key), even though the
+ * issue only reports the GSI case.
+ */
+class SortKeyNamesJacksonRoundTripTest {
+
+    /** Same configuration {@code PersistentStorage}, {@code HybridStorage} and {@code WalStorage} use. */
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    SortKeyNamesJacksonRoundTripTest() {
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+    }
+
+    private List<KeySchemaElement> hashAndRangeSchema(String hashName, String rangeName) {
+        return List.of(
+                new KeySchemaElement(hashName, "HASH"),
+                new KeySchemaElement(rangeName, "RANGE"));
+    }
+
+    @Test
+    void globalSecondaryIndexWithSortKeySurvivesARoundTrip() {
+        GlobalSecondaryIndex gsi = new GlobalSecondaryIndex(
+                "GSI1", hashAndRangeSchema("GSI1PK", "GSI1SK"), null, "ALL", null);
+
+        String json = assertDoesNotThrow(() -> mapper.writeValueAsString(gsi));
+        GlobalSecondaryIndex reloaded =
+                assertDoesNotThrow(() -> mapper.readValue(json, GlobalSecondaryIndex.class));
+
+        assertEquals(List.of("GSI1SK"), reloaded.getSortKeyNames());
+    }
+
+    @Test
+    void localSecondaryIndexWithSortKeySurvivesARoundTrip() {
+        LocalSecondaryIndex lsi = new LocalSecondaryIndex(
+                "LSI1", hashAndRangeSchema("PK", "LSI1SK"), null, "ALL");
+
+        String json = assertDoesNotThrow(() -> mapper.writeValueAsString(lsi));
+        LocalSecondaryIndex reloaded =
+                assertDoesNotThrow(() -> mapper.readValue(json, LocalSecondaryIndex.class));
+
+        assertEquals(List.of("LSI1SK"), reloaded.getSortKeyNames());
+    }
+
+    @Test
+    void tableWithACompositePrimaryKeySurvivesARoundTrip() {
+        TableDefinition table = new TableDefinition();
+        table.setTableName("orders");
+        table.setKeySchema(hashAndRangeSchema("PK", "SK"));
+
+        String json = assertDoesNotThrow(() -> mapper.writeValueAsString(table));
+        TableDefinition reloaded =
+                assertDoesNotThrow(() -> mapper.readValue(json, TableDefinition.class));
+
+        assertEquals(List.of("SK"), reloaded.getSortKeyNames());
+    }
+}


### PR DESCRIPTION
## Summary

`GlobalSecondaryIndex`, `LocalSecondaryIndex`, and `TableDefinition` each expose `getSortKeyNames()` with no backing setter. Jackson's getter-as-setter fallback appends into the list it returns, which is an immutable `Stream.toList()`, throwing `UnsupportedOperationException` whenever the schema has a RANGE key. On startup, `PersistentStorage`, `HybridStorage`, and `WalStorage` each catch that as an unreadable file and reload with zero tables, taking down every table in the store rather than only the one whose schema triggered it. This fix marks `getSortKeyNames()` `@JsonIgnore` on all three classes, since the value is already derived from `keySchema` and was always redundant with `getSortKeyName()`. Closes #2415.

While reviewing the AWS documentation for the multi-attribute key schema feature this bug lives in (added in #2114), I found four further compatibility gaps in the same feature area that are out of scope for this fix and are tracked separately in #2459, #2460, #2461, and #2462.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Any table whose GSI or LSI had a sort key, or whose own primary key was composite (partition key plus sort key), failed to reload after a restart under `persistent`, `hybrid`, or `wal` storage. The `persistent` backend additionally renamed the on-disk snapshot to `.corrupt`, making the loss permanent rather than recoverable. Reproduced with the AWS CLI against a local floci instance both before and after the fix; the regression tests added here reproduce the exact stack trace from #2415 and confirm the restart now round-trips the table correctly.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
