### PR TITLE
feat(ses): support +label subaddressing on mailbox simulator addresses

### DIFF
--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -271,6 +271,8 @@ Floci recognises the AWS [mailbox simulator addresses](https://docs.aws.amazon.c
 | `complaint@simulator.amazonses.com` | `Complaint` |
 | `suppressionlist@simulator.amazonses.com` | `Reject` |
 
+A `+label` subaddress is supported on any of these, so `bounce+order-123@simulator.amazonses.com` triggers a `Bounce` just like the bare address — the label lets senders distinguish test messages. Only `+` separates the label; `bounce-label@...` is not a simulator address.
+
 A successful send without a simulator-address recipient emits only the `Send` event.
 
 Account-level VDM (Virtual Deliverability Manager) attributes are stored per region. `PutAccountVdmAttributes` sets `VdmEnabled` (opt-in, defaults `DISABLED`) plus the optional `DashboardAttributes.EngagementMetrics` and `GuardianAttributes.OptimizedSharedDelivery`. `GetAccount` omits `VdmAttributes` until VDM has been configured for the region, then returns `VdmEnabled`, adding the `DashboardAttributes`/`GuardianAttributes` sub-objects only while `VdmEnabled` is `ENABLED`. Floci stores the settings but does not run VDM analytics.

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SimulatorAddresses.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SimulatorAddresses.java
@@ -4,6 +4,12 @@ package io.github.hectorvent.floci.services.ses;
  * Recognises the AWS Amazon SES mailbox simulator addresses
  * (see https://docs.aws.amazon.com/ses/latest/dg/send-an-email-from-console.html#send-email-simulator)
  * so Floci can deterministically emit the matching event types.
+ *
+ * <p>The simulator supports a label (subaddressing) on the local part so senders can distinguish test
+ * messages, e.g. {@code bounce+order-123@simulator.amazonses.com} triggers a bounce just like the bare
+ * {@code bounce@simulator.amazonses.com}. Matching strips a {@code +label} suffix from the local part
+ * (only {@code +} is a separator — {@code bounce-label@...} is not a bounce) before comparing the type
+ * case-insensitively.
  */
 final class SimulatorAddresses {
 
@@ -15,22 +21,37 @@ final class SimulatorAddresses {
     private SimulatorAddresses() {}
 
     static boolean isSuccess(String address) {
-        return SUCCESS.equalsIgnoreCase(strip(address));
+        return SUCCESS.equalsIgnoreCase(canonicalize(address));
     }
 
     static boolean isBounce(String address) {
-        return BOUNCE.equalsIgnoreCase(strip(address));
+        return BOUNCE.equalsIgnoreCase(canonicalize(address));
     }
 
     static boolean isComplaint(String address) {
-        return COMPLAINT.equalsIgnoreCase(strip(address));
+        return COMPLAINT.equalsIgnoreCase(canonicalize(address));
     }
 
     static boolean isSuppressionList(String address) {
-        return SUPPRESSION_LIST.equalsIgnoreCase(strip(address));
+        return SUPPRESSION_LIST.equalsIgnoreCase(canonicalize(address));
     }
 
-    private static String strip(String address) {
-        return address == null ? null : address.trim();
+    // Drop a +label subaddress from the local part so labelled simulator addresses match their type,
+    // leaving the domain untouched. A non-simulator or malformed address is returned trimmed as-is.
+    private static String canonicalize(String address) {
+        if (address == null) {
+            return null;
+        }
+        String trimmed = address.trim();
+        int at = trimmed.indexOf('@');
+        if (at < 0) {
+            return trimmed;
+        }
+        String localPart = trimmed.substring(0, at);
+        int plus = localPart.indexOf('+');
+        if (plus < 0) {
+            return trimmed;
+        }
+        return localPart.substring(0, plus) + trimmed.substring(at);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SimulatorAddressesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SimulatorAddressesTest.java
@@ -30,11 +30,39 @@ class SimulatorAddressesTest {
     }
 
     @Test
+    void recognisesLabelledAddresses() {
+        // The simulator supports a +label subaddress so senders can distinguish test messages.
+        assertTrue(SimulatorAddresses.isBounce("bounce+order-123@simulator.amazonses.com"));
+        assertTrue(SimulatorAddresses.isSuccess("success+anything@simulator.amazonses.com"));
+        assertTrue(SimulatorAddresses.isComplaint("complaint+abc@simulator.amazonses.com"));
+        assertTrue(SimulatorAddresses.isSuppressionList("suppressionlist+x@simulator.amazonses.com"));
+        // Label with dots, an empty label, and an upper-case type are all still recognised.
+        assertTrue(SimulatorAddresses.isBounce("bounce+a.b.c@simulator.amazonses.com"));
+        assertTrue(SimulatorAddresses.isBounce("bounce+@simulator.amazonses.com"));
+        assertTrue(SimulatorAddresses.isBounce("Bounce+Label@simulator.amazonses.com"));
+    }
+
+    @Test
+    void onlyPlusIsALabelSeparator() {
+        // A hyphen is part of the local part, not a label separator, so this is not a bounce.
+        assertFalse(SimulatorAddresses.isBounce("bounce-mylabel@simulator.amazonses.com"));
+    }
+
+    @Test
+    void labelDoesNotMakeUnknownTypesMatch() {
+        // An unknown type with a label is not any simulator event.
+        assertFalse(SimulatorAddresses.isSuccess("delivery+x@simulator.amazonses.com"));
+        assertFalse(SimulatorAddresses.isBounce("delivery+x@simulator.amazonses.com"));
+    }
+
+    @Test
     void rejectsRegularAddresses() {
         assertFalse(SimulatorAddresses.isSuccess("user@example.com"));
         assertFalse(SimulatorAddresses.isBounce("user@example.com"));
         assertFalse(SimulatorAddresses.isComplaint("user@example.com"));
         assertFalse(SimulatorAddresses.isSuppressionList("user@example.com"));
+        // A +label on a non-simulator domain must not match either.
+        assertFalse(SimulatorAddresses.isBounce("bounce+label@example.com"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

The SES mailbox simulator lets senders add a `+label` to distinguish test messages, so
`bounce+order-123@simulator.amazonses.com` triggers a bounce just like the bare
`bounce@simulator.amazonses.com`. Floci previously matched the simulator addresses by exact
(trimmed, case-insensitive) equality, so any labelled address was treated as a normal recipient and
emitted only the `Send` event.

`SimulatorAddresses` now strips a `+label` suffix from the local part before comparing the type
case-insensitively. Only `+` separates the label (a hyphen does not — `bounce-label@...` is not a
simulator address), the domain is left untouched, and a `+label` on a non-simulator domain does not
match. This affects `success`, `bounce`, `complaint`, and `suppressionlist`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the real AWS SES mailbox simulator (SES v2 `SendEmail`, us-east-1): labelled
addresses (`bounce+mylabel`, `success+order-123`, empty label `bounce+`, upper-case type
`Bounce+Label`, dotted label `bounce+a.b.c`) are all accepted, matching the documented `+`
subaddressing. The `+`-before-label type rule follows the AWS mailbox-simulator documentation. Unit
tests cover the label, edge, and non-matching cases; the SES send/event integration tests pass
unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
