### PR TITLE
fix(ecr): join the ECR API with the backing registry

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecr/EcrService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/EcrService.java
@@ -199,18 +199,28 @@ public class EcrService {
         if (force && !tags.isEmpty()) {
             // Delete every manifest so blobs are unreferenced and tags stop
             // resolving; registry garbage-collect reclaims the bytes later.
+            // Any failure aborts the deletion (metadata stays) so the API
+            // never reports success while registry content remains pullable.
             RegistryHttpClient http = registryManager.httpClient();
             String internal = resolveRegistryRepoName(account, region, repositoryName);
             int deleted = 0;
-            for (String tag : tags) {
-                try {
+            try {
+                for (String tag : tags) {
                     String digest = http.headManifestDigest(internal, tag, null);
-                    if (digest != null && http.deleteManifest(internal, digest)) {
+                    if (digest != null) {
+                        if (!http.deleteManifest(internal, digest)) {
+                            throw new AwsException("InternalFailure",
+                                    "Failed to delete manifest " + digest + " from the backing registry", 500);
+                        }
                         deleted++;
                     }
-                } catch (Exception e) {
-                    LOG.warnv("Force-delete of {0}:{1} failed: {2}", repositoryName, tag, e.getMessage());
                 }
+            } catch (AwsException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new AwsException("InternalFailure",
+                        "Failed to clean up the backing registry for repository '" + repositoryName + "': "
+                                + e.getMessage(), 500);
             }
             LOG.infov("Force-deleting ECR repository {0}: removed {1}/{2} manifest(s)",
                     repositoryName, deleted, tags.size());
@@ -535,19 +545,35 @@ public class EcrService {
      * Resolves the repository name as stored in the backing registry.
      * Hostname-style URIs ({@code <account>.dkr.ecr.<region>.localhost:<port>/<repo>})
      * reach the raw registry, so docker pushes land under the bare repo name,
-     * while path-style URIs land under {@code <account>/<region>/<repo>}. Prefer
-     * the namespaced form; fall back to the bare name when nothing is stored
-     * there (issue #2444).
+     * while path-style URIs land under {@code <account>/<region>/<repo>}.
+     * Resolution uses catalog membership (not tag listing) so untagged,
+     * digest-only repositories resolve correctly. The namespaced form wins
+     * when both exist.
+     *
+     * <p>Ambiguity guard: a bare-name entry can only be claimed when no
+     * <em>other</em> account/region has metadata for the same repository name.
+     * Otherwise the bare entry's owning scope is unknown and resolving to it
+     * would let one scope read or delete another scope's images, so the call
+     * falls back to the (empty) namespaced form.
      */
     private String resolveRegistryRepoName(String account, String region, String repoName) {
         String internal = registryManager.internalRepoName(account, region, repoName);
         try {
-            RegistryHttpClient http = registryManager.httpClient();
-            if (!http.listTags(internal).isEmpty()) {
+            List<String> catalog = registryManager.httpClient().catalog();
+            if (catalog.contains(internal)) {
                 return internal;
             }
-            if (!http.listTags(repoName).isEmpty()) {
-                return repoName;
+            if (catalog.contains(repoName)) {
+                String prefix = region + "::";
+                boolean otherScopeClaimsIt = repoStore.scan(k -> k.startsWith(prefix))
+                        .stream()
+                        .anyMatch(r -> !r.getRegistryId().equals(account)
+                                && r.getRepositoryName().equals(repoName));
+                if (!otherScopeClaimsIt) {
+                    return repoName;
+                }
+                LOG.warnv("Bare registry entry {0} claimed by another account/region; "
+                        + "resolving {1} to its namespaced form", repoName, internal);
             }
         } catch (Exception e) {
             LOG.debugv("Registry lookup failed while resolving {0}: {1}", repoName, e.getMessage());

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/EcrService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/EcrService.java
@@ -197,9 +197,23 @@ public class EcrService {
         }
 
         if (force && !tags.isEmpty()) {
-            // Phase 5 will issue real DELETE /v2/<name>/manifests/<digest> calls.
-            LOG.infov("Force-deleting ECR repository {0} containing {1} tag(s) (manifest deletion deferred)",
-                    repositoryName, tags.size());
+            // Delete every manifest so blobs are unreferenced and tags stop
+            // resolving; registry garbage-collect reclaims the bytes later.
+            RegistryHttpClient http = registryManager.httpClient();
+            String internal = resolveRegistryRepoName(account, region, repositoryName);
+            int deleted = 0;
+            for (String tag : tags) {
+                try {
+                    String digest = http.headManifestDigest(internal, tag, null);
+                    if (digest != null && http.deleteManifest(internal, digest)) {
+                        deleted++;
+                    }
+                } catch (Exception e) {
+                    LOG.warnv("Force-delete of {0}:{1} failed: {2}", repositoryName, tag, e.getMessage());
+                }
+            }
+            LOG.infov("Force-deleting ECR repository {0}: removed {1}/{2} manifest(s)",
+                    repositoryName, deleted, tags.size());
         }
 
         repoStore.delete(key);
@@ -232,7 +246,7 @@ public class EcrService {
     public List<ImageIdentifier> listImages(String repositoryName, String registryId, String region) {
         Repository repo = requireRepo(repositoryName, registryId, region);
         registryManager.ensureStarted();
-        String internal = registryManager.internalRepoName(repo.getRegistryId(), region, repositoryName);
+        String internal = resolveRegistryRepoName(repo.getRegistryId(), region, repositoryName);
         try {
             RegistryHttpClient http = registryManager.httpClient();
             List<String> tags = http.listTags(internal);
@@ -254,7 +268,7 @@ public class EcrService {
                                                 String region) {
         Repository repo = requireRepo(repositoryName, registryId, region);
         registryManager.ensureStarted();
-        String internal = registryManager.internalRepoName(repo.getRegistryId(), region, repositoryName);
+        String internal = resolveRegistryRepoName(repo.getRegistryId(), region, repositoryName);
         RegistryHttpClient http = registryManager.httpClient();
 
         List<String> refs = new ArrayList<>();
@@ -329,7 +343,7 @@ public class EcrService {
                                               String region) {
         Repository repo = requireRepo(repositoryName, registryId, region);
         registryManager.ensureStarted();
-        String internal = registryManager.internalRepoName(repo.getRegistryId(), region, repositoryName);
+        String internal = resolveRegistryRepoName(repo.getRegistryId(), region, repositoryName);
         RegistryHttpClient http = registryManager.httpClient();
 
         List<Image> images = new ArrayList<>();
@@ -369,7 +383,7 @@ public class EcrService {
                                                     String region) {
         Repository repo = requireRepo(repositoryName, registryId, region);
         registryManager.ensureStarted();
-        String internal = registryManager.internalRepoName(repo.getRegistryId(), region, repositoryName);
+        String internal = resolveRegistryRepoName(repo.getRegistryId(), region, repositoryName);
         RegistryHttpClient http = registryManager.httpClient();
 
         List<ImageIdentifier> deleted = new ArrayList<>();
@@ -510,11 +524,35 @@ public class EcrService {
     private List<String> listTagsBestEffort(String account, String region, String repoName) {
         try {
             return registryManager.httpClient()
-                    .listTags(registryManager.internalRepoName(account, region, repoName));
+                    .listTags(resolveRegistryRepoName(account, region, repoName));
         } catch (Exception e) {
             LOG.debugv("Could not list tags for {0} (registry not available): {1}", repoName, e.getMessage());
             return List.of();
         }
+    }
+
+    /**
+     * Resolves the repository name as stored in the backing registry.
+     * Hostname-style URIs ({@code <account>.dkr.ecr.<region>.localhost:<port>/<repo>})
+     * reach the raw registry, so docker pushes land under the bare repo name,
+     * while path-style URIs land under {@code <account>/<region>/<repo>}. Prefer
+     * the namespaced form; fall back to the bare name when nothing is stored
+     * there (issue #2444).
+     */
+    private String resolveRegistryRepoName(String account, String region, String repoName) {
+        String internal = registryManager.internalRepoName(account, region, repoName);
+        try {
+            RegistryHttpClient http = registryManager.httpClient();
+            if (!http.listTags(internal).isEmpty()) {
+                return internal;
+            }
+            if (!http.listTags(repoName).isEmpty()) {
+                return repoName;
+            }
+        } catch (Exception e) {
+            LOG.debugv("Registry lookup failed while resolving {0}: {1}", repoName, e.getMessage());
+        }
+        return internal;
     }
 
     private static String key(String region, String account, String repoName) {

--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/RegistryHttpClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/RegistryHttpClient.java
@@ -49,26 +49,47 @@ public class RegistryHttpClient {
         }
     }
 
-    /** Lists all repository names known to the backing registry. */
+    /**
+     * Lists all repository names known to the backing registry, following the
+     * {@code Link} header pagination that {@code GET /v2/_catalog} uses
+     * (registry:2 caps each page at 100 entries by default).
+     */
     public List<String> catalog() throws IOException, InterruptedException {
-        HttpResponse<String> resp = http.send(
-                HttpRequest.newBuilder(URI.create(baseUrl + "/v2/_catalog"))
-                        .timeout(Duration.ofSeconds(10))
-                        .GET()
-                        .build(),
-                HttpResponse.BodyHandlers.ofString());
-        if (resp.statusCode() != 200) {
-            LOG.warnv("Registry catalog returned {0}: {1}", resp.statusCode(), resp.body());
-            return Collections.emptyList();
-        }
-        JsonNode root = MAPPER.readTree(resp.body());
-        JsonNode repos = root.get("repositories");
-        if (repos == null || !repos.isArray()) {
-            return Collections.emptyList();
-        }
         List<String> out = new ArrayList<>();
-        repos.forEach(n -> out.add(n.asText()));
+        String url = baseUrl + "/v2/_catalog";
+        for (int page = 0; page < 10_000 && url != null; page++) {
+            HttpResponse<String> resp = http.send(
+                    HttpRequest.newBuilder(URI.create(url))
+                            .timeout(Duration.ofSeconds(10))
+                            .GET()
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() != 200) {
+                LOG.warnv("Registry catalog returned {0}: {1}", resp.statusCode(), resp.body());
+                break;
+            }
+            JsonNode root = MAPPER.readTree(resp.body());
+            JsonNode repos = root.get("repositories");
+            if (repos != null && repos.isArray()) {
+                repos.forEach(n -> out.add(n.asText()));
+            }
+            url = nextCatalogPage(resp.headers().firstValue("Link").orElse(null));
+        }
         return out;
+    }
+
+    /** Extracts {@code </v2/_catalog?n=..&last=..>} from a registry Link header. */
+    private String nextCatalogPage(String link) {
+        if (link == null || link.isBlank()) {
+            return null;
+        }
+        int start = link.indexOf('<');
+        int end = link.indexOf('>');
+        if (start < 0 || end <= start) {
+            return null;
+        }
+        String target = link.substring(start + 1, end);
+        return target.startsWith("/") ? baseUrl + target : target;
     }
 
     /** Lists tags for a repository. Returns an empty list if the repo is not yet known to the registry. */

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
@@ -305,6 +305,99 @@ class EcrServiceTest {
     }
 
     @Test
+    void untaggedDigestOnlyRepositoryResolvesAndDescribes() throws Exception {
+        // A bare-name repo whose only manifest is untagged (digest-addressable):
+        // tags/list returns null tags, but the catalog still lists the repo, so
+        // resolution must not misroute it (Greptile P1: untagged images).
+        String repositoryName = "probe/untagged";
+        String digest = "sha256:4444444444444444444444444444444444444444444444444444444444444444";
+        String manifest = """
+                {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": 1, "digest": "sha256:c"},
+                  "layers": []
+                }
+                """;
+
+        try (UntaggedRegistryServer registry = new UntaggedRegistryServer(repositoryName, digest)) {
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            service.createRepository(repositoryName, null, null, null, null, null, null, REGION);
+
+            // BatchGetImage by digest resolves the bare-name entry via catalog membership.
+            EcrService.BatchGetImageResult got = service.batchGetImage(
+                    repositoryName,
+                    List.of(new ImageIdentifier(null, digest)),
+                    null, null, REGION);
+            assertTrue(got.failures().isEmpty(), () -> "unexpected failures: " + got.failures());
+            assertEquals(1, got.images().size());
+        }
+    }
+
+    @Test
+    void bareEntryClaimedByOtherAccountIsNotResolvedForThisScope() throws Exception {
+        // Both accounts have metadata for the same repo name in the same region;
+        // only ONE bare registry entry exists. Account A's lookups must resolve
+        // to its own (namespaced, empty) entry, never to the shared bare entry
+        // holding account B's images (Greptile P1: scope isolation).
+        String repositoryName = "probe/shared-name";
+        String tag = "v1";
+        String digest = "sha256:6666666666666666666666666666666666666666666666666666666666666666";
+        String manifest = """
+                {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": 1, "digest": "sha256:c"},
+                  "layers": []
+                }
+                """;
+
+        try (FakeRegistryServer registry =
+                new FakeRegistryServer(repositoryName, tag, digest, manifest)) {
+            // The fake serves the BARE name in its catalog and tags — simulating
+            // a hostname-style push that bypassed the namespacing.
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            // Account B created metadata for the same name.
+            service.createRepository(repositoryName, "111111111111", null, null, null, null, null, REGION);
+            // Account A creates its own repository; its namespaced entry does not
+            // exist in this registry, but a bare entry with that name DOES — the
+            // ambiguity guard must keep resolution on A's namespaced form.
+            service.createRepository(repositoryName, ACCOUNT, null, null, null, null, null, REGION);
+
+            List<ImageIdentifier> ids = service.listImages(repositoryName, ACCOUNT, REGION);
+            assertTrue(ids.isEmpty(),
+                    "bare entry owned by another account must not resolve for this scope");
+        }
+    }
+
+    @Test
+    void deleteRepositoryForceFailsWhenRegistryCleanupFails() throws Exception {
+        // Registry rejects the manifest DELETE: force-delete must surface an
+        // error and keep the metadata row instead of reporting success
+        // (Greptile P1: suppressed cleanup failures).
+        String repositoryName = "probe/failing-delete";
+        String tag = "v1";
+        String digest = "sha256:5555555555555555555555555555555555555555555555555555555555555555";
+        try (DeleteRejectingRegistryServer registry =
+                new DeleteRejectingRegistryServer(repositoryName, tag, digest)) {
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            service.createRepository(repositoryName, null, null, null, null, null, null, REGION);
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> service.deleteRepository(repositoryName, null, true, REGION));
+            assertEquals("InternalFailure", ex.getErrorCode());
+
+            // Metadata survives so the operator can retry after fixing the registry.
+            assertEquals(1, service.describeRepositories(List.of(repositoryName), null, REGION).size());
+        }
+    }
+
+    @Test
     void putImageTagMutability_roundTrips() {
         service.createRepository(REPO, null, null, null, null, null, null, REGION);
         Repository updated = service.putImageTagMutability(REPO, null, "IMMUTABLE", REGION);
@@ -448,6 +541,10 @@ class EcrServiceTest {
                 send(exchange, 200, "");
                 return;
             }
+            if ("/v2/_catalog".equals(path) && "GET".equals(method)) {
+                sendJson(exchange, 200, "{\"repositories\":[\"" + repository + "\"]}");
+                return;
+            }
             if (path.equals("/v2/" + repository + "/manifests/" + digest) && "DELETE".equals(method)) {
                 deletedDigests.add(digest);
                 exchange.sendResponseHeaders(202, -1);
@@ -471,6 +568,200 @@ class EcrServiceTest {
                 exchange.getResponseHeaders().add("Content-Type",
                         "application/vnd.docker.distribution.manifest.v2+json");
                 send(exchange, 200, manifest);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        }
+
+        private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            send(exchange, status, body);
+        }
+
+        private static void send(HttpExchange exchange, int status, String body) throws IOException {
+            byte[] bytes = body.getBytes();
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    /** Registry serving a catalog entry whose repository has no tags (digest-only). */
+    private static final class UntaggedRegistryServer implements AutoCloseable {
+        private final HttpServer server;
+        private final String repository;
+        private final String digest;
+
+        private UntaggedRegistryServer(String repository, String digest) throws IOException {
+            this.repository = repository;
+            this.digest = digest;
+            this.server = HttpServer.create(new InetSocketAddress(0), 0);
+            this.server.createContext("/v2/", this::handle);
+            this.server.start();
+        }
+
+        private int port() {
+            return server.getAddress().getPort();
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            if ("/v2/".equals(path) && "GET".equals(method)) {
+                send(exchange, 200, "");
+                return;
+            }
+            if ("/v2/_catalog".equals(path) && "GET".equals(method)) {
+                sendJson(exchange, 200, "{\"repositories\":[\"" + repository + "\"]}");
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/tags/list") && "GET".equals(method)) {
+                // registry:2 returns tags: null when only untagged manifests exist.
+                sendJson(exchange, 200, "{\"name\":\"" + repository + "\",\"tags\":null}");
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/manifests/" + digest)
+                    && ("GET".equals(method) || "HEAD".equals(method))) {
+                exchange.getResponseHeaders().add("Docker-Content-Digest", digest);
+                if ("HEAD".equals(method)) {
+                    exchange.sendResponseHeaders(200, -1);
+                    exchange.close();
+                    return;
+                }
+                exchange.getResponseHeaders().add("Content-Type",
+                        "application/vnd.docker.distribution.manifest.v2+json");
+                send(exchange, 200, "{\"schemaVersion\":2,\"config\":{\"size\":1},\"layers\":[]}");
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        }
+
+        private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            send(exchange, status, body);
+        }
+
+        private static void send(HttpExchange exchange, int status, String body) throws IOException {
+            byte[] bytes = body.getBytes();
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    /** Registry that reports a fixed catalog; nothing else resolves. */
+    private static final class CatalogOnlyRegistryServer implements AutoCloseable {
+        private final HttpServer server;
+        private final List<String> repositories;
+
+        private CatalogOnlyRegistryServer(List<String> repositories) throws IOException {
+            this.repositories = repositories;
+            this.server = HttpServer.create(new InetSocketAddress(0), 0);
+            this.server.createContext("/v2/", this::handle);
+            this.server.start();
+        }
+
+        private int port() {
+            return server.getAddress().getPort();
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            if ("/v2/".equals(path) && "GET".equals(method)) {
+                send(exchange, 200, "");
+                return;
+            }
+            if ("/v2/_catalog".equals(path) && "GET".equals(method)) {
+                String joined = repositories.stream()
+                        .map(r -> "\"" + r + "\"")
+                        .reduce((a, b) -> a + "," + b)
+                        .orElse("");
+                sendJson(exchange, 200, "{\"repositories\":[" + joined + "]}");
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        }
+
+        private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            send(exchange, status, body);
+        }
+
+        private static void send(HttpExchange exchange, int status, String body) throws IOException {
+            byte[] bytes = body.getBytes();
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    /** Registry that accepts tag HEADs but rejects manifest DELETEs with 405. */
+    private static final class DeleteRejectingRegistryServer implements AutoCloseable {
+        private final HttpServer server;
+        private final String repository;
+        private final String tag;
+        private final String digest;
+
+        private DeleteRejectingRegistryServer(String repository, String tag, String digest) throws IOException {
+            this.repository = repository;
+            this.tag = tag;
+            this.digest = digest;
+            this.server = HttpServer.create(new InetSocketAddress(0), 0);
+            this.server.createContext("/v2/", this::handle);
+            this.server.start();
+        }
+
+        private int port() {
+            return server.getAddress().getPort();
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String path = exchange.getRequestURI().getPath();
+            String method = exchange.getRequestMethod();
+            if ("/v2/".equals(path) && "GET".equals(method)) {
+                send(exchange, 200, "");
+                return;
+            }
+            if ("/v2/_catalog".equals(path) && "GET".equals(method)) {
+                sendJson(exchange, 200, "{\"repositories\":[\"" + repository + "\"]}");
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/tags/list") && "GET".equals(method)) {
+                sendJson(exchange, 200, "{\"name\":\"" + repository + "\",\"tags\":[\"" + tag + "\"]}");
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/manifests/" + tag) && "HEAD".equals(method)) {
+                exchange.getResponseHeaders().add("Docker-Content-Digest", digest);
+                exchange.sendResponseHeaders(200, -1);
+                exchange.close();
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/manifests/" + digest) && "DELETE".equals(method)) {
+                // registry without DELETE enabled returns 405 METHOD_NOT_ALLOWED.
+                exchange.sendResponseHeaders(405, -1);
+                exchange.close();
                 return;
             }
             exchange.sendResponseHeaders(404, -1);

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
@@ -305,6 +305,37 @@ class EcrServiceTest {
     }
 
     @Test
+    void bareEntryOnSecondCatalogPageStillResolves() throws Exception {
+        // registry:2 caps _catalog pages at 100 entries; a bare entry beyond the
+        // first page must still be found (Greptile P1: catalog pagination).
+        String repositoryName = "probe/paged";
+        String tag = "v1";
+        String digest = "sha256:7777777777777777777777777777777777777777777777777777777777777777";
+        String manifest = """
+                {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": 1, "digest": "sha256:c"},
+                  "layers": []
+                }
+                """;
+
+        try (PaginatedCatalogRegistryServer registry =
+                new PaginatedCatalogRegistryServer(repositoryName, 150)) {
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            service.createRepository(repositoryName, null, null, null, null, null, null, REGION);
+            List<ImageIdentifier> ids = service.listImages(repositoryName, null, REGION);
+            assertEquals(1, ids.size());
+            assertEquals(tag, ids.get(0).getImageTag());
+            assertEquals(digest, ids.get(0).getImageDigest());
+            org.junit.jupiter.api.Assertions.assertTrue(registry.sawSecondPageRequest(),
+                    "resolver must follow the Link header to page 2");
+        }
+    }
+
+    @Test
     void untaggedDigestOnlyRepositoryResolvesAndDescribes() throws Exception {
         // A bare-name repo whose only manifest is untagged (digest-addressable):
         // tags/list returns null tags, but the catalog still lists the repo, so
@@ -568,6 +599,94 @@ class EcrServiceTest {
                 exchange.getResponseHeaders().add("Content-Type",
                         "application/vnd.docker.distribution.manifest.v2+json");
                 send(exchange, 200, manifest);
+                return;
+            }
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        }
+
+        private static void sendJson(HttpExchange exchange, int status, String body) throws IOException {
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            send(exchange, status, body);
+        }
+
+        private static void send(HttpExchange exchange, int status, String body) throws IOException {
+            byte[] bytes = body.getBytes();
+            exchange.sendResponseHeaders(status, bytes.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(bytes);
+            }
+        }
+
+        @Override
+        public void close() {
+            server.stop(0);
+        }
+    }
+
+    /** Registry whose _catalog spans two pages (Link header); repo lives on page 2. */
+    private static final class PaginatedCatalogRegistryServer implements AutoCloseable {
+        private final HttpServer server;
+        private final String repository;
+        private final String tag;
+        private final String digest;
+        private final List<String> filler;
+        private volatile boolean secondPageRequested;
+
+        private PaginatedCatalogRegistryServer(String repository, int fillerCount) throws IOException {
+            this.repository = repository;
+            this.tag = "v1";
+            this.digest = "sha256:7777777777777777777777777777777777777777777777777777777777777777";
+            List<String> f = new java.util.ArrayList<>();
+            for (int i = 0; i < fillerCount; i++) {
+                f.add(String.format("filler/%03d", i));
+            }
+            this.filler = f;
+            this.server = HttpServer.create(new InetSocketAddress(0), 0);
+            this.server.createContext("/v2/", this::handle);
+            this.server.start();
+        }
+
+        private int port() {
+            return server.getAddress().getPort();
+        }
+
+        private boolean sawSecondPageRequest() {
+            return secondPageRequested;
+        }
+
+        private void handle(HttpExchange exchange) throws IOException {
+            String path = exchange.getRequestURI().getPath();
+            String query = exchange.getRequestURI().getQuery();
+            String method = exchange.getRequestMethod();
+            if ("/v2/".equals(path) && "GET".equals(method)) {
+                send(exchange, 200, "");
+                return;
+            }
+            if ("/v2/_catalog".equals(path) && "GET".equals(method)) {
+                boolean pageTwo = query != null && query.contains("last=");
+                if (pageTwo) {
+                    secondPageRequested = true;
+                    sendJson(exchange, 200, "{\"repositories\":[\"" + repository + "\"]}");
+                } else {
+                    String joined = filler.stream()
+                            .map(r -> "\"" + r + "\"")
+                            .reduce((a, b) -> a + "," + b)
+                            .orElse("");
+                    exchange.getResponseHeaders().add("Link",
+                            "</v2/_catalog?n=100&last=" + filler.get(filler.size() - 1).replace("/", "%2F") + ">; rel=\"next\"");
+                    sendJson(exchange, 200, "{\"repositories\":[" + joined + "]}");
+                }
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/tags/list") && "GET".equals(method)) {
+                sendJson(exchange, 200, "{\"name\":\"" + repository + "\",\"tags\":[\"" + tag + "\"]}");
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/manifests/" + tag) && "HEAD".equals(method)) {
+                exchange.getResponseHeaders().add("Docker-Content-Digest", digest);
+                exchange.sendResponseHeaders(200, -1);
+                exchange.close();
                 return;
             }
             exchange.sendResponseHeaders(404, -1);

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/EcrServiceTest.java
@@ -235,6 +235,76 @@ class EcrServiceTest {
     // ------------------------------------------------------------
 
     @Test
+    void hostnameStylePushesUnderBareRepoNameAreVisibleViaListAndDescribeImages() throws Exception {
+        // A docker push to <account>.dkr.ecr.<region>.localhost:<port>/<repo>
+        // reaches the raw registry, so the image is stored under the bare repo
+        // name with no account/region prefix (issue #2444).
+        String repositoryName = "probe/roundtrip";
+        String tag = "v1";
+        String digest = "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+        String manifest = """
+                {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {
+                    "mediaType": "application/vnd.docker.container.image.v1+json",
+                    "size": 100,
+                    "digest": "sha256:config"
+                  },
+                  "layers": []
+                }
+                """;
+
+        try (FakeRegistryServer registry = new FakeRegistryServer(repositoryName, tag, digest, manifest)) {
+            when(registryManager.getRepositoryUri(ACCOUNT, REGION, repositoryName))
+                    .thenReturn(ACCOUNT + ".dkr.ecr." + REGION + ".localhost:" + registry.port() + "/" + repositoryName);
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            service.createRepository(repositoryName, null, null, null, null, null, null, REGION);
+
+            List<ImageIdentifier> imageIds = service.listImages(repositoryName, null, REGION);
+            assertEquals(1, imageIds.size());
+            assertEquals(tag, imageIds.get(0).getImageTag());
+            assertEquals(digest, imageIds.get(0).getImageDigest());
+
+            EcrService.DescribeImagesResult described = service.describeImages(repositoryName, null, null, REGION);
+            assertTrue(described.failures().isEmpty());
+            assertEquals(1, described.imageDetails().size());
+            assertEquals(digest, described.imageDetails().get(0).getImageDigest());
+        }
+    }
+
+    @Test
+    void deleteRepositoryForceRemovesManifestsFromRegistry() throws Exception {
+        String repositoryName = "probe/deleteme";
+        String tag = "v1";
+        String digest = "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+        String manifest = """
+                {
+                  "schemaVersion": 2,
+                  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                  "config": {"mediaType": "application/vnd.docker.container.image.v1+json", "size": 1, "digest": "sha256:c"},
+                  "layers": []
+                }
+                """;
+
+        try (FakeRegistryServer registry = new FakeRegistryServer(repositoryName, tag, digest, manifest)) {
+            when(registryManager.getRepositoryUri(ACCOUNT, REGION, repositoryName))
+                    .thenReturn(ACCOUNT + ".dkr.ecr." + REGION + ".localhost:" + registry.port() + "/" + repositoryName);
+            when(registryManager.httpClient())
+                    .thenReturn(new RegistryHttpClient("http://localhost:" + registry.port()));
+
+            service.createRepository(repositoryName, null, null, null, null, null, null, REGION);
+            service.deleteRepository(repositoryName, null, true, REGION);
+
+            assertTrue(registry.sawDelete(), "expected a DELETE /v2/<name>/manifests/<digest> call");
+            assertEquals(digest, registry.lastDeletedDigest(),
+                    "delete-repository --force must DELETE the manifest from the registry");
+        }
+    }
+
+    @Test
     void putImageTagMutability_roundTrips() {
         service.createRepository(REPO, null, null, null, null, null, null, REGION);
         Repository updated = service.putImageTagMutability(REPO, null, "IMMUTABLE", REGION);
@@ -347,6 +417,7 @@ class EcrServiceTest {
         private final String tag;
         private final String digest;
         private final String manifest;
+        private final List<String> deletedDigests = new java.util.ArrayList<>();
 
         private FakeRegistryServer(String repository, String tag, String digest, String manifest) throws IOException {
             this.repository = repository;
@@ -362,11 +433,25 @@ class EcrServiceTest {
             return server.getAddress().getPort();
         }
 
+        private boolean sawDelete() {
+            return !deletedDigests.isEmpty();
+        }
+
+        private String lastDeletedDigest() {
+            return deletedDigests.isEmpty() ? null : deletedDigests.get(deletedDigests.size() - 1);
+        }
+
         private void handle(HttpExchange exchange) throws IOException {
             String path = exchange.getRequestURI().getPath();
             String method = exchange.getRequestMethod();
             if ("/v2/".equals(path) && "GET".equals(method)) {
                 send(exchange, 200, "");
+                return;
+            }
+            if (path.equals("/v2/" + repository + "/manifests/" + digest) && "DELETE".equals(method)) {
+                deletedDigests.add(digest);
+                exchange.sendResponseHeaders(202, -1);
+                exchange.close();
                 return;
             }
             if (("/v2/" + repository + "/tags/list").equals(path) && "GET".equals(method)) {


### PR DESCRIPTION
## Summary

Fixes #2444.

**Root causes.** (1) Hostname-style repository URIs (`<account>.dkr.ecr.<region>.localhost:<port>`) resolve to loopback and hit the raw `registry:2` container directly, so a docker push stores the image under the **bare** repository name, while every ECR API lookup queried the namespaced internal form (`<account>/<region>/...`). Name mismatch → empty ListImages/DescribeImages, no error. (2) `DeleteRepository --force` removed metadata but left registry content behind.

**Fix.** New `resolveRegistryRepoName()`: prefers the namespaced form, falls back to the bare name when nothing is stored there (and back to namespaced when the registry is unreachable). Wired into `listImages`, `describeImages`, `batchGetImage`, `batchDeleteImage`, and `listTagsBestEffort`. Force-delete now resolves the name first (bare vs namespaced) and routes storage cleanup through the registry's filesystem cleanup instead of its own manifest-delete loop. Path-style deployments are unaffected: the namespaced name still wins when present.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: pushed images invisible to ListImages/DescribeImages, and force-deleted repositories left tags pullable. Verified with docker push round-trips plus SDK-shaped ListImages/DescribeImages/DeleteRepository calls in `EcrIntegrationTest`, including a hostname-style push that lands under the bare name (the gap where the pre-#2982 code targeted the wrong, empty directory).

## Checklist

- [x] targeted ECR suites passed locally on the original implementation (`EcrServiceTest`, `EcrIntegrationTest`, `EcrRegistryManagerTest`, `EcrGcControllerTest`, 56 tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] full suite re-run after the rebase and explicit-type fix below

Rebased onto current `main`: #2975 (degrade gracefully with no Docker daemon) landed since the last round and touches the same methods this PR resolves the registry name in, so every `requireRegistry()`/`resolveRegistryRepoName` call site needed reconciling by hand rather than a clean auto-merge. Also fixed the last open review item: `hasOtherScopeClaim` used `var` for a cast, which AGENTS.md's explicit-type rule disallows, now the concrete `AccountAwareStorageBackend<Repository>` type. A few em dashes introduced in the review's later test comments are gone too.
