### PR TITLE
fix(dynamodb): validate cursor key types

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
@@ -184,6 +184,23 @@ class DynamoDbAccessPathValidationTest {
                 .expressionAttributeValues(Map.of(":status", value("open")))));
     }
 
+    @Test
+    void queryAndScanRejectWrongExclusiveStartKeyTypes() {
+        Map<String, AttributeValue> invalidStartKey = Map.of(
+                "pk", AttributeValue.builder().n("1").build(),
+                "sk", value("s1"));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .keyConditionExpression("pk = :pk")
+                .expressionAttributeValues(Map.of(":pk", value("p1")))
+                .exclusiveStartKey(invalidStartKey)));
+
+        assertValidationException(() -> ddb.scan(request -> request
+                .tableName(TABLE)
+                .exclusiveStartKey(invalidStartKey)));
+    }
+
     private static void assertValidationException(org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {
         assertThatThrownBy(call)
                 .isInstanceOf(DynamoDbException.class)

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -718,29 +718,40 @@ public class DynamoDbJsonHandler {
         return changedAttributes;
     }
 
-    // DynamoDB rejects an ExclusiveStartKey whose attribute set does not exactly match the
-    // key schema being paged: the table's primary key, plus the index's key attributes when
-    // an IndexName is supplied. Query and Scan report different messages for the same fault.
+    // DynamoDB requires an ExclusiveStartKey to exactly match the paged key schema's
+    // attribute names and scalar types. Query and Scan report different messages for faults.
     private void validateExclusiveStartKey(JsonNode exclusiveStartKey, TableDefinition table,
-                                           String indexName, boolean isScan) {
+                                           DynamoDbAccessPath accessPath, boolean isScan) {
         if (exclusiveStartKey == null || exclusiveStartKey.isNull()) return;
         Set<String> expected = new HashSet<>();
         expected.add(table.getPartitionKeyName());
         String sortKey = table.getSortKeyName();
         if (sortKey != null) expected.add(sortKey);
-        if (indexName != null) {
-            table.findGsi(indexName).ifPresent(g ->
-                    g.getKeySchema().forEach(k -> expected.add(k.getAttributeName())));
-            table.findLsi(indexName).ifPresent(l ->
-                    l.getKeySchema().forEach(k -> expected.add(k.getAttributeName())));
+        if (accessPath.isIndex()) {
+            expected.addAll(accessPath.keyAttributeNames());
         }
         Set<String> actual = new HashSet<>();
         exclusiveStartKey.fieldNames().forEachRemaining(actual::add);
-        if (!actual.equals(expected)) {
-            throw new AwsException("ValidationException", isScan
-                    ? "The provided starting key is invalid: The provided key element does not match the schema"
-                    : "The provided starting key is invalid", 400);
+        if (!actual.equals(expected) || hasInvalidKeyType(exclusiveStartKey, table, expected)) {
+            throw invalidStartingKey(isScan);
         }
+    }
+
+    private boolean hasInvalidKeyType(JsonNode exclusiveStartKey, TableDefinition table,
+                                      Set<String> expected) {
+        return table.getAttributeDefinitions().stream()
+                .filter(definition -> expected.contains(definition.getAttributeName()))
+                .anyMatch(definition -> {
+                    JsonNode value = exclusiveStartKey.get(definition.getAttributeName());
+                    return value == null || !value.isObject() || value.size() != 1
+                            || !value.has(definition.getAttributeType());
+                });
+    }
+
+    private AwsException invalidStartingKey(boolean isScan) {
+        return new AwsException("ValidationException", isScan
+                ? "The provided starting key is invalid: The provided key element does not match the schema"
+                : "The provided starting key is invalid", 400);
     }
 
     private static final Set<String> VALID_SELECT = Set.of(
@@ -861,7 +872,7 @@ public class DynamoDbJsonHandler {
         }
 
         if (exclusiveStartKey != null) {
-            validateExclusiveStartKey(exclusiveStartKey, queryTable, indexName, false);
+            validateExclusiveStartKey(exclusiveStartKey, queryTable, queryAccessPath, false);
         }
 
         DynamoDbService.QueryResult result = dynamoDbService.query(tableName, keyConditions,
@@ -983,7 +994,7 @@ public class DynamoDbJsonHandler {
                 projectionExpressionScan, attributesToGetScan, exprAttrNames);
 
         if (exclusiveStartKey != null) {
-            validateExclusiveStartKey(exclusiveStartKey, scanTable, indexNameScan, true);
+            validateExclusiveStartKey(exclusiveStartKey, scanTable, scanAccessPath, true);
         }
 
         DynamoDbService.ScanResult result = dynamoDbService.scan(

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -732,20 +732,45 @@ public class DynamoDbJsonHandler {
         }
         Set<String> actual = new HashSet<>();
         exclusiveStartKey.fieldNames().forEachRemaining(actual::add);
-        if (!actual.equals(expected) || hasInvalidKeyType(exclusiveStartKey, table, expected)) {
+        if (!actual.equals(expected) || hasInvalidKeyValue(exclusiveStartKey, table, expected)) {
             throw invalidStartingKey(isScan);
         }
     }
 
-    private boolean hasInvalidKeyType(JsonNode exclusiveStartKey, TableDefinition table,
-                                      Set<String> expected) {
-        return table.getAttributeDefinitions().stream()
-                .filter(definition -> expected.contains(definition.getAttributeName()))
-                .anyMatch(definition -> {
-                    JsonNode value = exclusiveStartKey.get(definition.getAttributeName());
-                    return value == null || !value.isObject() || value.size() != 1
-                            || !value.has(definition.getAttributeType());
-                });
+    private boolean hasInvalidKeyValue(JsonNode exclusiveStartKey, TableDefinition table,
+                                       Set<String> expected) {
+        if (table.getAttributeDefinitions() == null) {
+            return true;
+        }
+        for (String attribute : expected) {
+            String expectedType = table.getAttributeDefinitions().stream()
+                    .filter(definition -> attribute.equals(definition.getAttributeName()))
+                    .map(AttributeDefinition::getAttributeType)
+                    .findFirst()
+                    .orElse(null);
+            if (expectedType == null || hasInvalidScalarValue(exclusiveStartKey.get(attribute), expectedType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasInvalidScalarValue(JsonNode value, String expectedType) {
+        if (value == null || !value.isObject() || value.size() != 1 || !value.has(expectedType)) {
+            return true;
+        }
+        JsonNode payload = value.get(expectedType);
+        if (payload == null || !payload.isTextual() || payload.textValue().isEmpty()) {
+            return true;
+        }
+        if ("N".equals(expectedType)) {
+            DynamoDbNumberUtils.validateAndNormalize(payload.textValue());
+        }
+        if ("B".equals(expectedType)) {
+            return !payload.textValue().matches(
+                    "(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?");
+        }
+        return false;
     }
 
     private AwsException invalidStartingKey(boolean isScan) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
@@ -272,10 +272,62 @@ class DynamoDbAccessPathIntegrationTest {
             .body("__type", equalTo("ValidationException"))
             .body("message", equalTo("The provided starting key is invalid: "
                     + "The provided key element does not match the schema"));
+
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "KeyConditionExpression":"pk = :pk",
+                  "ExpressionAttributeValues":{":pk":{"S":"p1"}},
+                  "ExclusiveStartKey":{"pk":{"S":null},"sk":{"S":"s1"}}
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("The provided starting key is invalid"));
+
+        request("DynamoDB_20120810.Scan", """
+                {
+                  "TableName":"%s",
+                  "ExclusiveStartKey":{"pk":{"S":123},"sk":{"S":"s1"}}
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
     }
 
     @Test
     @Order(10)
+    void queryRejectsMalformedNumericExclusiveStartKey() {
+        String numericTable = TABLE + "-numeric";
+        request("DynamoDB_20120810.CreateTable", """
+                {
+                  "TableName":"%s",
+                  "AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"N"}],
+                  "KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+                  "BillingMode":"PAY_PER_REQUEST"
+                }
+                """.formatted(numericTable))
+            .statusCode(200);
+
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "KeyConditionExpression":"pk = :pk",
+                  "ExpressionAttributeValues":{":pk":{"N":"1"}},
+                  "ExclusiveStartKey":{"pk":{"N":"not-a-number"}}
+                }
+                """.formatted(numericTable))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        request("DynamoDB_20120810.DeleteTable", """
+                {"TableName":"%s"}
+                """.formatted(numericTable))
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(11)
     void queryRejectsWrongIndexExclusiveStartKeyType() {
         request("DynamoDB_20120810.Query", """
                 {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
@@ -248,6 +248,56 @@ class DynamoDbAccessPathIntegrationTest {
     }
 
     @Test
+    @Order(9)
+    void queryAndScanRejectWrongExclusiveStartKeyTypes() {
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "KeyConditionExpression":"pk = :pk",
+                  "ExpressionAttributeValues":{":pk":{"S":"p1"}},
+                  "ExclusiveStartKey":{"pk":{"N":"1"},"sk":{"S":"s1"}}
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("The provided starting key is invalid"));
+
+        request("DynamoDB_20120810.Scan", """
+                {
+                  "TableName":"%s",
+                  "ExclusiveStartKey":{"pk":{"S":"p1"},"sk":{"BOOL":true}}
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("The provided starting key is invalid: "
+                    + "The provided key element does not match the schema"));
+    }
+
+    @Test
+    @Order(10)
+    void queryRejectsWrongIndexExclusiveStartKeyType() {
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "IndexName":"status-index",
+                  "KeyConditionExpression":"#status = :status",
+                  "ExpressionAttributeNames":{"#status":"status"},
+                  "ExpressionAttributeValues":{":status":{"S":"open"}},
+                  "ExclusiveStartKey":{
+                    "pk":{"S":"p1"},
+                    "sk":{"S":"s1"},
+                    "status":{"S":"open"},
+                    "createdAt":{"N":"1"}
+                  }
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("The provided starting key is invalid"));
+    }
+
+    @Test
     @Order(99)
     void deleteTable() {
         given()


### PR DESCRIPTION
## Summary

- validate `ExclusiveStartKey` attribute types against table schema definitions
- include secondary-index key attributes when validating indexed pagination
- preserve Query and Scan validation error shapes

## Proof

Before this change, Floci returned HTTP 200 for Query and Scan requests whose `ExclusiveStartKey` used the wrong scalar type. DynamoDB Local 3.3.1 rejects both with `ValidationException`; the DynamoDB API restricts key values to scalar `S`, `N`, or `B` values matching the schema.

## Tests

- `./mvnw test -Dtest=DynamoDbAccessPathIntegrationTest,DynamoDbServiceTest` (119 passed)
- `cd compatibility-tests/sdk-test-java && ../../mvnw test -Dtest=DynamoDbAccessPathValidationTest` against live Floci (10 passed)

Closes #2468
