### PR TITLE
fix(dynamodb): enforce composite query order

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
@@ -186,6 +186,7 @@ class DynamoDbAccessPathValidationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void queryRejectsInvalidCompositeSortKeyConditions() {
         assertValidationException(() -> ddb.query(request -> request
                 .tableName(TABLE)
@@ -206,6 +207,21 @@ class DynamoDbAccessPathValidationTest {
                         ":status", value("open"),
                         ":createdAt", value("2026-01-01"),
                         ":alternate", value("a1")))));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditions(Map.of(
+                        "status", condition(ComparisonOperator.EQ, "open"),
+                        "alternate", condition(ComparisonOperator.EQ, "a1")))));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditions(Map.of(
+                        "status", condition(ComparisonOperator.EQ, "open"),
+                        "createdAt", condition(ComparisonOperator.GT, "2026-01-01"),
+                        "alternate", condition(ComparisonOperator.EQ, "a1")))));
     }
 
     private static void assertValidationException(org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
@@ -41,7 +41,8 @@ class DynamoDbAccessPathValidationTest {
                         attribute("createdAt"), attribute("alternate"))
                 .globalSecondaryIndexes(GlobalSecondaryIndex.builder()
                         .indexName("status-index")
-                        .keySchema(key("status", KeyType.HASH), key("createdAt", KeyType.RANGE))
+                        .keySchema(key("status", KeyType.HASH), key("createdAt", KeyType.RANGE),
+                                key("alternate", KeyType.RANGE))
                         .projection(Projection.builder()
                                 .projectionType(ProjectionType.INCLUDE)
                                 .nonKeyAttributes("summary")
@@ -209,6 +210,29 @@ class DynamoDbAccessPathValidationTest {
         assertValidationException(() -> ddb.scan(request -> request
                 .tableName(TABLE)
                 .exclusiveStartKey(invalidStartKey)));
+    }
+
+    @Test
+    void queryRejectsInvalidCompositeSortKeyConditions() {
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditionExpression("#status = :status AND alternate = :alternate")
+                .expressionAttributeNames(Map.of("#status", "status"))
+                .expressionAttributeValues(Map.of(
+                        ":status", value("open"),
+                        ":alternate", value("a1")))));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditionExpression("#status = :status AND createdAt > :createdAt "
+                        + "AND alternate = :alternate")
+                .expressionAttributeNames(Map.of("#status", "status"))
+                .expressionAttributeValues(Map.of(
+                        ":status", value("open"),
+                        ":createdAt", value("2026-01-01"),
+                        ":alternate", value("a1")))));
     }
 
     private static void assertValidationException(org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
@@ -213,6 +213,7 @@ class DynamoDbAccessPathValidationTest {
     }
 
     @Test
+    @SuppressWarnings("deprecation")
     void queryRejectsInvalidCompositeSortKeyConditions() {
         assertValidationException(() -> ddb.query(request -> request
                 .tableName(TABLE)
@@ -233,6 +234,21 @@ class DynamoDbAccessPathValidationTest {
                         ":status", value("open"),
                         ":createdAt", value("2026-01-01"),
                         ":alternate", value("a1")))));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditions(Map.of(
+                        "status", condition(ComparisonOperator.EQ, "open"),
+                        "alternate", condition(ComparisonOperator.EQ, "a1")))));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditions(Map.of(
+                        "status", condition(ComparisonOperator.EQ, "open"),
+                        "createdAt", condition(ComparisonOperator.GT, "2026-01-01"),
+                        "alternate", condition(ComparisonOperator.EQ, "a1")))));
     }
 
     private static void assertValidationException(org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
@@ -41,7 +41,8 @@ class DynamoDbAccessPathValidationTest {
                         attribute("createdAt"), attribute("alternate"))
                 .globalSecondaryIndexes(GlobalSecondaryIndex.builder()
                         .indexName("status-index")
-                        .keySchema(key("status", KeyType.HASH), key("createdAt", KeyType.RANGE))
+                        .keySchema(key("status", KeyType.HASH), key("createdAt", KeyType.RANGE),
+                                key("alternate", KeyType.RANGE))
                         .projection(Projection.builder()
                                 .projectionType(ProjectionType.INCLUDE)
                                 .nonKeyAttributes("summary")
@@ -182,6 +183,29 @@ class DynamoDbAccessPathValidationTest {
                 .keyConditionExpression("#status = :status")
                 .expressionAttributeNames(Map.of("#status", "status"))
                 .expressionAttributeValues(Map.of(":status", value("open")))));
+    }
+
+    @Test
+    void queryRejectsInvalidCompositeSortKeyConditions() {
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditionExpression("#status = :status AND alternate = :alternate")
+                .expressionAttributeNames(Map.of("#status", "status"))
+                .expressionAttributeValues(Map.of(
+                        ":status", value("open"),
+                        ":alternate", value("a1")))));
+
+        assertValidationException(() -> ddb.query(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .keyConditionExpression("#status = :status AND createdAt > :createdAt "
+                        + "AND alternate = :alternate")
+                .expressionAttributeNames(Map.of("#status", "status"))
+                .expressionAttributeValues(Map.of(
+                        ":status", value("open"),
+                        ":createdAt", value("2026-01-01"),
+                        ":alternate", value("a1")))));
     }
 
     private static void assertValidationException(org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
@@ -96,7 +96,7 @@ final class DynamoDbAccessPathValidator {
         int partitionConditions = 0;
         String partitionKeyValuePlaceholder = null;
         Set<String> conditionedAttributes = new HashSet<>();
-        Map<String, Expr> sortKeyConditions = new HashMap<>();
+        Map<String, Boolean> sortKeyEqualities = new HashMap<>();
 
         for (Expr condition : conditions) {
             String attribute = conditionAttribute(condition, names);
@@ -114,7 +114,7 @@ final class DynamoDbAccessPathValidator {
                 if (!isSupportedSortKeyCondition(condition)) {
                     throw new AwsException("ValidationException", "Query key condition not supported", 400);
                 }
-                sortKeyConditions.put(attribute, condition);
+                sortKeyEqualities.put(attribute, isEqualityCondition(condition));
             } else {
                 throw new AwsException("ValidationException", "Query key condition not supported", 400);
             }
@@ -128,20 +128,20 @@ final class DynamoDbAccessPathValidator {
             throw new AwsException("ValidationException",
                     "KeyConditionExpressions must only contain one condition per key", 400);
         }
-        validateCompositeSortKeyConditions(sortKeys, sortKeyConditions);
+        validateCompositeSortKeyConditions(sortKeys, sortKeyEqualities);
         return partitionKeyValuePlaceholder;
     }
 
     private static void validateCompositeSortKeyConditions(List<String> sortKeys,
-                                                            Map<String, Expr> conditions) {
+                                                            Map<String, Boolean> equalities) {
         for (int laterIndex = 1; laterIndex < sortKeys.size(); laterIndex++) {
             String laterSortKey = sortKeys.get(laterIndex);
-            if (!conditions.containsKey(laterSortKey)) {
+            if (!equalities.containsKey(laterSortKey)) {
                 continue;
             }
             for (int priorIndex = 0; priorIndex < laterIndex; priorIndex++) {
                 String priorSortKey = sortKeys.get(priorIndex);
-                if (!isEqualityCondition(conditions.get(priorSortKey))) {
+                if (!Boolean.TRUE.equals(equalities.get(priorSortKey))) {
                     throw validationException("RANGE key attributes " + priorSortKey
                             + " must have equality conditions specified in the query because a condition is present "
                             + "on key attribute " + laterSortKey);
@@ -198,7 +198,8 @@ final class DynamoDbAccessPathValidator {
                     "Query condition missed key schema element: " + partitionKey, 400);
         }
 
-        Set<String> sortKeys = Set.copyOf(accessPath.sortKeyNames());
+        List<String> sortKeys = accessPath.sortKeyNames();
+        Map<String, Boolean> sortKeyEqualities = new HashMap<>();
         keyConditions.fields().forEachRemaining(entry -> {
             String attribute = entry.getKey();
             String operator = entry.getValue().path("ComparisonOperator").asText();
@@ -211,8 +212,11 @@ final class DynamoDbAccessPathValidator {
                     || !LEGACY_SORT_KEY_COMPARATORS.contains(operator)
                     || ("BETWEEN".equals(operator) ? values != 2 : values != 1)) {
                 throw new AwsException("ValidationException", "Query key condition not supported", 400);
+            } else {
+                sortKeyEqualities.put(attribute, "EQ".equals(operator));
             }
         });
+        validateCompositeSortKeyConditions(sortKeys, sortKeyEqualities);
     }
 
     private static void validateFilterExpression(DynamoDbAccessPath accessPath,

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
@@ -18,8 +18,10 @@ import io.github.hectorvent.floci.services.dynamodb.ExpressionEvaluator.TokenTyp
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 final class DynamoDbAccessPathValidator {
@@ -98,10 +100,11 @@ final class DynamoDbAccessPathValidator {
                 ? and.operands() : List.of(root);
         List<String> partitionKeys = accessPath.partitionKeyNames();
         Set<String> partitionKeySet = Set.copyOf(partitionKeys);
-        Set<String> sortKeys = Set.copyOf(accessPath.sortKeyNames());
+        List<String> sortKeys = accessPath.sortKeyNames();
         Set<String> conditionedPartitionKeys = new HashSet<>();
         String partitionKeyValuePlaceholder = null;
         Set<String> conditionedAttributes = new HashSet<>();
+        Map<String, Expr> sortKeyConditions = new HashMap<>();
 
         for (Expr condition : conditions) {
             String attribute = conditionAttribute(condition, names);
@@ -121,6 +124,7 @@ final class DynamoDbAccessPathValidator {
                 if (!isSupportedSortKeyCondition(condition)) {
                     throw new AwsException("ValidationException", "Query key condition not supported", 400);
                 }
+                sortKeyConditions.put(attribute, condition);
             } else {
                 throw new AwsException("ValidationException", "Query key condition not supported", 400);
             }
@@ -134,7 +138,30 @@ final class DynamoDbAccessPathValidator {
             throw new AwsException("ValidationException",
                     "Query condition missed key schema element: " + missing, 400);
         }
+        validateCompositeSortKeyConditions(sortKeys, sortKeyConditions);
         return partitionKeyValuePlaceholder;
+    }
+
+    private static void validateCompositeSortKeyConditions(List<String> sortKeys,
+                                                            Map<String, Expr> conditions) {
+        for (int laterIndex = 1; laterIndex < sortKeys.size(); laterIndex++) {
+            String laterSortKey = sortKeys.get(laterIndex);
+            if (!conditions.containsKey(laterSortKey)) {
+                continue;
+            }
+            for (int priorIndex = 0; priorIndex < laterIndex; priorIndex++) {
+                String priorSortKey = sortKeys.get(priorIndex);
+                if (!isEqualityCondition(conditions.get(priorSortKey))) {
+                    throw validationException("RANGE key attributes " + priorSortKey
+                            + " must have equality conditions specified in the query because a condition is present "
+                            + "on key attribute " + laterSortKey);
+                }
+            }
+        }
+    }
+
+    private static boolean isEqualityCondition(Expr condition) {
+        return condition instanceof CompareExpr compare && compare.op() == TokenType.EQ;
     }
 
     private static boolean isPartitionKeyEquality(Expr condition) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
@@ -17,8 +17,10 @@ import io.github.hectorvent.floci.services.dynamodb.ExpressionEvaluator.Placehol
 import io.github.hectorvent.floci.services.dynamodb.ExpressionEvaluator.TokenType;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 final class DynamoDbAccessPathValidator {
@@ -90,10 +92,11 @@ final class DynamoDbAccessPathValidator {
         List<Expr> conditions = root instanceof AndExpr and
                 ? and.operands() : List.of(root);
         String partitionKey = accessPath.partitionKeyName();
-        Set<String> sortKeys = Set.copyOf(accessPath.sortKeyNames());
+        List<String> sortKeys = accessPath.sortKeyNames();
         int partitionConditions = 0;
         String partitionKeyValuePlaceholder = null;
         Set<String> conditionedAttributes = new HashSet<>();
+        Map<String, Expr> sortKeyConditions = new HashMap<>();
 
         for (Expr condition : conditions) {
             String attribute = conditionAttribute(condition, names);
@@ -111,6 +114,7 @@ final class DynamoDbAccessPathValidator {
                 if (!isSupportedSortKeyCondition(condition)) {
                     throw new AwsException("ValidationException", "Query key condition not supported", 400);
                 }
+                sortKeyConditions.put(attribute, condition);
             } else {
                 throw new AwsException("ValidationException", "Query key condition not supported", 400);
             }
@@ -124,7 +128,30 @@ final class DynamoDbAccessPathValidator {
             throw new AwsException("ValidationException",
                     "KeyConditionExpressions must only contain one condition per key", 400);
         }
+        validateCompositeSortKeyConditions(sortKeys, sortKeyConditions);
         return partitionKeyValuePlaceholder;
+    }
+
+    private static void validateCompositeSortKeyConditions(List<String> sortKeys,
+                                                            Map<String, Expr> conditions) {
+        for (int laterIndex = 1; laterIndex < sortKeys.size(); laterIndex++) {
+            String laterSortKey = sortKeys.get(laterIndex);
+            if (!conditions.containsKey(laterSortKey)) {
+                continue;
+            }
+            for (int priorIndex = 0; priorIndex < laterIndex; priorIndex++) {
+                String priorSortKey = sortKeys.get(priorIndex);
+                if (!isEqualityCondition(conditions.get(priorSortKey))) {
+                    throw validationException("RANGE key attributes " + priorSortKey
+                            + " must have equality conditions specified in the query because a condition is present "
+                            + "on key attribute " + laterSortKey);
+                }
+            }
+        }
+    }
+
+    private static boolean isEqualityCondition(Expr condition) {
+        return condition instanceof CompareExpr compare && compare.op() == TokenType.EQ;
     }
 
     private static boolean isPartitionKeyEquality(Expr condition) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
@@ -104,7 +104,7 @@ final class DynamoDbAccessPathValidator {
         Set<String> conditionedPartitionKeys = new HashSet<>();
         String partitionKeyValuePlaceholder = null;
         Set<String> conditionedAttributes = new HashSet<>();
-        Map<String, Expr> sortKeyConditions = new HashMap<>();
+        Map<String, Boolean> sortKeyEqualities = new HashMap<>();
 
         for (Expr condition : conditions) {
             String attribute = conditionAttribute(condition, names);
@@ -124,7 +124,7 @@ final class DynamoDbAccessPathValidator {
                 if (!isSupportedSortKeyCondition(condition)) {
                     throw new AwsException("ValidationException", "Query key condition not supported", 400);
                 }
-                sortKeyConditions.put(attribute, condition);
+                sortKeyEqualities.put(attribute, isEqualityCondition(condition));
             } else {
                 throw new AwsException("ValidationException", "Query key condition not supported", 400);
             }
@@ -138,20 +138,20 @@ final class DynamoDbAccessPathValidator {
             throw new AwsException("ValidationException",
                     "Query condition missed key schema element: " + missing, 400);
         }
-        validateCompositeSortKeyConditions(sortKeys, sortKeyConditions);
+        validateCompositeSortKeyConditions(sortKeys, sortKeyEqualities);
         return partitionKeyValuePlaceholder;
     }
 
     private static void validateCompositeSortKeyConditions(List<String> sortKeys,
-                                                            Map<String, Expr> conditions) {
+                                                            Map<String, Boolean> equalities) {
         for (int laterIndex = 1; laterIndex < sortKeys.size(); laterIndex++) {
             String laterSortKey = sortKeys.get(laterIndex);
-            if (!conditions.containsKey(laterSortKey)) {
+            if (!equalities.containsKey(laterSortKey)) {
                 continue;
             }
             for (int priorIndex = 0; priorIndex < laterIndex; priorIndex++) {
                 String priorSortKey = sortKeys.get(priorIndex);
-                if (!isEqualityCondition(conditions.get(priorSortKey))) {
+                if (!Boolean.TRUE.equals(equalities.get(priorSortKey))) {
                     throw validationException("RANGE key attributes " + priorSortKey
                             + " must have equality conditions specified in the query because a condition is present "
                             + "on key attribute " + laterSortKey);
@@ -243,7 +243,8 @@ final class DynamoDbAccessPathValidator {
         }
 
         Set<String> partitionKeySet = Set.copyOf(partitionKeys);
-        Set<String> sortKeys = Set.copyOf(accessPath.sortKeyNames());
+        List<String> sortKeys = accessPath.sortKeyNames();
+        Map<String, Boolean> sortKeyEqualities = new HashMap<>();
         keyConditions.fields().forEachRemaining(entry -> {
             String attribute = entry.getKey();
             String operator = entry.getValue().path("ComparisonOperator").asText();
@@ -256,6 +257,8 @@ final class DynamoDbAccessPathValidator {
                     || !LEGACY_SORT_KEY_COMPARATORS.contains(operator)
                     || ("BETWEEN".equals(operator) ? values != 2 : values != 1)) {
                 throw new AwsException("ValidationException", "Query key condition not supported", 400);
+            } else {
+                sortKeyEqualities.put(attribute, "EQ".equals(operator));
             }
             String expectedType = attributeType(table, attribute);
             entry.getValue().path("AttributeValueList").forEach(value -> {
@@ -264,6 +267,7 @@ final class DynamoDbAccessPathValidator {
                 }
             });
         });
+        validateCompositeSortKeyConditions(sortKeys, sortKeyEqualities);
     }
 
     private static String attributeType(TableDefinition table, String attribute) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
@@ -34,7 +34,8 @@ class DynamoDbAccessPathValidatorTest {
         table.setGlobalSecondaryIndexes(List.of(new GlobalSecondaryIndex(
                 "status-index",
                 List.of(new KeySchemaElement("status", "HASH"),
-                        new KeySchemaElement("createdAt", "RANGE")),
+                        new KeySchemaElement("createdAt", "RANGE"),
+                        new KeySchemaElement("sequence", "RANGE")),
                 null, "INCLUDE", List.of("summary"))));
         table.setLocalSecondaryIndexes(List.of(new LocalSecondaryIndex(
                 "alternate-index",
@@ -72,6 +73,33 @@ class DynamoDbAccessPathValidatorTest {
         assertEquals(":status", DynamoDbAccessPathValidator.validateQuery(
                 gsiPath, null, "#status = :status AND createdAt BETWEEN :start AND :end",
                 null, null, names));
+    }
+
+    @Test
+    void acceptsCompositeSortKeyPrefixWithInequalityLast() {
+        assertDoesNotThrow(() -> validateExpression(gsiPath,
+                "status = :status AND createdAt = :createdAt AND sequence >= :sequence"));
+        assertDoesNotThrow(() -> validateExpression(gsiPath,
+                "status = :status AND createdAt BETWEEN :start AND :end"));
+    }
+
+    @Test
+    void rejectsSkippedCompositeSortKey() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> validateExpression(gsiPath, "status = :status AND sequence = :sequence"));
+
+        assertEquals("RANGE key attributes createdAt must have equality conditions specified in the query "
+                + "because a condition is present on key attribute sequence", error.getMessage());
+    }
+
+    @Test
+    void rejectsCompositeSortKeyConditionAfterInequality() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> validateExpression(gsiPath,
+                        "status = :status AND createdAt > :createdAt AND sequence = :sequence"));
+
+        assertEquals("RANGE key attributes createdAt must have equality conditions specified in the query "
+                + "because a condition is present on key attribute sequence", error.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
@@ -38,6 +38,7 @@ class DynamoDbAccessPathValidatorTest {
                 new AttributeDefinition("sk", "S"),
                 new AttributeDefinition("status", "S"),
                 new AttributeDefinition("createdAt", "S"),
+                new AttributeDefinition("sequence", "S"),
                 new AttributeDefinition("alternate", "S"),
                 new AttributeDefinition("tenantId", "S"),
                 new AttributeDefinition("region", "S")));
@@ -45,7 +46,8 @@ class DynamoDbAccessPathValidatorTest {
                 new GlobalSecondaryIndex(
                         "status-index",
                         List.of(new KeySchemaElement("status", "HASH"),
-                                new KeySchemaElement("createdAt", "RANGE")),
+                                new KeySchemaElement("createdAt", "RANGE"),
+                                new KeySchemaElement("sequence", "RANGE")),
                         null, "INCLUDE", List.of("summary")),
                 new GlobalSecondaryIndex(
                         "tenant-region-index",
@@ -128,6 +130,33 @@ class DynamoDbAccessPathValidatorTest {
         assertEquals(":status", DynamoDbAccessPathValidator.validateQuery(
                 table, gsiPath, null, "#status = :status AND createdAt BETWEEN :start AND :end",
                 null, null, names, expressionValues(":status", ":start", ":end")));
+    }
+
+    @Test
+    void acceptsCompositeSortKeyPrefixWithInequalityLast() {
+        assertDoesNotThrow(() -> validateExpression(gsiPath,
+                "status = :status AND createdAt = :createdAt AND sequence >= :sequence"));
+        assertDoesNotThrow(() -> validateExpression(gsiPath,
+                "status = :status AND createdAt BETWEEN :start AND :end"));
+    }
+
+    @Test
+    void rejectsSkippedCompositeSortKey() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> validateExpression(gsiPath, "status = :status AND sequence = :sequence"));
+
+        assertEquals("RANGE key attributes createdAt must have equality conditions specified in the query "
+                + "because a condition is present on key attribute sequence", error.getMessage());
+    }
+
+    @Test
+    void rejectsCompositeSortKeyConditionAfterInequality() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> validateExpression(gsiPath,
+                        "status = :status AND createdAt > :createdAt AND sequence = :sequence"));
+
+        assertEquals("RANGE key attributes createdAt must have equality conditions specified in the query "
+                + "because a condition is present on key attribute sequence", error.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
@@ -224,6 +224,30 @@ class DynamoDbAccessPathValidatorTest {
     }
 
     @Test
+    void validatesLegacyCompositeSortKeyOrder() {
+        ObjectNode valid = mapper.createObjectNode();
+        valid.set("status", legacyCondition("EQ", attributeValues("open")));
+        valid.set("createdAt", legacyCondition("EQ", attributeValues("2026-01-01")));
+        valid.set("sequence", legacyCondition("GE", attributeValues("1")));
+        assertDoesNotThrow(() -> DynamoDbAccessPathValidator.validateQuery(
+                table, gsiPath, valid, null, null, null, null, null));
+
+        ObjectNode skipped = mapper.createObjectNode();
+        skipped.set("status", legacyCondition("EQ", attributeValues("open")));
+        skipped.set("sequence", legacyCondition("EQ", attributeValues("1")));
+        AwsException skippedError = assertThrows(AwsException.class,
+                () -> DynamoDbAccessPathValidator.validateQuery(
+                        table, gsiPath, skipped, null, null, null, null, null));
+        assertEquals("RANGE key attributes createdAt must have equality conditions specified in the query "
+                + "because a condition is present on key attribute sequence", skippedError.getMessage());
+
+        ObjectNode nonFinalInequality = valid.deepCopy();
+        nonFinalInequality.set("createdAt", legacyCondition("GT", attributeValues("2026-01-01")));
+        assertThrows(AwsException.class, () -> DynamoDbAccessPathValidator.validateQuery(
+                table, gsiPath, nonFinalInequality, null, null, null, null, null));
+    }
+
+    @Test
     void rejectsSelectedKeysInQueryFilters() {
         assertThrows(AwsException.class, () -> DynamoDbAccessPathValidator.validateQuery(
                 table, gsiPath, null, "status = :status", "createdAt > :cutoff", null, null,

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
@@ -166,6 +166,30 @@ class DynamoDbAccessPathValidatorTest {
     }
 
     @Test
+    void validatesLegacyCompositeSortKeyOrder() {
+        ObjectNode valid = mapper.createObjectNode();
+        valid.set("status", legacyCondition("EQ", attributeValues("open")));
+        valid.set("createdAt", legacyCondition("EQ", attributeValues("2026-01-01")));
+        valid.set("sequence", legacyCondition("GE", attributeValues("1")));
+        assertDoesNotThrow(() -> DynamoDbAccessPathValidator.validateQuery(
+                gsiPath, valid, null, null, null, null));
+
+        ObjectNode skipped = mapper.createObjectNode();
+        skipped.set("status", legacyCondition("EQ", attributeValues("open")));
+        skipped.set("sequence", legacyCondition("EQ", attributeValues("1")));
+        AwsException skippedError = assertThrows(AwsException.class,
+                () -> DynamoDbAccessPathValidator.validateQuery(
+                        gsiPath, skipped, null, null, null, null));
+        assertEquals("RANGE key attributes createdAt must have equality conditions specified in the query "
+                + "because a condition is present on key attribute sequence", skippedError.getMessage());
+
+        ObjectNode nonFinalInequality = valid.deepCopy();
+        nonFinalInequality.set("createdAt", legacyCondition("GT", attributeValues("2026-01-01")));
+        assertThrows(AwsException.class, () -> DynamoDbAccessPathValidator.validateQuery(
+                gsiPath, nonFinalInequality, null, null, null, null));
+    }
+
+    @Test
     void rejectsSelectedKeysInQueryFilters() {
         assertThrows(AwsException.class, () -> DynamoDbAccessPathValidator.validateQuery(
                 gsiPath, null, "status = :status", "createdAt > :cutoff", null, null));

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
@@ -280,4 +280,58 @@ class DynamoDbCompositeSortKeyQueryIntegrationTest {
                 "2026-07-14T00:00:03Z"), collected,
                 "Expected all rows once, in full composite order");
     }
+
+    @Test
+    @Order(7)
+    void queryRejectsSkippedCompositeSortKey() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditionExpression": "memberName = :pk AND createdAt >= :from",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "alice"},
+                        ":from": {"S": "2026-01-01T00:00:00Z"}
+                    }
+                }
+                """.formatted(TABLE, INDEX))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("RANGE key attributes state must have equality conditions specified "
+                    + "in the query because a condition is present on key attribute createdAt"));
+    }
+
+    @Test
+    @Order(8)
+    void queryRejectsCompositeSortKeyConditionAfterInequality() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditionExpression": "memberName = :pk AND #st > :st AND createdAt = :createdAt",
+                    "ExpressionAttributeNames": {"#st": "state"},
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "alice"},
+                        ":st": {"S": "ACTIVE"},
+                        ":createdAt": {"S": "2026-07-14T00:00:01Z"}
+                    }
+                }
+                """.formatted(TABLE, INDEX))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("RANGE key attributes state must have equality conditions specified "
+                    + "in the query because a condition is present on key attribute createdAt"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbCompositeSortKeyQueryIntegrationTest.java
@@ -334,4 +334,35 @@ class DynamoDbCompositeSortKeyQueryIntegrationTest {
             .body("message", equalTo("RANGE key attributes state must have equality conditions specified "
                     + "in the query because a condition is present on key attribute createdAt"));
     }
+
+    @Test
+    @Order(9)
+    void legacyQueryRejectsInvalidCompositeSortKeyConditions() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "%s",
+                    "KeyConditions": {
+                        "memberName": {
+                            "ComparisonOperator": "EQ",
+                            "AttributeValueList": [{"S": "alice"}]
+                        },
+                        "createdAt": {
+                            "ComparisonOperator": "GE",
+                            "AttributeValueList": [{"S": "2026-01-01T00:00:00Z"}]
+                        }
+                    }
+                }
+                """.formatted(TABLE, INDEX))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("RANGE key attributes state must have equality conditions specified "
+                    + "in the query because a condition is present on key attribute createdAt"));
+    }
 }


### PR DESCRIPTION
## Summary

- enforce left-to-right conditions for multi-attribute GSI sort keys
- require equality on every conditioned sort-key component before the final component
- apply identical validation to expression and legacy `KeyConditions` query forms

Closes #2462

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci returned HTTP 200 when a Query skipped an earlier composite sort-key component, or used an inequality on it before conditioning a later component. DynamoDB Local 3.3.1 rejects both with `ValidationException`. This change matches that left-to-right rule and validation message for modern expressions and legacy `KeyConditions`.

## Tests

- `./mvnw.cmd test "-Dtest=DynamoDbAccessPathValidatorTest,DynamoDbCompositeSortKeyQueryIntegrationTest,DynamoDbServiceTest"` (151 passed after rebase)
- `./mvnw.cmd -f compatibility-tests/sdk-test-java/pom.xml test-compile -DskipTests` (passed after rebase)
- SDK compatibility test against live Floci before rebase (10 passed)

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)