### PR TITLE
fix: inject AWS SDK environment into Flink sidecars

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.E
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
+import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
 import io.github.hectorvent.floci.services.kinesisanalytics.KinesisAnalyticsRuntimes;
 import io.github.hectorvent.floci.services.kinesisanalytics.model.FlinkApplication;
 import io.github.hectorvent.floci.services.kinesisanalytics.model.Snapshot;
@@ -35,7 +36,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -68,6 +71,7 @@ public class FlinkContainerManager {
     private final ContainerDetector containerDetector;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
+    private final LaunchedContainerAwsEnv awsEnv;
     private final S3Service s3Service;
     private final FlinkRestClient flinkRest;
     private final ObjectMapper objectMapper;
@@ -87,6 +91,7 @@ public class FlinkContainerManager {
                                  ContainerDetector containerDetector,
                                  EmulatorConfig config,
                                  RegionResolver regionResolver,
+                                 LaunchedContainerAwsEnv awsEnv,
                                  S3Service s3Service,
                                  FlinkRestClient flinkRest,
                                  ObjectMapper objectMapper) {
@@ -96,6 +101,7 @@ public class FlinkContainerManager {
         this.containerDetector = containerDetector;
         this.config = config;
         this.regionResolver = regionResolver;
+        this.awsEnv = awsEnv;
         this.objectMapper = objectMapper;
         this.s3Service = s3Service;
         this.flinkRest = flinkRest;
@@ -129,6 +135,7 @@ public class FlinkContainerManager {
         // Read the JAR before starting anything so a missing/empty artifact fails fast, before any
         // container is created. (S3 read runs on the request thread → account context is available.)
         byte[] jarBytes = app.hasCode() ? readJar(app) : null;
+        List<String> awsBaselineEnv = awsEnv.sdkBaselineEnv(config.defaultRegion(), Optional.empty());
 
         LOG.infov("Starting Flink cluster for application {0} using image {1}{2}",
                 app.getApplicationName(), image, app.hasCode() ? " (with TaskManager)" : "");
@@ -141,8 +148,11 @@ public class FlinkContainerManager {
         ContainerBuilder.Builder jmSpec = containerBuilder.newContainer(image)
                 .withName(jmName)
                 .withCmd("jobmanager")
+                .withEnv(awsBaselineEnv)
                 .withEnv("FLINK_PROPERTIES", jmProps)
                 .withDockerNetwork(config.services().dockerNetwork())
+                .withHostDockerInternalOnLinux()
+                .withEmbeddedDns()
                 .withLogRotation();
         // Named volume (not the container's ephemeral filesystem) so snapshots survive a
         // Stop/StartApplication cycle — stopCluster() removes the JobManager container, but this
@@ -180,6 +190,7 @@ public class FlinkContainerManager {
             ContainerSpec tmSpec = containerBuilder.newContainer(image)
                     .withName(tmName)
                     .withCmd("taskmanager")
+                    .withEnv(awsBaselineEnv)
                     .withEnv("FLINK_PROPERTIES", tmProps)
                     .withNetworkMode("container:" + jm.containerId())
                     .withLogRotation()

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
@@ -7,42 +7,118 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
+import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
 import io.github.hectorvent.floci.services.kinesisanalytics.model.FlinkApplication;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
- * Unit coverage for {@link FlinkContainerManager}'s {@code application_properties.json} construction —
- * the JSON shape must exactly match real MSF/KDA's runtime file so a real
- * {@code KinesisAnalyticsRuntime.getApplicationProperties()} call in a user's JAR finds it. The
- * container-injection path itself (tar-entry-prefix trick to create the non-existent {@code /etc/flink}
- * directory via the daemon-level copy) was verified live against a real {@code apache/flink} image
- * rather than re-implemented here with a mocked DockerClient — see the design notes on the injection
- * call sites for what was checked and why.
+ * Unit coverage for {@link FlinkContainerManager}'s container specifications and
+ * {@code application_properties.json} construction. The JSON shape must exactly match real MSF/KDA's
+ * runtime file so a real {@code KinesisAnalyticsRuntime.getApplicationProperties()} call in a user's
+ * JAR finds it. The file-injection path itself was verified live against a real {@code apache/flink}
+ * image rather than re-implemented here with a mocked DockerClient.
  */
 class FlinkContainerManagerTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final List<String> AWS_ENV = List.of(
+            "AWS_DEFAULT_REGION=us-west-2",
+            "AWS_REGION=us-west-2",
+            "AWS_ACCESS_KEY_ID=test",
+            "AWS_SECRET_ACCESS_KEY=test",
+            "AWS_SESSION_TOKEN=test",
+            "FLOCI_HOSTNAME=localhost.floci.io",
+            "FLOCI_ENDPOINT=http://localhost.floci.io:4566",
+            "AWS_ENDPOINT_URL=http://localhost.floci.io:4566");
 
-    private FlinkContainerManager manager() {
-        return new FlinkContainerManager(
-                Mockito.mock(ContainerBuilder.class),
-                Mockito.mock(ContainerLifecycleManager.class),
-                Mockito.mock(ContainerLogStreamer.class),
-                Mockito.mock(ContainerDetector.class),
-                Mockito.mock(EmulatorConfig.class),
-                Mockito.mock(RegionResolver.class),
-                Mockito.mock(S3Service.class),
-                Mockito.mock(FlinkRestClient.class),
+    private ContainerLifecycleManager lifecycleManager;
+    private LaunchedContainerAwsEnv awsEnv;
+    private S3Service s3Service;
+    private FlinkContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        EmulatorConfig.DockerConfig dockerConfig = mock(EmulatorConfig.DockerConfig.class);
+        when(dockerConfig.imageRegistryBase()).thenReturn(Optional.empty());
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.empty());
+        when(dockerConfig.logMaxSize()).thenReturn("10m");
+        when(dockerConfig.logMaxFile()).thenReturn("3");
+
+        EmulatorConfig.KinesisAnalyticsServiceConfig kinesisAnalyticsConfig =
+                mock(EmulatorConfig.KinesisAnalyticsServiceConfig.class);
+        when(kinesisAnalyticsConfig.defaultImage()).thenReturn(Optional.empty());
+
+        EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
+        when(servicesConfig.kinesisAnalytics()).thenReturn(kinesisAnalyticsConfig);
+        when(servicesConfig.dockerNetwork()).thenReturn(Optional.of("floci-network"));
+
+        EmulatorConfig.DnsConfig dnsConfig = mock(EmulatorConfig.DnsConfig.class);
+        when(dnsConfig.containerFallbackEnabled()).thenReturn(false);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        when(config.docker()).thenReturn(dockerConfig);
+        when(config.services()).thenReturn(servicesConfig);
+        when(config.dns()).thenReturn(dnsConfig);
+        when(config.defaultRegion()).thenReturn("us-west-2");
+
+        DockerHostResolver dockerHostResolver = mock(DockerHostResolver.class);
+        when(dockerHostResolver.isLinuxHost()).thenReturn(true);
+        EmbeddedDnsServer embeddedDnsServer = mock(EmbeddedDnsServer.class);
+        when(embeddedDnsServer.getServerIp()).thenReturn(Optional.of("172.18.0.2"));
+        ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer);
+
+        lifecycleManager = mock(ContainerLifecycleManager.class);
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        s3Service = mock(S3Service.class);
+        awsEnv = mock(LaunchedContainerAwsEnv.class);
+        when(awsEnv.sdkBaselineEnv(eq("us-west-2"), eq(Optional.empty()))).thenReturn(AWS_ENV);
+
+        manager = new FlinkContainerManager(
+                containerBuilder,
+                lifecycleManager,
+                logStreamer,
+                containerDetector,
+                config,
+                regionResolver,
+                awsEnv,
+                s3Service,
+                mock(FlinkRestClient.class),
                 MAPPER);
+    }
+
+    private FlinkApplication application(String name) {
+        return new FlinkApplication(name,
+                "arn:aws:kinesisanalytics:us-west-2:000000000000:application/" + name,
+                "FLINK-1_18", "arn:aws:iam::000000000000:role/x", "STREAMING");
     }
 
     @Test
@@ -54,7 +130,7 @@ class FlinkContainerManagerTest {
         groups.put("ConsumerConfigProperties", Map.of("aws.region", "us-west-2"));
         app.setEnvironmentProperties(groups);
 
-        byte[] json = manager().applicationPropertiesJson(app);
+        byte[] json = manager.applicationPropertiesJson(app);
         JsonNode root = MAPPER.readTree(json);
 
         assertTrue(root.isArray());
@@ -70,12 +146,98 @@ class FlinkContainerManagerTest {
         FlinkApplication app = new FlinkApplication("bare", "arn:aws:kinesisanalytics:us-east-1:000000000000:application/bare",
                 "FLINK-1_18", "arn:aws:iam::000000000000:role/x", "STREAMING");
 
-        byte[] json = manager().applicationPropertiesJson(app);
+        byte[] json = manager.applicationPropertiesJson(app);
         JsonNode root = MAPPER.readTree(json);
 
         // Real MSF always provides the file, even with zero property groups configured, so
         // KinesisAnalyticsRuntime.getApplicationProperties() never has to handle a missing file.
         assertTrue(root.isArray());
         assertEquals(0, root.size());
+    }
+
+    @Test
+    void bareClusterInjectsAwsSdkEnvironmentAndContainerReachability() {
+        FlinkApplication app = application("bare");
+        when(lifecycleManager.createAndStart(any())).thenReturn(new ContainerInfo(
+                "jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))));
+
+        manager.startCluster(app);
+
+        ContainerSpec jmSpec = captureCreatedSpecs().getFirst();
+        assertTrue(jmSpec.env().containsAll(AWS_ENV));
+        assertTrue(jmSpec.env().contains(
+                "FLINK_PROPERTIES=jobmanager.rpc.address: localhost\nrest.bind-address: 0.0.0.0"));
+        assertEquals(List.of("jobmanager"), jmSpec.cmd());
+        assertEquals("floci-network", jmSpec.networkMode());
+        assertTrue(jmSpec.extraHosts().contains("host.docker.internal:host-gateway"));
+        assertTrue(jmSpec.dnsServers().contains("172.18.0.2"));
+        verify(awsEnv).sdkBaselineEnv("us-west-2", Optional.empty());
+    }
+
+    @Test
+    void codeClusterInjectsTheSameAwsSdkEnvironmentIntoBothFlinkProcesses() {
+        FlinkApplication app = application("with-code");
+        app.setCodeS3Bucket("code-bucket");
+        app.setCodeS3Key("jobs/demo.jar");
+        app.setParallelism(3);
+        when(s3Service.getObject("code-bucket", "jobs/demo.jar", null))
+                .thenReturn(new S3Object("code-bucket", "jobs/demo.jar", new byte[]{1}, "application/java-archive"));
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))))
+                .thenReturn(new ContainerInfo("tm-id", Map.of()));
+
+        manager.startCluster(app);
+
+        List<ContainerSpec> specs = captureCreatedSpecs();
+        ContainerSpec jmSpec = specs.get(0);
+        ContainerSpec tmSpec = specs.get(1);
+        assertTrue(jmSpec.env().containsAll(AWS_ENV));
+        assertTrue(tmSpec.env().containsAll(AWS_ENV));
+        assertEquals(List.of("jobmanager"), jmSpec.cmd());
+        assertEquals(List.of("taskmanager"), tmSpec.cmd());
+        assertTrue(jmSpec.env().stream().anyMatch(env -> env.startsWith("FLINK_PROPERTIES=jobmanager.rpc.address")));
+        assertTrue(tmSpec.env().contains(
+                "FLINK_PROPERTIES=jobmanager.rpc.address: localhost\ntaskmanager.numberOfTaskSlots: 3"));
+        assertEquals("container:jm-id", tmSpec.networkMode());
+        verify(awsEnv).sdkBaselineEnv("us-west-2", Optional.empty());
+    }
+
+    @Test
+    void jobManagerStartFailureRemovesThePartialCluster() {
+        FlinkApplication app = application("jm-failure");
+        when(lifecycleManager.createAndStart(any())).thenThrow(new RuntimeException("jobmanager failed"));
+
+        assertThrows(RuntimeException.class, () -> manager.startCluster(app));
+
+        verify(lifecycleManager, times(2)).removeIfExists("floci-kinesisanalytics-jm-failure");
+        verify(lifecycleManager, atLeastOnce()).removeIfExists("floci-kinesisanalytics-jm-failure-tm");
+        assertNull(app.getContainerId());
+        assertNull(app.getTaskManagerContainerId());
+    }
+
+    @Test
+    void taskManagerStartFailureStopsTheJobManagerAndClearsClusterState() {
+        FlinkApplication app = application("tm-failure");
+        app.setCodeS3Bucket("code-bucket");
+        app.setCodeS3Key("jobs/demo.jar");
+        when(s3Service.getObject("code-bucket", "jobs/demo.jar", null))
+                .thenReturn(new S3Object("code-bucket", "jobs/demo.jar", new byte[]{1}, "application/java-archive"));
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))))
+                .thenThrow(new RuntimeException("taskmanager failed"));
+
+        assertThrows(RuntimeException.class, () -> manager.startCluster(app));
+
+        verify(lifecycleManager).stopAndRemove("jm-id", null);
+        verify(lifecycleManager, atLeastOnce()).removeIfExists("floci-kinesisanalytics-tm-failure-tm");
+        assertNull(app.getContainerId());
+        assertNull(app.getRestEndpoint());
+        assertNull(app.getTaskManagerContainerId());
+    }
+
+    private List<ContainerSpec> captureCreatedSpecs() {
+        ArgumentCaptor<ContainerSpec> captor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager, atLeastOnce()).createAndStart(captor.capture());
+        return captor.getAllValues();
     }
 }


### PR DESCRIPTION
## Summary

Inject `LaunchedContainerAwsEnv` into `FlinkContainerManager` and resolve one baseline from the configured default region with no mounted AWS config, preserving the established host-credential-or-placeholder behavior. Apply that baseline to both the JobManager and TaskManager specifications while retaining each process's existing `FLINK_PROPERTIES`; user code may execute in either container, so both require identical AWS SDK variables. Configure the JobManager's network setup consistently with other launched workloads so the helper's container-reachable endpoint resolves from the shared network namespace used by the TaskManager.

`StartApplication` creates Flink JobManager and TaskManager containers with only `FLINK_PROPERTIES`, leaving AWS SDKs inside the application without a region, credentials, or an endpoint for Floci. The failure is isolated to the Kinesis Analytics container-launch path; `LaunchedContainerAwsEnv` already defines the shared baseline used by Lambda, ECS, and MWAA. As a result, otherwise healthy Flink jobs fail as soon as their default credential chain attempts to access S3, Kinesis, or another AWS-compatible service. The supplied reproduction is concrete, and the issue has no assignee, claim, competing PR, or prior closed attempt.

Closes #2404

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This change is specifically about AWS compatibility inside launched Flink
containers. It reuses the existing `LaunchedContainerAwsEnv` baseline already
used by the Lambda, ECS, and MWAA launch paths rather than introducing a new
one, so region, credential, and endpoint resolution stay consistent with those
workloads. No AWS SDK version or API surface changes.

## Checklist

- [ ] `./mvnw test` passes locally
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
