### PR TITLE
fix(bedrock-agentcore): allow maxResults up to 1000

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/Pagination.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/Pagination.java
@@ -25,12 +25,20 @@ public final class Pagination {
     private Pagination() {}
 
     public static <T> PaginatedResult<T> paginate(List<T> all, Function<T, String> cursorOf,
+                                                Integer maxResults, String nextToken,
+                                                int maxPage, String errorCode) {
+        return paginate(all, cursorOf, maxResults, nextToken, maxPage, maxPage, errorCode);
+    }
+
+    public static <T> PaginatedResult<T> paginate(List<T> all, Function<T, String> cursorOf,
                                                     Integer maxResults, String nextToken,
-                                                    int maxPage, String errorCode) {
-        if (maxResults != null && (maxResults < 1 || maxResults > maxPage)) {
-            throw new AwsException(errorCode, "maxResults must be between 1 and " + maxPage, 400);
+                                                    int defaultPageSize, int maxResultsLimit,
+                                                    String errorCode) {
+        if (maxResults != null && (maxResults < 1 || maxResults > maxResultsLimit)) {
+            throw new AwsException(errorCode,
+                    "maxResults must be between 1 and " + maxResultsLimit, 400);
         }
-        int limit = maxResults != null ? maxResults : maxPage;
+        int limit = maxResults != null ? maxResults : defaultPageSize;
 
         List<T> sorted = all.stream().sorted(Comparator.comparing(cursorOf)).collect(Collectors.toList());
         String after = decodeToken(nextToken, errorCode);

--- a/src/main/java/io/github/hectorvent/floci/services/bedrockagentcorecontrol/BedrockAgentCoreGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrockagentcorecontrol/BedrockAgentCoreGatewayService.java
@@ -28,7 +28,8 @@ public class BedrockAgentCoreGatewayService {
     private static final String STATUS_DELETING = "DELETING";
     private static final String LOWER = "abcdefghijklmnopqrstuvwxyz0123456789";
     private static final String ALNUM = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    private static final int MAX_PAGE = 100;
+    private static final int DEFAULT_PAGE = 100;
+    private static final int MAX_PAGE = 1000;
 
     private final StorageBackend<String, Gateway> storage;
     private final RegionResolver regionResolver;
@@ -140,7 +141,14 @@ public class BedrockAgentCoreGatewayService {
     public PaginatedResult<Gateway> list(Integer maxResults, String nextToken, String region) {
         String prefix = keyPrefix(region);
         List<Gateway> all = storage.scan(k -> k.startsWith(prefix));
-        return Pagination.paginate(all, Gateway::getGatewayId, maxResults, nextToken, MAX_PAGE, "ValidationException");
+        return Pagination.paginate(
+                all,
+                Gateway::getGatewayId,
+                maxResults,
+                nextToken,
+                DEFAULT_PAGE,
+                MAX_PAGE,
+                "ValidationException");
     }
 
     public String gatewayArn(Gateway gateway, String region) {
@@ -199,8 +207,14 @@ public class BedrockAgentCoreGatewayService {
 
     public PaginatedResult<GatewayTarget> listTargets(String gatewayId, Integer maxResults, String nextToken, String region) {
         Gateway gateway = get(gatewayId, region);
-        return Pagination.paginate(gateway.getTargets(), GatewayTarget::getTargetId, maxResults, nextToken,
-                MAX_PAGE, "ValidationException");
+        return Pagination.paginate(
+                gateway.getTargets(),
+                GatewayTarget::getTargetId,
+                maxResults,
+                nextToken,
+                DEFAULT_PAGE,
+                MAX_PAGE,
+                "ValidationException");
     }
 
     private GatewayTarget findTarget(Gateway gateway, String targetId) {

--- a/src/test/java/io/github/hectorvent/floci/services/bedrockagentcorecontrol/BedrockAgentCoreGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrockagentcorecontrol/BedrockAgentCoreGatewayIntegrationTest.java
@@ -25,85 +25,248 @@ class BedrockAgentCoreGatewayIntegrationTest {
     @Test
     @Order(1)
     void createGateway() {
-        gatewayId = given().contentType("application/json").body(CREATE)
-                .when().post("/gateways/")
-                .then().statusCode(202)
+        gatewayId = given()
+                .contentType("application/json")
+                .body(CREATE)
+                .when()
+                .post("/gateways/")
+                .then()
+                .statusCode(202)
                 .body("gatewayId", notNullValue())
                 .body("gatewayArn", containsString(":gateway/"))
                 .body("status", equalTo("READY"))
                 .body("workloadIdentityDetails.workloadIdentityArn", notNullValue())
-                .extract().path("gatewayId");
+                .extract()
+                .path("gatewayId");
     }
 
     @Test
     @Order(2)
     void getAndListGateway() {
-        given().when().get("/gateways/" + gatewayId + "/")
-                .then().statusCode(200)
+        given()
+                .when()
+                .get("/gateways/" + gatewayId + "/")
+                .then()
+                .statusCode(200)
                 .body("name", equalTo("myGateway"))
                 .body("protocolType", equalTo("MCP"));
 
-        given().when().get("/gateways/")
-                .then().statusCode(200)
+        given()
+                .when()
+                .get("/gateways/")
+                .then()
+                .statusCode(200)
                 .body("items.gatewayId", hasItem(gatewayId));
     }
 
     @Test
     @Order(3)
-    void createAndGetTarget() {
-        targetId = given().contentType("application/json")
-                .body("{\"name\":\"t1\",\"targetConfiguration\":{\"mcp\":{\"lambda\":{}}}}")
-                .when().post("/gateways/" + gatewayId + "/targets/")
-                .then().statusCode(202)
-                .body("targetId", notNullValue())
-                .body("gatewayArn", containsString(":gateway/"))
-                .extract().path("targetId");
+    void listGatewaysAcceptsMaxResultsUpTo1000() {
+        given()
+                .queryParam("maxResults", 101)
+                .when()
+                .get("/gateways/")
+                .then()
+                .statusCode(200)
+                .body("items.gatewayId", hasItem(gatewayId));
 
-        given().when().get("/gateways/" + gatewayId + "/targets/" + targetId + "/")
-                .then().statusCode(200)
-                .body("targetId", equalTo(targetId))
-                .body("targetConfiguration.mcp.lambda", notNullValue());
+        given()
+                .queryParam("maxResults", 500)
+                .when()
+                .get("/gateways/")
+                .then()
+                .statusCode(200)
+                .body("items.gatewayId", hasItem(gatewayId));
 
-        given().when().get("/gateways/" + gatewayId + "/targets/")
-                .then().statusCode(200)
-                .body("items.targetId", hasItem(targetId));
+        given()
+                .queryParam("maxResults", 1000)
+                .when()
+                .get("/gateways/")
+                .then()
+                .statusCode(200)
+                .body("items.gatewayId", hasItem(gatewayId));
     }
 
     @Test
     @Order(4)
-    void updateGatewayAndTarget() {
-        given().contentType("application/json")
-                .body("{\"name\":\"myGateway\",\"authorizerType\":\"AWS_IAM\","
-                        + "\"roleArn\":\"arn:aws:iam::000000000000:role/gw2\",\"description\":\"updated gw\"}")
-                .when().put("/gateways/" + gatewayId + "/")
-                .then().statusCode(202);
-        given().when().get("/gateways/" + gatewayId + "/")
-                .then().statusCode(200)
-                .body("roleArn", equalTo("arn:aws:iam::000000000000:role/gw2"))
-                .body("description", equalTo("updated gw"));
+    void listGatewaysRejectsInvalidMaxResults() {
+        given()
+                .queryParam("maxResults", 0)
+                .when()
+                .get("/gateways/")
+                .then()
+                .statusCode(400)
+                .body("message",
+                        containsString("maxResults must be between 1 and 1000"));
 
-        given().contentType("application/json")
-                .body("{\"targetConfiguration\":{\"mcp\":{\"lambda\":{\"arn\":\"x\"}}},\"description\":\"t2\"}")
-                .when().put("/gateways/" + gatewayId + "/targets/" + targetId + "/")
-                .then().statusCode(202);
-        given().when().get("/gateways/" + gatewayId + "/targets/" + targetId + "/")
-                .then().statusCode(200)
-                .body("description", equalTo("t2"))
-                .body("targetConfiguration.mcp.lambda.arn", equalTo("x"));
+        given()
+                .queryParam("maxResults", 1001)
+                .when()
+                .get("/gateways/")
+                .then()
+                .statusCode(400)
+                .body("message",
+                        containsString("maxResults must be between 1 and 1000"));
     }
 
     @Test
     @Order(5)
+    void createAndGetTarget() {
+        targetId = given()
+                .contentType("application/json")
+                .body("""
+                        {"name":"t1","targetConfiguration":{"mcp":{"lambda":{}}}}
+                        """)
+                .when()
+                .post("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(202)
+                .body("targetId", notNullValue())
+                .body("gatewayArn", containsString(":gateway/"))
+                .extract()
+                .path("targetId");
+
+        given()
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/" + targetId + "/")
+                .then()
+                .statusCode(200)
+                .body("targetId", equalTo(targetId))
+                .body("targetConfiguration.mcp.lambda", notNullValue());
+
+        given()
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(200)
+                .body("items.targetId", hasItem(targetId));
+    }
+
+    @Test
+    @Order(6)
+    void listGatewayTargetsAcceptsMaxResultsUpTo1000() {
+        given()
+                .queryParam("maxResults", 101)
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(200)
+                .body("items.targetId", hasItem(targetId));
+
+        given()
+                .queryParam("maxResults", 500)
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(200)
+                .body("items.targetId", hasItem(targetId));
+
+        given()
+                .queryParam("maxResults", 1000)
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(200)
+                .body("items.targetId", hasItem(targetId));
+    }
+
+    @Test
+    @Order(7)
+    void listGatewayTargetsRejectsInvalidMaxResults() {
+        given()
+                .queryParam("maxResults", 0)
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(400)
+                .body("message",
+                        containsString("maxResults must be between 1 and 1000"));
+
+        given()
+                .queryParam("maxResults", 1001)
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/")
+                .then()
+                .statusCode(400)
+                .body("message",
+                        containsString("maxResults must be between 1 and 1000"));
+    }
+
+    @Test
+    @Order(8)
+    void updateGatewayAndTarget() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "name":"myGateway",
+                          "authorizerType":"AWS_IAM",
+                          "roleArn":"arn:aws:iam::000000000000:role/gw2",
+                          "description":"updated gw"
+                        }
+                        """)
+                .when()
+                .put("/gateways/" + gatewayId + "/")
+                .then()
+                .statusCode(202);
+
+        given()
+                .when()
+                .get("/gateways/" + gatewayId + "/")
+                .then()
+                .statusCode(200)
+                .body("roleArn",
+                        equalTo("arn:aws:iam::000000000000:role/gw2"))
+                .body("description", equalTo("updated gw"));
+
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "targetConfiguration":{
+                            "mcp":{
+                              "lambda":{
+                                "arn":"x"
+                              }
+                            }
+                          },
+                          "description":"t2"
+                        }
+                        """)
+                .when()
+                .put("/gateways/" + gatewayId + "/targets/" + targetId + "/")
+                .then()
+                .statusCode(202);
+
+        given()
+                .when()
+                .get("/gateways/" + gatewayId + "/targets/" + targetId + "/")
+                .then()
+                .statusCode(200)
+                .body("description", equalTo("t2"))
+                .body("targetConfiguration.mcp.lambda.arn", equalTo("x"));
+    }
+    @Test
+    @Order(9)
     void deleteTargetAndGateway() {
-        given().when().delete("/gateways/" + gatewayId + "/targets/" + targetId + "/")
-                .then().statusCode(202)
+        given()
+                .when()
+                .delete("/gateways/" + gatewayId + "/targets/" + targetId + "/")
+                .then()
+                .statusCode(202)
                 .body("status", equalTo("DELETING"));
 
-        given().when().delete("/gateways/" + gatewayId + "/")
-                .then().statusCode(202)
+        given()
+                .when()
+                .delete("/gateways/" + gatewayId + "/")
+                .then()
+                .statusCode(202)
                 .body("status", equalTo("DELETING"));
 
-        given().when().get("/gateways/" + gatewayId + "/")
-                .then().statusCode(404);
+        given()
+                .when()
+                .get("/gateways/" + gatewayId + "/")
+                .then()
+                .statusCode(404);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2418

Fixes `ListGateways` and `ListGatewayTargets` rejecting valid `maxResults` values between 101 and 1000.

The Bedrock AgentCore service model allows `maxResults` up to 1000, but Floci was limiting it to 100. This change separates the default page size from the maximum allowed `maxResults` value.

The default page size remains 100 to preserve existing pagination behavior.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The previous implementation rejected valid requests with:

```text
maxResults must be between 1 and 100