### PR TITLE
fix(msk): accept an empty serverProperties on Create/UpdateConfiguration

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -134,7 +134,10 @@ public class MskService {
             throw new AwsException("BadRequestException",
                     "Configuration name must match the pattern \"^[0-9A-Za-z][0-9A-Za-z-]{0,}$\".", 400);
         }
-        if (serverProperties == null || serverProperties.isBlank()) {
+        // Only an absent member (null) is rejected. A zero-length blob is a legitimate value
+        // meaning "no property overrides": Terraform modules that build serverProperties by
+        // joining a map defaulting to {} send exactly that, and real MSK accepts it.
+        if (serverProperties == null) {
             throw new AwsException("BadRequestException", "serverProperties is required.", 400);
         }
         if (configurationStorage.scan(k -> true).stream().anyMatch(c -> c.getName().equals(name))) {
@@ -178,7 +181,9 @@ public class MskService {
     }
 
     public MskConfiguration updateConfiguration(String arn, String description, String serverProperties) {
-        if (serverProperties == null || serverProperties.isBlank()) {
+        // Same absent-vs-empty distinction as createConfiguration: "" is a valid revision
+        // body that clears every override, only a missing member is an error.
+        if (serverProperties == null) {
             throw new AwsException("BadRequestException", "serverProperties is required.", 400);
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
@@ -162,16 +162,20 @@ class MskControllerIntegrationTest {
             .statusCode(200)
             .body("latestRevision.revision", equalTo(2));
 
-        given()
-        .when()
-            .get("/v1/configurations/{arn}/revisions/{revision}", arn, 1)
-        .then()
-            .statusCode(200)
-            .body("serverProperties", equalTo(""));
+        // Both revisions, not just the one create wrote: an empty update has to store ""
+        // rather than silently carry the previous revision's properties forward.
+        for (int revision : new int[] { 1, 2 }) {
+            given()
+            .when()
+                .get("/v1/configurations/{arn}/revisions/{revision}", arn, revision)
+            .then()
+                .statusCode(200)
+                .body("serverProperties", equalTo(""));
+        }
     }
 
     @Test
-    void createConfigurationRejectsAbsentServerProperties() {
+    void createConfigurationRejectsMissingServerProperties() {
         given()
             .contentType("application/json")
             .body("""

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
@@ -133,6 +133,56 @@ class MskControllerIntegrationTest {
             .statusCode(404);
     }
 
+    // An empty base64 blob decodes to "" and means "no property overrides". Absent and
+    // present-but-empty stay distinguishable at the REST layer: a missing member arrives as
+    // null, an empty one as a zero-length String, so only the former is rejected.
+    @Test
+    void createAndUpdateConfigurationAcceptEmptyServerProperties() {
+        String arn = given()
+            .contentType("application/json")
+            .body("""
+                {"name": "empty-props-%s", "kafkaVersions": ["3.6.0"], "serverProperties": ""}
+                """.formatted(UUID.randomUUID().toString().substring(0, 8)))
+        .when()
+            .post("/v1/configurations")
+        .then()
+            .statusCode(200)
+            .body("state", equalTo("ACTIVE"))
+            .body("latestRevision.revision", equalTo(1))
+            .extract().path("arn");
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {"description": "still empty", "serverProperties": ""}
+                """)
+        .when()
+            .put("/v1/configurations/{arn}", arn)
+        .then()
+            .statusCode(200)
+            .body("latestRevision.revision", equalTo(2));
+
+        given()
+        .when()
+            .get("/v1/configurations/{arn}/revisions/{revision}", arn, 1)
+        .then()
+            .statusCode(200)
+            .body("serverProperties", equalTo(""));
+    }
+
+    @Test
+    void createConfigurationRejectsAbsentServerProperties() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"name": "no-props-config", "kafkaVersions": ["3.6.0"]}
+                """)
+        .when()
+            .post("/v1/configurations")
+        .then()
+            .statusCode(400);
+    }
+
     @Test
     void createConfigurationRejectsNonBase64ServerProperties() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -149,6 +149,25 @@ class MskServiceTest {
     }
 
     @Test
+    void createConfigurationAcceptsEmptyServerProperties() {
+        // A zero-length blob means "no property overrides" - Gruntwork's msk module joins a
+        // map that defaults to {} and creates aws_msk_configuration unconditionally.
+        MskConfiguration configuration = mskService.createConfiguration(
+                "empty-props-config", "desc", List.of("3.6.0"), "");
+
+        assertEquals("", configuration.getServerPropertiesByRevision().get(1L));
+        assertEquals(ConfigurationState.ACTIVE, configuration.getState());
+    }
+
+    @Test
+    void createConfigurationAcceptsNonEmptyServerProperties() {
+        MskConfiguration configuration = mskService.createConfiguration(
+                "props-config", "desc", List.of("3.6.0"), "num.partitions=3");
+
+        assertEquals("num.partitions=3", configuration.getServerPropertiesByRevision().get(1L));
+    }
+
+    @Test
     void createConfigurationRejectsDuplicateName() {
         mskService.createConfiguration("test-config", "desc", List.of("3.6.0"), "props");
         assertThrows(AwsException.class, () ->
@@ -240,6 +259,28 @@ class MskServiceTest {
                 "test-config", "desc", List.of("3.6.0"), "props");
         assertThrows(AwsException.class, () ->
                 mskService.updateConfiguration(created.getArn(), "desc", null));
+    }
+
+    @Test
+    void updateConfigurationAcceptsEmptyServerProperties() {
+        MskConfiguration created = mskService.createConfiguration(
+                "test-config", "desc", List.of("3.6.0"), "num.partitions=3");
+
+        MskConfiguration updated = mskService.updateConfiguration(created.getArn(), "cleared", "");
+
+        assertEquals(2L, updated.getLatestRevision().getRevision());
+        assertEquals("", updated.getServerPropertiesByRevision().get(2L));
+    }
+
+    @Test
+    void updateConfigurationAcceptsNonEmptyServerProperties() {
+        MskConfiguration created = mskService.createConfiguration(
+                "test-config", "desc", List.of("3.6.0"), "");
+
+        MskConfiguration updated = mskService.updateConfiguration(
+                created.getArn(), "desc", "num.partitions=3");
+
+        assertEquals("num.partitions=3", updated.getServerPropertiesByRevision().get(2L));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`MskService` validated `serverProperties` with `== null || isBlank()` in both `createConfiguration` and `updateConfiguration`, which conflates *member absent* with *member present but empty*. A zero-length blob is a legitimate value in MSK: it means "no property overrides". Both call sites now reject only `null`.

Absent and empty stay distinguishable at the REST layer, so the validation can stay exactly where it is: `MskController.asString` returns `null` for a missing JSON member, while `decodeServerProperties` turns the empty base64 string into `""`. An absent member is still a 400.

This codebase already treats `""` as the canonical "no property overrides" value. `MskConfiguration.setLegacyLatestRevision` deliberately migrates a pre-revision-history entry with no `serverProperties` to `""` rather than `null`, because `serverPropertiesByRevision` is a `ConcurrentHashMap` and `DescribeConfigurationRevision` base64-encodes whatever it finds without a null check. The one value that could not round-trip through storage was already excluded; `""` was never the problem.

### Tests

Four new unit tests (create/update x empty/non-empty accepted; the existing null-rejection tests already cover `null`), plus REST-level tests proving that empty round-trips as `""` through create *and* update. Both revisions are read back, so an update that silently carried the previous revision's properties forward would fail. An absent member still returns 400 on create; the absent-on-update case was already covered by `MskControllerIntegrationTest.updateConfigurationRejectsMissingServerProperties`.

Confirmed adversarially by reverting the production change: `createConfigurationAcceptsEmptyServerProperties`, `updateConfigurationAcceptsEmptyServerProperties`, `updateConfigurationAcceptsNonEmptyServerProperties` and `createAndUpdateConfigurationAcceptEmptyServerProperties` all go red. Removing the `null` guard instead turns the two missing-member tests red.

`./mvnw test -Dtest='*Msk*'` -> 62 tests, 0 failures. Full suite: `./mvnw test` -> 11568 tests, 0 failures.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behaviour** — a present-but-empty `serverProperties` was rejected:

```
$ aws kafka create-configuration --name repro --kafka-versions 3.6.0 --server-properties ""
BadRequestException: serverProperties is required.
```

The same guard was present in `UpdateConfiguration`.

**Why an empty value is legal.** AWS's own service model settles it — `kafka/service-2.json`:

```
CreateConfiguration input required: ["ServerProperties", "Name"]
ServerProperties: { "shape": "__blob", "locationName": "serverProperties" }
__blob:           { "type": "blob" }
```

`required` with **no `min` constraint**. In the AWS models `required` means the member must be *present*; a length floor is expressed explicitly as `min`. So a zero-length blob is a valid `ServerProperties`.

**Real-world impact.** Terraform modules that expose server properties as an optional map render an empty map to an empty string — e.g. Gruntwork's `msk` module builds `server_properties = join("\n", [for k, v in var.server_properties : "${k}=${v}"])` with `default = {}` and creates `aws_msk_configuration` unconditionally. Three examples in that repo fail on this today.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
