### PR TITLE
fix(ec2): store and report a route's IPv6 destination, and stop DeleteRoute NPEing

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -815,11 +815,12 @@ public class CloudFormationResourceProvisioner {
         String routeTableId = resolveOptional(props, "RouteTableId", engine);
         String destinationCidr = resolveOptional(props, "DestinationCidrBlock", engine);
         String destinationIpv6Cidr = resolveOptional(props, "DestinationIpv6CidrBlock", engine);
+        String destinationPrefixListId = resolveOptional(props, "DestinationPrefixListId", engine);
         String gatewayId = resolveOptional(props, "GatewayId", engine);
         String natGatewayId = resolveOptional(props, "NatGatewayId", engine);
         String egressOnlyInternetGatewayId = resolveOptional(props, "EgressOnlyInternetGatewayId", engine);
         ec2Service.createRoute(region, routeTableId, destinationCidr, destinationIpv6Cidr,
-                gatewayId, natGatewayId, egressOnlyInternetGatewayId);
+                destinationPrefixListId, gatewayId, natGatewayId, egressOnlyInternetGatewayId);
         r.setPhysicalId(r.getLogicalId() + "-" + UUID.randomUUID().toString().substring(0, 8));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -814,9 +814,12 @@ public class CloudFormationResourceProvisioner {
     private void provisionRoute(StackResource r, JsonNode props, CloudFormationTemplateEngine engine, String region) {
         String routeTableId = resolveOptional(props, "RouteTableId", engine);
         String destinationCidr = resolveOptional(props, "DestinationCidrBlock", engine);
+        String destinationIpv6Cidr = resolveOptional(props, "DestinationIpv6CidrBlock", engine);
         String gatewayId = resolveOptional(props, "GatewayId", engine);
         String natGatewayId = resolveOptional(props, "NatGatewayId", engine);
-        ec2Service.createRoute(region, routeTableId, destinationCidr, gatewayId, natGatewayId);
+        String egressOnlyInternetGatewayId = resolveOptional(props, "EgressOnlyInternetGatewayId", engine);
+        ec2Service.createRoute(region, routeTableId, destinationCidr, destinationIpv6Cidr,
+                gatewayId, natGatewayId, egressOnlyInternetGatewayId);
         r.setPhysicalId(r.getLogicalId() + "-" + UUID.randomUUID().toString().substring(0, 8));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -2405,9 +2405,14 @@ public class Ec2QueryHandler {
     private Response handleCreateRoute(MultivaluedMap<String, String> p, String region) {
         String rtId = p.getFirst("RouteTableId");
         String dest = p.getFirst("DestinationCidrBlock");
+        String destIpv6 = p.getFirst("DestinationIpv6CidrBlock");
         String gwId = p.getFirst("GatewayId");
         String natGwId = p.getFirst("NatGatewayId");
-        service.createRoute(region, rtId, dest, gwId, natGwId);
+        // The gateway itself is not modelled (CreateEgressOnlyInternetGateway is still
+        // unimplemented), but the id the caller sent is stored and reported back so an IPv6
+        // egress route is not silently rewritten into a targetless one.
+        String eigwId = p.getFirst("EgressOnlyInternetGatewayId");
+        service.createRoute(region, rtId, dest, destIpv6, gwId, natGwId, eigwId);
         return booleanResponse("CreateRoute");
     }
 
@@ -2423,6 +2428,7 @@ public class Ec2QueryHandler {
         }
         String rtId = p.getFirst("RouteTableId");
         String dest = p.getFirst("DestinationCidrBlock");
+        String destIpv6 = p.getFirst("DestinationIpv6CidrBlock");
         String gwId = p.getFirst("GatewayId");
         String natGwId = p.getFirst("NatGatewayId");
         // Resetting a route to the local target is expressible: `local` is the gateway id the
@@ -2434,14 +2440,15 @@ public class Ec2QueryHandler {
             }
             gwId = LOCAL_GATEWAY_ID;
         }
-        service.replaceRoute(region, rtId, dest, gwId, natGwId);
+        service.replaceRoute(region, rtId, dest, destIpv6, gwId, natGwId);
         return booleanResponse("ReplaceRoute");
     }
 
     private Response handleDeleteRoute(MultivaluedMap<String, String> p, String region) {
         String rtId = p.getFirst("RouteTableId");
         String dest = p.getFirst("DestinationCidrBlock");
-        service.deleteRoute(region, rtId, dest);
+        String destIpv6 = p.getFirst("DestinationIpv6CidrBlock");
+        service.deleteRoute(region, rtId, dest, destIpv6);
         return booleanResponse("DeleteRoute");
     }
 
@@ -3197,8 +3204,10 @@ public class Ec2QueryHandler {
         for (Route r : rt.getRoutes()) {
             xml.start("item")
                     .elem("destinationCidrBlock", r.getDestinationCidrBlock())
+                    .elem("destinationIpv6CidrBlock", r.getDestinationIpv6CidrBlock())
                     .elem("gatewayId", r.getGatewayId())
                     .elem("natGatewayId", r.getNatGatewayId())
+                    .elem("egressOnlyInternetGatewayId", r.getEgressOnlyInternetGatewayId())
                     .elem("state", r.getState())
                     .elem("origin", r.getOrigin())
                     .end("item");

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -2406,13 +2406,17 @@ public class Ec2QueryHandler {
         String rtId = p.getFirst("RouteTableId");
         String dest = p.getFirst("DestinationCidrBlock");
         String destIpv6 = p.getFirst("DestinationIpv6CidrBlock");
+        // A prefix list is a destination in its own right per the CreateRoute reference. The
+        // prefix list itself is not modelled, but the id is stored and reported so the route
+        // stays addressable by DeleteRoute and ReplaceRoute.
+        String destPrefixList = p.getFirst("DestinationPrefixListId");
         String gwId = p.getFirst("GatewayId");
         String natGwId = p.getFirst("NatGatewayId");
         // The gateway itself is not modelled (CreateEgressOnlyInternetGateway is still
         // unimplemented), but the id the caller sent is stored and reported back so an IPv6
         // egress route is not silently rewritten into a targetless one.
         String eigwId = p.getFirst("EgressOnlyInternetGatewayId");
-        service.createRoute(region, rtId, dest, destIpv6, gwId, natGwId, eigwId);
+        service.createRoute(region, rtId, dest, destIpv6, destPrefixList, gwId, natGwId, eigwId);
         return booleanResponse("CreateRoute");
     }
 
@@ -2429,6 +2433,7 @@ public class Ec2QueryHandler {
         String rtId = p.getFirst("RouteTableId");
         String dest = p.getFirst("DestinationCidrBlock");
         String destIpv6 = p.getFirst("DestinationIpv6CidrBlock");
+        String destPrefixList = p.getFirst("DestinationPrefixListId");
         String gwId = p.getFirst("GatewayId");
         String natGwId = p.getFirst("NatGatewayId");
         // Resetting a route to the local target is expressible: `local` is the gateway id the
@@ -2440,7 +2445,7 @@ public class Ec2QueryHandler {
             }
             gwId = LOCAL_GATEWAY_ID;
         }
-        service.replaceRoute(region, rtId, dest, destIpv6, gwId, natGwId);
+        service.replaceRoute(region, rtId, dest, destIpv6, destPrefixList, gwId, natGwId);
         return booleanResponse("ReplaceRoute");
     }
 
@@ -2448,7 +2453,8 @@ public class Ec2QueryHandler {
         String rtId = p.getFirst("RouteTableId");
         String dest = p.getFirst("DestinationCidrBlock");
         String destIpv6 = p.getFirst("DestinationIpv6CidrBlock");
-        service.deleteRoute(region, rtId, dest, destIpv6);
+        String destPrefixList = p.getFirst("DestinationPrefixListId");
+        service.deleteRoute(region, rtId, dest, destIpv6, destPrefixList);
         return booleanResponse("DeleteRoute");
     }
 
@@ -3205,6 +3211,7 @@ public class Ec2QueryHandler {
             xml.start("item")
                     .elem("destinationCidrBlock", r.getDestinationCidrBlock())
                     .elem("destinationIpv6CidrBlock", r.getDestinationIpv6CidrBlock())
+                    .elem("destinationPrefixListId", r.getDestinationPrefixListId())
                     .elem("gatewayId", r.getGatewayId())
                     .elem("natGatewayId", r.getNatGatewayId())
                     .elem("egressOnlyInternetGatewayId", r.getEgressOnlyInternetGatewayId())

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4451,47 +4451,89 @@ public class Ec2Service implements ContainerTeardown {
      * an IPv6 route in the table used to make every DeleteRoute against that table throw, IPv4
      * ones included.
      */
-    private static boolean matchesDestination(Route route, String destinationCidrBlock, String destinationIpv6CidrBlock) {
+    private static boolean matchesDestination(Route route, String destinationCidrBlock,
+                                              String destinationIpv6CidrBlock, String destinationPrefixListId) {
         if (isSet(destinationCidrBlock) && destinationCidrBlock.equals(route.getDestinationCidrBlock())) {
             return true;
         }
-        return isSet(destinationIpv6CidrBlock) && destinationIpv6CidrBlock.equals(route.getDestinationIpv6CidrBlock());
+        if (isSet(destinationIpv6CidrBlock) && destinationIpv6CidrBlock.equals(route.getDestinationIpv6CidrBlock())) {
+            return true;
+        }
+        return isSet(destinationPrefixListId) && destinationPrefixListId.equals(route.getDestinationPrefixListId());
     }
 
     /** The destination naming a route, for error messages. */
-    private static String destinationLabel(String destinationCidrBlock, String destinationIpv6CidrBlock) {
-        return isSet(destinationCidrBlock) ? destinationCidrBlock : destinationIpv6CidrBlock;
+    private static String destinationLabel(String destinationCidrBlock, String destinationIpv6CidrBlock,
+                                           String destinationPrefixListId) {
+        if (isSet(destinationCidrBlock)) {
+            return destinationCidrBlock;
+        }
+        return isSet(destinationIpv6CidrBlock) ? destinationIpv6CidrBlock : destinationPrefixListId;
     }
 
     /**
-     * AWS takes one destination per route: DestinationCidrBlock or DestinationIpv6CidrBlock
-     * (or a prefix list, which this emulator does not model). Neither is a MissingParameter;
-     * both would leave a route reachable under two addresses.
+     * AWS takes one destination per route, and there are three kinds of it: DestinationCidrBlock,
+     * DestinationIpv6CidrBlock and DestinationPrefixListId. The CreateRoute reference is explicit
+     * that a prefix list is a destination in its own right — "You must specify either a destination
+     * CIDR block or a prefix list ID" — and all three are members of the Route output shape, so a
+     * prefix-list route is stored and reported like any other rather than rejected.
+     *
+     * <p>Naming none of them is the case that has no valid reading: the route could never be
+     * addressed again by DeleteRoute or ReplaceRoute, which match on the destination. AWS declares
+     * no operation-specific error for CreateRoute, DeleteRoute or ReplaceRoute — the API reference
+     * Errors section is empty and the service model carries no error shapes — so the code here is
+     * chosen from EC2's common client error codes rather than confirmed against the real service.
+     * MissingParameter ("the request is missing a required parameter") is the closest fit.
      */
-    private static void requireExactlyOneDestination(String action, String destinationCidrBlock, String destinationIpv6CidrBlock) {
-        boolean hasIpv4 = isSet(destinationCidrBlock);
-        boolean hasIpv6 = isSet(destinationIpv6CidrBlock);
-        if (!hasIpv4 && !hasIpv6) {
+    private static void requireExactlyOneDestination(String action, String destinationCidrBlock,
+                                                     String destinationIpv6CidrBlock, String destinationPrefixListId) {
+        int given = (isSet(destinationCidrBlock) ? 1 : 0)
+                + (isSet(destinationIpv6CidrBlock) ? 1 : 0)
+                + (isSet(destinationPrefixListId) ? 1 : 0);
+        if (given == 0) {
             throw new AwsException("MissingParameter",
-                    "The request must include DestinationCidrBlock or DestinationIpv6CidrBlock; "
-                            + "routes are matched on their destination.", 400);
+                    "The request must include DestinationCidrBlock, DestinationIpv6CidrBlock or "
+                            + "DestinationPrefixListId; routes are matched on their destination.", 400);
         }
-        if (hasIpv4 && hasIpv6) {
+        if (given > 1) {
             throw new AwsException("InvalidParameterCombination",
-                    action + " takes one destination: DestinationCidrBlock or DestinationIpv6CidrBlock, not both.", 400);
+                    action + " takes one destination: DestinationCidrBlock, DestinationIpv6CidrBlock or "
+                            + "DestinationPrefixListId, not several.", 400);
+        }
+    }
+
+    /**
+     * An egress-only internet gateway is IPv6-only and is a target in its own right, so it cannot
+     * be combined with the IPv4 targets. Only the newly accepted parameter is validated here:
+     * CreateRoute has never enforced exclusivity between GatewayId and NatGatewayId, and starting
+     * to would be a behaviour change beyond this fix.
+     */
+    private static void requireEgressOnlyGatewayIsTheOnlyTarget(String gatewayId, String natGatewayId,
+                                                                String egressOnlyInternetGatewayId) {
+        if (!isSet(egressOnlyInternetGatewayId)) {
+            return;
+        }
+        if (isSet(gatewayId) || isSet(natGatewayId)) {
+            throw new AwsException("InvalidParameterCombination",
+                    "EgressOnlyInternetGatewayId cannot be combined with GatewayId or NatGatewayId; "
+                            + "a route takes one target.", 400);
         }
     }
 
     public void createRoute(String region, String routeTableId, String destinationCidrBlock,
-                            String destinationIpv6CidrBlock, String gatewayId, String natGatewayId,
+                            String destinationIpv6CidrBlock, String destinationPrefixListId,
+                            String gatewayId, String natGatewayId,
                             String egressOnlyInternetGatewayId) {
-        requireExactlyOneDestination("CreateRoute", destinationCidrBlock, destinationIpv6CidrBlock);
+        requireExactlyOneDestination("CreateRoute", destinationCidrBlock, destinationIpv6CidrBlock,
+                destinationPrefixListId);
+        requireEgressOnlyGatewayIsTheOnlyTarget(gatewayId, natGatewayId, egressOnlyInternetGatewayId);
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
             Route route = new Route(destinationCidrBlock, gatewayId, "CreateRoute");
             route.setDestinationIpv6CidrBlock(destinationIpv6CidrBlock);
+            route.setDestinationPrefixListId(destinationPrefixListId);
             route.setNatGatewayId(natGatewayId);
             route.setEgressOnlyInternetGatewayId(egressOnlyInternetGatewayId);
             next.add(route);
@@ -4501,8 +4543,10 @@ public class Ec2Service implements ContainerTeardown {
     }
 
     public void replaceRoute(String region, String routeTableId, String destinationCidrBlock,
-                             String destinationIpv6CidrBlock, String gatewayId, String natGatewayId) {
-        requireExactlyOneDestination("ReplaceRoute", destinationCidrBlock, destinationIpv6CidrBlock);
+                             String destinationIpv6CidrBlock, String destinationPrefixListId,
+                             String gatewayId, String natGatewayId) {
+        requireExactlyOneDestination("ReplaceRoute", destinationCidrBlock, destinationIpv6CidrBlock,
+                destinationPrefixListId);
         // AWS takes exactly one target. Rejecting both-or-neither also keeps the targets this
         // emulator cannot model (transit gateway, network interface, peering connection, ...) from
         // silently clearing the route and reporting success.
@@ -4518,17 +4562,20 @@ public class Ec2Service implements ContainerTeardown {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
             Route existing = next.stream()
-                    .filter(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock))
+                    .filter(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock,
+                            destinationPrefixListId))
                     .findFirst()
                     .orElseThrow(() -> new AwsException("InvalidRoute.NotFound",
                             "The route identified by "
-                                    + destinationLabel(destinationCidrBlock, destinationIpv6CidrBlock)
+                                    + destinationLabel(destinationCidrBlock, destinationIpv6CidrBlock,
+                                            destinationPrefixListId)
                                     + " does not exist", 400));
 
             // The target the request does not name is cleared rather than carried over from the
             // route being replaced.
             Route replacement = new Route(destinationCidrBlock, hasGateway ? gatewayId : null, existing.getOrigin());
             replacement.setDestinationIpv6CidrBlock(destinationIpv6CidrBlock);
+            replacement.setDestinationPrefixListId(destinationPrefixListId);
             replacement.setNatGatewayId(hasNatGateway ? natGatewayId : null);
             next.set(next.indexOf(existing), replacement);
             current.setRoutes(next);
@@ -4536,13 +4583,16 @@ public class Ec2Service implements ContainerTeardown {
         }
     }
 
-    public void deleteRoute(String region, String routeTableId, String destinationCidrBlock, String destinationIpv6CidrBlock) {
-        requireExactlyOneDestination("DeleteRoute", destinationCidrBlock, destinationIpv6CidrBlock);
+    public void deleteRoute(String region, String routeTableId, String destinationCidrBlock,
+                            String destinationIpv6CidrBlock, String destinationPrefixListId) {
+        requireExactlyOneDestination("DeleteRoute", destinationCidrBlock, destinationIpv6CidrBlock,
+                destinationPrefixListId);
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
-            next.removeIf(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock));
+            next.removeIf(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock,
+                    destinationPrefixListId));
             current.setRoutes(next);
             routeTables.put(key(region, routeTableId), current);
         }
@@ -4930,6 +4980,9 @@ public class Ec2Service implements ContainerTeardown {
                 case "route.destination-ipv6-cidr-block" -> rt.getRoutes().stream()
                         .anyMatch(r -> r.getDestinationIpv6CidrBlock() != null
                                 && matchesValue(values, r.getDestinationIpv6CidrBlock()));
+                case "route.destination-prefix-list-id" -> rt.getRoutes().stream()
+                        .anyMatch(r -> r.getDestinationPrefixListId() != null
+                                && matchesValue(values, r.getDestinationPrefixListId()));
                 default -> true;
             };
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4440,29 +4440,74 @@ public class Ec2Service implements ContainerTeardown {
         }
     }
 
-    public void createRoute(String region, String routeTableId, String destinationCidrBlock, String gatewayId, String natGatewayId) {
+    private static boolean isSet(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    /**
+     * A route is addressed by exactly one destination, and a table can hold an IPv4 and an IPv6
+     * route side by side, so the member the route does not carry is null. Comparing from the
+     * request side rather than the stored side keeps a null destination from being dereferenced:
+     * an IPv6 route in the table used to make every DeleteRoute against that table throw, IPv4
+     * ones included.
+     */
+    private static boolean matchesDestination(Route route, String destinationCidrBlock, String destinationIpv6CidrBlock) {
+        if (isSet(destinationCidrBlock) && destinationCidrBlock.equals(route.getDestinationCidrBlock())) {
+            return true;
+        }
+        return isSet(destinationIpv6CidrBlock) && destinationIpv6CidrBlock.equals(route.getDestinationIpv6CidrBlock());
+    }
+
+    /** The destination naming a route, for error messages. */
+    private static String destinationLabel(String destinationCidrBlock, String destinationIpv6CidrBlock) {
+        return isSet(destinationCidrBlock) ? destinationCidrBlock : destinationIpv6CidrBlock;
+    }
+
+    /**
+     * AWS takes one destination per route: DestinationCidrBlock or DestinationIpv6CidrBlock
+     * (or a prefix list, which this emulator does not model). Neither is a MissingParameter;
+     * both would leave a route reachable under two addresses.
+     */
+    private static void requireExactlyOneDestination(String action, String destinationCidrBlock, String destinationIpv6CidrBlock) {
+        boolean hasIpv4 = isSet(destinationCidrBlock);
+        boolean hasIpv6 = isSet(destinationIpv6CidrBlock);
+        if (!hasIpv4 && !hasIpv6) {
+            throw new AwsException("MissingParameter",
+                    "The request must include DestinationCidrBlock or DestinationIpv6CidrBlock; "
+                            + "routes are matched on their destination.", 400);
+        }
+        if (hasIpv4 && hasIpv6) {
+            throw new AwsException("InvalidParameterCombination",
+                    action + " takes one destination: DestinationCidrBlock or DestinationIpv6CidrBlock, not both.", 400);
+        }
+    }
+
+    public void createRoute(String region, String routeTableId, String destinationCidrBlock,
+                            String destinationIpv6CidrBlock, String gatewayId, String natGatewayId,
+                            String egressOnlyInternetGatewayId) {
+        requireExactlyOneDestination("CreateRoute", destinationCidrBlock, destinationIpv6CidrBlock);
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
             Route route = new Route(destinationCidrBlock, gatewayId, "CreateRoute");
+            route.setDestinationIpv6CidrBlock(destinationIpv6CidrBlock);
             route.setNatGatewayId(natGatewayId);
+            route.setEgressOnlyInternetGatewayId(egressOnlyInternetGatewayId);
             next.add(route);
             current.setRoutes(next);
             routeTables.put(key(region, routeTableId), current);
         }
     }
 
-    public void replaceRoute(String region, String routeTableId, String destinationCidrBlock, String gatewayId, String natGatewayId) {
-        if (destinationCidrBlock == null || destinationCidrBlock.isBlank()) {
-            throw new AwsException("MissingParameter",
-                    "The request must include DestinationCidrBlock; routes are matched on their IPv4 destination.", 400);
-        }
+    public void replaceRoute(String region, String routeTableId, String destinationCidrBlock,
+                             String destinationIpv6CidrBlock, String gatewayId, String natGatewayId) {
+        requireExactlyOneDestination("ReplaceRoute", destinationCidrBlock, destinationIpv6CidrBlock);
         // AWS takes exactly one target. Rejecting both-or-neither also keeps the targets this
         // emulator cannot model (transit gateway, network interface, peering connection, ...) from
         // silently clearing the route and reporting success.
-        boolean hasGateway = gatewayId != null && !gatewayId.isBlank();
-        boolean hasNatGateway = natGatewayId != null && !natGatewayId.isBlank();
+        boolean hasGateway = isSet(gatewayId);
+        boolean hasNatGateway = isSet(natGatewayId);
         if (hasGateway == hasNatGateway) {
             throw new AwsException("InvalidParameterCombination",
                     "ReplaceRoute takes exactly one target, and only GatewayId or NatGatewayId is supported.", 400);
@@ -4473,14 +4518,17 @@ public class Ec2Service implements ContainerTeardown {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
             Route existing = next.stream()
-                    .filter(r -> destinationCidrBlock.equals(r.getDestinationCidrBlock()))
+                    .filter(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock))
                     .findFirst()
                     .orElseThrow(() -> new AwsException("InvalidRoute.NotFound",
-                            "The route identified by " + destinationCidrBlock + " does not exist", 400));
+                            "The route identified by "
+                                    + destinationLabel(destinationCidrBlock, destinationIpv6CidrBlock)
+                                    + " does not exist", 400));
 
             // The target the request does not name is cleared rather than carried over from the
             // route being replaced.
             Route replacement = new Route(destinationCidrBlock, hasGateway ? gatewayId : null, existing.getOrigin());
+            replacement.setDestinationIpv6CidrBlock(destinationIpv6CidrBlock);
             replacement.setNatGatewayId(hasNatGateway ? natGatewayId : null);
             next.set(next.indexOf(existing), replacement);
             current.setRoutes(next);
@@ -4488,12 +4536,13 @@ public class Ec2Service implements ContainerTeardown {
         }
     }
 
-    public void deleteRoute(String region, String routeTableId, String destinationCidrBlock) {
+    public void deleteRoute(String region, String routeTableId, String destinationCidrBlock, String destinationIpv6CidrBlock) {
+        requireExactlyOneDestination("DeleteRoute", destinationCidrBlock, destinationIpv6CidrBlock);
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
-            next.removeIf(r -> r.getDestinationCidrBlock().equals(destinationCidrBlock));
+            next.removeIf(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock));
             current.setRoutes(next);
             routeTables.put(key(region, routeTableId), current);
         }
@@ -4878,6 +4927,9 @@ public class Ec2Service implements ContainerTeardown {
                         .anyMatch(a -> a.getGatewayId() != null && matchesValue(values, a.getGatewayId()));
                 case "association.main" -> rt.getAssociations().stream()
                         .anyMatch(a -> matchesValue(values, String.valueOf(a.isMain())));
+                case "route.destination-ipv6-cidr-block" -> rt.getRoutes().stream()
+                        .anyMatch(r -> r.getDestinationIpv6CidrBlock() != null
+                                && matchesValue(values, r.getDestinationIpv6CidrBlock()));
                 default -> true;
             };
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Route.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Route.java
@@ -9,6 +9,7 @@ public class Route {
 
     private String destinationCidrBlock;
     private String destinationIpv6CidrBlock;
+    private String destinationPrefixListId;
     private String gatewayId;
     private String natGatewayId;
     private String egressOnlyInternetGatewayId;
@@ -28,6 +29,9 @@ public class Route {
 
     public String getDestinationIpv6CidrBlock() { return destinationIpv6CidrBlock; }
     public void setDestinationIpv6CidrBlock(String destinationIpv6CidrBlock) { this.destinationIpv6CidrBlock = destinationIpv6CidrBlock; }
+
+    public String getDestinationPrefixListId() { return destinationPrefixListId; }
+    public void setDestinationPrefixListId(String destinationPrefixListId) { this.destinationPrefixListId = destinationPrefixListId; }
 
     public String getGatewayId() { return gatewayId; }
     public void setGatewayId(String gatewayId) { this.gatewayId = gatewayId; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Route.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Route.java
@@ -8,8 +8,10 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 public class Route {
 
     private String destinationCidrBlock;
+    private String destinationIpv6CidrBlock;
     private String gatewayId;
     private String natGatewayId;
+    private String egressOnlyInternetGatewayId;
     private String state = "active";
     private String origin;
 
@@ -24,11 +26,17 @@ public class Route {
     public String getDestinationCidrBlock() { return destinationCidrBlock; }
     public void setDestinationCidrBlock(String destinationCidrBlock) { this.destinationCidrBlock = destinationCidrBlock; }
 
+    public String getDestinationIpv6CidrBlock() { return destinationIpv6CidrBlock; }
+    public void setDestinationIpv6CidrBlock(String destinationIpv6CidrBlock) { this.destinationIpv6CidrBlock = destinationIpv6CidrBlock; }
+
     public String getGatewayId() { return gatewayId; }
     public void setGatewayId(String gatewayId) { this.gatewayId = gatewayId; }
 
     public String getNatGatewayId() { return natGatewayId; }
     public void setNatGatewayId(String natGatewayId) { this.natGatewayId = natGatewayId; }
+
+    public String getEgressOnlyInternetGatewayId() { return egressOnlyInternetGatewayId; }
+    public void setEgressOnlyInternetGatewayId(String egressOnlyInternetGatewayId) { this.egressOnlyInternetGatewayId = egressOnlyInternetGatewayId; }
 
     public String getState() { return state; }
     public void setState(String state) { this.state = state; }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2Ipv6RouteTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2Ipv6RouteTest.java
@@ -1,0 +1,319 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.xml.HasXPath.hasXPath;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+
+/**
+ * A route is addressed by one destination, and per
+ * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Route.html the Route type carries the
+ * IPv4 and IPv6 destinations as separate members. CreateRoute used to accept
+ * DestinationIpv6CidrBlock and drop it, storing a route with no destination at all: it could never
+ * be matched (so a create-waiter polls to its deadline) and its null destination made every
+ * DeleteRoute against the same table throw, IPv4 ones included.
+ *
+ * <p>The XPath assertions use {@code local-name()} because EC2 responses carry a default namespace.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2Ipv6RouteTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static final String VPC_CIDR = "203.0.113.0/24";
+    private static final String IPV4_ROUTE = "0.0.0.0/0";
+    private static final String IPV6_ROUTE = "::/0";
+    private static final String INTERNET_GATEWAY = "igw-0ipv6route0test0";
+    private static final String NAT_GATEWAY = "nat-0ipv6route0test0";
+    private static final String ROUTE_SET =
+            "DescribeRouteTablesResponse.routeTableSet.item.routeSet.item";
+    private static final String IPV6_NODE =
+            ROUTE_SET + ".find { it.destinationIpv6CidrBlock == '" + IPV6_ROUTE + "' }";
+    private static final String IPV4_NODE =
+            ROUTE_SET + ".find { it.destinationCidrBlock == '" + IPV4_ROUTE + "' }";
+
+    private static String routeTableId;
+
+    private static io.restassured.specification.RequestSpecification ec2() {
+        return given().header("Authorization", AUTH_HEADER);
+    }
+
+    private static io.restassured.response.ValidatableResponse describe() {
+        return ec2()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(1)
+    void createARouteTableWithAnIpv4AndAnIpv6Route() {
+        String vpcId = ec2()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", VPC_CIDR)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        routeTableId = ec2()
+            .formParam("Action", "CreateRouteTable")
+            .formParam("VpcId", vpcId)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateRouteTableResponse.routeTable.routeTableId");
+
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", IPV4_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateRouteResponse.return", equalTo("true"));
+
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", IPV6_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateRouteResponse.return", equalTo("true"));
+    }
+
+    /**
+     * The failure this fixes: the IPv6 route came back with no destination element at all, so the
+     * Terraform provider's create-waiter never saw the route it had just created.
+     */
+    @Test
+    @Order(2)
+    void anIpv6RouteReportsItsDestination() {
+        String table = describe()
+            .body(IPV6_NODE + ".gatewayId", equalTo(INTERNET_GATEWAY))
+            .body(IPV6_NODE + ".state", equalTo("active"))
+            .body(IPV6_NODE + ".origin", equalTo("CreateRoute"))
+            .extract().asString();
+
+        assertThat(table, containsString("<destinationIpv6CidrBlock>" + IPV6_ROUTE
+                + "</destinationIpv6CidrBlock>"));
+    }
+
+    /** The IPv4 route is unchanged, and carries no IPv6 destination member. */
+    @Test
+    @Order(3)
+    void anIpv4RouteStillReportsItsDestination() {
+        describe()
+            .body(IPV4_NODE + ".gatewayId", equalTo(INTERNET_GATEWAY))
+            // ...and carries no IPv6 destination member: the two are separate members of Route,
+            // not one field reused.
+            .body(hasXPath("count(//*[local-name()='item']"
+                    + "[*[local-name()='destinationCidrBlock']='" + IPV4_ROUTE + "']"
+                    + "/*[local-name()='destinationIpv6CidrBlock'])", equalTo("0")));
+    }
+
+    /**
+     * Both destinations live in one table as separate routes — three in total with the local route
+     * CreateRouteTable inserts. A model that reused a single destination field would show two.
+     */
+    @Test
+    @Order(4)
+    void bothRoutesCoexistInTheSameTable() {
+        describe()
+            .body(hasXPath("count(//*[local-name()='routeSet']/*[local-name()='item'])",
+                    equalTo("3")))
+            .body(hasXPath("count(//*[local-name()='destinationIpv6CidrBlock'])", equalTo("1")))
+            // The local route plus the IPv4 default route.
+            .body(hasXPath("count(//*[local-name()='destinationCidrBlock'])", equalTo("2")));
+    }
+
+    /** DescribeRouteTables can be filtered on the IPv6 destination, and the filter discriminates. */
+    @Test
+    @Order(5)
+    void routeTablesCanBeFilteredOnTheIpv6Destination() {
+        String matching = ec2()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("Filter.1.Name", "route.destination-ipv6-cidr-block")
+            .formParam("Filter.1.Value.1", IPV6_ROUTE)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        assertThat(matching, containsString(routeTableId));
+
+        // An unrelated IPv6 destination must not match: the branch used to fall through to
+        // `default -> true`, so this filter matched every route table rather than none.
+        String notMatching = ec2()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("Filter.1.Name", "route.destination-ipv6-cidr-block")
+            .formParam("Filter.1.Value.1", "2001:db8::/32")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().asString();
+
+        assertThat(notMatching, not(containsString(routeTableId)));
+    }
+
+    /** ReplaceRoute used to hard-reject any request without an IPv4 destination. */
+    @Test
+    @Order(6)
+    void replaceRouteRepointsTheIpv6Route() {
+        ec2()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", IPV6_ROUTE)
+            .formParam("NatGatewayId", NAT_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ReplaceRouteResponse.return", equalTo("true"));
+
+        describe()
+            .body(IPV6_NODE + ".natGatewayId", equalTo(NAT_GATEWAY))
+            // Replace, not merge: the gateway the route used to carry is gone...
+            .body(hasXPath("count(//*[local-name()='item']"
+                    + "[*[local-name()='destinationIpv6CidrBlock']='" + IPV6_ROUTE + "']"
+                    + "/*[local-name()='gatewayId'])", equalTo("0")))
+            // ...and only the addressed route moved.
+            .body(IPV4_NODE + ".gatewayId", equalTo(INTERNET_GATEWAY));
+    }
+
+    /**
+     * The regression that broke `terraform destroy` independently of the create failure: with an
+     * IPv6 route in the table, deleting an IPv4 route dereferenced the IPv6 route's null IPv4
+     * destination and returned InternalFailure.
+     */
+    @Test
+    @Order(7)
+    void deletingAnIpv4RouteWorksWhileAnIpv6RouteIsPresent() {
+        ec2()
+            .formParam("Action", "DeleteRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", IPV4_ROUTE)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeleteRouteResponse.return", equalTo("true"));
+
+        describe()
+            // The local route and the IPv6 route are left; the IPv4 default route is gone.
+            .body(hasXPath("count(//*[local-name()='routeSet']/*[local-name()='item'])",
+                    equalTo("2")))
+            .body(hasXPath("count(//*[local-name()='destinationCidrBlock'][text()='"
+                    + IPV4_ROUTE + "'])", equalTo("0")))
+            // The IPv6 route is untouched.
+            .body(IPV6_NODE + ".natGatewayId", equalTo(NAT_GATEWAY));
+    }
+
+    @Test
+    @Order(8)
+    void deletingTheIpv6RouteRemovesIt() {
+        ec2()
+            .formParam("Action", "DeleteRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", IPV6_ROUTE)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeleteRouteResponse.return", equalTo("true"));
+
+        describe()
+            .body(hasXPath("count(//*[local-name()='destinationIpv6CidrBlock'])", equalTo("0")))
+            // Only the local route CreateRouteTable inserted is left.
+            .body(hasXPath("count(//*[local-name()='routeSet']/*[local-name()='item'])",
+                    equalTo("1")));
+    }
+
+    /**
+     * A prefix-list route arrives with neither destination. Storing it would put a route in the
+     * table that nothing can ever address again — AWS answers MissingParameter instead.
+     */
+    @Test
+    @Order(9)
+    void createRouteWithNoDestinationIsRejected() {
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationPrefixListId", "pl-0ipv6route0test0")
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"));
+
+        // ...and nothing was added to the table.
+        describe()
+            .body(hasXPath("count(//*[local-name()='routeSet']/*[local-name()='item'])",
+                    equalTo("1")));
+    }
+
+    /** One destination per route: a request naming both would be addressable two ways. */
+    @Test
+    @Order(10)
+    void createRouteWithBothDestinationsIsRejected() {
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", IPV4_ROUTE)
+            .formParam("DestinationIpv6CidrBlock", IPV6_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+    }
+
+    /**
+     * The egress-only internet gateway actions are not implemented, but the id a caller sends is
+     * stored and reported rather than dropped, so the route is not left targetless.
+     */
+    @Test
+    @Order(11)
+    void anEgressOnlyInternetGatewayTargetIsReportedBack() {
+        String egressOnlyGateway = "eigw-0ipv6route0test";
+
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", IPV6_ROUTE)
+            .formParam("EgressOnlyInternetGatewayId", egressOnlyGateway)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateRouteResponse.return", equalTo("true"));
+
+        describe()
+            .body(IPV6_NODE + ".egressOnlyInternetGatewayId", equalTo(egressOnlyGateway));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2Ipv6RouteTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2Ipv6RouteTest.java
@@ -253,16 +253,67 @@ class Ec2Ipv6RouteTest {
     }
 
     /**
-     * A prefix-list route arrives with neither destination. Storing it would put a route in the
-     * table that nothing can ever address again — AWS answers MissingParameter instead.
+     * A prefix list is the third destination kind, not the absence of one: the CreateRoute
+     * reference says "You must specify either a destination CIDR block or a prefix list ID", and
+     * DestinationPrefixListId is a member of the Route output shape alongside the two CIDR
+     * members. It round-trips and stays addressable, like the other two.
      */
     @Test
     @Order(9)
+    void aPrefixListRouteRoundTripsAndIsDeletable() {
+        String prefixList = "pl-0ipv6route0test0";
+
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationPrefixListId", prefixList)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateRouteResponse.return", equalTo("true"));
+
+        String prefixListNode =
+                ROUTE_SET + ".find { it.destinationPrefixListId == '" + prefixList + "' }";
+        describe()
+            .body(prefixListNode + ".gatewayId", equalTo(INTERNET_GATEWAY))
+            // It carries neither CIDR member: the three destinations are separate members.
+            .body(hasXPath("count(//*[local-name()='item']"
+                    + "[*[local-name()='destinationPrefixListId']='" + prefixList + "']"
+                    + "/*[local-name()='destinationCidrBlock'])", equalTo("0")))
+            .body(hasXPath("count(//*[local-name()='item']"
+                    + "[*[local-name()='destinationPrefixListId']='" + prefixList + "']"
+                    + "/*[local-name()='destinationIpv6CidrBlock'])", equalTo("0")));
+
+        // Addressable again — before it was stored with no destination at all, so nothing could
+        // ever match it, and its null IPv4 destination made every DeleteRoute on the table throw.
+        ec2()
+            .formParam("Action", "DeleteRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationPrefixListId", prefixList)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        describe()
+            .body(hasXPath("count(//*[local-name()='destinationPrefixListId'])", equalTo("0")))
+            .body(hasXPath("count(//*[local-name()='routeSet']/*[local-name()='item'])",
+                    equalTo("1")));
+    }
+
+    /**
+     * Naming no destination at all is the case with no valid reading: nothing could ever address
+     * the route again. AWS documents no operation-specific error here, so the code is chosen from
+     * EC2's common client error codes rather than confirmed against the real service.
+     */
+    @Test
+    @Order(10)
     void createRouteWithNoDestinationIsRejected() {
         ec2()
             .formParam("Action", "CreateRoute")
             .formParam("RouteTableId", routeTableId)
-            .formParam("DestinationPrefixListId", "pl-0ipv6route0test0")
             .formParam("GatewayId", INTERNET_GATEWAY)
         .when()
             .post("/")
@@ -276,9 +327,9 @@ class Ec2Ipv6RouteTest {
                     equalTo("1")));
     }
 
-    /** One destination per route: a request naming both would be addressable two ways. */
+    /** One destination per route: a request naming two would be addressable two ways. */
     @Test
-    @Order(10)
+    @Order(11)
     void createRouteWithBothDestinationsIsRejected() {
         ec2()
             .formParam("Action", "CreateRoute")
@@ -298,7 +349,7 @@ class Ec2Ipv6RouteTest {
      * stored and reported rather than dropped, so the route is not left targetless.
      */
     @Test
-    @Order(11)
+    @Order(12)
     void anEgressOnlyInternetGatewayTargetIsReportedBack() {
         String egressOnlyGateway = "eigw-0ipv6route0test";
 
@@ -315,5 +366,44 @@ class Ec2Ipv6RouteTest {
 
         describe()
             .body(IPV6_NODE + ".egressOnlyInternetGatewayId", equalTo(egressOnlyGateway));
+    }
+
+    /**
+     * An egress-only internet gateway is IPv6-only and is a target in its own right, so combining
+     * it with an IPv4 target would persist a route with two targets and report both back. Only the
+     * newly accepted parameter is validated: CreateRoute has never enforced exclusivity between
+     * GatewayId and NatGatewayId, and starting to would be a behaviour change beyond this fix.
+     */
+    @Test
+    @Order(13)
+    void anEgressOnlyInternetGatewayCannotBeCombinedWithAnotherTarget() {
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", "2001:db8:1::/48")
+            .formParam("EgressOnlyInternetGatewayId", "eigw-0ipv6route0test")
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", "2001:db8:1::/48")
+            .formParam("EgressOnlyInternetGatewayId", "eigw-0ipv6route0test")
+            .formParam("NatGatewayId", NAT_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
+
+        // Nothing was persisted by either attempt.
+        describe()
+            .body(hasXPath("count(//*[local-name()='destinationIpv6CidrBlock']"
+                    + "[text()='2001:db8:1::/48'])", equalTo("0")));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ReplaceRouteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ReplaceRouteIntegrationTest.java
@@ -304,8 +304,8 @@ class Ec2ReplaceRouteIntegrationTest {
     }
 
     /**
-     * A prefix-list ReplaceRoute carries neither DestinationCidrBlock nor DestinationIpv6CidrBlock;
-     * it must not 500. IPv6 destinations are now accepted — see {@code Ec2Ipv6RouteTest}.
+     * A ReplaceRoute naming no destination at all cannot identify a route; it must not 500. All
+     * three destination kinds are now accepted — see {@code Ec2Ipv6RouteTest}.
      */
     @Test
     @Order(7)
@@ -313,7 +313,6 @@ class Ec2ReplaceRouteIntegrationTest {
         given()
             .formParam("Action", "ReplaceRoute")
             .formParam("RouteTableId", routeTableId)
-            .formParam("DestinationPrefixListId", "pl-0replace0route0test")
             .formParam("GatewayId", INTERNET_GATEWAY)
             .header("Authorization", AUTH_HEADER)
         .when()

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ReplaceRouteIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ReplaceRouteIntegrationTest.java
@@ -303,14 +303,17 @@ class Ec2ReplaceRouteIntegrationTest {
             .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
     }
 
-    /** An IPv6 or prefix-list ReplaceRoute carries no DestinationCidrBlock; it must not 500. */
+    /**
+     * A prefix-list ReplaceRoute carries neither DestinationCidrBlock nor DestinationIpv6CidrBlock;
+     * it must not 500. IPv6 destinations are now accepted — see {@code Ec2Ipv6RouteTest}.
+     */
     @Test
     @Order(7)
-    void replaceRouteWithoutAnIpv4DestinationIsRejected() {
+    void replaceRouteWithoutADestinationIsRejected() {
         given()
             .formParam("Action", "ReplaceRoute")
             .formParam("RouteTableId", routeTableId)
-            .formParam("DestinationIpv6CidrBlock", "::/0")
+            .formParam("DestinationPrefixListId", "pl-0replace0route0test")
             .formParam("GatewayId", INTERNET_GATEWAY)
             .header("Authorization", AUTH_HEADER)
         .when()


### PR DESCRIPTION
## Summary

Two linked defects in EC2 route handling.

**1. An IPv6 route is stored with no destination.** `CreateRoute` never reads `DestinationIpv6CidrBlock`, so a route created with one is persisted with a null IPv4 destination and no IPv6 destination.

**2. `DeleteRoute` then throws an NPE — and takes unrelated routes with it.** `deleteRoute`'s `removeIf` dereferences `getDestinationCidrBlock()` for *every* route in the table, so once a table holds one IPv6 route, deleting an ordinary IPv4 route fails:

```
$ aws ec2 create-route --route-table-id $RT --destination-cidr-block 0.0.0.0/0 --gateway-id $IGW
$ aws ec2 create-route --route-table-id $RT --destination-ipv6-cidr-block ::/0 --gateway-id $IGW
$ aws ec2 delete-route --route-table-id $RT --destination-cidr-block 0.0.0.0/0
InternalFailure: ... Route.getDestinationCidrBlock() is null
```

An `InternalFailure` is never a correct response here, independent of any modelling question.

Routes now carry whichever destination they were created with; `DeleteRoute` matches on the destination the request names; `DescribeRouteTables` reports `destinationIpv6CidrBlock`. A prefix list is treated as the third destination kind rather than as the absence of one, and the `removeIf` null-safety covers all three.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behaviour:** an IPv6 or prefix-list route lost its destination on create, making it unaddressable by `DeleteRoute`/`ReplaceRoute`, and its null IPv4 destination made every `DeleteRoute` against the same table throw `InternalFailure`.

Verified against the botocore EC2 model (`ec2/service-2.json`), which declares the three destinations as separate optional members:

```
CreateRoute input:  DestinationCidrBlock, DestinationIpv6CidrBlock, DestinationPrefixListId
DeleteRoute input:  DestinationCidrBlock, DestinationIpv6CidrBlock, DestinationPrefixListId
Route (output):     DestinationCidrBlock, DestinationIpv6CidrBlock, DestinationPrefixListId
```

`EgressOnlyInternetGatewayId` is declared on `CreateRoute`/`ReplaceRoute` but not `DeleteRoute`, which is what the implementation follows.

**Impact:** Terraform retries the 500, so this surfaces as a `destroy` that hangs rather than as an error. Measured on a real Terratest run: `aws_route.internet[0]: Still destroying... 19m30s elapsed`, then a runner timeout. With the fix, `Destroy complete! Resources: 46 destroyed` in ~12s.

**Behaviour change beyond the bug — please review.** `CreateRoute`/`DeleteRoute`/`ReplaceRoute` naming **no** destination member now return an error where they previously succeeded. A route stored with no destination can never be addressed again, so erroring is correct in principle, but it is a deliberate change.

**On the error code — inferred, not confirmed.** AWS declares no operation-specific errors for these three actions: the `CreateRoute` reference has an empty Errors section and `ec2/service-2.json` carries no error shapes. `MissingParameter` is chosen from EC2's common client error codes rather than confirmed against the real service; `InvalidParameterCombination` would also fit. Happy to change it if you know which the real service returns.

`EgressOnlyInternetGatewayId` combined with `GatewayId` or `NatGatewayId` is also rejected. That is scoped deliberately to the parameter this PR newly accepts — `CreateRoute` has never enforced exclusivity between `GatewayId` and `NatGatewayId`, and starting to would be a change beyond this fix.

**Known, deliberately out of scope:** creating the same destination twice persists a duplicate. As you noted, `main` has the identical `next.add(route)` with no dedup for IPv4 today, so this PR extends existing behaviour consistently rather than worsening it. Happy to open a follow-up covering all three destination kinds at once.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
