### PR TITLE
fix(kinesis): apply CreateStream's Tags instead of dropping them

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -120,10 +120,8 @@ public class KinesisJsonHandler {
         // hand-written script but not to Terraform: aws_kinesis_stream sets tags at create
         // time and then reads them back with ListTagsForStream, so an empty read produces a
         // permanent "tags will be updated in-place" diff on an unchanged configuration.
-        JsonNode tagsNode = request.path("Tags");
-        if (tagsNode.isObject() && !tagsNode.isEmpty()) {
-            Map<String, String> tags = new HashMap<>();
-            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        Map<String, String> tags = parseTags(request);
+        if (!tags.isEmpty()) {
             service.addTagsToStream(streamName, tags, region);
         }
         return Response.ok(objectMapper.createObjectNode()).build();
@@ -398,9 +396,7 @@ public class KinesisJsonHandler {
 
     private Response handleAddTagsToStream(JsonNode request, String region) {
         String streamName = resolveStreamName(request);
-        Map<String, String> tags = new HashMap<>();
-        request.path("Tags").fields().forEachRemaining(entry -> tags.put(entry.getKey(), entry.getValue().asText()));
-        service.addTagsToStream(streamName, tags, region);
+        service.addTagsToStream(streamName, parseTags(request), region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
@@ -424,6 +420,17 @@ public class KinesisJsonHandler {
         });
         response.put("HasMoreTags", false);
         return Response.ok(response).build();
+    }
+
+    // Shared by CreateStream and AddTagsToStream so the two paths cannot drift: the same
+    // request shape has to produce the same stored tags whichever operation carries it.
+    // A missing or non-object Tags member yields an empty map rather than an error, which
+    // is what AddTagsToStream already did before CreateStream started calling this.
+    private Map<String, String> parseTags(JsonNode request) {
+        Map<String, String> tags = new HashMap<>();
+        request.path("Tags").fields()
+                .forEachRemaining(entry -> tags.put(entry.getKey(), entry.getValue().asText()));
+        return tags;
     }
 
     private Response handleStartStreamEncryption(JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -116,6 +116,16 @@ public class KinesisJsonHandler {
         }
         service.createStream(streamName, shardCount, streamMode,
                 optionalMaxRecordSize(request), region);
+        // CreateStream's optional Tags member was being dropped. That is invisible to a
+        // hand-written script but not to Terraform: aws_kinesis_stream sets tags at create
+        // time and then reads them back with ListTagsForStream, so an empty read produces a
+        // permanent "tags will be updated in-place" diff on an unchanged configuration.
+        JsonNode tagsNode = request.path("Tags");
+        if (tagsNode.isObject() && !tagsNode.isEmpty()) {
+            Map<String, String> tags = new HashMap<>();
+            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+            service.addTagsToStream(streamName, tags, region);
+        }
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -1133,6 +1133,66 @@ class KinesisIntegrationTest {
             .body("Records.size()", equalTo(0));
     }
 
+    @Test
+    @Order(65)
+    void createStreamAppliesTagsFromTheRequest() {
+        // CreateStream's Tags member used to be dropped, which Terraform surfaces as a
+        // permanent tags diff: aws_kinesis_stream tags at create time, then reads back
+        // with ListTagsForStream and finds nothing.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "create-with-tags", "ShardCount": 1,
+                 "Tags": {"Foo": "Bar", "gw:example": "kinesis"}}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListTagsForStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "create-with-tags"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags.size()", equalTo(2))
+            .body("Tags.find { it.Key == 'Foo' }.Value", equalTo("Bar"))
+            .body("Tags.find { it.Key == 'gw:example' }.Value", equalTo("kinesis"));
+    }
+
+    @Test
+    @Order(66)
+    void createStreamWithoutTagsLeavesTheStreamUntagged() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "create-without-tags", "ShardCount": 1}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.ListTagsForStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "create-without-tags"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags.size()", equalTo(0));
+    }
+
     private JsonNode decodeFirstEventStreamMessage(byte[] data) throws Exception {
         ByteBuffer buf = ByteBuffer.wrap(data);
         // Skip the first message (initial-response)

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -875,5 +876,50 @@ class KinesisJsonHandlerTest {
         AwsException ex = assertThrows(AwsException.class,
                 () -> handler.handle("UpdateMaxRecordSize", update, REGION));
         assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void createStreamAppliesTagsFromTheRequest() {
+        ObjectNode create = MAPPER.createObjectNode();
+        create.put("StreamName", "tagged-stream");
+        create.put("ShardCount", 1);
+        create.putObject("Tags").put("Foo", "Bar").put("gw:example", "kinesis");
+        assertThat(handler.handle("CreateStream", create, REGION).getStatus(), is(200));
+
+        assertEquals(Map.of("Foo", "Bar", "gw:example", "kinesis"),
+                service.listTagsForStream("tagged-stream", REGION));
+    }
+
+    @Test
+    void createStreamWithoutTagsLeavesTheStreamUntagged() {
+        createStream("test-stream");
+
+        assertTrue(service.listTagsForStream("test-stream", REGION).isEmpty());
+    }
+
+    /** An empty Tags object is not an error; it simply leaves the stream untagged. */
+    @Test
+    void createStreamWithAnEmptyTagsObjectLeavesTheStreamUntagged() {
+        ObjectNode create = MAPPER.createObjectNode();
+        create.put("StreamName", "empty-tags-stream");
+        create.put("ShardCount", 1);
+        create.putObject("Tags");
+        assertThat(handler.handle("CreateStream", create, REGION).getStatus(), is(200));
+
+        assertTrue(service.listTagsForStream("empty-tags-stream", REGION).isEmpty());
+    }
+
+    /** CreateStream and AddTagsToStream share one parser, so the same map has to land either way. */
+    @Test
+    void addTagsToStreamAppliesTheSameTagsCreateStreamWould() {
+        createStream("test-stream");
+
+        ObjectNode add = MAPPER.createObjectNode();
+        add.put("StreamName", "test-stream");
+        add.putObject("Tags").put("Foo", "Bar").put("gw:example", "kinesis");
+        assertThat(handler.handle("AddTagsToStream", add, REGION).getStatus(), is(200));
+
+        assertEquals(Map.of("Foo", "Bar", "gw:example", "kinesis"),
+                service.listTagsForStream("test-stream", REGION));
     }
 }


### PR DESCRIPTION
## Summary

`CreateStream` parsed `StreamName`, `ShardCount`, `StreamModeDetails` and `MaxRecordSizeInKiB` and silently ignored the optional `Tags` member, so a stream created with tags came back untagged from `ListTagsForStream`. The tag store itself was fine — `AddTagsToStream` on the same stream persisted correctly — only the create path dropped the parameter.

`CreateStream` now applies the request's `Tags`, reusing the existing tag store rather than adding a second path. The parse is factored into a private `parseTags(JsonNode)` shared by `CreateStream` and `AddTagsToStream`, following the `parseTags` helpers `CodeBuildJsonHandler` and `SecretsManagerJsonHandler` already have. Behaviour is unchanged for `AddTagsToStream`; the point is that the two operations cannot answer the same request differently.

This is the same class of bug as #2301 (`msk: CreateCluster discards ... tags`), on a different service.

### Scope — deliberately left out

- **Tag validation.** `asText()` coerces a non-string tag value, and nothing enforces AWS's 50-tags-per-stream cap. Both are pre-existing behaviour of `AddTagsToStream`, not introduced here. The Kinesis service model types `TagValue` as a `string`, so no AWS SDK can emit the input this describes; sharing one parser is what keeps the two paths from answering the same malformed request differently. Rejecting non-string tag values is a separate input-validation fix that should land on its own, across every tag operation.
- **`RegisterStreamConsumer` also declares `Tags` and also drops them**, and `KinesisConsumer` has no tag field to put them in. `TagResource` / `UntagResource` / `ListTagsForResource` are unimplemented. Separate work.

### Tests

New handler-level unit tests, which the class had none of for tags: create with tags, create without, create with an empty `Tags` object, and `AddTagsToStream` applying the same map. Unlike the ordered integration tests, these get a fresh service per test.

Confirmed adversarially by reverting the production change: `KinesisIntegrationTest.createStreamAppliesTagsFromTheRequest` and `KinesisJsonHandlerTest.createStreamAppliesTagsFromTheRequest` both go red, while the untagged-stream guards stay green.

Beyond unit tests, this flips a real end-to-end suite: `terraform-aws-messaging`'s `TestKinesis` goes **FAIL -> PASS**, all four subtests, driven by Terratest against a local emulator.

`./mvnw test -Dtest='*Kinesis*'` -> 248 tests, 0 failures. Full suite: `./mvnw test` -> 11568 tests, 0 failures.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behaviour** — tags supplied to `CreateStream` were accepted and discarded:

```
$ aws kinesis create-stream --stream-name repro --shard-count 1 --tags Foo=Bar
$ aws kinesis list-tags-for-stream --stream-name repro
{"Tags": [], "HasMoreTags": false}
```

`kinesis/service-2.json` declares `Tags` as a member of `CreateStream`:

```
CreateStream members: [StreamName, ShardCount, StreamModeDetails, Tags, WarmThroughputMiBps, MaxRecordSizeInKiB]
required: [StreamName]
```

**Real-world impact.** Terraform's `aws_kinesis_stream` sets tags at create time and reads them back on refresh, so a dropped `Tags` is a permanent diff — every plan after a successful apply reports "tags will be updated in-place" on an unchanged configuration and the resource never converges. That is what fails `terraform-aws-messaging`'s `TestKinesis`, whose four subtests all assert `terraform plan` returns exit code 0 after apply; every other assertion in that test (shard count, encryption type, retention period) already passed.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
