### PR TITLE
feat(ses): support v2 PutAccountDetails and GetAccount Details

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesAccountAttributesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesAccountAttributesTest.java
@@ -17,18 +17,24 @@ import software.amazon.awssdk.services.ses.model.GetAccountSendingEnabledRespons
 import software.amazon.awssdk.services.ses.model.UpdateAccountSendingEnabledRequest;
 
 import software.amazon.awssdk.services.sesv2.SesV2Client;
+import software.amazon.awssdk.services.sesv2.model.AccountDetails;
+import software.amazon.awssdk.services.sesv2.model.ContactLanguage;
 import software.amazon.awssdk.services.sesv2.model.DashboardAttributes;
 import software.amazon.awssdk.services.sesv2.model.FeatureStatus;
 import software.amazon.awssdk.services.sesv2.model.GetAccountRequest;
 import software.amazon.awssdk.services.sesv2.model.GetAccountResponse;
 import software.amazon.awssdk.services.sesv2.model.GuardianAttributes;
+import software.amazon.awssdk.services.sesv2.model.MailType;
+import software.amazon.awssdk.services.sesv2.model.PutAccountDetailsRequest;
 import software.amazon.awssdk.services.sesv2.model.PutAccountSendingAttributesRequest;
 import software.amazon.awssdk.services.sesv2.model.PutAccountSuppressionAttributesRequest;
 import software.amazon.awssdk.services.sesv2.model.PutAccountVdmAttributesRequest;
+import software.amazon.awssdk.services.sesv2.model.SesV2Exception;
 import software.amazon.awssdk.services.sesv2.model.SuppressionListReason;
 import software.amazon.awssdk.services.sesv2.model.VdmAttributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("SES account attributes: sending, suppression, VDM (v1 + v2)")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -197,5 +203,51 @@ class SesAccountAttributesTest {
 
         GetAccountSendingEnabledResponse afterV2Enable = sesV1.getAccountSendingEnabled();
         assertThat(afterV2Enable.enabled()).isTrue();
+    }
+
+    @Test
+    @Order(6)
+    void putAndGet_accountDetailsRoundTrip() {
+        // PutAccountDetails is POST (unlike the sibling PUT account operations); the SDK exercises the
+        // real verb, so a mis-wired route would surface here. Status is set by AWS's review and is not
+        // controllable, so assert only that ReviewDetails is present with a status and case id.
+        //
+        // PutAccountDetails has no delete/reset API and AWS owns the resulting ReviewDetails/case, so
+        // this mutation cannot be undone — re-submitting captured fields cannot restore the prior
+        // review status or case id. Skip it entirely on real AWS rather than risk changing a real
+        // caller's account; against Floci the in-memory store makes the round-trip safe and it still
+        // catches a mis-wired route there.
+        org.junit.jupiter.api.Assumptions.assumeFalse(TestFixtures.isRealAws(),
+                "skipping on real AWS: PutAccountDetails cannot be reset and AWS owns ReviewDetails");
+        sesV2.putAccountDetails(PutAccountDetailsRequest.builder()
+                .mailType(MailType.TRANSACTIONAL)
+                .websiteURL("https://example.com")
+                .contactLanguage(ContactLanguage.EN)
+                .useCaseDescription("compatibility test")
+                .additionalContactEmailAddresses("ops@example.com")
+                .build());
+
+        GetAccountResponse account = sesV2.getAccount(GetAccountRequest.builder().build());
+        AccountDetails details = account.details();
+        assertThat(details).isNotNull();
+        assertThat(details.mailType()).isEqualTo(MailType.TRANSACTIONAL);
+        assertThat(details.websiteURL()).isEqualTo("https://example.com");
+        assertThat(details.contactLanguage()).isEqualTo(ContactLanguage.EN);
+        assertThat(details.additionalContactEmailAddresses()).contains("ops@example.com");
+        assertThat(details.reviewDetails()).isNotNull();
+        assertThat(details.reviewDetails().statusAsString()).isNotBlank();
+        assertThat(details.reviewDetails().caseId()).isNotBlank();
+    }
+
+    @Test
+    @Order(7)
+    void putAccountDetails_invalidMailType_throwsBadRequest() {
+        // Server-side enum validation (the string bypasses the SDK's typed enum), rejected without
+        // mutating account state.
+        assertThatThrownBy(() -> sesV2.putAccountDetails(PutAccountDetailsRequest.builder()
+                        .mailType("SPAM")
+                        .websiteURL("https://example.com")
+                        .build()))
+                .isInstanceOf(SesV2Exception.class);
     }
 }

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -209,6 +209,7 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `PUT` | `/v2/email/account/sending` | `PutAccountSendingAttributes` |
 | `PUT` | `/v2/email/account/suppression` | `PutAccountSuppressionAttributes` |
 | `PUT` | `/v2/email/account/vdm` | `PutAccountVdmAttributes` |
+| `POST` | `/v2/email/account/details` | `PutAccountDetails` |
 | `POST` | `/v2/email/templates` | `CreateEmailTemplate` |
 | `GET` | `/v2/email/templates` | `ListEmailTemplates` |
 | `GET` | `/v2/email/templates/{templateName}` | `GetEmailTemplate` |
@@ -276,6 +277,8 @@ A `+label` subaddress is supported on any of these, so `bounce+order-123@simulat
 A successful send without a simulator-address recipient emits only the `Send` event.
 
 Account-level VDM (Virtual Deliverability Manager) attributes are stored per region. `PutAccountVdmAttributes` sets `VdmEnabled` (opt-in, defaults `DISABLED`) plus the optional `DashboardAttributes.EngagementMetrics` and `GuardianAttributes.OptimizedSharedDelivery`. `GetAccount` omits `VdmAttributes` until VDM has been configured for the region, then returns `VdmEnabled`, adding the `DashboardAttributes`/`GuardianAttributes` sub-objects only while `VdmEnabled` is `ENABLED`. Floci stores the settings but does not run VDM analytics.
+
+Account provisioning details are stored per region. `PutAccountDetails` sets `MailType` (required, ∈ {`MARKETING`, `TRANSACTIONAL`}) and `WebsiteURL` (required, 1–1000 chars) plus the optional `ContactLanguage` (∈ {`EN`, `JA`}), `UseCaseDescription` (≤5000 chars), `AdditionalContactEmailAddresses` (1–4 entries, each 6–254 chars matching `^(.+)@(.+)$`), and `ProductionAccessEnabled`. Floci stores `ProductionAccessEnabled` as given but stays production-enabled regardless (it has no sandbox), so the flag has no functional effect. Like `VdmAttributes`, `GetAccount` omits `Details` until it has been configured for the region, then echoes the stored fields under `Details` with a `ReviewDetails` block. Matching AWS, all modeled-constraint violations (null / enum / length / list) are aggregated into a single `BadRequestException` reporting every failure; a malformed (but in-range) `WebsiteURL` is reported separately as `Url contains invalid format`. Floci has no sandbox and does not run a production-access review, so `ReviewDetails.Status` is always `GRANTED`.
 
 Suppression list entries are stored per region with `Reason` ∈ {`BOUNCE`, `COMPLAINT`}. At send time, a recipient is suppressed when it appears on the suppression list AND its stored `Reason` is contained in the **effective** `SuppressedReasons` for the send. The effective list is the configuration set's `SuppressionOptions.SuppressedReasons` (set via `PutConfigurationSetSuppressionOptions`) when present — an **empty list is preserved as an explicit "no suppression filtering for this configuration set"** — otherwise it falls back to the account-level `AccountSuppressionAttributes.SuppressedReasons` (set via `PutAccountSuppressionAttributes`, default `[BOUNCE, COMPLAINT]`). Following the AWS V2 contract, there is no dedicated `GetConfigurationSetSuppressionOptions` action; once set, the block is read back through `GetConfigurationSet`'s response (the field is omitted when the configuration set has no override).
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesAccountService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesAccountService.java
@@ -1,23 +1,31 @@
 package io.github.hectorvent.floci.services.ses;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ses.model.AccountDetails;
 import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Account-level SES settings, extracted from {@link SesService} as part of the store-based domain
  * split. Reached through the {@code SesService} facade, which delegates here.
  *
- * <p>Owns the account sending-enabled flag ({@code accountSettingsStore}) and the VDM (Virtual
- * Deliverability Manager) attributes ({@code accountVdmStore}). Account suppression is account-level
- * too, but it shares {@code validateSuppressionReason} with the suppression list, so it lives in
+ * <p>Owns the account sending-enabled flag ({@code accountSettingsStore}), the VDM (Virtual
+ * Deliverability Manager) attributes ({@code accountVdmStore}), and the provisioning details
+ * ({@code accountDetailsStore}). Account suppression is account-level too, but it shares
+ * {@code validateSuppressionReason} with the suppression list, so it lives in
  * {@link SesSuppressionService} instead.
  */
 @ApplicationScoped
@@ -27,6 +35,7 @@ public class SesAccountService {
 
     private final StorageBackend<String, Boolean> accountSettingsStore;
     private final StorageBackend<String, AccountVdmAttributes> accountVdmStore;
+    private final StorageBackend<String, AccountDetails> accountDetailsStore;
 
     @Inject
     public SesAccountService(StorageFactory storageFactory) {
@@ -34,12 +43,16 @@ public class SesAccountService {
                 new TypeReference<Map<String, Boolean>>() {});
         this.accountVdmStore = storageFactory.create("ses", "ses-account-vdm.json",
                 new TypeReference<Map<String, AccountVdmAttributes>>() {});
+        this.accountDetailsStore = storageFactory.create("ses", "ses-account-details.json",
+                new TypeReference<Map<String, AccountDetails>>() {});
     }
 
     SesAccountService(StorageBackend<String, Boolean> accountSettingsStore,
-                      StorageBackend<String, AccountVdmAttributes> accountVdmStore) {
+                      StorageBackend<String, AccountVdmAttributes> accountVdmStore,
+                      StorageBackend<String, AccountDetails> accountDetailsStore) {
         this.accountSettingsStore = accountSettingsStore;
         this.accountVdmStore = accountVdmStore;
+        this.accountDetailsStore = accountDetailsStore;
     }
 
     public boolean isAccountSendingEnabled(String region) {
@@ -66,5 +79,119 @@ public class SesAccountService {
 
     private static String accountVdmKey(String region) {
         return "account-vdm::" + region;
+    }
+
+    // Provisioning details are opt-in and per region, like VDM: GetAccount omits Details entirely
+    // until PutAccountDetails is called for the region, so this returns empty for an unconfigured
+    // region.
+    public Optional<AccountDetails> findAccountDetails(String region) {
+        return accountDetailsStore.get(accountDetailsKey(region));
+    }
+
+    // Owns the domain behavior for account details so it can't be bypassed by another caller: it
+    // validates the modeled constraints, mints the synthetic review/case (Floci has no sandbox and
+    // runs no production-access review, so the review is always GRANTED), and persists the record. The
+    // controller only parses the REST JSON and rejects wrong JSON types before calling this.
+    public AccountDetails putAccountDetails(String region, String mailType, String websiteUrl,
+                                            String contactLanguage, String useCaseDescription,
+                                            List<String> additionalContacts, boolean productionAccessEnabled) {
+        validateAccountDetails(mailType, websiteUrl, contactLanguage, useCaseDescription, additionalContacts);
+        AccountDetails details = new AccountDetails(mailType, websiteUrl, contactLanguage,
+                useCaseDescription, additionalContacts, productionAccessEnabled, "GRANTED",
+                syntheticCaseId(region, mailType, websiteUrl));
+        accountDetailsStore.put(accountDetailsKey(region), details);
+        LOG.infov("Updated account details for region {0}: mailType={1}, productionAccess={2}",
+                region, mailType, productionAccessEnabled);
+        return details;
+    }
+
+    private static String accountDetailsKey(String region) {
+        return "account-details::" + region;
+    }
+
+    // A stable, region-scoped synthetic case id (kept constant across GetAccount reads for the same
+    // input). Floci has no real review case; the value only matches AWS's numeric-string shape.
+    private static String syntheticCaseId(String region, String mailType, String websiteUrl) {
+        return String.valueOf(1_000_000_000L
+                + Math.floorMod((region + "::" + mailType + "::" + websiteUrl).hashCode(), 1_000_000_000));
+    }
+
+    private static final Set<String> MAIL_TYPES = Set.of("MARKETING", "TRANSACTIONAL");
+    private static final Set<String> CONTACT_LANGUAGES = Set.of("EN", "JA");
+    // Modeled constraint bounds (from the SES v2 SDK model, probe-confirmed against real AWS).
+    private static final int WEBSITE_URL_MAX = 1000;
+    private static final int USE_CASE_DESCRIPTION_MAX = 5000;
+    private static final int CONTACTS_MAX = 4;
+    private static final int CONTACT_MIN = 6;
+    private static final int CONTACT_MAX = 254;
+    private static final Pattern CONTACT_PATTERN = Pattern.compile("^(.+)@(.+)$");
+
+    // AWS aggregates every modeled-constraint violation (null / enum / length / list / element) into a
+    // single "N validation errors detected: ..." response. Floci mirrors the message text and count;
+    // the order across fields is deterministic here (declared order) rather than AWS's internal order.
+    // The "Url contains invalid format" business check is separate and only runs once the modeled
+    // constraints pass (probe-confirmed: a well-formed-length but non-URL value returns it standalone).
+    private static void validateAccountDetails(String mailType, String websiteUrl, String contactLanguage,
+                                               String useCaseDescription, List<String> additionalContacts) {
+        List<String> errors = new ArrayList<>();
+        if (mailType == null) {
+            errors.add(constraint("mailType", "Member must not be null"));
+        } else if (!MAIL_TYPES.contains(mailType)) {
+            errors.add(constraint("mailType", "Member must satisfy enum value set: [MARKETING, TRANSACTIONAL]"));
+        }
+        if (websiteUrl == null) {
+            errors.add(constraint("websiteURL", "Member must not be null"));
+        } else if (websiteUrl.isEmpty()) {
+            errors.add(constraint("websiteURL", "Member must have length greater than or equal to 1"));
+        } else if (websiteUrl.length() > WEBSITE_URL_MAX) {
+            errors.add(constraint("websiteURL", "Member must have length less than or equal to " + WEBSITE_URL_MAX));
+        }
+        if (contactLanguage != null && !CONTACT_LANGUAGES.contains(contactLanguage)) {
+            errors.add(constraint("contactLanguage", "Member must satisfy enum value set: [EN, JA]"));
+        }
+        if (useCaseDescription != null && useCaseDescription.length() > USE_CASE_DESCRIPTION_MAX) {
+            errors.add(constraint("useCaseDescription",
+                    "Member must have length less than or equal to " + USE_CASE_DESCRIPTION_MAX));
+        }
+        if (additionalContacts != null) {
+            if (additionalContacts.isEmpty()) {
+                errors.add(constraint("additionalContactEmailAddresses",
+                        "Member must have length greater than or equal to 1"));
+            } else if (additionalContacts.size() > CONTACTS_MAX) {
+                errors.add(constraint("additionalContactEmailAddresses",
+                        "Member must have length less than or equal to " + CONTACTS_MAX));
+            }
+            for (String contact : additionalContacts) {
+                if (contact == null || contact.length() < CONTACT_MIN || contact.length() > CONTACT_MAX
+                        || !CONTACT_PATTERN.matcher(contact).matches()) {
+                    // AWS reports all three element sub-constraints together regardless of which failed.
+                    errors.add(constraint("additionalContactEmailAddresses",
+                            "Member must satisfy constraint: [Member must have length less than or equal to "
+                                    + CONTACT_MAX + ", Member must have length greater than or equal to "
+                                    + CONTACT_MIN + ", Member must satisfy regular expression pattern: ^(.+)@(.+)$]"));
+                }
+            }
+        }
+        if (!errors.isEmpty()) {
+            throw new AwsException("BadRequestException",
+                    errors.size() + " validation error" + (errors.size() > 1 ? "s" : "")
+                            + " detected: " + String.join("; ", errors), 400);
+        }
+        if (!isValidUrl(websiteUrl)) {
+            throw new AwsException("BadRequestException", "Url contains invalid format", 400);
+        }
+    }
+
+    private static String constraint(String field, String detail) {
+        return "Value at '" + field + "' failed to satisfy constraint: " + detail;
+    }
+
+    private static boolean isValidUrl(String url) {
+        try {
+            URI uri = URI.create(url);
+            return uri.getScheme() != null && uri.getHost() != null;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -1870,6 +1870,27 @@ public class SesController {
             }
         });
 
+        // Like VdmAttributes, AWS omits Details until PutAccountDetails has run for the region.
+        sesService.findAccountDetails(region).ifPresent(details -> {
+            ObjectNode d = result.putObject("Details");
+            d.put("MailType", details.mailType());
+            d.put("WebsiteURL", details.websiteUrl());
+            if (details.contactLanguage() != null) {
+                d.put("ContactLanguage", details.contactLanguage());
+            }
+            if (details.useCaseDescription() != null) {
+                d.put("UseCaseDescription", details.useCaseDescription());
+            }
+            if (details.additionalContactEmailAddresses() != null
+                    && !details.additionalContactEmailAddresses().isEmpty()) {
+                ArrayNode addrs = d.putArray("AdditionalContactEmailAddresses");
+                details.additionalContactEmailAddresses().forEach(addrs::add);
+            }
+            ObjectNode review = d.putObject("ReviewDetails");
+            review.put("Status", details.reviewStatus());
+            review.put("CaseId", details.caseId());
+        });
+
         return Response.ok(result).build();
     }
 
@@ -1908,6 +1929,75 @@ public class SesController {
         } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
             throw new AwsException("BadRequestException", e.getMessage(), 400);
         }
+    }
+
+    @POST
+    @Path("/account/details")
+    public Response putAccountDetails(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = (body == null || body.isBlank())
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(body);
+            requireJsonObject(request);
+
+            // Parse every member first (rejecting wrong JSON types as a serialization error, the way
+            // AWS does before validation), then validate the parsed values together so all constraint
+            // violations are aggregated into one response.
+            String mailType = requireStringOrAbsent(request, "MailType");
+            String websiteUrl = requireStringOrAbsent(request, "WebsiteURL");
+            String contactLanguage = requireStringOrAbsent(request, "ContactLanguage");
+            String useCaseDescription = requireStringOrAbsent(request, "UseCaseDescription");
+
+            List<String> additionalContacts = null;
+            JsonNode contacts = request.path("AdditionalContactEmailAddresses");
+            if (!contacts.isMissingNode() && !contacts.isNull()) {
+                // A typed list member: reject a non-array, and reject non-string elements, rather than
+                // coercing (asText would turn 123 into "123"), matching how AWS rejects type mismatches.
+                if (!contacts.isArray()) {
+                    throw new AwsException("SerializationException", null, 400);
+                }
+                additionalContacts = new ArrayList<>();
+                for (JsonNode node : contacts) {
+                    if (!node.isTextual()) {
+                        throw new AwsException("SerializationException", null, 400);
+                    }
+                    additionalContacts.add(node.textValue());
+                }
+            }
+            JsonNode productionAccess = request.path("ProductionAccessEnabled");
+            if (!productionAccess.isMissingNode() && !productionAccess.isNull() && !productionAccess.isBoolean()) {
+                throw new AwsException("SerializationException", null, 400);
+            }
+            boolean productionAccessEnabled = productionAccess.asBoolean(false);
+
+            // The service owns validation and the synthetic review/case so they can't be bypassed; the
+            // controller only parses the REST JSON and rejects wrong JSON types.
+            sesService.putAccountDetails(region, mailType, websiteUrl, contactLanguage,
+                    useCaseDescription, additionalContacts, productionAccessEnabled);
+            LOG.infov("SES V2 PutAccountDetails: region={0}, mailType={1}", region, mailType);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            // AWS reports a malformed JSON body as a SerializationException, the same error type used
+            // for wrong-typed members above.
+            throw new AwsException("SerializationException", null, 400);
+        }
+    }
+
+    // Read a typed string member: absent/null returns null, but a present value of the wrong JSON type
+    // is rejected rather than coerced (asText would turn 123 into "123"), the same as the identity and
+    // configuration-set string members elsewhere in this controller.
+    private static String requireStringOrAbsent(JsonNode parent, String field) {
+        JsonNode n = parent.path(field);
+        if (n.isMissingNode() || n.isNull()) {
+            return null;
+        }
+        if (!n.isTextual()) {
+            throw new AwsException("SerializationException", null, 400);
+        }
+        return n.textValue();
     }
 
     // Parse an AWS FeatureStatus (ENABLED/DISABLED) field. A required member that is absent, or any

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.route53.model.HostedZone;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
 import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
+import io.github.hectorvent.floci.services.ses.model.AccountDetails;
 import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
 import io.github.hectorvent.floci.services.ses.model.ArchivingOptions;
 import io.github.hectorvent.floci.services.ses.model.BulkEmailEntry;
@@ -1122,6 +1123,17 @@ public class SesService {
 
     public void setAccountSendingEnabled(String region, boolean enabled) {
         accountService.setAccountSendingEnabled(region, enabled);
+    }
+
+    public Optional<AccountDetails> findAccountDetails(String region) {
+        return accountService.findAccountDetails(region);
+    }
+
+    public AccountDetails putAccountDetails(String region, String mailType, String websiteUrl,
+                                            String contactLanguage, String useCaseDescription,
+                                            List<String> additionalContacts, boolean productionAccessEnabled) {
+        return accountService.putAccountDetails(region, mailType, websiteUrl, contactLanguage,
+                useCaseDescription, additionalContacts, productionAccessEnabled);
     }
 
     public Optional<AccountVdmAttributes> findAccountVdmAttributes(String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/model/AccountDetails.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/model/AccountDetails.java
@@ -1,0 +1,26 @@
+package io.github.hectorvent.floci.services.ses.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/**
+ * Account-level provisioning details, set by PutAccountDetails and surfaced under GetAccount's
+ * {@code Details}. Per region and present-when-set: GetAccount omits the block entirely until
+ * PutAccountDetails is called for the region.
+ *
+ * <p>{@code reviewStatus}/{@code caseId} back the AWS {@code ReviewDetails} sub-structure. AWS runs a
+ * real production-access review; Floci has no sandbox, so it reports a granted review.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AccountDetails(String mailType,
+                             String websiteUrl,
+                             String contactLanguage,
+                             String useCaseDescription,
+                             List<String> additionalContactEmailAddresses,
+                             boolean productionAccessEnabled,
+                             String reviewStatus,
+                             String caseId) {
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountDetailsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountDetailsV2IntegrationTest.java
@@ -1,0 +1,243 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests for the SES V2 account provisioning details: {@code POST /v2/email/account/details}
+ * (PutAccountDetails) and the {@code GET /v2/email/account} (GetAccount) {@code Details} round-trip.
+ * Shapes, defaults, and validation are verified against real AWS: Details is per-region and
+ * present-when-set (GetAccount omits it until configured), MailType/WebsiteURL are required and their
+ * null violations are reported together, and MailType/ContactLanguage are enum-constrained. Floci has
+ * no sandbox, so ReviewDetails is reported as GRANTED.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesAccountDetailsV2IntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/ca-central-1/ses/aws4_request";
+
+    @Test
+    @Order(0)
+    void getAccount_detailsAbsentUntilConfigured() {
+        // A region where PutAccountDetails was never called omits the Details key entirely. Assert the
+        // key is absent (not merely null): JsonPath can't tell a missing key from an explicit null, and
+        // omission is the AWS-compatible behavior under test.
+        given().header("Authorization", AUTH)
+        .when().get("/v2/email/account").then().statusCode(200)
+                .body("$", not(hasKey("Details")));
+    }
+
+    @Test
+    @Order(1)
+    void putDetails_roundTripsThroughGetAccount() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("""
+                    {"MailType":"TRANSACTIONAL","WebsiteURL":"https://example.com",
+                     "ContactLanguage":"EN","UseCaseDescription":"transactional mail",
+                     "AdditionalContactEmailAddresses":["ops@example.com"]}
+                    """)
+        .when().post("/v2/email/account/details").then().statusCode(200);
+
+        given().header("Authorization", AUTH)
+        .when().get("/v2/email/account").then().statusCode(200)
+                .body("Details.MailType", equalTo("TRANSACTIONAL"))
+                .body("Details.WebsiteURL", equalTo("https://example.com"))
+                .body("Details.ContactLanguage", equalTo("EN"))
+                .body("Details.UseCaseDescription", equalTo("transactional mail"))
+                .body("Details.AdditionalContactEmailAddresses[0]", equalTo("ops@example.com"))
+                .body("Details.ReviewDetails.Status", equalTo("GRANTED"))
+                .body("Details.ReviewDetails.CaseId", notNullValue());
+    }
+
+    @Test
+    @Order(2)
+    void putDetails_missingBothRequired_reportsAggregatedError() {
+        // AWS reports both null violations at once (mailType before websiteURL).
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("__type", equalTo("BadRequestException"))
+                .body("message", equalTo("2 validation errors detected: Value at 'mailType' failed to "
+                        + "satisfy constraint: Member must not be null; Value at 'websiteURL' failed to "
+                        + "satisfy constraint: Member must not be null"));
+    }
+
+    @Test
+    @Order(3)
+    void putDetails_missingWebsiteUrl_reportsSingleError() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at 'websiteURL' failed to "
+                        + "satisfy constraint: Member must not be null"));
+    }
+
+    @Test
+    @Order(4)
+    void putDetails_invalidMailTypeEnum_returnsBadRequest() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"SPAM\",\"WebsiteURL\":\"https://example.com\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at 'mailType' failed to "
+                        + "satisfy constraint: Member must satisfy enum value set: [MARKETING, TRANSACTIONAL]"));
+    }
+
+    @Test
+    @Order(5)
+    void putDetails_invalidContactLanguageEnum_returnsBadRequest() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"ContactLanguage\":\"FR\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at 'contactLanguage' failed "
+                        + "to satisfy constraint: Member must satisfy enum value set: [EN, JA]"));
+    }
+
+    @Test
+    @Order(6)
+    void putDetails_blankWebsiteUrl_returnsLengthError() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at 'websiteURL' failed to "
+                        + "satisfy constraint: Member must have length greater than or equal to 1"));
+    }
+
+    @Test
+    @Order(7)
+    void putDetails_nonUrlWebsite_returnsFormatError() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"not a url\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("Url contains invalid format"));
+    }
+
+    @Test
+    @Order(8)
+    void putDetails_nonStringTypedMember_returnsBadRequest() {
+        // A present-but-wrong-type typed member is rejected rather than coerced (asText would turn 123
+        // into "123"), matching the identity/configuration-set string members.
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":123,\"WebsiteURL\":\"https://example.com\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(9)
+    void putDetails_nonArrayAdditionalContacts_returnsBadRequest() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"AdditionalContactEmailAddresses\":\"ops@example.com\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(10)
+    void putDetails_nonBooleanProductionAccess_returnsBadRequest() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"ProductionAccessEnabled\":\"yes\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(11)
+    void putDetails_websiteUrlTooLong_returnsLengthError() {
+        String longUrl = "https://example.com/" + "a".repeat(1001);
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"" + longUrl + "\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at 'websiteURL' failed to "
+                        + "satisfy constraint: Member must have length less than or equal to 1000"));
+    }
+
+    @Test
+    @Order(12)
+    void putDetails_useCaseDescriptionTooLong_returnsLengthError() {
+        String longDesc = "x".repeat(5001);
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"UseCaseDescription\":\"" + longDesc + "\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at 'useCaseDescription' failed "
+                        + "to satisfy constraint: Member must have length less than or equal to 5000"));
+    }
+
+    @Test
+    @Order(13)
+    void putDetails_tooManyContacts_returnsLengthError() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"AdditionalContactEmailAddresses\":[\"a1@example.com\",\"a2@example.com\","
+                        + "\"a3@example.com\",\"a4@example.com\",\"a5@example.com\"]}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'additionalContactEmailAddresses' failed to satisfy constraint: Member must "
+                        + "have length less than or equal to 4"));
+    }
+
+    @Test
+    @Order(14)
+    void putDetails_emptyContactsList_returnsLengthError() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"AdditionalContactEmailAddresses\":[]}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'additionalContactEmailAddresses' failed to satisfy constraint: Member must "
+                        + "have length greater than or equal to 1"));
+    }
+
+    @Test
+    @Order(15)
+    void putDetails_contactElementTooShort_returnsElementConstraint() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"https://example.com\","
+                        + "\"AdditionalContactEmailAddresses\":[\"a@b\"]}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("1 validation error detected: Value at "
+                        + "'additionalContactEmailAddresses' failed to satisfy constraint: Member must "
+                        + "satisfy constraint: [Member must have length less than or equal to 254, "
+                        + "Member must have length greater than or equal to 6, Member must satisfy "
+                        + "regular expression pattern: ^(.+)@(.+)$]"));
+    }
+
+    @Test
+    @Order(16)
+    void putDetails_multipleLengthViolations_areAggregated() {
+        String longUrl = "https://example.com/" + "a".repeat(1001);
+        String longDesc = "x".repeat(5001);
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"MailType\":\"TRANSACTIONAL\",\"WebsiteURL\":\"" + longUrl + "\","
+                        + "\"UseCaseDescription\":\"" + longDesc + "\"}")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("message", equalTo("2 validation errors detected: Value at 'websiteURL' failed to "
+                        + "satisfy constraint: Member must have length less than or equal to 1000; "
+                        + "Value at 'useCaseDescription' failed to satisfy constraint: Member must have "
+                        + "length less than or equal to 5000"));
+    }
+
+    @Test
+    @Order(17)
+    void putDetails_malformedJson_returnsSerializationException() {
+        // AWS reports a malformed JSON body as a SerializationException, not BadRequestException.
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{ not json")
+        .when().post("/v2/email/account/details").then().statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountDetailsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountDetailsV2IntegrationTest.java
@@ -240,4 +240,28 @@ class SesAccountDetailsV2IntegrationTest {
         .when().post("/v2/email/account/details").then().statusCode(400)
                 .body("__type", equalTo("SerializationException"));
     }
+
+    @Test
+    @Order(18)
+    void putDetails_productionAccessEnabled_topLevelStaysTrueAndNotInDetails() {
+        // ProductionAccessEnabled is a GetAccount top-level member, not an AccountDetails field. Floci
+        // has no sandbox and runs no production-access review, so the top-level flag stays true
+        // regardless of the value sent to PutAccountDetails, and it never appears inside Details. Use a
+        // dedicated region so this is independent of the other ordered cases.
+        String euAuth = "AWS4-HMAC-SHA256 Credential=AKID/20260101/eu-west-2/ses/aws4_request";
+        given().contentType("application/json").header("Authorization", euAuth)
+                .body("""
+                    {"MailType":"MARKETING","WebsiteURL":"https://example.org",
+                     "ProductionAccessEnabled":false}
+                    """)
+        .when().post("/v2/email/account/details").then().statusCode(200);
+
+        given().header("Authorization", euAuth)
+        .when().get("/v2/email/account").then().statusCode(200)
+                // The top-level flag stays true even though false was sent.
+                .body("ProductionAccessEnabled", equalTo(true))
+                // Details is present (configured) but carries no ProductionAccessEnabled member.
+                .body("Details.MailType", equalTo("MARKETING"))
+                .body("Details", not(hasKey("ProductionAccessEnabled")));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountServiceTest.java
@@ -1,11 +1,18 @@
 package io.github.hectorvent.floci.services.ses;
 
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.AccountDetails;
 import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -20,7 +27,7 @@ class SesAccountServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new SesAccountService(new InMemoryStorage<>(), new InMemoryStorage<>());
+        service = new SesAccountService(new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>());
     }
 
     @Test
@@ -53,5 +60,31 @@ class SesAccountServiceTest {
         assertTrue(vdm.vdmEnabled());
         assertTrue(vdm.engagementMetrics());
         assertFalse(vdm.optimizedSharedDelivery());
+    }
+
+    @Test
+    void accountDetails_absentUntilConfigured_thenRoundTrip() {
+        // Opt-in like VDM: a never-configured region has no Details at all.
+        assertTrue(service.findAccountDetails(REGION).isEmpty());
+
+        AccountDetails stored = service.putAccountDetails(REGION, "TRANSACTIONAL",
+                "https://example.com", "EN", "use case", List.of("ops@example.com"), true);
+        assertEquals("GRANTED", stored.reviewStatus());
+        assertNotNull(stored.caseId());
+
+        AccountDetails d = service.findAccountDetails(REGION).orElseThrow();
+        assertEquals("TRANSACTIONAL", d.mailType());
+        assertEquals("https://example.com", d.websiteUrl());
+        assertEquals("GRANTED", d.reviewStatus());
+        assertTrue(service.findAccountDetails("eu-west-1").isEmpty());
+    }
+
+    @Test
+    void accountDetails_invalidInput_isRejectedByService() {
+        // Domain validation lives in the service, so it can't be bypassed by another caller.
+        assertThrows(AwsException.class, () -> service.putAccountDetails(REGION, "SPAM",
+                "https://example.com", null, null, null, false));
+        assertThrows(AwsException.class, () -> service.putAccountDetails(REGION, null,
+                null, null, null, null, false));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountServiceTest.java
@@ -76,6 +76,9 @@ class SesAccountServiceTest {
         assertEquals("TRANSACTIONAL", d.mailType());
         assertEquals("https://example.com", d.websiteUrl());
         assertEquals("GRANTED", d.reviewStatus());
+        // ProductionAccessEnabled is stored as given (the GetAccount top-level flag stays true
+        // regardless — asserted at the controller layer).
+        assertTrue(d.productionAccessEnabled());
         assertTrue(service.findAccountDetails("eu-west-1").isEmpty());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ses;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.AccountDetails;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
@@ -33,6 +34,7 @@ final class SesServiceTestBuilder {
     private final InMemoryStorage<String, SentEmail> emailStore = new InMemoryStorage<>();
     private final InMemoryStorage<String, Boolean> accountSettingsStore = new InMemoryStorage<>();
     private final InMemoryStorage<String, AccountVdmAttributes> accountVdmStore = new InMemoryStorage<>();
+    private final InMemoryStorage<String, AccountDetails> accountDetailsStore = new InMemoryStorage<>();
     private final InMemoryStorage<String, EmailTemplate> templateStore = new InMemoryStorage<>();
     private final InMemoryStorage<String, ConfigurationSet> configSetStore = new InMemoryStorage<>();
     private final InMemoryStorage<String, SuppressedDestination> suppressionStore = new InMemoryStorage<>();
@@ -110,7 +112,7 @@ final class SesServiceTestBuilder {
         return new SesService(
                 identityStore,
                 new SesSentEmailService(emailStore),
-                new SesAccountService(accountSettingsStore, accountVdmStore),
+                new SesAccountService(accountSettingsStore, accountVdmStore, accountDetailsStore),
                 new SesTemplateService(templateStore),
                 configSetStore,
                 new SesSuppressionService(suppressionStore, accountSuppressionStore),


### PR DESCRIPTION
## Summary

Add the SES v2 `PutAccountDetails` operation and surface its data under `GetAccount`'s
`Details`. Details are per-region and present-when-set (like `VdmAttributes`): `GetAccount`
omits the block entirely until `PutAccountDetails` has been called for the region. The store
lives in `SesAccountService`, the facade delegates, and the v2 controller adds
`POST /v2/email/account/details` plus the `Details` rendering in `GetAccount`.

`MailType` and `WebsiteURL` are required; a request missing both reports the two null
violations together (aggregated), matching AWS. `MailType` (`MARKETING`/`TRANSACTIONAL`) and
`ContactLanguage` (`EN`/`JA`) are enum-constrained; a blank `WebsiteURL` fails the length
check and a malformed one fails the URL-format check. Floci has no sandbox and runs no
production-access review, so `ReviewDetails.Status` is reported as `GRANTED`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Shapes, defaults, and validation were verified against real AWS SES v2 (SDK for Java v2 /
botocore). Confirmed: `Details` is per-region and omitted until configured; the required-member
checks are aggregated with the exact Smithy messages; `MailType`/`ContactLanguage` enum sets;
blank vs malformed `WebsiteURL` distinction; and the `Details` shape including
`ReviewDetails{Status, CaseId}`. Unit tests cover the service round-trip; integration tests
cover the `POST` + `GetAccount` round-trip and every validation error path against Floci.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)