### PR TITLE
fix(ses): report the sending account in send-event payloads

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ses;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.route53.Route53Service;
@@ -117,6 +118,9 @@ public class SesService {
     // placeholder and the List-Unsubscribe header) that resolve to Floci's own unsubscribe endpoint.
     private final String baseUrl;
     private final Route53Service route53Service;
+    // Resolves the caller's account per request so send-event payloads report the sending account, not
+    // the fixed default. Null in the package-private test constructors (falls back to defaultAccountId).
+    private final RegionResolver regionResolver;
     private final Clock clock;
     private final ConcurrentHashMap<String, DkimLookupCacheEntry> dkimLookupCache = new ConcurrentHashMap<>();
 
@@ -128,7 +132,7 @@ public class SesService {
                        SesTemplateService templateService, SesSentEmailService sentEmailService,
                        SmtpRelay smtpRelay, ObjectMapper objectMapper,
                        SesEventPublisher eventPublisher, EmulatorConfig config, Route53Service route53Service,
-                       Clock clock) {
+                       RegionResolver regionResolver, Clock clock) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
                 new TypeReference<Map<String, Identity>>() {});
         this.sentEmailService = sentEmailService;
@@ -148,6 +152,7 @@ public class SesService {
         this.defaultAccountId = config.defaultAccountId();
         this.baseUrl = config.effectiveBaseUrl();
         this.route53Service = route53Service;
+        this.regionResolver = regionResolver;
         this.clock = clock;
     }
 
@@ -202,6 +207,7 @@ public class SesService {
         this.defaultAccountId = "000000000000";
         this.baseUrl = "http://localhost:4566";
         this.route53Service = route53Service;
+        this.regionResolver = null;
         this.clock = clock;
     }
 
@@ -500,7 +506,9 @@ public class SesService {
         List<String> envelope = envelopeDestinations != null
                 ? envelopeDestinations : Collections.emptyList();
         Instant timestamp = Instant.now();
-        String sendingAccountId = defaultAccountId;
+        // Report the caller's account (resolved per request) in the event payload and source ARN,
+        // falling back to the default account outside a request context (e.g. unit tests).
+        String sendingAccountId = regionResolver != null ? regionResolver.getAccountId() : defaultAccountId;
         String sourceArn = (source == null || source.isBlank())
                 ? null
                 : AwsArnUtils.Arn.of("ses", region, sendingAccountId,

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEventPublishingAccountV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEventPublishingAccountV2IntegrationTest.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that a SES send authenticated as a non-default account reports THAT account in the event
+ * payload — {@code mail.sendingAccountId} and {@code mail.sourceArn} — rather than the fixed default.
+ * Floci derives the account from a 12-digit access key id (the LocalStack multi-account convention),
+ * so every resource here (queue, topic, identity, configuration set) is created under the same
+ * non-default account and is account-isolated by the storage layer.
+ */
+@QuarkusTest
+class SesEventPublishingAccountV2IntegrationTest {
+
+    private static final String ACCOUNT = "210987654321";
+    private static final String SES_AUTH =
+            "AWS4-HMAC-SHA256 Credential=" + ACCOUNT + "/20260101/us-east-1/ses/aws4_request";
+    private static final String SNS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=" + ACCOUNT + "/20260101/us-east-1/sns/aws4_request";
+    private static final String SQS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=" + ACCOUNT + "/20260101/us-east-1/sqs/aws4_request";
+    private static final String AWS_JSON = "application/x-amz-json-1.0";
+    private static final String SENDER = "acct-sender@floci.test";
+    private static final String CS = "acct-evt-cs";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void send_reportsCallerAccountInEventPayload() throws Exception {
+        String queueUrl = given().contentType(AWS_JSON).header("Authorization", SQS_AUTH)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("{\"QueueName\":\"acct-ses-events-queue\"}")
+        .when().post("/").then().statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+        assertNotNull(queueUrl);
+
+        String queueArn = given().contentType(AWS_JSON).header("Authorization", SQS_AUTH)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"AttributeNames\":[\"All\"]}")
+        .when().post("/").then().statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+        // The queue ARN carries the caller's account.
+        assertEquals("arn:aws:sqs:us-east-1:" + ACCOUNT + ":acct-ses-events-queue", queueArn);
+
+        String topicArn = given().contentType(AWS_JSON).header("Authorization", SNS_AUTH)
+                .header("X-Amz-Target", "SNS_20100331.CreateTopic")
+                .body("{\"Name\":\"acct-ses-events-topic\"}")
+        .when().post("/").then().statusCode(200)
+                .extract().jsonPath().getString("TopicArn");
+
+        given().contentType(AWS_JSON).header("Authorization", SNS_AUTH)
+                .header("X-Amz-Target", "SNS_20100331.Subscribe")
+                .body("{\"TopicArn\":\"" + topicArn + "\",\"Protocol\":\"sqs\",\"Endpoint\":\"" + queueArn + "\"}")
+        .when().post("/").then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"EmailIdentity\":\"" + SENDER + "\"}")
+        .when().post("/v2/email/identities").then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("{\"ConfigurationSetName\":\"" + CS + "\"}")
+        .when().post("/v2/email/configuration-sets").then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("""
+                    {"EventDestinationName":"ed-sns","EventDestination":{"Enabled":true,
+                     "MatchingEventTypes":["SEND","DELIVERY"],"SnsDestination":{"TopicArn":"%s"}}}
+                    """.formatted(topicArn))
+        .when().post("/v2/email/configuration-sets/" + CS + "/event-destinations").then().statusCode(200);
+
+        given().contentType("application/json").header("Authorization", SES_AUTH)
+                .body("""
+                    {"FromEmailAddress":"%s","Destination":{"ToAddresses":["success@simulator.amazonses.com"]},
+                     "ConfigurationSetName":"%s",
+                     "Content":{"Simple":{"Subject":{"Data":"acct-evt"},"Body":{"Text":{"Data":"hi"}}}}}
+                    """.formatted(SENDER, CS))
+        .when().post("/v2/email/outbound-emails").then().statusCode(200);
+
+        List<JsonNode> events = receiveEvents(queueUrl, 2);
+        assertTrue(events.size() >= 1, "expected at least one SES event");
+        for (JsonNode evt : events) {
+            JsonNode mail = evt.path("mail");
+            assertEquals(ACCOUNT, mail.path("sendingAccountId").asText(),
+                    "event should report the caller's account, not the default");
+            assertEquals("arn:aws:ses:us-east-1:" + ACCOUNT + ":identity/" + SENDER,
+                    mail.path("sourceArn").asText());
+        }
+    }
+
+    private List<JsonNode> receiveEvents(String queueUrl, int expectedAtLeast) throws Exception {
+        List<JsonNode> events = new ArrayList<>();
+        for (int attempt = 0; attempt < 10 && events.size() < expectedAtLeast; attempt++) {
+            Response r = given().contentType(AWS_JSON).header("Authorization", SQS_AUTH)
+                    .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                    .body("{\"QueueUrl\":\"" + queueUrl + "\",\"MaxNumberOfMessages\":10,\"WaitTimeSeconds\":1}")
+            .when().post("/").then().statusCode(200).extract().response();
+            List<String> bodies = r.jsonPath().getList("Messages.Body");
+            if (bodies == null) {
+                continue;
+            }
+            for (String body : bodies) {
+                JsonNode snsWrapper = MAPPER.readTree(body);
+                events.add(MAPPER.readTree(snsWrapper.path("Message").asText()));
+            }
+        }
+        return events;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesEventPublishingV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesEventPublishingV2IntegrationTest.java
@@ -195,6 +195,11 @@ class SesEventPublishingV2IntegrationTest {
                 .filter(e -> "Delivery".equals(e.path("eventType").asText()))
                 .findFirst().orElseThrow();
         assertEquals(SENDER, delivery.path("mail").path("source").asText());
+        // The event reports the sending account (resolved per request; the default account here) in
+        // both sendingAccountId and the source ARN.
+        assertEquals("000000000000", delivery.path("mail").path("sendingAccountId").asText());
+        assertEquals("arn:aws:ses:us-east-1:000000000000:identity/" + SENDER,
+                delivery.path("mail").path("sourceArn").asText());
         assertEquals("success@simulator.amazonses.com",
                 delivery.path("delivery").path("recipients").get(0).asText());
         assertEquals(CS, delivery.path("mail").path("tags").path("ses:configuration-set").get(0).asText());


### PR DESCRIPTION
## Summary

The SES send-event notification payload built `mail.sendingAccountId` and `mail.sourceArn` (the
sender identity ARN) from the fixed default account, so under Floci's per-request multi-account
support they always showed `000000000000` regardless of the caller.

`publishSendEvents` now resolves the account per request via `RegionResolver.getAccountId()` (the
same request-scoped mechanism the account-aware services use), falling back to the default account
outside a request context (e.g. unit tests). Because the whole send family (`SendEmail`,
`SendRawEmail`, templated, bulk — v1 and v2) shares `publishSendEvents`, this is a single fix point.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS populates the event's `sendingAccountId`/`sourceArn` with the sending account. Floci resolves it
from the caller's credential (a 12-digit access key id is the account, matching the multi-account
convention), so a send authenticated as account `2109...` now reports that account instead of the
default. The delivery-event integration test asserts `mail.sendingAccountId` and `mail.sourceArn`
carry the resolved account. No wire-shape change; only the previously-hardcoded account value is now
per-request.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)