### PR TITLE
chore(ci): raise the test job timeout to 30 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   test:
     name: Build and Test
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7.0.1
 


### PR DESCRIPTION
The test suite now runs close to the 20 minute job timeout and gets cancelled. Noticed in #2452, and recent runs on main hit it too.