### PR TITLE
fix(ci): replace setup-java's broken maven cache with actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,18 @@ jobs:
         with:
           java-version: '25'
           distribution: 'temurin'
-          cache: maven
+
+      # setup-java's built-in `cache: maven` never actually saves a cache on this action
+      # version - every run restores nothing ("maven cache is not found") and then fails to
+      # save with "Path Validation Error: Path(s) specified in the action for caching do(es)
+      # not exist", so every run has been resolving all dependencies cold. Using actions/cache
+      # directly instead, which is the same mechanism setup-java's option wraps.
+      - uses: actions/cache@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-${{ runner.os }}-
 
       - name: Run tests
         run: mvn test -B

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/cache@v6.1.0
         with:
           path: ~/.m2/repository
-          key: maven-${{ runner.os }}-${{ hashFiles('**/pom.xml') }}
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
           restore-keys: |
             maven-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary

The simplest, zero-cost item from the CI build-performance investigation (P0, Finding 1):
`setup-java@v5.6.0`'s built-in `cache: maven` has never actually worked on this repo. Checked
3 independent CI runs spanning ~7 hours — all 3 show the identical pair of lines:

```
maven cache is not found
...
##[warning]Error: Path Validation Error: Path(s) specified in the action for caching
do(es) not exist, hence no cache is being saved.
```

Restore misses every time *because* the save fails every time — no cache has ever been
successfully populated for this repo, so every single CI run resolves the full Maven
dependency tree cold. No custom `localRepository` override exists anywhere (`pom.xml`,
`.mvn/`, `Makefile`) that would explain the path mismatch — this looks like a bug in this
specific pinned action version.

Swapped it for an explicit `actions/cache@v6.1.0` step keyed on `pom.xml`'s hash — the same
underlying mechanism `setup-java`'s `cache: maven` option wraps, just transparent and
debuggable instead of silently broken.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Cost / Risk

- **Cost**: none — GitHub Actions cache storage is free up to 10GB/repo.
- **Risk**: low — workflow-only change, no build or test logic touched, same runner.
- **Expected savings**: modest (~15-30s/run, GitHub's link to Maven Central is already fast),
  but it eliminates 100% pure waste and a warning that fires on every single job.

## How to verify

After merge, the next CI run should show `Cache restored from key: maven-Linux-...` on restore,
and no `Path Validation Error` warning at the end of the job. Rollback is a one-line revert of
this workflow file.

## Checklist

- [x] Workflow-only change; validated YAML syntax locally
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
