### PR TITLE
ci: surface per-class timings from the compatibility test legs

### DIFF
--- a/.github/ci/compat-timing-report.py
+++ b/.github/ci/compat-timing-report.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Print per-class timings from junit XMLs, slowest first.
+
+Usage: compat-timing-report.py <results-dir>
+Also appends the table to GITHUB_STEP_SUMMARY when set. Never fails the job:
+bad or absent XMLs produce an empty report, not an error.
+"""
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+def main():
+    d = sys.argv[1] if len(sys.argv) > 1 else 'test-results'
+    rows = []
+    for f in glob.glob(os.path.join(d, '*.xml')):
+        try:
+            root = ET.parse(f).getroot()
+        except ET.ParseError:
+            continue
+        suites = root.iter('testsuite') if root.tag != 'testsuite' else [root]
+        for ts in suites:
+            rows.append((float(ts.get('time') or 0), int(ts.get('tests') or 0),
+                         ts.get('name') or os.path.basename(f)))
+    rows.sort(reverse=True)
+    total_t = sum(r[0] for r in rows)
+    total_n = sum(r[1] for r in rows)
+    lines = [f'== {len(rows)} suites, {total_n} tests, {total_t / 60:.1f} min total test time',
+             '== slowest 25 classes:']
+    lines += [f'{t:8.1f}s {n:5d} tests  {name}' for t, n, name in rows[:25]]
+    report = '\n'.join(lines)
+    print(report)
+    summary = os.environ.get('GITHUB_STEP_SUMMARY')
+    if summary:
+        with open(summary, 'a') as fh:
+            fh.write('```\n' + report + '\n```\n')
+
+if __name__ == '__main__':
+    main()

--- a/.github/ci/compat-timing-report.py
+++ b/.github/ci/compat-timing-report.py
@@ -16,12 +16,17 @@ def main():
     for f in glob.glob(os.path.join(d, '*.xml')):
         try:
             root = ET.parse(f).getroot()
-        except ET.ParseError:
+        except (ET.ParseError, OSError) as exc:
+            print(f'warning: skipping unreadable JUnit XML {f}: {exc}', file=sys.stderr)
             continue
         suites = root.iter('testsuite') if root.tag != 'testsuite' else [root]
         for ts in suites:
-            rows.append((float(ts.get('time') or 0), int(ts.get('tests') or 0),
-                         ts.get('name') or os.path.basename(f)))
+            try:
+                rows.append((float(ts.get('time') or 0), int(ts.get('tests') or 0),
+                             ts.get('name') or os.path.basename(f)))
+            except ValueError as exc:
+                print(f'warning: skipping suite with non-numeric attributes in {f}: {exc}',
+                      file=sys.stderr)
     rows.sort(reverse=True)
     total_t = sum(r[0] for r in rows)
     total_n = sum(r[1] for r in rows)

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -240,6 +240,8 @@ jobs:
       # machine-readable across runs.
       - name: Report slowest test classes
         if: always() && steps.tests.outcome != 'skipped'
+        # Measurement-only: a reporting bug must never fail an otherwise-green leg.
+        continue-on-error: true
         run: python3 .github/ci/compat-timing-report.py test-results
 
       - name: Upload test results

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -10,6 +10,7 @@ on:
       - 'docker/entrypoint.sh'
       - 'docker/localstack-parity.sh'
       - 'compatibility-tests/**'
+      - '.github/ci/compat-timing-report.py'
       - '.github/workflows/compatibility.yml'
 
 permissions:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -179,7 +179,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7.0.1
         with:
-          sparse-checkout: compatibility-tests
+          sparse-checkout: |
+            compatibility-tests
+            .github/ci
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -229,6 +231,23 @@ jobs:
         uses: test-summary/action@37b508cfee6d4d080eedd00b5bb240a6a784a6a5 # v2
         with:
           paths: test-results/*.xml
+
+      # The test body inside the container runs its build tool quietly, so the
+      # job log carries no per-class timings and the slow legs (sdk-test-java,
+      # ~10 min) are a black box. Surface the timings from the junit XMLs the
+      # suites already export, and upload the raw XMLs so the numbers are
+      # machine-readable across runs.
+      - name: Report slowest test classes
+        if: always() && steps.tests.outcome != 'skipped'
+        run: python3 .github/ci/compat-timing-report.py test-results
+
+      - name: Upload test results
+        if: always() && steps.tests.outcome != 'skipped'
+        uses: actions/upload-artifact@v7
+        with:
+          name: compat-results-${{ matrix.test }}
+          path: test-results/
+          if-no-files-found: warn
 
       - name: Dump floci logs
         if: failure()


### PR DESCRIPTION
## Summary

Instruments the compatibility-test legs so their runtime is measurable. The slowest leg (`sdk-test-java`, ~10 minutes of the ~18-minute compat critical path) is currently a black box: the container runs `mvn test -q`, so the CI log has no per-class times, and the junit XMLs the suites already copy to `test-results/` are read once by the summary action and discarded.

- **Report slowest test classes**: a small parser (`.github/ci/compat-timing-report.py`) prints the slowest 25 classes plus the suite total to the job log and step summary, from the XMLs every leg already exports. It never fails the job; absent or malformed XMLs produce an empty report.
- **Upload `test-results/` as a per-leg artifact** (`compat-results-<leg>`), so timings are machine-readable and comparable across runs.
- The leg's sparse checkout gains `.github/ci` so the parser is present.

This is measurement only, deciding how to split or speed up the java leg should follow the data rather than precede it. Parser dry-run against the last local `sdk-test-java` results: 121 suites / 1,414 tests / 3.1 min summed, top classes Ec2Tests 32.8s, OpenSearchTest 15.6s, EcsTests 13.5s.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A: CI workflow instrumentation only; no emulated surface or test behavior is touched.

## Checklist

- [x] `./mvnw test` passes locally (no Java changed; parser dry-run verified against real junit XMLs, workflow YAML validated)
- [ ] New or updated integration test added (not applicable: CI-only change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
