### PR TITLE
fix(dynamodb): tolerate whitespace before a function's own parenthesis

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1753,7 +1753,7 @@ public class DynamoDbService {
                     throw new AwsException("ValidationException",
                             "The parameter cannot be converted to a numeric value", 400);
                 }
-            } else if (valuePart.startsWith("if_not_exists(")) {
+            } else if (startsWithFunctionCall(valuePart, "if_not_exists")) {
                 // if_not_exists(attrRef, fallbackExpr) evaluates to:
                 //   attrRef's current value  — when attrRef exists in the item
                 //   fallbackExpr             — otherwise
@@ -1776,7 +1776,7 @@ public class DynamoDbService {
                         setValueAtPath(item, attrPath, resolved, exprAttrNames);
                     }
                 }
-            } else if (valuePart.toLowerCase().startsWith("list_append(")) {
+            } else if (startsWithFunctionCall(valuePart.toLowerCase(), "list_append")) {
                 int open = valuePart.indexOf('(');
                 int close = valuePart.lastIndexOf(')');
                 if (open >= 0 && close > open) {
@@ -1854,7 +1854,7 @@ public class DynamoDbService {
 
     private JsonNode evaluateSetExpr(ObjectNode item, String expr,
                                      JsonNode exprAttrNames, JsonNode exprAttrValues) {
-        if (expr.toLowerCase().startsWith("if_not_exists(")) {
+        if (startsWithFunctionCall(expr.toLowerCase(), "if_not_exists")) {
             String[] args = extractFunctionArgs(expr);
             if (args.length == 2) {
                 String checkAttr = resolveAttributeName(args[0].trim(), exprAttrNames);
@@ -2452,6 +2452,18 @@ public class DynamoDbService {
             }
         }
         return -1;
+    }
+
+    /**
+     * Whether {@code value} opens with a call to {@code functionName}, tolerating optional
+     * whitespace between the function name and the opening parenthesis. DynamoDB's
+     * UpdateExpression grammar is whitespace-insensitive there, but SDKs commonly emit the
+     * spaced form (e.g. PynamoDB always generates {@code "list_append (x, y)"}), which a plain
+     * {@code startsWith(functionName + "(")} rejects.
+     */
+    private static boolean startsWithFunctionCall(String value, String functionName) {
+        return value.startsWith(functionName)
+                && value.substring(functionName.length()).stripLeading().startsWith("(");
     }
 
     private String[] extractFunctionArgs(String funcCall) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbUpdateExpressionWhitespaceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbUpdateExpressionWhitespaceTest.java
@@ -159,6 +159,36 @@ class DynamoDbUpdateExpressionWhitespaceTest {
             .body("Attributes.c.N", equalTo("6"));
     }
 
+    /**
+     * Regression test for #2509: a space between a function name and its own opening
+     * parenthesis (e.g. {@code "list_append ("} rather than {@code "list_append("}) is
+     * accepted by real AWS and is exactly what PynamoDB always emits, but
+     * {@code applySetClause}/{@code evaluateSetExpr} gated on a literal
+     * {@code startsWith(functionName + "(")} check, so the spaced form fell through to the
+     * "plain attribute reference" branch and silently failed to resolve - the SET was a
+     * no-op with no error. Distinct from #1640 above: this whitespace sits between the
+     * function name and its own parenthesis, not between clause keywords or a function's
+     * arguments, so #1640's tokenizer-level normalization didn't reach it.
+     */
+    @Test
+    void spaceBeforeFunctionParenthesisIsAccepted() {
+        createAndSeed("UpdWsFuncSpace", """
+            {"pk":{"S":"x"},"l":{"L":[{"S":"one"}]},"m":{"S":"present"}}""");
+        given().header("X-Amz-Target", "DynamoDB_20120810.UpdateItem").contentType(CT).body("""
+            {"TableName":"UpdWsFuncSpace","Key":{"pk":{"S":"x"}},
+             "UpdateExpression":"SET #l = list_append (#l, :more), #m = if_not_exists (#missing, :fallback)",
+             "ReturnValues":"ALL_NEW",
+             "ExpressionAttributeNames":{"#l":"l","#m":"m","#missing":"missing"},
+             "ExpressionAttributeValues":{":more":{"L":[{"S":"two"}]},":fallback":{"S":"unused"}}}
+            """)
+        .when().post("/").then()
+            .statusCode(200)
+            .body("Attributes.l.L.size()", equalTo(2))
+            .body("Attributes.l.L[0].S", equalTo("one"))
+            .body("Attributes.l.L[1].S", equalTo("two"))
+            .body("Attributes.m.S", equalTo("unused"));
+    }
+
     @Test
     void invalidLeadingKeywordIsStillRejected() {
         createAndSeed("UpdWsBad");


### PR DESCRIPTION
## Summary

Fixes #2509

`applySetClause`/`evaluateSetExpr` gate `list_append` and `if_not_exists` on a literal `startsWith(functionName + "(")`. When there's a space between the function name and its own opening parenthesis - `"list_append (x, y)"` instead of `"list_append(x, y)"` - that check fails, the value falls through to the "plain attribute reference" branch, resolves to nothing, and the `SET` silently no-ops. No exception, no error - the write is just dropped.

This matters because PynamoDB (a widely used Python DynamoDB ORM) always emits the spaced form for `list_append`, and real AWS DynamoDB's UpdateExpression grammar is whitespace-insensitive around function calls, so this form works fine against real AWS. Confirmed via botocore debug logging on the PynamoDB side, then isolated to the space alone by replaying the identical expression through the raw AWS CLI (see #2509 for the full trace).

### Relationship to #1640

#1640 (already fixed) normalized whitespace between clause keywords (`SET`/`REMOVE`/etc.) and between a function's arguments. This is a distinct gap: whitespace between a function's own name and its own parenthesis, evaluated in the per-clause value evaluator rather than the top-level tokenizer, so #1640's fix and tests didn't reach it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** an `UpdateExpression` with whitespace between a function name and its opening parenthesis — `SET #l = list_append (#l, :v)` — was silently ignored. `UpdateItem` returned success with no error, but the attribute was never modified. The same expression without the space worked correctly.

DynamoDB's `UpdateExpression` grammar is whitespace-insensitive around function calls, and real AWS accepts both forms. This is not a theoretical edge case: **PynamoDB always emits the spaced form** (`format_string = 'list_append ({0}, {1})'` in `pynamodb/expressions/operand.py`), so every `list_append` issued through that ORM was silently dropped rather than applied — a data-loss-shaped failure with no signal to the caller.

Verified with AWS CLI v2 against a locally built JVM jar:

```
SET #i = list_append(#i, :v)     → applied      (worked before this PR too)
SET #i = list_append (#i, :v)    → applied      (silently no-op'd before this PR)
SET #m = if_not_exists (#x, :v)  → applied      (same latent bug, also fixed)
```

## Fix

Added a small `startsWithFunctionCall(value, functionName)` helper that tolerates optional whitespace before the parenthesis, and used it at all three existing `list_append(`/`if_not_exists(` gate checks (case-sensitivity preserved per call site - one of the three was already case-sensitive, which I left as-is rather than changing unrelated behavior).

## Testing

- Added `spaceBeforeFunctionParenthesisIsAccepted` to `DynamoDbUpdateExpressionWhitespaceTest` (the existing whitespace-regression suite), covering both `list_append` and `if_not_exists` with the space form.
- Ran the full `io.github.hectorvent.floci.services.dynamodb.*Test` package: 302 tests, 0 failures.
- Manually verified via raw `awslocal dynamodb update-item` against a locally built JVM jar that: the spaced form now works, the existing non-spaced form still works (no regression), and `if_not_exists (...)` (also affected by the same pattern) now works too.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
