### PR TITLE
fix(secretsmanager): raise InvalidRequestException, not ResourceNotFoundException, for pending-deletion secrets

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -138,11 +138,7 @@ public class SecretsManagerService {
 
     public SecretVersion getSecretValue(String secretId, String versionId, String versionStage, String region) {
         Secret secret = resolveSecret(secretId, region);
-
-        if (secret.getDeletedDate() != null) {
-            throw new AwsException("ResourceNotFoundException",
-                    "Secrets Manager can't find the specified secret.", 400);
-        }
+        throwIfPendingDeletion(secret);
 
         SecretVersion version;
         if (versionId != null && !versionId.isEmpty()) {
@@ -178,11 +174,7 @@ public class SecretsManagerService {
                                         String secretBinary, String clientRequestToken, String region,
                                         List<String> versionStages) {
         Secret secret = resolveSecret(secretId, region);
-
-        if (secret.getDeletedDate() != null) {
-            throw new AwsException("ResourceNotFoundException",
-                    "Secrets Manager can't find the specified secret.", 400);
-        }
+        throwIfPendingDeletion(secret);
 
         if (clientRequestToken != null && (clientRequestToken.length() < 32 || clientRequestToken.length() > 64)) {
             throw new AwsException("InvalidParameterException", "ClientRequestToken must be between 32 and 64 characters long.", 400);
@@ -285,11 +277,7 @@ public class SecretsManagerService {
 
     public Secret updateSecret(String secretId, String description, String kmsKeyId, String region) {
         Secret secret = resolveSecret(secretId, region);
-
-        if (secret.getDeletedDate() != null) {
-            throw new AwsException("ResourceNotFoundException",
-                    "Secrets Manager can't find the specified secret.", 400);
-        }
+        throwIfPendingDeletion(secret);
 
         if (description != null) {
             secret.setDescription(description);
@@ -370,10 +358,7 @@ public class SecretsManagerService {
         Secret resolved = resolveSecret(secretId, region);
         synchronized (lockFor(resolved.getArn())) {
             Secret secret = resolveSecret(resolved.getArn(), region);
-            if (secret.getDeletedDate() != null) {
-                throw new AwsException("ResourceNotFoundException",
-                        "Secrets Manager can't find the specified secret.", 400);
-            }
+            throwIfPendingDeletion(secret);
 
             String existingOwner = secret.getTargetAttachmentOwner();
             if (existingOwner != null && !existingOwner.equals(attachmentOwner)) {
@@ -585,11 +570,7 @@ public class SecretsManagerService {
     public Secret rotateSecret(String secretId, String clientRequestToken, String rotationLambdaArn, Secret.RotationRules rotationRules,
                                boolean rotateImmediately, String region) {
         Secret secret = resolveSecret(secretId, region);
-
-        if (secret.getDeletedDate() != null) {
-            throw new AwsException("ResourceNotFoundException",
-                    "Secrets Manager can't find the specified secret.", 400);
-        }
+        throwIfPendingDeletion(secret);
 
         if (clientRequestToken != null && (clientRequestToken.length() < 32 || clientRequestToken.length() > 64)) {
             throw new AwsException("InvalidParameterException", "ClientRequestToken must be between 32 and 64 characters long.", 400);
@@ -838,9 +819,7 @@ public class SecretsManagerService {
         }
 
         Secret secret = resolveSecret(secretId, region);
-        if (secret.getDeletedDate() != null) {
-            throw new AwsException("ResourceNotFoundException", "Secrets Manager can't find the specified secret.", 400);
-        }
+        throwIfPendingDeletion(secret);
 
         SecretVersion versionByStage = findVersionByStage(secret, versionStage);
         String currentVersionId = versionByStage != null
@@ -931,6 +910,22 @@ public class SecretsManagerService {
     ) {
         public static BatchGetSecretValueResult empty() {
             return new BatchGetSecretValueResult(Collections.emptyList(), Collections.emptyList());
+        }
+    }
+
+    /**
+     * A secret found by {@link #resolveSecret} with {@code deletedDate} set is on the
+     * recovery-window path (still in {@code store}, still restorable) - {@link
+     * #deleteSecret} force-deletes by removing the entry from {@code store} outright, so a
+     * fully, permanently gone secret never reaches this check; {@code resolveSecret} throws
+     * ResourceNotFoundException for that case on its own. Real AWS's error for the
+     * recoverable case is InvalidRequestException, matching what {@code batchGetSecretValue}
+     * already does correctly - the other call sites threw ResourceNotFoundException instead.
+     */
+    private void throwIfPendingDeletion(Secret secret) {
+        if (secret.getDeletedDate() != null) {
+            throw new AwsException("InvalidRequestException",
+                    "You can't perform this operation on the secret because it was marked for deletion.", 400);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -251,9 +251,34 @@ class SecretsManagerServiceTest {
 
         assertNotNull(deleted.getDeletedDate());
 
-        // The secret still exists but marked deleted
-        assertThrows(AwsException.class, () ->
+        // The secret still exists but marked deleted: real AWS raises InvalidRequestException
+        // here, distinct from the ResourceNotFoundException a genuinely absent secret gets.
+        // A bare assertThrows(AwsException.class, ...) doesn't distinguish the two - regression
+        // test for the bug where every one of these sites except batchGetSecretValue threw the
+        // wrong (not-found) code.
+        AwsException ex = assertThrows(AwsException.class, () ->
                 service.getSecretValue("my-secret", null, null, REGION));
+        assertEquals("InvalidRequestException", ex.getErrorCode());
+    }
+
+    @Test
+    void operationsOnPendingDeletionSecretRaiseInvalidRequestNotResourceNotFound() {
+        service.createSecret("my-secret", "value", null, null, null, null, REGION);
+        service.deleteSecret("my-secret", 7, false, REGION);
+
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.getSecretValue("my-secret", null, null, REGION)).getErrorCode());
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.putSecretValue("my-secret", "v2", null, null, REGION, null)).getErrorCode());
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.updateSecret("my-secret", "new description", null, REGION)).getErrorCode());
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.claimTargetAttachment("my-secret", "owner-1", REGION)).getErrorCode());
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.rotateSecret("my-secret", null, "arn:aws:lambda:us-east-1:000000000000:function:rotator",
+                        null, false, REGION)).getErrorCode());
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.updateSecretVersionStage("my-secret", null, null, "AWSCURRENT", REGION)).getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #2513

`DeleteSecret` without `ForceDeleteWithoutRecovery` sets `deletedDate` on the secret to a future date and keeps it in `store` (recoverable via `RestoreSecret`) - it's only removed from `store` outright on a force delete. That means any `secret.getDeletedDate() != null` check reached *after* `resolveSecret()` has already succeeded can only mean one thing: the secret is still present, just scheduled for deletion. `resolveSecret()` already raises `ResourceNotFoundException` on its own for a secret that's genuinely gone (force-deleted or never existed).

Real AWS reports the pending-deletion case as `InvalidRequestException` ("You can't perform this operation on the secret because it was marked for deletion."), distinct from `ResourceNotFoundException`. Six call sites - `getSecretValue`, `putSecretValue`, `updateSecret`, `claimTargetAttachment`, `rotateSecret`, and `updateSecretVersionStage` - instead raised `ResourceNotFoundException`, making a still-restorable secret indistinguishable by error code from one that's genuinely gone.

`batchGetSecretValue` in the same file already had this right (`InvalidRequestException` with the correct message), so there was already an internal precedent for the correct behavior - it just wasn't applied consistently. (As @pgermosen noted in review, `restoreSecret` is a second precedent: it already raises `InvalidRequestException` for the mirror-image "was not deleted" case.)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** operations on a secret scheduled for deletion (the recovery-window path, not a force delete) raised `ResourceNotFoundException` instead of `InvalidRequestException`. That made a still-restorable secret indistinguishable, by error code alone, from one that is genuinely gone — so a caller can't tell "recoverable, call `RestoreSecret`" from "never existed".

`InvalidRequestException` in `secretsmanager/2017-10-17/service-2.json` documents this case explicitly as a cause: *"A parameter value is not valid for the current state of the resource. Possible causes: The secret is scheduled for deletion."* All six operations touched here declare `InvalidRequestException` in their error lists.

`DescribeSecret` and `ListSecretVersionIds` deliberately **not** touched — they don't declare `InvalidRequestException`, and describing a scheduled secret is how a caller reads its `DeletedDate`.

Verified against `floci/floci:1.7.0-compat` and a locally built JVM jar with AWS CLI v2:

```
get-secret-value            → InvalidRequestException   "You can't perform this operation…"
put-secret-value            → InvalidRequestException
update-secret               → InvalidRequestException
rotate-secret               → InvalidRequestException
update-secret-version-stage → InvalidRequestException
describe-secret             → 200   (correct — AWS allows this)
restore-secret              → 200   (correct)
```

`claimTargetAttachment` isn't reachable from the CLI, so it's covered by unit test rather than a CLI probe.

## Fix

Extracted the correct check into a shared `throwIfPendingDeletion(Secret secret)` helper (matching `batchGetSecretValue`'s existing message) and applied it at all six affected call sites.

## Testing

- Strengthened `deleteSecretWithRecoveryWindow`: it previously only asserted `AwsException.class`, which passes regardless of error code and didn't catch this bug. Now asserts the specific error code.
- Added `operationsOnPendingDeletionSecretRaiseInvalidRequestNotResourceNotFound`, covering all six affected operations.
- Ran the full `io.github.hectorvent.floci.services.secretsmanager.*Test` package: 118 tests, 0 failures.
- Manually verified via raw `aws secretsmanager` CLI against a locally built JVM jar: `GetSecretValue` on a scheduled-for-deletion secret now returns `InvalidRequestException` with the expected message instead of `ResourceNotFoundException`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Follow-up

Filed as #2549 per review: four more operations (`createSecret`, `tagResource`, `untagResource`, and a repeat `deleteSecret`) don't check pending-deletion state **at all** — including a data-loss path where `CreateSecret` silently overwrites a secret inside its recovery window. All pre-existing, none introduced here; kept out of this PR so the data-loss case is findable on its own and gets its own test.
