### PR TITLE
fix(s3): route the replication subresource instead of falling through

### DIFF
--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -148,7 +148,6 @@ When `FLOCI_SERVICES_ATHENA_MOCK=true` is set, Athena queries are stubbed but fl
 
 These AWS S3 features have no handler in Floci. Calls will return an error (typically `404` or `NoSuchBucket`-style):
 
-- Replication (`PutBucketReplication`, `GetBucketReplication`, `DeleteBucketReplication`)
 - Access logging (`PutBucketLogging`, `GetBucketLogging`)
 - Request payment (`PutBucketRequestPayment`, `GetBucketRequestPayment`)
 - Intelligent-Tiering configurations

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamActionRegistry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamActionRegistry.java
@@ -170,6 +170,12 @@ public class IamActionRegistry {
             "uploads", "notification", "versioning", "versions", "location", "object-lock",
             "website", "logging", "policy", "cors", "lifecycle", "encryption",
             "publicAccessBlock", "ownershipControls", "requestPayment");
+    // S3Controller's DELETE chain dispatches these ahead of replication (tagging is
+    // resolved above). Accelerate is NOT here: on DELETE it is dispatched after
+    // replication. Mirrors the controller's dispatch order — extend together.
+    private static final List<String> DELETE_SUBRESOURCES_BEFORE_REPLICATION = List.of(
+            "website", "policy", "cors", "lifecycle", "encryption",
+            "publicAccessBlock", "ownershipControls");
 
     /**
      * Resolves S3 sub-resource ops (ACL, tagging, retention, etc.) that
@@ -182,7 +188,8 @@ public class IamActionRegistry {
         boolean acl = params.containsKey("acl");
         boolean tagging = params.containsKey("tagging");
         boolean accelerate = params.containsKey("accelerate");
-        if (!acl && !tagging && !accelerate) {
+        boolean replication = params.containsKey("replication");
+        if (!acl && !tagging && !accelerate && !replication) {
             return null;
         }
         // /{bucket}?acl → bucket-level; /{bucket}/{key}?acl → object-level
@@ -223,24 +230,49 @@ public class IamActionRegistry {
                 default -> null;
             };
         }
-        // Accelerate is a bucket-only subresource, and ?accelerate on an object path is
-        // inert — the object routes ignore it — so only a bucket-level request maps here;
-        // everything else falls through to the standard rule table.
+        // Accelerate and replication are bucket-only subresources; on an object path
+        // both are inert — the object routes ignore them — so only a bucket-level
+        // request maps here; everything else falls through to the standard rule table.
         if (!isBucketLevel) {
             return null;
         }
-        List<String> dispatchedFirst = "PUT".equals(method)
-                ? PUT_SUBRESOURCES_BEFORE_ACCELERATE
-                : GET_SUBRESOURCES_BEFORE_ACCELERATE;
+        // S3Controller's PUT and GET chains dispatch accelerate ahead of replication,
+        // so accelerate resolves when both ride along. Its DELETE chain routes
+        // replication and never routes accelerate to an operation, so on DELETE
+        // replication resolves even when accelerate is also present.
+        if (accelerate && !(replication && "DELETE".equals(method))) {
+            List<String> dispatchedFirst = "PUT".equals(method)
+                    ? PUT_SUBRESOURCES_BEFORE_ACCELERATE
+                    : GET_SUBRESOURCES_BEFORE_ACCELERATE;
+            for (String subresource : dispatchedFirst) {
+                if (params.containsKey(subresource)) {
+                    return null;
+                }
+            }
+            return switch (method) {
+                case "GET" -> "s3:GetAccelerateConfiguration";
+                case "PUT" -> "s3:PutAccelerateConfiguration";
+                // AWS defines no DELETE for the subresource.
+                default -> null;
+            };
+        }
+        // Replication. On PUT and GET this is only reached without ?accelerate, so the
+        // accelerate before-lists cover everything dispatched ahead of replication too.
+        List<String> dispatchedFirst = switch (method) {
+            case "PUT" -> PUT_SUBRESOURCES_BEFORE_ACCELERATE;
+            case "GET" -> GET_SUBRESOURCES_BEFORE_ACCELERATE;
+            default -> DELETE_SUBRESOURCES_BEFORE_REPLICATION;
+        };
         for (String subresource : dispatchedFirst) {
             if (params.containsKey(subresource)) {
                 return null;
             }
         }
         return switch (method) {
-            case "GET" -> "s3:GetAccelerateConfiguration";
-            case "PUT" -> "s3:PutAccelerateConfiguration";
-            // AWS defines no DELETE for the subresource.
+            case "GET" -> "s3:GetReplicationConfiguration";
+            case "PUT" -> "s3:PutReplicationConfiguration";
+            // AWS authorizes DeleteBucketReplication with the put action.
+            case "DELETE" -> "s3:PutReplicationConfiguration";
             default -> null;
         };
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -324,6 +324,10 @@ public class S3Controller {
                 s3Service.putBucketAccelerateConfiguration(bucket, new String(body, StandardCharsets.UTF_8));
                 return Response.ok().build();
             }
+            if (hasQueryParam(uriInfo, "replication")) {
+                s3Service.putBucketReplication(bucket, new String(body, StandardCharsets.UTF_8));
+                return Response.ok().build();
+            }
             // Must be handled here: an unmatched subresource falls through to CreateBucket below,
             // which answers a metrics call with BucketAlreadyOwnedByYou.
             if (hasQueryParam(uriInfo, "metrics")) {
@@ -407,9 +411,7 @@ public class S3Controller {
                 return Response.noContent().build();
             }
             if (hasQueryParam(uriInfo, "replication")) {
-                // Floci does not model bucket replication; DeleteBucketReplication is a
-                // no-op that always returns 204, matching real S3. Crucially it must be
-                // handled here so it does NOT fall through to deleting the whole bucket.
+                s3Service.deleteBucketReplication(bucket);
                 return Response.noContent().build();
             }
             if (hasQueryParam(uriInfo, "metrics")) {
@@ -527,6 +529,10 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "accelerate")) {
                 s3Service.authorizeBucketRead(bucket, "s3:GetAccelerateConfiguration", authorization);
                 return Response.ok(s3Service.getBucketAccelerateConfiguration(bucket)).build();
+            }
+            if (hasQueryParam(uriInfo, "replication")) {
+                s3Service.authorizeBucketRead(bucket, "s3:GetReplicationConfiguration", authorization);
+                return Response.ok(s3Service.getBucketReplication(bucket)).build();
             }
             // GetBucketMetricsConfiguration and ListBucketMetricsConfigurations share ?metrics and
             // are told apart by the id, which only the single-configuration read carries.

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -2494,6 +2494,42 @@ public class S3Service implements Resettable {
                 .build();
     }
 
+    /**
+     * Stores the bucket replication configuration verbatim. Floci does not model
+     * replication behavior — the configuration is only stored and echoed back,
+     * which is what the SDK and the Terraform provider need. The
+     * ReplicationConfiguration root is required, so a body that does not parse
+     * to one is rejected with {@code MalformedXML}.
+     */
+    public void putBucketReplication(String bucketName, String replicationXml) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        if (!"ReplicationConfiguration".equals(XmlParser.rootElementName(replicationXml))) {
+            throw new AwsException("MalformedXML",
+                    "The XML you provided was not well-formed or did not validate against our published schema.",
+                    400);
+        }
+        bucket.setReplicationConfiguration(replicationXml);
+        bucketStore.put(bucketName, bucket);
+    }
+
+    public String getBucketReplication(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        if (bucket.getReplicationConfiguration() == null) {
+            throw new AwsException("ReplicationConfigurationNotFoundError",
+                    "The replication configuration was not found", 404);
+        }
+        return bucket.getReplicationConfiguration();
+    }
+
+    public void deleteBucketReplication(String bucketName) {
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+        bucket.setReplicationConfiguration(null);
+        bucketStore.put(bucketName, bucket);
+    }
+
     public void restoreObject(String bucketName, String key, String versionId, String restoreXml) {
         // Validation only - stub implementation
         getObject(bucketName, key, versionId);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -27,6 +27,7 @@ public class Bucket {
     private String encryptionConfiguration; // XML string
     private String publicAccessBlockConfiguration; // XML string
     private String ownershipControlsConfiguration; // XML string
+    private String replicationConfiguration; // XML string; null until first PUT
     private String requestPaymentPayer; // "BucketOwner" (default) or "Requester"; null until first PUT
     private String accelerateStatus; // "Enabled" or "Suspended"; null until first PUT
     private String region;
@@ -106,6 +107,11 @@ public class Bucket {
     public String getOwnershipControlsConfiguration() { return ownershipControlsConfiguration; }
     public void setOwnershipControlsConfiguration(String ownershipControlsConfiguration) {
         this.ownershipControlsConfiguration = ownershipControlsConfiguration;
+    }
+
+    public String getReplicationConfiguration() { return replicationConfiguration; }
+    public void setReplicationConfiguration(String replicationConfiguration) {
+        this.replicationConfiguration = replicationConfiguration;
     }
 
     public String getRequestPaymentPayer() { return requestPaymentPayer; }

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamActionRegistryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamActionRegistryTest.java
@@ -199,6 +199,102 @@ class IamActionRegistryTest {
     }
 
     @Test
+    void s3ReplicationResolvesToItsOwnActions() {
+        // Without the override, PUT ?replication resolves to s3:CreateBucket — a
+        // principal allowed only to create buckets could rewrite the replication
+        // configuration.
+        MultivaluedMap<String, String> replication = new MultivaluedHashMap<>();
+        replication.add("replication", "");
+        assertEquals("s3:PutReplicationConfiguration",
+                registry.resolve("s3", mockCtx("PUT", "/bucket", replication, null, "")));
+        assertEquals("s3:GetReplicationConfiguration",
+                registry.resolve("s3", mockCtx("GET", "/bucket", replication, null, "")));
+        // AWS authorizes DeleteBucketReplication with the put action.
+        assertEquals("s3:PutReplicationConfiguration",
+                registry.resolve("s3", mockCtx("DELETE", "/bucket", replication, null, "")));
+    }
+
+    @Test
+    void s3ReplicationOnAnObjectPathKeepsTheObjectActions() {
+        // The object routes ignore ?replication, so mapping it there would let a
+        // principal with only replication permissions read or write arbitrary objects.
+        MultivaluedMap<String, String> replication = new MultivaluedHashMap<>();
+        replication.add("replication", "");
+        assertEquals("s3:GetObject",
+                registry.resolve("s3", mockCtx("GET", "/bucket/secret.txt", replication, null, "")));
+        assertEquals("s3:PutObject",
+                registry.resolve("s3", mockCtx("PUT", "/bucket/key.txt", replication, null, "")));
+        assertEquals("s3:DeleteObject",
+                registry.resolve("s3", mockCtx("DELETE", "/bucket/key.txt", replication, null, "")));
+    }
+
+    @Test
+    void s3ReplicationYieldsToSubresourcesDispatchedFirst() {
+        // The controller executes the requestPayment operation for this request, so the
+        // replication mapping must not claim it; resolution falls back to the rule table.
+        MultivaluedMap<String, String> withRequestPayment = new MultivaluedHashMap<>();
+        withRequestPayment.add("requestPayment", "");
+        withRequestPayment.add("replication", "");
+        assertEquals("s3:CreateBucket",
+                registry.resolve("s3", mockCtx("PUT", "/bucket", withRequestPayment, null, "")));
+        MultivaluedMap<String, String> withLocation = new MultivaluedHashMap<>();
+        withLocation.add("location", "");
+        withLocation.add("replication", "");
+        assertEquals("s3:ListBucket",
+                registry.resolve("s3", mockCtx("GET", "/bucket", withLocation, null, "")));
+        // The DELETE chain dispatches website ahead of replication.
+        MultivaluedMap<String, String> withWebsite = new MultivaluedHashMap<>();
+        withWebsite.add("website", "");
+        withWebsite.add("replication", "");
+        assertEquals("s3:DeleteBucket",
+                registry.resolve("s3", mockCtx("DELETE", "/bucket", withWebsite, null, "")));
+        // requestPayment has no DELETE dispatch branch; it is inert there and
+        // replication executes, so the mapping must still claim the request.
+        MultivaluedMap<String, String> deleteWithRequestPayment = new MultivaluedHashMap<>();
+        deleteWithRequestPayment.add("requestPayment", "");
+        deleteWithRequestPayment.add("replication", "");
+        assertEquals("s3:PutReplicationConfiguration",
+                registry.resolve("s3", mockCtx("DELETE", "/bucket", deleteWithRequestPayment, null, "")));
+        // uploads is a GET-only dispatch branch; on PUT it is inert and replication
+        // executes, so the mapping must still claim the request there.
+        MultivaluedMap<String, String> putWithUploads = new MultivaluedHashMap<>();
+        putWithUploads.add("uploads", "");
+        putWithUploads.add("replication", "");
+        assertEquals("s3:PutReplicationConfiguration",
+                registry.resolve("s3", mockCtx("PUT", "/bucket", putWithUploads, null, "")));
+    }
+
+    @Test
+    void s3ReplicationAndAcceleratePrecedenceFollowsEachMethodsDispatchOrder() {
+        // PUT and GET dispatch accelerate ahead of replication; DELETE routes
+        // replication and never routes accelerate to an operation.
+        MultivaluedMap<String, String> both = new MultivaluedHashMap<>();
+        both.add("accelerate", "");
+        both.add("replication", "");
+        assertEquals("s3:PutAccelerateConfiguration",
+                registry.resolve("s3", mockCtx("PUT", "/bucket", both, null, "")));
+        assertEquals("s3:GetAccelerateConfiguration",
+                registry.resolve("s3", mockCtx("GET", "/bucket", both, null, "")));
+        assertEquals("s3:PutReplicationConfiguration",
+                registry.resolve("s3", mockCtx("DELETE", "/bucket", both, null, "")));
+    }
+
+    @Test
+    void s3ReplicationDoesNotPreemptAclOrTagging() {
+        // Appending an inert ?replication must not downgrade a stricter resolution.
+        MultivaluedMap<String, String> withAcl = new MultivaluedHashMap<>();
+        withAcl.add("replication", "");
+        withAcl.add("acl", "");
+        assertEquals("s3:PutBucketAcl",
+                registry.resolve("s3", mockCtx("PUT", "/bucket", withAcl, null, "")));
+        MultivaluedMap<String, String> withTagging = new MultivaluedHashMap<>();
+        withTagging.add("replication", "");
+        withTagging.add("tagging", "");
+        assertEquals("s3:DeleteBucketTagging",
+                registry.resolve("s3", mockCtx("DELETE", "/bucket", withTagging, null, "")));
+    }
+
+    @Test
     void s3AccelerateDoesNotPreemptAclOrTagging() {
         // Appending an inert ?accelerate must not downgrade a stricter resolution.
         MultivaluedMap<String, String> withAcl = new MultivaluedHashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ReplicationConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ReplicationConfigurationIntegrationTest.java
@@ -1,0 +1,318 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3ReplicationConfigurationIntegrationTest {
+
+    private static final String BUCKET = "replication-config-int-test";
+    private static final String REPLICATION_XML = """
+            <ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Role>arn:aws:iam::000000000000:role/replication-role</Role>
+                <Rule>
+                    <ID>rule1</ID>
+                    <Status>Enabled</Status>
+                    <Destination>
+                        <Bucket>arn:aws:s3:::replication-config-int-test-target</Bucket>
+                    </Destination>
+                </Rule>
+            </ReplicationConfiguration>
+            """;
+    private static final String REPLACEMENT_XML = """
+            <ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Role>arn:aws:iam::000000000000:role/replication-role-two</Role>
+                <Rule>
+                    <ID>rule2</ID>
+                    <Status>Disabled</Status>
+                    <Destination>
+                        <Bucket>arn:aws:s3:::replication-config-int-test-other</Bucket>
+                    </Destination>
+                </Rule>
+            </ReplicationConfiguration>
+            """;
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    /**
+     * A bucket without a replication configuration answers
+     * {@code ReplicationConfigurationNotFoundError} (404) — what the SDK and the
+     * Terraform provider treat as "not configured". Before the replication
+     * subresource was routed this fell through to ListObjects and returned a
+     * {@code ListBucketResult}, which the SDK parsed as an empty configuration —
+     * a silent wrong answer instead of the 404.
+     */
+    @Test
+    @Order(2)
+    void getReplicationBeforePutReturnsNotFoundError() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("ReplicationConfigurationNotFoundError"))
+            .body(not(containsString("ListBucketResult")));
+    }
+
+    /**
+     * Regression test for the fall-through to the bucket-creation handler: outside the
+     * default region it returned {@code BucketAlreadyOwnedByYou}, and inside it the
+     * idempotent-create path answered a silent 200 with a {@code Location} header
+     * without storing a replication configuration — the absent header
+     * distinguishes the routed response.
+     */
+    @Test
+    @Order(3)
+    void putReplicationOnExistingBucketReturns200() {
+        given()
+            .body(REPLICATION_XML)
+        .when()
+            .put("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(200)
+            .header("Location", nullValue())
+            .body(not(containsString("BucketAlreadyOwnedByYou")));
+    }
+
+    /** The stored configuration is echoed back verbatim. */
+    @Test
+    @Order(4)
+    void getReplicationEchoesTheStoredConfiguration() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ReplicationConfiguration"))
+            .body(containsString("role/replication-role"))
+            .body(containsString("<ID>rule1</ID>"));
+    }
+
+    @Test
+    @Order(5)
+    void putReplicationReplacesTheStoredConfiguration() {
+        given()
+            .body(REPLACEMENT_XML)
+        .when()
+            .put("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(200);
+        given()
+        .when()
+            .get("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ID>rule2</ID>"))
+            .body(not(containsString("<ID>rule1</ID>")));
+    }
+
+    /** The ReplicationConfiguration root is Required: Yes, so a body that does not parse to one is malformed. */
+    @Test
+    @Order(6)
+    void putReplicationRejectsAnUnparseableBody() {
+        for (String body : new String[] {
+                "",
+                "garbage {} not xml",
+                """
+                <ReplicationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                    <Role>arn:aws:iam::000000000000:role/replication-role""" }) {
+            given()
+                .body(body)
+            .when()
+                .put("/" + BUCKET + "?replication")
+            .then()
+                .statusCode(400)
+                .body(containsString("MalformedXML"));
+        }
+        given()
+        .when()
+            .get("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ID>rule2</ID>"));
+    }
+
+    /** A configuration inside the wrong root must not store anything. */
+    @Test
+    @Order(7)
+    void putReplicationRejectsAWrongRootElement() {
+        given()
+            .body("""
+                    <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Status>Enabled</Status>
+                    </VersioningConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"));
+        given()
+        .when()
+            .get("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ID>rule2</ID>"));
+    }
+
+    @Test
+    @Order(8)
+    void putReplicationOnMissingBucketReturns404() {
+        given()
+            .body(REPLICATION_XML)
+        .when()
+            .put("/this-bucket-does-not-exist-repl?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+
+    @Test
+    @Order(9)
+    void getReplicationOnMissingBucketReturns404() {
+        given()
+        .when()
+            .get("/this-bucket-does-not-exist-repl?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+
+    /**
+     * DeleteBucketReplication removes the stored configuration and answers 204;
+     * a later GET is back to the not-configured 404. The bucket itself must
+     * survive — before the subresource was handled a {@code DELETE
+     * /{bucket}?replication} would have fallen through to {@code DeleteBucket}.
+     */
+    @Test
+    @Order(10)
+    void deleteReplicationClearsTheStoredConfiguration() {
+        given()
+        .when()
+            .delete("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(204);
+        given()
+        .when()
+            .get("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("ReplicationConfigurationNotFoundError"));
+        given()
+        .when()
+            .get("/" + BUCKET + "?location")
+        .then()
+            .statusCode(200);
+    }
+
+    /** Matching real S3, deleting an already-absent configuration still answers 204. */
+    @Test
+    @Order(11)
+    void deleteReplicationWithoutConfigurationStillReturns204() {
+        given()
+        .when()
+            .delete("/" + BUCKET + "?replication")
+        .then()
+            .statusCode(204);
+    }
+
+    @Test
+    @Order(12)
+    void deleteReplicationOnMissingBucketReturns404() {
+        given()
+        .when()
+            .delete("/this-bucket-does-not-exist-repl?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+
+    /**
+     * Pins the per-method precedence at the wire: the PUT and GET chains dispatch
+     * accelerate ahead of replication, while the DELETE chain routes replication —
+     * accelerate's DELETE arm is a 405 and must not preempt it. The IAM mapping
+     * mirrors exactly this order, so a silent controller reorder would desynchronize
+     * the two.
+     */
+    @Test
+    @Order(13)
+    void accelerateAndReplicationPrecedenceFollowsEachMethodsDispatchOrder() {
+        String bucket = "replication-precedence-test";
+        given()
+        .when()
+            .put("/" + bucket)
+        .then()
+            .statusCode(200);
+
+        // PUT ?accelerate&replication executes accelerate: the accelerate body is
+        // accepted, and nothing lands in the replication store.
+        given()
+            .body("""
+                    <AccelerateConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Status>Enabled</Status>
+                    </AccelerateConfiguration>
+                    """)
+        .when()
+            .put("/" + bucket + "?accelerate&replication")
+        .then()
+            .statusCode(200);
+        given()
+        .when()
+            .get("/" + bucket + "?accelerate")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Status>Enabled</Status>"));
+        given()
+        .when()
+            .get("/" + bucket + "?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("ReplicationConfigurationNotFoundError"));
+
+        // GET ?accelerate&replication executes accelerate: an AccelerateConfiguration
+        // comes back, not the replication 404.
+        given()
+        .when()
+            .get("/" + bucket + "?accelerate&replication")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AccelerateConfiguration"));
+
+        // DELETE ?accelerate&replication executes replication: the stored
+        // configuration is cleared at 204 — not accelerate's 405.
+        given()
+            .body(REPLICATION_XML)
+        .when()
+            .put("/" + bucket + "?replication")
+        .then()
+            .statusCode(200);
+        given()
+        .when()
+            .delete("/" + bucket + "?accelerate&replication")
+        .then()
+            .statusCode(204);
+        given()
+        .when()
+            .get("/" + bucket + "?replication")
+        .then()
+            .statusCode(404)
+            .body(containsString("ReplicationConfigurationNotFoundError"));
+    }
+}


### PR DESCRIPTION
## Summary

Routes `PUT` and `GET /{bucket}?replication` alongside the DELETE case that was already handled, exactly as the issue suggests: the configuration is stored verbatim and echoed back, since Floci doesn't model replication behavior and neither the SDK nor the Terraform provider needs it to — they need the three verbs to be distinguishable from `CreateBucket` and `ListObjects`. Closes #2296.

- `PUT` validates the `ReplicationConfiguration` root (`MalformedXML` 400 on anything else, checked before storing) and stores the body on the bucket, answering the AWS-documented empty 200. No rule-level validation, per the issue's verbatim-store scope.
- `GET` echoes the stored configuration, or answers `ReplicationConfigurationNotFoundError` (404) when none is stored — the code `aws_s3_bucket_replication_configuration` matches on to mean "not configured". Before this it fell through to `ListObjects` and the SDK parsed the `ListBucketResult` as an empty configuration, a silent wrong answer.
- `DELETE` now clears the stored configuration instead of no-opping (the no-op was only correct while nothing could be stored). Still an unconditional 204 on an existing bucket, matching AWS.
- `IamActionRegistry` maps the three verbs: `s3:PutReplicationConfiguration` for PUT **and** DELETE (AWS documents that `DeleteBucketReplication` requires the put action), `s3:GetReplicationConfiguration` for GET. The mapping mirrors the controller's per-method dispatch order — PUT and GET dispatch accelerate ahead of replication, while the DELETE chain routes replication and never routes accelerate to an operation — so a request that executes another subresource's operation keeps that operation's resolution.

Two deliberate behavior changes beyond the routing, both pinned by tests: `DELETE ?replication` on a missing bucket now answers `NoSuchBucket` 404 (the old no-op answered 204 before any bucket check), and the three verbs move off the rule-table fallback (`s3:CreateBucket`/`s3:ListBucket`/`s3:DeleteBucket`) onto the real actions.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Verified against the API reference for all three operations: `PutBucketReplication` (root `Required: Yes`, 200 empty body, `s3:PutReplicationConfiguration`), `GetBucketReplication` (200 `ReplicationConfiguration`, `s3:GetReplicationConfiguration`), `DeleteBucketReplication` (204 empty, authorized by the put action). The 404 code string is the one the Terraform provider matches (`errCodeReplicationConfigurationNotFound = "ReplicationConfigurationNotFoundError"` in `internal/service/s3/errors.go`). Content-MD5 is not enforced, matching every sibling subresource here.

## Checklist

- [x] `./mvnw test` run locally: 11,944 tests, with failures only in 23 Docker-backed classes (Docker isn't available on this machine — API Gateway/WebSocket, CloudFormation ECR/SAM, ECR, ELBv2-Lambda, Lambda, Neptune, SWF); the s3 and iam packages are fully green (1,276/0 in that run). New `S3ReplicationConfigurationIntegrationTest` (13 tests, incl. the two fall-through regressions and a wire-level accelerate/replication precedence test), 5 new `IamActionRegistryTest` cases (per-method precedence, dispatched-first yields, object-path guard), and the accelerate suite stays green (13/13). Red-proof: without the routes 11 of 13 integration tests fail; without the registry change the 3 new-resolution cases fail.
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
