### PR TITLE
ci: run the compatibility Flink tests in mock mode

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -171,6 +171,7 @@ jobs:
             -e FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED=true \
             -e FLOCI_TLS_ENABLED=true \
             -e FLOCI_SERVICES_EC2_MOCK=true \
+            -e FLOCI_SERVICES_KINESIS_ANALYTICS_MOCK=true \
             floci:test-native
 
       - name: Wait for floci to be ready


### PR DESCRIPTION
## Summary

Runs the compatibility suite's Managed Flink (Kinesis Analytics V2) tests against mock mode, the same pattern as the existing `FLOCI_SERVICES_EC2_MOCK=true`.

Why: the new per-leg timing report (#2507) showed `KinesisAnalyticsV2Flink118Test` at **309.9s for 6 tests**, 48% of the `sdk-test-java` leg's test time. Digging in: `apache/flink:1.15/1.18/1.19` publish **amd64-only manifests** (1.20/2.0/2.3 are multi-arch), and the compat legs run on `ubuntu-24.04-arm`. The JobManager container can never become healthy, `StartApplication` succeeds (provisioning is async), and the test polls for RUNNING for its full 300-second budget before aborting via assumption, so the suite stays green while the FLINK-1_x coverage silently never runs.

With `FLOCI_SERVICES_KINESIS_ANALYTICS_MOCK=true`, `StartApplication` transitions to RUNNING with no backing container: all six lifecycle tests in both Flink classes actually pass (~1s each), and the leg drops about 5.5 minutes.

Trade-off, stated plainly: the mock toggle is service-wide, so Flink 2.3's real cluster boot (16s, the only Flink runtime that genuinely worked on the arm runners) is no longer exercised in CI either. Real-cluster provisioning remains covered by local runs against a non-mock Floci.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A for the emulator: CI configuration only. The control-plane lifecycle (Create/Start/Describe/List/Stop/Delete, unsupported-runtime rejection) is still verified with the real AWS SDK for Java v2 against the mocked provisioning path.

## Checklist

- [x] `./mvnw test` passes locally (no source changed; workflow YAML validated)
- [ ] New or updated integration test added (not applicable: CI env change; the existing Flink lifecycle tests now execute instead of skipping)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
