### PR TITLE
ci: fail pull requests whose commits carry AI attribution trailers

### DIFF
--- a/.github/workflows/ai-attribution.yml
+++ b/.github/workflows/ai-attribution.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7.0.1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -30,15 +30,33 @@ jobs:
           # This job enforces that. It deliberately does NOT reject
           # Co-authored-by outright: human co-authors are legitimate and GitHub
           # adds the trailer on every squash merge that carries review commits,
-          # so main already holds ~125 of them. Only trailers naming an AI tool
-          # are rejected, plus the session/marker lines such tools add on their
-          # own.
+          # so main already holds ~125 of them.
           #
-          # Remove an entry from AI_IDENTITY to start allowing that tool.
+          # Matching is anchored on the address a tool commits from, plus
+          # product names no person is called. A bare substring match on the
+          # tool name is NOT safe: Claude and Devin are ordinary human given
+          # names, so "claude" alone would reject a contributor the convention
+          # explicitly allows.
+          #
           # Merge commits are skipped via --no-merges, matching the
           # Conventional Commits job.
 
-          AI_IDENTITY='claude|copilot|cursor|devin|codex|chatgpt|openai|anthropic|gemini|aider|windsurf'
+          # Addresses these tools commit from. noreply@anthropic.com rather
+          # than the bare domain, so a person working at one of these companies
+          # is not caught by their own work email.
+          AI_EMAIL='noreply@anthropic\.com|devin-ai-integration|\+copilot@users\.noreply\.github\.com|noreply@openai\.com|cursoragent@cursor\.com'
+
+          # Display names, as a backstop for tools not in the address list.
+          # Every entry is a phrase no human display name takes.
+          AI_NAME='claude (code|opus|sonnet|haiku)|devin ai|copilot autofix|github copilot|cursor agent|openai codex|chatgpt|gemini code assist|\baider\b|powered by ai'
+
+          # A tool name in the display name only counts when the address is the
+          # matching vendor's, which catches "Claude <claude@anthropic.com>"
+          # while leaving "Claude Dupont <claude.dupont@example.fr>" alone.
+          AI_TOKEN='claude|copilot|devin|codex|cursor|gemini|chatgpt'
+          AI_VENDOR='@anthropic\.com|@openai\.com|@cursor\.(com|sh)|@users\.noreply\.github\.com'
+
+          # Trailer keys and generator markers that are AI-only by construction.
           AI_ONLY_TRAILER='^(claude-session|codex-session|chatgpt-session):'
           AI_MARKER='(Generated with \[Claude Code\]|🤖 Generated with)'
 
@@ -50,15 +68,28 @@ jobs:
 
             while IFS= read -r line; do
               lower=$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')
+
               case "$lower" in
                 co-authored-by:*)
-                  # A co-author is only a problem when it names an AI tool.
-                  if printf '%s' "$lower" | grep -qE "^co-authored-by:.*($AI_IDENTITY)"; then
+                  value=${lower#co-authored-by:}
+                  email=$(printf '%s' "$value" | sed -n 's/.*<\(.*\)>.*/\1/p')
+                  name=$(printf '%s' "$value" | sed 's/<[^>]*>//' | sed 's/^ *//; s/ *$//')
+
+                  hit=0
+                  if [ -n "$email" ] && printf '%s' "$email" | grep -qE "$AI_EMAIL"; then
+                    hit=1
+                  elif printf '%s' "$name" | grep -qE "$AI_NAME"; then
+                    hit=1
+                  elif printf '%s' "$name" | grep -qE "$AI_TOKEN" \
+                       && [ -n "$email" ] && printf '%s' "$email" | grep -qE "$AI_VENDOR"; then
+                    hit=1
+                  fi
+
+                  if [ "$hit" -eq 1 ]; then
                     offending="${offending}${line}"$'\n'
                   fi
                   ;;
                 *)
-                  # Session trailers and generator markers are AI-only by construction.
                   offending="${offending}${line}"$'\n'
                   ;;
               esac
@@ -85,6 +116,8 @@ jobs:
             echo "  commit messages. Attribution should be limited to human contributors.\""
             echo ""
             echo "  Human co-authors are fine — only trailers naming an AI tool are rejected."
+            echo "  If this fired on a person, that is a bug in the matcher and not your commit:"
+            echo "  please say so on the pull request."
             echo ""
             echo "  To fix a single commit:"
             echo "    git commit --amend            # delete the trailer lines, save"
@@ -92,10 +125,6 @@ jobs:
             echo ""
             echo "  To fix several:"
             echo "    git rebase --root -x 'git commit --amend --no-edit'"
-            echo "  or rewrite the messages with:"
-            echo "    git filter-branch --msg-filter \\"
-            echo "      'grep -viE \"^co-authored-by:.*(claude|copilot|cursor|devin|codex)|^claude-session:\"' \\"
-            echo "      \"\$BASE_SHA\"..HEAD"
             echo ""
             echo "  Configure your agent not to add them in the first place — for Claude Code,"
             echo "  set includeCoAuthoredBy: false in .claude/settings.json."

--- a/.github/workflows/ai-attribution.yml
+++ b/.github/workflows/ai-attribution.yml
@@ -21,46 +21,95 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           # CONTRIBUTING.md and AGENTS.md both state:
           #
           #   "Do not include Co-Authored-By trailers for AI tools in commit
           #    messages. Attribution should be limited to human contributors."
           #
-          # This job enforces that. It deliberately does NOT reject
-          # Co-authored-by outright: human co-authors are legitimate and GitHub
-          # adds the trailer on every squash merge that carries review commits,
-          # so main already holds ~125 of them.
+          # This job enforces that. It does NOT try to recognise an AI by its
+          # name. Names are not a usable signal in either direction: Claude and
+          # Devin are ordinary human given names, so matching on them rejects
+          # real contributors, while any list of product names is stale the
+          # moment a new agent ships.
           #
-          # Matching is anchored on the address a tool commits from, plus
-          # product names no person is called. A bare substring match on the
-          # tool name is NOT safe: Claude and Devin are ordinary human given
-          # names, so "claude" alone would reject a contributor the convention
-          # explicitly allows.
+          # Instead a co-author is rejected only on evidence that the identity
+          # is not a person:
+          #
+          #   1. Its GitHub privacy address resolves to an account of type Bot.
+          #      GitHub is the authority here, and agents commit through GitHub
+          #      Apps, so this keeps working for tools that do not exist yet.
+          #   2. Its address is a noreply@ mailbox on some other domain - a
+          #      fabricated, uncontactable address. No person's git identity is
+          #      noreply@.
+          #
+          # A false positive costs far more than a false negative here: a
+          # missed trailer is untidy attribution, but a blocked contributor is
+          # a person turned away by a linter. So anything this cannot resolve
+          # is allowed through, and a GitHub API failure never fails the build.
           #
           # Merge commits are skipped via --no-merges, matching the
           # Conventional Commits job.
 
-          # Addresses these tools commit from. noreply@anthropic.com rather
-          # than the bare domain, so a person working at one of these companies
-          # is not caught by their own work email.
-          AI_EMAIL='noreply@anthropic\.com|devin-ai-integration|\+copilot@users\.noreply\.github\.com|noreply@openai\.com|cursoragent@cursor\.com'
-
-          # Display names, as a backstop for tools not in the address list.
-          # Every entry is a phrase no human display name takes.
-          AI_NAME='claude (code|opus|sonnet|haiku)|devin ai|copilot autofix|github copilot|cursor agent|openai codex|chatgpt|gemini code assist|\baider\b|powered by ai'
-
-          # A tool name in the display name only counts when the address is the
-          # matching vendor's, which catches "Claude <claude@anthropic.com>"
-          # while leaving "Claude Dupont <claude.dupont@example.fr>" alone.
-          AI_TOKEN='claude|copilot|devin|codex|cursor|gemini|chatgpt'
-          AI_VENDOR='@anthropic\.com|@openai\.com|@cursor\.(com|sh)|@users\.noreply\.github\.com'
+          # Bot accounts that may legitimately co-author. Keep this short.
+          ALLOWED_BOTS='dependabot[bot]'
 
           # Trailer keys and generator markers that are AI-only by construction.
+          # These are literal strings no person writes, not identity matching.
           AI_ONLY_TRAILER='^(claude-session|codex-session|chatgpt-session):'
           AI_MARKER='(Generated with \[Claude Code\]|🤖 Generated with)'
 
+          CACHE=$(mktemp)
           FAILED=0
+
+          # Prints "bot <login>" if the address belongs to a bot account,
+          # "noreply" for a fabricated noreply mailbox, nothing otherwise.
+          classify() {
+            local email="$1" local_part login id cached type
+            local_part=${email%@*}
+
+            case "$email" in
+              *@users.noreply.github.com)
+                case "$local_part" in
+                  *+*) id=${local_part%%+*}; login=${local_part#*+} ;;
+                  *)   id=""; login=$local_part ;;
+                esac
+
+                # A [bot] suffix is GitHub's own convention; no lookup needed.
+                case "$login" in
+                  *'[bot]'*) printf 'bot %s' "$login"; return ;;
+                esac
+
+                cached=$(grep -m1 "^${id}|${login} " "$CACHE" 2>/dev/null || true)
+                if [ -n "$cached" ]; then
+                  type=${cached##* }
+                else
+                  if [ -n "$id" ]; then
+                    type=$(gh api "user/$id" --jq .type 2>/dev/null || echo "")
+                  else
+                    type=$(gh api "users/$login" --jq .type 2>/dev/null || echo "")
+                  fi
+                  # Unresolvable (deleted account, API trouble) is not evidence.
+                  [ -z "$type" ] && type="Unknown"
+                  printf '%s|%s %s\n' "$id" "$login" "$type" >> "$CACHE"
+                fi
+
+                if [ "$type" = "Bot" ]; then
+                  printf 'bot %s' "$login"
+                fi
+                ;;
+              *)
+                # noreply@example.com, but not GitHub's own privacy domain.
+                case "$local_part" in
+                  noreply|no-reply) printf 'noreply' ;;
+                esac
+                ;;
+            esac
+            # Never let a "this is a person" verdict look like a failure:
+            # the job runs under set -e and this is called in a $( ).
+            return 0
+          }
 
           for sha in $(git log --no-merges --format=%H "$BASE_SHA".."$HEAD_SHA"); do
             subject=$(git show -s --format=%s "$sha")
@@ -71,23 +120,22 @@ jobs:
 
               case "$lower" in
                 co-authored-by:*)
-                  value=${lower#co-authored-by:}
-                  email=$(printf '%s' "$value" | sed -n 's/.*<\(.*\)>.*/\1/p')
-                  name=$(printf '%s' "$value" | sed 's/<[^>]*>//' | sed 's/^ *//; s/ *$//')
+                  email=$(printf '%s' "$lower" | sed -n 's/.*<\(.*\)>.*/\1/p')
+                  [ -z "$email" ] && continue
 
-                  hit=0
-                  if [ -n "$email" ] && printf '%s' "$email" | grep -qE "$AI_EMAIL"; then
-                    hit=1
-                  elif printf '%s' "$name" | grep -qE "$AI_NAME"; then
-                    hit=1
-                  elif printf '%s' "$name" | grep -qE "$AI_TOKEN" \
-                       && [ -n "$email" ] && printf '%s' "$email" | grep -qE "$AI_VENDOR"; then
-                    hit=1
-                  fi
-
-                  if [ "$hit" -eq 1 ]; then
-                    offending="${offending}${line}"$'\n'
-                  fi
+                  verdict=$(classify "$email")
+                  case "$verdict" in
+                    bot\ *)
+                      login=${verdict#bot }
+                      # -F because a login like dependabot[bot] is not a pattern.
+                      if ! printf '%s\n' "$ALLOWED_BOTS" | grep -Fxq "$login"; then
+                        offending="${offending}${line}    <- ${login} is a bot account"$'\n'
+                      fi
+                      ;;
+                    noreply)
+                      offending="${offending}${line}    <- noreply address, not a contactable person"$'\n'
+                      ;;
+                  esac
                   ;;
                 *)
                   offending="${offending}${line}"$'\n'
@@ -115,9 +163,8 @@ jobs:
             echo "  CONTRIBUTING.md: \"Do not include Co-Authored-By trailers for AI tools in"
             echo "  commit messages. Attribution should be limited to human contributors.\""
             echo ""
-            echo "  Human co-authors are fine — only trailers naming an AI tool are rejected."
-            echo "  If this fired on a person, that is a bug in the matcher and not your commit:"
-            echo "  please say so on the pull request."
+            echo "  Co-authoring a person is fine and is never rejected — this only fires when"
+            echo "  the address belongs to a bot account or is a noreply mailbox."
             echo ""
             echo "  To fix a single commit:"
             echo "    git commit --amend            # delete the trailer lines, save"

--- a/.github/workflows/ai-attribution.yml
+++ b/.github/workflows/ai-attribution.yml
@@ -1,0 +1,104 @@
+name: AI Attribution
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-trailers:
+    name: Commits omit AI attribution trailers
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check commit trailers
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # CONTRIBUTING.md and AGENTS.md both state:
+          #
+          #   "Do not include Co-Authored-By trailers for AI tools in commit
+          #    messages. Attribution should be limited to human contributors."
+          #
+          # This job enforces that. It deliberately does NOT reject
+          # Co-authored-by outright: human co-authors are legitimate and GitHub
+          # adds the trailer on every squash merge that carries review commits,
+          # so main already holds ~125 of them. Only trailers naming an AI tool
+          # are rejected, plus the session/marker lines such tools add on their
+          # own.
+          #
+          # Remove an entry from AI_IDENTITY to start allowing that tool.
+          # Merge commits are skipped via --no-merges, matching the
+          # Conventional Commits job.
+
+          AI_IDENTITY='claude|copilot|cursor|devin|codex|chatgpt|openai|anthropic|gemini|aider|windsurf'
+          AI_ONLY_TRAILER='^(claude-session|codex-session|chatgpt-session):'
+          AI_MARKER='(Generated with \[Claude Code\]|🤖 Generated with)'
+
+          FAILED=0
+
+          for sha in $(git log --no-merges --format=%H "$BASE_SHA".."$HEAD_SHA"); do
+            subject=$(git show -s --format=%s "$sha")
+            offending=""
+
+            while IFS= read -r line; do
+              lower=$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')
+              case "$lower" in
+                co-authored-by:*)
+                  # A co-author is only a problem when it names an AI tool.
+                  if printf '%s' "$lower" | grep -qE "^co-authored-by:.*($AI_IDENTITY)"; then
+                    offending="${offending}${line}"$'\n'
+                  fi
+                  ;;
+                *)
+                  # Session trailers and generator markers are AI-only by construction.
+                  offending="${offending}${line}"$'\n'
+                  ;;
+              esac
+            done < <(git show -s --format=%B "$sha" | grep -iE "^co-authored-by:|$AI_ONLY_TRAILER|$AI_MARKER" || true)
+
+            if [ -n "$offending" ]; then
+              echo "::error::Commit carries AI attribution: $sha $subject"
+              echo ""
+              echo "  Commit: $sha"
+              echo "  $subject"
+              echo ""
+              echo "  Offending line(s):"
+              printf '%s' "$offending" | sed 's/^/    /'
+              echo ""
+              FAILED=1
+            else
+              echo "ok: $sha $subject"
+            fi
+          done
+
+          if [ "$FAILED" -ne 0 ]; then
+            echo ""
+            echo "  CONTRIBUTING.md: \"Do not include Co-Authored-By trailers for AI tools in"
+            echo "  commit messages. Attribution should be limited to human contributors.\""
+            echo ""
+            echo "  Human co-authors are fine — only trailers naming an AI tool are rejected."
+            echo ""
+            echo "  To fix a single commit:"
+            echo "    git commit --amend            # delete the trailer lines, save"
+            echo "    git push --force-with-lease"
+            echo ""
+            echo "  To fix several:"
+            echo "    git rebase --root -x 'git commit --amend --no-edit'"
+            echo "  or rewrite the messages with:"
+            echo "    git filter-branch --msg-filter \\"
+            echo "      'grep -viE \"^co-authored-by:.*(claude|copilot|cursor|devin|codex)|^claude-session:\"' \\"
+            echo "      \"\$BASE_SHA\"..HEAD"
+            echo ""
+            echo "  Configure your agent not to add them in the first place — for Claude Code,"
+            echo "  set includeCoAuthoredBy: false in .claude/settings.json."
+          fi
+
+          exit $FAILED

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ wip: still working on this          # "wip" is not a recognised type
 
 Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attribution should be limited to human contributors.
 
-CI enforces this: the **Commits omit AI attribution trailers** check fails a pull request whose commits carry a `Co-Authored-By` naming an AI tool, or the session and generator lines such tools add on their own. Co-authoring a human is unaffected — that trailer is how GitHub credits reviewers on a squash merge. If the check fires, drop the offending lines with `git commit --amend` (or a rebase for several commits) and force-push.
+CI enforces this: the **Commits omit AI attribution trailers** check fails a pull request whose commits carry a `Co-Authored-By` for an identity that is not a person — one whose GitHub address belongs to a bot account, or that uses a `noreply@` mailbox — along with the session and generator lines such tools add on their own. It never judges a co-author by name, so co-authoring a person is always fine; that trailer is how GitHub credits reviewers on a squash merge. `dependabot[bot]` is allowlisted. If the check fires, drop the offending lines with `git commit --amend` (or a rebase for several commits) and force-push.
 
 ## Architecture
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,8 @@ wip: still working on this          # "wip" is not a recognised type
 
 Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attribution should be limited to human contributors.
 
+CI enforces this: the **Commits omit AI attribution trailers** check fails a pull request whose commits carry a `Co-Authored-By` naming an AI tool, or the session and generator lines such tools add on their own. Co-authoring a human is unaffected — that trailer is how GitHub credits reviewers on a squash merge. If the check fires, drop the offending lines with `git commit --amend` (or a rebase for several commits) and force-push.
+
 ## Architecture
 
 See [AGENTS.md](AGENTS.md) for a detailed description of the three-layer architecture (Controller → Service → Storage), the AWS wire protocol mapping, and conventions for adding new services.


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` and `AGENTS.md` both say:

> Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attribution should be limited to human contributors.

Nothing enforced it, so the rule was only ever caught by a human reading the commit list — and three commits have reached `main` carrying one:

| commit | trailer |
|---|---|
| `9bb1db3a` (#1431) | `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` |
| `3cc04994` (#697) | `Co-authored-by: Copilot Autofix powered by AI <…>` |
| `1e59f8dc` (#120) | `Co-authored-by: Devin AI <…devin-ai-integration[bot]…>` |

It also came up twice in review this week, which is what prompted this.

Adds `.github/workflows/ai-attribution.yml`, modelled on the existing `conventional-commits.yml`: same trigger, same `contents: read`, same `--no-merges` walk of `BASE..HEAD`, same "print every commit, fail at the end" shape.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## What it does and does not reject

**It does not ban `Co-Authored-By`.** Human co-authors are legitimate, and GitHub adds the trailer on every squash merge that carries review commits — `main` holds **125** of them. Rejecting the trailer outright would fail almost every PR in the repo. Only a co-author naming an AI tool is rejected, plus the lines those tools add on their own (`Claude-Session:`, `🤖 Generated with [Claude Code]`).

**Matching is scoped to trailer lines, not the whole message.** This matters more than it looks: the tool names appear legitimately in prose throughout `main` — commits describe *"cursor pagination"*, *"an Anthropic-shaped body"*, *"a Codex finding"*, *"a Gemini suggestion"*, *"Review feedback on #2280 (Copilot + Greptile)"*, and *"HMAC material is generated with SecureRandom"*. A message-wide grep for these words fails all of them.

A commit mixing both kinds reports only the offending lines:

```
::error::Commit carries AI attribution: … fix(x): mixed human and AI co-authors

  Offending line(s):
    Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
    Claude-Session: https://claude.ai/code/session_01Abc

  # Co-authored-by: Real Person <real@example.com>  → untouched
  # Signed-off-by:  Real Person <real@example.com>  → untouched
```

The failure message quotes the convention, shows the `git commit --amend` / rebase fix, and points at `includeCoAuthoredBy: false` so the next commit doesn't reproduce it.

## Verification

Ran the check over **every commit in `main`**:

```
commits scanned:  1433
commits flagged:  3      ← exactly the three in the table above
false positives:  0
```

Synthetic cases, all behaving:

| commit | result |
|---|---|
| human co-authors + `Signed-off-by` only | pass |
| prose containing *cursor / Anthropic / Codex / Gemini / Copilot / generated with* | pass |
| `Claude-Session: https://…` | fail |
| `🤖 Generated with [Claude Code](…)` | fail |
| human co-author **and** Claude co-author in one commit | fail, flagging only the AI lines |

This PR's own commit passes both this check and the Conventional Commits gate.

## Why this earns its place, and where it doesn't

Worth being precise about the weighting, because the three historical commits are not equally representative.

The check earns its place on the **Claude- and Devin-style trailers** — the ones an agent appends to *every* commit by default, unprompted, until someone notices. That is the failure mode this repo actually has. AI participation here is continuous: Greptile and Copilot review every pull request, one contributor recently had these trailers on five open PRs at once, and `9bb1db3a` carried one all the way into `main`. And `Co-Authored-By` is not decoration — GitHub treats it as commit attribution. No AI identity currently appears in this repo's contributor list, and that is the state the convention is protecting.

The enforcement gap was the asymmetry: Conventional Commits has a gate, this rule had nothing but a human reading the commit list. That is how three got through.

**`Copilot Autofix` is a rounding error either way, and I want to be accurate about it rather than dress it up as a tradeoff.** It has appeared exactly once, on 2026-05-05, in one commit out of 1433 — the two lines in `3cc04994` are the same trailer duplicated by the squash, not two separate uses. And it did not come from a code-scanning autofix: that commit reads *"Apply suggestions from code review"*, which is someone clicking **commit suggestion** on a Copilot review comment. There is no CodeQL workflow file in this repo, and I could not read the default-setup configuration to check whether autofix is even enabled.

So keeping `copilot` on the list costs close to nothing, and the moment it would fire — a human committing an AI's suggestion — is the convention's target case rather than an exception to it. `AI_IDENTITY` is a single commented variable at the top of the script, so it stays a one-line change if you disagree.

The three historical commits are untouched; this only applies to new pull requests.

## Checklist

- [X] `./mvnw test` passes locally *(no Java changed — workflow and `CONTRIBUTING.md` only)*
- [X] New or updated integration test added *(n/a — verified by running the check across all 1433 commits in `main`, see above)*
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

