### PR TITLE
test(kinesisanalytics): disable the Flink 1.18 lifecycle test on arm64

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KinesisAnalyticsV2Flink118Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KinesisAnalyticsV2Flink118Test.java
@@ -1,8 +1,19 @@
 package com.floci.test;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
-/** Runs the Managed Flink lifecycle against the Flink 1.x line (FLINK-1_18). */
+/**
+ * Runs the Managed Flink lifecycle against the Flink 1.x line (FLINK-1_18).
+ *
+ * <p>Disabled on arm64: apache/flink 1.15/1.18/1.19 publish amd64-only images, so on an
+ * arm64 host (the CI runners) the JobManager can never become healthy and the RUNNING
+ * wait burns its full 300s budget before skipping. Flink 1.x coverage on arm64 would
+ * need a multi-arch mirror; until then the 2.x line ({@link KinesisAnalyticsV2Flink23Test})
+ * keeps the real-cluster path covered there.
+ */
+@DisabledOnOs(architectures = "aarch64",
+        disabledReason = "apache/flink:1.18 has no arm64 image; the cluster cannot start")
 @DisplayName("Managed Service for Apache Flink — Flink 1.18")
 class KinesisAnalyticsV2Flink118Test extends AbstractKinesisAnalyticsV2LifecycleTest {
 


### PR DESCRIPTION
## Summary

`KinesisAnalyticsV2Flink118Test` burns its full 300-second RUNNING wait on arm64 hosts (including the compat CI runners) because apache/flink 1.15/1.18/1.19 publish amd64-only images — the JobManager can never become healthy, so the 310s of sdk-test-java wall time bought zero coverage. `@DisabledOnOs(architectures = "aarch64")` skips the class at discovery on arm64 while keeping it live on amd64; the Flink 2.x line (`KinesisAnalyticsV2Flink23Test`, multi-arch image) keeps the real-cluster path covered everywhere.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

None of the above: test-only change (`test:`, no release bump).

## AWS Compatibility

N/A — no emulated surface touched; this only skips one compat lifecycle test on
a platform where its backing image cannot run.

## Checklist

- [x] `./mvnw test` passes locally — main-module suite unaffected (change is in
  the compat project); the touched class is the one being disabled
- [ ] New or updated integration test added — not applicable, the change is test
  infrastructure itself
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

