### PR TITLE
fix(eventbridge): return 400 for missing resources

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeReplayTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeReplayTest.java
@@ -229,6 +229,16 @@ class EventBridgeReplayTest {
         assertThat(desc.eventLastReplayedTime()).isNotNull();
     }
 
+    @Test
+    @Order(23)
+    void missingReplayUsesTypedResourceNotFoundStatus() {
+        assertThatThrownBy(() -> eb.describeReplay(DescribeReplayRequest.builder()
+                .replayName("missing-replay").build()))
+                .isInstanceOfSatisfying(
+                        software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException.class,
+                        error -> assertThat(error.statusCode()).isEqualTo(400));
+    }
+
     // ──────────────────────────── Cleanup ────────────────────────────
 
     @Test
@@ -238,6 +248,8 @@ class EventBridgeReplayTest {
 
         assertThatThrownBy(() ->
                 eb.describeArchive(DescribeArchiveRequest.builder().archiveName(archiveName).build()))
-                .isInstanceOf(software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException.class);
+                .isInstanceOfSatisfying(
+                        software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException.class,
+                        error -> assertThat(error.statusCode()).isEqualTo(400));
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/EventBridgeTest.java
@@ -3,6 +3,7 @@ package com.floci.test;
 import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.*;
+import software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.*;
 
@@ -331,16 +332,30 @@ class EventBridgeTest {
     @Order(91)
     void deleteRule() {
         eb.deleteRule(DeleteRuleRequest.builder().name(ruleName).build());
+        assertThatCode(() -> eb.deleteRule(DeleteRuleRequest.builder().name(ruleName).build()))
+                .doesNotThrowAnyException();
         assertThatThrownBy(() ->
                 eb.describeRule(DescribeRuleRequest.builder().name(ruleName).build()))
-                .isInstanceOf(software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException.class);
+                .isInstanceOf(ResourceNotFoundException.class)
+                .satisfies(error -> assertThat(((ResourceNotFoundException) error).statusCode())
+                        .isEqualTo(400));
     }
 
     @Test
     @Order(92)
     void deleteEventBus() {
         eb.deleteEventBus(DeleteEventBusRequest.builder().name(busName).build());
+        assertThatCode(() -> eb.deleteEventBus(DeleteEventBusRequest.builder().name(busName).build()))
+                .doesNotThrowAnyException();
         ListEventBusesResponse response = eb.listEventBuses(ListEventBusesRequest.builder().build());
         assertThat(response.eventBuses()).extracting(EventBus::name).doesNotContain(busName);
+
+        assertThatThrownBy(() -> eb.deleteRule(DeleteRuleRequest.builder()
+                .name("missing-rule")
+                .eventBusName(busName)
+                .build()))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .satisfies(error -> assertThat(((ResourceNotFoundException) error).statusCode())
+                        .isEqualTo(400));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -335,10 +335,12 @@ public class EventBridgeService {
 
     public void deleteRule(String name, String busName, String region) {
         String effectiveBus = resolvedBusName(busName);
+        ensureBusExists(effectiveBus, region);
         String key = ruleKey(region, effectiveBus, name);
-        Rule rule = ruleStore.get(key)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Rule not found: " + name, 404));
+        Rule rule = ruleStore.get(key).orElse(null);
+        if (rule == null) {
+            return;
+        }
         List<Target> targets = targetStore.get(key).orElse(List.of());
         if (!targets.isEmpty()) {
             throw new AwsException("ValidationException",
@@ -358,7 +360,7 @@ public class EventBridgeService {
         String effectiveBus = resolvedBusName(busName);
         return ruleStore.get(ruleKey(region, effectiveBus, name))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Rule not found: " + name, 404));
+                        "Rule not found: " + name, 400));
     }
 
     public List<Rule> listRules(String busName, String namePrefix, String region) {
@@ -377,7 +379,7 @@ public class EventBridgeService {
         String key = ruleKey(region, effectiveBus, name);
         Rule rule = ruleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Rule not found: " + name, 404));
+                        "Rule not found: " + name, 400));
         rule.setState(RuleState.ENABLED);
         ruleStore.put(key, rule);
         startSchedulerIfNeeded(rule);
@@ -388,7 +390,7 @@ public class EventBridgeService {
         String key = ruleKey(region, effectiveBus, name);
         Rule rule = ruleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Rule not found: " + name, 404));
+                        "Rule not found: " + name, 400));
         rule.setState(RuleState.DISABLED);
         ruleStore.put(key, rule);
 
@@ -404,7 +406,7 @@ public class EventBridgeService {
         String key = ruleKey(region, effectiveBus, ruleName);
         ruleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Rule not found: " + ruleName, 404));
+                        "Rule not found: " + ruleName, 400));
         List<Target> existing = new ArrayList<>(targetStore.get(key).orElse(new ArrayList<>()));
         for (Target newTarget : newTargets) {
             existing.removeIf(t -> t.getId().equals(newTarget.getId()));
@@ -437,7 +439,7 @@ public class EventBridgeService {
         String key = ruleKey(region, effectiveBus, ruleName);
         ruleStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Rule not found: " + ruleName, 404));
+                        "Rule not found: " + ruleName, 400));
         return targetStore.get(key).orElse(List.of());
     }
 
@@ -490,7 +492,7 @@ public class EventBridgeService {
             String key = archiveKey(region, archiveName);
             Archive archive = archiveStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                            "Archive not found: " + archiveName, 404));
+                            "Archive not found: " + archiveName, 400));
             archive.getTags().putAll(tags);
             archiveStore.put(key, archive);
             resourceGroupsTaggingService.tagResources(List.of(resourceArn), tags, region);
@@ -501,7 +503,7 @@ public class EventBridgeService {
             String key = busKey(region, busName);
             EventBus bus = busStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                            "Resource not found: " + resourceArn, 404));
+                            "Resource not found: " + resourceArn, 400));
             bus.getTags().putAll(tags);
             busStore.put(key, bus);
             resourceGroupsTaggingService.tagResources(List.of(resourceArn), tags, region);
@@ -512,13 +514,13 @@ public class EventBridgeService {
             String key = ruleKey(region, ref.busName(), ref.ruleName());
             Rule rule = ruleStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                            "Resource not found: " + resourceArn, 404));
+                            "Resource not found: " + resourceArn, 400));
             rule.getTags().putAll(tags);
             ruleStore.put(key, rule);
             resourceGroupsTaggingService.tagResources(List.of(resourceArn), tags, region);
             return;
         }
-        throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 404);
+        throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 400);
     }
 
     public void untagResource(String resourceArn, List<String> tagKeys, String region) {
@@ -528,7 +530,7 @@ public class EventBridgeService {
             String key = archiveKey(region, archiveName);
             Archive archive = archiveStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                            "Archive not found: " + archiveName, 404));
+                            "Archive not found: " + archiveName, 400));
             tagKeys.forEach(archive.getTags()::remove);
             archiveStore.put(key, archive);
             resourceGroupsTaggingService.untagResources(List.of(resourceArn), tagKeys, region);
@@ -539,7 +541,7 @@ public class EventBridgeService {
             String key = busKey(region, busName);
             EventBus bus = busStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                            "Resource not found: " + resourceArn, 404));
+                            "Resource not found: " + resourceArn, 400));
             tagKeys.forEach(bus.getTags()::remove);
             busStore.put(key, bus);
             resourceGroupsTaggingService.untagResources(List.of(resourceArn), tagKeys, region);
@@ -550,13 +552,13 @@ public class EventBridgeService {
             String key = ruleKey(region, ref.busName(), ref.ruleName());
             Rule rule = ruleStore.get(key)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                            "Resource not found: " + resourceArn, 404));
+                            "Resource not found: " + resourceArn, 400));
             tagKeys.forEach(rule.getTags()::remove);
             ruleStore.put(key, rule);
             resourceGroupsTaggingService.untagResources(List.of(resourceArn), tagKeys, region);
             return;
         }
-        throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 404);
+        throw new AwsException("ResourceNotFoundException", "Resource not found: " + resourceArn, 400);
     }
 
     // ──────────────────────────── Permissions ────────────────────────────
@@ -570,7 +572,7 @@ public class EventBridgeService {
         String key = busKey(region, effectiveBus);
         EventBus bus = busStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "EventBus not found: " + effectiveBus, 404));
+                        "EventBus not found: " + effectiveBus, 400));
 
         try {
             if (policyJson != null && !policyJson.isBlank()) {
@@ -639,7 +641,7 @@ public class EventBridgeService {
         String key = busKey(region, effectiveBus);
         EventBus bus = busStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "EventBus not found: " + effectiveBus, 404));
+                        "EventBus not found: " + effectiveBus, 400));
 
         if (removeAll) {
             bus.setPolicy(null);
@@ -1079,7 +1081,7 @@ public class EventBridgeService {
         }
         busStore.get(busKey(region, busName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "EventBus not found: " + busName, 404));
+                        "EventBus not found: " + busName, 400));
     }
 
     private static boolean isBlank(Object value) {
@@ -1166,7 +1168,7 @@ public class EventBridgeService {
     public Archive describeArchive(String archiveName, String region) {
         return archiveStore.get(archiveKey(region, archiveName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Archive not found: " + archiveName, 404));
+                        "Archive not found: " + archiveName, 400));
     }
 
     public Archive updateArchive(String archiveName, String description,
@@ -1174,7 +1176,7 @@ public class EventBridgeService {
         String key = archiveKey(region, archiveName);
         Archive archive = archiveStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Archive not found: " + archiveName, 404));
+                        "Archive not found: " + archiveName, 400));
         if (description != null) {
             archive.setDescription(description);
         }
@@ -1188,7 +1190,7 @@ public class EventBridgeService {
         String key = archiveKey(region, archiveName);
         Archive archive = archiveStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Archive not found: " + archiveName, 404));
+                        "Archive not found: " + archiveName, 400));
         archiveStore.delete(key);
         archivedEventStore.delete(archivedEventKey(region, archiveName));
         resourceGroupsTaggingService.deleteResources(List.of(archive.getArchiveArn()), region);
@@ -1260,7 +1262,7 @@ public class EventBridgeService {
     public Connection describeConnection(String name, String region) {
         return connectionStore.get(connectionKey(region, name))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Connection " + name + " does not exist.", 404));
+                        "Connection " + name + " does not exist.", 400));
     }
 
     public Connection updateConnection(String name, String description, String authorizationType,
@@ -1269,7 +1271,7 @@ public class EventBridgeService {
         String key = connectionKey(region, name);
         Connection connection = connectionStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Connection " + name + " does not exist.", 404));
+                        "Connection " + name + " does not exist.", 400));
         if (authorizationType != null) {
             validateAuthorizationType(authorizationType);
             if (!authorizationType.equals(connection.getAuthorizationType()) && authParameters == null) {
@@ -1302,7 +1304,7 @@ public class EventBridgeService {
         String key = connectionKey(region, name);
         Connection connection = connectionStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Connection " + name + " does not exist.", 404));
+                        "Connection " + name + " does not exist.", 400));
         connectionStore.delete(key);
         LOG.infov("Deleted connection: {0}", name);
         return connection;
@@ -1399,7 +1401,7 @@ public class EventBridgeService {
         String archiveName = archiveNameFromArn(eventSourceArn);
         Archive archive = archiveStore.get(archiveKey(region, archiveName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Archive not found: " + archiveName, 404));
+                        "Archive not found: " + archiveName, 400));
 
         List<ArchivedEvent> events = archivedEventStore
                 .get(archivedEventKey(region, archiveName))
@@ -1435,14 +1437,14 @@ public class EventBridgeService {
     public Replay describeReplay(String replayName, String region) {
         return replayStore.get(replayKey(region, replayName))
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Replay not found: " + replayName, 404));
+                        "Replay not found: " + replayName, 400));
     }
 
     public Replay cancelReplay(String replayName, String region) {
         String key = replayKey(region, replayName);
         Replay replay = replayStore.get(key)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "Replay not found: " + replayName, 404));
+                        "Replay not found: " + replayName, 400));
         if (replay.getState() != ReplayState.RUNNING && replay.getState() != ReplayState.STARTING) {
             throw new AwsException("IllegalStatusException",
                     "Replay is not in a cancellable state: " + replay.getState(), 400);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -3812,7 +3812,8 @@ class CloudFormationIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeConnectionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeConnectionIntegrationTest.java
@@ -182,7 +182,7 @@ class EventBridgeConnectionIntegrationTest {
                 .header("X-Amz-Target", "AWSEvents.DescribeConnection")
                 .body("{\"Name\":\"no-such-connection\"}")
                 .when().post("/")
-                .then().statusCode(404)
+                .then().statusCode(400)
                 .body("__type", equalTo("ResourceNotFoundException"));
     }
 
@@ -223,7 +223,7 @@ class EventBridgeConnectionIntegrationTest {
                 .header("X-Amz-Target", "AWSEvents.DescribeConnection")
                 .body("{\"Name\":\"test-http-ingress-connection\"}")
                 .when().post("/")
-                .then().statusCode(404)
+                .then().statusCode(400)
                 .body("__type", equalTo("ResourceNotFoundException"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeIntegrationTest.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.hamcrest.Matchers.notNullValue;
@@ -189,5 +190,68 @@ class EventBridgeIntegrationTest {
                 .statusCode(200)
                 .body("Messages", hasSize(1))
                 .body("Messages[0].Body", notNullValue());
+    }
+
+    @Test
+    @Order(7)
+    void deleteOperationsAreIdempotentAndMissingResourcesUseAwsStatus() {
+        String busName = "eb-delete-compat-bus";
+        String ruleName = "eb-delete-compat-rule";
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.CreateEventBus")
+                .body("{\"Name\":\"" + busName + "\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("{\"Name\":\"" + ruleName + "\",\"EventBusName\":\"" + busName + "\"}")
+                .when().post("/")
+                .then().statusCode(200);
+
+        for (int attempt = 0; attempt < 2; attempt++) {
+            given()
+                    .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                    .header("X-Amz-Target", "AWSEvents.DeleteRule")
+                    .body("{\"Name\":\"" + ruleName + "\",\"EventBusName\":\"" + busName + "\"}")
+                    .when().post("/")
+                    .then().statusCode(200);
+        }
+
+        for (int attempt = 0; attempt < 2; attempt++) {
+            given()
+                    .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                    .header("X-Amz-Target", "AWSEvents.DeleteEventBus")
+                    .body("{\"Name\":\"" + busName + "\"}")
+                    .when().post("/")
+                    .then().statusCode(200);
+        }
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DeleteRule")
+                .body("{\"Name\":\"" + ruleName + "\",\"EventBusName\":\"" + busName + "\"}")
+                .when().post("/")
+                .then().statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundException"));
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.DescribeRule")
+                .body("{\"Name\":\"missing-rule\"}")
+                .when().post("/")
+                .then().statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundException"));
+
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.ListTargetsByRule")
+                .body("{\"Rule\":\"missing-target-rule\"}")
+                .when().post("/")
+                .then().statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundException"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgePermissionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgePermissionIntegrationTest.java
@@ -184,7 +184,7 @@ class EventBridgePermissionIntegrationTest {
 
     @Test
     @Order(6)
-    void putPermissionOnNonExistentBusReturns404() {
+    void putPermissionOnNonExistentBusReturnsResourceNotFound() {
         given()
             .contentType(EVENT_BRIDGE_CONTENT_TYPE)
             .header("X-Amz-Target", "AWSEvents.PutPermission")
@@ -199,7 +199,8 @@ class EventBridgePermissionIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeReplayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeReplayIntegrationTest.java
@@ -304,6 +304,19 @@ class EventBridgeReplayIntegrationTest {
                 .header("X-Amz-Target", "AWSEvents.DescribeArchive")
                 .body("{\"ArchiveName\":\"replay-test-archive\"}")
                 .when().post("/")
-                .then().statusCode(404);
+                .then().statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    @Order(13)
+    void missingReplayUsesAwsResourceNotFoundStatus() {
+        given()
+                .contentType(EB_CT)
+                .header("X-Amz-Target", "AWSEvents.DescribeReplay")
+                .body("{\"ReplayName\":\"missing-replay\"}")
+                .when().post("/")
+                .then().statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundException"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -127,6 +127,7 @@ class EventBridgeServiceTest {
     void deleteEventBus() {
         service.createEventBus("my-bus", null, null, REGION);
         service.deleteEventBus("my-bus", REGION);
+        assertDoesNotThrow(() -> service.deleteEventBus("my-bus", REGION));
 
         assertThrows(AwsException.class, () ->
                 service.describeEventBus("my-bus", REGION));
@@ -221,12 +222,22 @@ class EventBridgeServiceTest {
     }
 
     @Test
-    void deleteRule() {
+    void deleteRuleIsIdempotent() {
         service.putRule("my-rule", null, null, "rate(1 minute)", RuleState.ENABLED,
                 null, null, null, REGION);
         service.deleteRule("my-rule", null, REGION);
+        assertDoesNotThrow(() -> service.deleteRule("my-rule", null, REGION));
 
         assertTrue(service.listRules(null, null, REGION).isEmpty());
+    }
+
+    @Test
+    void deleteRuleForMissingCustomBusThrowsResourceNotFound() {
+        AwsException error = assertThrows(AwsException.class, () ->
+                service.deleteRule("missing-rule", "missing-bus", REGION));
+
+        assertEquals("ResourceNotFoundException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTagResourceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeTagResourceIntegrationTest.java
@@ -214,7 +214,8 @@ class EventBridgeTagResourceIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
     }
 
     @Test
@@ -232,7 +233,8 @@ class EventBridgeTagResourceIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
     }
 
     @Test
@@ -511,4 +513,3 @@ class EventBridgeTagResourceIntegrationTest {
             .statusCode(200);
     }
 }
-


### PR DESCRIPTION
## Summary

- Return EventBridge `ResourceNotFoundException` responses with the AWS JSON 1.1 client-error status, HTTP 400, across rules, targets, tags, permissions, archives, connections, and replays.
- Preserve AWS delete semantics: repeated `DeleteRule` calls succeed after the event bus is validated, and repeated `DeleteEventBus` calls remain idempotent.
- Add raw JSON 1.1 and AWS SDK regressions for the corrected status, error type, and delete behavior.

Closes #2258

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously returned HTTP 404 for most EventBridge `ResourceNotFoundException` paths. AWS EventBridge uses JSON 1.1, and its modeled client errors return HTTP 400. The fix also aligns `DeleteRule` with AWS's documented repeated-delete behavior while retaining a modeled missing-bus error.

Verified with AWS SDK for Java v2.52.0 against a packaged local Floci server.

## Testing

- `./mvnw test -Dtest='EventBridge*'` — 261 tests, 0 failures/errors
- `./mvnw test` — 12,039 tests, 0 failures/errors, 9 skipped
- Java SDK `EventBridgeTest,EventBridgeReplayTest` — 33 tests, 0 failures/errors
- `make docs-check`
- `git diff --check`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
