### PR TITLE
fix(secretsmanager): stop CreateSecret overwriting a secret inside its recovery window

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -104,7 +104,13 @@ public class SecretsManagerService implements ResourceProvider {
         String storageKey = regionKey(region, name);
         Secret existing = store.get(storageKey).orElse(null);
 
-        if (existing != null && existing.getDeletedDate() == null) {
+        if (existing != null) {
+            // A name inside its recovery window is still taken: the secret is recoverable via
+            // RestoreSecret, so reusing the name has to be refused rather than allowed to
+            // overwrite it. Without this the create would replace the stored secret at the same
+            // key AND clear its deletedDate, so the original value became unrecoverable and
+            // RestoreSecret then reported "was not deleted" - silent data loss.
+            throwIfPendingDeletion(existing);
             throw new AwsException("ResourceExistsException",
                     "A secret with the name " + name + " already exists.", 400);
         }
@@ -549,6 +555,13 @@ public class SecretsManagerService implements ResourceProvider {
             return secret;
         }
 
+        // Guard placed AFTER the force-delete branch on purpose: force-deleting a secret that is
+        // already inside its recovery window is a legitimate "skip the window, remove it now"
+        // escape hatch, so only the scheduling path is refused. Re-scheduling an already-scheduled
+        // secret silently moved its DeletionDate, which would quietly extend a window a caller
+        // believed was already counting down.
+        throwIfPendingDeletion(secret);
+
         int windowDays = (recoveryWindowInDays != null) ? recoveryWindowInDays : defaultRecoveryWindowDays;
         Instant deletedDate = Instant.now().plusSeconds((long) windowDays * 86400);
         secret.setDeletedDate(deletedDate);
@@ -739,6 +752,7 @@ public class SecretsManagerService implements ResourceProvider {
 
     public void tagResource(String secretId, List<Secret.Tag> tags, String region) {
         Secret secret = resolveSecret(secretId, region);
+        throwIfPendingDeletion(secret);
 
         List<Secret.Tag> existing = secret.getTags() != null ? new ArrayList<>(secret.getTags()) : new ArrayList<>();
         for (Secret.Tag newTag : tags) {
@@ -751,6 +765,7 @@ public class SecretsManagerService implements ResourceProvider {
 
     public void untagResource(String secretId, List<String> tagKeys, String region) {
         Secret secret = resolveSecret(secretId, region);
+        throwIfPendingDeletion(secret);
 
         List<Secret.Tag> existing = secret.getTags() != null ? new ArrayList<>(secret.getTags()) : new ArrayList<>();
         existing.removeIf(t -> tagKeys.contains(t.key()));

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerServiceTest.java
@@ -281,6 +281,70 @@ class SecretsManagerServiceTest {
                 service.updateSecretVersionStage("my-secret", null, null, "AWSCURRENT", REGION)).getErrorCode());
     }
 
+    /**
+     * The data-loss case from #2549: CreateSecret against a name inside its recovery window used
+     * to fall through the "already exists" guard (which only fired when {@code deletedDate} was
+     * null), overwrite the recoverable secret at the same storage key, and clear its
+     * {@code deletedDate} as a side effect. The original value became unrecoverable and
+     * RestoreSecret then reported "was not deleted", so nothing surfaced the loss.
+     */
+    @Test
+    void createSecretOnPendingDeletionNameIsRefusedAndLeavesOriginalRecoverable() {
+        service.createSecret("my-secret", "ORIGINAL-VALUE", null, null, null, null, REGION);
+        service.deleteSecret("my-secret", 7, false, REGION);
+
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.createSecret("my-secret", "NEW-VALUE", null, null, null, null, REGION)).getErrorCode());
+
+        // The recovery window still means what it says: restore works and returns the original.
+        service.restoreSecret("my-secret", REGION);
+        assertEquals("ORIGINAL-VALUE",
+                service.getSecretValue("my-secret", null, null, REGION).getSecretString());
+    }
+
+    @Test
+    void tagUntagAndRescheduleOnPendingDeletionSecretRaiseInvalidRequest() {
+        service.createSecret("my-secret", "value", null, null, null, null, REGION);
+        service.deleteSecret("my-secret", 7, false, REGION);
+
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.tagResource("my-secret", List.of(new Secret.Tag("k", "v")), REGION)).getErrorCode());
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.untagResource("my-secret", List.of("k"), REGION)).getErrorCode());
+        // A second non-force DeleteSecret used to silently move DeletionDate forward.
+        assertEquals("InvalidRequestException", assertThrows(AwsException.class, () ->
+                service.deleteSecret("my-secret", 7, false, REGION)).getErrorCode());
+    }
+
+    /**
+     * Force delete stays available as the documented "skip the recovery window" escape hatch, so
+     * the guard added above must not block it. Pins the guard's placement after the force branch.
+     */
+    @Test
+    void forceDeleteStillWorksOnAPendingDeletionSecret() {
+        service.createSecret("my-secret", "value", null, null, null, null, REGION);
+        service.deleteSecret("my-secret", 7, false, REGION);
+
+        service.deleteSecret("my-secret", null, true, REGION);
+
+        assertEquals("ResourceNotFoundException", assertThrows(AwsException.class, () ->
+                service.describeSecret("my-secret", REGION)).getErrorCode());
+    }
+
+    /**
+     * DescribeSecret is how a caller reads a scheduled secret's DeletedDate, and AWS does not
+     * declare InvalidRequestException for it. Pins that the guard was not over-applied.
+     */
+    @Test
+    void describeSecretRemainsAllowedOnPendingDeletionSecret() {
+        service.createSecret("my-secret", "value", null, null, null, null, REGION);
+        service.deleteSecret("my-secret", 7, false, REGION);
+
+        Secret described = service.describeSecret("my-secret", REGION);
+        assertEquals("my-secret", described.getName());
+        assertNotNull(described.getDeletedDate());
+    }
+
     @Test
     void forceDeleteSecret() {
         service.createSecret("my-secret", "value", null, null, null, null, REGION);


### PR DESCRIPTION
## Summary

Fixes #2549

Rebased onto `main` now that #2514 has merged, so this is down to just the four new guards. Follow-up to #2514, filed at @pgermosen's suggestion in [review](https://github.com/floci-io/floci/pull/2514#issuecomment-5402247305). #2514 fixed six operations that raised the **wrong** error code on a pending-deletion secret. These four are a distinct set: they don't check pending-deletion state **at all**, which is why they didn't surface in the same search. All pre-existing; none introduced by #2514.

**The `CreateSecret` case loses data.** Its "already exists" guard was `existing != null && existing.getDeletedDate() == null`, so a name scheduled for deletion fell straight through and overwrote the recoverable secret at the same storage key. That also cleared `deletedDate`, so the subsequent `RestoreSecret` reported *"was not deleted"* — the recovery path doesn't just come back empty, it actively claims there's nothing to recover, which makes the loss easy to miss.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** four operations against a secret inside its recovery window returned 200 instead of `InvalidRequestException`. `CreateSecret`, `TagResource`, `UntagResource`, and `DeleteSecret` all declare `InvalidRequestException` in their error lists in `secretsmanager/2017-10-17/service-2.json`, with "The secret is scheduled for deletion" listed among the documented causes.

Before — the data-loss path:

```bash
create-secret --name s2 --secret-string ORIGINAL-VALUE
delete-secret --secret-id s2                          # 30-day recovery window
create-secret --name s2 --secret-string NEW-VALUE     → 200          (AWS: InvalidRequestException)
restore-secret --secret-id s2                         → InvalidRequestException "was not deleted"
get-secret-value --secret-id s2                       → "NEW-VALUE"  ORIGINAL-VALUE unrecoverable
```

After, verified with AWS CLI v2 against a locally built JVM jar:

```
create-secret (scheduled name)  → InvalidRequestException
tag-resource                    → InvalidRequestException
untag-resource                  → InvalidRequestException
delete-secret (repeat, no force)→ InvalidRequestException

restore-secret → 200, and get-secret-value returns ORIGINAL-VALUE
```

Deliberately still allowed, all CLI-confirmed after the change:

```
describe-secret                      → 200   (how a caller reads DeletedDate; AWS doesn't declare IRE)
restore-secret                       → 200
delete-secret --force-delete-…       → 200   (documented "skip the window" escape hatch)
```

**One judgement call worth flagging:** `deleteSecret`'s guard sits *after* the force-delete branch, so force-deleting an already-scheduled secret still works. I read that as a legitimate escape hatch rather than something to refuse, and the reviewer's probe only covered the plain repeat delete. If real AWS actually rejects force-delete-on-scheduled too, say so and I'll move the guard above the branch — `forceDeleteStillWorksOnAPendingDeletionSecret` pins the current placement either way.

`ListSecretVersionIds` left alone for the same reason as `DescribeSecret`.

## Fix

`CreateSecret` gets the check inside its existing-secret branch, before the `ResourceExistsException` — a scheduled name is still taken, so the create is refused rather than allowed to overwrite. The other three reuse `throwIfPendingDeletion` directly.

## Testing

- `createSecretOnPendingDeletionNameIsRefusedAndLeavesOriginalRecoverable` — the data-loss regression. Asserts the create is refused **and** that after `RestoreSecret` the value is still `ORIGINAL-VALUE`, so it fails if the overwrite ever returns.
- `tagUntagAndRescheduleOnPendingDeletionSecretRaiseInvalidRequest` — the other three.
- `forceDeleteStillWorksOnAPendingDeletionSecret` — pins the guard placement so a later "tidy-up" can't accidentally block force delete.
- `describeSecretRemainsAllowedOnPendingDeletionSecret` — pins that the guard wasn't over-applied.
- Confirmed the data-loss test actually catches the bug: reverting just `createSecret`'s guard fails it with *"Expected AwsException to be thrown, but nothing was thrown"*, and nothing else in the suite fails — so it's the test carrying that invariant, not a side effect of another assertion.
- Full `io.github.hectorvent.floci.services.secretsmanager.*Test` package: 122 tests, 0 failures — re-run after the rebase onto current `main`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

