### PR TITLE
fix(msk): reject fractional broker counts that round-trip through double precision

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -187,7 +187,14 @@ public class MskService implements ResourceProvider {
         merged.setTags(request.getTags());
         if (request.getProvisioned() != null) {
             merged.setKafkaVersion(request.getProvisioned().getKafkaVersion());
-            merged.setNumberOfBrokerNodes(request.getProvisioned().getNumberOfBrokerNodes());
+            // A malformed numberOfBrokerNodes carries no int value to copy (see BrokerCount),
+            // so its "malformed" state has to be propagated explicitly rather than lost when
+            // getNumberOfBrokerNodes() returns null the same way "absent" would.
+            if (request.getProvisioned().isNumberOfBrokerNodesMalformed()) {
+                merged.markNumberOfBrokerNodesMalformed();
+            } else {
+                merged.setNumberOfBrokerNodes(request.getProvisioned().getNumberOfBrokerNodes());
+            }
             merged.setBrokerNodeGroupInfo(request.getProvisioned().getBrokerNodeGroupInfo());
             merged.setEncryptionInfo(request.getProvisioned().getEncryptionInfo());
             merged.setClientAuthentication(request.getProvisioned().getClientAuthentication());
@@ -222,6 +229,13 @@ public class MskService implements ResourceProvider {
         if (clusterName.length() > MAX_CLUSTER_NAME_LENGTH) {
             throw badRequest("clusterName",
                     "clusterName must be between 1 and " + MAX_CLUSTER_NAME_LENGTH + " characters.");
+        }
+
+        // A fractional or otherwise non-integral numberOfBrokerNodes (e.g. 2.7, or a literal
+        // like 1.0000000000000001 that only looks whole once collapsed into a double) is
+        // malformed rather than something to round - see BrokerCountDeserializer/BrokerCount.
+        if (request.isNumberOfBrokerNodesMalformed()) {
+            throw badRequest("numberOfBrokerNodes", "numberOfBrokerNodes must be a whole number.");
         }
 
         Integer brokerNodes = request.getNumberOfBrokerNodes();

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/BrokerCount.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/BrokerCount.java
@@ -1,0 +1,45 @@
+package io.github.hectorvent.floci.services.msk.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Result of parsing {@code numberOfBrokerNodes}: either an exact whole-number value, or a
+ * marker that the request supplied something else.
+ *
+ * <p>{@link BrokerCountDeserializer} can't simply throw on malformed input: an exception
+ * raised from inside a Jackson deserializer is caught while the request body is being read,
+ * before the JAX-RS resource method - and therefore this service's own AWS-shaped
+ * {@code AwsException} handling - ever runs, so the caller gets a bodyless 400 instead of an
+ * MSK-style error. Carrying "malformed" as a value instead lets normal request validation
+ * (see {@code MskService#validateCreateRequest}) raise the proper error once binding has
+ * finished successfully.
+ */
+@RegisterForReflection
+public final class BrokerCount {
+
+    private static final BrokerCount MALFORMED = new BrokerCount(null, true);
+
+    private final Integer value;
+    private final boolean malformed;
+
+    private BrokerCount(Integer value, boolean malformed) {
+        this.value = value;
+        this.malformed = malformed;
+    }
+
+    public static BrokerCount of(Integer value) {
+        return new BrokerCount(value, false);
+    }
+
+    public static BrokerCount malformed() {
+        return MALFORMED;
+    }
+
+    public Integer value() {
+        return value;
+    }
+
+    public boolean isMalformed() {
+        return malformed;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/BrokerCountDeserializer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/BrokerCountDeserializer.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.msk.model;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+/**
+ * Parses {@code numberOfBrokerNodes} without losing the precision needed to tell a whole
+ * number from a fractional one.
+ *
+ * <p>Binding the field straight to {@code Integer} isn't safe: Jackson's default float-to-int
+ * coercion (on by default) truncates a JSON float token the same way {@code intValue()} would,
+ * silently turning 2.7 into 2. Comparing the value as a {@code double} after the fact doesn't
+ * fix that either - it just moves the precision loss earlier. A literal like
+ * {@code 1.0000000000000001} has no exact {@code double} representation, so parsing it into a
+ * double collapses it to exactly {@code 1.0} before any {@code d == Math.rint(d)} check ever
+ * runs, and the malformed input is silently accepted as a valid integer.
+ *
+ * <p>{@link JsonParser#getDecimalValue()} avoids that: it builds a {@link BigDecimal} straight
+ * from the token's source text, the same way {@code new BigDecimal(String)} would, so it never
+ * routes the value through a lossy {@code double}. Checking exactness on that value catches a
+ * fractional literal - including one only a double comparison would have missed - while still
+ * accepting a whole number written with a decimal point (e.g. {@code 3.0}).
+ *
+ * <p>This deserializer never throws on malformed input; it returns {@link BrokerCount#malformed()}
+ * instead. See that class for why - in short, an exception raised here is caught while the
+ * request body is still being read, before this service's AWS-shaped error handling ever runs.
+ */
+@RegisterForReflection
+public class BrokerCountDeserializer extends JsonDeserializer<BrokerCount> {
+
+    @Override
+    public BrokerCount deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        JsonToken token = p.currentToken();
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        if (token == JsonToken.VALUE_NUMBER_INT || token == JsonToken.VALUE_NUMBER_FLOAT) {
+            BigDecimal decimal = p.getDecimalValue();
+            if (decimal.stripTrailingZeros().scale() <= 0) {
+                try {
+                    return BrokerCount.of(decimal.intValueExact());
+                } catch (ArithmeticException overflow) {
+                    // Falls through to "malformed" below - out of int range is as malformed as
+                    // a fractional value.
+                }
+            }
+        }
+        return BrokerCount.malformed();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/CreateClusterRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/CreateClusterRequest.java
@@ -1,7 +1,9 @@
 package io.github.hectorvent.floci.services.msk.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.util.Map;
@@ -16,8 +18,12 @@ public class CreateClusterRequest {
     @JsonProperty("kafkaVersion")
     private String kafkaVersion;
 
+    // See BrokerCountDeserializer: binding straight to Integer would let Jackson (or a later
+    // double comparison) silently narrow a fractional or precision-collapsed value. BrokerCount
+    // carries "malformed" as a value rather than throwing during binding - see that class.
     @JsonProperty("numberOfBrokerNodes")
-    private Integer numberOfBrokerNodes;
+    @JsonDeserialize(using = BrokerCountDeserializer.class)
+    private BrokerCount numberOfBrokerNodes;
 
     @JsonProperty("brokerNodeGroupInfo")
     private BrokerNodeGroupInfo brokerNodeGroupInfo;
@@ -57,8 +63,27 @@ public class CreateClusterRequest {
     public String getKafkaVersion() { return kafkaVersion; }
     public void setKafkaVersion(String kafkaVersion) { this.kafkaVersion = kafkaVersion; }
 
-    public Integer getNumberOfBrokerNodes() { return numberOfBrokerNodes; }
-    public void setNumberOfBrokerNodes(Integer numberOfBrokerNodes) { this.numberOfBrokerNodes = numberOfBrokerNodes; }
+    // @JsonIgnore'd because their Integer signature would otherwise win as the property's
+    // Jackson accessor (by JavaBean naming convention) over the field itself, and Jackson
+    // would then try to hand a deserialized BrokerCount to a setter expecting Integer -
+    // an IllegalArgumentException at invocation time. Ignoring these forces Jackson back onto
+    // the annotated field, which is typed correctly for @JsonDeserialize to bind against.
+    @JsonIgnore
+    public Integer getNumberOfBrokerNodes() { return numberOfBrokerNodes != null ? numberOfBrokerNodes.value() : null; }
+    @JsonIgnore
+    public void setNumberOfBrokerNodes(Integer numberOfBrokerNodes) {
+        this.numberOfBrokerNodes = numberOfBrokerNodes != null ? BrokerCount.of(numberOfBrokerNodes) : null;
+    }
+
+    /** True when the request supplied a numberOfBrokerNodes that isn't an exact whole number. */
+    public boolean isNumberOfBrokerNodesMalformed() {
+        return numberOfBrokerNodes != null && numberOfBrokerNodes.isMalformed();
+    }
+
+    /** Propagates a malformed numberOfBrokerNodes from a CreateClusterV2Request's provisioned block. */
+    public void markNumberOfBrokerNodesMalformed() {
+        this.numberOfBrokerNodes = BrokerCount.malformed();
+    }
 
     public BrokerNodeGroupInfo getBrokerNodeGroupInfo() { return brokerNodeGroupInfo; }
     public void setBrokerNodeGroupInfo(BrokerNodeGroupInfo brokerNodeGroupInfo) { this.brokerNodeGroupInfo = brokerNodeGroupInfo; }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/ProvisionedRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/ProvisionedRequest.java
@@ -1,7 +1,9 @@
 package io.github.hectorvent.floci.services.msk.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
@@ -11,8 +13,12 @@ public class ProvisionedRequest {
     @JsonProperty("kafkaVersion")
     private String kafkaVersion;
 
+    // See BrokerCountDeserializer: binding straight to Integer would let Jackson (or a later
+    // double comparison) silently narrow a fractional or precision-collapsed value. BrokerCount
+    // carries "malformed" as a value rather than throwing during binding - see that class.
     @JsonProperty("numberOfBrokerNodes")
-    private Integer numberOfBrokerNodes;
+    @JsonDeserialize(using = BrokerCountDeserializer.class)
+    private BrokerCount numberOfBrokerNodes;
 
     @JsonProperty("brokerNodeGroupInfo")
     private BrokerNodeGroupInfo brokerNodeGroupInfo;
@@ -46,8 +52,18 @@ public class ProvisionedRequest {
     public String getKafkaVersion() { return kafkaVersion; }
     public void setKafkaVersion(String kafkaVersion) { this.kafkaVersion = kafkaVersion; }
 
-    public Integer getNumberOfBrokerNodes() { return numberOfBrokerNodes; }
-    public void setNumberOfBrokerNodes(Integer numberOfBrokerNodes) { this.numberOfBrokerNodes = numberOfBrokerNodes; }
+    // See CreateClusterRequest's identical accessors for why these are @JsonIgnore'd.
+    @JsonIgnore
+    public Integer getNumberOfBrokerNodes() { return numberOfBrokerNodes != null ? numberOfBrokerNodes.value() : null; }
+    @JsonIgnore
+    public void setNumberOfBrokerNodes(Integer numberOfBrokerNodes) {
+        this.numberOfBrokerNodes = numberOfBrokerNodes != null ? BrokerCount.of(numberOfBrokerNodes) : null;
+    }
+
+    /** True when the request supplied a numberOfBrokerNodes that isn't an exact whole number. */
+    public boolean isNumberOfBrokerNodesMalformed() {
+        return numberOfBrokerNodes != null && numberOfBrokerNodes.isMalformed();
+    }
 
     public BrokerNodeGroupInfo getBrokerNodeGroupInfo() { return brokerNodeGroupInfo; }
     public void setBrokerNodeGroupInfo(BrokerNodeGroupInfo brokerNodeGroupInfo) { this.brokerNodeGroupInfo = brokerNodeGroupInfo; }

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
@@ -1048,6 +1048,102 @@ class MskControllerIntegrationTest {
             .body("clusterInfo.numberOfBrokerNodes", equalTo(30));
     }
 
+    /**
+     * A fractional count must not be narrowed into a plausible one: Jackson's default
+     * float-to-int coercion would otherwise turn 2.7 into 2 and report a cluster the caller
+     * never asked for.
+     */
+    @Test
+    void createClusterRejectsAFractionalBrokerCountInsteadOfTruncatingIt() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v1-brokers-fractional-test", "kafkaVersion": "3.6.0",
+                 "numberOfBrokerNodes": 2.7}
+                """)
+        .when()
+            .post("/v1/clusters")
+        .then()
+            .statusCode(400)
+            .body("invalidParameter", equalTo("numberOfBrokerNodes"));
+
+        // ...and nothing was created under that name.
+        given()
+        .when()
+            .get("/v1/clusters")
+        .then()
+            .statusCode(200)
+            .body("clusterInfoList.clusterName", not(hasItem("v1-brokers-fractional-test")));
+    }
+
+    /**
+     * A literal like 1.0000000000000001 has no exact double representation - parsing it as a
+     * double collapses it to precisely 1.0, so a d == Math.rint(d) check performed after that
+     * conversion would wrongly accept it as whole. This value must still be rejected: reading
+     * the token as a BigDecimal (see BrokerCountDeserializer) catches the fractional part a
+     * double comparison already lost.
+     */
+    @Test
+    void createClusterRejectsABrokerCountThatOnlyLooksWholeAsADouble() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v1-brokers-precision-test", "kafkaVersion": "3.6.0",
+                 "numberOfBrokerNodes": 1.0000000000000001}
+                """)
+        .when()
+            .post("/v1/clusters")
+        .then()
+            .statusCode(400)
+            .body("invalidParameter", equalTo("numberOfBrokerNodes"));
+
+        given()
+        .when()
+            .get("/v1/clusters")
+        .then()
+            .statusCode(200)
+            .body("clusterInfoList.clusterName", not(hasItem("v1-brokers-precision-test")));
+    }
+
+    /** A whole number written with a decimal point (e.g. 3.0) is not fractional and is accepted. */
+    @Test
+    void createClusterAcceptsAWholeNumberBrokerCountWrittenAsADecimal() {
+        String clusterArn = given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v1-brokers-whole-decimal-test", "kafkaVersion": "3.6.0",
+                 "numberOfBrokerNodes": 3.0}
+                """)
+        .when()
+            .post("/v1/clusters")
+        .then()
+            .statusCode(200)
+            .extract().path("clusterArn");
+
+        given()
+        .when()
+            .get("/v1/clusters/{clusterArn}", clusterArn)
+        .then()
+            .statusCode(200)
+            .body("clusterInfo.numberOfBrokerNodes", equalTo(3));
+    }
+
+    /** The V2 path nests the count under provisioned and must reject a fractional value too. */
+    @Test
+    void createClusterV2RejectsAFractionalBrokerCount() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"clusterName": "v2-brokers-fractional-test",
+                 "provisioned": {"kafkaVersion": "3.6.0", "numberOfBrokerNodes": 2.7}}
+                """)
+        .when()
+            .post("/api/v2/clusters")
+        .then()
+            .statusCode(400)
+            .body("invalidParameter", equalTo("numberOfBrokerNodes"));
+    }
+
     // ── Serverless clusters ──────────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

This PR previously implemented broker-count/tags round-tripping and a broker-count
ceiling for `CreateCluster`. Upstream's `0205e4ed` (merged after this PR's last
push) independently replaced the raw-map `CreateCluster` handling with typed
request DTOs that already round-trip `numberOfBrokerNodes`, tags, and considerably
more, and separately resolved the broker-ceiling question by choosing not to
enforce one at all. This PR has been rebased onto that commit; every one of its
original commits is now empty (fully superseded) and was dropped rather than
force-kept.

What's left, and what this PR now is: a real, still-present gap in the code
`0205e4ed` landed. `CreateClusterRequest`/`ProvisionedRequest#numberOfBrokerNodes`
binds directly to `Integer` via Jackson, which two ways to accept malformed input:

- Default float-to-int coercion silently truncates a fractional value
  (`2.7` -> `2`), the exact narrowing bug the original PR set out to reject.
- A value like `1.0000000000000001` has no exact `double` representation and
  collapses to precisely `1.0` under IEEE-754 rounding, so any check performed
  *after* the value has passed through a `double` (e.g. `d == Math.rint(d)`) sees
  a value that looks whole and lets it through, even though the caller's literal
  was fractional.

Fix: a custom Jackson deserializer (`BrokerCountDeserializer`) reads the token via
`JsonParser#getDecimalValue()`, which builds a `BigDecimal` directly from the
source text rather than routing through `double` — so a genuinely-fractional
literal is distinguished correctly from one that only looks whole after
floating-point rounding, in both cases. It returns a small value object
(`BrokerCount`, carrying either the parsed value or a malformed flag) rather than
throwing directly from inside the deserializer, since an exception thrown there is
swallowed by the JAX-RS body reader before this service's own `AwsExceptionMapper`
ever runs, producing a bodyless 400 instead of the documented
`{message, invalidParameter}` shape. `MskService#validateCreateRequest` raises the
proper `AwsException` after binding succeeds, the same way every other
`CreateCluster` validation already does. The V1 and V2 (`provisioned.*`) request
shapes are both covered.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real MSK rejects a non-integer `numberOfBrokerNodes` outright rather than
narrowing or rounding it. This closes a path where Floci could silently accept a
fractional broker count that happens to collapse to a whole number under double
rounding, and creates a cluster the caller never actually asked for.

## Checklist

- [x] New/updated tests: rejects `2.7` (plain fractional), rejects
      `1.0000000000000001` (the double-collapse case), accepts `3.0` (a whole
      number legitimately written with a decimal point), and the V2
      `provisioned.numberOfBrokerNodes` path rejects `2.7` the same way — all
      assert `invalidParameter: "numberOfBrokerNodes"` on the 400 body.
- [x] `MskControllerIntegrationTest` 42/42, `MskControllerTest` 2/2,
      `MskServiceTest` 56/56 — 100 tests, 0 failures/errors.
- [x] Commit messages follow Conventional Commits
