### PR TITLE
fix(msk): return BadRequestException when a configuration ARN does not exist

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -157,8 +157,13 @@ public class MskService {
     }
 
     public MskConfiguration describeConfiguration(String arn) {
+        // Real MSK reports an unknown configuration ARN as BadRequestException (400), not
+        // NotFoundException. The message prefix is a compatibility contract: terraform-provider-aws
+        // (and the Pulumi provider bridging it) substring-matches "Configuration ARN does not exist"
+        // to detect that a configuration is gone, so its post-delete waiter can complete.
         return configurationStorage.get(arn)
-                .orElseThrow(() -> new AwsException("NotFoundException", "Configuration not found: " + arn, 404));
+                .orElseThrow(() -> new AwsException("BadRequestException",
+                        "Configuration ARN does not exist: " + arn, 400));
     }
 
     public PaginatedResult<MskConfiguration> listConfigurations(Integer maxResults, String nextToken) {

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
@@ -8,6 +8,7 @@ import java.util.Base64;
 import java.util.UUID;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -126,11 +127,16 @@ class MskControllerIntegrationTest {
             .body("arn", equalTo(arn))
             .body("state", equalTo("DELETING"));
 
+        // Real MSK signals a deleted configuration as BadRequestException, and the terraform/pulumi
+        // provider's delete waiter only recognizes that code plus this exact message substring as
+        // "gone" - assert the full wire contract, not just a status code.
         given()
         .when()
             .get("/v1/configurations/{arn}", arn)
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .header("X-Amzn-Errortype", equalTo("BadRequestException"))
+            .body("message", containsString("Configuration ARN does not exist"));
     }
 
     // An empty base64 blob decodes to "" and means "no property overrides". Absent and
@@ -242,12 +248,14 @@ class MskControllerIntegrationTest {
     }
 
     @Test
-    void describeConfigurationReturnsNotFoundForUnknownArn() {
+    void describeConfigurationReturnsBadRequestForUnknownArn() {
         given()
         .when()
             .get("/v1/configurations/{arn}", "arn:aws:kafka:us-east-1:000000000000:configuration/missing/id")
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .header("X-Amzn-Errortype", equalTo("BadRequestException"))
+            .body("message", containsString("Configuration ARN does not exist"));
     }
 
     // kafkaVersions is optional on CreateConfigurationRequest. Omitting it must not leak a
@@ -421,14 +429,15 @@ class MskControllerIntegrationTest {
     }
 
     @Test
-    void updateConfigurationReturnsNotFoundForUnknownArn() {
+    void updateConfigurationReturnsBadRequestForUnknownArn() {
         given()
             .contentType("application/json")
             .body("{\"serverProperties\": \"cHJvcHM=\"}")
         .when()
             .put("/v1/configurations/{arn}", "arn:aws:kafka:us-east-1:000000000000:configuration/missing/id")
         .then()
-            .statusCode(404);
+            .statusCode(400)
+            .body("message", containsString("Configuration ARN does not exist"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskControllerIntegrationTest.java
@@ -437,6 +437,7 @@ class MskControllerIntegrationTest {
             .put("/v1/configurations/{arn}", "arn:aws:kafka:us-east-1:000000000000:configuration/missing/id")
         .then()
             .statusCode(400)
+            .header("X-Amzn-Errortype", equalTo("BadRequestException"))
             .body("message", containsString("Configuration ARN does not exist"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -183,9 +183,14 @@ class MskServiceTest {
     }
 
     @Test
-    void describeConfigurationNotFoundThrows() {
-        assertThrows(AwsException.class, () ->
+    void describeConfigurationUnknownArnThrowsBadRequest() {
+        // Real MSK uses BadRequestException with this message for unknown configuration ARNs;
+        // terraform-provider-aws substring-matches it to detect a deleted configuration.
+        AwsException ex = assertThrows(AwsException.class, () ->
                 mskService.describeConfiguration("arn:aws:kafka:us-east-1:000000000000:configuration/missing/id"));
+        assertEquals("BadRequestException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("Configuration ARN does not exist"));
     }
 
     @Test
@@ -238,6 +243,18 @@ class MskServiceTest {
     }
 
     @Test
+    void describeConfigurationAfterDeleteThrowsBadRequest() {
+        MskConfiguration configuration = mskService.createConfiguration(
+                "test-config", "desc", List.of("3.6.0"), "props");
+        mskService.deleteConfiguration(configuration.getArn());
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                mskService.describeConfiguration(configuration.getArn()));
+        assertEquals("BadRequestException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("Configuration ARN does not exist"));
+    }
+
+    @Test
     void updateConfiguration() {
         MskConfiguration created = mskService.createConfiguration(
                 "test-config", "v1 desc", List.of("3.6.0"), "auto.create.topics.enable=true");
@@ -284,10 +301,11 @@ class MskServiceTest {
     }
 
     @Test
-    void updateConfigurationNotFoundThrows() {
-        assertThrows(AwsException.class, () ->
+    void updateConfigurationUnknownArnThrowsBadRequest() {
+        AwsException ex = assertThrows(AwsException.class, () ->
                 mskService.updateConfiguration(
                         "arn:aws:kafka:us-east-1:000000000000:configuration/missing/id", "desc", "props"));
+        assertEquals("BadRequestException", ex.getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -306,6 +306,8 @@ class MskServiceTest {
                 mskService.updateConfiguration(
                         "arn:aws:kafka:us-east-1:000000000000:configuration/missing/id", "desc", "props"));
         assertEquals("BadRequestException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("Configuration ARN does not exist"));
     }
 
     @Test


### PR DESCRIPTION
Destroying an `aws_msk_configuration` with Terraform or Pulumi can never complete against floci. Create works, destroy always breaks in the provider's delete waiter.

The provider only treats a configuration as gone when `DescribeConfiguration` fails with `BadRequestException` and a message containing `Configuration ARN does not exist`. That is what real MSK returns for a missing configuration ARN (unlike clusters, where it really is `NotFoundException`). floci returns `NotFoundException` 404, which the provider does not recognize as not-found, so `waitConfigurationDeleted` surfaces it as a raw error and the destroy fails every time.

Provider source, [`internal/service/kafka/configuration.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/kafka/configuration.go):

```go
if errs.IsAErrorMessageContains[*types.BadRequestException](err, "Configuration ARN does not exist") {
    return nil, &retry.NotFoundError{ ... }
}
```

The same match exists back to v4.x (`FindConfigurationByARN` in `find.go`), which pulumi-aws v5 bridges. On current main the provider also tolerates this error on the `DeleteConfiguration` call itself.

Change:
1. `MskService#describeConfiguration` now throws `BadRequestException` 400 with `Configuration ARN does not exist: <arn>` for an unknown ARN. All configuration operations resolve ARNs through it (describe, update, delete, list/describe revisions), so they all share the corrected shape.
2. Cluster APIs untouched.

Tests:
1. `configurationCrudRoundTrip` now asserts the full wire contract after delete: 400, `X-Amzn-Errortype: BadRequestException`, message contains `Configuration ARN does not exist`. That substring is exactly what the provider matches on, so this is the regression test for the destroy flow.
2. Unknown-ARN describe/update integration tests updated from 404 to the new shape.
3. Service-level regression for describe-after-delete.

Verified with `mvn test -Dtest='MskServiceTest,MskControllerTest,MskControllerIntegrationTest'` on JDK 25.
