### PR TITLE
feat(cloudwatch-logs): add AssociateKmsKey support

### DIFF
--- a/docs/services/cloudwatch.md
+++ b/docs/services/cloudwatch.md
@@ -17,6 +17,7 @@ Floci supports both CloudWatch Logs and CloudWatch Metrics.
 | `DeleteLogGroup` | Delete a log group |
 | `PutLogGroupDeletionProtection` | Enable or disable deletion protection for a log group by name or ARN |
 | `DescribeLogGroups` | List log groups |
+| `AssociateKmsKey` | Associate a KMS key with a log group |
 | `CreateLogStream` | Create a log stream inside a log group |
 | `DeleteLogStream` | Delete a log stream |
 | `DescribeLogStreams` | List log streams in a group |

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandler.java
@@ -46,6 +46,7 @@ public class CloudWatchLogsHandler {
             case "PutRetentionPolicy" -> handlePutRetentionPolicy(request, region);
             case "DeleteRetentionPolicy" -> handleDeleteRetentionPolicy(request, region);
             case "PutLogGroupDeletionProtection" -> handlePutLogGroupDeletionProtection(request, region);
+            case "AssociateKmsKey" -> handleAssociateKmsKey(request, region);
             case "TagLogGroup" -> handleTagLogGroup(request, region);
             case "UntagLogGroup" -> handleUntagLogGroup(request, region);
             case "ListTagsLogGroup" -> handleListTagsLogGroup(request, region);
@@ -95,6 +96,19 @@ public class CloudWatchLogsHandler {
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
+    private Response handleAssociateKmsKey(JsonNode request, String region) {
+        String groupName = request.path("logGroupName").asText(null);
+        if (groupName == null || groupName.isBlank()) {
+            throw new AwsException("InvalidParameterException", "logGroupName is required.", 400);
+        }
+        String kmsKeyId = request.path("kmsKeyId").asText(null);
+        if (kmsKeyId == null || kmsKeyId.isBlank()) {
+            throw new AwsException("InvalidParameterException", "kmsKeyId is required.", 400);
+        }
+        logsService.associateKmsKey(groupName, kmsKeyId, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
     private Response handleDescribeLogGroups(JsonNode request, String region) {
         String prefix = request.path("logGroupNamePrefix").asText(null);
         List<LogGroup> groups = logsService.describeLogGroups(prefix, region);
@@ -108,6 +122,9 @@ public class CloudWatchLogsHandler {
             node.put("arn", logsService.buildArn(g.getLogGroupName(), region));
             if (g.getRetentionInDays() != null) {
                 node.put("retentionInDays", g.getRetentionInDays());
+            }
+            if (g.getKmsKeyId() != null) {
+                node.put("kmsKeyId", g.getKmsKeyId());
             }
             node.put("deletionProtectionEnabled", g.isDeletionProtectionEnabled());
             node.put("storedBytes", 0);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsService.java
@@ -232,6 +232,15 @@ public class CloudWatchLogsService {
         groupStore.put(key, group);
     }
 
+    public void associateKmsKey(String groupName, String kmsKeyId, String region) {
+        String key = groupKey(region, groupName);
+        LogGroup group = groupStore.get(key)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified log group does not exist: " + groupName, 400));
+        group.setKmsKeyId(kmsKeyId);
+        groupStore.put(key, group);
+    }
+
     public void putRetentionPolicy(String groupName, int days, String region) {
         String key = groupKey(region, groupName);
         LogGroup group = groupStore.get(key)

--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/model/LogGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/logs/model/LogGroup.java
@@ -13,6 +13,7 @@ public class LogGroup {
     private String logGroupName;
     private long createdTime;
     private Integer retentionInDays;
+    private String kmsKeyId;
     private boolean deletionProtectionEnabled;
     private Map<String, String> tags = new HashMap<>();
 
@@ -26,6 +27,9 @@ public class LogGroup {
 
     public Integer getRetentionInDays() { return retentionInDays; }
     public void setRetentionInDays(Integer retentionInDays) { this.retentionInDays = retentionInDays; }
+
+    public String getKmsKeyId() { return kmsKeyId; }
+    public void setKmsKeyId(String kmsKeyId) { this.kmsKeyId = kmsKeyId; }
 
     public boolean isDeletionProtectionEnabled() { return deletionProtectionEnabled; }
     public void setDeletionProtectionEnabled(boolean deletionProtectionEnabled) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/logs/CloudWatchLogsHandlerTest.java
@@ -146,6 +146,23 @@ class CloudWatchLogsHandlerTest {
     }
 
     @Test
+    void associateKmsKeyIsReturnedByDescribeLogGroups() {
+        String kmsKeyArn = "arn:aws:kms:" + REGION + ":" + ACCOUNT + ":key/test-key";
+        ObjectNode associate = MAPPER.createObjectNode();
+        associate.put("logGroupName", GROUP);
+        associate.put("kmsKeyId", kmsKeyArn);
+
+        Response response = handler.handle("AssociateKmsKey", associate, REGION);
+
+        assertEquals(200, response.getStatus());
+        ObjectNode describe = MAPPER.createObjectNode();
+        describe.put("logGroupNamePrefix", GROUP);
+        JsonNode group = ((JsonNode) handler.handle("DescribeLogGroups", describe, REGION).getEntity())
+                .path("logGroups").get(0);
+        assertEquals(kmsKeyArn, group.path("kmsKeyId").asText());
+    }
+
+    @Test
     void putLogGroupDeletionProtectionPersistsByName() {
         ObjectNode request = MAPPER.createObjectNode();
         request.put("logGroupIdentifier", GROUP);


### PR DESCRIPTION
## Summary

Add CloudWatch Logs `AssociateKmsKey` handling, persist the KMS key on the target log group, and return it from log-group descriptions. The generated supported-actions documentation is updated with the new action.

Fixes #2540

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The CloudWatch Logs JSON 1.1 request and response path is covered by focused handler tests. External AWS SDK and CLI smoke testing was not performed.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused verification: `CloudWatchLogsHandlerTest` (27 tests) and `make docs-check` pass locally.

