### PR TITLE
fix(s3): emit post events for browser uploads

### DIFF
--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -28,6 +28,11 @@
 
 **RestoreObject** is accepted but stubbed: Floci validates the request and returns `202 Accepted`, but no restore state machine runs.
 
+## Event Notifications
+
+Browser and presigned POST uploads emit `s3:ObjectCreated:Post`, matching AWS S3. They do not emit
+`s3:ObjectCreated:Put`; use `s3:ObjectCreated:*` to subscribe to objects created by either method.
+
 ## Website Hosting
 
 Static website requests use a bucket website hostname such as

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -2698,7 +2698,7 @@ public class S3Controller {
             }
         }
 
-        S3Object obj = s3Service.putObject(bucket, key, fileData, objectContentType,
+        S3Object obj = s3Service.postObject(bucket, key, fileData, objectContentType,
                 metadata.isEmpty() ? null : metadata);
         LOG.infov("Presigned POST upload: {0}/{1} ({2} bytes)", bucket, key, fileData.length);
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -343,8 +343,24 @@ public class S3Service implements Resettable, ResourceProvider {
 
     public S3Object putObject(String bucketName, String key, byte[] data,
                               String contentType, Map<String, String> metadata, PutObjectOptions options) {
+        return createObject(bucketName, key, data, contentType, metadata, options, "ObjectCreated:Put");
+    }
+
+    public S3Object postObject(String bucketName, String key, byte[] data,
+                               String contentType, Map<String, String> metadata) {
+        return postObject(bucketName, key, data, contentType, metadata, new PutObjectOptions());
+    }
+
+    public S3Object postObject(String bucketName, String key, byte[] data,
+                               String contentType, Map<String, String> metadata, PutObjectOptions options) {
+        return createObject(bucketName, key, data, contentType, metadata, options, "ObjectCreated:Post");
+    }
+
+    private S3Object createObject(String bucketName, String key, byte[] data,
+                                  String contentType, Map<String, String> metadata,
+                                  PutObjectOptions options, String eventName) {
         S3Object object = storeObject(bucketName, key, data, contentType, metadata, null, null, options);
-        fireNotifications(bucketName, key, "ObjectCreated:Put", object);
+        fireNotifications(bucketName, key, eventName, object);
         return object;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
@@ -70,6 +70,113 @@ class S3PresignedPostIntegrationTest {
     }
 
     @Test
+    @Order(15)
+    void presignedPostEmitsPostNotification() {
+        String postQueueName = "presigned-post-notification-queue";
+        String putQueueName = "presigned-put-notification-queue";
+        String wildcardQueueName = "presigned-wildcard-notification-queue";
+        String postQueueUrl = createQueue(postQueueName);
+        String putQueueUrl = createQueue(putQueueName);
+        String wildcardQueueUrl = createQueue(wildcardQueueName);
+
+        try {
+            given()
+                .contentType("application/xml")
+                .queryParam("notification", "")
+                .body("""
+                    <NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <QueueConfiguration>
+                            <Id>post-notification</Id>
+                            <Queue>arn:aws:sqs:us-east-1:000000000000:%s</Queue>
+                            <Event>s3:ObjectCreated:Post</Event>
+                        </QueueConfiguration>
+                        <QueueConfiguration>
+                            <Id>put-notification</Id>
+                            <Queue>arn:aws:sqs:us-east-1:000000000000:%s</Queue>
+                            <Event>s3:ObjectCreated:Put</Event>
+                        </QueueConfiguration>
+                        <QueueConfiguration>
+                            <Id>wildcard-notification</Id>
+                            <Queue>arn:aws:sqs:us-east-1:000000000000:%s</Queue>
+                            <Event>s3:ObjectCreated:*</Event>
+                        </QueueConfiguration>
+                    </NotificationConfiguration>
+                    """.formatted(postQueueName, putQueueName, wildcardQueueName))
+            .when()
+                .put("/" + BUCKET)
+            .then()
+                .statusCode(200);
+
+            given()
+                .multiPart("key", "uploads/notified.txt")
+                .multiPart("file", "notified.txt", "notified".getBytes(StandardCharsets.UTF_8), "text/plain")
+            .when()
+                .post("/" + BUCKET)
+            .then()
+                .statusCode(204);
+
+            assertQueueContainsPostNotification(postQueueUrl);
+            assertQueueContainsPostNotification(wildcardQueueUrl);
+
+            String putQueueResponse = given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", putQueueUrl)
+                .formParam("MaxNumberOfMessages", "1")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().body().asString();
+            assertThat(putQueueResponse, not(containsString("<Message>")));
+        } finally {
+            given()
+                .contentType("application/xml")
+                .queryParam("notification", "")
+                .body("<NotificationConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\"/>")
+                .put("/" + BUCKET);
+
+            deleteQueue(postQueueUrl);
+            deleteQueue(putQueueUrl);
+            deleteQueue(wildcardQueueUrl);
+        }
+    }
+
+    private String createQueue(String queueName) {
+        return given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", queueName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+    }
+
+    private void assertQueueContainsPostNotification(String queueUrl) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ReceiveMessageResponse.ReceiveMessageResult.Message.Body",
+                containsString("\"eventName\":\"ObjectCreated:Post\""));
+    }
+
+    private void deleteQueue(String queueUrl) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteQueue")
+            .formParam("QueueUrl", queueUrl)
+            .post("/");
+    }
+
+    @Test
     @Order(20)
     void presignedPostWithBinaryData() {
         String key = "uploads/binary-data.bin";
@@ -515,6 +622,7 @@ class S3PresignedPostIntegrationTest {
     void cleanupBucket() {
         // Delete all objects
         given().delete("/" + BUCKET + "/uploads/test-file.txt");
+        given().delete("/" + BUCKET + "/uploads/notified.txt");
         given().delete("/" + BUCKET + "/uploads/binary-data.bin");
         given().delete("/" + BUCKET + "/uploads/no-policy.txt");
         given().delete("/" + BUCKET + "/uploads/typed-file.json");


### PR DESCRIPTION
## Summary

Preserve the HTTP upload method through S3 object creation so browser-based presigned POST uploads emit `ObjectCreated:Post` notifications instead of `ObjectCreated:Put`. Adds integration coverage for POST-specific and wildcard event filters.

Fixes #2399

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Objects created through presigned browser POST uploads were mislabeled as PUT events, preventing `s3:ObjectCreated:Post` filters from matching. Notifications now reflect the originating HTTP method.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused verification: `S3PresignedPostIntegrationTest` (20 tests) passes locally.

