### PR TITLE
feat(secretsmanager): persist and return secret resource policies

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecretsManagerTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecretsManagerTest.java
@@ -19,17 +19,23 @@ import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueR
 import software.amazon.awssdk.services.secretsmanager.model.BatchGetSecretValueResponse;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.CreateSecretResponse;
+import software.amazon.awssdk.services.secretsmanager.model.DeleteResourcePolicyRequest;
+import software.amazon.awssdk.services.secretsmanager.model.DeleteResourcePolicyResponse;
 import software.amazon.awssdk.services.secretsmanager.model.DeleteSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DescribeSecretRequest;
 import software.amazon.awssdk.services.secretsmanager.model.DescribeSecretResponse;
 import software.amazon.awssdk.services.secretsmanager.model.GetRandomPasswordRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetRandomPasswordResponse;
+import software.amazon.awssdk.services.secretsmanager.model.GetResourcePolicyRequest;
+import software.amazon.awssdk.services.secretsmanager.model.GetResourcePolicyResponse;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueResponse;
 import software.amazon.awssdk.services.secretsmanager.model.ListSecretVersionIdsRequest;
 import software.amazon.awssdk.services.secretsmanager.model.ListSecretVersionIdsResponse;
 import software.amazon.awssdk.services.secretsmanager.model.ListSecretsRequest;
 import software.amazon.awssdk.services.secretsmanager.model.ListSecretsResponse;
+import software.amazon.awssdk.services.secretsmanager.model.PutResourcePolicyRequest;
+import software.amazon.awssdk.services.secretsmanager.model.PutResourcePolicyResponse;
 import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueRequest;
 import software.amazon.awssdk.services.secretsmanager.model.PutSecretValueResponse;
 import software.amazon.awssdk.services.secretsmanager.model.RotateSecretRequest;
@@ -458,5 +464,44 @@ class SecretsManagerTest {
             } catch (Exception ignored) {
             }
         }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Resource policy round trip (PutResourcePolicy / GetResourcePolicy /
+    // DeleteResourcePolicy)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(21)
+    @DisplayName("resource policy round trip: put returns ARN/Name, get returns the policy, delete clears it")
+    void resourcePolicyRoundTrip() {
+        Assumptions.assumeTrue(secretArn != null, "CreateSecret must succeed first");
+
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+                + "\"Principal\":{\"AWS\":\"*\"},\"Action\":\"secretsmanager:GetSecretValue\",\"Resource\":\"*\"}]}";
+
+        PutResourcePolicyResponse put = sm.putResourcePolicy(PutResourcePolicyRequest.builder()
+                .secretId(secretArn)
+                .resourcePolicy(policy)
+                .build());
+        // The terraform provider uses this ARN as the aws_secretsmanager_secret_policy id.
+        assertThat(put.arn()).isEqualTo(secretArn);
+        assertThat(put.name()).isEqualTo(secretName);
+
+        GetResourcePolicyResponse got = sm.getResourcePolicy(GetResourcePolicyRequest.builder()
+                .secretId(secretArn)
+                .build());
+        assertThat(got.arn()).isEqualTo(secretArn);
+        assertThat(got.resourcePolicy()).isEqualTo(policy);
+
+        DeleteResourcePolicyResponse deleted = sm.deleteResourcePolicy(DeleteResourcePolicyRequest.builder()
+                .secretId(secretArn)
+                .build());
+        assertThat(deleted.arn()).isEqualTo(secretArn);
+        assertThat(deleted.name()).isEqualTo(secretName);
+
+        assertThat(sm.getResourcePolicy(GetResourcePolicyRequest.builder()
+                .secretId(secretArn)
+                .build()).resourcePolicy()).isNull();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandler.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.secretsmanager;
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.services.secretsmanager.model.Secret;
 import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -48,8 +49,8 @@ public class SecretsManagerJsonHandler {
             case "GetResourcePolicy" -> handleGetResourcePolicy(request, region);
             case "GetRandomPassword" -> handleGetRandomPassword(request, region);
             case "BatchGetSecretValue" -> handleBatchGetSecretValue(request, region);
-            case "DeleteResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
-            case "PutResourcePolicy" -> Response.ok(objectMapper.createObjectNode()).build();
+            case "DeleteResourcePolicy" -> handleDeleteResourcePolicy(request, region);
+            case "PutResourcePolicy" -> handlePutResourcePolicy(request, region);
             case "UpdateSecretVersionStage" -> handleUpdateSecretVersionStage(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
@@ -538,7 +539,55 @@ public class SecretsManagerJsonHandler {
 
     private Response handleGetResourcePolicy(JsonNode request, String region) {
         String secretId = request.path("SecretId").asText();
-        Secret secret = service.describeSecret(secretId, region);
+        Secret secret = service.getResourcePolicy(secretId, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("ARN", secret.getArn());
+        response.put("Name", secret.getName());
+        // AWS omits ResourcePolicy entirely when no policy is attached; the terraform provider
+        // reads the absent field as "no policy" rather than as an error.
+        if (secret.getResourcePolicy() != null) {
+            response.put("ResourcePolicy", secret.getResourcePolicy());
+        }
+        return Response.ok(response).build();
+    }
+
+    // BlockPublicPolicy is accepted but not enforced: the emulator does no public-policy
+    // analysis, so PublicPolicyException is never raised.
+    private Response handlePutResourcePolicy(JsonNode request, String region) {
+        String secretId = request.path("SecretId").asText();
+        String resourcePolicy = request.hasNonNull("ResourcePolicy") ? request.get("ResourcePolicy").asText() : null;
+        if (resourcePolicy == null || resourcePolicy.isBlank()) {
+            return Response.status(400)
+                    .entity(new AwsErrorResponse("InvalidParameterException",
+                            "Invalid parameter: ResourcePolicy must not be null or empty."))
+                    .build();
+        }
+
+        JsonNode parsedPolicy;
+        try {
+            parsedPolicy = objectMapper.readTree(resourcePolicy);
+        } catch (JsonProcessingException e) {
+            parsedPolicy = null;
+        }
+        if (parsedPolicy == null || !parsedPolicy.isObject()) {
+            return Response.status(400)
+                    .entity(new AwsErrorResponse("MalformedPolicyDocumentException",
+                            "The resource policy is not a valid JSON policy document."))
+                    .build();
+        }
+
+        Secret secret = service.putResourcePolicy(secretId, resourcePolicy, region);
+        ObjectNode response = objectMapper.createObjectNode();
+        // The terraform provider uses the returned ARN as the aws_secretsmanager_secret_policy
+        // resource id, so an empty response breaks its create outright.
+        response.put("ARN", secret.getArn());
+        response.put("Name", secret.getName());
+        return Response.ok(response).build();
+    }
+
+    private Response handleDeleteResourcePolicy(JsonNode request, String region) {
+        String secretId = request.path("SecretId").asText();
+        Secret secret = service.deleteResourcePolicy(secretId, region);
         ObjectNode response = objectMapper.createObjectNode();
         response.put("ARN", secret.getArn());
         response.put("Name", secret.getName());

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerService.java
@@ -758,6 +758,33 @@ public class SecretsManagerService implements ResourceProvider {
         store.put(regionKey(region, secret.getName()), secret);
     }
 
+    public Secret putResourcePolicy(String secretId, String resourcePolicy, String region) {
+        Secret secret = resolveSecret(secretId, region);
+        throwIfPendingDeletion(secret);
+        secret.setResourcePolicy(resourcePolicy);
+        store.put(regionKey(region, secret.getName()), secret);
+        LOG.infov("Put resource policy on secret: {0}", secret.getName());
+        return secret;
+    }
+
+    // Real AWS rejects GetResourcePolicy on a secret in its recovery window the same way it
+    // rejects the mutating ops; the terraform provider matches that InvalidRequestException's
+    // "marked for deletion" message to treat the policy as gone, so the guard applies here too.
+    public Secret getResourcePolicy(String secretId, String region) {
+        Secret secret = resolveSecret(secretId, region);
+        throwIfPendingDeletion(secret);
+        return secret;
+    }
+
+    public Secret deleteResourcePolicy(String secretId, String region) {
+        Secret secret = resolveSecret(secretId, region);
+        throwIfPendingDeletion(secret);
+        secret.setResourcePolicy(null);
+        store.put(regionKey(region, secret.getName()), secret);
+        LOG.infov("Deleted resource policy on secret: {0}", secret.getName());
+        return secret;
+    }
+
     public Map<String, List<String>> listSecretVersionIds(String secretId, String region) {
         Secret secret = resolveSecret(secretId, region);
 

--- a/src/main/java/io/github/hectorvent/floci/services/secretsmanager/model/Secret.java
+++ b/src/main/java/io/github/hectorvent/floci/services/secretsmanager/model/Secret.java
@@ -31,6 +31,8 @@ public class Secret {
     private String targetAttachmentOwner;
     /** The AWS service that owns this secret and rotates it itself, such as {@code rds}. */
     private String owningService;
+    /** Resource-based policy JSON attached via PutResourcePolicy, or null when none is attached. */
+    private String resourcePolicy;
 
     @RegisterForReflection
     public record RotationRules(
@@ -190,5 +192,13 @@ public class Secret {
 
     public void setOwningService(String owningService) {
         this.owningService = owningService;
+    }
+
+    public String getResourcePolicy() {
+        return resourcePolicy;
+    }
+
+    public void setResourcePolicy(String resourcePolicy) {
+        this.resourcePolicy = resourcePolicy;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/secretsmanager/SecretsManagerJsonHandlerTest.java
@@ -626,4 +626,171 @@ class SecretsManagerJsonHandlerTest {
         assertThat(body.get("RotationRules").get("AutomaticallyAfterDays").asInt(), is(45));
         assertThat(body.get("RotationRules").get("Duration").asText(), is("2h"));
     }
+
+    // ─── Resource policy ─────────────────────────────────────────────────────
+
+    private static final String RESOURCE_POLICY =
+            "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Principal\":{\"AWS\":\"*\"},\"Action\":\"secretsmanager:GetSecretValue\",\"Resource\":\"*\"}]}";
+
+    private String createSecretReturningArn(String name) {
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("Name", name);
+        request.put("SecretString", "value");
+        Response response = handler.handle("CreateSecret", request, REGION);
+        assertThat(response.getStatus(), is(200));
+        return ((ObjectNode) response.getEntity()).get("ARN").asText();
+    }
+
+    @Test
+    void putResourcePolicyReturnsArnAndNameAndRoundTripsThroughGet() {
+        // Address the secret by full ARN: the terraform provider always sends secret_arn as
+        // SecretId, and uses the ARN echoed back by PutResourcePolicy as the resource id.
+        String arn = createSecretReturningArn("policy-secret");
+
+        ObjectNode put = MAPPER.createObjectNode();
+        put.put("SecretId", arn);
+        put.put("ResourcePolicy", RESOURCE_POLICY);
+        put.put("BlockPublicPolicy", true);
+        Response putResponse = handler.handle("PutResourcePolicy", put, REGION);
+        assertThat(putResponse.getStatus(), is(200));
+        ObjectNode putBody = (ObjectNode) putResponse.getEntity();
+        assertThat(putBody.get("ARN").asText(), is(arn));
+        assertThat(putBody.get("Name").asText(), is("policy-secret"));
+
+        ObjectNode get = MAPPER.createObjectNode();
+        get.put("SecretId", arn);
+        Response getResponse = handler.handle("GetResourcePolicy", get, REGION);
+        assertThat(getResponse.getStatus(), is(200));
+        ObjectNode getBody = (ObjectNode) getResponse.getEntity();
+        assertThat(getBody.get("ARN").asText(), is(arn));
+        assertThat(getBody.get("Name").asText(), is("policy-secret"));
+        assertThat(getBody.get("ResourcePolicy").asText(), is(RESOURCE_POLICY));
+    }
+
+    @Test
+    void getResourcePolicyOmitsResourcePolicyWhenNoneAttached() {
+        createSecretReturningArn("no-policy-secret");
+
+        ObjectNode get = MAPPER.createObjectNode();
+        get.put("SecretId", "no-policy-secret");
+        Response response = handler.handle("GetResourcePolicy", get, REGION);
+        assertThat(response.getStatus(), is(200));
+        ObjectNode body = (ObjectNode) response.getEntity();
+        // AWS omits the member entirely when no policy is attached; the terraform provider
+        // reads the absent field as "no policy", not as an error.
+        assertThat(body.has("ResourcePolicy"), is(false));
+        assertThat(body.get("Name").asText(), is("no-policy-secret"));
+    }
+
+    @Test
+    void deleteResourcePolicyClearsPolicyAndReturnsArnAndName() {
+        String arn = createSecretReturningArn("delete-policy-secret");
+
+        ObjectNode put = MAPPER.createObjectNode();
+        put.put("SecretId", arn);
+        put.put("ResourcePolicy", RESOURCE_POLICY);
+        assertThat(handler.handle("PutResourcePolicy", put, REGION).getStatus(), is(200));
+
+        ObjectNode delete = MAPPER.createObjectNode();
+        delete.put("SecretId", arn);
+        Response deleteResponse = handler.handle("DeleteResourcePolicy", delete, REGION);
+        assertThat(deleteResponse.getStatus(), is(200));
+        ObjectNode deleteBody = (ObjectNode) deleteResponse.getEntity();
+        assertThat(deleteBody.get("ARN").asText(), is(arn));
+        assertThat(deleteBody.get("Name").asText(), is("delete-policy-secret"));
+
+        ObjectNode get = MAPPER.createObjectNode();
+        get.put("SecretId", arn);
+        ObjectNode getBody = (ObjectNode) handler.handle("GetResourcePolicy", get, REGION).getEntity();
+        assertThat(getBody.has("ResourcePolicy"), is(false));
+    }
+
+    @Test
+    void deleteResourcePolicyWithoutPolicyAttachedSucceeds() {
+        String arn = createSecretReturningArn("never-had-policy-secret");
+
+        ObjectNode delete = MAPPER.createObjectNode();
+        delete.put("SecretId", arn);
+        Response response = handler.handle("DeleteResourcePolicy", delete, REGION);
+        assertThat(response.getStatus(), is(200));
+        assertThat(((ObjectNode) response.getEntity()).get("ARN").asText(), is(arn));
+    }
+
+    @Test
+    void putResourcePolicyRejectsMissingOrEmptyPolicy() {
+        String arn = createSecretReturningArn("missing-policy-secret");
+
+        ObjectNode missing = MAPPER.createObjectNode();
+        missing.put("SecretId", arn);
+        Response missingResponse = handler.handle("PutResourcePolicy", missing, REGION);
+        assertThat(missingResponse.getStatus(), is(400));
+        assertThat(((AwsErrorResponse) missingResponse.getEntity()).type(), is("InvalidParameterException"));
+
+        ObjectNode empty = MAPPER.createObjectNode();
+        empty.put("SecretId", arn);
+        empty.put("ResourcePolicy", "");
+        assertThat(handler.handle("PutResourcePolicy", empty, REGION).getStatus(), is(400));
+    }
+
+    @Test
+    void putResourcePolicyRejectsMalformedPolicyJson() {
+        String arn = createSecretReturningArn("malformed-policy-secret");
+
+        ObjectNode put = MAPPER.createObjectNode();
+        put.put("SecretId", arn);
+        put.put("ResourcePolicy", "not-a-json-policy");
+        Response response = handler.handle("PutResourcePolicy", put, REGION);
+        assertThat(response.getStatus(), is(400));
+        assertThat(((AwsErrorResponse) response.getEntity()).type(), is("MalformedPolicyDocumentException"));
+    }
+
+    @Test
+    void resourcePolicyOpsOnUnknownSecretThrowResourceNotFound() {
+        for (String action : new String[] { "GetResourcePolicy", "DeleteResourcePolicy" }) {
+            ObjectNode request = MAPPER.createObjectNode();
+            request.put("SecretId", "missing-secret");
+            io.github.hectorvent.floci.core.common.AwsException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                    io.github.hectorvent.floci.core.common.AwsException.class,
+                    () -> handler.handle(action, request, REGION));
+            assertThat(ex.getErrorCode(), is("ResourceNotFoundException"));
+        }
+
+        ObjectNode put = MAPPER.createObjectNode();
+        put.put("SecretId", "missing-secret");
+        put.put("ResourcePolicy", RESOURCE_POLICY);
+        io.github.hectorvent.floci.core.common.AwsException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> handler.handle("PutResourcePolicy", put, REGION));
+        assertThat(ex.getErrorCode(), is("ResourceNotFoundException"));
+    }
+
+    @Test
+    void resourcePolicyOpsOnSecretMarkedForDeletionThrowInvalidRequest() {
+        String arn = createSecretReturningArn("pending-deletion-policy-secret");
+        ObjectNode deleteSecret = MAPPER.createObjectNode();
+        deleteSecret.put("SecretId", arn);
+        assertThat(handler.handle("DeleteSecret", deleteSecret, REGION).getStatus(), is(200));
+
+        // The message substring is a compatibility contract: the terraform provider matches
+        // "marked for deletion" on GetResourcePolicy to treat the policy as gone.
+        for (String action : new String[] { "GetResourcePolicy", "DeleteResourcePolicy" }) {
+            ObjectNode request = MAPPER.createObjectNode();
+            request.put("SecretId", arn);
+            io.github.hectorvent.floci.core.common.AwsException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                    io.github.hectorvent.floci.core.common.AwsException.class,
+                    () -> handler.handle(action, request, REGION));
+            assertThat(ex.getErrorCode(), is("InvalidRequestException"));
+            assertThat(ex.getMessage(), containsString("marked for deletion"));
+        }
+
+        ObjectNode put = MAPPER.createObjectNode();
+        put.put("SecretId", arn);
+        put.put("ResourcePolicy", RESOURCE_POLICY);
+        io.github.hectorvent.floci.core.common.AwsException ex = org.junit.jupiter.api.Assertions.assertThrows(
+                io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> handler.handle("PutResourcePolicy", put, REGION));
+        assertThat(ex.getErrorCode(), is("InvalidRequestException"));
+        assertThat(ex.getMessage(), containsString("marked for deletion"));
+    }
 }


### PR DESCRIPTION
Secret resource policies now round-trip: `PutResourcePolicy` persists the policy on the secret and returns `ARN`/`Name`, `GetResourcePolicy` returns it, `DeleteResourcePolicy` clears it. Before this, Put and Delete were inert stubs returning `{}` and Get never returned a policy, so `aws_secretsmanager_secret_policy` could not be created through Terraform or Pulumi at all: the provider does `d.SetId(output.ARN)` on the Put response ([`secret_policy.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/secretsmanager/secret_policy.go)), and an empty response fails the create with an empty resource id.

Behavior, matching the AWS API model and the provider's expectations:

1. `PutResourcePolicy` resolves the secret (name, full ARN, or partial ARN), validates `ResourcePolicy` is present and valid JSON, persists it, and returns `{ARN, Name}`.
2. `GetResourcePolicy` returns `{ARN, Name}` plus `ResourcePolicy` only when one is attached. AWS omits the member entirely otherwise, and the provider reads the absent field as "no policy" rather than as an error.
3. `DeleteResourcePolicy` clears the policy and returns `{ARN, Name}`.
4. All three ops reject a secret in its deletion recovery window with `InvalidRequestException` ("...marked for deletion"), reusing the existing guard. The provider substring-matches that message on `GetResourcePolicy` to treat the policy as gone, so this is part of the wire contract.
5. Unknown secret raises the existing `ResourceNotFoundException`.

Scope notes (kept deliberately narrow):

1. `BlockPublicPolicy` is accepted but not enforced. The emulator does no public-policy analysis, so `PublicPolicyException` is never raised.
2. `MalformedPolicyDocumentException` fires on JSON-parse failure only. No Statement or principal validation.
3. `DeleteResourcePolicy` on a secret with no policy attached succeeds with `{ARN, Name}`. The provider tolerates either behavior; quiet success seemed the safer emulation, happy to change if real AWS is known to differ.

Tests:

1. Handler-level (`SecretsManagerJsonHandlerTest`, real service instance): put/get/delete round trip addressed by full ARN as the provider sends it, ARN/Name echoed on Put and Delete, `ResourcePolicy` absent when none attached, missing/empty policy 400, malformed policy 400, unknown secret, and the marked-for-deletion contract on all three ops.
2. SDK-level (`compatibility-tests` `SecretsManagerTest`): a put/get/delete round trip with the real AWS Java SDK v2 covering the JSON wire shapes end to end.

The three actions were already dispatched in the handler switch, so the generated Supported Actions table is unchanged.
