### PR TITLE
docs(getting-started): Switch to the `io.floci` test container

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,9 +568,11 @@ aws --endpoint-url http://localhost:4566 s3 ls
 
 Floci has Testcontainers modules for starting isolated Floci instances directly from tests. This avoids shared state, manual daemon setup, and port conflicts.
 
+For Testcontainers 1.x, use the versions as indicated in the table below.
+
 | Language | Package | Latest | Registry | Source |
 |---|---|---|---|---|
-| Java | `io.floci:testcontainers-floci` | `1.4.0` | [Maven Central](https://mvnrepository.com/artifact/io.floci/testcontainers-floci) | [GitHub](https://github.com/floci-io/testcontainers-floci) |
+| Java | `io.floci:testcontainers-floci` | `1.14.0` | [Maven Central](https://mvnrepository.com/artifact/io.floci/testcontainers-floci) | [GitHub](https://github.com/floci-io/testcontainers-floci) |
 | Node.js | `@floci/testcontainers` | `0.1.0` | [npm](https://www.npmjs.com/package/@floci/testcontainers) | [GitHub](https://github.com/floci-io/testcontainers-floci-node) |
 | Python | `testcontainers-floci` | `0.1.1` | [PyPI](https://pypi.org/project/testcontainers-floci/) | [GitHub](https://github.com/floci-io/testcontainers-floci-python) |
 | Go | In progress | In progress | N/A | [GitHub](https://github.com/floci-io/testcontainers-floci-go) |
@@ -582,7 +584,7 @@ Floci has Testcontainers modules for starting isolated Floci instances directly 
 <dependency>
     <groupId>io.floci</groupId>
     <artifactId>testcontainers-floci</artifactId>
-    <version>1.4.0</version>
+    <version>1.14.0</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -609,7 +611,7 @@ class S3IntegrationTest {
 }
 ```
 
-For Testcontainers 2.x / Spring Boot 4.x, use version `2.5.0`.
+For Testcontainers 2.x / Spring Boot 4.x, use version `2.15.0`.
 
 </details>
 

--- a/docs/getting-started/migrate-from-localstack.md
+++ b/docs/getting-started/migrate-from-localstack.md
@@ -144,14 +144,15 @@ If you wait on `/_localstack/init` or `/_localstack/health` in CI or scripts, no
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
+      <version>1.21.4</version>
       <scope>test</scope>
     </dependency>
 
     <!-- After -->
     <dependency>
-      <groupId>io.github.hectorvent</groupId>
-      <artifactId>floci-testcontainers</artifactId>
-      <version>LATEST</version>
+      <groupId>io.floci</groupId>
+      <artifactId>testcontainers-floci</artifactId>
+      <version>1.14.0</version>
       <scope>test</scope>
     </dependency>
     ```

--- a/docs/testcontainers/index.md
+++ b/docs/testcontainers/index.md
@@ -4,12 +4,16 @@ Floci has first-class Testcontainers modules for every major SDK language. Each 
 
 ## Available modules
 
+For Testcontainers 1.x, use the versions as indicated in the table below.
+
 | Language | Package | Version | Registry | Source |
 |---|---|---|---|---|
-| Java | `io.floci:testcontainers-floci` | `1.4.0` | [Maven Central](https://mvnrepository.com/artifact/io.floci/testcontainers-floci) | [GitHub](https://github.com/floci-io/testcontainers-floci) |
+| Java | `io.floci:testcontainers-floci` | `1.14.0` | [Maven Central](https://mvnrepository.com/artifact/io.floci/testcontainers-floci) | [GitHub](https://github.com/floci-io/testcontainers-floci) |
 | Node.js | `@floci/testcontainers` | `0.1.0` | [npm](https://www.npmjs.com/package/@floci/testcontainers) | [GitHub](https://github.com/floci-io/testcontainers-floci-node) |
 | Python | `testcontainers-floci` | `0.1.1` | [PyPI](https://pypi.org/project/testcontainers-floci/) | [GitHub](https://github.com/floci-io/testcontainers-floci-python) |
 | Go | — | 🚧 In progress | — | [GitHub](https://github.com/floci-io/testcontainers-floci-go) |
+
+For Testcontainers 2.x / Spring Boot 4.x, use version `2.15.0`.
 
 ## How it works
 

--- a/docs/testcontainers/java.md
+++ b/docs/testcontainers/java.md
@@ -6,8 +6,8 @@ Two artifact lines are published to keep in sync with the Testcontainers major v
 
 | Testcontainers version | Spring Boot | Artifact version |
 |---|---|---|
-| 1.x | 3.x | `1.4.0` |
-| 2.x | 4.x | `2.5.0` |
+| 1.x | 3.x | `1.14.0` |
+| 2.x | 4.x | `2.15.0` |
 
 ## Installation
 
@@ -17,7 +17,7 @@ Two artifact lines are published to keep in sync with the Testcontainers major v
     <dependency>
         <groupId>io.floci</groupId>
         <artifactId>testcontainers-floci</artifactId>
-        <version>1.4.0</version>
+        <version>1.14.0</version>
         <scope>test</scope>
     </dependency>
     ```
@@ -25,7 +25,7 @@ Two artifact lines are published to keep in sync with the Testcontainers major v
 === "Gradle"
 
     ```groovy
-    testImplementation 'io.floci:testcontainers-floci:1.4.0'
+    testImplementation 'io.floci:testcontainers-floci:1.14.0'
     ```
 
 ## Basic usage — JUnit 5
@@ -146,7 +146,7 @@ Add the Spring Boot companion artifact for zero-config auto-wiring. The `@Servic
     <dependency>
         <groupId>io.floci</groupId>
         <artifactId>spring-boot-testcontainers-floci</artifactId>
-        <version>1.4.0</version>
+        <version>1.14.0</version>
         <scope>test</scope>
     </dependency>
     ```
@@ -154,7 +154,7 @@ Add the Spring Boot companion artifact for zero-config auto-wiring. The `@Servic
 === "Gradle"
 
     ```groovy
-    testImplementation 'io.floci:spring-boot-testcontainers-floci:1.4.0'
+    testImplementation 'io.floci:spring-boot-testcontainers-floci:1.14.0'
     ```
 
 ```java


### PR DESCRIPTION
## Summary

Update the migration guide that still pointed at the pre-rename testcontainers coordinates. Also align referenced version to the actual latest.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A

## Checklist

- [ ] `./mvnw test` passes locally ()N/A
- [ ] New or updated integration test added (N/A)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
