### PR TITLE
feat(aps): add Amazon Managed Service for Prometheus workspaces

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -78,6 +78,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>amp</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sqs</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -60,6 +60,7 @@ import software.amazon.awssdk.services.apigatewayv2.ApiGatewayV2Client;
 import software.amazon.awssdk.services.elasticache.ElastiCacheClient;
 import software.amazon.awssdk.services.elasticbeanstalk.ElasticBeanstalkClient;
 import software.amazon.awssdk.services.acm.AcmClient;
+import software.amazon.awssdk.services.amp.AmpClient;
 import software.amazon.awssdk.services.efs.EfsClient;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ecr.EcrClient;
@@ -508,6 +509,14 @@ public final class TestFixtures {
 
     public static SecretsManagerClient secretsManagerClient() {
         return SecretsManagerClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static AmpClient ampClient() {
+        return AmpClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AmpTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AmpTest.java
@@ -1,0 +1,127 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import software.amazon.awssdk.services.amp.AmpClient;
+import software.amazon.awssdk.services.amp.model.CreateWorkspaceResponse;
+import software.amazon.awssdk.services.amp.model.DescribeWorkspaceResponse;
+import software.amazon.awssdk.services.amp.model.ListWorkspacesResponse;
+import software.amazon.awssdk.services.amp.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.amp.model.WorkspaceStatusCode;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Managed Prometheus (AMP)")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class AmpTest {
+
+    private static AmpClient amp;
+    private static String alias;
+    private static String workspaceId;
+    private static String workspaceArn;
+
+    @BeforeAll
+    static void setup() {
+        amp = TestFixtures.ampClient();
+        alias = "sdk-test-workspace-" + System.currentTimeMillis();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (amp != null) {
+            if (workspaceId != null) {
+                try {
+                    amp.deleteWorkspace(r -> r.workspaceId(workspaceId));
+                } catch (Exception ignored) {}
+            }
+            amp.close();
+        }
+    }
+
+    @Test
+    @Order(1)
+    void createWorkspace() {
+        CreateWorkspaceResponse response = amp.createWorkspace(r -> r
+                .alias(alias)
+                .tags(Map.of("team", "devops")));
+
+        workspaceId = response.workspaceId();
+        workspaceArn = response.arn();
+
+        assertThat(workspaceId).startsWith("ws-");
+        assertThat(workspaceArn).contains(":aps:").contains(":workspace/" + workspaceId);
+        assertThat(response.status().statusCode()).isEqualTo(WorkspaceStatusCode.ACTIVE);
+        assertThat(response.tags()).containsEntry("team", "devops");
+    }
+
+    @Test
+    @Order(2)
+    void describeWorkspace() {
+        DescribeWorkspaceResponse response = amp.describeWorkspace(r -> r.workspaceId(workspaceId));
+
+        assertThat(response.workspace().workspaceId()).isEqualTo(workspaceId);
+        assertThat(response.workspace().alias()).isEqualTo(alias);
+        assertThat(response.workspace().arn()).isEqualTo(workspaceArn);
+        assertThat(response.workspace().status().statusCode()).isEqualTo(WorkspaceStatusCode.ACTIVE);
+        assertThat(response.workspace().prometheusEndpoint()).contains("/workspaces/" + workspaceId);
+        // Proves the wire timestamp is restJson1 epoch-seconds: an ISO string here fails SDK
+        // deserialization before any assertion runs.
+        assertThat(response.workspace().createdAt()).isNotNull();
+        assertThat(response.workspace().tags()).containsEntry("team", "devops");
+    }
+
+    @Test
+    @Order(3)
+    void listWorkspacesByAliasPrefix() {
+        ListWorkspacesResponse response = amp.listWorkspaces(r -> r.alias("sdk-test-workspace-"));
+
+        assertThat(response.workspaces())
+                .anySatisfy(w -> assertThat(w.workspaceId()).isEqualTo(workspaceId));
+    }
+
+    @Test
+    @Order(4)
+    void updateWorkspaceAlias() {
+        amp.updateWorkspaceAlias(r -> r.workspaceId(workspaceId).alias(alias + "-renamed"));
+
+        assertThat(amp.describeWorkspace(r -> r.workspaceId(workspaceId)).workspace().alias())
+                .isEqualTo(alias + "-renamed");
+    }
+
+    @Test
+    @Order(5)
+    void tagResourceRoundTrip() {
+        amp.tagResource(r -> r.resourceArn(workspaceArn).tags(Map.of("env", "test")));
+
+        assertThat(amp.listTagsForResource(r -> r.resourceArn(workspaceArn)).tags())
+                .containsEntry("team", "devops")
+                .containsEntry("env", "test");
+
+        amp.untagResource(r -> r.resourceArn(workspaceArn).tagKeys("env"));
+
+        assertThat(amp.listTagsForResource(r -> r.resourceArn(workspaceArn)).tags())
+                .containsEntry("team", "devops")
+                .doesNotContainKey("env");
+    }
+
+    @Test
+    @Order(6)
+    void deleteWorkspaceThenDescribeThrowsResourceNotFound() {
+        amp.deleteWorkspace(r -> r.workspaceId(workspaceId));
+
+        // The terraform/pulumi provider's delete waiter matches this typed exception
+        // (errs.IsA[*types.ResourceNotFoundException]) to treat the workspace as gone.
+        assertThatThrownBy(() -> amp.describeWorkspace(r -> r.workspaceId(workspaceId)))
+                .isInstanceOf(ResourceNotFoundException.class);
+
+        workspaceId = null;
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -86,6 +86,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [CodeDeploy](codedeploy.md) | `POST /` + `X-Amz-Target: CodeDeploy_20141006.*` | JSON 1.1 | 30 |
 | [CodePipeline](codepipeline.md) | `POST /` + `X-Amz-Target: CodePipeline_20150709.*` | JSON 1.1 | 44 |
 | [Control Tower](controltower.md) | `/list-landingzones`, `/get-landingzone`, `/create-landingzone`, `/*-baseline*` | REST JSON | 15 |
+| [Managed Prometheus (AMP)](managed-prometheus.md) | `/workspaces/*`, `/tags/*` | REST JSON | 8 |
 | [AWS Backup](backup.md) | `/backup-vaults/*`, `/backup/plans/*`, `/backup-jobs/*`, `/supported-resource-types` | REST JSON | 20 |
 | [AWS FIS](fis.md) | `/experimentTemplates/*`, `/experiments/*`, `/actions/*`, `/targetResourceTypes/*`, `/safetyLevers/*`, `/tags/*` | REST JSON | 26 |
 | [CloudFront](cloudfront.md) | `/2020-05-31/distribution/*`, `/2020-05-31/cache-policy/*`, `/2020-05-31/function/*` | REST XML | 50 |

--- a/docs/services/managed-prometheus.md
+++ b/docs/services/managed-prometheus.md
@@ -1,0 +1,37 @@
+# Amazon Managed Service for Prometheus (AMP)
+
+**Protocol:** REST JSON
+**Endpoint:** `http://localhost:4566`
+
+Floci implements the AMP **workspace** lifecycle — the surface Terraform's and Pulumi's
+`aws_prometheus_workspace` resource uses — plus tagging through the shared
+`/tags/{resourceArn}` dispatcher. Alert manager definitions, rule groups namespaces, scrapers
+and logging configurations are not implemented.
+
+## Emulation notes
+
+- A workspace is **ACTIVE from birth**. Real AMP answers the create `202` with status
+  `CREATING`; Floci provisions nothing, so `DescribeWorkspace` reports `ACTIVE` immediately and
+  the Terraform provider's create waiter (`CREATING` → `ACTIVE`) completes on its first poll.
+- `DeleteWorkspace` removes the workspace immediately; a subsequent `DescribeWorkspace` returns
+  `ResourceNotFoundException` (404), which the provider's delete waiter treats as gone.
+- `prometheusEndpoint` is reported in the real AWS shape
+  (`https://aps-workspaces.<region>.amazonaws.com/workspaces/<id>/`). It is not a live
+  ingestion/query endpoint.
+- The `alias` parameter of `ListWorkspaces` is a **prefix** filter, matching the provider's
+  `alias_prefix` data-source argument.
+- `clientToken` on `CreateWorkspace` is accepted and ignored: creates are not deduplicated.
+- `kmsKeyArn` is stored and echoed back but no encryption is performed.
+
+## Supported Operations
+
+| Operation | Method and path | Description |
+|---|---|---|
+| `CreateWorkspace` | `POST /workspaces` | Creates a workspace (`202`); returns `workspaceId`, `arn`, `status`, `tags` |
+| `DescribeWorkspace` | `GET /workspaces/{workspaceId}` | Returns the workspace description including `prometheusEndpoint` |
+| `ListWorkspaces` | `GET /workspaces` | Lists workspaces; `alias` prefix filter, `maxResults`/`nextToken` pagination |
+| `UpdateWorkspaceAlias` | `POST /workspaces/{workspaceId}/alias` | Updates the alias (`204`) |
+| `DeleteWorkspace` | `DELETE /workspaces/{workspaceId}` | Deletes the workspace (`202`) |
+| `ListTagsForResource` | `GET /tags/{resourceArn}` | Lists workspace tags (shared tags dispatcher) |
+| `TagResource` | `POST /tags/{resourceArn}` | Adds or overwrites workspace tags (`200`) |
+| `UntagResource` | `DELETE /tags/{resourceArn}?tagKeys=...` | Removes workspace tags (`200`) |

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -289,8 +289,17 @@ public interface EmulatorConfig {
 
         ControlTowerStorageConfig controltower();
 
+        ApsStorageConfig aps();
+
         LakeFormationStorageConfig lakeformation();
         EfsStorageConfig efs();
+    }
+
+    interface ApsStorageConfig {
+        Optional<String> mode();
+
+        @WithDefault("5000")
+        long flushIntervalMs();
     }
 
     interface SsmStorageConfig {
@@ -675,8 +684,15 @@ public interface EmulatorConfig {
 
         ControlTowerServiceConfig controltower();
 
+        ApsServiceConfig aps();
+
         LakeFormationServiceConfig lakeformation();
         EfsServiceConfig efs();
+    }
+
+    interface ApsServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     interface IotServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -31,6 +31,7 @@ import io.github.hectorvent.floci.services.ses.SesController;
 import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import io.github.hectorvent.floci.services.rdsdata.RdsDataController;
 import io.github.hectorvent.floci.services.guardduty.GuardDutyController;
+import io.github.hectorvent.floci.services.aps.ApsController;
 import io.github.hectorvent.floci.services.controltower.ControlTowerController;
 import io.github.hectorvent.floci.services.rum.RumController;
 import io.github.hectorvent.floci.services.s3vectors.S3VectorsController;
@@ -508,6 +509,11 @@ public class ResolvedServiceCatalog {
                         config.storage().services().controltower().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
                         Set.of(), Set.of("controltower"), Set.of(), Set.of(ControlTowerController.class)),
+                descriptor("aps", "aps", config.services().aps().enabled(), true,
+                        "aps", storageMode(config.storage().services().aps().mode(), config.storage().mode()),
+                        config.storage().services().aps().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(), Set.of("aps"), Set.of(), Set.of(ApsController.class)),
 
                 descriptor("lakeformation", "lakeformation", config.services().lakeformation().enabled(), true,
                         "lakeformation",

--- a/src/main/java/io/github/hectorvent/floci/services/aps/ApsController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/aps/ApsController.java
@@ -1,0 +1,166 @@
+package io.github.hectorvent.floci.services.aps;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
+import io.github.hectorvent.floci.services.aps.model.PrometheusWorkspace;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Amazon Managed Service for Prometheus (Smithy restJson1, SigV4 scope {@code aps}) — the
+ * workspace lifecycle only: create/describe/list/delete plus alias update. Tagging goes through
+ * the shared {@code /tags/{resourceArn}} dispatcher, which routes {@code arn:aws:aps:...} to
+ * {@link ApsService}'s TagHandler implementation.
+ *
+ * <p>The literal {@code /workspaces} path segment takes JAX-RS precedence over S3's
+ * {@code /{bucket}} template route, so these routes need no extra routing wiring (see
+ * {@link io.github.hectorvent.floci.services.controltower.ControlTowerController}).
+ */
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ApsController {
+
+    private final ApsService service;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public ApsController(ApsService service, ObjectMapper objectMapper) {
+        this.service = service;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/workspaces")
+    public Response createWorkspace(Map<String, Object> request) {
+        Map<String, Object> body = request != null ? request : Map.of();
+        String alias = asString(body.get("alias"), "alias");
+        String kmsKeyArn = asString(body.get("kmsKeyArn"), "kmsKeyArn");
+        Map<String, String> tags = asStringMap(body.get("tags"), "tags");
+        // clientToken is accepted and ignored: creates are not deduplicated.
+
+        PrometheusWorkspace workspace = service.createWorkspace(alias, tags, kmsKeyArn);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("workspaceId", workspace.getWorkspaceId());
+        response.put("arn", workspace.getArn());
+        response.set("status", statusNode(workspace));
+        response.set("tags", objectMapper.valueToTree(workspace.getTags()));
+        if (workspace.getKmsKeyArn() != null) {
+            response.put("kmsKeyArn", workspace.getKmsKeyArn());
+        }
+        return Response.status(202).entity(response).build();
+    }
+
+    @GET
+    @Path("/workspaces")
+    public Response listWorkspaces(@QueryParam("alias") String alias,
+                                   @QueryParam("maxResults") String maxResultsParam,
+                                   @QueryParam("nextToken") String nextToken) {
+        PaginatedResult<PrometheusWorkspace> result = service.listWorkspaces(alias,
+                Pagination.parseMaxResults(maxResultsParam, "ValidationException"), nextToken);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("workspaces", result.items().stream().map(this::toWorkspaceSummary).toList());
+        if (result.nextToken() != null) {
+            response.put("nextToken", result.nextToken());
+        }
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/workspaces/{workspaceId}")
+    public Response describeWorkspace(@PathParam("workspaceId") String workspaceId) {
+        PrometheusWorkspace workspace = service.describeWorkspace(workspaceId);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("workspace", toWorkspaceDescription(workspace));
+        return Response.ok(response).build();
+    }
+
+    @DELETE
+    @Path("/workspaces/{workspaceId}")
+    public Response deleteWorkspace(@PathParam("workspaceId") String workspaceId) {
+        service.deleteWorkspace(workspaceId);
+        return Response.status(202).entity(objectMapper.createObjectNode()).build();
+    }
+
+    @POST
+    @Path("/workspaces/{workspaceId}/alias")
+    public Response updateWorkspaceAlias(@PathParam("workspaceId") String workspaceId,
+                                         Map<String, Object> request) {
+        Map<String, Object> body = request != null ? request : Map.of();
+        String alias = asString(body.get("alias"), "alias");
+        service.updateWorkspaceAlias(workspaceId, alias);
+        return Response.status(204).build();
+    }
+
+    private ObjectNode toWorkspaceDescription(PrometheusWorkspace workspace) {
+        ObjectNode node = toWorkspaceSummary(workspace);
+        node.put("prometheusEndpoint", workspace.getPrometheusEndpoint());
+        return node;
+    }
+
+    // AWS's WorkspaceSummary shape (ListWorkspaces) carries every WorkspaceDescription member
+    // except prometheusEndpoint.
+    private ObjectNode toWorkspaceSummary(PrometheusWorkspace workspace) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("workspaceId", workspace.getWorkspaceId());
+        if (workspace.getAlias() != null) {
+            node.put("alias", workspace.getAlias());
+        }
+        node.put("arn", workspace.getArn());
+        node.set("status", statusNode(workspace));
+        // Smithy restJson1 timestamps with no timestampFormat trait are epoch-seconds; an ISO
+        // string here fails deserialization inside the AWS SDKs.
+        node.put("createdAt", workspace.getCreatedAt().toEpochMilli() / 1000.0);
+        node.set("tags", objectMapper.valueToTree(workspace.getTags()));
+        if (workspace.getKmsKeyArn() != null) {
+            node.put("kmsKeyArn", workspace.getKmsKeyArn());
+        }
+        return node;
+    }
+
+    private ObjectNode statusNode(PrometheusWorkspace workspace) {
+        ObjectNode status = objectMapper.createObjectNode();
+        status.put("statusCode", workspace.getStatus());
+        return status;
+    }
+
+    private String asString(Object value, String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String s)) {
+            throw new AwsException("ValidationException", fieldName + " must be a string.", 400);
+        }
+        return s;
+    }
+
+    private Map<String, String> asStringMap(Object value, String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof Map<?, ?> map)
+                || map.entrySet().stream().anyMatch(e -> !(e.getKey() instanceof String) || !(e.getValue() instanceof String))) {
+            throw new AwsException("ValidationException", fieldName + " must be a map of strings.", 400);
+        }
+        Map<String, String> result = new HashMap<>();
+        map.forEach((k, v) -> result.put((String) k, (String) v));
+        return result;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/aps/ApsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/aps/ApsService.java
@@ -1,6 +1,5 @@
 package io.github.hectorvent.floci.services.aps;
 
-import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.PaginatedResult;
@@ -28,22 +27,19 @@ public class ApsService implements TagHandler {
     private static final int MAX_PAGE = 1000;
 
     private final StorageBackend<String, PrometheusWorkspace> storage;
-    private final EmulatorConfig config;
     private final RegionResolver regionResolver;
 
     @Inject
-    public ApsService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver) {
+    public ApsService(StorageFactory storageFactory, RegionResolver regionResolver) {
         this.storage = storageFactory.create("aps", "aps-workspaces.json",
                 new TypeReference<Map<String, PrometheusWorkspace>>() {});
-        this.config = config;
         this.regionResolver = regionResolver;
     }
 
     public PrometheusWorkspace createWorkspace(String alias, Map<String, String> tags, String kmsKeyArn) {
         String workspaceId = "ws-" + UUID.randomUUID();
-        String region = config.defaultRegion();
-        String arn = AwsArnUtils.Arn.of("aps", region, regionResolver.getAccountId(),
-                "workspace/" + workspaceId).toString();
+        String region = regionResolver.getRegion();
+        String arn = regionResolver.buildArn("aps", region, "workspace/" + workspaceId);
 
         PrometheusWorkspace workspace = new PrometheusWorkspace();
         workspace.setWorkspaceId(workspaceId);
@@ -83,19 +79,16 @@ public class ApsService implements TagHandler {
                 MAX_PAGE, "ValidationException");
     }
 
-    public PrometheusWorkspace deleteWorkspace(String workspaceId) {
-        PrometheusWorkspace workspace = describeWorkspace(workspaceId);
-        workspace.setStatus("DELETING");
+    public void deleteWorkspace(String workspaceId) {
+        describeWorkspace(workspaceId);
         storage.delete(workspaceId);
         LOG.infov("Deleted AMP workspace: {0}", workspaceId);
-        return workspace;
     }
 
-    public PrometheusWorkspace updateWorkspaceAlias(String workspaceId, String alias) {
+    public void updateWorkspaceAlias(String workspaceId, String alias) {
         PrometheusWorkspace workspace = describeWorkspace(workspaceId);
         workspace.setAlias(alias);
         storage.put(workspaceId, workspace);
-        return workspace;
     }
 
     // ── TagHandler: the shared /tags/{resourceArn} dispatcher routes aps ARNs here ──
@@ -137,10 +130,17 @@ public class ApsService implements TagHandler {
 
     private PrometheusWorkspace workspaceByArn(String arn) {
         // arn:aws:aps:<region>:<account>:workspace/<workspaceId>
-        int slash = arn.lastIndexOf('/');
-        if (slash < 0 || slash == arn.length() - 1) {
-            throw new AwsException("ValidationException", "Invalid AMP resource ARN: " + arn, 400);
+        String resource;
+        try {
+            resource = AwsArnUtils.parse(arn).resource();
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ValidationException", "Invalid resource ARN: " + arn, 400);
         }
-        return describeWorkspace(arn.substring(slash + 1));
+        String prefix = "workspace/";
+        if (!resource.startsWith(prefix) || resource.length() == prefix.length()) {
+            throw new AwsException("ValidationException",
+                    "Tags are only supported on AMP workspaces: " + arn, 400);
+        }
+        return describeWorkspace(resource.substring(prefix.length()));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/aps/ApsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/aps/ApsService.java
@@ -1,0 +1,146 @@
+package io.github.hectorvent.floci.services.aps;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.TagHandler;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.aps.model.PrometheusWorkspace;
+import com.fasterxml.jackson.core.type.TypeReference;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class ApsService implements TagHandler {
+
+    private static final Logger LOG = Logger.getLogger(ApsService.class);
+    // AMP's ListWorkspacesRequest declares maxResults with a maximum of 1000.
+    private static final int MAX_PAGE = 1000;
+
+    private final StorageBackend<String, PrometheusWorkspace> storage;
+    private final EmulatorConfig config;
+    private final RegionResolver regionResolver;
+
+    @Inject
+    public ApsService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver) {
+        this.storage = storageFactory.create("aps", "aps-workspaces.json",
+                new TypeReference<Map<String, PrometheusWorkspace>>() {});
+        this.config = config;
+        this.regionResolver = regionResolver;
+    }
+
+    public PrometheusWorkspace createWorkspace(String alias, Map<String, String> tags, String kmsKeyArn) {
+        String workspaceId = "ws-" + UUID.randomUUID();
+        String region = config.defaultRegion();
+        String arn = AwsArnUtils.Arn.of("aps", region, regionResolver.getAccountId(),
+                "workspace/" + workspaceId).toString();
+
+        PrometheusWorkspace workspace = new PrometheusWorkspace();
+        workspace.setWorkspaceId(workspaceId);
+        workspace.setAlias(alias);
+        workspace.setArn(arn);
+        // Real AMP answers the create 202 with status CREATING; the emulator provisions nothing,
+        // so the workspace is ACTIVE from birth and the terraform/pulumi provider's create waiter
+        // (Pending CREATING, Target ACTIVE) completes on its first DescribeWorkspace poll.
+        workspace.setStatus("ACTIVE");
+        workspace.setPrometheusEndpoint(
+                "https://aps-workspaces." + region + ".amazonaws.com/workspaces/" + workspaceId + "/");
+        workspace.setCreatedAt(Instant.now());
+        workspace.setKmsKeyArn(kmsKeyArn);
+        if (tags != null) {
+            workspace.getTags().putAll(tags);
+        }
+
+        storage.put(workspaceId, workspace);
+        LOG.infov("Created AMP workspace: {0}", workspaceId);
+        return workspace;
+    }
+
+    public PrometheusWorkspace describeWorkspace(String workspaceId) {
+        return storage.get(workspaceId)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "Workspace not found: " + workspaceId, 404));
+    }
+
+    // The alias parameter is a prefix filter, not an exact match: the terraform provider's
+    // aws_prometheus_workspaces data source exposes it as alias_prefix.
+    public PaginatedResult<PrometheusWorkspace> listWorkspaces(String aliasPrefix, Integer maxResults, String nextToken) {
+        List<PrometheusWorkspace> all = storage.scan(k -> true).stream()
+                .filter(w -> aliasPrefix == null || aliasPrefix.isEmpty()
+                        || (w.getAlias() != null && w.getAlias().startsWith(aliasPrefix)))
+                .toList();
+        return Pagination.paginate(all, PrometheusWorkspace::getWorkspaceId, maxResults, nextToken,
+                MAX_PAGE, "ValidationException");
+    }
+
+    public PrometheusWorkspace deleteWorkspace(String workspaceId) {
+        PrometheusWorkspace workspace = describeWorkspace(workspaceId);
+        workspace.setStatus("DELETING");
+        storage.delete(workspaceId);
+        LOG.infov("Deleted AMP workspace: {0}", workspaceId);
+        return workspace;
+    }
+
+    public PrometheusWorkspace updateWorkspaceAlias(String workspaceId, String alias) {
+        PrometheusWorkspace workspace = describeWorkspace(workspaceId);
+        workspace.setAlias(alias);
+        storage.put(workspaceId, workspace);
+        return workspace;
+    }
+
+    // ── TagHandler: the shared /tags/{resourceArn} dispatcher routes aps ARNs here ──
+
+    @Override
+    public String serviceKey() {
+        return "aps";
+    }
+
+    // AMP defines TagResource/UntagResource with a 200 response, not the dispatcher's default 204.
+    @Override
+    public int tagResourceSuccessStatus() {
+        return 200;
+    }
+
+    @Override
+    public int untagResourceSuccessStatus() {
+        return 200;
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        return Map.copyOf(workspaceByArn(arn).getTags());
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        PrometheusWorkspace workspace = workspaceByArn(arn);
+        workspace.getTags().putAll(tags);
+        storage.put(workspace.getWorkspaceId(), workspace);
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        PrometheusWorkspace workspace = workspaceByArn(arn);
+        tagKeys.forEach(workspace.getTags()::remove);
+        storage.put(workspace.getWorkspaceId(), workspace);
+    }
+
+    private PrometheusWorkspace workspaceByArn(String arn) {
+        // arn:aws:aps:<region>:<account>:workspace/<workspaceId>
+        int slash = arn.lastIndexOf('/');
+        if (slash < 0 || slash == arn.length() - 1) {
+            throw new AwsException("ValidationException", "Invalid AMP resource ARN: " + arn, 400);
+        }
+        return describeWorkspace(arn.substring(slash + 1));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/aps/model/PrometheusWorkspace.java
+++ b/src/main/java/io/github/hectorvent/floci/services/aps/model/PrometheusWorkspace.java
@@ -14,8 +14,7 @@ public class PrometheusWorkspace {
     private String workspaceId;
     private String alias;
     private String arn;
-    // WorkspaceStatusCode: the emulator only ever stores ACTIVE (creation is instantaneous) and
-    // reports DELETING on the delete response itself.
+    // WorkspaceStatusCode: the emulator only ever stores ACTIVE (creation is instantaneous).
     private String status;
     private String prometheusEndpoint;
     private Instant createdAt;

--- a/src/main/java/io/github/hectorvent/floci/services/aps/model/PrometheusWorkspace.java
+++ b/src/main/java/io/github/hectorvent/floci/services/aps/model/PrometheusWorkspace.java
@@ -1,0 +1,53 @@
+package io.github.hectorvent.floci.services.aps.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PrometheusWorkspace {
+
+    private String workspaceId;
+    private String alias;
+    private String arn;
+    // WorkspaceStatusCode: the emulator only ever stores ACTIVE (creation is instantaneous) and
+    // reports DELETING on the delete response itself.
+    private String status;
+    private String prometheusEndpoint;
+    private Instant createdAt;
+    private String kmsKeyArn;
+    private Map<String, String> tags = new ConcurrentHashMap<>();
+
+    public PrometheusWorkspace() {
+    }
+
+    public String getWorkspaceId() { return workspaceId; }
+    public void setWorkspaceId(String workspaceId) { this.workspaceId = workspaceId; }
+
+    public String getAlias() { return alias; }
+    public void setAlias(String alias) { this.alias = alias; }
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+
+    public String getPrometheusEndpoint() { return prometheusEndpoint; }
+    public void setPrometheusEndpoint(String prometheusEndpoint) { this.prometheusEndpoint = prometheusEndpoint; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public String getKmsKeyArn() { return kmsKeyArn; }
+    public void setKmsKeyArn(String kmsKeyArn) { this.kmsKeyArn = kmsKeyArn; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags != null ? new ConcurrentHashMap<>(tags) : new ConcurrentHashMap<>();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -549,6 +549,8 @@ floci:
       enabled: true
     controltower:
       enabled: true
+    aps:
+      enabled: true
     lakeformation:
       enabled: true
     tagging:

--- a/src/test/java/io/github/hectorvent/floci/services/aps/ApsControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/aps/ApsControllerIntegrationTest.java
@@ -1,0 +1,180 @@
+package io.github.hectorvent.floci.services.aps;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+class ApsControllerIntegrationTest {
+
+    private String createWorkspace(String alias) {
+        return given()
+            .contentType("application/json")
+            .body("""
+                {"alias": "%s", "tags": {"team": "devops"}, "clientToken": "token-123"}
+                """.formatted(alias))
+        .when()
+            .post("/workspaces")
+        .then()
+            .statusCode(202)
+            .body("workspaceId", startsWith("ws-"))
+            .body("arn", containsString(":workspace/ws-"))
+            .body("status.statusCode", equalTo("ACTIVE"))
+            .body("tags.team", equalTo("devops"))
+            .extract().path("workspaceId");
+    }
+
+    @Test
+    void workspaceLifecycleRoundTrip() {
+        String workspaceId = createWorkspace("lifecycle-test");
+
+        given()
+        .when()
+            .get("/workspaces/{workspaceId}", workspaceId)
+        .then()
+            .statusCode(200)
+            .body("workspace.workspaceId", equalTo(workspaceId))
+            .body("workspace.alias", equalTo("lifecycle-test"))
+            .body("workspace.status.statusCode", equalTo("ACTIVE"))
+            .body("workspace.prometheusEndpoint",
+                    equalTo("https://aps-workspaces.us-east-1.amazonaws.com/workspaces/" + workspaceId + "/"))
+            // Epoch-seconds number, not an ISO string: restJson1 timestamps with no
+            // timestampFormat trait fail SDK deserialization as strings.
+            .body("workspace.createdAt", notNullValue())
+            .body("workspace.tags.team", equalTo("devops"));
+
+        given()
+        .when()
+            .get("/workspaces")
+        .then()
+            .statusCode(200)
+            .body("workspaces.workspaceId", hasItem(workspaceId))
+            // The WorkspaceSummary shape never carries prometheusEndpoint.
+            .body("workspaces.find { it.workspaceId == '" + workspaceId + "' }.prometheusEndpoint",
+                    equalTo(null));
+
+        given()
+        .when()
+            .delete("/workspaces/{workspaceId}", workspaceId)
+        .then()
+            .statusCode(202);
+
+        // The terraform/pulumi provider's delete waiter matches the typed error via the
+        // X-Amzn-Errortype header; assert the wire contract, not just the status.
+        given()
+        .when()
+            .get("/workspaces/{workspaceId}", workspaceId)
+        .then()
+            .statusCode(404)
+            .header("X-Amzn-Errortype", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    void listWorkspacesFiltersByAliasPrefix() {
+        String matching = createWorkspace("prefix-match-a");
+        createWorkspace("other-alias");
+
+        given()
+        .when()
+            .get("/workspaces?alias=prefix-match")
+        .then()
+            .statusCode(200)
+            .body("workspaces.workspaceId", hasItem(matching))
+            .body("workspaces.alias", not(hasItem("other-alias")));
+    }
+
+    @Test
+    void listWorkspacesRejectsZeroMaxResults() {
+        given()
+        .when()
+            .get("/workspaces?maxResults=0")
+        .then()
+            .statusCode(400)
+            .header("X-Amzn-Errortype", equalTo("ValidationException"));
+    }
+
+    @Test
+    void updateWorkspaceAliasReturns204AndPersists() {
+        String workspaceId = createWorkspace("alias-before");
+
+        given()
+            .contentType("application/json")
+            .body("{\"alias\": \"alias-after\"}")
+        .when()
+            .post("/workspaces/{workspaceId}/alias", workspaceId)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/workspaces/{workspaceId}", workspaceId)
+        .then()
+            .statusCode(200)
+            .body("workspace.alias", equalTo("alias-after"));
+    }
+
+    @Test
+    void deleteWorkspaceUnknownIdReturns404() {
+        given()
+        .when()
+            .delete("/workspaces/{workspaceId}", "ws-missing")
+        .then()
+            .statusCode(404)
+            .header("X-Amzn-Errortype", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    void tagsRoundTripThroughSharedTagsDispatcher() {
+        String workspaceId = createWorkspace("tags-test");
+        String arn = given()
+            .when().get("/workspaces/{workspaceId}", workspaceId)
+            .then().statusCode(200)
+            .extract().path("workspace.arn");
+
+        given()
+        .when()
+            .get("/tags/{arn}", arn)
+        .then()
+            .statusCode(200)
+            .body("tags.team", equalTo("devops"));
+
+        // AMP defines TagResource/UntagResource with 200 responses, not the dispatcher's
+        // default 204.
+        given()
+            .contentType("application/json")
+            .body("{\"tags\": {\"env\": \"test\"}}")
+        .when()
+            .post("/tags/{arn}", arn)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/tags/{arn}", arn)
+        .then()
+            .statusCode(200)
+            .body("tags.team", equalTo("devops"))
+            .body("tags.env", equalTo("test"));
+
+        given()
+        .when()
+            .delete("/tags/{arn}?tagKeys=team", arn)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/tags/{arn}", arn)
+        .then()
+            .statusCode(200)
+            .body("tags.env", equalTo("test"))
+            .body("tags", not(org.hamcrest.Matchers.hasKey("team")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/aps/ApsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/aps/ApsServiceTest.java
@@ -1,0 +1,134 @@
+package io.github.hectorvent.floci.services.aps;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.aps.model.PrometheusWorkspace;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class ApsServiceTest {
+
+    private ApsService service;
+
+    @BeforeEach
+    void setUp() {
+        StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
+        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenAnswer(invocation -> AccountAwareStorageBackend.inMemory("000000000000"));
+
+        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
+        when(config.defaultRegion()).thenReturn("us-east-1");
+
+        service = new ApsService(storageFactory, config, new RegionResolver("us-east-1", "000000000000"));
+    }
+
+    @Test
+    void createWorkspaceIsActiveWithArnAndEndpoint() {
+        PrometheusWorkspace workspace = service.createWorkspace("my-workspace", Map.of("team", "devops"), null);
+
+        assertTrue(workspace.getWorkspaceId().startsWith("ws-"));
+        assertEquals("ACTIVE", workspace.getStatus());
+        assertEquals("arn:aws:aps:us-east-1:000000000000:workspace/" + workspace.getWorkspaceId(),
+                workspace.getArn());
+        assertEquals("https://aps-workspaces.us-east-1.amazonaws.com/workspaces/"
+                + workspace.getWorkspaceId() + "/", workspace.getPrometheusEndpoint());
+        assertNotNull(workspace.getCreatedAt());
+        assertEquals("devops", workspace.getTags().get("team"));
+    }
+
+    @Test
+    void describeWorkspaceUnknownIdThrowsResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class, () -> service.describeWorkspace("ws-missing"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals(404, ex.getHttpStatus());
+    }
+
+    @Test
+    void describeWorkspaceAfterDeleteThrowsResourceNotFound() {
+        PrometheusWorkspace workspace = service.createWorkspace("doomed", null, null);
+        service.deleteWorkspace(workspace.getWorkspaceId());
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.describeWorkspace(workspace.getWorkspaceId()));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void listWorkspacesFiltersByAliasPrefix() {
+        service.createWorkspace("prod-metrics", null, null);
+        service.createWorkspace("prod-traces", null, null);
+        service.createWorkspace("staging-metrics", null, null);
+
+        assertEquals(2, service.listWorkspaces("prod-", null, null).items().size());
+        assertEquals(3, service.listWorkspaces(null, null, null).items().size());
+        assertEquals(0, service.listWorkspaces("missing", null, null).items().size());
+    }
+
+    @Test
+    void listWorkspacesPaginates() {
+        service.createWorkspace("a", null, null);
+        service.createWorkspace("b", null, null);
+        service.createWorkspace("c", null, null);
+
+        PaginatedResult<PrometheusWorkspace> firstPage = service.listWorkspaces(null, 2, null);
+        assertEquals(2, firstPage.items().size());
+        assertNotNull(firstPage.nextToken());
+
+        PaginatedResult<PrometheusWorkspace> secondPage = service.listWorkspaces(null, 2, firstPage.nextToken());
+        assertEquals(1, secondPage.items().size());
+        assertNull(secondPage.nextToken());
+    }
+
+    @Test
+    void listWorkspacesRejectsZeroMaxResultsWithValidationException() {
+        AwsException ex = assertThrows(AwsException.class, () -> service.listWorkspaces(null, 0, null));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateWorkspaceAliasPersists() {
+        PrometheusWorkspace workspace = service.createWorkspace("old-alias", null, null);
+        service.updateWorkspaceAlias(workspace.getWorkspaceId(), "new-alias");
+        assertEquals("new-alias", service.describeWorkspace(workspace.getWorkspaceId()).getAlias());
+    }
+
+    @Test
+    void tagHandlerRoundTripsTagsByArn() {
+        PrometheusWorkspace workspace = service.createWorkspace("tagged", Map.of("env", "test"), null);
+        String arn = workspace.getArn();
+
+        assertEquals("aps", service.serviceKey());
+        assertEquals(Map.of("env", "test"), service.listTags("us-east-1", arn));
+
+        service.tagResource("us-east-1", arn, Map.of("team", "devops"));
+        assertEquals(Map.of("env", "test", "team", "devops"), service.listTags("us-east-1", arn));
+
+        service.untagResource("us-east-1", arn, List.of("env"));
+        assertEquals(Map.of("team", "devops"), service.listTags("us-east-1", arn));
+    }
+
+    @Test
+    void tagHandlerUnknownWorkspaceArnThrowsResourceNotFound() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.listTags("us-east-1", "arn:aws:aps:us-east-1:000000000000:workspace/ws-missing"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void tagHandlerMalformedArnThrowsValidationException() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.listTags("us-east-1", "arn:aws:aps:us-east-1:000000000000:workspace"));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/aps/ApsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/aps/ApsServiceTest.java
@@ -1,6 +1,5 @@
 package io.github.hectorvent.floci.services.aps;
 
-import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -27,10 +26,7 @@ class ApsServiceTest {
         when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
                 .thenAnswer(invocation -> AccountAwareStorageBackend.inMemory("000000000000"));
 
-        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
-        when(config.defaultRegion()).thenReturn("us-east-1");
-
-        service = new ApsService(storageFactory, config, new RegionResolver("us-east-1", "000000000000"));
+        service = new ApsService(storageFactory, new RegionResolver("us-east-1", "000000000000"));
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -343,6 +343,8 @@ floci:
       enabled: true
     controltower:
       enabled: true
+    aps:
+      enabled: true
     lakeformation:
       enabled: true
     tagging:


### PR DESCRIPTION
Adds Amazon Managed Service for Prometheus (`aps`) as a new service, scoped to the workspace lifecycle that Terraform's and Pulumi's `aws_prometheus_workspace` resource drives: `CreateWorkspace`, `DescribeWorkspace`, `ListWorkspaces`, `UpdateWorkspaceAlias`, `DeleteWorkspace`, plus tagging through the shared `/tags/{resourceArn}` dispatcher. Before this, `CreateWorkspace` had no service to answer it at all.

Wire behavior, matching the AWS restJson1 model and the provider's waiters ([`internal/service/amp/workspace.go`](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/service/amp/workspace.go)):

1. A workspace is ACTIVE from birth. Real AMP answers the create `202` with `CREATING`; the emulator provisions nothing, so the provider's create waiter (`CREATING` to `ACTIVE`) completes on its first `DescribeWorkspace` poll.
2. `DeleteWorkspace` (`202`) removes the workspace immediately; a later `DescribeWorkspace` returns `ResourceNotFoundException` `404`, which the provider's delete waiter matches as a typed exception to treat the workspace as gone.
3. `DescribeWorkspace` returns the full description including `prometheusEndpoint` in the real AWS shape; the `ListWorkspaces` summary omits it, per the `WorkspaceSummary` shape.
4. `createdAt` goes out as restJson1 epoch-seconds. An ISO string here fails deserialization inside the AWS SDKs, so the compatibility test asserts it through the real Java SDK.
5. The `alias` parameter of `ListWorkspaces` is a prefix filter (the provider exposes it as `alias_prefix`), with `maxResults`/`nextToken` pagination and `ValidationException` on out-of-range values.
6. Tagging routes through `SharedTagsController` via a `TagHandler` with service key `aps`, with the success statuses overridden to `200` per the AMP model.

Scope notes (kept deliberately narrow):

1. Alert manager definitions, rule groups namespaces, scrapers and logging configurations are not implemented. The workspace surface is what IaC providers need to manage the resource.
2. `prometheusEndpoint` is reported in the real AWS shape but is not a live ingestion/query endpoint.
3. `clientToken` is accepted and ignored: creates are not deduplicated.
4. `kmsKeyArn` is stored and echoed back; no encryption is performed.

Tests:

1. Unit (`ApsServiceTest`): create/describe/list/delete/alias semantics, alias-prefix filtering, pagination and its `ValidationException`, and the TagHandler ARN round trip.
2. REST integration (`ApsControllerIntegrationTest`): full lifecycle over HTTP including the `X-Amzn-Errortype: ResourceNotFoundException` header after delete (what the provider's waiter matches), the `202`/`204` response codes, and tags through `/tags/{arn}`.
3. SDK compatibility (`compatibility-tests` `AmpTest`, new `software.amazon.awssdk:amp` dependency): the same lifecycle through the real AWS Java SDK v2, which proves the timestamp and error wire shapes end to end.

Docs: `docs/services/managed-prometheus.md` plus an index row, following the hand-written style of the Control Tower page (no switch handler, so the generated action tables are unaffected).
