### PR TITLE
test(ses): pin the explicit "message":null in the empty-TagKeys error body

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
@@ -309,10 +309,10 @@ class SesTagsV2IntegrationTest {
         .then()
             .statusCode(400)
             .header("X-Amzn-Errortype", containsString("ValidationException"))
-            .body("__type", equalTo("ValidationException"))
-            // Raw-body match: GPath's nullValue() also passes when the member is absent, so it
-            // can't pin that the body carries an explicit "message":null.
-            .body(containsString("\"message\":null"));
+            // Exact raw-body match: GPath member assertions can't distinguish an absent member
+            // from an explicit JSON null, and a substring can't reject extra members — this
+            // pins the documented shape wholesale.
+            .body(equalTo("{\"__type\":\"ValidationException\",\"message\":null}"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTagsV2IntegrationTest.java
@@ -310,7 +310,9 @@ class SesTagsV2IntegrationTest {
             .statusCode(400)
             .header("X-Amzn-Errortype", containsString("ValidationException"))
             .body("__type", equalTo("ValidationException"))
-            .body("message", nullValue());
+            // Raw-body match: GPath's nullValue() also passes when the member is absent, so it
+            // can't pin that the body carries an explicit "message":null.
+            .body(containsString("\"message\":null"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up to the review of #2589: `.body("message", nullValue())` passes both when
`message` is present as a JSON null and when the member is absent entirely (GPath
returns null in both cases), so the assertion couldn't pin the documented body shape.
Assert the raw body instead — a future `@JsonInclude(NON_NULL)` tidy-up on
`AwsErrorResponse` would now fail this test rather than silently invalidating the
documented `{"__type":"ValidationException","message":null}` shape.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No behavior change. The wire shape was probed against real AWS during the #2589
review; the raw-body match also confirms the serializer emits `"message":null`
exactly (no spacing).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
