### PR TITLE
feat(iot): add TLS/mTLS listener to the embedded MQTT broker

### DIFF
--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -59,10 +59,36 @@ Broker scope:
 - Target real AWS IoT/device SDK style MQTT clients, not only handcrafted packet tests.
 - Support MQTT v3 and MQTT 5 CONNECT handling used by local compatibility tests.
 - Support QoS 0 and QoS 1 publish/subscribe behavior for the local AWS IoT slice.
-- Keep MQTT plaintext-only for this phase; TLS and mTLS are out of scope.
+- Serve plaintext MQTT by default, plus an optional TLS listener with required client certificates (mTLS); both listeners share the same session registry, subscriptions, and fan-out.
 - Keep MQTT authorization permissive for now, but leave room for a later pluggable IoT certificate and policy authorizer.
 - Keep MQTT broker logging minimal.
 - Validate the relevant IoT compatibility tests against the native binary before considering the phase complete.
+
+### TLS / mTLS
+
+The broker can expose a TLS listener alongside the plaintext one, mirroring AWS IoT
+Core's mTLS endpoint on port 8883. It is disabled by default; when enabled it
+requires clients to present a certificate that chains to the configured CA
+(`require-client-auth: false` downgrades it to server-only TLS).
+
+```yaml
+floci:
+  services:
+    iot:
+      mqtt:
+        tls:
+          enabled: true                 # default false (FLOCI_SERVICES_IOT_MQTT_TLS_ENABLED)
+          port: 8883
+          cert-path: /certs/server.pem  # server certificate (PEM)
+          key-path: /certs/server.key   # server private key (PEM)
+          ca-path: /certs/ca.pem        # CA that client certificates must chain to
+          require-client-auth: true     # default true
+```
+
+Startup fails fast with a descriptive error when TLS is enabled without the
+required paths. The TLS layer authenticates the transport only: certificate and
+policy resources are still not evaluated as broker authorization (see Known gaps
+and the pluggable authorizer note above).
 
 ## Reserved Topics
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -705,6 +705,25 @@ public interface EmulatorConfig {
 
         @WithDefault("1883")
         int port();
+
+        MqttTlsConfig tls();
+    }
+
+    interface MqttTlsConfig {
+        @WithDefault("false")
+        boolean enabled();
+
+        @WithDefault("8883")
+        int port();
+
+        Optional<String> certPath();
+
+        Optional<String> keyPath();
+
+        Optional<String> caPath();
+
+        @WithDefault("true")
+        boolean requireClientAuth();
     }
 
     interface IotDataServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
@@ -93,11 +93,20 @@ public class IotMqttBrokerService {
             server = plaintextServer;
             tlsServer = secureServer;
         } catch (Exception e) {
-            plaintextServer.close();
-            if (secureServer != null) {
-                secureServer.close();
-            }
+            closeAndAwait(plaintextServer);
+            closeAndAwait(secureServer);
             throw new IllegalStateException("Failed to start IoT MQTT broker", e);
+        }
+    }
+
+    private void closeAndAwait(MqttServer mqttServer) {
+        if (mqttServer == null) {
+            return;
+        }
+        try {
+            mqttServer.close().toCompletionStage().toCompletableFuture().join();
+        } catch (Exception closeFailure) {
+            LOG.warnv("Failed to close IoT MQTT listener during startup rollback: {0}", closeFailure.getMessage());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
@@ -7,6 +7,9 @@ import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.ClientAuth;
+import io.vertx.core.net.PemKeyCertOptions;
+import io.vertx.core.net.PemTrustOptions;
 import io.vertx.core.net.SocketAddress;
 import io.vertx.mqtt.MqttEndpoint;
 import io.vertx.mqtt.MqttServer;
@@ -40,6 +43,7 @@ public class IotMqttBrokerService {
     private final Map<String, ClientSession> sessionsByClient = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Subscription>> subscriptionsByClient = new ConcurrentHashMap<>();
     private MqttServer server;
+    private MqttServer tlsServer;
 
     @Inject
     public IotMqttBrokerService(EmulatorConfig config, Vertx vertx, Instance<IotService> iotService) {
@@ -72,21 +76,58 @@ public class IotMqttBrokerService {
             return;
         }
 
-        MqttServer mqttServer = MqttServer.create(vertx, new MqttServerOptions()
-                .setHost(config.services().iot().mqtt().host())
-                .setPort(config.services().iot().mqtt().port()));
-        mqttServer.endpointHandler(this::handleEndpoint);
-        mqttServer.exceptionHandler(error -> LOG.warnv("IoT MQTT broker error: {0}", error.getMessage()));
+        EmulatorConfig.MqttConfig mqttConfig = config.services().iot().mqtt();
+        MqttServerOptions tlsOptions = mqttConfig.tls().enabled() ? tlsServerOptions(mqttConfig) : null;
+        MqttServer plaintextServer = createServer(new MqttServerOptions()
+                .setHost(mqttConfig.host())
+                .setPort(mqttConfig.port()));
+        MqttServer secureServer = tlsOptions == null ? null : createServer(tlsOptions);
 
         try {
-            mqttServer.listen().toCompletionStage().toCompletableFuture().join();
-            server = mqttServer;
-            LOG.infov("IoT MQTT broker started on {0}:{1}",
-                    config.services().iot().mqtt().host(), config.services().iot().mqtt().port());
+            plaintextServer.listen().toCompletionStage().toCompletableFuture().join();
+            LOG.infov("IoT MQTT broker started on {0}:{1}", mqttConfig.host(), mqttConfig.port());
+            if (secureServer != null) {
+                secureServer.listen().toCompletionStage().toCompletableFuture().join();
+                LOG.infov("IoT MQTT TLS broker started on {0}:{1}", mqttConfig.host(), mqttConfig.tls().port());
+            }
+            server = plaintextServer;
+            tlsServer = secureServer;
         } catch (Exception e) {
-            mqttServer.close();
+            plaintextServer.close();
+            if (secureServer != null) {
+                secureServer.close();
+            }
             throw new IllegalStateException("Failed to start IoT MQTT broker", e);
         }
+    }
+
+    private MqttServer createServer(MqttServerOptions options) {
+        MqttServer mqttServer = MqttServer.create(vertx, options);
+        mqttServer.endpointHandler(this::handleEndpoint);
+        mqttServer.exceptionHandler(error -> LOG.warnv("IoT MQTT broker error: {0}", error.getMessage()));
+        return mqttServer;
+    }
+
+    private MqttServerOptions tlsServerOptions(EmulatorConfig.MqttConfig mqttConfig) {
+        EmulatorConfig.MqttTlsConfig tlsConfig = mqttConfig.tls();
+        MqttServerOptions options = new MqttServerOptions();
+        options.setHost(mqttConfig.host());
+        options.setPort(tlsConfig.port());
+        options.setSsl(true);
+        options.setKeyCertOptions(new PemKeyCertOptions()
+                .setCertPath(requireTlsPath(tlsConfig.certPath(), "cert-path"))
+                .setKeyPath(requireTlsPath(tlsConfig.keyPath(), "key-path")));
+        if (tlsConfig.requireClientAuth()) {
+            options.setClientAuth(ClientAuth.REQUIRED);
+            options.setTrustOptions(new PemTrustOptions()
+                    .addCertPath(requireTlsPath(tlsConfig.caPath(), "ca-path")));
+        }
+        return options;
+    }
+
+    private static String requireTlsPath(Optional<String> value, String key) {
+        return value.filter(path -> !path.isBlank()).orElseThrow(() -> new IllegalStateException(
+                "IoT MQTT TLS is enabled but floci.services.iot.mqtt.tls." + key + " is not set"));
     }
 
     synchronized void stop() {
@@ -95,10 +136,15 @@ public class IotMqttBrokerService {
             return;
         }
         server = null;
+        MqttServer secureServer = tlsServer;
+        tlsServer = null;
         sessionsByClient.values().forEach(session -> session.endpoint().close());
         sessionsByClient.clear();
         subscriptionsByClient.clear();
         mqttServer.close().toCompletionStage().toCompletableFuture().join();
+        if (secureServer != null) {
+            secureServer.close().toCompletionStage().toCompletableFuture().join();
+        }
         LOG.info("IoT MQTT broker stopped");
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -533,6 +533,10 @@ floci:
         auto-start: false
         host: 0.0.0.0
         port: 1883
+        tls:
+          enabled: false
+          port: 8883
+          require-client-auth: true
     iotdata:
       enabled: true
     cloudhsmv2:

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsIntegrationTest.java
@@ -1,0 +1,197 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLSocketFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestProfile(IotMqttTlsIntegrationTest.TlsMqttProfile.class)
+class IotMqttTlsIntegrationTest {
+
+    private static final int PLAINTEXT_PORT = 18833;
+    private static final int TLS_PORT = 18834;
+    private static final String PLAINTEXT_BROKER_URI = "tcp://127.0.0.1:" + PLAINTEXT_PORT;
+    private static final String TLS_BROKER_URI = "ssl://127.0.0.1:" + TLS_PORT;
+
+    @Test
+    void tlsClientWithTrustedCertConnectsAndPubSubs() throws Exception {
+        String topic = "tls/devices/one/events/" + System.nanoTime();
+        byte[] payload = "hello-over-tls".getBytes(StandardCharsets.UTF_8);
+
+        try (MqttTestClient subscriber = connectTls("tls-sub")) {
+            assertTrue(subscriber.isConnected());
+            subscriber.subscribe(topic);
+
+            try (MqttTestClient publisher = connectTls("tls-pub")) {
+                publisher.publish(topic, payload);
+            }
+
+            MqttPublish received = subscriber.takePublish();
+            assertEquals(topic, received.topic());
+            assertArrayEquals(payload, received.payload());
+        }
+    }
+
+
+
+
+    @Test
+    void tlsClientWithoutClientCertIsRejected() {
+        assertThrows(Exception.class, () -> {
+            try (MqttTestClient client = connect(TLS_BROKER_URI, uniqueClientId("tls-no-cert"),
+                    IotMqttTlsTestPki.INSTANCE.withoutClientCertSocketFactory())) {
+                // connect() must fail: the listener requires a client certificate
+            }
+        });
+    }
+
+    @Test
+    void tlsClientWithUntrustedClientCertIsRejected() {
+        assertThrows(Exception.class, () -> {
+            try (MqttTestClient client = connect(TLS_BROKER_URI, uniqueClientId("tls-untrusted"),
+                    IotMqttTlsTestPki.INSTANCE.untrustedClientSocketFactory())) {
+                // connect() must fail: the client certificate is not signed by the configured CA
+            }
+        });
+    }
+
+    @Test
+    void plaintextListenerStillWorksAndSharesFanOutWithTls() throws Exception {
+        String topic = "tls/devices/mixed/events/" + System.nanoTime();
+        byte[] payload = "hello-across-listeners".getBytes(StandardCharsets.UTF_8);
+
+        try (MqttTestClient tlsSubscriber = connectTls("mixed-tls-sub")) {
+            tlsSubscriber.subscribe(topic);
+
+            try (MqttTestClient plaintextPublisher =
+                         connect(PLAINTEXT_BROKER_URI, uniqueClientId("mixed-plain-pub"), null)) {
+                assertTrue(plaintextPublisher.isConnected());
+                plaintextPublisher.publish(topic, payload);
+            }
+
+            MqttPublish received = tlsSubscriber.takePublish();
+            assertEquals(topic, received.topic());
+            assertArrayEquals(payload, received.payload());
+        }
+    }
+
+    private MqttTestClient connectTls(String clientIdPrefix) throws MqttException {
+        return connect(TLS_BROKER_URI, uniqueClientId(clientIdPrefix),
+                IotMqttTlsTestPki.INSTANCE.trustedClientSocketFactory());
+    }
+
+    private String uniqueClientId(String prefix) {
+        return prefix + "-" + System.nanoTime();
+    }
+
+    private static MqttTestClient connect(String brokerUri, String clientId, SSLSocketFactory socketFactory)
+            throws MqttException {
+        return MqttTestClient.connect(brokerUri, clientId, socketFactory);
+    }
+
+    private record MqttPublish(String topic, byte[] payload) {
+    }
+
+    private static final class MqttTestClient implements AutoCloseable {
+        private final MqttClient client;
+        private final BlockingQueue<MqttPublish> publishes = new LinkedBlockingQueue<>();
+
+        private MqttTestClient(MqttClient client) {
+            this.client = client;
+        }
+
+        static MqttTestClient connect(String brokerUri, String clientId, SSLSocketFactory socketFactory)
+                throws MqttException {
+            MqttClient client = new MqttClient(brokerUri, clientId, new MemoryPersistence());
+            MqttTestClient testClient = new MqttTestClient(client);
+            client.setCallback(new MqttCallback() {
+                @Override
+                public void connectionLost(Throwable cause) {
+                }
+
+                @Override
+                public void messageArrived(String topic, MqttMessage message) {
+                    testClient.publishes.add(new MqttPublish(topic, message.getPayload()));
+                }
+
+                @Override
+                public void deliveryComplete(IMqttDeliveryToken token) {
+                }
+            });
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setCleanSession(true);
+            options.setConnectionTimeout(2);
+            options.setKeepAliveInterval(60);
+            options.setAutomaticReconnect(false);
+            if (socketFactory != null) {
+                options.setSocketFactory(socketFactory);
+            }
+            client.connect(options);
+            return testClient;
+        }
+
+        boolean isConnected() {
+            return client.isConnected();
+        }
+
+        void subscribe(String topic) throws MqttException {
+            client.subscribe(topic, 0);
+        }
+
+        void publish(String topic, byte[] payload) throws MqttException {
+            client.publish(topic, payload, 0, false);
+        }
+
+        MqttPublish takePublish() throws InterruptedException {
+            return Optional.ofNullable(publishes.poll(2, TimeUnit.SECONDS))
+                    .orElseThrow(() -> new AssertionError("No MQTT publish received"));
+        }
+
+        @Override
+        public void close() throws MqttException {
+            if (client.isConnected()) {
+                client.disconnect();
+            }
+            client.close();
+        }
+    }
+
+    public static final class TlsMqttProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            IotMqttTlsTestPki pki = IotMqttTlsTestPki.INSTANCE;
+            return Map.of(
+                    "floci.services.iot.mqtt.enabled", "true",
+                    "floci.services.iot.mqtt.auto-start", "true",
+                    "floci.services.iot.mqtt.host", "127.0.0.1",
+                    "floci.services.iot.mqtt.port", Integer.toString(PLAINTEXT_PORT),
+                    "floci.services.iot.mqtt.tls.enabled", "true",
+                    "floci.services.iot.mqtt.tls.port", Integer.toString(TLS_PORT),
+                    "floci.services.iot.mqtt.tls.cert-path", pki.serverCertPath(),
+                    "floci.services.iot.mqtt.tls.key-path", pki.serverKeyPath(),
+                    "floci.services.iot.mqtt.tls.ca-path", pki.caPath()
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsMisconfiguredIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsMisconfiguredIntegrationTest.java
@@ -1,0 +1,44 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestProfile(IotMqttTlsMisconfiguredIntegrationTest.MisconfiguredTlsProfile.class)
+class IotMqttTlsMisconfiguredIntegrationTest {
+
+    @Inject
+    IotMqttBrokerService mqttBrokerService;
+
+    @Test
+    void startFailsFastWhenTlsEnabledWithoutCertificatePaths() {
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> mqttBrokerService.startIfEnabled());
+        assertTrue(failure.getMessage().contains("floci.services.iot.mqtt.tls.cert-path"),
+                "message should name the missing config key, was: " + failure.getMessage());
+        assertFalse(mqttBrokerService.isRunning(), "a misconfigured broker must not stay half-started");
+    }
+
+    public static final class MisconfiguredTlsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.services.iot.mqtt.enabled", "true",
+                    "floci.services.iot.mqtt.auto-start", "false",
+                    "floci.services.iot.mqtt.host", "127.0.0.1",
+                    "floci.services.iot.mqtt.port", "18835",
+                    "floci.services.iot.mqtt.tls.enabled", "true",
+                    "floci.services.iot.mqtt.tls.port", "18836"
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsStartupRollbackIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsStartupRollbackIntegrationTest.java
@@ -1,0 +1,64 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@QuarkusTest
+@TestProfile(IotMqttTlsStartupRollbackIntegrationTest.BrokenTlsProfile.class)
+class IotMqttTlsStartupRollbackIntegrationTest {
+
+    private static final int PLAINTEXT_PORT = 18837;
+
+    @Inject
+    IotMqttBrokerService mqttBrokerService;
+
+    @Test
+    void failedTlsStartupReleasesThePlaintextPortBeforeReporting() throws Exception {
+        // The rollback must complete before startIfEnabled reports failure: the
+        // plaintext port has to be released again by the time the caller sees the
+        // exception, or an immediate lazy-start retry fails with
+        // address-already-in-use on the plaintext port instead of the real cause.
+        for (int attempt = 0; attempt < 20; attempt++) {
+            IllegalStateException failure = assertThrows(IllegalStateException.class,
+                    () -> mqttBrokerService.startIfEnabled());
+            Throwable root = failure;
+            while (root.getCause() != null) {
+                root = root.getCause();
+            }
+            assertFalse(root instanceof java.net.BindException,
+                    "attempt " + attempt + " failed on the plaintext port instead of the TLS cause: " + root);
+        }
+        assertFalse(mqttBrokerService.isRunning());
+
+        try (ServerSocket socket = new ServerSocket()) {
+            socket.bind(new InetSocketAddress("127.0.0.1", PLAINTEXT_PORT));
+        }
+    }
+
+    public static final class BrokenTlsProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.services.iot.mqtt.enabled", "true",
+                    "floci.services.iot.mqtt.auto-start", "false",
+                    "floci.services.iot.mqtt.host", "127.0.0.1",
+                    "floci.services.iot.mqtt.port", Integer.toString(PLAINTEXT_PORT),
+                    "floci.services.iot.mqtt.tls.enabled", "true",
+                    "floci.services.iot.mqtt.tls.port", "18838",
+                    "floci.services.iot.mqtt.tls.cert-path", "/nonexistent/server.pem",
+                    "floci.services.iot.mqtt.tls.key-path", "/nonexistent/server.key",
+                    "floci.services.iot.mqtt.tls.ca-path", "/nonexistent/ca.pem"
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsTestPki.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttTlsTestPki.java
@@ -1,0 +1,274 @@
+package io.github.hectorvent.floci.services.iot;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.SecureRandom;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+/**
+ * Generates a throwaway PKI for the MQTT TLS integration tests: a trusted CA with a
+ * server certificate and a device (client) certificate signed by it, plus a second,
+ * untrusted CA with its own device certificate. Broker-side material is written as
+ * PEM files for {@code floci.services.iot.mqtt.tls.*}; client-side material is
+ * exposed as in-memory {@link SSLSocketFactory} instances for Paho.
+ *
+ * <p>{@code @QuarkusTest} loads this class once for the test profile and again in the
+ * runtime classloader, so {@code INSTANCE} exists twice per JVM. The first instance
+ * generates the PKI and records its directory in a system property; later instances
+ * reload the identical material from disk, keeping broker config and test clients on
+ * the same certificate chain.</p>
+ */
+final class IotMqttTlsTestPki {
+
+    static final IotMqttTlsTestPki INSTANCE = generate();
+
+    private final Path caPem;
+    private final Path serverCertPem;
+    private final Path serverKeyPem;
+    private final X509Certificate caCert;
+    private final KeyPair clientKeyPair;
+    private final X509Certificate clientCert;
+    private final KeyPair untrustedClientKeyPair;
+    private final X509Certificate untrustedClientCert;
+
+    private IotMqttTlsTestPki(Path caPem, Path serverCertPem, Path serverKeyPem,
+                              X509Certificate caCert,
+                              KeyPair clientKeyPair, X509Certificate clientCert,
+                              KeyPair untrustedClientKeyPair, X509Certificate untrustedClientCert) {
+        this.caPem = caPem;
+        this.serverCertPem = serverCertPem;
+        this.serverKeyPem = serverKeyPem;
+        this.caCert = caCert;
+        this.clientKeyPair = clientKeyPair;
+        this.clientCert = clientCert;
+        this.untrustedClientKeyPair = untrustedClientKeyPair;
+        this.untrustedClientCert = untrustedClientCert;
+    }
+
+    String caPath() {
+        return caPem.toAbsolutePath().toString();
+    }
+
+    String serverCertPath() {
+        return serverCertPem.toAbsolutePath().toString();
+    }
+
+    String serverKeyPath() {
+        return serverKeyPem.toAbsolutePath().toString();
+    }
+
+    SSLSocketFactory trustedClientSocketFactory() {
+        return socketFactory(clientKeyPair.getPrivate(), clientCert);
+    }
+
+    SSLSocketFactory withoutClientCertSocketFactory() {
+        return socketFactory(null, null);
+    }
+
+    SSLSocketFactory untrustedClientSocketFactory() {
+        return socketFactory(untrustedClientKeyPair.getPrivate(), untrustedClientCert);
+    }
+
+    private static final String DIR_PROPERTY = "floci-tests.iot-mqtt-tls-dir";
+
+    private static IotMqttTlsTestPki generate() {
+        String existingDir = System.getProperty(DIR_PROPERTY);
+        if (existingDir != null) {
+            return load(Path.of(existingDir));
+        }
+        try {
+            KeyPair caKeyPair = newKeyPair();
+            X509Certificate caCert = newCaCertificate("CN=Floci IoT Test CA", caKeyPair);
+
+            KeyPair serverKeyPair = newKeyPair();
+            X509Certificate serverCert = newLeafCertificate(
+                    "CN=localhost", serverKeyPair, caCert, caKeyPair, KeyPurposeId.id_kp_serverAuth);
+
+            KeyPair clientKeyPair = newKeyPair();
+            X509Certificate clientCert = newLeafCertificate(
+                    "CN=floci-test-device", clientKeyPair, caCert, caKeyPair, KeyPurposeId.id_kp_clientAuth);
+
+            KeyPair untrustedCaKeyPair = newKeyPair();
+            X509Certificate untrustedCaCert = newCaCertificate("CN=Floci IoT Untrusted CA", untrustedCaKeyPair);
+            KeyPair untrustedClientKeyPair = newKeyPair();
+            X509Certificate untrustedClientCert = newLeafCertificate(
+                    "CN=floci-untrusted-device", untrustedClientKeyPair,
+                    untrustedCaCert, untrustedCaKeyPair, KeyPurposeId.id_kp_clientAuth);
+
+            Path dir = Files.createTempDirectory("floci-iot-mqtt-tls");
+            dir.toFile().deleteOnExit();
+            Path caPem = writePem(dir.resolve("ca.pem"), caCert);
+            Path serverCertPem = writePem(dir.resolve("server-cert.pem"), serverCert);
+            Path serverKeyPem = writePem(dir.resolve("server-key.pem"), serverKeyPair.getPrivate());
+            writePem(dir.resolve("client-cert.pem"), clientCert);
+            writePem(dir.resolve("client-key.pem"), clientKeyPair.getPrivate());
+            writePem(dir.resolve("untrusted-client-cert.pem"), untrustedClientCert);
+            writePem(dir.resolve("untrusted-client-key.pem"), untrustedClientKeyPair.getPrivate());
+            System.setProperty(DIR_PROPERTY, dir.toAbsolutePath().toString());
+
+            return new IotMqttTlsTestPki(caPem, serverCertPem, serverKeyPem, caCert,
+                    clientKeyPair, clientCert, untrustedClientKeyPair, untrustedClientCert);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to generate MQTT TLS test PKI", e);
+        }
+    }
+
+    private static IotMqttTlsTestPki load(Path dir) {
+        try {
+            X509Certificate caCert = readCertificate(dir.resolve("ca.pem"));
+            X509Certificate clientCert = readCertificate(dir.resolve("client-cert.pem"));
+            KeyPair clientKeyPair = readKeyPair(dir.resolve("client-key.pem"), clientCert);
+            X509Certificate untrustedClientCert = readCertificate(dir.resolve("untrusted-client-cert.pem"));
+            KeyPair untrustedClientKeyPair = readKeyPair(dir.resolve("untrusted-client-key.pem"), untrustedClientCert);
+            return new IotMqttTlsTestPki(dir.resolve("ca.pem"), dir.resolve("server-cert.pem"),
+                    dir.resolve("server-key.pem"), caCert,
+                    clientKeyPair, clientCert, untrustedClientKeyPair, untrustedClientCert);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to load MQTT TLS test PKI from " + dir, e);
+        }
+    }
+
+    private static X509Certificate readCertificate(Path file) throws Exception {
+        try (var in = Files.newInputStream(file)) {
+            return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(in);
+        }
+    }
+
+    private static KeyPair readKeyPair(Path file, X509Certificate certificate) throws Exception {
+        try (Reader reader = Files.newBufferedReader(file); PEMParser parser = new PEMParser(reader)) {
+            Object parsed = parser.readObject();
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            PrivateKey privateKey = parsed instanceof PEMKeyPair pemKeyPair
+                    ? converter.getKeyPair(pemKeyPair).getPrivate()
+                    : converter.getPrivateKey((org.bouncycastle.asn1.pkcs.PrivateKeyInfo) parsed);
+            return new KeyPair(certificate.getPublicKey(), privateKey);
+        }
+    }
+
+    private static KeyPair newKeyPair() throws Exception {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048, new SecureRandom());
+        return keyGen.generateKeyPair();
+    }
+
+    private static X509Certificate newCaCertificate(String subjectDn, KeyPair keyPair) throws Exception {
+        X500Name subject = new X500Name(subjectDn);
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                subject, newSerial(), yesterday(), inOneYear(), subject, keyPair.getPublic());
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+        builder.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+        return sign(builder, keyPair.getPrivate());
+    }
+
+    private static X509Certificate newLeafCertificate(String subjectDn, KeyPair keyPair,
+                                                      X509Certificate issuerCert, KeyPair issuerKeyPair,
+                                                      KeyPurposeId extendedKeyUsage) throws Exception {
+        X509v3CertificateBuilder builder = new JcaX509v3CertificateBuilder(
+                issuerCert, newSerial(), yesterday(), inOneYear(),
+                new X500Name(subjectDn), keyPair.getPublic());
+        builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(false));
+        builder.addExtension(Extension.keyUsage, true,
+                new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+        builder.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(extendedKeyUsage));
+        if (KeyPurposeId.id_kp_serverAuth.equals(extendedKeyUsage)) {
+            builder.addExtension(Extension.subjectAlternativeName, false, new GeneralNames(new GeneralName[]{
+                    new GeneralName(GeneralName.dNSName, "localhost"),
+                    new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+            }));
+        }
+        return sign(builder, issuerKeyPair.getPrivate());
+    }
+
+    private static X509Certificate sign(X509v3CertificateBuilder builder, PrivateKey issuerKey) throws Exception {
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA").build(issuerKey);
+        X509CertificateHolder holder = builder.build(signer);
+        return new JcaX509CertificateConverter().getCertificate(holder);
+    }
+
+    private static BigInteger newSerial() {
+        return new BigInteger(128, new SecureRandom());
+    }
+
+    private static Date yesterday() {
+        return Date.from(Instant.now().minus(1, ChronoUnit.DAYS));
+    }
+
+    private static Date inOneYear() {
+        return Date.from(Instant.now().plus(365, ChronoUnit.DAYS));
+    }
+
+    private static Path writePem(Path file, Object object) throws IOException {
+        StringWriter writer = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(writer)) {
+            pemWriter.writeObject(object);
+        }
+        Files.writeString(file, writer.toString());
+        file.toFile().deleteOnExit();
+        return file;
+    }
+
+    private SSLSocketFactory socketFactory(PrivateKey clientKey, X509Certificate clientCertificate) {
+        try {
+            TrustManagerFactory trustManagerFactory =
+                    TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            trustStore.load(null, null);
+            trustStore.setCertificateEntry("ca", caCert);
+            trustManagerFactory.init(trustStore);
+
+            KeyManagerFactory keyManagerFactory = null;
+            if (clientKey != null) {
+                keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+                KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+                keyStore.load(null, null);
+                keyStore.setKeyEntry("device", clientKey, new char[0], new Certificate[]{clientCertificate});
+                keyManagerFactory.init(keyStore, new char[0]);
+            }
+
+            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(
+                    keyManagerFactory == null ? null : keyManagerFactory.getKeyManagers(),
+                    trustManagerFactory.getTrustManagers(),
+                    new SecureRandom());
+            return sslContext.getSocketFactory();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to build test SSL socket factory", e);
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -327,6 +327,10 @@ floci:
         auto-start: false
         host: 127.0.0.1
         port: 1883
+        tls:
+          enabled: false
+          port: 8883
+          require-client-auth: true
     iotdata:
       enabled: true
     cloudhsmv2:


### PR DESCRIPTION
## Summary

Adds an optional TLS listener to the embedded IoT MQTT broker alongside the existing plaintext listener, mirroring AWS IoT Core's mTLS endpoint on port 8883. This is "Layer 1" of the design discussed in #2594; the pluggable certificate/policy authorizer from that issue is intentionally out of scope here.

- Disabled by default (`floci.services.iot.mqtt.tls.enabled: false`) — plaintext behavior is completely unchanged.
- When enabled, clients must present a certificate that chains to the configured CA (`require-client-auth: true` by default; `false` gives server-only TLS).
- Both listeners share the session registry, subscription registry, and fan-out: a TLS subscriber receives messages published by plaintext clients and vice versa, and the IoT Data connection APIs see sessions from either listener.
- Startup fails fast with an error naming the missing `floci.services.iot.mqtt.tls.*` key when TLS is enabled without the required paths.
- No new dependencies — Vert.x-native `PemKeyCertOptions` / `PemTrustOptions` / `ClientAuth.REQUIRED`.

## Configuration

```yaml
floci:
  services:
    iot:
      mqtt:
        tls:
          enabled: true                 # default false
          port: 8883
          cert-path: /certs/server.pem  # server certificate (PEM)
          key-path: /certs/server.key   # server private key (PEM)
          ca-path: /certs/ca.pem        # CA that client certificates must chain to
          require-client-auth: true     # default true
```

## Testing

- `IotMqttTlsIntegrationTest` (Paho over `ssl://`): trusted client connects and pub/subs; a client without a certificate is rejected; a client with a certificate from an untrusted CA is rejected; the plaintext listener still works and shares fan-out with TLS.
- `IotMqttTlsMisconfiguredIntegrationTest`: fail-fast startup validation names the missing config key and leaves the broker stopped.
- The test PKI is generated per JVM with BouncyCastle (already a dependency), so no certificate files are committed and nothing can expire.
- Full local suite: 12,396 tests green; `make docs-check` clean.
- Manually verified with `mosquitto_pub`/`mosquitto_sub` as a device-style client: mTLS pub/sub round-trip, rejection without a client certificate, plaintext unaffected.

Docs: `docs/services/iot.md` MQTT Broker section updated with the TLS scope and configuration.

Refs #2594.