### PR TITLE
fix(s3): return x-amz-version-id from presigned POST

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -2711,10 +2711,13 @@ public class S3Controller {
                 .elem("ETag", obj.getETag())
                 .end("PostResponse")
                 .build();
-        return Response.status(204)
+        var response = Response.status(204)
                 .header("ETag", obj.getETag())
-                .header("Location", bucket + "/" + key)
-                .build();
+                .header("Location", bucket + "/" + key);
+        if (obj.getVersionId() != null) {
+            response.header("x-amz-version-id", obj.getVersionId());
+        }
+        return response.build();
     }
 
     private void validatePolicyConditions(String policyBase64, String bucket,

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3PresignedPostIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.*;
 class S3PresignedPostIntegrationTest {
 
     private static final String BUCKET = "presigned-post-bucket";
+    private static final String VERSIONED_BUCKET = "presigned-post-versioned-bucket";
     private static final DateTimeFormatter AMZ_DATE_FORMAT =
             DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
 
@@ -563,5 +564,52 @@ class S3PresignedPostIntegrationTest {
                   ]
                 }
                 """.formatted(expiration, bucket, keyPrefix, contentTypePrefix, minSize, maxSize);
+    }
+
+    @Test
+    @Order(110)
+    void presignedPostReturnsVersionIdOnAVersionedBucket() {
+        given()
+        .when()
+            .put("/" + VERSIONED_BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+            .body("<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>")
+        .when()
+            .put("/" + VERSIONED_BUCKET + "?versioning")
+        .then()
+            .statusCode(200);
+
+        String key = "uploads/versioned.txt";
+        String contentType = "text/plain";
+        String policy = buildPolicy(VERSIONED_BUCKET, key, contentType, 0, 10485760);
+        String policyBase64 = Base64.getEncoder().encodeToString(policy.getBytes(StandardCharsets.UTF_8));
+
+        String versionId =
+            given()
+                .multiPart("key", key)
+                .multiPart("Content-Type", contentType)
+                .multiPart("policy", policyBase64)
+                .multiPart("x-amz-algorithm", "AWS4-HMAC-SHA256")
+                .multiPart("x-amz-date", AMZ_DATE_FORMAT.format(Instant.now()))
+                .multiPart("file", "versioned.txt",
+                        "Hello from a versioned presigned POST!".getBytes(StandardCharsets.UTF_8), contentType)
+            .when()
+                .post("/" + VERSIONED_BUCKET)
+            .then()
+                .statusCode(204)
+                .extract()
+                .header("x-amz-version-id");
+
+        assertThat(versionId, is(notNullValue()));
+
+        given()
+        .when()
+            .head("/" + VERSIONED_BUCKET + "/" + key)
+        .then()
+            .statusCode(200)
+            .header("x-amz-version-id", is(versionId));
     }
 }


### PR DESCRIPTION
## Summary

A presigned POST to a versioning-enabled bucket creates a new object version, but the response omits `x-amz-version-id`, so the uploader cannot discover the version it just created. Unlike every other write path there is no SDK response object to fall back on — a browser form upload only ever sees the HTTP response — so the version is simply unavailable to the caller.

This breaks the ordinary direct-to-S3 upload pattern, where the browser uploads through a presigned POST, reads `x-amz-version-id`, and reports it back to the application so the version can be recorded against the file.

`doHandlePresignedPost` already holds the `S3Object` returned by `putObject`; it just never read `getVersionId()`. The fix sets the header behind the same null guard the rest of `S3Controller` uses (`putObject`, `copyObject`, `completeMultipartUpload` and others all do this).

Closes #2607

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** on a versioned bucket, `POST Object` returned `204` with only `ETag` and `Location`. Real S3 also returns `x-amz-version-id` for the version the POST created.

Verified against `floci/floci:1.7.0` with boto3 1.43.0 / botocore 1.43.0, comparing three ways of writing the same object to the same versioned bucket. Only the POST path was affected, which is what pointed at the handler rather than at versioning or the HTTP layer:

```
[OK ] PutObject (SDK)          version reported: e49634c8-…   version created: e49634c8-…
[OK ] Presigned PUT (HTTP)     version reported: 1e8cb334-…   version created: 1e8cb334-…
[GAP] Presigned POST (HTTP)    version reported: (none)       version created: 2b82f46c-…
```

"version created" is taken by diffing `ListObjectVersions` either side of each write. The full reproduction script is in #2607.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

On the first box — I ran the S3 suite rather than the whole thing, since the full run wants Docker-backed services (Lambda, RDS, ElastiCache) that my environment could not provide, and failures there would have said more about my setup than about this change:

```
./mvnw test -Dtest='S3*Test'   →  990 tests, 0 failures, 0 errors
```

The new test, `S3PresignedPostIntegrationTest#presignedPostReturnsVersionIdOnAVersionedBucket`, was checked both ways: it fails on `main` without the change (`Expected: is not null`) and passes with it. It asserts the header is present and that it matches what a subsequent `HeadObject` reports, so it pins the value rather than just its existence.

## One thing I noticed nearby, not changed here

In the same method, the `String xml = new XmlBuilder()…` building a `PostResponse` document is never used — the status is hardcoded to `204` and the document discarded. On real S3 that document is the `201` body when the policy sets `success_action_status`, and I confirmed Floci currently returns `204` with no body in that case. I left it alone to keep this PR to one behaviour; happy to open a separate issue, or fold it in here if you would rather have both together.
