### PR TITLE
fix(iam): implement UpdateAccountPasswordPolicy, Get and Delete

### DIFF
--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -176,6 +176,27 @@ no effect on later starts — the skip is logged at debug with both values. `/_f
 clears the alias without re-seeding it, as it does the optional deployer principal; the seed
 returns on restart.
 
+### Account Password Policy
+
+| Action | Description |
+|--------|-------------|
+| GetAccountPasswordPolicy | Returns the account's password policy. |
+| UpdateAccountPasswordPolicy | Replaces the account's password policy wholesale. |
+| DeleteAccountPasswordPolicy | Removes the account's password policy. |
+
+An account holds one password policy. `UpdateAccountPasswordPolicy` replaces it wholesale rather
+than merging — a field the caller omits resets to its AWS-documented default (`false` for the
+boolean requirements and `AllowUsersToChangePassword`, `6` for `MinimumPasswordLength`, unset for
+the optional `MaxPasswordAge`, `PasswordReusePrevention` and `HardExpiry`) rather than carrying
+over the previous value. `ExpirePasswords` is derived, not stored: it reports `true` exactly when
+`MaxPasswordAge` is set.
+
+`GetAccountPasswordPolicy` and `DeleteAccountPasswordPolicy` both return `NoSuchEntity` when no
+policy has ever been set — a documented, expected result the Terraform provider's
+`aws_iam_account_password_policy` resource branches on. `MinimumPasswordLength` must be 6–128,
+`MaxPasswordAge` 1–1095, and `PasswordReusePrevention` 1–24; a value outside those ranges is
+rejected with `ValidationError`.
+
 ### OIDC Identity Providers
 
 | Action | Description |

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -195,7 +195,9 @@ over the previous value. `ExpirePasswords` is derived, not stored: it reports `t
 policy has ever been set — a documented, expected result the Terraform provider's
 `aws_iam_account_password_policy` resource branches on. `MinimumPasswordLength` must be 6–128,
 `MaxPasswordAge` 1–1095, and `PasswordReusePrevention` 1–24; a value outside those ranges is
-rejected with `ValidationError`.
+rejected with `ValidationError`. The boolean parameters accept only `true`/`false`
+(case-insensitive, matching the numeric fields); any other value is rejected with
+`ValidationError` rather than silently treated as `false`.
 
 ### OIDC Identity Providers
 

--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -186,18 +186,21 @@ returns on restart.
 
 An account holds one password policy. `UpdateAccountPasswordPolicy` replaces it wholesale rather
 than merging — a field the caller omits resets to its AWS-documented default (`false` for the
-boolean requirements and `AllowUsersToChangePassword`, `6` for `MinimumPasswordLength`, unset for
-the optional `MaxPasswordAge`, `PasswordReusePrevention` and `HardExpiry`) rather than carrying
-over the previous value. `ExpirePasswords` is derived, not stored: it reports `true` exactly when
-`MaxPasswordAge` is set.
+boolean requirements, `AllowUsersToChangePassword` and `HardExpiry`; `6` for
+`MinimumPasswordLength`; unset for the optional `MaxPasswordAge` and `PasswordReusePrevention`)
+rather than carrying over the previous value. Unlike the two optional integer fields,
+`HardExpiry` is never absent from the response — AWS documents it as a boolean that always
+defaults to `false`, so `GetAccountPasswordPolicy` always echoes it back. `ExpirePasswords` is
+derived, not stored: it reports `true` exactly when `MaxPasswordAge` is set.
 
 `GetAccountPasswordPolicy` and `DeleteAccountPasswordPolicy` both return `NoSuchEntity` when no
 policy has ever been set — a documented, expected result the Terraform provider's
 `aws_iam_account_password_policy` resource branches on. `MinimumPasswordLength` must be 6–128,
 `MaxPasswordAge` 1–1095, and `PasswordReusePrevention` 1–24; a value outside those ranges is
-rejected with `ValidationError`. The boolean parameters accept only `true`/`false`
-(case-insensitive, matching the numeric fields); any other value is rejected with
-`ValidationError` rather than silently treated as `false`.
+rejected with `ValidationError`. The integer parameters (`MinimumPasswordLength`, `MaxPasswordAge`,
+`PasswordReusePrevention`) and the boolean parameters both reject anything that isn't parseable —
+a malformed integer or a value other than `true`/`false` (case-insensitive) returns
+`ValidationError` rather than silently falling back to a default.
 
 ### OIDC Identity Providers
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.iam;
 
 import io.github.hectorvent.floci.core.common.*;
 import io.github.hectorvent.floci.services.iam.model.AccessKey;
+import io.github.hectorvent.floci.services.iam.model.AccountPasswordPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamGroup;
 import io.github.hectorvent.floci.services.iam.model.IamPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamRole;
@@ -82,6 +83,11 @@ public class IamQueryHandler {
             case "ListAccountAliases" -> handleListAccountAliases(params);
             case "CreateAccountAlias" -> handleCreateAccountAlias(params);
             case "DeleteAccountAlias" -> handleDeleteAccountAlias(params);
+
+            // Account Password Policy
+            case "GetAccountPasswordPolicy" -> handleGetAccountPasswordPolicy(params);
+            case "UpdateAccountPasswordPolicy" -> handleUpdateAccountPasswordPolicy(params);
+            case "DeleteAccountPasswordPolicy" -> handleDeleteAccountPasswordPolicy(params);
 
             // Groups
             case "CreateGroup" -> handleCreateGroup(params);
@@ -429,6 +435,85 @@ public class IamQueryHandler {
     private Response handleDeleteAccountAlias(MultivaluedMap<String, String> params) {
         iamService.deleteAccountAlias(getParam(params, "AccountAlias"));
         return Response.ok(AwsQueryResponse.envelopeNoResult("DeleteAccountAlias", AwsNamespaces.IAM)).build();
+    }
+
+    // =========================================================================
+    // Account Password Policy
+    // =========================================================================
+
+    // AWS raises NoSuchEntity (404) when the account has never had a policy set — a documented,
+    // expected result, the same shape GetLoginProfile answers when a user has no console password.
+    private Response handleGetAccountPasswordPolicy(MultivaluedMap<String, String> params) {
+        AccountPasswordPolicy policy = iamService.getAccountPasswordPolicy()
+                .orElse(null);
+        if (policy == null) {
+            return AwsQueryResponse.error("NoSuchEntity",
+                    "The account policy with name PasswordPolicy cannot be found.", AwsNamespaces.IAM, 404);
+        }
+        return Response.ok(AwsQueryResponse.envelope(
+                "GetAccountPasswordPolicy", AwsNamespaces.IAM, passwordPolicyXml(policy))).build();
+    }
+
+    private Response handleUpdateAccountPasswordPolicy(MultivaluedMap<String, String> params) {
+        AccountPasswordPolicy policy = new AccountPasswordPolicy();
+        policy.setMinimumPasswordLength(getIntParam(params, "MinimumPasswordLength", 6));
+        policy.setRequireSymbols("true".equalsIgnoreCase(getParam(params, "RequireSymbols")));
+        policy.setRequireNumbers("true".equalsIgnoreCase(getParam(params, "RequireNumbers")));
+        policy.setRequireUppercaseCharacters(
+                "true".equalsIgnoreCase(getParam(params, "RequireUppercaseCharacters")));
+        policy.setRequireLowercaseCharacters(
+                "true".equalsIgnoreCase(getParam(params, "RequireLowercaseCharacters")));
+        policy.setAllowUsersToChangePassword(
+                "true".equalsIgnoreCase(getParam(params, "AllowUsersToChangePassword")));
+        policy.setMaxPasswordAge(getOptionalIntParam(params, "MaxPasswordAge"));
+        policy.setPasswordReusePrevention(getOptionalIntParam(params, "PasswordReusePrevention"));
+        String hardExpiry = getParam(params, "HardExpiry");
+        if (hardExpiry != null) {
+            policy.setHardExpiry(Boolean.parseBoolean(hardExpiry));
+        }
+        iamService.updateAccountPasswordPolicy(policy);
+        return Response.ok(AwsQueryResponse.envelopeNoResult("UpdateAccountPasswordPolicy", AwsNamespaces.IAM))
+                .build();
+    }
+
+    private Response handleDeleteAccountPasswordPolicy(MultivaluedMap<String, String> params) {
+        iamService.deleteAccountPasswordPolicy();
+        return Response.ok(AwsQueryResponse.envelopeNoResult("DeleteAccountPasswordPolicy", AwsNamespaces.IAM))
+                .build();
+    }
+
+    private String passwordPolicyXml(AccountPasswordPolicy policy) {
+        var xml = new XmlBuilder().start("PasswordPolicy")
+                .elem("MinimumPasswordLength", policy.getMinimumPasswordLength())
+                .elem("RequireSymbols", policy.isRequireSymbols())
+                .elem("RequireNumbers", policy.isRequireNumbers())
+                .elem("RequireUppercaseCharacters", policy.isRequireUppercaseCharacters())
+                .elem("RequireLowercaseCharacters", policy.isRequireLowercaseCharacters())
+                .elem("AllowUsersToChangePassword", policy.isAllowUsersToChangePassword())
+                .elem("ExpirePasswords", policy.isExpirePasswords());
+        if (policy.getMaxPasswordAge() != null) {
+            xml.elem("MaxPasswordAge", policy.getMaxPasswordAge());
+        }
+        if (policy.getPasswordReusePrevention() != null) {
+            xml.elem("PasswordReusePrevention", policy.getPasswordReusePrevention());
+        }
+        if (policy.getHardExpiry() != null) {
+            xml.elem("HardExpiry", policy.getHardExpiry());
+        }
+        return xml.end("PasswordPolicy").build();
+    }
+
+    /** Unlike {@link #getIntParam}, absence is meaningful here — it must not collapse to a default. */
+    private Integer getOptionalIntParam(MultivaluedMap<String, String> params, String name) {
+        String value = params.getFirst(name);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new AwsException("ValidationError", "Invalid value for " + name + ": " + value, 400);
+        }
     }
 
     // =========================================================================

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -456,7 +456,7 @@ public class IamQueryHandler {
 
     private Response handleUpdateAccountPasswordPolicy(MultivaluedMap<String, String> params) {
         AccountPasswordPolicy policy = new AccountPasswordPolicy();
-        policy.setMinimumPasswordLength(getIntParam(params, "MinimumPasswordLength", 6));
+        policy.setMinimumPasswordLength(getStrictIntParam(params, "MinimumPasswordLength", 6));
         policy.setRequireSymbols(getBooleanParam(params, "RequireSymbols", false));
         policy.setRequireNumbers(getBooleanParam(params, "RequireNumbers", false));
         policy.setRequireUppercaseCharacters(getBooleanParam(params, "RequireUppercaseCharacters", false));
@@ -464,7 +464,7 @@ public class IamQueryHandler {
         policy.setAllowUsersToChangePassword(getBooleanParam(params, "AllowUsersToChangePassword", false));
         policy.setMaxPasswordAge(getOptionalIntParam(params, "MaxPasswordAge"));
         policy.setPasswordReusePrevention(getOptionalIntParam(params, "PasswordReusePrevention"));
-        policy.setHardExpiry(getOptionalBooleanParam(params, "HardExpiry"));
+        policy.setHardExpiry(getBooleanParam(params, "HardExpiry", false));
         iamService.updateAccountPasswordPolicy(policy);
         return Response.ok(AwsQueryResponse.envelopeNoResult("UpdateAccountPasswordPolicy", AwsNamespaces.IAM))
                 .build();
@@ -484,15 +484,13 @@ public class IamQueryHandler {
                 .elem("RequireUppercaseCharacters", policy.isRequireUppercaseCharacters())
                 .elem("RequireLowercaseCharacters", policy.isRequireLowercaseCharacters())
                 .elem("AllowUsersToChangePassword", policy.isAllowUsersToChangePassword())
-                .elem("ExpirePasswords", policy.isExpirePasswords());
+                .elem("ExpirePasswords", policy.isExpirePasswords())
+                .elem("HardExpiry", policy.isHardExpiry());
         if (policy.getMaxPasswordAge() != null) {
             xml.elem("MaxPasswordAge", policy.getMaxPasswordAge());
         }
         if (policy.getPasswordReusePrevention() != null) {
             xml.elem("PasswordReusePrevention", policy.getPasswordReusePrevention());
-        }
-        if (policy.getHardExpiry() != null) {
-            xml.elem("HardExpiry", policy.getHardExpiry());
         }
         return xml.end("PasswordPolicy").build();
     }
@@ -510,21 +508,27 @@ public class IamQueryHandler {
         }
     }
 
+    // Unlike getIntParam's silent fallback, an integer parameter that is present but not
+    // parseable is a caller mistake, not an absence — it must be rejected rather than coerced
+    // to the default.
+    private int getStrictIntParam(MultivaluedMap<String, String> params, String name, int defaultValue) {
+        String value = params.getFirst(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new AwsException("ValidationError", "Invalid value for " + name + ": " + value, 400);
+        }
+    }
+
     // Unlike getIntParam's silent fallback, a boolean parameter that is present but not "true"/
     // "false" is a caller mistake, not an absence — it must be rejected rather than coerced to false.
     private boolean getBooleanParam(MultivaluedMap<String, String> params, String name, boolean defaultValue) {
         String value = params.getFirst(name);
         if (value == null) {
             return defaultValue;
-        }
-        return parseStrictBoolean(name, value);
-    }
-
-    /** Unlike {@link #getBooleanParam}, absence is meaningful here — it must not collapse to a default. */
-    private Boolean getOptionalBooleanParam(MultivaluedMap<String, String> params, String name) {
-        String value = params.getFirst(name);
-        if (value == null) {
-            return null;
         }
         return parseStrictBoolean(name, value);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -457,20 +457,14 @@ public class IamQueryHandler {
     private Response handleUpdateAccountPasswordPolicy(MultivaluedMap<String, String> params) {
         AccountPasswordPolicy policy = new AccountPasswordPolicy();
         policy.setMinimumPasswordLength(getIntParam(params, "MinimumPasswordLength", 6));
-        policy.setRequireSymbols("true".equalsIgnoreCase(getParam(params, "RequireSymbols")));
-        policy.setRequireNumbers("true".equalsIgnoreCase(getParam(params, "RequireNumbers")));
-        policy.setRequireUppercaseCharacters(
-                "true".equalsIgnoreCase(getParam(params, "RequireUppercaseCharacters")));
-        policy.setRequireLowercaseCharacters(
-                "true".equalsIgnoreCase(getParam(params, "RequireLowercaseCharacters")));
-        policy.setAllowUsersToChangePassword(
-                "true".equalsIgnoreCase(getParam(params, "AllowUsersToChangePassword")));
+        policy.setRequireSymbols(getBooleanParam(params, "RequireSymbols", false));
+        policy.setRequireNumbers(getBooleanParam(params, "RequireNumbers", false));
+        policy.setRequireUppercaseCharacters(getBooleanParam(params, "RequireUppercaseCharacters", false));
+        policy.setRequireLowercaseCharacters(getBooleanParam(params, "RequireLowercaseCharacters", false));
+        policy.setAllowUsersToChangePassword(getBooleanParam(params, "AllowUsersToChangePassword", false));
         policy.setMaxPasswordAge(getOptionalIntParam(params, "MaxPasswordAge"));
         policy.setPasswordReusePrevention(getOptionalIntParam(params, "PasswordReusePrevention"));
-        String hardExpiry = getParam(params, "HardExpiry");
-        if (hardExpiry != null) {
-            policy.setHardExpiry(Boolean.parseBoolean(hardExpiry));
-        }
+        policy.setHardExpiry(getOptionalBooleanParam(params, "HardExpiry"));
         iamService.updateAccountPasswordPolicy(policy);
         return Response.ok(AwsQueryResponse.envelopeNoResult("UpdateAccountPasswordPolicy", AwsNamespaces.IAM))
                 .build();
@@ -514,6 +508,35 @@ public class IamQueryHandler {
         } catch (NumberFormatException e) {
             throw new AwsException("ValidationError", "Invalid value for " + name + ": " + value, 400);
         }
+    }
+
+    // Unlike getIntParam's silent fallback, a boolean parameter that is present but not "true"/
+    // "false" is a caller mistake, not an absence — it must be rejected rather than coerced to false.
+    private boolean getBooleanParam(MultivaluedMap<String, String> params, String name, boolean defaultValue) {
+        String value = params.getFirst(name);
+        if (value == null) {
+            return defaultValue;
+        }
+        return parseStrictBoolean(name, value);
+    }
+
+    /** Unlike {@link #getBooleanParam}, absence is meaningful here — it must not collapse to a default. */
+    private Boolean getOptionalBooleanParam(MultivaluedMap<String, String> params, String name) {
+        String value = params.getFirst(name);
+        if (value == null) {
+            return null;
+        }
+        return parseStrictBoolean(name, value);
+    }
+
+    private boolean parseStrictBoolean(String name, String value) {
+        if ("true".equalsIgnoreCase(value)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(value)) {
+            return false;
+        }
+        throw new AwsException("ValidationError", "Invalid value for " + name + ": " + value, 400);
     }
 
     // =========================================================================

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -13,6 +13,7 @@ import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.iam.model.AccessKey;
+import io.github.hectorvent.floci.services.iam.model.AccountPasswordPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamGroup;
 import io.github.hectorvent.floci.services.iam.model.IamPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamRole;
@@ -67,6 +68,14 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
     private static final int MAX_OIDC_CLIENT_IDS = 100;
     private static final int MAX_OIDC_THUMBPRINTS = 5;
     private static final int MAX_OIDC_URL_LENGTH = 255;
+    private static final String ACCOUNT_PASSWORD_POLICY_KEY = "account-password-policy";
+    /** AWS-documented bounds for the account password policy's numeric fields. */
+    private static final int MIN_PASSWORD_LENGTH_FLOOR = 6;
+    private static final int MIN_PASSWORD_LENGTH_CEILING = 128;
+    private static final int MAX_PASSWORD_AGE_FLOOR = 1;
+    private static final int MAX_PASSWORD_AGE_CEILING = 1095;
+    private static final int PASSWORD_REUSE_PREVENTION_FLOOR = 1;
+    private static final int PASSWORD_REUSE_PREVENTION_CEILING = 24;
 
     /** Guards the read-modify-write in the OIDC provider mutators. */
     private final Object oidcProviderLock = new Object();
@@ -99,6 +108,11 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
      * silently keeping only one. A single lock across accounts is enough: alias writes are rare.
      */
     private final Object accountAliasLock = new Object();
+    /**
+     * Holds at most one entry per account under {@link #ACCOUNT_PASSWORD_POLICY_KEY} — same
+     * single-value-per-account shape as {@link #accountAliases}.
+     */
+    private final StorageBackend<String, AccountPasswordPolicy> passwordPolicies;
     private final StorageBackend<String, OpenIDConnectProvider> oidcProviders;
     /** Deletion is synchronous, so an issued task id is a completed one; the value is its role. */
     private final StorageBackend<String, String> serviceLinkedRoleDeletions;
@@ -124,6 +138,7 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
             storageFactory.create("iam", "iam-instance-profiles.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-sessions.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-account-aliases.json", new TypeReference<>() {}),
+            storageFactory.create("iam", "iam-password-policy.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-oidc-providers.json", new TypeReference<>() {}),
             storageFactory.create("iam", "iam-slr-deletions.json", new TypeReference<>() {}),
             regionResolver,
@@ -153,7 +168,7 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
                RegionResolver regionResolver,
                boolean seedDeployerPrincipal) {
         this(users, groups, roles, policies, accessKeys, instanceProfiles, sessions,
-                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 regionResolver, seedDeployerPrincipal, null);
     }
 
@@ -165,6 +180,7 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
                StorageBackend<String, InstanceProfile> instanceProfiles,
                StorageBackend<String, SessionCredential> sessions,
                StorageBackend<String, String> accountAliases,
+               StorageBackend<String, AccountPasswordPolicy> passwordPolicies,
                StorageBackend<String, OpenIDConnectProvider> oidcProviders,
                StorageBackend<String, String> serviceLinkedRoleDeletions,
                RegionResolver regionResolver,
@@ -178,6 +194,7 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
         this.instanceProfiles = instanceProfiles;
         this.sessions = sessions;
         this.accountAliases = accountAliases;
+        this.passwordPolicies = passwordPolicies;
         this.oidcProviders = oidcProviders;
         this.serviceLinkedRoleDeletions = serviceLinkedRoleDeletions;
         this.regionResolver = regionResolver;
@@ -1366,6 +1383,63 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
                     "The specified value for accountAlias is invalid. It must be a minimum length of 3 "
                             + "characters and maximum length of 63 characters, contain only digits, lowercase "
                             + "letters, and hyphens (-), but cannot begin or end with a hyphen.", 400);
+        }
+    }
+
+    // =========================================================================
+    // Account Password Policy
+    // =========================================================================
+
+    public Optional<AccountPasswordPolicy> getAccountPasswordPolicy() {
+        return passwordPolicies.get(ACCOUNT_PASSWORD_POLICY_KEY);
+    }
+
+    /**
+     * Unlike the account alias, an account password policy is set wholesale — every call replaces
+     * the stored policy rather than merging into it, matching AWS: fields the caller omits reset to
+     * their documented defaults instead of carrying over the previous policy's value.
+     */
+    public AccountPasswordPolicy updateAccountPasswordPolicy(AccountPasswordPolicy policy) {
+        validateAccountPasswordPolicy(policy);
+        passwordPolicies.put(ACCOUNT_PASSWORD_POLICY_KEY, policy);
+        LOG.infov("Updated IAM account password policy");
+        return policy;
+    }
+
+    /**
+     * AWS raises NoSuchEntity when no custom policy has ever been set, rather than treating the
+     * delete as a no-op — DeleteAccountAlias's mismatch case is the same shape of "there is nothing
+     * here to remove."
+     */
+    public void deleteAccountPasswordPolicy() {
+        if (passwordPolicies.get(ACCOUNT_PASSWORD_POLICY_KEY).isEmpty()) {
+            throw new AwsException("NoSuchEntity",
+                    "The account policy with name PasswordPolicy cannot be found.", 404);
+        }
+        passwordPolicies.delete(ACCOUNT_PASSWORD_POLICY_KEY);
+        LOG.infov("Deleted IAM account password policy");
+    }
+
+    private void validateAccountPasswordPolicy(AccountPasswordPolicy policy) {
+        int minLength = policy.getMinimumPasswordLength();
+        if (minLength < MIN_PASSWORD_LENGTH_FLOOR || minLength > MIN_PASSWORD_LENGTH_CEILING) {
+            throw new AwsException("ValidationError",
+                    "MinimumPasswordLength must be between " + MIN_PASSWORD_LENGTH_FLOOR + " and "
+                            + MIN_PASSWORD_LENGTH_CEILING + ".", 400);
+        }
+        Integer maxAge = policy.getMaxPasswordAge();
+        if (maxAge != null && (maxAge < MAX_PASSWORD_AGE_FLOOR || maxAge > MAX_PASSWORD_AGE_CEILING)) {
+            throw new AwsException("ValidationError",
+                    "MaxPasswordAge must be between " + MAX_PASSWORD_AGE_FLOOR + " and "
+                            + MAX_PASSWORD_AGE_CEILING + ".", 400);
+        }
+        Integer reusePrevention = policy.getPasswordReusePrevention();
+        if (reusePrevention != null
+                && (reusePrevention < PASSWORD_REUSE_PREVENTION_FLOOR
+                        || reusePrevention > PASSWORD_REUSE_PREVENTION_CEILING)) {
+            throw new AwsException("ValidationError",
+                    "PasswordReusePrevention must be between " + PASSWORD_REUSE_PREVENTION_FLOOR + " and "
+                            + PASSWORD_REUSE_PREVENTION_CEILING + ".", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/model/AccountPasswordPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/model/AccountPasswordPolicy.java
@@ -5,9 +5,11 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * An account holds at most one password policy — this is the whole shape of it, not a
- * per-resource record. Unset optional fields ({@code maxPasswordAge}, {@code
- * passwordReusePrevention}, {@code hardExpiry}) are {@code null} rather than defaulted, matching
- * AWS: {@code GetAccountPasswordPolicy} omits the element entirely when the caller never set it.
+ * per-resource record. Unset optional integer fields ({@code maxPasswordAge}, {@code
+ * passwordReusePrevention}) are {@code null} rather than defaulted, matching AWS:
+ * {@code GetAccountPasswordPolicy} omits the element entirely when the caller never set it.
+ * {@code hardExpiry} is different — AWS documents it as a boolean that always defaults to
+ * {@code false}, so unlike the two integer fields it is never absent from the response.
  */
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -21,7 +23,7 @@ public class AccountPasswordPolicy {
     private boolean allowUsersToChangePassword;
     private Integer maxPasswordAge;
     private Integer passwordReusePrevention;
-    private Boolean hardExpiry;
+    private boolean hardExpiry;
 
     public AccountPasswordPolicy() {}
 
@@ -59,8 +61,8 @@ public class AccountPasswordPolicy {
         this.passwordReusePrevention = passwordReusePrevention;
     }
 
-    public Boolean getHardExpiry() { return hardExpiry; }
-    public void setHardExpiry(Boolean hardExpiry) { this.hardExpiry = hardExpiry; }
+    public boolean isHardExpiry() { return hardExpiry; }
+    public void setHardExpiry(boolean hardExpiry) { this.hardExpiry = hardExpiry; }
 
     /** AWS derives ExpirePasswords from whether a max age is set — it is never stored directly. */
     public boolean isExpirePasswords() { return maxPasswordAge != null; }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/model/AccountPasswordPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/model/AccountPasswordPolicy.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.iam.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * An account holds at most one password policy — this is the whole shape of it, not a
+ * per-resource record. Unset optional fields ({@code maxPasswordAge}, {@code
+ * passwordReusePrevention}, {@code hardExpiry}) are {@code null} rather than defaulted, matching
+ * AWS: {@code GetAccountPasswordPolicy} omits the element entirely when the caller never set it.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AccountPasswordPolicy {
+
+    private int minimumPasswordLength = 6;
+    private boolean requireSymbols;
+    private boolean requireNumbers;
+    private boolean requireUppercaseCharacters;
+    private boolean requireLowercaseCharacters;
+    private boolean allowUsersToChangePassword;
+    private Integer maxPasswordAge;
+    private Integer passwordReusePrevention;
+    private Boolean hardExpiry;
+
+    public AccountPasswordPolicy() {}
+
+    public int getMinimumPasswordLength() { return minimumPasswordLength; }
+    public void setMinimumPasswordLength(int minimumPasswordLength) {
+        this.minimumPasswordLength = minimumPasswordLength;
+    }
+
+    public boolean isRequireSymbols() { return requireSymbols; }
+    public void setRequireSymbols(boolean requireSymbols) { this.requireSymbols = requireSymbols; }
+
+    public boolean isRequireNumbers() { return requireNumbers; }
+    public void setRequireNumbers(boolean requireNumbers) { this.requireNumbers = requireNumbers; }
+
+    public boolean isRequireUppercaseCharacters() { return requireUppercaseCharacters; }
+    public void setRequireUppercaseCharacters(boolean requireUppercaseCharacters) {
+        this.requireUppercaseCharacters = requireUppercaseCharacters;
+    }
+
+    public boolean isRequireLowercaseCharacters() { return requireLowercaseCharacters; }
+    public void setRequireLowercaseCharacters(boolean requireLowercaseCharacters) {
+        this.requireLowercaseCharacters = requireLowercaseCharacters;
+    }
+
+    public boolean isAllowUsersToChangePassword() { return allowUsersToChangePassword; }
+    public void setAllowUsersToChangePassword(boolean allowUsersToChangePassword) {
+        this.allowUsersToChangePassword = allowUsersToChangePassword;
+    }
+
+    public Integer getMaxPasswordAge() { return maxPasswordAge; }
+    public void setMaxPasswordAge(Integer maxPasswordAge) { this.maxPasswordAge = maxPasswordAge; }
+
+    public Integer getPasswordReusePrevention() { return passwordReusePrevention; }
+    public void setPasswordReusePrevention(Integer passwordReusePrevention) {
+        this.passwordReusePrevention = passwordReusePrevention;
+    }
+
+    public Boolean getHardExpiry() { return hardExpiry; }
+    public void setHardExpiry(Boolean hardExpiry) { this.hardExpiry = hardExpiry; }
+
+    /** AWS derives ExpirePasswords from whether a max age is set — it is never stored directly. */
+    public boolean isExpirePasswords() { return maxPasswordAge != null; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamAccountPasswordPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamAccountPasswordPolicyIntegrationTest.java
@@ -180,6 +180,34 @@ class IamAccountPasswordPolicyIntegrationTest {
     }
 
     @Test
+    @Order(6)
+    void updateWithMalformedRequireSymbolsIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("RequireSymbols", "banana")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithMalformedHardExpiryIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("HardExpiry", "banana")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
     @Order(7)
     void deleteRemovesThePolicy() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamAccountPasswordPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamAccountPasswordPolicyIntegrationTest.java
@@ -1,0 +1,202 @@
+package io.github.hectorvent.floci.services.iam;
+
+import io.github.hectorvent.floci.core.common.AwsQueryController;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Integration tests for the IAM account password policy via the Query Protocol, covering the full
+ * HTTP stack through {@link AwsQueryController} → {@link IamQueryHandler}.
+ *
+ * <p>Ordered: the policy is a single per-account value, so these cases share state deliberately —
+ * missing before any update, get-after-update, wholesale replace, range rejection, delete.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class IamAccountPasswordPolicyIntegrationTest {
+
+    // The Query-protocol controller resolves the target service from the credential scope,
+    // so every IAM call carries one.
+    private static final String IAM_CREDENTIAL =
+            "AWS4-HMAC-SHA256 Credential=test/20260227/us-east-1/iam/aws4_request";
+
+    @Test
+    @Order(1)
+    void getBeforeAnyUpdateIsNoSuchEntity() {
+        given()
+            .formParam("Action", "GetAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body("ErrorResponse.Error.Code", equalTo("NoSuchEntity"));
+    }
+
+    @Test
+    @Order(2)
+    void deleteBeforeAnyUpdateIsNoSuchEntity() {
+        given()
+            .formParam("Action", "DeleteAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body("ErrorResponse.Error.Code", equalTo("NoSuchEntity"));
+    }
+
+    @Test
+    @Order(3)
+    void updateSetsThePolicy() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MinimumPasswordLength", "12")
+            .formParam("RequireSymbols", "true")
+            .formParam("RequireNumbers", "true")
+            .formParam("RequireUppercaseCharacters", "true")
+            .formParam("RequireLowercaseCharacters", "true")
+            .formParam("AllowUsersToChangePassword", "true")
+            .formParam("MaxPasswordAge", "90")
+            .formParam("PasswordReusePrevention", "5")
+            .formParam("HardExpiry", "true")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml");
+    }
+
+    @Test
+    @Order(4)
+    void getReturnsThePolicyJustSet() {
+        given()
+            .formParam("Action", "GetAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "MinimumPasswordLength", equalTo("12"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "RequireSymbols", equalTo("true"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "RequireNumbers", equalTo("true"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "RequireUppercaseCharacters", equalTo("true"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "RequireLowercaseCharacters", equalTo("true"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "AllowUsersToChangePassword", equalTo("true"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "ExpirePasswords", equalTo("true"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "MaxPasswordAge", equalTo("90"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "PasswordReusePrevention", equalTo("5"))
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "HardExpiry", equalTo("true"));
+    }
+
+    @Test
+    @Order(5)
+    void updateReplacesTheEntirePolicyRatherThanMerging() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MinimumPasswordLength", "8")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "GetAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "MinimumPasswordLength", equalTo("8"))
+            // RequireSymbols was true from the previous update; an omitted field resets rather
+            // than carries over.
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "RequireSymbols", equalTo("false"))
+            // MaxPasswordAge was set previously; omitted here it must not be echoed back at all.
+            .body(not(containsString("MaxPasswordAge")));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithMinimumLengthOutOfRangeIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MinimumPasswordLength", "129")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithMaxPasswordAgeOutOfRangeIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MaxPasswordAge", "1096")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithPasswordReusePreventionOutOfRangeIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("PasswordReusePrevention", "25")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(7)
+    void deleteRemovesThePolicy() {
+        given()
+            .formParam("Action", "DeleteAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "GetAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body("ErrorResponse.Error.Code", equalTo("NoSuchEntity"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamAccountPasswordPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamAccountPasswordPolicyIntegrationTest.java
@@ -134,7 +134,11 @@ class IamAccountPasswordPolicyIntegrationTest {
             .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
                     + "RequireSymbols", equalTo("false"))
             // MaxPasswordAge was set previously; omitted here it must not be echoed back at all.
-            .body(not(containsString("MaxPasswordAge")));
+            .body(not(containsString("MaxPasswordAge")))
+            // HardExpiry was true from the previous update; omitted here it must reset to its
+            // AWS-documented default of false, not be echoed back as true nor omitted entirely.
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "HardExpiry", equalTo("false"));
     }
 
     @Test
@@ -205,6 +209,77 @@ class IamAccountPasswordPolicyIntegrationTest {
         .then()
             .statusCode(400)
             .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithMalformedMinimumPasswordLengthIsRejected() {
+        // A non-numeric MinimumPasswordLength must be rejected outright, not silently coerced
+        // to the field's default (6) — that would let a caller's typo succeed with 200 while
+        // quietly ignoring the value they asked for.
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MinimumPasswordLength", "abc")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithMalformedMaxPasswordAgeIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MaxPasswordAge", "abc")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithMalformedPasswordReusePreventionIsRejected() {
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("PasswordReusePrevention", "abc")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("ErrorResponse.Error.Code", equalTo("ValidationError"));
+    }
+
+    @Test
+    @Order(6)
+    void updateWithHardExpiryOmittedDefaultsToFalseInResponse() {
+        // HardExpiry has no "optional/absent" state on the wire — AWS documents it as a boolean
+        // that always defaults to false, unlike MaxPasswordAge/PasswordReusePrevention which stay
+        // absent when unset.
+        given()
+            .formParam("Action", "UpdateAccountPasswordPolicy")
+            .formParam("MinimumPasswordLength", "10")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "GetAccountPasswordPolicy")
+            .header("Authorization", IAM_CREDENTIAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("GetAccountPasswordPolicyResponse.GetAccountPasswordPolicyResult.PasswordPolicy."
+                    + "HardExpiry", equalTo("false"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamManagedPolicyAccountScopeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamManagedPolicyAccountScopeTest.java
@@ -320,7 +320,7 @@ class IamManagedPolicyAccountScopeTest {
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
-                aliases, new InMemoryStorage<>(), new InMemoryStorage<>(),
+                aliases, new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 new RegionResolver("us-east-1", DEFAULT_ACCT), false, null);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServicePersistenceTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.PersistentStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.iam.model.AccessKey;
+import io.github.hectorvent.floci.services.iam.model.AccountPasswordPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamGroup;
 import io.github.hectorvent.floci.services.iam.model.IamPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamRole;
@@ -93,6 +94,7 @@ class IamServicePersistenceTest {
                 load(dir, "iam-instance-profiles.json", new TypeReference<Map<String, InstanceProfile>>() {}),
                 load(dir, "iam-sessions.json", new TypeReference<Map<String, SessionCredential>>() {}),
                 load(dir, "iam-account-aliases.json", new TypeReference<Map<String, String>>() {}),
+                load(dir, "iam-password-policy.json", new TypeReference<Map<String, AccountPasswordPolicy>>() {}),
                 load(dir, "iam-oidc-providers.json", new TypeReference<Map<String, OpenIDConnectProvider>>() {}),
                 load(dir, "iam-slr-deletions.json", new TypeReference<Map<String, String>>() {}),
                 new RegionResolver("us-east-1", "000000000000"),


### PR DESCRIPTION
## Summary

`UpdateAccountPasswordPolicy` returned `UnsupportedOperation`, which blocks Terraform's `aws_iam_account_password_policy` resource outright (observed across the Gruntwork `terraform-aws-security` account-baseline examples). This PR implements the account password policy trio — `UpdateAccountPasswordPolicy`, `GetAccountPasswordPolicy`, `DeleteAccountPasswordPolicy` — mirroring the existing account-alias pattern: one stored value per account, replaced wholesale on update (matching AWS semantics, where omitted fields reset to their defaults rather than merging), and `NoSuchEntity` from Get/Delete when no policy has ever been set.

Validation follows the documented AWS ranges: `MinimumPasswordLength` 6–128, `MaxPasswordAge` 1–1095, `PasswordReusePrevention` 1–24. `ExpirePasswords` in the Get response is derived from whether `MaxPasswordAge` is set, as in real IAM.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior: any call to `UpdateAccountPasswordPolicy` failed with `UnsupportedOperation`, so the resource could never be created, and `GetAccountPasswordPolicy` could never read one back.

Verified with the AWS CLI against a local build: `update-account-password-policy` succeeds, `get-account-password-policy` returns the stored policy with the documented response shape, `delete` then `get` correctly raises `NoSuchEntity`; the same sequence against an unpatched build still fails with `UnsupportedOperation`, confirming the check discriminates. Query-protocol XML element names follow the IAM 2010-05-08 service model.

## Checklist

- [x] `./mvnw test` passes locally (full suite: 12923 tests, 0 failures, 0 errors, 9 skipped)
- [x] New or updated integration test added (`IamAccountPasswordPolicyIntegrationTest`, 9 tests: round-trip, wholesale replace, range validation for all three bounded fields, NoSuchEntity on get/delete-before-set)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)