### PR TITLE
fix(rds): store and return the encryption and backup settings given on create

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -281,3 +281,64 @@ teardown() {
 
     aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
 }
+
+@test "rds: storage and backup settings given on create are returned by describe and modify" {
+    run aws_cmd kms create-key --description "$DB_ID"
+    assert_success
+    KEY_ARN=$(json_get "$output" '.KeyMetadata.Arn')
+    KEY_ID=$(json_get "$output" '.KeyMetadata.KeyId')
+    aws_cmd kms create-alias --alias-name "alias/$DB_ID" --target-key-id "$KEY_ID" >/dev/null
+
+    # the key is given as an alias and must come back as the key ARN, as on AWS
+    run aws_cmd rds create-db-instance \
+        --db-instance-identifier "$DB_ID" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10 \
+        --storage-encrypted --kms-key-id "alias/$DB_ID" \
+        --backup-retention-period 7 --copy-tags-to-snapshot \
+        --preferred-backup-window 23:30-00:00 --preferred-maintenance-window Sun:03:08-Sun:03:38
+    assert_success
+
+    run aws_cmd rds describe-db-instances --db-instance-identifier "$DB_ID" \
+        --query 'DBInstances[0].[StorageEncrypted,KmsKeyId,BackupRetentionPeriod,PreferredBackupWindow,CopyTagsToSnapshot,PreferredMaintenanceWindow]'
+    assert_success
+    assert_output --partial 'true'
+    assert_output --partial "$KEY_ARN"
+    assert_output --partial '7'
+    assert_output --partial '"23:30-00:00"'
+    assert_output --partial '"sun:03:08-sun:03:38"'
+
+    run aws_cmd rds modify-db-instance --db-instance-identifier "$DB_ID" \
+        --backup-retention-period 3 --preferred-backup-window 01:00-01:30 --apply-immediately
+    assert_success
+
+    run aws_cmd rds describe-db-instances --db-instance-identifier "$DB_ID" \
+        --query 'DBInstances[0].[BackupRetentionPeriod,PreferredBackupWindow,CopyTagsToSnapshot]'
+    assert_success
+    assert_output --partial '3'
+    assert_output --partial '"01:00-01:30"'
+    assert_output --partial 'true'
+}
+
+@test "rds: a KmsKeyId that names no key is refused as on AWS" {
+    run aws_cmd rds create-db-instance \
+        --db-instance-identifier "$DB_ID" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10 \
+        --storage-encrypted --kms-key-id "alias/does-not-exist-$DB_ID"
+    assert_failure
+    assert_output --partial 'KMSKeyNotAccessibleFault'
+}
+
+@test "rds: KmsKeyId without StorageEncrypted is refused as on AWS" {
+    run aws_cmd rds create-db-instance \
+        --db-instance-identifier "$DB_ID" \
+        --engine postgres \
+        --db-instance-class db.t3.micro \
+        --allocated-storage 10 \
+        --no-storage-encrypted --kms-key-id "arn:aws:kms:us-east-1:000000000000:key/00000000-0000-0000-0000-000000000000"
+    assert_failure
+    assert_output --partial 'InvalidParameterCombination'
+}

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -66,7 +66,9 @@ windows are at least 30 minutes and may not overlap). `KmsKeyId` is accepted as 
 key id, alias ARN or alias name, resolved against the KMS store in the request's region and
 returned as the key ARN; a key that does not exist or is not enabled is
 `KMSKeyNotAccessibleFault`. Where AWS picks a random window,
-Floci uses `04:00-06:00` and `mon:00:00-mon:03:00`; modifications apply immediately —
+Floci uses `04:00-06:00` and `mon:00:00-mon:03:00` (or `06:30-07:00` / `sun:06:30-sun:07:00`
+when the window given on create overlaps the usual default); a window given on modify is
+checked against the instance's other window. Modifications apply immediately —
 `PendingModifiedValues` is not modeled.
 
 ## Configuration

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -66,8 +66,8 @@ windows are at least 30 minutes and may not overlap). `KmsKeyId` is accepted as 
 key id, alias ARN or alias name, resolved against the KMS store in the request's region and
 returned as the key ARN; a key that does not exist or is not enabled is
 `KMSKeyNotAccessibleFault`. Where AWS picks a random window,
-Floci uses `04:00-06:00` and `mon:00:00-mon:03:00` (or `06:30-07:00` / `sun:06:30-sun:07:00`
-when the window given on create overlaps the usual default); a window given on modify is
+Floci uses `04:00-06:00` and `mon:00:00-mon:03:00` (or, when the window given on create overlaps the
+usual default, a 30-minute window starting where the given one ends); a window given on modify is
 checked against the instance's other window. Modifications apply immediately —
 `PendingModifiedValues` is not modeled.
 

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -58,6 +58,17 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `RemoveTagsFromResource` | Remove tags from a DB resource |
 <!-- floci:actions:end -->
 
+`CreateDBInstance` stores `StorageEncrypted`, `KmsKeyId`, `BackupRetentionPeriod`,
+`PreferredBackupWindow`, `PreferredMaintenanceWindow` and `CopyTagsToSnapshot`, and
+`DescribeDBInstances` returns them; `ModifyDBInstance` changes the backup settings and
+the windows. The same checks as on AWS apply (`KmsKeyId` needs `StorageEncrypted`,
+windows are at least 30 minutes and may not overlap). `KmsKeyId` is accepted as a key ARN,
+key id, alias ARN or alias name, resolved against the KMS store in the request's region and
+returned as the key ARN; a key that does not exist or is not enabled is
+`KMSKeyNotAccessibleFault`. Where AWS picks a random window,
+Floci uses `04:00-06:00` and `mon:00:00-mon:03:00`; modifications apply immediately —
+`PendingModifiedValues` is not modeled.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -1274,9 +1274,6 @@ public class RdsQueryHandler {
         return new XmlBuilder().start("DBInstance").raw(dbInstanceInnerXml(i)).end("DBInstance").build();
     }
 
-    private static final String DEFAULT_MAINTENANCE_WINDOW = "mon:00:00-mon:03:00";
-    private static final String DEFAULT_BACKUP_WINDOW = "04:00-06:00";
-
     private String dbInstanceInnerXml(DbInstance i) {
         DbEndpoint ep = i.getEndpoint();
         String engineStr = instanceEngine(i);
@@ -1306,9 +1303,9 @@ public class RdsQueryHandler {
            .elem("PubliclyAccessible", false)
            .elem("AvailabilityZone", i.getAvailabilityZone() != null ? i.getAvailabilityZone() : config.defaultAvailabilityZone())
            .elem("PreferredMaintenanceWindow", i.getPreferredMaintenanceWindow() != null
-                   ? i.getPreferredMaintenanceWindow() : DEFAULT_MAINTENANCE_WINDOW)
+                   ? i.getPreferredMaintenanceWindow() : DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW)
            .elem("PreferredBackupWindow", i.getPreferredBackupWindow() != null
-                   ? i.getPreferredBackupWindow() : DEFAULT_BACKUP_WINDOW)
+                   ? i.getPreferredBackupWindow() : DbInstanceSettings.DEFAULT_BACKUP_WINDOW)
            .elem("BackupRetentionPeriod", i.getBackupRetentionPeriod())
            .elem("StorageEncrypted", i.isStorageEncrypted())
            .elem("CopyTagsToSnapshot", i.isCopyTagsToSnapshot())

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.docdb.DocDbQueryHandler;
 import io.github.hectorvent.floci.services.neptune.NeptuneQueryHandler;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbInstanceSettings;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbProxy;
@@ -156,12 +157,13 @@ public class RdsQueryHandler {
         }
 
         try {
+            DbInstanceSettings settings = instanceSettings(params);
             List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
             DbInstance instance = service.createDbInstance(id, engine, engineVersion, masterUsername,
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
                     paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
                     manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
-                    optionGroupName, region, autoMinorVersionUpgrade);
+                    optionGroupName, region, autoMinorVersionUpgrade, settings);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -250,14 +252,50 @@ public class RdsQueryHandler {
         Boolean autoMinorVersionUpgrade = autoMinorVersionUpgradeStr != null
                 ? Boolean.parseBoolean(autoMinorVersionUpgradeStr) : null;
         try {
+            DbInstanceSettings settings = instanceSettings(params, false);
             List<String> vpcSecurityGroupIds = vpcSecurityGroupIds(params);
             DbInstance instance = service.modifyDbInstance(
                     id, newPassword, iamEnabled, dbSubnetGroupName,
-                    vpcSecurityGroupIds, optionGroupName, region, autoMinorVersionUpgrade);
+                    vpcSecurityGroupIds, optionGroupName, region, autoMinorVersionUpgrade, settings);
             String result = dbInstanceXml(instance);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
+        }
+    }
+
+    private static DbInstanceSettings instanceSettings(MultivaluedMap<String, String> params) {
+        return instanceSettings(params, true);
+    }
+
+    /**
+     * ModifyDBInstance has no StorageEncrypted or KmsKeyId in its request shape — encryption is
+     * fixed at create — so a modify reads only the backup settings and the windows.
+     */
+    private static DbInstanceSettings instanceSettings(MultivaluedMap<String, String> params,
+                                                       boolean includeEncryption) {
+        return new DbInstanceSettings(
+                includeEncryption ? optionalBoolean(params.getFirst("StorageEncrypted")) : null,
+                includeEncryption ? params.getFirst("KmsKeyId") : null,
+                optionalInt(params.getFirst("BackupRetentionPeriod")),
+                params.getFirst("PreferredBackupWindow"),
+                params.getFirst("PreferredMaintenanceWindow"),
+                optionalBoolean(params.getFirst("CopyTagsToSnapshot")));
+    }
+
+    private static Boolean optionalBoolean(String value) {
+        return value == null ? null : Boolean.parseBoolean(value);
+    }
+
+    private static Integer optionalInt(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value " + value + " is not a valid integer.", 400);
         }
     }
 
@@ -1236,6 +1274,9 @@ public class RdsQueryHandler {
         return new XmlBuilder().start("DBInstance").raw(dbInstanceInnerXml(i)).end("DBInstance").build();
     }
 
+    private static final String DEFAULT_MAINTENANCE_WINDOW = "mon:00:00-mon:03:00";
+    private static final String DEFAULT_BACKUP_WINDOW = "04:00-06:00";
+
     private String dbInstanceInnerXml(DbInstance i) {
         DbEndpoint ep = i.getEndpoint();
         String engineStr = instanceEngine(i);
@@ -1264,14 +1305,22 @@ public class RdsQueryHandler {
            .elem("StorageType", "gp2")
            .elem("PubliclyAccessible", false)
            .elem("AvailabilityZone", i.getAvailabilityZone() != null ? i.getAvailabilityZone() : config.defaultAvailabilityZone())
-           .elem("PreferredMaintenanceWindow", "mon:00:00-mon:03:00")
-           .elem("PreferredBackupWindow", "04:00-06:00")
+           .elem("PreferredMaintenanceWindow", i.getPreferredMaintenanceWindow() != null
+                   ? i.getPreferredMaintenanceWindow() : DEFAULT_MAINTENANCE_WINDOW)
+           .elem("PreferredBackupWindow", i.getPreferredBackupWindow() != null
+                   ? i.getPreferredBackupWindow() : DEFAULT_BACKUP_WINDOW)
+           .elem("BackupRetentionPeriod", i.getBackupRetentionPeriod())
+           .elem("StorageEncrypted", i.isStorageEncrypted())
+           .elem("CopyTagsToSnapshot", i.isCopyTagsToSnapshot())
            .raw(vpcSecurityGroupsXml(i))
            .raw(dbParameterGroupsXml(i))
            .raw(optionGroupMembershipsXml(i))
            .raw(dbSubnetGroupXml(dbSubnetGroupForInstance(i)))
            .elem("DbiResourceId", i.getDbiResourceId())
            .elem("DBInstanceArn", i.getDbInstanceArn());
+        if (i.getKmsKeyId() != null && !i.getKmsKeyId().isBlank()) {
+            xml.elem("KmsKeyId", i.getKmsKeyId());
+        }
         if (i.getMasterUserSecretArn() != null && !i.getMasterUserSecretArn().isBlank()) {
             xml.start("MasterUserSecret")
                     .elem("SecretArn", i.getMasterUserSecretArn())

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -26,6 +26,9 @@ import io.github.hectorvent.floci.services.rds.model.DbCluster;
 import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.kms.KmsService;
+import io.github.hectorvent.floci.services.kms.model.KmsKey;
+import io.github.hectorvent.floci.services.rds.model.DbInstanceSettings;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbProxy;
@@ -146,6 +149,7 @@ public class RdsService implements Resettable, ResourceProvider {
     private final RegionResolver regionResolver;
     private final EmulatorConfig config;
     private final SecretsManagerService secretsManagerService;
+    private final KmsService kmsService;
     private final DockerHostResolver dockerHostResolver;
     private final CurrentContainerNetworkResolver currentContainerNetworkResolver;
     private final ResourceGroupsTaggingService taggingService;
@@ -181,13 +185,15 @@ public class RdsService implements Resettable, ResourceProvider {
                       SecretsManagerService secretsManagerService,
                       DockerHostResolver dockerHostResolver,
                       CurrentContainerNetworkResolver currentContainerNetworkResolver,
-                      ResourceGroupsTaggingService taggingService) {
+                      ResourceGroupsTaggingService taggingService,
+                      KmsService kmsService) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.ec2Service = ec2Service;
         this.regionResolver = regionResolver;
         this.config = config;
         this.secretsManagerService = secretsManagerService;
+        this.kmsService = kmsService;
         this.dockerHostResolver = dockerHostResolver;
         this.currentContainerNetworkResolver = currentContainerNetworkResolver;
         this.taggingService = taggingService;
@@ -299,7 +305,7 @@ public class RdsService implements Resettable, ResourceProvider {
         this(containerManager, proxyManager, ec2Service, regionResolver, config,
                 instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups,
                 secretsManagerService, dockerHostResolver, currentContainerNetworkResolver,
-                proxies, proxyTargetGroups, new InMemoryStorage<>(), null);
+                proxies, proxyTargetGroups, new InMemoryStorage<>(), null, null);
     }
 
     RdsService(RdsContainerManager containerManager,
@@ -318,13 +324,15 @@ public class RdsService implements Resettable, ResourceProvider {
                StorageBackend<String, DbProxy> proxies,
                StorageBackend<String, DbProxyTargetGroup> proxyTargetGroups,
                StorageBackend<String, OptionGroup> optionGroups,
-               ResourceGroupsTaggingService taggingService) {
+               ResourceGroupsTaggingService taggingService,
+               KmsService kmsService) {
         this.containerManager = containerManager;
         this.proxyManager = proxyManager;
         this.ec2Service = ec2Service;
         this.regionResolver = regionResolver;
         this.config = config;
         this.secretsManagerService = secretsManagerService;
+        this.kmsService = kmsService;
         this.dockerHostResolver = dockerHostResolver;
         this.currentContainerNetworkResolver = currentContainerNetworkResolver;
         this.instances = instances;
@@ -483,6 +491,28 @@ public class RdsService implements Resettable, ResourceProvider {
                                        String optionGroupName,
                                        String region,
                                        boolean autoMinorVersionUpgrade) {
+        return createDbInstance(id, engineParam, engineVersion, masterUsername, masterPassword,
+                dbName, dbInstanceClass, allocatedStorage, iamEnabled, paramGroupName,
+                dbSubnetGroupName, dbClusterIdentifier, availabilityZone, multiAz,
+                manageMasterUserPassword, masterUserSecretKmsKeyId, tags, vpcSecurityGroupIds,
+                optionGroupName, region, autoMinorVersionUpgrade, DbInstanceSettings.defaults());
+    }
+
+    public DbInstance createDbInstance(String id, String engineParam, String engineVersion,
+                                       String masterUsername, String masterPassword,
+                                       String dbName, String dbInstanceClass,
+                                       int allocatedStorage, boolean iamEnabled,
+                                       String paramGroupName, String dbSubnetGroupName,
+                                       String dbClusterIdentifier, String availabilityZone,
+                                       boolean multiAz, boolean manageMasterUserPassword,
+                                       String masterUserSecretKmsKeyId,
+                                       Map<String, String> tags,
+                                       List<String> vpcSecurityGroupIds,
+                                       String optionGroupName,
+                                       String region,
+                                       boolean autoMinorVersionUpgrade,
+                                       DbInstanceSettings settings) {
+        validateInstanceSettings(settings);
         String provisioningKey = "instance:" + currentAccountId() + ":"
                 + dbResourceKey(effectiveRegion(region), id);
         if (!provisioningIds.add(provisioningKey)) {
@@ -494,7 +524,8 @@ public class RdsService implements Resettable, ResourceProvider {
                     masterPassword, dbName, dbInstanceClass, allocatedStorage, iamEnabled,
                     paramGroupName, dbSubnetGroupName, dbClusterIdentifier, availabilityZone,
                     multiAz, manageMasterUserPassword, masterUserSecretKmsKeyId, tags,
-                    vpcSecurityGroupIds, optionGroupName, region, autoMinorVersionUpgrade);
+                    vpcSecurityGroupIds, optionGroupName, region, autoMinorVersionUpgrade,
+                    settings);
         } finally {
             provisioningIds.remove(provisioningKey);
         }
@@ -512,7 +543,8 @@ public class RdsService implements Resettable, ResourceProvider {
                                           List<String> vpcSecurityGroupIds,
                                           String optionGroupName,
                                           String region,
-                                          boolean autoMinorVersionUpgrade) {
+                                          boolean autoMinorVersionUpgrade,
+                                          DbInstanceSettings settings) {
         String effectiveRegion = effectiveRegion(region);
         String dbiResourceId = "db-" + java.util.UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase();
@@ -530,6 +562,9 @@ public class RdsService implements Resettable, ResourceProvider {
         validateInstanceParameterGroup(
                 paramGroupName, engineParam, engineVersion, effectiveRegion);
         validateInstanceOptionGroup(optionGroupName, engineParam, engineVersion, effectiveRegion);
+        // resolved with the other validations, before a port is taken or a container started
+        DbInstanceSettings resolvedSettings =
+                settings.withKmsKeyId(resolveKmsKeyArn(settings.kmsKeyId(), effectiveRegion));
         boolean mock = config.services().rds().mock();
         // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
         // is consistent; mock mode only skips starting the container and auth proxy.
@@ -620,6 +655,7 @@ public class RdsService implements Resettable, ResourceProvider {
         instance.setSubnetAvailabilityZones(placement.subnetAvailabilityZones());
         instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
         instance.setEngineIdentifier(engineIdentifier);
+        resolvedSettings.applyTo(instance);
 
         instance.setDbiResourceId(dbiResourceId);
         instance.setDbInstanceArn(dbInstanceArn);
@@ -1018,6 +1054,19 @@ public class RdsService implements Resettable, ResourceProvider {
             String id, String newPassword, Boolean iamEnabled,
             String dbSubnetGroupName, List<String> vpcSecurityGroupIds,
             String optionGroupName, String region, Boolean autoMinorVersionUpgrade) {
+        return modifyDbInstance(id, newPassword, iamEnabled, dbSubnetGroupName,
+                vpcSecurityGroupIds, optionGroupName, region, autoMinorVersionUpgrade,
+                DbInstanceSettings.unchanged());
+    }
+
+    // synchronized like the tag and delete paths: an unguarded read-modify-write here could
+    // write an instance back after deleteDbInstance removed it
+    public synchronized DbInstance modifyDbInstance(
+            String id, String newPassword, Boolean iamEnabled,
+            String dbSubnetGroupName, List<String> vpcSecurityGroupIds,
+            String optionGroupName, String region, Boolean autoMinorVersionUpgrade,
+            DbInstanceSettings settings) {
+        validateInstanceSettings(settings);
         String effectiveRegion = effectiveRegion(region);
         DbInstance instance = getDbInstance(id, effectiveRegion);
         instance.setStatus(DbInstanceStatus.AVAILABLE);
@@ -1043,9 +1092,43 @@ public class RdsService implements Resettable, ResourceProvider {
         if (autoMinorVersionUpgrade != null) {
             instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
         }
+        settings.applyTo(instance);
         putInstanceForScope(currentAccountId(), effectiveRegion, id, instance);
         LOG.infov("DB instance {0} modified", id);
         return instance;
+    }
+
+    private static void validateInstanceSettings(DbInstanceSettings settings) {
+        settings.validate();
+    }
+
+    /**
+     * A live account takes the key as an ARN, a key id, an alias ARN or an alias name and reports
+     * the key ARN on the instance; a key it cannot use is one fault whatever the reason.
+     */
+    private String resolveKmsKeyArn(String kmsKeyId, String region) {
+        if (kmsKeyId == null || kmsKeyId.isBlank()) {
+            return null;
+        }
+        if (kmsService == null) {
+            throw new IllegalStateException("RdsService was built without a KmsService; "
+                    + "a KmsKeyId cannot be resolved");
+        }
+        KmsKey key;
+        try {
+            key = kmsService.describeKey(kmsKeyId, region);
+        } catch (AwsException e) {
+            throw kmsKeyNotAccessible(kmsKeyId);
+        }
+        if (!key.isEnabled() || "PendingDeletion".equals(key.getKeyState())) {
+            throw kmsKeyNotAccessible(kmsKeyId);
+        }
+        return key.getArn();
+    }
+
+    private static AwsException kmsKeyNotAccessible(String kmsKeyId) {
+        return new AwsException("KMSKeyNotAccessibleFault", "The specified KMS key [" + kmsKeyId
+                + "] does not exist, is not enabled or you do not have permissions to access it.", 400);
     }
 
     public List<Map<String, String>> describeOrderableDbInstanceOptions(String engine,

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1128,6 +1128,15 @@ public class RdsService implements Resettable, ResourceProvider {
                         ? DbInstanceSettings.maintenanceWindowAfter(backup)
                         : DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW;
             }
+            // a derived window is clear unless the given one leaves no 30-minute gap at all
+            if (DbInstanceSettings.windowsOverlap(backup, maintenance)) {
+                if (!maintenanceGiven) {
+                    throw DbInstanceSettings.noRoomForMaintenanceWindow();
+                }
+                if (!backupGiven) {
+                    throw DbInstanceSettings.noRoomForBackupWindow();
+                }
+            }
         } else {
             if (!backupGiven) {
                 backup = current.getPreferredBackupWindow() != null

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -563,8 +563,8 @@ public class RdsService implements Resettable, ResourceProvider {
                 paramGroupName, engineParam, engineVersion, effectiveRegion);
         validateInstanceOptionGroup(optionGroupName, engineParam, engineVersion, effectiveRegion);
         // resolved with the other validations, before a port is taken or a container started
-        DbInstanceSettings resolvedSettings =
-                settings.withKmsKeyId(resolveKmsKeyArn(settings.kmsKeyId(), effectiveRegion));
+        DbInstanceSettings resolvedSettings = withEffectiveWindows(settings, null)
+                .withKmsKeyId(resolveKmsKeyArn(settings.kmsKeyId(), effectiveRegion));
         boolean mock = config.services().rds().mock();
         // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
         // is consistent; mock mode only skips starting the container and auth proxy.
@@ -1069,6 +1069,7 @@ public class RdsService implements Resettable, ResourceProvider {
         validateInstanceSettings(settings);
         String effectiveRegion = effectiveRegion(region);
         DbInstance instance = getDbInstance(id, effectiveRegion);
+        DbInstanceSettings effective = withEffectiveWindows(settings, instance);
         instance.setStatus(DbInstanceStatus.AVAILABLE);
         if (optionGroupName != null && !optionGroupName.isBlank()) {
             validateInstanceOptionGroup(optionGroupName,
@@ -1092,7 +1093,7 @@ public class RdsService implements Resettable, ResourceProvider {
         if (autoMinorVersionUpgrade != null) {
             instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
         }
-        settings.applyTo(instance);
+        effective.applyTo(instance);
         putInstanceForScope(currentAccountId(), effectiveRegion, id, instance);
         LOG.infov("DB instance {0} modified", id);
         return instance;
@@ -1100,6 +1101,47 @@ public class RdsService implements Resettable, ResourceProvider {
 
     private static void validateInstanceSettings(DbInstanceSettings settings) {
         settings.validate();
+    }
+
+    /**
+     * The windows that will be in effect after the request, checked against each other the way a
+     * live account checks them. On create ({@code current} null) a window given alone is paired
+     * with a default, and with the alternate default when it would overlap the usual one — AWS
+     * picks a random window clear of the given one. On modify the counterpart is the instance's.
+     */
+    private static DbInstanceSettings withEffectiveWindows(DbInstanceSettings settings, DbInstance current) {
+        String backup = settings.preferredBackupWindow();
+        String maintenance = settings.preferredMaintenanceWindow();
+        boolean backupGiven = backup != null;
+        boolean maintenanceGiven = maintenance != null;
+        if (current == null) {
+            if (!backupGiven) {
+                backup = maintenanceGiven && DbInstanceSettings.windowsOverlap(
+                        DbInstanceSettings.DEFAULT_BACKUP_WINDOW, maintenance)
+                        ? DbInstanceSettings.ALTERNATE_BACKUP_WINDOW
+                        : DbInstanceSettings.DEFAULT_BACKUP_WINDOW;
+            }
+            if (!maintenanceGiven) {
+                maintenance = backupGiven && DbInstanceSettings.windowsOverlap(
+                        backup, DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW)
+                        ? DbInstanceSettings.ALTERNATE_MAINTENANCE_WINDOW
+                        : DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW;
+            }
+        } else {
+            if (!backupGiven) {
+                backup = current.getPreferredBackupWindow() != null
+                        ? current.getPreferredBackupWindow() : DbInstanceSettings.DEFAULT_BACKUP_WINDOW;
+            }
+            if (!maintenanceGiven) {
+                maintenance = current.getPreferredMaintenanceWindow() != null
+                        ? current.getPreferredMaintenanceWindow() : DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW;
+            }
+        }
+        if (DbInstanceSettings.windowsOverlap(backup, maintenance)) {
+            throw DbInstanceSettings.overlappingWindows();
+        }
+        return new DbInstanceSettings(settings.storageEncrypted(), settings.kmsKeyId(),
+                settings.backupRetentionPeriod(), backup, maintenance, settings.copyTagsToSnapshot());
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1106,8 +1106,9 @@ public class RdsService implements Resettable, ResourceProvider {
     /**
      * The windows that will be in effect after the request, checked against each other the way a
      * live account checks them. On create ({@code current} null) a window given alone is paired
-     * with a default, and with the alternate default when it would overlap the usual one — AWS
-     * picks a random window clear of the given one. On modify the counterpart is the instance's.
+     * with the default, or with a window starting where the given one ends when the default would
+     * overlap it — AWS picks a random window clear of the given one. On modify the counterpart is
+     * the instance's.
      */
     private static DbInstanceSettings withEffectiveWindows(DbInstanceSettings settings, DbInstance current) {
         String backup = settings.preferredBackupWindow();
@@ -1118,13 +1119,13 @@ public class RdsService implements Resettable, ResourceProvider {
             if (!backupGiven) {
                 backup = maintenanceGiven && DbInstanceSettings.windowsOverlap(
                         DbInstanceSettings.DEFAULT_BACKUP_WINDOW, maintenance)
-                        ? DbInstanceSettings.ALTERNATE_BACKUP_WINDOW
+                        ? DbInstanceSettings.backupWindowAfter(maintenance)
                         : DbInstanceSettings.DEFAULT_BACKUP_WINDOW;
             }
             if (!maintenanceGiven) {
                 maintenance = backupGiven && DbInstanceSettings.windowsOverlap(
                         backup, DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW)
-                        ? DbInstanceSettings.ALTERNATE_MAINTENANCE_WINDOW
+                        ? DbInstanceSettings.maintenanceWindowAfter(backup)
                         : DbInstanceSettings.DEFAULT_MAINTENANCE_WINDOW;
             }
         } else {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -36,6 +36,14 @@ public class DbInstance {
     // AWS defaults this to true when CreateDBInstance omits it (minor engine upgrades are
     // applied automatically unless explicitly opted out).
     private boolean autoMinorVersionUpgrade = true;
+    private boolean storageEncrypted;
+    private String kmsKeyId;
+    // AWS defaults to one day of automated backups when CreateDBInstance omits it; a record
+    // persisted before the field existed reads the same way.
+    private int backupRetentionPeriod = 1;
+    private String preferredBackupWindow;
+    private String preferredMaintenanceWindow;
+    private boolean copyTagsToSnapshot;
     private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
     private String dbiResourceId;
     private String dbInstanceArn;
@@ -166,6 +174,24 @@ public class DbInstance {
 
     public String getMasterUserSecretStatus() { return masterUserSecretStatus; }
     public void setMasterUserSecretStatus(String masterUserSecretStatus) { this.masterUserSecretStatus = masterUserSecretStatus; }
+
+    public boolean isStorageEncrypted() { return storageEncrypted; }
+    public void setStorageEncrypted(boolean storageEncrypted) { this.storageEncrypted = storageEncrypted; }
+
+    public String getKmsKeyId() { return kmsKeyId; }
+    public void setKmsKeyId(String kmsKeyId) { this.kmsKeyId = kmsKeyId; }
+
+    public int getBackupRetentionPeriod() { return backupRetentionPeriod; }
+    public void setBackupRetentionPeriod(int backupRetentionPeriod) { this.backupRetentionPeriod = backupRetentionPeriod; }
+
+    public String getPreferredBackupWindow() { return preferredBackupWindow; }
+    public void setPreferredBackupWindow(String preferredBackupWindow) { this.preferredBackupWindow = preferredBackupWindow; }
+
+    public String getPreferredMaintenanceWindow() { return preferredMaintenanceWindow; }
+    public void setPreferredMaintenanceWindow(String preferredMaintenanceWindow) { this.preferredMaintenanceWindow = preferredMaintenanceWindow; }
+
+    public boolean isCopyTagsToSnapshot() { return copyTagsToSnapshot; }
+    public void setCopyTagsToSnapshot(boolean copyTagsToSnapshot) { this.copyTagsToSnapshot = copyTagsToSnapshot; }
 
     public String getMasterUserSecretKmsKeyId() { return masterUserSecretKmsKeyId; }
     public void setMasterUserSecretKmsKeyId(String masterUserSecretKmsKeyId) { this.masterUserSecretKmsKeyId = masterUserSecretKmsKeyId; }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.rds.model;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The storage and backup settings of a DB instance as a request carries them: a null member is
+ * one the request left out. On create that means the AWS default, on modify it means unchanged.
+ */
+@RegisterForReflection
+public record DbInstanceSettings(Boolean storageEncrypted,
+                                 String kmsKeyId,
+                                 Integer backupRetentionPeriod,
+                                 String preferredBackupWindow,
+                                 String preferredMaintenanceWindow,
+                                 Boolean copyTagsToSnapshot) {
+
+    private static final Pattern TIME = Pattern.compile("^([01]\\d|2[0-3]):([0-5]\\d)$");
+    private static final List<String> DAYS = List.of("mon", "tue", "wed", "thu", "fri", "sat", "sun");
+    private static final int MINUTES_PER_DAY = 24 * 60;
+    private static final int MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
+    private static final int MINIMUM_WINDOW_MINUTES = 30;
+
+    public static DbInstanceSettings defaults() {
+        return new DbInstanceSettings(null, null, null, null, null, null);
+    }
+
+    public static DbInstanceSettings unchanged() {
+        return defaults();
+    }
+
+    /**
+     * The checks a live account applies to these parameters, with its wording. The retention
+     * period is not range-checked: AWS accepted 40 days on a postgres instance.
+     */
+    public void validate() {
+        if (kmsKeyId != null && !kmsKeyId.isBlank() && !Boolean.TRUE.equals(storageEncrypted)) {
+            throw new AwsException("InvalidParameterCombination",
+                    "You must enable StorageEncrypted when you specify KmsKeyId", 400);
+        }
+        int[] backup = preferredBackupWindow == null ? null : parseBackupWindow(preferredBackupWindow);
+        int[] maintenance = preferredMaintenanceWindow == null ? null
+                : parseMaintenanceWindow(preferredMaintenanceWindow);
+        if (backup != null && maintenance != null && overlap(backup, maintenance)) {
+            throw new AwsException("InvalidParameterValue",
+                    "The backup window and maintenance window must not overlap.", 400);
+        }
+    }
+
+    /** Start and end as minutes of the day; the end is pushed past midnight when the window wraps. */
+    private static int[] parseBackupWindow(String window) {
+        String[] parts = window.split("-", -1);
+        if (parts.length != 2) {
+            throw invalidBackupTime(window);
+        }
+        int start = minuteOfDay(parts[0], () -> invalidBackupTime(parts[0]));
+        int end = minuteOfDay(parts[1], () -> invalidBackupTime(parts[1]));
+        if (end <= start) {
+            end += MINUTES_PER_DAY;
+        }
+        if (end - start < MINIMUM_WINDOW_MINUTES) {
+            throw new AwsException("InvalidParameterValue",
+                    "Backup window must be at least " + MINIMUM_WINDOW_MINUTES + " minutes.", 400);
+        }
+        return new int[] {start, end};
+    }
+
+    /** Start and end as minutes of the week; the end is pushed past Sunday when the window wraps. */
+    private static int[] parseMaintenanceWindow(String window) {
+        String[] parts = window.split("-", -1);
+        if (parts.length != 2) {
+            throw invalidMaintenanceTime(window);
+        }
+        int start = minuteOfWeek(parts[0]);
+        int end = minuteOfWeek(parts[1]);
+        if (end <= start) {
+            end += MINUTES_PER_WEEK;
+        }
+        if (end - start < MINIMUM_WINDOW_MINUTES) {
+            throw new AwsException("InvalidParameterValue",
+                    "Maintenance window must be at least " + MINIMUM_WINDOW_MINUTES + " minutes.", 400);
+        }
+        return new int[] {start, end};
+    }
+
+    private static int minuteOfWeek(String dayAndTime) {
+        int colon = dayAndTime.indexOf(':');
+        int day = colon < 0 ? -1 : DAYS.indexOf(dayAndTime.substring(0, colon).toLowerCase());
+        if (day < 0) {
+            throw invalidMaintenanceTime(dayAndTime);
+        }
+        return day * MINUTES_PER_DAY
+                + minuteOfDay(dayAndTime.substring(colon + 1), () -> invalidMaintenanceTime(dayAndTime));
+    }
+
+    private static int minuteOfDay(String time, Supplier<AwsException> invalid) {
+        Matcher m = TIME.matcher(time);
+        if (!m.matches()) {
+            throw invalid.get();
+        }
+        return Integer.parseInt(m.group(1)) * 60 + Integer.parseInt(m.group(2));
+    }
+
+    private static boolean overlap(int[] dailyBackup, int[] weeklyMaintenance) {
+        for (int day = 0; day < 7; day++) {
+            int start = day * MINUTES_PER_DAY + dailyBackup[0];
+            int end = day * MINUTES_PER_DAY + dailyBackup[1];
+            for (int shift : new int[] {0, MINUTES_PER_WEEK}) {
+                if (start < weeklyMaintenance[1] - shift && weeklyMaintenance[0] - shift < end) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static AwsException invalidBackupTime(String time) {
+        return new AwsException("InvalidParameterValue", "Invalid backup window time '" + time
+                + "' specified. Should be specified as a time hh24:mi (24H Clock UTC). Example: 03:15", 400);
+    }
+
+    private static AwsException invalidMaintenanceTime(String time) {
+        return new AwsException("InvalidParameterValue", "Invalid maintenance window time '" + time
+                + "' specified. Should be specified as a time ddd:hh24:mi (24H Clock UTC). Example: Mon:00:15", 400);
+    }
+
+    public DbInstanceSettings withKmsKeyId(String resolvedKmsKeyId) {
+        return new DbInstanceSettings(storageEncrypted, resolvedKmsKeyId, backupRetentionPeriod,
+                preferredBackupWindow, preferredMaintenanceWindow, copyTagsToSnapshot);
+    }
+
+    public void applyTo(DbInstance instance) {
+        if (storageEncrypted != null) {
+            instance.setStorageEncrypted(storageEncrypted);
+        }
+        if (kmsKeyId != null && !kmsKeyId.isBlank()) {
+            instance.setKmsKeyId(kmsKeyId);
+        }
+        if (backupRetentionPeriod != null) {
+            instance.setBackupRetentionPeriod(backupRetentionPeriod);
+        }
+        if (preferredBackupWindow != null && !preferredBackupWindow.isBlank()) {
+            instance.setPreferredBackupWindow(preferredBackupWindow);
+        }
+        if (preferredMaintenanceWindow != null && !preferredMaintenanceWindow.isBlank()) {
+            instance.setPreferredMaintenanceWindow(preferredMaintenanceWindow.toLowerCase());
+        }
+        if (copyTagsToSnapshot != null) {
+            instance.setCopyTagsToSnapshot(copyTagsToSnapshot);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
@@ -127,11 +127,16 @@ public record DbInstanceSettings(Boolean storageEncrypted,
         return Integer.parseInt(m.group(1)) * 60 + Integer.parseInt(m.group(2));
     }
 
+    /**
+     * The backup window recurs every day, so it is laid over each day of the week and compared
+     * with the maintenance window in the same week, the week before and the week after — a
+     * window that wraps past Sunday midnight or before Monday midnight lands in a neighbour.
+     */
     private static boolean overlap(int[] dailyBackup, int[] weeklyMaintenance) {
         for (int day = 0; day < 7; day++) {
             int start = day * MINUTES_PER_DAY + dailyBackup[0];
             int end = day * MINUTES_PER_DAY + dailyBackup[1];
-            for (int shift : new int[] {0, MINUTES_PER_WEEK}) {
+            for (int shift : new int[] {-MINUTES_PER_WEEK, 0, MINUTES_PER_WEEK}) {
                 if (start < weeklyMaintenance[1] - shift && weeklyMaintenance[0] - shift < end) {
                     return true;
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
@@ -26,6 +26,16 @@ public record DbInstanceSettings(Boolean storageEncrypted,
     private static final int MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
     private static final int MINIMUM_WINDOW_MINUTES = 30;
 
+    /**
+     * Where AWS picks a random 30-minute window, Floci picks these; the alternates are used when a
+     * window given on create overlaps the default of the other kind, since AWS would have picked a
+     * random window clear of it.
+     */
+    public static final String DEFAULT_BACKUP_WINDOW = "04:00-06:00";
+    public static final String DEFAULT_MAINTENANCE_WINDOW = "mon:00:00-mon:03:00";
+    public static final String ALTERNATE_BACKUP_WINDOW = "06:30-07:00";
+    public static final String ALTERNATE_MAINTENANCE_WINDOW = "sun:06:30-sun:07:00";
+
     public static DbInstanceSettings defaults() {
         return new DbInstanceSettings(null, null, null, null, null, null);
     }
@@ -35,21 +45,32 @@ public record DbInstanceSettings(Boolean storageEncrypted,
     }
 
     /**
-     * The checks a live account applies to these parameters, with its wording. The retention
-     * period is not range-checked: AWS accepted 40 days on a postgres instance.
+     * The per-parameter checks a live account applies, with its wording. The retention period is
+     * not range-checked: AWS accepted 40 days on a postgres instance. Overlap between the windows
+     * is checked by the service against the windows that will be in effect, since the counterpart
+     * of a window given alone comes from the instance or from a default.
      */
     public void validate() {
         if (kmsKeyId != null && !kmsKeyId.isBlank() && !Boolean.TRUE.equals(storageEncrypted)) {
             throw new AwsException("InvalidParameterCombination",
                     "You must enable StorageEncrypted when you specify KmsKeyId", 400);
         }
-        int[] backup = preferredBackupWindow == null ? null : parseBackupWindow(preferredBackupWindow);
-        int[] maintenance = preferredMaintenanceWindow == null ? null
-                : parseMaintenanceWindow(preferredMaintenanceWindow);
-        if (backup != null && maintenance != null && overlap(backup, maintenance)) {
-            throw new AwsException("InvalidParameterValue",
-                    "The backup window and maintenance window must not overlap.", 400);
+        if (preferredBackupWindow != null) {
+            parseBackupWindow(preferredBackupWindow);
         }
+        if (preferredMaintenanceWindow != null) {
+            parseMaintenanceWindow(preferredMaintenanceWindow);
+        }
+    }
+
+    /** Whether a daily backup window and a weekly maintenance window share any minute. */
+    public static boolean windowsOverlap(String backupWindow, String maintenanceWindow) {
+        return overlap(parseBackupWindow(backupWindow), parseMaintenanceWindow(maintenanceWindow));
+    }
+
+    public static AwsException overlappingWindows() {
+        return new AwsException("InvalidParameterValue",
+                "The backup window and maintenance window must not overlap.", 400);
     }
 
     /** Start and end as minutes of the day; the end is pushed past midnight when the window wraps. */

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
@@ -1,12 +1,9 @@
 package io.github.hectorvent.floci.services.rds.model;
 
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.BackupWindows;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
-import java.util.List;
-import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * The storage and backup settings of a DB instance as a request carries them: a null member is
@@ -20,15 +17,9 @@ public record DbInstanceSettings(Boolean storageEncrypted,
                                  String preferredMaintenanceWindow,
                                  Boolean copyTagsToSnapshot) {
 
-    private static final Pattern TIME = Pattern.compile("^([01]\\d|2[0-3]):([0-5]\\d)$");
-    private static final List<String> DAYS = List.of("mon", "tue", "wed", "thu", "fri", "sat", "sun");
-    private static final int MINUTES_PER_DAY = 24 * 60;
-    private static final int MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
-    private static final int MINIMUM_WINDOW_MINUTES = 30;
-
     /** Where AWS picks a random 30-minute window, Floci picks these. */
-    public static final String DEFAULT_BACKUP_WINDOW = "04:00-06:00";
-    public static final String DEFAULT_MAINTENANCE_WINDOW = "mon:00:00-mon:03:00";
+    public static final String DEFAULT_BACKUP_WINDOW = BackupWindows.DEFAULT_BACKUP_WINDOW;
+    public static final String DEFAULT_MAINTENANCE_WINDOW = BackupWindows.DEFAULT_MAINTENANCE_WINDOW;
 
     public static DbInstanceSettings defaults() {
         return new DbInstanceSettings(null, null, null, null, null, null);
@@ -50,16 +41,16 @@ public record DbInstanceSettings(Boolean storageEncrypted,
                     "You must enable StorageEncrypted when you specify KmsKeyId", 400);
         }
         if (preferredBackupWindow != null) {
-            parseBackupWindow(preferredBackupWindow);
+            BackupWindows.parseBackupWindow(preferredBackupWindow);
         }
         if (preferredMaintenanceWindow != null) {
-            parseMaintenanceWindow(preferredMaintenanceWindow);
+            BackupWindows.parseMaintenanceWindow(preferredMaintenanceWindow);
         }
     }
 
     /** Whether a daily backup window and a weekly maintenance window share any minute. */
     public static boolean windowsOverlap(String backupWindow, String maintenanceWindow) {
-        return overlap(parseBackupWindow(backupWindow), parseMaintenanceWindow(maintenanceWindow));
+        return BackupWindows.overlap(backupWindow, maintenanceWindow);
     }
 
     /**
@@ -68,24 +59,12 @@ public record DbInstanceSettings(Boolean storageEncrypted,
      * window is given.
      */
     public static String maintenanceWindowAfter(String backupWindow) {
-        int end = parseBackupWindow(backupWindow)[1] % MINUTES_PER_DAY;
-        return weeklyWindow(end, end + MINIMUM_WINDOW_MINUTES);
+        return BackupWindows.maintenanceWindowAfter(backupWindow);
     }
 
     /** A 30-minute daily backup window starting the minute the given maintenance window ends. */
     public static String backupWindowAfter(String maintenanceWindow) {
-        int end = parseMaintenanceWindow(maintenanceWindow)[1] % MINUTES_PER_DAY;
-        return time(end) + "-" + time(end + MINIMUM_WINDOW_MINUTES);
-    }
-
-    private static String weeklyWindow(int startMinuteOfDay, int endMinuteOfDay) {
-        return DAYS.get(0) + ":" + time(startMinuteOfDay) + "-"
-                + DAYS.get(endMinuteOfDay / MINUTES_PER_DAY) + ":" + time(endMinuteOfDay);
-    }
-
-    private static String time(int minuteOfDay) {
-        int m = minuteOfDay % MINUTES_PER_DAY;
-        return String.format("%02d:%02d", m / 60, m % 60);
+        return BackupWindows.backupWindowAfter(maintenanceWindow);
     }
 
     /** A window given alone that leaves no room for the other kind, in AWS's words. */
@@ -102,94 +81,7 @@ public record DbInstanceSettings(Boolean storageEncrypted,
     }
 
     public static AwsException overlappingWindows() {
-        return new AwsException("InvalidParameterValue",
-                "The backup window and maintenance window must not overlap.", 400);
-    }
-
-    /** Start and end as minutes of the day; the end is pushed past midnight when the window wraps. */
-    private static int[] parseBackupWindow(String window) {
-        String[] parts = window.split("-", -1);
-        if (parts.length != 2) {
-            throw invalidBackupTime(window);
-        }
-        int start = minuteOfDay(parts[0], () -> invalidBackupTime(parts[0]));
-        int end = minuteOfDay(parts[1], () -> invalidBackupTime(parts[1]));
-        if (end <= start) {
-            end += MINUTES_PER_DAY;
-        }
-        if (end - start < MINIMUM_WINDOW_MINUTES) {
-            throw new AwsException("InvalidParameterValue",
-                    "Backup window must be at least " + MINIMUM_WINDOW_MINUTES + " minutes.", 400);
-        }
-        return new int[] {start, end};
-    }
-
-    /** Start and end as minutes of the week; the end is pushed past Sunday when the window wraps. */
-    private static int[] parseMaintenanceWindow(String window) {
-        String[] parts = window.split("-", -1);
-        if (parts.length != 2) {
-            throw invalidMaintenanceTime(window);
-        }
-        int start = minuteOfWeek(parts[0]);
-        int end = minuteOfWeek(parts[1]);
-        if (end <= start) {
-            end += MINUTES_PER_WEEK;
-        }
-        if (end - start < MINIMUM_WINDOW_MINUTES) {
-            throw new AwsException("InvalidParameterValue",
-                    "Maintenance window must be at least " + MINIMUM_WINDOW_MINUTES + " minutes.", 400);
-        }
-        if (end - start >= MINUTES_PER_DAY) {
-            throw new AwsException("InvalidParameterValue",
-                    "Maintenance window must be less than 24 hours.", 400);
-        }
-        return new int[] {start, end};
-    }
-
-    private static int minuteOfWeek(String dayAndTime) {
-        int colon = dayAndTime.indexOf(':');
-        int day = colon < 0 ? -1 : DAYS.indexOf(dayAndTime.substring(0, colon).toLowerCase());
-        if (day < 0) {
-            throw invalidMaintenanceTime(dayAndTime);
-        }
-        return day * MINUTES_PER_DAY
-                + minuteOfDay(dayAndTime.substring(colon + 1), () -> invalidMaintenanceTime(dayAndTime));
-    }
-
-    private static int minuteOfDay(String time, Supplier<AwsException> invalid) {
-        Matcher m = TIME.matcher(time);
-        if (!m.matches()) {
-            throw invalid.get();
-        }
-        return Integer.parseInt(m.group(1)) * 60 + Integer.parseInt(m.group(2));
-    }
-
-    /**
-     * The backup window recurs every day, so it is laid over each day of the week and compared
-     * with the maintenance window in the same week, the week before and the week after — a
-     * window that wraps past Sunday midnight or before Monday midnight lands in a neighbour.
-     */
-    private static boolean overlap(int[] dailyBackup, int[] weeklyMaintenance) {
-        for (int day = 0; day < 7; day++) {
-            int start = day * MINUTES_PER_DAY + dailyBackup[0];
-            int end = day * MINUTES_PER_DAY + dailyBackup[1];
-            for (int shift : new int[] {-MINUTES_PER_WEEK, 0, MINUTES_PER_WEEK}) {
-                if (start < weeklyMaintenance[1] - shift && weeklyMaintenance[0] - shift < end) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
-    private static AwsException invalidBackupTime(String time) {
-        return new AwsException("InvalidParameterValue", "Invalid backup window time '" + time
-                + "' specified. Should be specified as a time hh24:mi (24H Clock UTC). Example: 03:15", 400);
-    }
-
-    private static AwsException invalidMaintenanceTime(String time) {
-        return new AwsException("InvalidParameterValue", "Invalid maintenance window time '" + time
-                + "' specified. Should be specified as a time ddd:hh24:mi (24H Clock UTC). Example: Mon:00:15", 400);
+        return BackupWindows.overlapping();
     }
 
     public DbInstanceSettings withKmsKeyId(String resolvedKmsKeyId) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
@@ -88,6 +88,19 @@ public record DbInstanceSettings(Boolean storageEncrypted,
         return String.format("%02d:%02d", m / 60, m % 60);
     }
 
+    /** A window given alone that leaves no room for the other kind, in AWS's words. */
+    public static AwsException noRoomForMaintenanceWindow() {
+        return new AwsException("InvalidParameterValue", "The specified backup window overlaps all "
+                + "available default maintenance windows. Shrink the backup window or specify a "
+                + "non-overlapping maintenance window.", 400);
+    }
+
+    public static AwsException noRoomForBackupWindow() {
+        return new AwsException("InvalidParameterValue", "The specified maintenance window overlaps "
+                + "all available default backup windows. Shrink the maintenance window or specify a "
+                + "non-overlapping backup window.", 400);
+    }
+
     public static AwsException overlappingWindows() {
         return new AwsException("InvalidParameterValue",
                 "The backup window and maintenance window must not overlap.", 400);
@@ -125,6 +138,10 @@ public record DbInstanceSettings(Boolean storageEncrypted,
         if (end - start < MINIMUM_WINDOW_MINUTES) {
             throw new AwsException("InvalidParameterValue",
                     "Maintenance window must be at least " + MINIMUM_WINDOW_MINUTES + " minutes.", 400);
+        }
+        if (end - start >= MINUTES_PER_DAY) {
+            throw new AwsException("InvalidParameterValue",
+                    "Maintenance window must be less than 24 hours.", 400);
         }
         return new int[] {start, end};
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstanceSettings.java
@@ -26,15 +26,9 @@ public record DbInstanceSettings(Boolean storageEncrypted,
     private static final int MINUTES_PER_WEEK = 7 * MINUTES_PER_DAY;
     private static final int MINIMUM_WINDOW_MINUTES = 30;
 
-    /**
-     * Where AWS picks a random 30-minute window, Floci picks these; the alternates are used when a
-     * window given on create overlaps the default of the other kind, since AWS would have picked a
-     * random window clear of it.
-     */
+    /** Where AWS picks a random 30-minute window, Floci picks these. */
     public static final String DEFAULT_BACKUP_WINDOW = "04:00-06:00";
     public static final String DEFAULT_MAINTENANCE_WINDOW = "mon:00:00-mon:03:00";
-    public static final String ALTERNATE_BACKUP_WINDOW = "06:30-07:00";
-    public static final String ALTERNATE_MAINTENANCE_WINDOW = "sun:06:30-sun:07:00";
 
     public static DbInstanceSettings defaults() {
         return new DbInstanceSettings(null, null, null, null, null, null);
@@ -66,6 +60,32 @@ public record DbInstanceSettings(Boolean storageEncrypted,
     /** Whether a daily backup window and a weekly maintenance window share any minute. */
     public static boolean windowsOverlap(String backupWindow, String maintenanceWindow) {
         return overlap(parseBackupWindow(backupWindow), parseMaintenanceWindow(maintenanceWindow));
+    }
+
+    /**
+     * A 30-minute maintenance window that starts the minute the given daily backup window ends,
+     * so it is clear of it on every day — what AWS's random pick achieves when only the backup
+     * window is given.
+     */
+    public static String maintenanceWindowAfter(String backupWindow) {
+        int end = parseBackupWindow(backupWindow)[1] % MINUTES_PER_DAY;
+        return weeklyWindow(end, end + MINIMUM_WINDOW_MINUTES);
+    }
+
+    /** A 30-minute daily backup window starting the minute the given maintenance window ends. */
+    public static String backupWindowAfter(String maintenanceWindow) {
+        int end = parseMaintenanceWindow(maintenanceWindow)[1] % MINUTES_PER_DAY;
+        return time(end) + "-" + time(end + MINIMUM_WINDOW_MINUTES);
+    }
+
+    private static String weeklyWindow(int startMinuteOfDay, int endMinuteOfDay) {
+        return DAYS.get(0) + ":" + time(startMinuteOfDay) + "-"
+                + DAYS.get(endMinuteOfDay / MINUTES_PER_DAY) + ":" + time(endMinuteOfDay);
+    }
+
+    private static String time(int minuteOfDay) {
+        int m = minuteOfDay % MINUTES_PER_DAY;
+        return String.format("%02d:%02d", m / 60, m % 60);
     }
 
     public static AwsException overlappingWindows() {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/DbInstanceSettingsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/DbInstanceSettingsTest.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.services.rds;
+
+import io.github.hectorvent.floci.services.rds.model.DbInstanceSettings;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DbInstanceSettingsTest {
+
+    private static String time(int minuteOfDay) {
+        int m = ((minuteOfDay % 1440) + 1440) % 1440;
+        return String.format("%02d:%02d", m / 60, m % 60);
+    }
+
+    @Test
+    void derivedMaintenanceWindowIsClearOfAnyBackupWindowThatLeavesRoomForOne() {
+        // every start minute and every length up to 23h30 — the longest daily window that still
+        // leaves a 30-minute gap; beyond that no clear counterpart exists at all
+        for (int start = 0; start < 1440; start += 5) {
+            for (int length = 30; length <= 1410; length += 5) {
+                String backup = time(start) + "-" + time(start + length);
+                String maintenance = DbInstanceSettings.maintenanceWindowAfter(backup);
+                assertFalse(DbInstanceSettings.windowsOverlap(backup, maintenance),
+                        backup + " vs derived " + maintenance);
+            }
+        }
+        // 23h45 leaves a 15-minute gap: the derived window necessarily overlaps
+        assertTrue(DbInstanceSettings.windowsOverlap("00:00-23:45",
+                DbInstanceSettings.maintenanceWindowAfter("00:00-23:45")));
+    }
+
+    @Test
+    void derivedBackupWindowIsClearOfAnyMaintenanceWindowThatLeavesRoomForOne() {
+        String[] days = {"mon", "tue", "wed", "thu", "fri", "sat", "sun"};
+        for (int start = 0; start < 7 * 1440; start += 37) {
+            for (int length = 30; length <= 1410; length += 25) {
+                int end = (start + length) % (7 * 1440);
+                String maintenance = days[start / 1440] + ":" + time(start) + "-"
+                        + days[end / 1440] + ":" + time(end);
+                String backup = DbInstanceSettings.backupWindowAfter(maintenance);
+                assertFalse(DbInstanceSettings.windowsOverlap(backup, maintenance),
+                        maintenance + " vs derived " + backup);
+            }
+        }
+        assertTrue(DbInstanceSettings.windowsOverlap(
+                DbInstanceSettings.backupWindowAfter("mon:00:00-mon:23:45"), "mon:00:00-mon:23:45"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/PausingStorageBackend.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/PausingStorageBackend.java
@@ -1,0 +1,123 @@
+package io.github.hectorvent.floci.services.rds;
+
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+/**
+ * A store that can be stopped in the middle of an operation, so a race can be staged rather than
+ * hoped for.
+ *
+ * <p>A concurrency test that loops and waits for an unlucky interleaving proves nothing when the
+ * window is a few instructions wide: it passes with the fix and without it. Holding one thread at a
+ * chosen call while another runs to completion makes the interleaving the test claims to cover the
+ * one it actually runs.
+ */
+final class PausingStorageBackend<V> implements StorageBackend<String, V> {
+
+    /** Which call to hold, and on which key. */
+    enum Call { PUT, DELETE, SCAN }
+
+    private final StorageBackend<String, V> delegate;
+    private volatile Call pauseOn;
+    private volatile String pauseKey;
+    private final java.util.concurrent.atomic.AtomicInteger skip =
+            new java.util.concurrent.atomic.AtomicInteger();
+    private final CountDownLatch reached = new CountDownLatch(1);
+    private final CountDownLatch release = new CountDownLatch(1);
+
+    PausingStorageBackend(StorageBackend<String, V> delegate) {
+        this.delegate = delegate;
+    }
+
+    /** Hold the next matching call until {@link #release()}; {@code key} may be null for SCAN. */
+    void pauseOn(Call call, String key) {
+        pauseOn(call, key, 0);
+    }
+
+    /** As above, after letting {@code skipFirst} matching calls through untouched. */
+    void pauseOn(Call call, String key, int skipFirst) {
+        this.pauseOn = call;
+        this.pauseKey = key;
+        this.skip.set(skipFirst);
+    }
+
+    /** Waits until the paused call has been reached. */
+    void awaitReached() throws InterruptedException {
+        if (!reached.await(10, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("the paused call was never reached");
+        }
+    }
+
+    void release() {
+        release.countDown();
+    }
+
+    private void pauseIfMatching(Call call, String key) {
+        // Keys arrive account-prefixed here, since this sits underneath the account-aware layer.
+        if (pauseOn != call || (pauseKey != null && (key == null || !key.endsWith(pauseKey)))) {
+            return;
+        }
+        if (skip.getAndDecrement() > 0) {
+            return;
+        }
+        pauseOn = null;
+        reached.countDown();
+        try {
+            if (!release.await(10, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("the paused call was never released");
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void put(String key, V value) {
+        pauseIfMatching(Call.PUT, key);
+        delegate.put(key, value);
+    }
+
+    @Override
+    public Optional<V> get(String key) {
+        return delegate.get(key);
+    }
+
+    @Override
+    public void delete(String key) {
+        pauseIfMatching(Call.DELETE, key);
+        delegate.delete(key);
+    }
+
+    @Override
+    public List<V> scan(Predicate<String> keyFilter) {
+        pauseIfMatching(Call.SCAN, null);
+        return delegate.scan(keyFilter);
+    }
+
+    @Override
+    public Set<String> keys() {
+        return delegate.keys();
+    }
+
+    @Override
+    public void flush() {
+        delegate.flush();
+    }
+
+    @Override
+    public void load() {
+        delegate.load();
+    }
+
+    @Override
+    public void clear() {
+        delegate.clear();
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.docdb.DocDbQueryHandler;
 import io.github.hectorvent.floci.services.neptune.NeptuneQueryHandler;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.rds.model.DbInstanceSettings;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbProxy;
@@ -217,7 +218,7 @@ class RdsQueryHandlerTest {
         when(service.listDbInstances(null, "us-west-2")).thenReturn(List.of());
         when(service.getDbInstance("mydb", "us-west-2")).thenReturn(instance);
         when(service.modifyDbInstance(
-                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"), isNull()))
+                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"), isNull(), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
         when(service.rebootDbInstance("mydb", "us-west-2")).thenReturn(instance);
         when(service.listDbClusters(null, "us-west-2")).thenReturn(List.of());
@@ -243,7 +244,7 @@ class RdsQueryHandlerTest {
         verify(service).getDbInstance("mydb", "us-west-2");
         verify(service).deleteDbInstance("mydb", "us-west-2");
         verify(service).modifyDbInstance(
-                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"), isNull());
+                eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(), eq("us-west-2"), isNull(), any(DbInstanceSettings.class));
         verify(service).rebootDbInstance("mydb", "us-west-2");
         verify(service).listDbClusters(null, "us-west-2");
         verify(service).getDbCluster("mycluster", "us-west-2");
@@ -357,7 +358,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull(), isNull(), eq(true)))
+                eq(java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb")), eq(List.of()), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -371,7 +372,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null, null, true);
+                java.util.Map.of("example:ClusterId", "cluster-a", "Name", "mydb"), List.of(), null, null, true, DbInstanceSettings.defaults());
     }
 
     @Test
@@ -381,7 +382,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false), eq(null),
-                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull(), isNull(), eq(true)))
+                eq(java.util.Map.of()), eq(List.of("sg-123", "sg-456")), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -396,7 +397,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<VpcSecurityGroupId>sg-456</VpcSecurityGroupId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 null, null, null, "db.t3.micro", 20, false, null, null, null, null, false, false, null,
-                java.util.Map.of(), List.of("sg-123", "sg-456"), null, null, true);
+                java.util.Map.of(), List.of("sg-123", "sg-456"), null, null, true, DbInstanceSettings.defaults());
     }
 
     @Test
@@ -512,7 +513,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -526,7 +527,7 @@ class RdsQueryHandlerTest {
 
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", "secret", "dbname", "db.t3.micro", 20, false, null, null, null, null, false, false,
-                null, java.util.Map.of(), List.of(), null, null, true);
+                null, java.util.Map.of(), List.of(), null, null, true, DbInstanceSettings.defaults());
     }
 
     @Test
@@ -538,7 +539,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq(null), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(true),
-                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
+                eq("kms-key-1"), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -557,7 +558,7 @@ class RdsQueryHandlerTest {
         assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
         verify(service).createDbInstance("mydb", "postgres", "16.3",
                 "admin", null, "dbname", "db.t3.micro", 20, false, null, null, null, null, false, true,
-                "kms-key-1", java.util.Map.of(), List.of(), null, null, true);
+                "kms-key-1", java.util.Map.of(), List.of(), null, null, true, DbInstanceSettings.defaults());
     }
 
     @Test
@@ -570,7 +571,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("default"), eq(null), eq("ap-northeast-1a"), eq(true),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -600,7 +601,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(false)))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(false), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -620,7 +621,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("postgres"), eq("16.3"),
                 eq("admin"), eq("secret"), eq("dbname"), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq("missing-subnet-group"), eq(null), eq(null), eq(false),
-                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
+                eq(false), eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenThrow(new AwsException("DBSubnetGroupNotFoundFault",
                         "DB subnet group missing-subnet-group not found.", 404));
 
@@ -712,7 +713,7 @@ class RdsQueryHandlerTest {
         when(service.createDbInstance(eq("mydb"), eq("oracle"), eq("1.0"),
                 eq(null), eq(null), eq(null), eq("db.t3.micro"),
                 eq(20), eq(false), eq(null), eq(null), eq(null), eq(null), eq(false), eq(false),
-                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true)))
+                eq(null), eq(java.util.Map.of()), eq(List.of()), isNull(), isNull(), eq(true), any(DbInstanceSettings.class)))
                 .thenThrow(new AwsException("InvalidParameterValue",
                         "Unsupported engine: oracle. Supported: postgres, mysql, mariadb.", 400));
 
@@ -1941,7 +1942,7 @@ class RdsQueryHandlerTest {
         DbInstance instance = makeInstance("mydb");
         when(service.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
                 anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
-                any(), any(), anyList(), any(), any(), anyBoolean()))
+                any(), any(), anyList(), any(), any(), anyBoolean(), any(DbInstanceSettings.class)))
                 .thenReturn(instance);
 
         MultivaluedMap<String, String> p = params();
@@ -1953,7 +1954,7 @@ class RdsQueryHandlerTest {
         assertEquals(200, response.getStatus());
         verify(service).createDbInstance(eq("mydb"), eq("mysql"), any(), any(), any(), any(),
                 any(), anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(),
-                anyBoolean(), any(), any(), anyList(), eq("og1"), any(), anyBoolean());
+                anyBoolean(), any(), any(), anyList(), eq("og1"), any(), anyBoolean(), any(DbInstanceSettings.class));
     }
 
     // ──────────────────────────── Helpers ────────────────────────────
@@ -2219,5 +2220,138 @@ class RdsQueryHandlerTest {
 
         String body = (String) handler.handle("DescribeDBInstances", params()).getEntity();
         assertTrue(body.contains("<DBInstanceIdentifier>graph-1</DBInstanceIdentifier>"), body);
+    }
+
+    @Test
+    void createDbInstance_passesStorageAndBackupSettingsToService() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), anyList(), any(), any(), anyBoolean(), any(DbInstanceSettings.class)))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("StorageEncrypted", "true");
+        p.add("KmsKeyId", "arn:aws:kms:us-east-1:123456789012:key/k1");
+        p.add("BackupRetentionPeriod", "7");
+        p.add("PreferredBackupWindow", "23:30-00:00");
+        p.add("PreferredMaintenanceWindow", "sun:03:08-sun:03:38");
+        p.add("CopyTagsToSnapshot", "true");
+
+        assertEquals(200, handler.handle("CreateDBInstance", p).getStatus());
+
+        ArgumentCaptor<DbInstanceSettings> captor = ArgumentCaptor.forClass(DbInstanceSettings.class);
+        verify(service).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), anyList(), any(), any(), anyBoolean(), captor.capture());
+        DbInstanceSettings settings = captor.getValue();
+        assertEquals(Boolean.TRUE, settings.storageEncrypted());
+        assertEquals("arn:aws:kms:us-east-1:123456789012:key/k1", settings.kmsKeyId());
+        assertEquals(7, settings.backupRetentionPeriod());
+        assertEquals("23:30-00:00", settings.preferredBackupWindow());
+        assertEquals("sun:03:08-sun:03:38", settings.preferredMaintenanceWindow());
+        assertEquals(Boolean.TRUE, settings.copyTagsToSnapshot());
+    }
+
+    @Test
+    void createDbInstance_omittedSettingsReachServiceAsNull() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), anyList(), any(), any(), anyBoolean(), any(DbInstanceSettings.class)))
+                .thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        handler.handle("CreateDBInstance", p);
+
+        ArgumentCaptor<DbInstanceSettings> captor = ArgumentCaptor.forClass(DbInstanceSettings.class);
+        verify(service).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), anyList(), any(), any(), anyBoolean(), captor.capture());
+        assertEquals(DbInstanceSettings.defaults(), captor.getValue());
+    }
+
+    @Test
+    void createDbInstance_nonNumericBackupRetentionIsAQueryError() {
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("BackupRetentionPeriod", "seven");
+
+        Response response = handler.handle("CreateDBInstance", p);
+
+        assertEquals(400, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>InvalidParameterValue</Code>"), body);
+        verify(service, never()).createDbInstance(any(), any(), any(), any(), any(), any(), any(),
+                anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(), anyBoolean(),
+                any(), any(), anyList(), any(), any(), anyBoolean(), any(DbInstanceSettings.class));
+    }
+
+    @Test
+    void describeDbInstances_emitsStoredStorageAndBackupSettings() {
+        DbInstance instance = makeInstance("mydb");
+        instance.setStorageEncrypted(true);
+        instance.setKmsKeyId("arn:aws:kms:us-east-1:123456789012:key/k1");
+        instance.setBackupRetentionPeriod(7);
+        instance.setPreferredBackupWindow("23:30-00:00");
+        instance.setPreferredMaintenanceWindow("sun:03:08-sun:03:38");
+        instance.setCopyTagsToSnapshot(true);
+        when(service.listDbInstances("mydb", null)).thenReturn(List.of(instance));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        String body = (String) handler.handle("DescribeDBInstances", p).getEntity();
+
+        assertTrue(body.contains("<StorageEncrypted>true</StorageEncrypted>"), body);
+        assertTrue(body.contains("<KmsKeyId>arn:aws:kms:us-east-1:123456789012:key/k1</KmsKeyId>"), body);
+        assertTrue(body.contains("<BackupRetentionPeriod>7</BackupRetentionPeriod>"), body);
+        assertTrue(body.contains("<PreferredBackupWindow>23:30-00:00</PreferredBackupWindow>"), body);
+        assertTrue(body.contains("<PreferredMaintenanceWindow>sun:03:08-sun:03:38</PreferredMaintenanceWindow>"), body);
+        assertTrue(body.contains("<CopyTagsToSnapshot>true</CopyTagsToSnapshot>"), body);
+    }
+
+    @Test
+    void describeDbInstances_recordWithoutSettingsReadsAsAwsDefaults() {
+        // a record persisted before these fields existed deserializes with them unset
+        DbInstance instance = makeInstance("mydb");
+        when(service.listDbInstances("mydb", null)).thenReturn(List.of(instance));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        String body = (String) handler.handle("DescribeDBInstances", p).getEntity();
+
+        assertTrue(body.contains("<StorageEncrypted>false</StorageEncrypted>"), body);
+        assertFalse(body.contains("<KmsKeyId>"), body);
+        assertTrue(body.contains("<BackupRetentionPeriod>1</BackupRetentionPeriod>"), body);
+        assertTrue(body.contains("<PreferredBackupWindow>04:00-06:00</PreferredBackupWindow>"), body);
+        assertTrue(body.contains("<PreferredMaintenanceWindow>mon:00:00-mon:03:00</PreferredMaintenanceWindow>"), body);
+        assertTrue(body.contains("<CopyTagsToSnapshot>false</CopyTagsToSnapshot>"), body);
+    }
+
+    @Test
+    void modifyDbInstance_passesBackupSettingsToService() {
+        DbInstance instance = makeInstance("mydb");
+        when(service.modifyDbInstance(eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(),
+                isNull(), isNull(), any(DbInstanceSettings.class))).thenReturn(instance);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("BackupRetentionPeriod", "3");
+        p.add("PreferredBackupWindow", "01:00-01:30");
+        p.add("CopyTagsToSnapshot", "true");
+        // not part of the ModifyDBInstance shape: encryption is fixed at create
+        p.add("StorageEncrypted", "true");
+        p.add("KmsKeyId", "arn:aws:kms:us-east-1:123456789012:key/other");
+        assertEquals(200, handler.handle("ModifyDBInstance", p).getStatus());
+
+        ArgumentCaptor<DbInstanceSettings> captor = ArgumentCaptor.forClass(DbInstanceSettings.class);
+        verify(service).modifyDbInstance(eq("mydb"), isNull(), isNull(), isNull(), anyList(), isNull(),
+                isNull(), isNull(), captor.capture());
+        assertEquals(new DbInstanceSettings(null, null, 3, "01:00-01:30", null, true), captor.getValue());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -17,6 +17,9 @@ import io.github.hectorvent.floci.services.rds.container.RdsContainerHandle;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
 import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
+import io.github.hectorvent.floci.services.kms.KmsService;
+import io.github.hectorvent.floci.services.kms.model.KmsKey;
+import io.github.hectorvent.floci.services.rds.model.DbInstanceSettings;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbProxy;
@@ -56,6 +59,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -103,6 +107,7 @@ class RdsServiceTest {
     private RdsProxyManager proxyManager;
     private Ec2Service ec2Service;
     private RegionResolver regionResolver;
+    private KmsService kmsService;
     private EmulatorConfig config;
     private EmulatorConfig.RdsServiceConfig rdsConfig;
 
@@ -112,6 +117,9 @@ class RdsServiceTest {
         proxyManager = mock(RdsProxyManager.class);
         ec2Service = mock(Ec2Service.class);
         regionResolver = new RegionResolver("us-east-1", "123456789012");
+        kmsService = mock(KmsService.class);
+        when(kmsService.describeKey(any(), any())).thenThrow(
+                new AwsException("NotFoundException", "Key not found", 404));
         config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
         rdsConfig = mock(EmulatorConfig.RdsServiceConfig.class);
@@ -4773,7 +4781,7 @@ class RdsServiceTest {
         return new RdsService(containerManager, proxyManager, ec2Service, resolver, config,
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 new InMemoryStorage<>(), new InMemoryStorage<>(), null, null, null,
-                new InMemoryStorage<>(), new InMemoryStorage<>(), optionGroups, null);
+                new InMemoryStorage<>(), new InMemoryStorage<>(), optionGroups, null, kmsService);
     }
 
     private DbInstance createInstanceWithOptionGroup(
@@ -4791,7 +4799,9 @@ class RdsServiceTest {
                                   StorageBackend<String, DbClusterParameterGroup> clusterParameterGroups,
                                   StorageBackend<String, DbSubnetGroup> subnetGroups) {
         return new RdsService(containerManager, proxyManager, ec2Service, regionResolver, config,
-                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups);
+                instances, clusters, parameterGroups, clusterParameterGroups, subnetGroups,
+                null, null, null, new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), null, kmsService);
     }
 
     private RdsService newService(RdsContainerManager containerManager,
@@ -4803,7 +4813,8 @@ class RdsServiceTest {
                                   SecretsManagerService secretsManager) {
         return new RdsService(containerManager, proxyManager, ec2Service, regionResolver, config,
                 instances, clusters, parameterGroups, clusterParameterGroups, new InMemoryStorage<>(),
-                secretsManager, null, null);
+                secretsManager, null, null, new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), null, kmsService);
     }
 
     private RdsService proxyStoreService(
@@ -5009,5 +5020,238 @@ class RdsServiceTest {
         assertEquals("aurora-postgresql", service.getDbInstance("legacy-member").getEngineIdentifier());
         assertEquals("mariadb", service.getDbInstance("legacy-plain").getEngineIdentifier());
         assertNull(service.getDbInstance("old-member").getEngineIdentifier());
+    }
+
+    private static final String KEY_ARN = "arn:aws:kms:us-east-1:123456789012:key/k1";
+
+    private KmsKey knownKey(String... acceptedForms) {
+        KmsKey key = new KmsKey();
+        key.setKeyId("k1");
+        key.setArn(KEY_ARN);
+        key.setEnabled(true);
+        key.setKeyState("Enabled");
+        for (String form : acceptedForms) {
+            doReturn(key).when(kmsService).describeKey(form, "us-east-1");
+        }
+        return key;
+    }
+
+    @Test
+    void createDbInstanceResolvesEveryKmsKeyFormToTheKeyArn() {
+        knownKey(KEY_ARN, "k1", "alias/rds", "arn:aws:kms:us-east-1:123456789012:alias/rds");
+        int n = 0;
+        for (String form : List.of("k1", "alias/rds", "arn:aws:kms:us-east-1:123456789012:alias/rds")) {
+            String id = "db" + (n++);
+            rdsService.createDbInstance(id, "postgres", "13", "admin", "password", "dbname",
+                    "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                    Map.of(), List.of(), null, null, true,
+                    new DbInstanceSettings(true, form, null, null, null, null));
+            assertEquals(KEY_ARN, rdsService.getDbInstance(id).getKmsKeyId(), form);
+        }
+    }
+
+    @Test
+    void createDbInstanceRejectsAKmsKeyItCannotUse() {
+        AwsException missing = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(true, "alias/does-not-exist", null, null, null, null)));
+        assertEquals("KMSKeyNotAccessibleFault", missing.getErrorCode());
+        assertEquals("The specified KMS key [alias/does-not-exist] does not exist, is not enabled "
+                + "or you do not have permissions to access it.", missing.getMessage());
+        assertThrows(AwsException.class, () -> rdsService.getDbInstance("mydb"));
+        // refused before any side effect: no container was started for the rejected create
+        verify(containerManager, never()).start(any(), any(), any(), any(), any(), any(), any(), any(), any());
+
+        KmsKey disabled = knownKey("k1");
+        disabled.setEnabled(false);
+        AwsException notEnabled = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(true, "k1", null, null, null, null)));
+        assertEquals("KMSKeyNotAccessibleFault", notEnabled.getErrorCode());
+    }
+
+    @Test
+    void createDbInstanceStoresStorageAndBackupSettings() {
+        knownKey(KEY_ARN);
+        DbInstanceSettings settings = new DbInstanceSettings(true,
+                "arn:aws:kms:us-east-1:123456789012:key/k1", 7, "23:30-00:00", "Sun:03:08-Sun:03:38", true);
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true, settings);
+
+        DbInstance stored = rdsService.getDbInstance("mydb");
+        assertTrue(stored.isStorageEncrypted());
+        assertEquals("arn:aws:kms:us-east-1:123456789012:key/k1", stored.getKmsKeyId());
+        assertEquals(7, stored.getBackupRetentionPeriod());
+        assertEquals("23:30-00:00", stored.getPreferredBackupWindow());
+        assertEquals("sun:03:08-sun:03:38", stored.getPreferredMaintenanceWindow());
+        assertTrue(stored.isCopyTagsToSnapshot());
+    }
+
+    @Test
+    void createDbInstanceWithoutSettingsUsesAwsDefaults() {
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        DbInstance stored = rdsService.getDbInstance("mydb");
+        assertFalse(stored.isStorageEncrypted());
+        assertNull(stored.getKmsKeyId());
+        assertEquals(1, stored.getBackupRetentionPeriod());
+        assertFalse(stored.isCopyTagsToSnapshot());
+    }
+
+    @Test
+    void createDbInstanceRejectsKmsKeyWithoutEncryption() {
+        DbInstanceSettings settings = new DbInstanceSettings(false,
+                "arn:aws:kms:us-east-1:123456789012:key/k1", null, null, null, null);
+        AwsException e = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true, settings));
+        assertEquals("InvalidParameterCombination", e.getErrorCode());
+        assertThrows(AwsException.class, () -> rdsService.getDbInstance("mydb"));
+
+        // leaving StorageEncrypted out is the same as false on a live account
+        AwsException omitted = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, "arn:aws:kms:us-east-1:123456789012:key/k1", null, null, null, null)));
+        assertEquals("InvalidParameterCombination", omitted.getErrorCode());
+    }
+
+    @Test
+    void createDbInstanceRejectsShortOrOverlappingWindows() {
+        AwsException tooShort = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, "02:00-02:10", null, null)));
+        assertEquals("InvalidParameterValue", tooShort.getErrorCode());
+        assertEquals("Backup window must be at least 30 minutes.", tooShort.getMessage());
+
+        AwsException overlapping = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, "02:00-02:30", "tue:02:15-tue:02:45", null)));
+        assertEquals("The backup window and maintenance window must not overlap.", overlapping.getMessage());
+
+        // a backup window that wraps midnight still collides with a maintenance window on the next day
+        AwsException wrapping = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, "23:45-00:15", "wed:00:00-wed:00:30", null)));
+        assertEquals("The backup window and maintenance window must not overlap.", wrapping.getMessage());
+
+        // AWS accepted a 40-day retention period, so it is not range-checked here
+        rdsService.createDbInstance("mydb", "postgres", "13", "admin", "password", "dbname",
+                "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 40, "02:00-02:30", "tue:03:00-tue:03:30", null));
+        assertEquals(40, rdsService.getDbInstance("mydb").getBackupRetentionPeriod());
+    }
+
+    @Test
+    void createDbInstanceRejectsMalformedWindows() {
+        AwsException backup = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, "25:00-26:00", null, null)));
+        assertEquals("InvalidParameterValue", backup.getErrorCode());
+
+        AwsException maintenance = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, null, "xxx:00:00-xxx:01:00", null)));
+        assertEquals("InvalidParameterValue", maintenance.getErrorCode());
+    }
+
+    @Test
+    void modifyDbInstanceAppliesGivenSettingsAndKeepsTheRest() {
+        knownKey(KEY_ARN);
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(true, "arn:aws:kms:us-east-1:123456789012:key/k1", 7,
+                        "23:30-00:00", "sun:03:08-sun:03:38", false));
+
+        rdsService.modifyDbInstance("mydb", null, null, null, List.of(), null, null, null,
+                new DbInstanceSettings(null, null, 3, "01:00-01:30", null, true));
+
+        DbInstance stored = rdsService.getDbInstance("mydb");
+        assertEquals(3, stored.getBackupRetentionPeriod());
+        assertEquals("01:00-01:30", stored.getPreferredBackupWindow());
+        assertTrue(stored.isCopyTagsToSnapshot());
+        assertTrue(stored.isStorageEncrypted());
+        assertEquals("arn:aws:kms:us-east-1:123456789012:key/k1", stored.getKmsKeyId());
+        assertEquals("sun:03:08-sun:03:38", stored.getPreferredMaintenanceWindow());
+    }
+
+    @Test
+    void modifyDbInstanceRejectsInvalidSettingsWithoutChangingTheRecord() {
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, null, null, null));
+
+        assertThrows(AwsException.class, () -> rdsService.modifyDbInstance(
+                "mydb", null, null, null, List.of(), null, null, null,
+                new DbInstanceSettings(null, null, null, "bad", null, null)));
+
+        assertEquals(7, rdsService.getDbInstance("mydb").getBackupRetentionPeriod());
+    }
+
+    @Test
+    void modifyDbInstanceCannotWriteAnInstanceBackAfterDelete() throws Exception {
+        // The interleaving this guards against: modify has read the instance, delete removes it,
+        // modify writes its copy back. The store is held inside modify's put so the delete can be
+        // run in that window, rather than hoping a loop hits it.
+        PausingStorageBackend<DbInstance> instances = new PausingStorageBackend<>(new InMemoryStorage<>());
+        RdsService service = newService(containerManager, proxyManager, instances,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>());
+        service.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        instances.pauseOn(PausingStorageBackend.Call.PUT, "::mydb");
+        java.util.concurrent.atomic.AtomicReference<Throwable> modifyOutcome = new java.util.concurrent.atomic.AtomicReference<>();
+        Thread modify = new Thread(() -> {
+            try {
+                service.modifyDbInstance("mydb", null, null, null, List.of(), null, null, null,
+                        new DbInstanceSettings(null, null, 3, null, null, null));
+            } catch (Throwable t) {
+                modifyOutcome.set(t);
+            }
+        });
+        modify.start();
+        instances.awaitReached();
+
+        Thread delete = new Thread(() -> service.deleteDbInstance("mydb"));
+        delete.start();
+        // guarded: the delete queues on the monitor modify holds; unguarded: it runs to completion
+        long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(5);
+        while (delete.getState() != Thread.State.BLOCKED && delete.getState() != Thread.State.TERMINATED) {
+            assertTrue(System.nanoTime() < deadline, "delete neither ran nor queued");
+            Thread.onSpinWait();
+        }
+        instances.release();
+        modify.join(5000);
+        delete.join(5000);
+
+        assertNull(modifyOutcome.get(), "modify completed before the delete");
+        assertThrows(AwsException.class, () -> service.getDbInstance("mydb"),
+                "the deleted instance must not come back from the modify");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -5151,6 +5151,27 @@ class RdsServiceTest {
                 new DbInstanceSettings(null, null, 7, "23:45-00:15", "wed:00:00-wed:00:30", null)));
         assertEquals("The backup window and maintenance window must not overlap.", wrapping.getMessage());
 
+        // across the week boundary in both directions: a Sunday backup window running into Monday
+        // against an early-Monday maintenance window, and a Sunday-night maintenance window running
+        // into Monday against an early-Monday backup window
+        AwsException sundayBackup = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, "23:45-00:15", "mon:00:00-mon:00:30", null)));
+        assertEquals("The backup window and maintenance window must not overlap.", sundayBackup.getMessage());
+        AwsException sundayMaintenance = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, "00:00-00:30", "sun:23:45-mon:00:15", null)));
+        assertEquals("The backup window and maintenance window must not overlap.", sundayMaintenance.getMessage());
+        // and the same shapes a minute apart are clear
+        rdsService.createDbInstance("clear", "postgres", "13", "admin", "password", "dbname",
+                "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, "23:45-00:15", "mon:00:15-mon:00:45", null));
+
         // a window given alone is checked against the one that will be in effect: on create the
         // default, which is swapped for the alternate rather than refused since AWS would have
         // picked a random window clear of the given one

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -5173,20 +5173,30 @@ class RdsServiceTest {
                 new DbInstanceSettings(null, null, 7, "23:45-00:15", "mon:00:15-mon:00:45", null));
 
         // a window given alone is checked against the one that will be in effect: on create the
-        // default, which is swapped for the alternate rather than refused since AWS would have
-        // picked a random window clear of the given one
+        // default, replaced by a window starting where the given one ends rather than refused,
+        // since AWS would have picked a random window clear of the given one
         rdsService.createDbInstance("alone", "postgres", "13", "admin", "password", "dbname",
                 "db.t3.micro", 20, false, null, null, null, null, false, false, null,
                 Map.of(), List.of(), null, null, true,
                 new DbInstanceSettings(null, null, null, "00:30-01:00", null, null));
-        assertEquals(DbInstanceSettings.ALTERNATE_MAINTENANCE_WINDOW,
-                rdsService.getDbInstance("alone").getPreferredMaintenanceWindow());
+        assertEquals("mon:01:00-mon:01:30", rdsService.getDbInstance("alone").getPreferredMaintenanceWindow());
+        // a long daily window that no fixed alternate could be clear of
+        rdsService.createDbInstance("long", "postgres", "13", "admin", "password", "dbname",
+                "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, "00:00-07:00", null, null));
+        assertEquals("mon:07:00-mon:07:30", rdsService.getDbInstance("long").getPreferredMaintenanceWindow());
+        // ending near midnight rolls the maintenance window onto the next day
+        rdsService.createDbInstance("midnight", "postgres", "13", "admin", "password", "dbname",
+                "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, "02:00-23:45", null, null));
+        assertEquals("mon:23:45-tue:00:15", rdsService.getDbInstance("midnight").getPreferredMaintenanceWindow());
         rdsService.createDbInstance("alone2", "postgres", "13", "admin", "password", "dbname",
                 "db.t3.micro", 20, false, null, null, null, null, false, false, null,
                 Map.of(), List.of(), null, null, true,
                 new DbInstanceSettings(null, null, null, null, "mon:04:30-mon:05:00", null));
-        assertEquals(DbInstanceSettings.ALTERNATE_BACKUP_WINDOW,
-                rdsService.getDbInstance("alone2").getPreferredBackupWindow());
+        assertEquals("05:00-05:30", rdsService.getDbInstance("alone2").getPreferredBackupWindow());
 
         // AWS accepted a 40-day retention period, so it is not range-checked here
         rdsService.createDbInstance("mydb", "postgres", "13", "admin", "password", "dbname",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -5198,6 +5198,29 @@ class RdsServiceTest {
                 new DbInstanceSettings(null, null, null, null, "mon:04:30-mon:05:00", null));
         assertEquals("05:00-05:30", rdsService.getDbInstance("alone2").getPreferredBackupWindow());
 
+        // a window alone that leaves no 30-minute gap for the other kind, and a maintenance window
+        // of a day or more — both refused with AWS's wording
+        AwsException noRoom = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, "00:00-23:45", null, null)));
+        assertEquals("The specified backup window overlaps all available default maintenance windows. "
+                + "Shrink the backup window or specify a non-overlapping maintenance window.", noRoom.getMessage());
+        AwsException noRoomForBackup = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, null, "mon:00:00-mon:23:45", null)));
+        assertEquals("The specified maintenance window overlaps all available default backup windows. "
+                + "Shrink the maintenance window or specify a non-overlapping backup window.", noRoomForBackup.getMessage());
+        AwsException tooLong = assertThrows(AwsException.class, () -> rdsService.createDbInstance(
+                "mydb", "postgres", "13", "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, null, "mon:00:00-wed:00:00", null)));
+        assertEquals("Maintenance window must be less than 24 hours.", tooLong.getMessage());
+
         // AWS accepted a 40-day retention period, so it is not range-checked here
         rdsService.createDbInstance("mydb", "postgres", "13", "admin", "password", "dbname",
                 "db.t3.micro", 20, false, null, null, null, null, false, false, null,

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -5151,6 +5151,22 @@ class RdsServiceTest {
                 new DbInstanceSettings(null, null, 7, "23:45-00:15", "wed:00:00-wed:00:30", null)));
         assertEquals("The backup window and maintenance window must not overlap.", wrapping.getMessage());
 
+        // a window given alone is checked against the one that will be in effect: on create the
+        // default, which is swapped for the alternate rather than refused since AWS would have
+        // picked a random window clear of the given one
+        rdsService.createDbInstance("alone", "postgres", "13", "admin", "password", "dbname",
+                "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, "00:30-01:00", null, null));
+        assertEquals(DbInstanceSettings.ALTERNATE_MAINTENANCE_WINDOW,
+                rdsService.getDbInstance("alone").getPreferredMaintenanceWindow());
+        rdsService.createDbInstance("alone2", "postgres", "13", "admin", "password", "dbname",
+                "db.t3.micro", 20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, null, null, "mon:04:30-mon:05:00", null));
+        assertEquals(DbInstanceSettings.ALTERNATE_BACKUP_WINDOW,
+                rdsService.getDbInstance("alone2").getPreferredBackupWindow());
+
         // AWS accepted a 40-day retention period, so it is not range-checked here
         rdsService.createDbInstance("mydb", "postgres", "13", "admin", "password", "dbname",
                 "db.t3.micro", 20, false, null, null, null, null, false, false, null,
@@ -5196,6 +5212,32 @@ class RdsServiceTest {
         assertTrue(stored.isStorageEncrypted());
         assertEquals("arn:aws:kms:us-east-1:123456789012:key/k1", stored.getKmsKeyId());
         assertEquals("sun:03:08-sun:03:38", stored.getPreferredMaintenanceWindow());
+    }
+
+    @Test
+    void modifyDbInstanceChecksAWindowAgainstTheStoredOther() {
+        rdsService.createDbInstance("mydb", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false, false, null,
+                Map.of(), List.of(), null, null, true,
+                new DbInstanceSettings(null, null, 7, "01:00-01:30", "thu:10:00-thu:10:30", null));
+
+        AwsException maintenance = assertThrows(AwsException.class, () -> rdsService.modifyDbInstance(
+                "mydb", null, null, null, List.of(), null, null, null,
+                new DbInstanceSettings(null, null, null, null, "mon:01:15-mon:01:45", null)));
+        assertEquals("The backup window and maintenance window must not overlap.", maintenance.getMessage());
+        AwsException backup = assertThrows(AwsException.class, () -> rdsService.modifyDbInstance(
+                "mydb", null, null, null, List.of(), null, null, null,
+                new DbInstanceSettings(null, null, null, "10:15-10:45", null, null)));
+        assertEquals("The backup window and maintenance window must not overlap.", backup.getMessage());
+        assertEquals("01:00-01:30", rdsService.getDbInstance("mydb").getPreferredBackupWindow());
+        assertEquals("thu:10:00-thu:10:30", rdsService.getDbInstance("mydb").getPreferredMaintenanceWindow());
+
+        // both replaced at once: only the new pair has to be clear of each other
+        rdsService.modifyDbInstance("mydb", null, null, null, List.of(), null, null, null,
+                new DbInstanceSettings(null, null, null, "10:00-10:30", "mon:01:00-mon:01:30", null));
+        assertEquals("10:00-10:30", rdsService.getDbInstance("mydb").getPreferredBackupWindow());
+        assertEquals("mon:01:00-mon:01:30", rdsService.getDbInstance("mydb").getPreferredMaintenanceWindow());
     }
 
     @Test


### PR DESCRIPTION
Closes #2611

## What

`DescribeDBInstances` never returned `StorageEncrypted`, `KmsKeyId`, `BackupRetentionPeriod` or
`CopyTagsToSnapshot`, and wrote `PreferredBackupWindow` / `PreferredMaintenanceWindow` as constants.
Terraform saw `storage_encrypted false -> true` and `+ kms_key_id` on the first plan after apply and
replaced every encrypted instance.

- `DbInstance` gains the six fields; `DbInstanceSettings` carries them from the request (a null member
  is one the request left out — AWS default on create, unchanged on modify) and validates them.
- `CreateDBInstance` stores them, `ModifyDBInstance` applies the backup settings and windows
  (`StorageEncrypted`/`KmsKeyId` are not in its request shape and are ignored there), and the
  instance XML emits them. `KmsKeyId` is written only when set.
- `KmsKeyId` is resolved through `KmsService` in the request's region — key ARN, key id, alias ARN or
  alias name — and stored as the key ARN, which is what a live account reports. A key that does not
  exist or is not enabled is `KMSKeyNotAccessibleFault`. The lookup runs with the other validations,
  before a proxy port is taken or a container started. `RdsService` therefore takes `KmsService`
  on its CDI constructor.
- `modifyDbInstance` is now `synchronized` like the tag and delete paths: its read-modify-write could
  otherwise write an instance back after `deleteDbInstance` removed it.
- A record persisted before the fields existed reads as the AWS defaults: not encrypted, retention 1,
  the previous constant windows.

## Checked against a live account

Every rule below was probed on AWS (eu-central-1, postgres 17) before being written:

| input | AWS | now Floci |
|---|---|---|
| omitted | `false` / `null` / `1` / random 30-min windows / `false` | same, with deterministic windows `04:00-06:00`, `mon:00:00-mon:03:00` |
| `KmsKeyId` as alias name, key id or alias ARN | `KmsKeyId` = key ARN on create and describe | same |
| `KmsKeyId` naming no key (ARN, alias, or garbage) | `KMSKeyNotAccessibleFault: The specified KMS key [x] does not exist, is not enabled or you do not have permissions to access it.` | same wording |
| `KmsKeyId` with `StorageEncrypted` false **or omitted** | `InvalidParameterCombination: You must enable StorageEncrypted when you specify KmsKeyId` | same |
| `--preferred-backup-window 25:00-26:00` | `InvalidParameterValue: Invalid backup window time '25:00' specified. Should be specified as a time hh24:mi (24H Clock UTC). Example: 03:15` | same wording |
| `xxx:00:00-xxx:01:00` maintenance | `InvalidParameterValue: Invalid maintenance window time 'xxx:00:00' …` | same wording |
| backup `02:00-02:10` | `Backup window must be at least 30 minutes.` | same |
| backup `02:00-02:30` + maintenance `tue:02:15-tue:02:45` | `The backup window and maintenance window must not overlap.` | same (checked across midnight and the week boundary) |
| `--backup-retention-period 40` | accepted | accepted — not range-checked |
| `Tue:04:00-Tue:04:30` | stored lower-case `tue:04:00-tue:04:30` | lower-cased |
| modify with `--apply-immediately` | applied on the next describe | applied |

Intentional deviation: AWS moves a `BackupRetentionPeriod 0` modify to `PendingModifiedValues`;
Floci has no pending model and applies every modify immediately, as it already did.

## Tests

- `RdsQueryHandlerTest`: parameters reach the service, omitted ones arrive as null, a non-numeric
  retention is a Query error, describe emits stored values, a record without the fields reads as
  defaults, modify ignores the encryption parameters.
- `RdsServiceTest`: stored on create, defaults when omitted, every key form resolves to the ARN, a
  missing or disabled key is refused with no container started, each validation rule, modify applies
  the given settings and keeps the rest, an invalid modify leaves the record untouched.
  `modifyDbInstanceCannotWriteAnInstanceBackAfterDelete` stages the interleaving with a store that
  pauses inside modify's `put` while the delete runs; it fails with the monitor removed (the deleted
  instance comes back) and passes with it.
- `rds.bats`: the CLI round trip with a real KMS key given as an alias and read back as its ARN,
  describe and modify, the missing-key and the KmsKeyId-without-encryption refusals — run against
  the packaged jar locally.
