### PR TITLE
fix(ec2): canonicalize IPv4 route destinations at the API boundary

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/CidrCanonicalizer.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/CidrCanonicalizer.java
@@ -1,0 +1,204 @@
+package io.github.hectorvent.floci.core.common;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.util.Optional;
+
+/**
+ * Canonicalises IPv4 and IPv6 CIDR blocks the way AWS does on write: the address is
+ * rewritten so every bit outside the prefix is zero, then re-rendered in AWS's own
+ * textual form (dotted-decimal for IPv4, compressed form for IPv6).
+ *
+ * <p>{@code 100.68.0.18/18} becomes {@code 100.68.0.0/18} — AWS's own documented
+ * example — because bits 18-31 of the address are host bits and AWS zeroes them
+ * before storing the block. A CIDR that is already canonical is returned unchanged
+ * (the identical string, not merely an equal one).
+ *
+ * <p>This class draws a hard line between "malformed" and "valid but non-canonical":
+ * {@link #canonicalize(String)} returns {@link Optional#empty()} only for a CIDR that
+ * cannot be parsed at all, never as a stand-in for "already canonical". Callers that
+ * need to tell the two apart before rewriting anything can call
+ * {@link #isCanonical(String)} directly.
+ *
+ * <p>Pure function: no I/O, no DNS resolution. The address half of the CIDR is parsed
+ * as a literal via {@link InetAddress#ofLiteral(String)}, which never triggers a
+ * hostname lookup — critical here, because {@link InetAddress#getByName(String)} would
+ * silently turn a malformed CIDR into a DNS query.
+ */
+public final class CidrCanonicalizer {
+
+    private CidrCanonicalizer() {}
+
+    /**
+     * Parses {@code cidr}, zeroes its host bits, and re-renders it in canonical form.
+     *
+     * @param cidr an IPv4 or IPv6 CIDR block, e.g. {@code "100.68.0.18/18"} or
+     *             {@code "2001:db8::1/32"}
+     * @return the canonical CIDR string, or {@link Optional#empty()} if {@code cidr} is
+     *     null, blank, missing a prefix, has a prefix out of range for the address
+     *     family (0-32 for IPv4, 0-128 for IPv6), or has an address half that is not a
+     *     literal IPv4/IPv6 address
+     */
+    public static Optional<String> canonicalize(String cidr) {
+        return parse(cidr).map(parsed -> {
+            String rendered = render(parsed);
+            // Preserve reference identity when the input was already canonical, so
+            // callers get the exact same String back rather than a merely-equal copy.
+            return rendered.equals(cidr) ? cidr : rendered;
+        });
+    }
+
+    /**
+     * Reports whether {@code cidr} is both parseable and already in canonical form,
+     * i.e. {@code canonicalize(cidr)} would return the identical string.
+     *
+     * @return {@code true} only when {@code cidr} is valid and already canonical;
+     *     {@code false} both when it is malformed and when it is valid but would be
+     *     rewritten — use {@link #canonicalize(String)} to distinguish those two cases
+     */
+    public static boolean isCanonical(String cidr) {
+        return parse(cidr).map(parsed -> render(parsed).equals(cidr)).orElse(false);
+    }
+
+    private static Optional<ParsedCidr> parse(String cidr) {
+        if (cidr == null || cidr.isBlank()) {
+            return Optional.empty();
+        }
+
+        int slash = cidr.lastIndexOf('/');
+        if (slash < 0 || slash == cidr.length() - 1) {
+            return Optional.empty();
+        }
+
+        String addressPart = cidr.substring(0, slash);
+        String prefixPart = cidr.substring(slash + 1);
+
+        int prefixLength;
+        try {
+            prefixLength = Integer.parseInt(prefixPart);
+        } catch (NumberFormatException e) {
+            return Optional.empty();
+        }
+        if (prefixLength < 0) {
+            return Optional.empty();
+        }
+
+        InetAddress address;
+        try {
+            // ofLiteral never resolves a hostname; a non-literal input throws instead
+            // of falling through to DNS, which is exactly what a malformed address
+            // half of a CIDR must do.
+            address = InetAddress.ofLiteral(addressPart);
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
+
+        int maxPrefixLength = address instanceof Inet4Address ? 32 : 128;
+        if (prefixLength > maxPrefixLength) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new ParsedCidr(address, prefixLength));
+    }
+
+    private static String render(ParsedCidr parsed) {
+        byte[] masked = maskHostBits(parsed.address().getAddress(), parsed.prefixLength());
+        InetAddress maskedAddress;
+        try {
+            maskedAddress = InetAddress.getByAddress(masked);
+        } catch (java.net.UnknownHostException e) {
+            // Only thrown for an address of the wrong byte length, which cannot
+            // happen here: `masked` is always copied from a real InetAddress.
+            throw new AssertionError("unreachable: masked address has invalid length", e);
+        }
+        return hostAddress(maskedAddress) + "/" + parsed.prefixLength();
+    }
+
+    /**
+     * Returns the textual form AWS uses: dotted-decimal for IPv4, RFC 5952 compressed
+     * form for IPv6.
+     *
+     * <p>{@link InetAddress#getHostAddress()} renders IPv6 addresses in fully expanded
+     * form ({@code 2001:db8:0:0:0:0:0:0}, not {@code 2001:db8::}), so the compression
+     * step is done here explicitly rather than delegated.
+     */
+    private static String hostAddress(InetAddress address) {
+        if (address instanceof Inet6Address v6) {
+            return compressIpv6(v6.getAddress());
+        }
+        return address.getHostAddress();
+    }
+
+    /**
+     * Renders 16 raw IPv6 address bytes as RFC 5952 compressed text: the longest run
+     * of two or more consecutive all-zero 16-bit groups is collapsed to {@code ::}
+     * (the leftmost run wins on a tie), and remaining groups are lowercase hex with no
+     * leading zeros.
+     */
+    private static String compressIpv6(byte[] bytes) {
+        int[] groups = new int[8];
+        for (int i = 0; i < 8; i++) {
+            groups[i] = ((bytes[i * 2] & 0xFF) << 8) | (bytes[i * 2 + 1] & 0xFF);
+        }
+
+        int bestStart = -1;
+        int bestLength = 0;
+        int runStart = -1;
+        for (int i = 0; i <= 8; i++) {
+            boolean zero = i < 8 && groups[i] == 0;
+            if (zero) {
+                if (runStart < 0) {
+                    runStart = i;
+                }
+            } else if (runStart >= 0) {
+                int runLength = i - runStart;
+                if (runLength > bestLength) {
+                    bestStart = runStart;
+                    bestLength = runLength;
+                }
+                runStart = -1;
+            }
+        }
+        // A run must be at least two groups to be worth eliding (RFC 5952 §4.2.2).
+        if (bestLength < 2) {
+            bestStart = -1;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 8; ) {
+            if (i == bestStart) {
+                sb.append("::");
+                i += bestLength;
+                continue;
+            }
+            if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ':') {
+                sb.append(':');
+            }
+            sb.append(Integer.toHexString(groups[i]));
+            i++;
+        }
+        // An address with no elided run at all (e.g. all groups non-zero) never hits
+        // the "::" branch, so nothing above needs a leading-colon special case; a run
+        // starting at index 0 naturally produces the correct leading "::".
+        return sb.toString();
+    }
+
+    private static byte[] maskHostBits(byte[] addressBytes, int prefixLength) {
+        byte[] masked = addressBytes.clone();
+        int fullBytes = prefixLength / 8;
+        int remainderBits = prefixLength % 8;
+
+        if (remainderBits != 0 && fullBytes < masked.length) {
+            int keepMask = 0xFF << (8 - remainderBits) & 0xFF;
+            masked[fullBytes] = (byte) (masked[fullBytes] & keepMask);
+            fullBytes++;
+        }
+        for (int i = fullBytes; i < masked.length; i++) {
+            masked[i] = 0;
+        }
+        return masked;
+    }
+
+    private record ParsedCidr(InetAddress address, int prefixLength) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -31,6 +31,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsRegions;
+import io.github.hectorvent.floci.core.common.CidrCanonicalizer;
 import io.github.hectorvent.floci.core.common.ContainerTeardown;
 import io.github.hectorvent.floci.core.resource.ExplorerResource;
 import io.github.hectorvent.floci.core.resource.ResourceProvider;
@@ -4614,6 +4615,36 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     }
 
     /**
+     * AWS canonicalizes an IPv4 destination CIDR on input: "We modify the specified CIDR block to
+     * its canonical form; for example, if you specify 100.68.0.18/18, we modify it to
+     * 100.68.0.0/18." Running every DestinationCidrBlock through this once, here, is what lets
+     * CreateRoute, ReplaceRoute and DeleteRoute agree on "same destination" — two spellings of the
+     * same network now collide as duplicates instead of coexisting as two routes with undefined
+     * ReplaceRoute/DeleteRoute behaviour — and it is also why DescribeRouteTables echoes back the
+     * canonical form: the stored Route never holds anything else.
+     *
+     * <p>DestinationIpv6CidrBlock has no equivalent sentence in the CreateRoute/ReplaceRoute model
+     * and is left untouched. DestinationPrefixListId is an opaque ID, not a CIDR, and is likewise
+     * untouched.
+     *
+     * <p>A block that is not a well-formed "IPv4/prefix" is returned unchanged: canonicalizing is
+     * not this method's job to validate the request, only to reduce what is already well-formed.
+     * The unmodified value fails downstream exactly as it did before this change.
+     *
+     * <p>Delegates the actual bit-twiddling to {@link CidrCanonicalizer}, which also understands
+     * IPv6. That is deliberately not used here: DestinationCidrBlock is AWS's IPv4-only field —
+     * the API reference's canonicalization sentence appears only under it, never under
+     * DestinationIpv6CidrBlock — so a value that parses as an IPv6 literal is left untouched
+     * rather than canonicalized, the same as any other malformed-for-this-field input.
+     */
+    private static String canonicalizeIpv4Cidr(String destinationCidrBlock) {
+        if (!isSet(destinationCidrBlock) || destinationCidrBlock.contains(":")) {
+            return destinationCidrBlock;
+        }
+        return CidrCanonicalizer.canonicalize(destinationCidrBlock).orElse(destinationCidrBlock);
+    }
+
+    /**
      * AWS takes one destination per route, and there are three kinds of it: DestinationCidrBlock,
      * DestinationIpv6CidrBlock and DestinationPrefixListId. The CreateRoute reference is explicit
      * that a prefix list is a destination in its own right — "You must specify either a destination
@@ -4669,6 +4700,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         requireExactlyOneDestination("CreateRoute", destinationCidrBlock, destinationIpv6CidrBlock,
                 destinationPrefixListId);
         requireEgressOnlyGatewayIsTheOnlyTarget(gatewayId, natGatewayId, egressOnlyInternetGatewayId);
+        final String canonicalDestinationCidrBlock = canonicalizeIpv4Cidr(destinationCidrBlock);
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
@@ -4677,15 +4709,15 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
             // removes every copy, so a table holding two routes with the same destination has no
             // well-defined behaviour for either. AWS rejects the second CreateRoute instead, and it
             // makes no exception for the local route seeded by CreateRouteTable.
-            if (next.stream().anyMatch(r -> matchesDestination(r, destinationCidrBlock,
+            if (next.stream().anyMatch(r -> matchesDestination(r, canonicalDestinationCidrBlock,
                     destinationIpv6CidrBlock, destinationPrefixListId))) {
                 throw new AwsException("RouteAlreadyExists",
                         "The route identified by "
-                                + destinationLabel(destinationCidrBlock, destinationIpv6CidrBlock,
+                                + destinationLabel(canonicalDestinationCidrBlock, destinationIpv6CidrBlock,
                                         destinationPrefixListId)
                                 + " already exists", 400);
             }
-            Route route = new Route(destinationCidrBlock, gatewayId, "CreateRoute");
+            Route route = new Route(canonicalDestinationCidrBlock, gatewayId, "CreateRoute");
             route.setDestinationIpv6CidrBlock(destinationIpv6CidrBlock);
             route.setDestinationPrefixListId(destinationPrefixListId);
             route.setNatGatewayId(natGatewayId);
@@ -4710,24 +4742,25 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
             throw new AwsException("InvalidParameterCombination",
                     "ReplaceRoute takes exactly one target, and only GatewayId or NatGatewayId is supported.", 400);
         }
+        final String canonicalDestinationCidrBlock = canonicalizeIpv4Cidr(destinationCidrBlock);
 
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
             Route existing = next.stream()
-                    .filter(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock,
+                    .filter(r -> matchesDestination(r, canonicalDestinationCidrBlock, destinationIpv6CidrBlock,
                             destinationPrefixListId))
                     .findFirst()
                     .orElseThrow(() -> new AwsException("InvalidRoute.NotFound",
                             "The route identified by "
-                                    + destinationLabel(destinationCidrBlock, destinationIpv6CidrBlock,
+                                    + destinationLabel(canonicalDestinationCidrBlock, destinationIpv6CidrBlock,
                                             destinationPrefixListId)
                                     + " does not exist", 400));
 
             // The target the request does not name is cleared rather than carried over from the
             // route being replaced.
-            Route replacement = new Route(destinationCidrBlock, hasGateway ? gatewayId : null, existing.getOrigin());
+            Route replacement = new Route(canonicalDestinationCidrBlock, hasGateway ? gatewayId : null, existing.getOrigin());
             replacement.setDestinationIpv6CidrBlock(destinationIpv6CidrBlock);
             replacement.setDestinationPrefixListId(destinationPrefixListId);
             replacement.setNatGatewayId(hasNatGateway ? natGatewayId : null);
@@ -4741,11 +4774,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                             String destinationIpv6CidrBlock, String destinationPrefixListId) {
         requireExactlyOneDestination("DeleteRoute", destinationCidrBlock, destinationIpv6CidrBlock,
                 destinationPrefixListId);
+        final String canonicalDestinationCidrBlock = canonicalizeIpv4Cidr(destinationCidrBlock);
         ensureDefaultResources(region);
         synchronized (lockFor(key(region, routeTableId))) {
             RouteTable current = getRequiredRouteTable(region, routeTableId);
             List<Route> next = new ArrayList<>(current.getRoutes());
-            next.removeIf(r -> matchesDestination(r, destinationCidrBlock, destinationIpv6CidrBlock,
+            next.removeIf(r -> matchesDestination(r, canonicalDestinationCidrBlock, destinationIpv6CidrBlock,
                     destinationPrefixListId));
             current.setRoutes(next);
             routeTables.put(key(region, routeTableId), current);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Route.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Route.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.ec2.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.github.hectorvent.floci.core.common.CidrCanonicalizer;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @RegisterForReflection
@@ -19,13 +20,36 @@ public class Route {
     public Route() {}
 
     public Route(String destinationCidrBlock, String gatewayId, String origin) {
-        this.destinationCidrBlock = destinationCidrBlock;
+        setDestinationCidrBlock(destinationCidrBlock);
         this.gatewayId = gatewayId;
         this.origin = origin;
     }
 
     public String getDestinationCidrBlock() { return destinationCidrBlock; }
-    public void setDestinationCidrBlock(String destinationCidrBlock) { this.destinationCidrBlock = destinationCidrBlock; }
+
+    /**
+     * Canonicalized on every set, not only via the constructor. {@link Ec2Service} already
+     * canonicalizes a {@code DestinationCidrBlock} before constructing a {@code Route} at the
+     * API boundary (CreateRoute/ReplaceRoute), so re-canonicalizing here is a no-op for that
+     * path. The path this setter actually fixes is Jackson deserialization: PersistentStorage
+     * reconstructs a {@code Route} from disk via this setter, so a route written before
+     * canonicalization existed (e.g. stored as {@code 100.68.0.18/18}) is normalized the moment
+     * it is read back into memory, and every later in-memory comparison
+     * ({@code matchesDestination} in CreateRoute/ReplaceRoute/DeleteRoute) is apples-to-apples
+     * with a freshly-canonicalized incoming destination.
+     *
+     * <p>Scoped to IPv4 only, matching the API-boundary decision: a value containing {@code ':'}
+     * (or anything else {@link CidrCanonicalizer} cannot parse) is left untouched, since
+     * DestinationCidrBlock is documented by AWS as an IPv4-only field and
+     * DestinationIpv6CidrBlock is a separate member with its own field/setter.
+     */
+    public void setDestinationCidrBlock(String destinationCidrBlock) {
+        if (destinationCidrBlock == null || destinationCidrBlock.isBlank() || destinationCidrBlock.contains(":")) {
+            this.destinationCidrBlock = destinationCidrBlock;
+            return;
+        }
+        this.destinationCidrBlock = CidrCanonicalizer.canonicalize(destinationCidrBlock).orElse(destinationCidrBlock);
+    }
 
     public String getDestinationIpv6CidrBlock() { return destinationIpv6CidrBlock; }
     public void setDestinationIpv6CidrBlock(String destinationIpv6CidrBlock) { this.destinationIpv6CidrBlock = destinationIpv6CidrBlock; }

--- a/src/test/java/io/github/hectorvent/floci/core/common/CidrCanonicalizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/CidrCanonicalizerTest.java
@@ -1,0 +1,164 @@
+package io.github.hectorvent.floci.core.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CidrCanonicalizerTest {
+
+    // -----------------------------------------------------------------
+    // Pinned cases from the bead — exact strings, not just equality.
+    // -----------------------------------------------------------------
+
+    @Test
+    void awsDocumentedExample_rewritesHostBitsToZero() {
+        assertEquals(Optional.of("100.68.0.0/18"), CidrCanonicalizer.canonicalize("100.68.0.18/18"));
+    }
+
+    @Test
+    void alreadyCanonicalIpv4_isIdentityNotJustEqual() {
+        String input = "10.0.0.0/16";
+        Optional<String> result = CidrCanonicalizer.canonicalize(input);
+        assertEquals(Optional.of("10.0.0.0/16"), result);
+        // Must be the identical string value, not merely equal.
+        assertSame(input, result.orElseThrow());
+    }
+
+    @Test
+    void defaultRouteIpv4_zeroPrefixDoesNotDivideByZeroOrShiftBy32() {
+        String input = "0.0.0.0/0";
+        Optional<String> result = CidrCanonicalizer.canonicalize(input);
+        assertEquals(Optional.of("0.0.0.0/0"), result);
+        assertSame(input, result.orElseThrow());
+    }
+
+    @Test
+    void hostRouteIpv4_slash32IsUnchanged() {
+        String input = "10.1.2.3/32";
+        Optional<String> result = CidrCanonicalizer.canonicalize(input);
+        assertEquals(Optional.of("10.1.2.3/32"), result);
+        assertSame(input, result.orElseThrow());
+    }
+
+    @Test
+    void ipv6_rewritesHostBitsToZero() {
+        assertEquals(Optional.of("2001:db8::/32"), CidrCanonicalizer.canonicalize("2001:db8::1/32"));
+    }
+
+    @Test
+    void defaultRouteIpv6_zeroPrefixIsUnchanged() {
+        String input = "::/0";
+        Optional<String> result = CidrCanonicalizer.canonicalize(input);
+        assertEquals(Optional.of("::/0"), result);
+        assertSame(input, result.orElseThrow());
+    }
+
+    @Test
+    void ipv6_expandedInputCanonicalizesToCompressedForm() {
+        // AWS itself returns compressed IPv6; an expanded round-trip would be a diff.
+        assertEquals(Optional.of("2001:db8::/48"), CidrCanonicalizer.canonicalize("2001:0db8:0000::/48"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "",
+                "not-a-cidr",
+                "10.0.0.0",
+                "10.0.0.0/",
+                "/24",
+                "10.0.0.0/-1",
+                "10.0.0.0/33",
+                "2001:db8::1/129",
+                "2001:db8::1/-1",
+                "999.0.0.0/24",
+                "10.0.0.256/24",
+                "10.0.0.0/abc",
+                "example.com/24",
+                "10.0.0.0/24/extra",
+            })
+    void malformedOrOutOfRangeCidr_isDistinguishablyInvalid(String input) {
+        assertEquals(Optional.empty(), CidrCanonicalizer.canonicalize(input));
+        assertFalse(CidrCanonicalizer.isCanonical(input));
+    }
+
+    @Test
+    void nullCidr_isDistinguishablyInvalid() {
+        assertEquals(Optional.empty(), CidrCanonicalizer.canonicalize(null));
+        assertFalse(CidrCanonicalizer.isCanonical(null));
+    }
+
+    // -----------------------------------------------------------------
+    // Additional coverage.
+    // -----------------------------------------------------------------
+
+    @Test
+    void ipv6HostRoute_slash128IsUnchanged() {
+        String input = "2001:db8::1/128";
+        Optional<String> result = CidrCanonicalizer.canonicalize(input);
+        assertEquals(Optional.of("2001:db8::1/128"), result);
+        assertSame(input, result.orElseThrow());
+    }
+
+    @Test
+    void ipv4MappedIpv6Literal_ofLiteralCollapsesItToIpv4_soPrefixIsBoundedByThirtyTwo() {
+        // InetAddress.ofLiteral("::ffff:a.b.c.d") returns an Inet4Address, not an
+        // Inet6Address — Java itself collapses the IPv4-mapped form. A prefix that
+        // would be valid for the 128-bit IPv6 reading (e.g. /120) is therefore out of
+        // range once resolved, and must be rejected rather than silently accepted
+        // against the wrong bit width.
+        assertEquals(Optional.empty(), CidrCanonicalizer.canonicalize("::ffff:192.168.1.1/120"));
+
+        // A prefix within IPv4's 0-32 range works, canonicalizing as plain IPv4.
+        Optional<String> result = CidrCanonicalizer.canonicalize("::ffff:192.168.1.1/24");
+        assertEquals(Optional.of("192.168.1.0/24"), result);
+        // Re-canonicalizing the output must be a no-op (idempotence).
+        assertEquals(result, CidrCanonicalizer.canonicalize(result.orElseThrow()));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "100.68.0.18/18, 100.68.0.0/18",
+        "10.0.0.0/16, 10.0.0.0/16",
+        "0.0.0.0/0, 0.0.0.0/0",
+        "10.1.2.3/32, 10.1.2.3/32",
+        "2001:db8::1/32, 2001:db8::/32",
+        "::/0, ::/0",
+        "2001:0db8:0000::/48, 2001:db8::/48",
+        "192.168.1.255/24, 192.168.1.0/24",
+        "172.16.5.5/22, 172.16.4.0/22",
+        "255.255.255.255/32, 255.255.255.255/32",
+        "2001:db8:abcd:0012:0000:0000:0000:0001/64, 2001:db8:abcd:12::/64",
+    })
+    void canonicalize_matchesExpected(String input, String expected) {
+        assertEquals(Optional.of(expected), CidrCanonicalizer.canonicalize(input));
+    }
+
+    @Test
+    void isCanonical_trueOnlyForAlreadyCanonicalCidr() {
+        assertTrue(CidrCanonicalizer.isCanonical("10.0.0.0/16"));
+        assertTrue(CidrCanonicalizer.isCanonical("0.0.0.0/0"));
+        assertTrue(CidrCanonicalizer.isCanonical("2001:db8::/32"));
+        assertFalse(CidrCanonicalizer.isCanonical("100.68.0.18/18"));
+        assertFalse(CidrCanonicalizer.isCanonical("2001:0db8:0000::/48"));
+    }
+
+    @Test
+    void prefixLengthZero_forBothFamilies_isAccepted() {
+        assertEquals(Optional.of("0.0.0.0/0"), CidrCanonicalizer.canonicalize("192.168.1.1/0"));
+        assertEquals(Optional.of("::/0"), CidrCanonicalizer.canonicalize("2001:db8::1/0"));
+    }
+
+    @Test
+    void whitespaceOnlyCidr_isDistinguishablyInvalid() {
+        assertEquals(Optional.empty(), CidrCanonicalizer.canonicalize("   "));
+        assertFalse(CidrCanonicalizer.isCanonical("   "));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2RouteCidrCanonicalizationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2RouteCidrCanonicalizationTest.java
@@ -1,0 +1,196 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.xml.HasXPath.hasXPath;
+
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import io.quarkus.test.junit.QuarkusTest;
+import static io.restassured.RestAssured.given;
+
+/**
+ * AWS canonicalizes an IPv4 destination CIDR on input:
+ * https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateRoute.html — "We modify the
+ * specified CIDR block to its canonical form; for example, if you specify 100.68.0.18/18, we
+ * modify it to 100.68.0.0/18." This is the property that makes RouteAlreadyExists (see
+ * {@link Ec2DuplicateRouteTest}) actually work for the destinations people write: two operators
+ * spelling the same /18 network differently must collide as the same route, and
+ * DescribeRouteTables must always echo the canonical spelling regardless of which spelling
+ * CreateRoute, ReplaceRoute or DeleteRoute were called with.
+ *
+ * <p>Canonicalization is IPv4-only. DestinationIpv6CidrBlock has no equivalent sentence in the
+ * model and DestinationPrefixListId is an opaque ID, not a CIDR, so neither is touched — the last
+ * test here pins that an IPv6 destination survives byte-for-byte.
+ *
+ * <p>The XPath assertions use {@code local-name()} because EC2 responses carry a default
+ * namespace.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2RouteCidrCanonicalizationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static final String VPC_CIDR = "203.0.113.0/24";
+    private static final String NON_CANONICAL = "100.68.0.18/18";
+    private static final String CANONICAL = "100.68.0.0/18";
+    private static final String OTHER_SPELLING_SAME_NETWORK = "100.68.63.255/18";
+    private static final String IPV6_ROUTE = "2001:db8::/32";
+    private static final String INTERNET_GATEWAY = "igw-0cidrcanon0test00";
+    private static final String OTHER_GATEWAY = "igw-0cidrcanon0othr00";
+
+    private static final String ROUTE_COUNT =
+            "count(//*[local-name()='routeSet']/*[local-name()='item'])";
+
+    private static String routeTableId;
+
+    private static io.restassured.specification.RequestSpecification ec2() {
+        return given().header("Authorization", AUTH_HEADER);
+    }
+
+    private static io.restassured.response.ValidatableResponse describe() {
+        return ec2()
+            .formParam("Action", "DescribeRouteTables")
+            .formParam("RouteTableId.1", routeTableId)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    private static io.restassured.specification.RequestSpecification createRoute(
+            String destinationCidrBlock, String gatewayId) {
+        return ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", destinationCidrBlock)
+            .formParam("GatewayId", gatewayId);
+    }
+
+    @Test
+    @Order(1)
+    void createARouteTable() {
+        String vpcId = ec2()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", VPC_CIDR)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        routeTableId = ec2()
+            .formParam("Action", "CreateRouteTable")
+            .formParam("VpcId", vpcId)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateRouteTableResponse.routeTable.routeTableId");
+    }
+
+    /** CreateRoute stores and echoes the canonical form, not the spelling the caller sent. */
+    @Test
+    @Order(2)
+    void createRouteCanonicalizesTheDestination() {
+        createRoute(NON_CANONICAL, INTERNET_GATEWAY).when().post("/").then().statusCode(200);
+
+        describe()
+            .body(hasXPath(ROUTE_COUNT, equalTo("2"))) // the seeded local route, plus this one
+            .body(hasXPath("//*[local-name()='routeSet']/*[local-name()='item']"
+                    + "[*[local-name()='destinationCidrBlock']='" + CANONICAL + "']"))
+            .body(hasXPath("count(//*[local-name()='routeSet']/*[local-name()='item']"
+                    + "[*[local-name()='destinationCidrBlock']='" + NON_CANONICAL + "'])", equalTo("0")));
+    }
+
+    /**
+     * A second CreateRoute spelling the same /18 network differently is the same destination as
+     * far as AWS is concerned, so it collides with RouteAlreadyExists exactly like a literal
+     * repeat would (see {@link Ec2DuplicateRouteTest}). Without canonicalizing on input, this
+     * would have silently created a second, functionally ambiguous route instead.
+     */
+    @Test
+    @Order(3)
+    void anEquivalentSpellingOfTheSameNetworkCollidesAsADuplicate() {
+        String message = createRoute(OTHER_SPELLING_SAME_NETWORK, INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("RouteAlreadyExists"))
+            .extract().path("Response.Errors.Error.Message");
+
+        // The error names the canonical destination, since that is what is actually on file.
+        assertThat(message, containsString(CANONICAL));
+
+        describe().body(hasXPath(ROUTE_COUNT, equalTo("2")));
+    }
+
+    /**
+     * ReplaceRoute must canonicalize its own DestinationCidrBlock before matching, or an
+     * equivalent-but-differently-spelled request would miss the stored canonical route entirely
+     * and fail with InvalidRoute.NotFound instead of retargeting it.
+     */
+    @Test
+    @Order(4)
+    void replaceRouteMatchesTheCanonicalRouteByAnEquivalentSpelling() {
+        ec2()
+            .formParam("Action", "ReplaceRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", OTHER_SPELLING_SAME_NETWORK)
+            .formParam("GatewayId", OTHER_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        describe()
+            .body(hasXPath(ROUTE_COUNT, equalTo("2")))
+            .body("DescribeRouteTablesResponse.routeTableSet.item.routeSet.item"
+                    + ".find { it.destinationCidrBlock == '" + CANONICAL + "' }.gatewayId",
+                    equalTo(OTHER_GATEWAY));
+    }
+
+    /**
+     * DeleteRoute must canonicalize the same way, or an equivalent spelling would silently match
+     * nothing and leave the route in place while reporting success.
+     */
+    @Test
+    @Order(5)
+    void deleteRouteMatchesTheCanonicalRouteByAnEquivalentSpelling() {
+        ec2()
+            .formParam("Action", "DeleteRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationCidrBlock", NON_CANONICAL)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        describe().body(hasXPath(ROUTE_COUNT, equalTo("1"))); // only the seeded local route remains
+    }
+
+    /** DestinationIpv6CidrBlock has no canonical form in the model and is stored byte-for-byte. */
+    @Test
+    @Order(6)
+    void ipv6DestinationsAreNotCanonicalized() {
+        ec2()
+            .formParam("Action", "CreateRoute")
+            .formParam("RouteTableId", routeTableId)
+            .formParam("DestinationIpv6CidrBlock", IPV6_ROUTE)
+            .formParam("GatewayId", INTERNET_GATEWAY)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        describe().body(hasXPath("//*[local-name()='routeSet']/*[local-name()='item']"
+                + "[*[local-name()='destinationIpv6CidrBlock']='" + IPV6_ROUTE + "']"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServicePersistenceTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ec2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.PersistentStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.ec2.model.Address;
@@ -32,11 +33,14 @@ import io.github.hectorvent.floci.services.ec2.portforward.Ec2PortForwardManager
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -159,6 +163,85 @@ class Ec2ServicePersistenceTest {
         assertEquals(source.getGroupId(), ingress.getFirst().getReferencedGroupInfo().getGroupId());
         assertEquals("000000000000", ingress.getFirst().getReferencedGroupInfo().getUserId());
         assertEquals("from-source-sg", ingress.getFirst().getDescription());
+    }
+
+    /**
+     * Regression test for the RouteAlreadyExists/InvalidRoute.NotFound gap Greptile flagged on
+     * the DestinationCidrBlock canonicalization fix: a route persisted BEFORE that fix stores its
+     * destination in whatever spelling CreateRoute was originally called with (here
+     * {@code 100.68.0.18/18} rather than the canonical {@code 100.68.0.0/18}). Without
+     * canonicalizing on load, that legacy spelling never matches a newly-canonicalized incoming
+     * destination under strict string comparison, so CreateRoute could create a duplicate,
+     * ReplaceRoute could wrongly 404, and DeleteRoute could silently no-op.
+     *
+     * <p>This hand-writes a pre-fix-shaped {@code ec2-route-tables.json} directly (bypassing
+     * {@link io.github.hectorvent.floci.services.ec2.model.Route}'s own setter, which now
+     * canonicalizes) to simulate a file written by a pre-canonicalization Floci, then restarts
+     * over it and asserts: (a) the reloaded route reads back canonical; (b) CreateRoute with an
+     * equivalent-but-differently-spelled destination is detected as a duplicate rather than
+     * creating a second route; (c) ReplaceRoute and DeleteRoute using the legacy, non-canonical
+     * spelling still find the same route. Reverting the {@code Route.setDestinationCidrBlock}
+     * change alone fails this test: (a) reads back {@code 100.68.0.18/18} instead of
+     * {@code 100.68.0.0/18}, and (b)/(c) then also fail because CreateRoute/ReplaceRoute/
+     * DeleteRoute never see the same string as the stored legacy route.
+     */
+    @Test
+    void legacyNonCanonicalRouteDestinationCanonicalizesOnRestart(@TempDir Path dir) throws IOException {
+        String routeTableId = "rtb-legacycidr01";
+        String vpcId = "vpc-legacycidr01";
+        String gatewayId = "igw-legacycidr01";
+        String legacyJson = """
+                {
+                  "%s::%s": {
+                    "routeTableId": "%s",
+                    "vpcId": "%s",
+                    "ownerId": "000000000000",
+                    "region": "%s",
+                    "routes": [
+                      {
+                        "destinationCidrBlock": "100.68.0.18/18",
+                        "gatewayId": "%s",
+                        "state": "active",
+                        "origin": "CreateRoute"
+                      }
+                    ],
+                    "associations": [],
+                    "tags": []
+                  }
+                }
+                """.formatted(REGION, routeTableId, routeTableId, vpcId, REGION, gatewayId);
+        Files.writeString(dir.resolve("ec2-route-tables.json"), legacyJson);
+
+        Ec2Service restarted = newService(dir);
+
+        // (a) the loaded route's destination reads back canonical.
+        RouteTable loaded =
+                restarted.describeRouteTables(REGION, List.of(routeTableId), Map.of()).getFirst();
+        assertEquals(1, loaded.getRoutes().size());
+        assertEquals("100.68.0.0/18", loaded.getRoutes().getFirst().getDestinationCidrBlock(),
+                "legacy route destination must be canonicalized on load");
+
+        // (b) CreateRoute with an equivalent-but-differently-spelled destination is a duplicate,
+        // not a new route, of the legacy one.
+        AwsException duplicate = assertThrows(AwsException.class, () -> restarted.createRoute(
+                REGION, routeTableId, "100.68.63.255/18", null, null, "igw-other00000000000", null, null));
+        assertEquals("RouteAlreadyExists", duplicate.getErrorCode());
+
+        // (c) ReplaceRoute against the legacy route's original, non-canonical spelling finds the
+        // same route rather than throwing InvalidRoute.NotFound.
+        restarted.replaceRoute(REGION, routeTableId, "100.68.0.18/18", null, null, "igw-replaced0000000", null);
+        RouteTable afterReplace =
+                restarted.describeRouteTables(REGION, List.of(routeTableId), Map.of()).getFirst();
+        assertEquals(1, afterReplace.getRoutes().size(), "replace must update the existing route in place");
+        assertEquals("igw-replaced0000000", afterReplace.getRoutes().getFirst().getGatewayId());
+        assertEquals("100.68.0.0/18", afterReplace.getRoutes().getFirst().getDestinationCidrBlock());
+
+        // (c) DeleteRoute against the same legacy spelling actually removes the route rather than
+        // reporting success while leaving it behind.
+        restarted.deleteRoute(REGION, routeTableId, "100.68.0.18/18", null, null);
+        RouteTable afterDelete =
+                restarted.describeRouteTables(REGION, List.of(routeTableId), Map.of()).getFirst();
+        assertEquals(0, afterDelete.getRoutes().size(), "delete must actually remove the legacy route");
     }
 
     private BlockDeviceMapping blockDeviceMapping(String snapshotId, int volumeSize) {


### PR DESCRIPTION
## Summary
AWS documents that a DestinationCidrBlock is reduced to its canonical form on input
(e.g. 100.68.0.18/18 becomes 100.68.0.0/18). Without that step, CreateRoute,
ReplaceRoute and DeleteRoute could each be handed a differently-spelled but
equivalent CIDR for the same network and silently disagree about which route it
named — two spellings of one /18 could coexist as distinct routes, or a
ReplaceRoute/DeleteRoute using an equivalent spelling could miss the stored route
entirely.

- Adds `CidrCanonicalizer`, a shared IPv4/IPv6 CIDR canonicalization utility in
  `core.common`.
- Wires `Ec2Service`'s CreateRoute/ReplaceRoute/DeleteRoute to canonicalize
  DestinationCidrBlock once, before it's matched against existing routes or stored.
  DescribeRouteTables then echoes the canonical form for free.
- DestinationIpv6CidrBlock is deliberately left untouched: AWS's canonical-form
  language appears only under DestinationCidrBlock in the API reference, not under
  DestinationIpv6CidrBlock, so this stays IPv4-only even though the new utility
  also supports IPv6. DestinationPrefixListId is an opaque ID, not a CIDR, and is
  likewise untouched.
- Follow-up to #2546 (RouteAlreadyExists duplicate-destination rejection), which
  this builds on: canonicalizing on input is what makes "same destination"
  detection actually catch equivalent spellings instead of just literal repeats.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility
Real EC2 canonicalizes an IPv4 route destination CIDR on input; Floci previously
stored it verbatim. This makes stored/returned state match AWS's canonical form,
and makes duplicate-destination detection correct for equivalent spellings.

## Checklist
- [x] `CidrCanonicalizerTest` — 38/38 pass
- [x] `Ec2RouteCidrCanonicalizationTest` — 6/6 pass (canonicalization on
      Create/Replace/Delete, duplicate-detection across spellings, IPv6 left
      untouched)
- [x] Full `services.ec2` suite — 517/517 pass, 0 failures/errors
- [x] Commit messages follow Conventional Commits
