### PR TITLE
fix(rds,docdb): list DocumentDB clusters and instances in the RDS-family list form

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -218,6 +218,8 @@ teardown() {
     aws_cmd ec2 delete-subnet --subnet-id "$S1" >/dev/null 2>&1 || true
     aws_cmd ec2 delete-subnet --subnet-id "$S2" >/dev/null 2>&1 || true
     aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
+}
+
 @test "docdb: a DocumentDB cluster is listed by describe-db-clusters on both endpoints" {
     CLUSTER_ID="bats-docdb-list-$(unique_name)"
     aws_cmd docdb create-db-cluster --db-cluster-identifier "$CLUSTER_ID" \

--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -218,4 +218,30 @@ teardown() {
     aws_cmd ec2 delete-subnet --subnet-id "$S1" >/dev/null 2>&1 || true
     aws_cmd ec2 delete-subnet --subnet-id "$S2" >/dev/null 2>&1 || true
     aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
+@test "docdb: a DocumentDB cluster is listed by describe-db-clusters on both endpoints" {
+    CLUSTER_ID="bats-docdb-list-$(unique_name)"
+    aws_cmd docdb create-db-cluster --db-cluster-identifier "$CLUSTER_ID" \
+        --engine docdb --master-username docdbadmin --master-user-password "secret99password" >/dev/null
+
+    run aws_cmd docdb describe-db-clusters --query 'DBClusters[].DBClusterIdentifier'
+    assert_success
+    assert_output --partial "$CLUSTER_ID"
+
+    run aws_cmd rds describe-db-clusters --query 'DBClusters[].DBClusterIdentifier'
+    assert_success
+    assert_output --partial "$CLUSTER_ID"
+
+    run aws_cmd docdb describe-db-clusters --filters Name=engine,Values=docdb --query 'DBClusters[].DBClusterIdentifier'
+    assert_success
+    assert_output --partial "$CLUSTER_ID"
+
+    run aws_cmd rds describe-db-clusters --filters Name=engine,Values=aurora-postgresql --query 'DBClusters[].DBClusterIdentifier'
+    assert_success
+    refute_output --partial "$CLUSTER_ID"
+
+    run aws_cmd rds describe-db-clusters --filters Name=engine,Values=nothing
+    assert_failure
+    assert_output --partial 'Unrecognized engine name: nothing'
+
+    aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
 }

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -4,7 +4,7 @@
 **Management Endpoint:** `POST http://localhost:4566/` with `Action=` param
 **Data Endpoint:** the `Endpoint` and `Port` returned by `DescribeDBClusters` (MongoDB wire protocol)
 
-Floci emulates Amazon DocumentDB by managing real [MongoDB](https://www.mongodb.com/) Docker containers behind an RDS-shaped control plane. DocumentDB is MongoDB-compatible, so the cluster endpoint returned by `DescribeDBClusters` speaks the MongoDB wire protocol and works with any standard MongoDB driver.
+Floci emulates Amazon DocumentDB by managing real [MongoDB](https://www.mongodb.com/) Docker containers behind an RDS-shaped control plane. As on AWS, the list form of `DescribeDBClusters` / `DescribeDBInstances` — on the `docdb` endpoint and the `rds` endpoint alike — returns DocumentDB and RDS records together; the `engine` filter (`docdb`, `aurora-postgresql`, ...) narrows it. DocumentDB is MongoDB-compatible, so the cluster endpoint returned by `DescribeDBClusters` speaks the MongoDB wire protocol and works with any standard MongoDB driver.
 
 > **Always read the host and port from `DescribeDBClusters`** rather than assuming a fixed port. MongoDB listens on `27017` *inside* the container, but the port you connect to depends on how Floci runs:
 >

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -4,7 +4,7 @@
 **Management Endpoint:** `POST http://localhost:4566/` with `Action=` param
 **Data Endpoint:** the `Endpoint` and `Port` returned by `DescribeDBClusters` (MongoDB wire protocol)
 
-Floci emulates Amazon DocumentDB by managing real [MongoDB](https://www.mongodb.com/) Docker containers behind an RDS-shaped control plane. As on AWS, the list form of `DescribeDBClusters` / `DescribeDBInstances` — on the `docdb` endpoint and the `rds` endpoint alike — returns DocumentDB and RDS records together; the `engine` filter (`docdb`, `aurora-postgresql`, ...) narrows it. DocumentDB is MongoDB-compatible, so the cluster endpoint returned by `DescribeDBClusters` speaks the MongoDB wire protocol and works with any standard MongoDB driver.
+Floci emulates Amazon DocumentDB by managing real [MongoDB](https://www.mongodb.com/) Docker containers behind an RDS-shaped control plane. As on AWS, the list form of `DescribeDBClusters` / `DescribeDBInstances` — on the `docdb` endpoint and the `rds` endpoint alike — returns DocumentDB, Neptune and RDS records together; the `engine` filter (`docdb`, `neptune`, `aurora-postgresql`, ...) narrows it. DocumentDB is MongoDB-compatible, so the cluster endpoint returned by `DescribeDBClusters` speaks the MongoDB wire protocol and works with any standard MongoDB driver.
 
 > **Always read the host and port from `DescribeDBClusters`** rather than assuming a fixed port. MongoDB listens on `27017` *inside* the container, but the port you connect to depends on how Floci runs:
 >

--- a/docs/services/neptune.md
+++ b/docs/services/neptune.md
@@ -6,6 +6,8 @@
 
 Floci manages real graph-database Docker containers and proxies connections to them, providing an API-compatible Neptune emulation for local development and testing.
 
+As on AWS, the list form of `DescribeDBClusters` / `DescribeDBInstances` on the `rds`, `docdb` and `neptune` endpoints returns Neptune records together with RDS and DocumentDB ones; the `engine` filter (`neptune`) narrows it.
+
 ## Backend engine (`db-type`)
 
 Neptune supports multiple query languages. Floci backs each one with a different container and proxies the matching wire protocol, selected globally via `FLOCI_SERVICES_NEPTUNE_DB_TYPE` (mirroring LocalStack's `NEPTUNE_DB_TYPE`):

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -14,7 +14,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | Action | Description |
 | --- | --- |
 | `CreateDBInstance` | Start a new database instance |
-| `DescribeDBInstances` | List instances and their connection info — the list form includes DocumentDB instances and takes an `engine` filter |
+| `DescribeDBInstances` | List instances and their connection info — the list form includes DocumentDB and Neptune instances and takes an `engine` filter |
 | `DeleteDBInstance` | Stop and remove an instance |
 | `ModifyDBInstance` | Update instance settings |
 | `RebootDBInstance` | Restart a database instance |
@@ -24,7 +24,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `ModifyDBSubnetGroup` | Update DB subnet group description and subnet list |
 | `DeleteDBSubnetGroup` | Delete a DB subnet group |
 | `CreateDBCluster` | Create an Aurora-compatible cluster |
-| `DescribeDBClusters` | List clusters — the list form covers the RDS family, DocumentDB clusters included, and takes an `engine` filter |
+| `DescribeDBClusters` | List clusters — the list form covers the RDS family, DocumentDB and Neptune clusters included, and takes an `engine` filter |
 | `DeleteDBCluster` | Delete a cluster |
 | `ModifyDBCluster` | Update cluster settings |
 | `CreateDBParameterGroup` | Create a parameter group |

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -14,7 +14,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | Action | Description |
 | --- | --- |
 | `CreateDBInstance` | Start a new database instance |
-| `DescribeDBInstances` | List instances and their connection info |
+| `DescribeDBInstances` | List instances and their connection info — the list form includes DocumentDB instances and takes an `engine` filter |
 | `DeleteDBInstance` | Stop and remove an instance |
 | `ModifyDBInstance` | Update instance settings |
 | `RebootDBInstance` | Restart a database instance |
@@ -24,7 +24,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `ModifyDBSubnetGroup` | Update DB subnet group description and subnet list |
 | `DeleteDBSubnetGroup` | Delete a DB subnet group |
 | `CreateDBCluster` | Create an Aurora-compatible cluster |
-| `DescribeDBClusters` | List clusters |
+| `DescribeDBClusters` | List clusters — the list form covers the RDS family, DocumentDB clusters included, and takes an `engine` filter |
 | `DeleteDBCluster` | Delete a cluster |
 | `ModifyDBCluster` | Update cluster settings |
 | `CreateDBParameterGroup` | Create a parameter group |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -322,7 +322,15 @@ public class AwsQueryController {
                 // The same check as on the rds scope: DocumentDB is reachable under either, and a
                 // create that skipped it here would put a second record under an ARN RDS owns.
                 Response clash = rdsAlreadyHoldsIdentifier(action, formParams, region);
-                yield clash != null ? clash : docDbQueryHandler.handle(action, formParams);
+                if (clash != null) {
+                    yield clash;
+                }
+                // The list form answers for the whole RDS family on either endpoint; the RDS
+                // handler assembles it from both stores.
+                if (isFamilyListing(action, formParams)) {
+                    yield rdsQueryHandler.handle(action, formParams, region);
+                }
+                yield docDbQueryHandler.handle(action, formParams);
             }
             case "email" -> sesQueryHandler.handle(action, formParams, region);
             case "monitoring" -> cloudWatchMetricsQueryHandler.handle(action, formParams, region);
@@ -378,6 +386,18 @@ public class AwsQueryController {
      * included — so one identifier keeps one answer. The collision is logged once, because the
      * RDS record behind it is unreachable on this scope and only deleting one of the two fixes it.
      */
+    private static boolean isFamilyListing(String action, MultivaluedMap<String, String> formParams) {
+        return switch (action) {
+            case "DescribeDBClusters" -> isBlank(formParams.getFirst("DBClusterIdentifier"));
+            case "DescribeDBInstances" -> isBlank(formParams.getFirst("DBInstanceIdentifier"));
+            default -> false;
+        };
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
     private boolean namesDocDbResource(String resourceName, String region) {
         if (!docDbService.hasResourceWithArn(resourceName)) {
             return false;

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -317,7 +317,9 @@ public class AwsQueryController {
                 }
                 yield rdsQueryHandler.handle(action, formParams, region);
             }
-            case "neptune" -> neptuneQueryHandler.handle(action, formParams);
+            case "neptune" -> isFamilyListing(action, formParams)
+                    ? rdsQueryHandler.handle(action, formParams, region)
+                    : neptuneQueryHandler.handle(action, formParams);
             case "docdb" -> {
                 // The same check as on the rds scope: DocumentDB is reachable under either, and a
                 // create that skipped it here would put a second record under an ARN RDS owns.

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbQueryHandler.java
@@ -111,6 +111,19 @@ public class DocDbQueryHandler {
         return Response.ok(AwsQueryResponse.envelope("DescribeDBClusters", AwsNamespaces.RDS, xml.build())).build();
     }
 
+    /**
+     * The rows the list form of DescribeDBClusters would return, for the RDS-family listing that
+     * {@code RdsQueryHandler} assembles: a live account lists DocumentDB clusters from the RDS
+     * endpoint and the DocumentDB endpoint alike.
+     */
+    public List<String> clusterRowsXml(String filterId) {
+        return service.listDbClusters(filterId).stream().map(this::clusterInnerXml).toList();
+    }
+
+    public List<String> instanceRowsXml(String filterId) {
+        return service.listDbInstances(filterId).stream().map(this::instanceInnerXml).toList();
+    }
+
     private Response handleDescribeGlobalClusters(MultivaluedMap<String, String> params) {
         // Global clusters are not modeled; an empty list is what completes the provider's read.
         // Real SDKs sign DocumentDB with the "rds" scope and land on RdsQueryHandler instead;

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.util.Collection;
+import java.util.List;
 
 @ApplicationScoped
 public class NeptuneQueryHandler {
@@ -90,6 +91,34 @@ public class NeptuneQueryHandler {
         }
         xml.end("DBClusters").start("Marker").end("Marker");
         return Response.ok(AwsQueryResponse.envelope("DescribeDBClusters", AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    /**
+     * The rows the list form of DescribeDBClusters would return for the region a request is signed
+     * for, for the RDS-family listing {@code RdsQueryHandler} assembles: a live account lists
+     * Neptune clusters from the RDS endpoint too. The Neptune store is not keyed by region, so the
+     * region is read off each record's ARN.
+     */
+    public List<String> clusterRowsXml(String filterId, String region) {
+        return service.listDbClusters(filterId).stream()
+                .filter(c -> inRegion(c.getDbClusterArn(), region))
+                .map(this::clusterInnerXml)
+                .toList();
+    }
+
+    public List<String> instanceRowsXml(String filterId, String region) {
+        return service.listDbInstances(filterId).stream()
+                .filter(i -> inRegion(i.getDbInstanceArn(), region))
+                .map(this::instanceInnerXml)
+                .toList();
+    }
+
+    private static boolean inRegion(String arn, String region) {
+        if (region == null || region.isBlank()) {
+            return true;
+        }
+        String[] parts = arn == null ? new String[0] : arn.split(":", -1);
+        return parts.length >= 4 && region.equals(parts[3]);
     }
 
     private Response handleDeleteDbCluster(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.rds.model.DbCluster;
 import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
 import io.github.hectorvent.floci.services.docdb.DocDbQueryHandler;
+import io.github.hectorvent.floci.services.neptune.NeptuneQueryHandler;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
@@ -42,11 +43,14 @@ public class RdsQueryHandler {
 
     private final RdsService service;
     private final DocDbQueryHandler docDbQueryHandler;
+    private final NeptuneQueryHandler neptuneQueryHandler;
     private final EmulatorConfig config;
 
     @Inject
-    public RdsQueryHandler(RdsService service, EmulatorConfig config, DocDbQueryHandler docDbQueryHandler) {
+    public RdsQueryHandler(RdsService service, EmulatorConfig config, DocDbQueryHandler docDbQueryHandler,
+                           NeptuneQueryHandler neptuneQueryHandler) {
         this.docDbQueryHandler = docDbQueryHandler;
+        this.neptuneQueryHandler = neptuneQueryHandler;
         this.service = service;
         this.config = config;
     }
@@ -200,6 +204,11 @@ public class RdsQueryHandler {
                     && extractRdsFilterValues(params, "dbi-resource-id").isEmpty();
             if (listForm && (engines.isEmpty() || engines.contains(DOCDB_ENGINE))) {
                 for (String row : docDbQueryHandler.instanceRowsXml(filterId)) {
+                    xml.start("DBInstance").raw(row).end("DBInstance");
+                }
+            }
+            if (listForm && (engines.isEmpty() || engines.contains(NEPTUNE_ENGINE))) {
+                for (String row : neptuneQueryHandler.instanceRowsXml(filterId, region)) {
                     xml.start("DBInstance").raw(row).end("DBInstance");
                 }
             }
@@ -473,11 +482,19 @@ public class RdsQueryHandler {
                     xml.start("DBCluster").raw(dbClusterInnerXml(c)).end("DBCluster");
                 }
             }
-            // The list form covers the whole RDS family: a live account lists DocumentDB clusters
-            // here too. The identifier form is routed to the store that owns the identifier.
-            if ((identifier == null || identifier.isBlank()) && (engines.isEmpty() || engines.contains(DOCDB_ENGINE))) {
-                for (String row : docDbQueryHandler.clusterRowsXml(filterId)) {
-                    xml.start("DBCluster").raw(row).end("DBCluster");
+            // The list form covers the whole RDS family: a live account lists DocumentDB and
+            // Neptune clusters here too. The identifier form is routed to the store that owns the
+            // identifier.
+            if (identifier == null || identifier.isBlank()) {
+                if (engines.isEmpty() || engines.contains(DOCDB_ENGINE)) {
+                    for (String row : docDbQueryHandler.clusterRowsXml(filterId)) {
+                        xml.start("DBCluster").raw(row).end("DBCluster");
+                    }
+                }
+                if (engines.isEmpty() || engines.contains(NEPTUNE_ENGINE)) {
+                    for (String row : neptuneQueryHandler.clusterRowsXml(filterId, region)) {
+                        xml.start("DBCluster").raw(row).end("DBCluster");
+                    }
                 }
             }
             xml.end("DBClusters").start("Marker").end("Marker");
@@ -1620,12 +1637,14 @@ public class RdsQueryHandler {
      * Returns null if no matching filter is present.
      */
     private static final String DOCDB_ENGINE = "docdb";
+    private static final String NEPTUNE_ENGINE = "neptune";
 
     /**
      * Every engine name the RDS family knows (the CreateDBInstance / CreateDBCluster lists in the
-     * API reference, plus DocumentDB and Neptune, which share the API). A live account refuses an
-     * {@code engine} filter naming anything else, and answers an empty list for a known engine it
-     * holds nothing of — including ones Floci cannot create.
+     * API reference, plus DocumentDB and Neptune, which share the API and whose records the list
+     * form merges in). A live account refuses an {@code engine} filter naming anything else, and
+     * answers an empty list for a known engine it holds nothing of — including ones Floci cannot
+     * create.
      */
     private static final java.util.Set<String> KNOWN_ENGINES = java.util.Set.of(
             "aurora", "aurora-mysql", "aurora-postgresql", "mysql", "mariadb", "postgres",
@@ -1633,7 +1652,7 @@ public class RdsQueryHandler {
             "custom-sqlserver-dev", "custom-sqlserver-ee", "custom-sqlserver-se", "custom-sqlserver-web",
             "db2-ae", "db2-se", "oracle-ee", "oracle-ee-cdb", "oracle-se2", "oracle-se2-cdb",
             "sqlserver-ee", "sqlserver-ex", "sqlserver-se", "sqlserver-web",
-            DOCDB_ENGINE, "neptune");
+            DOCDB_ENGINE, NEPTUNE_ENGINE);
 
     /** The {@code engine} filter, lower-cased: a live account matches engine names case-insensitively. */
     private static List<String> engineFilter(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 import io.github.hectorvent.floci.services.rds.model.DbCluster;
 import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.rds.model.DbEndpoint;
+import io.github.hectorvent.floci.services.docdb.DocDbQueryHandler;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
@@ -40,10 +41,12 @@ public class RdsQueryHandler {
     private static final Logger LOG = Logger.getLogger(RdsQueryHandler.class);
 
     private final RdsService service;
+    private final DocDbQueryHandler docDbQueryHandler;
     private final EmulatorConfig config;
 
     @Inject
-    public RdsQueryHandler(RdsService service, EmulatorConfig config) {
+    public RdsQueryHandler(RdsService service, EmulatorConfig config, DocDbQueryHandler docDbQueryHandler) {
+        this.docDbQueryHandler = docDbQueryHandler;
         this.service = service;
         this.config = config;
     }
@@ -186,9 +189,19 @@ public class RdsQueryHandler {
                 throw new AwsException("DBInstanceNotFound",
                         "DBInstance " + identifier + " not found.", 404);
             }
+            List<String> engines = engineFilter(params);
             XmlBuilder xml = new XmlBuilder().start("DBInstances");
             for (DbInstance i : result) {
-                xml.start("DBInstance").raw(dbInstanceInnerXml(i)).end("DBInstance");
+                if (engines.isEmpty() || engines.contains(instanceEngine(i))) {
+                    xml.start("DBInstance").raw(dbInstanceInnerXml(i)).end("DBInstance");
+                }
+            }
+            boolean listForm = (identifier == null || identifier.isBlank())
+                    && extractRdsFilterValues(params, "dbi-resource-id").isEmpty();
+            if (listForm && (engines.isEmpty() || engines.contains(DOCDB_ENGINE))) {
+                for (String row : docDbQueryHandler.instanceRowsXml(filterId)) {
+                    xml.start("DBInstance").raw(row).end("DBInstance");
+                }
             }
             xml.end("DBInstances").start("Marker").end("Marker");
             return Response.ok(AwsQueryResponse.envelope("DescribeDBInstances", AwsNamespaces.RDS, xml.build())).build();
@@ -453,9 +466,19 @@ public class RdsQueryHandler {
                 throw new AwsException("DBClusterNotFoundFault",
                         "DBCluster " + identifier + " not found.", 404);
             }
+            List<String> engines = engineFilter(params);
             XmlBuilder xml = new XmlBuilder().start("DBClusters");
             for (DbCluster c : result) {
-                xml.start("DBCluster").raw(dbClusterInnerXml(c)).end("DBCluster");
+                if (engines.isEmpty() || engines.contains(clusterEngine(c))) {
+                    xml.start("DBCluster").raw(dbClusterInnerXml(c)).end("DBCluster");
+                }
+            }
+            // The list form covers the whole RDS family: a live account lists DocumentDB clusters
+            // here too. The identifier form is routed to the store that owns the identifier.
+            if ((identifier == null || identifier.isBlank()) && (engines.isEmpty() || engines.contains(DOCDB_ENGINE))) {
+                for (String row : docDbQueryHandler.clusterRowsXml(filterId)) {
+                    xml.start("DBCluster").raw(row).end("DBCluster");
+                }
             }
             xml.end("DBClusters").start("Marker").end("Marker");
             return Response.ok(AwsQueryResponse.envelope("DescribeDBClusters", AwsNamespaces.RDS, xml.build())).build();
@@ -1596,6 +1619,44 @@ public class RdsQueryHandler {
      * {@code Filters.Filter.N.Name=filterName} / {@code Filters.Filter.N.Values.Value.1=value}.
      * Returns null if no matching filter is present.
      */
+    private static final String DOCDB_ENGINE = "docdb";
+
+    /**
+     * Every engine name the RDS family knows (the CreateDBInstance / CreateDBCluster lists in the
+     * API reference, plus DocumentDB and Neptune, which share the API). A live account refuses an
+     * {@code engine} filter naming anything else, and answers an empty list for a known engine it
+     * holds nothing of — including ones Floci cannot create.
+     */
+    private static final java.util.Set<String> KNOWN_ENGINES = java.util.Set.of(
+            "aurora", "aurora-mysql", "aurora-postgresql", "mysql", "mariadb", "postgres",
+            "custom-oracle-ee", "custom-oracle-ee-cdb", "custom-oracle-se2", "custom-oracle-se2-cdb",
+            "custom-sqlserver-dev", "custom-sqlserver-ee", "custom-sqlserver-se", "custom-sqlserver-web",
+            "db2-ae", "db2-se", "oracle-ee", "oracle-ee-cdb", "oracle-se2", "oracle-se2-cdb",
+            "sqlserver-ee", "sqlserver-ex", "sqlserver-se", "sqlserver-web",
+            DOCDB_ENGINE, "neptune");
+
+    /** The {@code engine} filter, lower-cased: a live account matches engine names case-insensitively. */
+    private static List<String> engineFilter(MultivaluedMap<String, String> params) {
+        List<String> engines = extractRdsFilterValues(params, "engine").stream().map(String::toLowerCase).toList();
+        for (String engine : engines) {
+            if (!KNOWN_ENGINES.contains(engine)) {
+                throw new AwsException("InvalidParameterValue", "Unrecognized engine name: " + engine, 400);
+            }
+        }
+        return engines;
+    }
+
+    private static String clusterEngine(DbCluster c) {
+        String engine = c.getEngineIdentifier() != null
+                ? c.getEngineIdentifier()
+                : c.getEngine() != null ? c.getEngine().name() : "";
+        return engine.toLowerCase();
+    }
+
+    private static String instanceEngine(DbInstance i) {
+        return i.getEngine() != null ? i.getEngine().name().toLowerCase() : "";
+    }
+
     private static String extractRdsFilterValue(MultivaluedMap<String, String> params, String filterName) {
         List<String> values = extractRdsFilterValues(params, filterName);
         return values.isEmpty() ? null : values.getFirst();

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -1221,7 +1221,7 @@ public class RdsQueryHandler {
 
     private String dbInstanceInnerXml(DbInstance i) {
         DbEndpoint ep = i.getEndpoint();
-        String engineStr = i.getEngine() != null ? i.getEngine().name() : "";
+        String engineStr = instanceEngine(i);
         String statusStr = i.getStatus() != null ? statusLabel(i.getStatus()) : "available";
 
         XmlBuilder xml = new XmlBuilder()
@@ -1653,7 +1653,14 @@ public class RdsQueryHandler {
         return engine.toLowerCase();
     }
 
+    /**
+     * The engine name AWS reports for the instance: the one the request gave (an Aurora member
+     * says aurora-postgresql, not postgres), or the enum for a record persisted before it was kept.
+     */
     private static String instanceEngine(DbInstance i) {
+        if (i.getEngineIdentifier() != null && !i.getEngineIdentifier().isBlank()) {
+            return i.getEngineIdentifier().toLowerCase();
+        }
         return i.getEngine() != null ? i.getEngine().name().toLowerCase() : "";
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -545,6 +545,8 @@ public class RdsService implements Resettable, ResourceProvider {
         String instanceStorageResourceId = dbiResourceId;
         PlacementResolution placement;
 
+        String engineIdentifier = engineParam != null && !engineParam.isBlank()
+                ? engineParam.toLowerCase() : null;
         if (dbClusterIdentifier != null && !dbClusterIdentifier.isBlank()) {
             // Cluster member — share the cluster's container (none exists in mock mode)
             DbCluster cluster = Optional.ofNullable(
@@ -553,6 +555,9 @@ public class RdsService implements Resettable, ResourceProvider {
                     .orElseThrow(() ->
                     new AwsException("DBClusterNotFoundFault",
                             "DB cluster " + dbClusterIdentifier + " not found.", 404));
+            if (engineIdentifier == null && cluster.getEngineIdentifier() != null) {
+                engineIdentifier = cluster.getEngineIdentifier().toLowerCase();
+            }
             backendHost = cluster.getContainerHost();
             backendPort = cluster.getContainerPort();
             containerId = cluster.getContainerId();
@@ -608,6 +613,7 @@ public class RdsService implements Resettable, ResourceProvider {
         instance.setMultiAz(placement.multiAz());
         instance.setSubnetAvailabilityZones(placement.subnetAvailabilityZones());
         instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
+        instance.setEngineIdentifier(engineIdentifier);
 
         instance.setDbiResourceId(dbiResourceId);
         instance.setDbInstanceArn(dbInstanceArn);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -847,9 +847,11 @@ public class RdsService implements Resettable, ResourceProvider {
 
     /**
      * Gives an instance persisted before {@code engineIdentifier} existed the engine name AWS would
-     * report: for a cluster member, its cluster's (an Aurora member is aurora-postgresql, which the
-     * enum alone cannot say); for a standalone instance, the enum's name. Read from the cluster,
-     * which is authoritative — never guessed from the instance's own identifier.
+     * report, and only when that name is known for certain: a cluster member takes its cluster's
+     * stored name (an Aurora member is aurora-postgresql, which the enum alone cannot say); a
+     * standalone instance takes the enum's, since a standalone RDS instance is never Aurora. A
+     * member whose cluster predates the field too is left unset rather than written down as the
+     * enum — a persisted guess would outlive the code that could later tell.
      */
     void backfillInstanceEngineIdentifiers() {
         try {
@@ -859,18 +861,20 @@ public class RdsService implements Resettable, ResourceProvider {
                 }
                 String accountId = accountIdFromArn(instance.getDbInstanceArn());
                 String region = regionFromArn(instance.getDbInstanceArn());
-                String engineIdentifier = null;
+                String engineIdentifier;
                 String clusterId = instance.getDbClusterIdentifier();
                 if (clusterId != null && !clusterId.isBlank()) {
                     DbCluster cluster = findClusterForScope(accountId, region, clusterId);
-                    if (cluster != null && cluster.getEngineIdentifier() != null) {
-                        engineIdentifier = cluster.getEngineIdentifier().toLowerCase();
+                    if (cluster == null || cluster.getEngineIdentifier() == null
+                            || cluster.getEngineIdentifier().isBlank()) {
+                        LOG.debugv("Instance {0} keeps no engine name: its cluster {1} has none stored",
+                                instance.getDbInstanceIdentifier(), clusterId);
+                        continue;
                     }
-                }
-                if (engineIdentifier == null && instance.getEngine() != null) {
+                    engineIdentifier = cluster.getEngineIdentifier().toLowerCase();
+                } else if (instance.getEngine() != null) {
                     engineIdentifier = instance.getEngine().name().toLowerCase();
-                }
-                if (engineIdentifier == null) {
+                } else {
                     continue;
                 }
                 instance.setEngineIdentifier(engineIdentifier);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -338,6 +338,7 @@ public class RdsService implements Resettable, ResourceProvider {
         restoreInstances();
         restoreProxies();
         backfillManagedSecretOwnership();
+        backfillInstanceEngineIdentifiers();
     }
 
     public void clear() {
@@ -841,6 +842,43 @@ public class RdsService implements Resettable, ResourceProvider {
             }
         } catch (RuntimeException e) {
             LOG.warnv(e, "Skipped the master user secret ownership backfill");
+        }
+    }
+
+    /**
+     * Gives an instance persisted before {@code engineIdentifier} existed the engine name AWS would
+     * report: for a cluster member, its cluster's (an Aurora member is aurora-postgresql, which the
+     * enum alone cannot say); for a standalone instance, the enum's name. Read from the cluster,
+     * which is authoritative — never guessed from the instance's own identifier.
+     */
+    void backfillInstanceEngineIdentifiers() {
+        try {
+            for (DbInstance instance : allInstances()) {
+                if (instance.getEngineIdentifier() != null && !instance.getEngineIdentifier().isBlank()) {
+                    continue;
+                }
+                String accountId = accountIdFromArn(instance.getDbInstanceArn());
+                String region = regionFromArn(instance.getDbInstanceArn());
+                String engineIdentifier = null;
+                String clusterId = instance.getDbClusterIdentifier();
+                if (clusterId != null && !clusterId.isBlank()) {
+                    DbCluster cluster = findClusterForScope(accountId, region, clusterId);
+                    if (cluster != null && cluster.getEngineIdentifier() != null) {
+                        engineIdentifier = cluster.getEngineIdentifier().toLowerCase();
+                    }
+                }
+                if (engineIdentifier == null && instance.getEngine() != null) {
+                    engineIdentifier = instance.getEngine().name().toLowerCase();
+                }
+                if (engineIdentifier == null) {
+                    continue;
+                }
+                instance.setEngineIdentifier(engineIdentifier);
+                putInstanceForScope(accountId, region, instance.getDbInstanceIdentifier(), instance);
+            }
+        } catch (RuntimeException e) {
+            // Reading persisted state must not be able to stop the emulator from starting.
+            LOG.warnv(e, "Skipped the instance engine name backfill");
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbInstance.java
@@ -13,6 +13,9 @@ public class DbInstance {
 
     private String dbInstanceIdentifier;
     private DatabaseEngine engine;
+    // the engine name the request gave (aurora-postgresql, postgres, ...): the enum collapses the
+    // Aurora names onto the community engine that backs them, which is not what AWS reports
+    private String engineIdentifier;
     private String engineVersion;
     private String masterUsername;
     private String masterPassword;
@@ -119,6 +122,9 @@ public class DbInstance {
 
     public String getDbSubnetGroupName() { return dbSubnetGroupName; }
     public void setDbSubnetGroupName(String dbSubnetGroupName) { this.dbSubnetGroupName = dbSubnetGroupName; }
+
+    public String getEngineIdentifier() { return engineIdentifier; }
+    public void setEngineIdentifier(String engineIdentifier) { this.engineIdentifier = engineIdentifier; }
 
     public String getDbClusterIdentifier() { return dbClusterIdentifier; }
     public void setDbClusterIdentifier(String dbClusterIdentifier) { this.dbClusterIdentifier = dbClusterIdentifier; }

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/RdsFamilyListingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/RdsFamilyListingIntegrationTest.java
@@ -1,0 +1,205 @@
+package io.github.hectorvent.floci.services.docdb;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.http.ContentType.URLENC;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * The list form of DescribeDBClusters / DescribeDBInstances covers the whole RDS family.
+ *
+ * <p>A live account lists a DocumentDB cluster from {@code aws rds describe-db-clusters} and
+ * {@code aws docdb describe-db-clusters} alike, with or without an {@code engine} filter; both
+ * CLIs sign with the {@code rds} scope, and Floci accepts {@code docdb} as well.
+ */
+@QuarkusTest
+@TestProfile(RdsFamilyListingIntegrationTest.NoContainersProfile.class)
+class RdsFamilyListingIntegrationTest {
+
+    public static class NoContainersProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.rds.mock", "true",
+                          "floci.services.docdb.mock", "true");
+        }
+    }
+
+    private static final String AURORA = "family-aurora";
+    private static final String DOCS = "family-docs";
+    private static final String DOCS_INSTANCE = "family-docs-1";
+
+    private static io.restassured.specification.RequestSpecification query(String scope, String region, String action) {
+        return given().header("Authorization",
+                        "AWS4-HMAC-SHA256 Credential=test/20260615/" + region + "/" + scope + "/aws4_request, "
+                        + "SignedHeaders=content-type;host, Signature=test")
+                .contentType(URLENC)
+                .formParam("Action", action)
+                .formParam("Version", "2014-10-31");
+    }
+
+    private void createBoth() {
+        query("rds", "us-east-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", AURORA)
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/").then().statusCode(200);
+        query("rds", "us-east-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", DOCS)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/").then().statusCode(200);
+        query("rds", "us-east-1", "CreateDBInstance")
+                .formParam("DBInstanceIdentifier", DOCS_INSTANCE)
+                .formParam("DBInstanceClass", "db.t3.medium")
+                .formParam("Engine", "docdb")
+                .formParam("DBClusterIdentifier", DOCS)
+        .when().post("/").then().statusCode(200);
+    }
+
+    @AfterEach
+    void cleanUp() {
+        query("rds", "us-east-1", "DeleteDBInstance").formParam("DBInstanceIdentifier", DOCS_INSTANCE)
+                .when().post("/");
+        query("rds", "us-east-1", "DeleteDBCluster").formParam("DBClusterIdentifier", DOCS)
+                .formParam("SkipFinalSnapshot", "true").when().post("/");
+        query("rds", "us-east-1", "DeleteDBCluster").formParam("DBClusterIdentifier", AURORA)
+                .formParam("SkipFinalSnapshot", "true").when().post("/");
+    }
+
+    @Test
+    void listFormOnEitherScopeCoversBothStores() {
+        createBoth();
+        for (String scope : new String[] {"rds", "docdb"}) {
+            query(scope, "us-east-1", "DescribeDBClusters")
+            .when().post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<DBClusterIdentifier>" + AURORA + "</DBClusterIdentifier>"))
+                .body(containsString("<DBClusterIdentifier>" + DOCS + "</DBClusterIdentifier>"));
+            query(scope, "us-east-1", "DescribeDBInstances")
+            .when().post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<DBInstanceIdentifier>" + DOCS_INSTANCE + "</DBInstanceIdentifier>"));
+        }
+    }
+
+    @Test
+    void engineFilterSelectsAcrossBothStores() {
+        createBoth();
+        query("docdb", "us-east-1", "DescribeDBClusters")
+                .formParam("Filters.Filter.1.Name", "engine")
+                .formParam("Filters.Filter.1.Values.Value.1", "docdb")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusterIdentifier>" + DOCS + "</DBClusterIdentifier>"))
+            .body(not(containsString("<DBClusterIdentifier>" + AURORA + "</DBClusterIdentifier>")));
+        query("rds", "us-east-1", "DescribeDBClusters")
+                .formParam("Filters.Filter.1.Name", "engine")
+                .formParam("Filters.Filter.1.Values.Value.1", "aurora-postgresql")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusterIdentifier>" + AURORA + "</DBClusterIdentifier>"))
+            .body(not(containsString("<DBClusterIdentifier>" + DOCS + "</DBClusterIdentifier>")));
+    }
+
+    @Test
+    void unknownEngineFilterIsRefusedOnEitherScope() {
+        createBoth();
+        for (String scope : new String[] {"rds", "docdb"}) {
+            query(scope, "us-east-1", "DescribeDBClusters")
+                    .formParam("Filters.Filter.1.Name", "engine")
+                    .formParam("Filters.Filter.1.Values.Value.1", "nothing")
+            .when().post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("Unrecognized engine name: nothing"));
+        }
+    }
+
+    @Test
+    void identifierFormStillFaultsForAnUnknownClusterOnEitherScope() {
+        createBoth();
+        for (String scope : new String[] {"rds", "docdb"}) {
+            query(scope, "us-east-1", "DescribeDBClusters")
+                    .formParam("DBClusterIdentifier", "family-absent")
+            .when().post("/")
+            .then()
+                .statusCode(404)
+                .body(containsString("DBClusterNotFoundFault"));
+        }
+    }
+
+    @Test
+    void bothHalvesOfTheListingFollowTheSignedRegionAwayFromTheDefault() {
+        // both stores keyed by the region the request was signed for, not the configured default:
+        // records created under eu-west-1 show up there and nowhere else
+        String aurora = "family-west-aurora";
+        String docs = "family-west-docs";
+        query("rds", "eu-west-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", aurora)
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("MasterUsername", "admin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/").then().statusCode(200);
+        query("docdb", "eu-west-1", "CreateDBCluster")
+                .formParam("DBClusterIdentifier", docs)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "docdbadmin")
+                .formParam("MasterUserPassword", "secret99password")
+        .when().post("/").then().statusCode(200);
+        try {
+            for (String scope : new String[] {"rds", "docdb"}) {
+                query(scope, "eu-west-1", "DescribeDBClusters")
+                .when().post("/")
+                .then()
+                    .statusCode(200)
+                    .body(containsString("<DBClusterIdentifier>" + aurora + "</DBClusterIdentifier>"))
+                    .body(containsString("<DBClusterIdentifier>" + docs + "</DBClusterIdentifier>"));
+                query(scope, "us-east-1", "DescribeDBClusters")
+                .when().post("/")
+                .then()
+                    .statusCode(200)
+                    .body(not(containsString("<DBClusterIdentifier>" + aurora + "</DBClusterIdentifier>")))
+                    .body(not(containsString("<DBClusterIdentifier>" + docs + "</DBClusterIdentifier>")));
+            }
+            // an ARN filter naming the other region's cluster finds nothing either
+            query("rds", "us-east-1", "DescribeDBClusters")
+                    .formParam("Filters.Filter.1.Name", "db-cluster-id")
+                    .formParam("Filters.Filter.1.Values.Value.1",
+                            "arn:aws:rds:eu-west-1:000000000000:cluster:" + docs)
+            .when().post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<DBClusterIdentifier>" + docs + "</DBClusterIdentifier>")));
+        } finally {
+            query("rds", "eu-west-1", "DeleteDBCluster").formParam("DBClusterIdentifier", docs)
+                    .formParam("SkipFinalSnapshot", "true").when().post("/");
+            query("rds", "eu-west-1", "DeleteDBCluster").formParam("DBClusterIdentifier", aurora)
+                    .formParam("SkipFinalSnapshot", "true").when().post("/");
+        }
+    }
+
+    @Test
+    void listingIsScopedToTheSignedRegion() {
+        createBoth();
+        query("rds", "eu-west-1", "DescribeDBClusters")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<DBClusterIdentifier>" + DOCS + "</DBClusterIdentifier>")))
+            .body(not(containsString("<DBClusterIdentifier>" + AURORA + "</DBClusterIdentifier>")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/RdsFamilyListingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/RdsFamilyListingIntegrationTest.java
@@ -130,6 +130,39 @@ class RdsFamilyListingIntegrationTest {
     }
 
     @Test
+    void auroraMemberInstancesAnswerToTheirAuroraEngineName() {
+        createBoth();
+        String member = "family-aurora-1";
+        query("rds", "us-east-1", "CreateDBInstance")
+                .formParam("DBInstanceIdentifier", member)
+                .formParam("DBInstanceClass", "db.t3.medium")
+                .formParam("Engine", "aurora-postgresql")
+                .formParam("DBClusterIdentifier", AURORA)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<Engine>aurora-postgresql</Engine>"));
+        try {
+            query("rds", "us-east-1", "DescribeDBInstances")
+                    .formParam("Filters.Filter.1.Name", "engine")
+                    .formParam("Filters.Filter.1.Values.Value.1", "aurora-postgresql")
+            .when().post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<DBInstanceIdentifier>" + member + "</DBInstanceIdentifier>"))
+                .body(not(containsString("<DBInstanceIdentifier>" + DOCS_INSTANCE + "</DBInstanceIdentifier>")));
+            query("rds", "us-east-1", "DescribeDBInstances")
+                    .formParam("Filters.Filter.1.Name", "engine")
+                    .formParam("Filters.Filter.1.Values.Value.1", "postgres")
+            .when().post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<DBInstanceIdentifier>" + member + "</DBInstanceIdentifier>")));
+        } finally {
+            query("rds", "us-east-1", "DeleteDBInstance").formParam("DBInstanceIdentifier", member)
+                    .when().post("/");
+        }
+    }
+
+    @Test
     void identifierFormStillFaultsForAnUnknownClusterOnEitherScope() {
         createBoth();
         for (String scope : new String[] {"rds", "docdb"}) {

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandlerRowsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandlerRowsTest.java
@@ -1,0 +1,39 @@
+package io.github.hectorvent.floci.services.neptune;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NeptuneQueryHandlerRowsTest {
+
+    private static NeptuneCluster cluster(String id, String region) {
+        NeptuneCluster c = new NeptuneCluster();
+        c.setDbClusterIdentifier(id);
+        c.setStatus("available");
+        c.setDbClusterArn("arn:aws:rds:" + region + ":000000000000:cluster:" + id);
+        return c;
+    }
+
+    @Test
+    void rowsForTheFamilyListingAreScopedToTheRequestRegionByArn() {
+        // the Neptune store is not keyed by region: the request's region has to be read off the ARN
+        NeptuneService service = mock(NeptuneService.class);
+        when(service.listDbClusters(isNull())).thenReturn(List.of(
+                cluster("east", "us-east-1"), cluster("west", "eu-west-1")));
+        NeptuneQueryHandler handler = new NeptuneQueryHandler(service, mock(EmulatorConfig.class));
+
+        List<String> rows = handler.clusterRowsXml(null, "us-east-1");
+
+        assertEquals(1, rows.size(), rows.toString());
+        assertTrue(rows.getFirst().contains("<DBClusterIdentifier>east</DBClusterIdentifier>"), rows.getFirst());
+        assertTrue(rows.getFirst().contains("<Engine>neptune</Engine>"), rows.getFirst());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -2,8 +2,10 @@ package io.github.hectorvent.floci.services.rds;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 import io.github.hectorvent.floci.services.rds.model.DbCluster;
 import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
+import io.github.hectorvent.floci.services.docdb.DocDbQueryHandler;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
@@ -34,6 +36,7 @@ import static org.mockito.Mockito.*;
 class RdsQueryHandlerTest {
 
     private RdsService service;
+    private DocDbQueryHandler docDbHandler;
     private RdsQueryHandler handler;
 
     @BeforeEach
@@ -45,7 +48,8 @@ class RdsQueryHandlerTest {
         when(config.services()).thenReturn(servicesConfig);
         when(servicesConfig.rds()).thenReturn(rdsConfig);
         when(config.defaultAvailabilityZone()).thenReturn("us-east-1a");
-        handler = new RdsQueryHandler(service, config);
+        docDbHandler = mock(DocDbQueryHandler.class);
+        handler = new RdsQueryHandler(service, config, docDbHandler);
     }
 
     // ──────────────────────────── DBInstances XML tag ────────────────────────────
@@ -2026,5 +2030,123 @@ class RdsQueryHandlerTest {
         assertEquals(200, handler.handle("CreateDBSubnetGroup", p).getStatus());
         verify(service).createDbSubnetGroup("tagged", "d", List.of("subnet-aaa", "subnet-bbb"), null,
                 java.util.Map.of("Name", "tagged", "env", "tst"));
+    // ──────────────────────────── RDS-family listing ────────────────────────────
+
+    @Test
+    void describeDbClusters_listFormIncludesDocumentDbClusters() {
+        DbCluster aurora = makeCluster("aurora");
+        when(service.listDbClusters(null, null)).thenReturn(List.of(aurora));
+        when(docDbHandler.clusterRowsXml(null)).thenReturn(List.of(
+                "<DBClusterIdentifier>docs</DBClusterIdentifier><Engine>docdb</Engine>"));
+
+        String body = (String) handler.handle("DescribeDBClusters", params()).getEntity();
+
+        assertTrue(body.contains("<DBClusterIdentifier>aurora</DBClusterIdentifier>"), body);
+        assertTrue(body.contains("<DBClusterIdentifier>docs</DBClusterIdentifier>"), body);
+    }
+
+    @Test
+    void describeDbClusters_identifierFormNeverConsultsDocumentDb() {
+        when(service.listDbClusters("aurora", null)).thenReturn(List.of(makeCluster("aurora")));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBClusterIdentifier", "aurora");
+        assertEquals(200, handler.handle("DescribeDBClusters", p).getStatus());
+
+        verify(docDbHandler, never()).clusterRowsXml(any());
+    }
+
+    @Test
+    void describeDbClusters_engineFilterSelectsAcrossBothStores() {
+        DbCluster aurora = makeCluster("aurora");
+        aurora.setEngineIdentifier("aurora-postgresql");
+        when(service.listDbClusters(null, null)).thenReturn(List.of(aurora));
+        when(docDbHandler.clusterRowsXml(null)).thenReturn(List.of(
+                "<DBClusterIdentifier>docs</DBClusterIdentifier><Engine>docdb</Engine>"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "docdb");
+        String body = (String) handler.handle("DescribeDBClusters", p).getEntity();
+        assertFalse(body.contains("<DBClusterIdentifier>aurora</DBClusterIdentifier>"), body);
+        assertTrue(body.contains("<DBClusterIdentifier>docs</DBClusterIdentifier>"), body);
+
+        p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "Aurora-PostgreSQL");
+        body = (String) handler.handle("DescribeDBClusters", p).getEntity();
+        assertTrue(body.contains("<DBClusterIdentifier>aurora</DBClusterIdentifier>"), body);
+        assertFalse(body.contains("<DBClusterIdentifier>docs</DBClusterIdentifier>"), body);
+        verify(docDbHandler, times(1)).clusterRowsXml(any());
+    }
+
+    @Test
+    void describeDbClusters_idFilterReachesDocumentDbToo() {
+        when(service.listDbClusters("docs", null)).thenReturn(List.of());
+        when(docDbHandler.clusterRowsXml("docs")).thenReturn(List.of(
+                "<DBClusterIdentifier>docs</DBClusterIdentifier><Engine>docdb</Engine>"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "db-cluster-id");
+        p.add("Filters.Filter.1.Values.Value.1", "docs");
+        String body = (String) handler.handle("DescribeDBClusters", p).getEntity();
+
+        assertTrue(body.contains("<DBClusterIdentifier>docs</DBClusterIdentifier>"), body);
+    }
+
+    @Test
+    void describeDbInstances_listFormIncludesDocumentDbInstancesAndHonoursEngineFilter() {
+        DbInstance postgres = makeInstance("pg");
+        postgres.setEngine(DatabaseEngine.POSTGRES);
+        when(service.listDbInstances(null, null)).thenReturn(List.of(postgres));
+        when(docDbHandler.instanceRowsXml(null)).thenReturn(List.of(
+                "<DBInstanceIdentifier>docs-1</DBInstanceIdentifier><Engine>docdb</Engine>"));
+
+        String body = (String) handler.handle("DescribeDBInstances", params()).getEntity();
+        assertTrue(body.contains("<DBInstanceIdentifier>pg</DBInstanceIdentifier>"), body);
+        assertTrue(body.contains("<DBInstanceIdentifier>docs-1</DBInstanceIdentifier>"), body);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "postgres");
+        body = (String) handler.handle("DescribeDBInstances", p).getEntity();
+        assertTrue(body.contains("<DBInstanceIdentifier>pg</DBInstanceIdentifier>"), body);
+        assertFalse(body.contains("<DBInstanceIdentifier>docs-1</DBInstanceIdentifier>"), body);
+
+        p = params();
+        p.add("DBInstanceIdentifier", "pg");
+        when(service.listDbInstances("pg", null)).thenReturn(List.of(postgres));
+        handler.handle("DescribeDBInstances", p);
+        verify(docDbHandler, times(1)).instanceRowsXml(any());
+    }
+
+    @Test
+    void describeDbClusters_engineFilterIsValidatedAgainstTheFamilysEngineNames() {
+        when(service.listDbClusters(null, null)).thenReturn(List.of(makeCluster("aurora")));
+        when(docDbHandler.clusterRowsXml(null)).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "nothing");
+        Response response = handler.handle("DescribeDBClusters", p);
+        assertEquals(400, response.getStatus());
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>InvalidParameterValue</Code>"), body);
+        assertTrue(body.contains("Unrecognized engine name: nothing"), body);
+
+        // an engine Floci cannot create is still a name AWS knows: an empty list, not a fault
+        p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "oracle-ee");
+        response = handler.handle("DescribeDBClusters", p);
+        assertEquals(200, response.getStatus());
+        assertFalse(((String) response.getEntity()).contains("<DBClusterIdentifier>"), (String) response.getEntity());
+
+        p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "bogus");
+        response = handler.handle("DescribeDBInstances", p);
+        assertEquals(400, response.getStatus());
+        assertTrue(((String) response.getEntity()).contains("Unrecognized engine name: bogus"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -2030,6 +2030,8 @@ class RdsQueryHandlerTest {
         assertEquals(200, handler.handle("CreateDBSubnetGroup", p).getStatus());
         verify(service).createDbSubnetGroup("tagged", "d", List.of("subnet-aaa", "subnet-bbb"), null,
                 java.util.Map.of("Name", "tagged", "env", "tst"));
+    }
+
     // ──────────────────────────── RDS-family listing ────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -2149,4 +2149,31 @@ class RdsQueryHandlerTest {
         assertEquals(400, response.getStatus());
         assertTrue(((String) response.getEntity()).contains("Unrecognized engine name: bogus"));
     }
+
+    @Test
+    void describeDbInstances_auroraMemberIsFilteredAndReportedByItsAuroraEngineName() {
+        DbInstance member = makeInstance("member");
+        member.setEngine(DatabaseEngine.POSTGRES);
+        member.setEngineIdentifier("aurora-postgresql");
+        DbInstance legacy = makeInstance("legacy");
+        legacy.setEngine(DatabaseEngine.POSTGRES);
+        when(service.listDbInstances(null, null)).thenReturn(List.of(member, legacy));
+        when(docDbHandler.instanceRowsXml(null)).thenReturn(List.of());
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "aurora-postgresql");
+        String body = (String) handler.handle("DescribeDBInstances", p).getEntity();
+        assertTrue(body.contains("<DBInstanceIdentifier>member</DBInstanceIdentifier>"), body);
+        assertTrue(body.contains("<Engine>aurora-postgresql</Engine>"), body);
+        assertFalse(body.contains("<DBInstanceIdentifier>legacy</DBInstanceIdentifier>"), body);
+
+        p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "postgres");
+        body = (String) handler.handle("DescribeDBInstances", p).getEntity();
+        assertFalse(body.contains("<DBInstanceIdentifier>member</DBInstanceIdentifier>"), body);
+        assertTrue(body.contains("<DBInstanceIdentifier>legacy</DBInstanceIdentifier>"), body);
+        assertTrue(body.contains("<Engine>postgres</Engine>"), body);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 import io.github.hectorvent.floci.services.rds.model.DbCluster;
 import io.github.hectorvent.floci.services.rds.model.DbClusterParameterGroup;
 import io.github.hectorvent.floci.services.docdb.DocDbQueryHandler;
+import io.github.hectorvent.floci.services.neptune.NeptuneQueryHandler;
 import io.github.hectorvent.floci.services.rds.model.DbInstance;
 import io.github.hectorvent.floci.services.rds.model.DbInstanceStatus;
 import io.github.hectorvent.floci.services.rds.model.DbParameterGroup;
@@ -37,6 +38,7 @@ class RdsQueryHandlerTest {
 
     private RdsService service;
     private DocDbQueryHandler docDbHandler;
+    private NeptuneQueryHandler neptuneHandler;
     private RdsQueryHandler handler;
 
     @BeforeEach
@@ -49,7 +51,8 @@ class RdsQueryHandlerTest {
         when(servicesConfig.rds()).thenReturn(rdsConfig);
         when(config.defaultAvailabilityZone()).thenReturn("us-east-1a");
         docDbHandler = mock(DocDbQueryHandler.class);
-        handler = new RdsQueryHandler(service, config, docDbHandler);
+        neptuneHandler = mock(NeptuneQueryHandler.class);
+        handler = new RdsQueryHandler(service, config, docDbHandler, neptuneHandler);
     }
 
     // ──────────────────────────── DBInstances XML tag ────────────────────────────
@@ -2177,5 +2180,44 @@ class RdsQueryHandlerTest {
         assertFalse(body.contains("<DBInstanceIdentifier>member</DBInstanceIdentifier>"), body);
         assertTrue(body.contains("<DBInstanceIdentifier>legacy</DBInstanceIdentifier>"), body);
         assertTrue(body.contains("<Engine>postgres</Engine>"), body);
+    }
+
+    @Test
+    void describeDbClusters_listFormIncludesNeptuneClustersAndTheEngineFilterSelectsThem() {
+        when(service.listDbClusters(null, null)).thenReturn(List.of(makeCluster("aurora")));
+        when(docDbHandler.clusterRowsXml(null)).thenReturn(List.of(
+                "<DBClusterIdentifier>docs</DBClusterIdentifier><Engine>docdb</Engine>"));
+        when(neptuneHandler.clusterRowsXml(null, null)).thenReturn(List.of(
+                "<DBClusterIdentifier>graph</DBClusterIdentifier><Engine>neptune</Engine>"));
+
+        String body = (String) handler.handle("DescribeDBClusters", params()).getEntity();
+        assertTrue(body.contains("<DBClusterIdentifier>aurora</DBClusterIdentifier>"), body);
+        assertTrue(body.contains("<DBClusterIdentifier>docs</DBClusterIdentifier>"), body);
+        assertTrue(body.contains("<DBClusterIdentifier>graph</DBClusterIdentifier>"), body);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("Filters.Filter.1.Name", "engine");
+        p.add("Filters.Filter.1.Values.Value.1", "neptune");
+        body = (String) handler.handle("DescribeDBClusters", p).getEntity();
+        assertFalse(body.contains("<DBClusterIdentifier>aurora</DBClusterIdentifier>"), body);
+        assertFalse(body.contains("<DBClusterIdentifier>docs</DBClusterIdentifier>"), body);
+        assertTrue(body.contains("<DBClusterIdentifier>graph</DBClusterIdentifier>"), body);
+        verify(docDbHandler, times(1)).clusterRowsXml(any());
+
+        p = params();
+        p.add("DBClusterIdentifier", "aurora");
+        handler.handle("DescribeDBClusters", p);
+        verify(neptuneHandler, times(2)).clusterRowsXml(any(), any());
+    }
+
+    @Test
+    void describeDbInstances_listFormIncludesNeptuneInstances() {
+        when(service.listDbInstances(null, null)).thenReturn(List.of());
+        when(docDbHandler.instanceRowsXml(null)).thenReturn(List.of());
+        when(neptuneHandler.instanceRowsXml(null, null)).thenReturn(List.of(
+                "<DBInstanceIdentifier>graph-1</DBInstanceIdentifier><Engine>neptune</Engine>"));
+
+        String body = (String) handler.handle("DescribeDBInstances", params()).getEntity();
+        assertTrue(body.contains("<DBInstanceIdentifier>graph-1</DBInstanceIdentifier>"), body);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -4937,6 +4937,9 @@ class RdsServiceTest {
         // and the tags are what a restart reads back, not a side table
         assertEquals(Map.of("Name", "tagged", "env", "stg", "extra", "yes"),
                 rdsService.getDbSubnetGroup("tagged", "us-east-1").getTags());
+    }
+
+    @Test
     void createDbInstanceKeepsTheEngineNameTheRequestGave() {
         rdsService.createDbCluster("aurora", "aurora-postgresql", null, "admin", "secret99password",
                 null, false, null);
@@ -4982,9 +4985,26 @@ class RdsServiceTest {
         legacyStandalone.setStatus(DbInstanceStatus.AVAILABLE);
         instances.put("us-east-1::legacy-plain", legacyStandalone);
 
+        // a member of a cluster that predates the field itself: nothing certain to write, so
+        // nothing is written — the enum would persist postgres for what may be Aurora
+        DbCluster nameless = new DbCluster();
+        nameless.setDbClusterIdentifier("old-cluster");
+        nameless.setEngine(DatabaseEngine.POSTGRES);
+        nameless.setStatus(DbInstanceStatus.AVAILABLE);
+        nameless.setDbClusterArn("arn:aws:rds:us-east-1:123456789012:cluster:old-cluster");
+        clusters.put("us-east-1::old-cluster", nameless);
+        DbInstance orphanedMember = new DbInstance();
+        orphanedMember.setDbInstanceIdentifier("old-member");
+        orphanedMember.setEngine(DatabaseEngine.POSTGRES);
+        orphanedMember.setDbClusterIdentifier("old-cluster");
+        orphanedMember.setDbInstanceArn("arn:aws:rds:us-east-1:123456789012:db:old-member");
+        orphanedMember.setStatus(DbInstanceStatus.AVAILABLE);
+        instances.put("us-east-1::old-member", orphanedMember);
+
         service.restorePersistedRuntime();
 
         assertEquals("aurora-postgresql", service.getDbInstance("legacy-member").getEngineIdentifier());
         assertEquals("mariadb", service.getDbInstance("legacy-plain").getEngineIdentifier());
+        assertNull(service.getDbInstance("old-member").getEngineIdentifier());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -4955,4 +4955,36 @@ class RdsServiceTest {
         assertEquals("aurora-postgresql", rdsService.getDbInstance("member-2").getEngineIdentifier());
         assertEquals("postgres", rdsService.getDbInstance("plain").getEngineIdentifier());
     }
+
+    @Test
+    void restoreGivesAPersistedAuroraMemberItsClusterEngineName() {
+        // A member written by a floci that predates engineIdentifier carries only the enum, which
+        // says postgres for an aurora-postgresql cluster. The cluster still knows, and the restore
+        // reads it there, so the member is reported and filtered as aurora-postgresql.
+        InMemoryStorage<String, DbInstance> instances = new InMemoryStorage<>();
+        InMemoryStorage<String, DbCluster> clusters = new InMemoryStorage<>();
+        RdsService service = newService(containerManager, proxyManager, instances, clusters,
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>());
+        service.createDbCluster("aurora", "aurora-postgresql", null, "admin", "secret99password",
+                null, false, null);
+
+        DbInstance legacyMember = new DbInstance();
+        legacyMember.setDbInstanceIdentifier("legacy-member");
+        legacyMember.setEngine(DatabaseEngine.POSTGRES);
+        legacyMember.setDbClusterIdentifier("aurora");
+        legacyMember.setDbInstanceArn("arn:aws:rds:us-east-1:123456789012:db:legacy-member");
+        legacyMember.setStatus(DbInstanceStatus.AVAILABLE);
+        instances.put("us-east-1::legacy-member", legacyMember);
+        DbInstance legacyStandalone = new DbInstance();
+        legacyStandalone.setDbInstanceIdentifier("legacy-plain");
+        legacyStandalone.setEngine(DatabaseEngine.MARIADB);
+        legacyStandalone.setDbInstanceArn("arn:aws:rds:us-east-1:123456789012:db:legacy-plain");
+        legacyStandalone.setStatus(DbInstanceStatus.AVAILABLE);
+        instances.put("us-east-1::legacy-plain", legacyStandalone);
+
+        service.restorePersistedRuntime();
+
+        assertEquals("aurora-postgresql", service.getDbInstance("legacy-member").getEngineIdentifier());
+        assertEquals("mariadb", service.getDbInstance("legacy-plain").getEngineIdentifier());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -4937,5 +4937,22 @@ class RdsServiceTest {
         // and the tags are what a restart reads back, not a side table
         assertEquals(Map.of("Name", "tagged", "env", "stg", "extra", "yes"),
                 rdsService.getDbSubnetGroup("tagged", "us-east-1").getTags());
+    void createDbInstanceKeepsTheEngineNameTheRequestGave() {
+        rdsService.createDbCluster("aurora", "aurora-postgresql", null, "admin", "secret99password",
+                null, false, null);
+        rdsService.createDbInstance("member", "aurora-postgresql", "16",
+                "admin", "password", null, "db.t3.medium",
+                20, false, null, null, "aurora", null, false);
+        rdsService.createDbInstance("member-2", null, "16",
+                "admin", "password", null, "db.t3.medium",
+                20, false, null, null, "aurora", null, false);
+        rdsService.createDbInstance("plain", "postgres", "13",
+                "admin", "password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        assertEquals("aurora-postgresql", rdsService.getDbInstance("member").getEngineIdentifier());
+        // a member created without Engine takes the cluster's
+        assertEquals("aurora-postgresql", rdsService.getDbInstance("member-2").getEngineIdentifier());
+        assertEquals("postgres", rdsService.getDbInstance("plain").getEngineIdentifier());
     }
 }


### PR DESCRIPTION
Closes #2613

## What

The list form of `DescribeDBClusters` / `DescribeDBInstances` answered from one store — on the `rds`
scope from RDS, on the `docdb` scope from DocumentDB — so a DocumentDB cluster was invisible to every
list while its identifier form worked. A live account lists the whole family from either endpoint.

- `RdsQueryHandler` assembles the list form from every store of the family: RDS rows, then DocumentDB
  rows rendered by `DocDbQueryHandler` and Neptune rows rendered by `NeptuneQueryHandler`
  (`clusterRowsXml` / `instanceRowsXml`), each store applying its own `db-cluster-id` /
  `db-instance-id` filter. The Neptune store is not keyed by region, so its rows are scoped to the
  request's region by ARN.
- New `engine` filter across both: case-insensitive, OR over values, refused with
  `InvalidParameterValue: Unrecognized engine name: X` for a name outside the family's engine list
  (the CreateDBInstance/CreateDBCluster lists plus `docdb`/`neptune`), so `oracle-ee` is valid and
  empty while `nothing` is refused.
- `AwsQueryController` sends the `docdb`- and `neptune`-scope list forms to the same assembly. The identifier form
  keeps routing to the store that owns the identifier, and still faults for an unknown one.
- Every part lists the region the request is signed for: the RDS half from the controller's resolved
  region, the DocumentDB half from the request context — same resolver, same header — and the Neptune
  rows by the region in their ARN.

## Checked against a live account

With an Aurora cluster and a DocumentDB cluster in one region (and, separately, a Neptune cluster):

| call | AWS | now Floci |
|---|---|---|
| `rds describe-db-clusters` / `docdb describe-db-clusters`, unfiltered | both clusters, on both endpoints | same |
| `--filters Name=engine,Values=docdb` (either endpoint) | DocumentDB cluster only | same |
| `Values=DOCDB` | same as lower-case | same |
| `Values=docdb,aurora-postgresql` | both | same |
| `Values=mysql` (known engine, none held) | empty list | same |
| `Values=nothing` | `InvalidParameterValue: Unrecognized engine name: nothing` (clusters and instances) | same wording |
| `db-cluster-id` filter with the DocumentDB cluster's ARN, on the rds endpoint | found | same |
| `docdb describe-db-instances` | lists RDS instances too | already did |
| Neptune cluster: `rds` / `docdb` / `neptune describe-db-clusters`, unfiltered | listed on all three | same |
| `--filters Name=engine,Values=neptune` (and `NEPTUNE`) | Neptune cluster only | same |

## Tests

- `RdsQueryHandlerTest`: list form merges DocumentDB and Neptune rows, identifier form never consults
  either, engine filter selects across all stores and is validated, id filter reaches DocumentDB,
  instance listing likewise. `NeptuneQueryHandlerRowsTest`: Neptune rows are scoped to the request's
  region by ARN (fails with the filter removed). Neptune has no mock mode — a cluster starts a Gremlin
  container — so its coverage stays at the handler level.
- `RdsFamilyListingIntegrationTest` (Quarkus, no containers): both scopes list both stores, engine
  filter, unknown engine refused on both scopes, identifier fault on both scopes, listing scoped to the
  signed region — including records created under `eu-west-1` listed there and absent from the
  default; the last one fails with the DocumentDB half read from the default region.
- `rds.bats`: `describe-db-clusters` on both endpoints, engine filter both ways, unknown engine refused
  — run against the packaged jar.

## Not covered here

- Unknown *filter names* are still ignored, where AWS answers `Unrecognized filter name: X` — this is
  how every RDS describe behaves today and touches filters this PR does not own.
- Neptune builds its ARNs from the configured default region and keys its store by id alone
  (`NeptuneService`, pre-existing), so a Neptune cluster created under another region still carries
  the default region's ARN and lists there; the region filter here reads the ARN and cannot do better
  than the ARN. Not made worse by this PR, and not fixed by it.
- The `dbi-resource-id` filter form does not consult DocumentDB (its instances carry no resource id).
