### PR TITLE
fix(rds): keep the tags given to CreateDBSubnetGroup

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -192,3 +192,30 @@ teardown() {
 
     aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
 }
+
+@test "rds: tags given to create-db-subnet-group are readable back" {
+    VPC_ID=$(aws_cmd ec2 create-vpc --cidr-block 10.77.0.0/16 --query Vpc.VpcId --output text)
+    S1=$(aws_cmd ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block 10.77.1.0/24 --availability-zone us-east-1a --query Subnet.SubnetId --output text)
+    S2=$(aws_cmd ec2 create-subnet --vpc-id "$VPC_ID" --cidr-block 10.77.2.0/24 --availability-zone us-east-1b --query Subnet.SubnetId --output text)
+    GROUP="bats-sng-$(unique_name)"
+
+    run aws_cmd rds create-db-subnet-group --db-subnet-group-name "$GROUP" --db-subnet-group-description d \
+        --subnet-ids "$S1" "$S2" --tags "Key=Name,Value=$GROUP" Key=env,Value=tst
+    assert_success
+    arn=$(json_get "$output" '.DBSubnetGroup.DBSubnetGroupArn')
+
+    run aws_cmd rds list-tags-for-resource --resource-name "$arn"
+    assert_success
+    assert_output --partial '"Key": "env"'
+    assert_output --partial "\"Value\": \"$GROUP\""
+
+    # the DocumentDB CLI reaches the same group through the same scope
+    run aws_cmd docdb list-tags-for-resource --resource-name "$arn"
+    assert_success
+    assert_output --partial '"Key": "env"'
+
+    aws_cmd rds delete-db-subnet-group --db-subnet-group-name "$GROUP" >/dev/null 2>&1 || true
+    aws_cmd ec2 delete-subnet --subnet-id "$S1" >/dev/null 2>&1 || true
+    aws_cmd ec2 delete-subnet --subnet-id "$S2" >/dev/null 2>&1 || true
+    aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
+}

--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -19,7 +19,7 @@ RDS Data API (`rds-data`) is documented separately because it uses REST JSON rou
 | `ModifyDBInstance` | Update instance settings |
 | `RebootDBInstance` | Restart a database instance |
 | `DescribeOrderableDBInstanceOptions` | List deterministic instance class options |
-| `CreateDBSubnetGroup` | Create a DB subnet group |
+| `CreateDBSubnetGroup` | Create a DB subnet group; tags given here are readable through `ListTagsForResource` |
 | `DescribeDBSubnetGroups` | List DB subnet groups |
 | `ModifyDBSubnetGroup` | Update DB subnet group description and subnet list |
 | `DeleteDBSubnetGroup` | Delete a DB subnet group |

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -304,7 +304,8 @@ public class RdsQueryHandler {
         String description = params.getFirst("DBSubnetGroupDescription");
         List<String> subnetIds = memberList(params, "SubnetIds");
         try {
-            DbSubnetGroup group = service.createDbSubnetGroup(name, description, subnetIds, region);
+            DbSubnetGroup group = service.createDbSubnetGroup(name, description, subnetIds, region,
+                    parseTags(params));
             return Response.ok(AwsQueryResponse.envelope("CreateDBSubnetGroup",
                     AwsNamespaces.RDS, dbSubnetGroupXml(group))).build();
         } catch (AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -2258,6 +2258,15 @@ public class RdsService implements Resettable, ResourceProvider {
     }
 
     public DbSubnetGroup createDbSubnetGroup(String name, String description, List<String> subnetIds, String region) {
+        return createDbSubnetGroup(name, description, subnetIds, region, Map.of());
+    }
+
+    /**
+     * Tags given at create are stored with the group in the same write — a live account reads
+     * them back from ListTagsForResource straight after CreateDBSubnetGroup.
+     */
+    public DbSubnetGroup createDbSubnetGroup(String name, String description, List<String> subnetIds,
+                                             String region, Map<String, String> tags) {
         if (name == null || name.isBlank()) {
             throw new AwsException("MissingParameter", "The request must contain the parameter DBSubnetGroupName.", 400);
         }
@@ -2274,6 +2283,9 @@ public class RdsService implements Resettable, ResourceProvider {
         }
 
         DbSubnetGroup group = buildSubnetGroup(name, description, subnetIds, effectiveRegion);
+        if (tags != null && !tags.isEmpty()) {
+            group.setTags(new LinkedHashMap<>(tags));
+        }
         putSubnetGroupForScope(currentAccountId(), effectiveRegion, name, group);
         return group;
     }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -633,7 +633,7 @@ class RdsQueryHandlerTest {
 
     @Test
     void createDbSubnetGroup_passesSubnetMembersToService() {
-        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), null))
+        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), null, java.util.Map.of()))
                 .thenReturn(new DbSubnetGroup(
                         "sample-db-subnets", "test", "vpc-123", List.of("subnet-aaa", "subnet-bbb"),
                         Map.of("subnet-aaa", "us-east-1a", "subnet-bbb", "us-east-1b")));
@@ -645,7 +645,7 @@ class RdsQueryHandlerTest {
         p.add("SubnetIds.SubnetIdentifier.2", "subnet-bbb");
         Response response = handler.handle("CreateDBSubnetGroup", p);
 
-        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), null);
+        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), null, java.util.Map.of());
         String body = (String) response.getEntity();
         assertEquals(200, response.getStatus());
         assertTrue(body.contains("<DBSubnetGroupName>sample-db-subnets</DBSubnetGroupName>"));
@@ -657,7 +657,7 @@ class RdsQueryHandlerTest {
 
     @Test
     void createDbSubnetGroupPassesRequestRegionToService() {
-        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), "us-west-2"))
+        when(service.createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), "us-west-2", java.util.Map.of()))
                 .thenReturn(new DbSubnetGroup(
                         "sample-db-subnets", "test", "vpc-123", List.of("subnet-aaa", "subnet-bbb"),
                         Map.of("subnet-aaa", "us-west-2a", "subnet-bbb", "us-west-2b")));
@@ -671,7 +671,7 @@ class RdsQueryHandlerTest {
         Response response = handler.handle("CreateDBSubnetGroup", p, "us-west-2");
 
         assertEquals(200, response.getStatus());
-        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), "us-west-2");
+        verify(service).createDbSubnetGroup("sample-db-subnets", "test", List.of("subnet-aaa", "subnet-bbb"), "us-west-2", java.util.Map.of());
     }
 
     @Test
@@ -862,7 +862,7 @@ class RdsQueryHandlerTest {
         group.setVpcId("vpc-12345678");
         group.setSubnetIds(List.of("subnet-a", "subnet-b"));
         group.setSubnetAvailabilityZones(Map.of("subnet-a", "us-east-1a", "subnet-b", "us-east-1b"));
-        when(service.createDbSubnetGroup("my-subnet-group", "test subnet group", List.of("subnet-a", "subnet-b"), null))
+        when(service.createDbSubnetGroup("my-subnet-group", "test subnet group", List.of("subnet-a", "subnet-b"), null, java.util.Map.of()))
                 .thenReturn(group);
 
         MultivaluedMap<String, String> p = params();
@@ -2003,5 +2003,28 @@ class RdsQueryHandlerTest {
         c.setEngineVersion("15");
         c.setMasterUsername("admin");
         return c;
+    }
+
+    @Test
+    void createDbSubnetGroup_passesCreateTagsToService() {
+        DbSubnetGroup group = new DbSubnetGroup();
+        group.setDbSubnetGroupName("tagged");
+        group.setDbSubnetGroupArn("arn:aws:rds:us-east-1:123456789012:subgrp:tagged");
+        when(service.createDbSubnetGroup(eq("tagged"), eq("d"), eq(List.of("subnet-aaa", "subnet-bbb")), isNull(),
+                eq(java.util.Map.of("Name", "tagged", "env", "tst")))).thenReturn(group);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBSubnetGroupName", "tagged");
+        p.add("DBSubnetGroupDescription", "d");
+        p.add("SubnetIds.SubnetIdentifier.1", "subnet-aaa");
+        p.add("SubnetIds.SubnetIdentifier.2", "subnet-bbb");
+        p.add("Tags.Tag.1.Key", "Name");
+        p.add("Tags.Tag.1.Value", "tagged");
+        p.add("Tags.Tag.2.Key", "env");
+        p.add("Tags.Tag.2.Value", "tst");
+
+        assertEquals(200, handler.handle("CreateDBSubnetGroup", p).getStatus());
+        verify(service).createDbSubnetGroup("tagged", "d", List.of("subnet-aaa", "subnet-bbb"), null,
+                java.util.Map.of("Name", "tagged", "env", "tst"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -4920,4 +4920,22 @@ class RdsServiceTest {
         subnet.setAvailabilityZone(availabilityZone);
         return subnet;
     }
+
+    @Test
+    void createDbSubnetGroupStoresTheTagsItIsGiven() {
+        rdsService.createDbSubnetGroup("tagged", "d", List.of("subnet-default-a", "subnet-default-b"), "us-east-1",
+                Map.of("Name", "tagged", "env", "tst"));
+        String arn = "arn:aws:rds:us-east-1:123456789012:subgrp:tagged";
+
+        assertEquals(Map.of("Name", "tagged", "env", "tst"), rdsService.listTagsForResource(arn, "us-east-1"));
+
+        // later tag calls build on the create-time tags rather than replacing them
+        rdsService.addTagsToResource(arn, Map.of("env", "stg", "extra", "yes"), "us-east-1");
+        assertEquals(Map.of("Name", "tagged", "env", "stg", "extra", "yes"),
+                rdsService.listTagsForResource(arn, "us-east-1"));
+
+        // and the tags are what a restart reads back, not a side table
+        assertEquals(Map.of("Name", "tagged", "env", "stg", "extra", "yes"),
+                rdsService.getDbSubnetGroup("tagged", "us-east-1").getTags());
+    }
 }


### PR DESCRIPTION
Closes #2612

## What

`CreateDBSubnetGroup` never read `Tags.Tag.N`, so a group created with tags answered an empty list
to `ListTagsForResource` — which terraform-provider-aws calls right after the create — although
`DbSubnetGroup` already carried a tag map and `AddTagsToResource` on the group's ARN worked (#1744/#1649).

- `RdsService.createDbSubnetGroup` gains a `tags` parameter and stores them with the group in the same
  write, so there is no window where the group exists untagged (the parameter-group path from #2408
  tags in a second call; this one does not need to).
- The handler passes the parsed tags through. DocumentDB subnet groups are the same records reached
  through the same `rds` scope, so `docdb create-db-subnet-group --tags` is covered by the same change.

`DescribeDBSubnetGroups` is unchanged: AWS's `DBSubnetGroup` shape has no `TagList`, so
`ListTagsForResource` is the only read path — the issue text saying otherwise was wrong.

## Checked against a live account

`create-db-subnet-group --tags Key=Name,Value=g1 Key=env,Value=tst` followed by
`list-tags-for-resource` on the `subgrp:` ARN returns both tags on the `rds` and `docdb` CLIs; Floci
returned `[]` and now returns both.

## Tests

- `RdsQueryHandlerTest.createDbSubnetGroup_passesCreateTagsToService`
- `RdsServiceTest.createDbSubnetGroupStoresTheTagsItIsGiven`: readable back, a later `AddTagsToResource`
  merges onto them, and they live on the stored record (fails with the store dropped:
  `expected {Name=tagged, env=tst} but was {}`)
- `rds.bats`: the CLI round trip on both endpoints, against the packaged jar

## Not covered

- CloudFormation `AWS::RDS::DBSubnetGroup` `Tags` are still dropped: that path is in the legacy
  `CloudFormationResourceProvisioner`, which AGENTS.md asks not to extend.
