### PR TITLE
fix(cloudformation): resolve IAM assume role policy intrinsics

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamRoleCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamRoleCfnProvisioner.java
@@ -58,9 +58,14 @@ public class IamRoleCfnProvisioner implements CfnResourceProvisioner {
             throw new AwsException("ValidationError",
                     "Updating RoleName requires resource replacement, which is not supported.", 400);
         }
-        String assumeDoc = props != null && props.has("AssumeRolePolicyDocument")
-                ? props.get("AssumeRolePolicyDocument").toString()
-                : "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        String assumeDoc = props == null
+                ? null
+                : ctx.engine().resolveJsonAttribute(props.path("AssumeRolePolicyDocument"));
+
+        if (assumeDoc == null) {
+            assumeDoc = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        }
+
         String path = ctx.resolveOptional(props, "Path");
         if (path == null) {
             path = "/";

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamRoleCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamRoleCfnProvisionerTest.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,17 +45,21 @@ class IamRoleCfnProvisionerTest {
 
     private ProvisionContext ctx() {
         CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+
         when(engine.resolve(any())).thenAnswer(inv -> {
-            JsonNode node = inv.getArgument(0);
-            return node == null ? null : node.asText();
+                JsonNode node = inv.getArgument(0);
+                return node == null ? null : node.asText();
         });
+
         when(engine.resolveNode(any())).thenAnswer(inv -> inv.getArgument(0));
+
         when(engine.resolveJsonAttribute(any())).thenAnswer(inv -> {
-            JsonNode node = inv.getArgument(0);
-            return node != null && node.isTextual() ? node.asText() : node.toString();
+                JsonNode node = inv.getArgument(0);
+                return node != null && node.isTextual() ? node.asText() : node.toString();
         });
+
         return new ProvisionContext(engine, "us-east-1", ACCOUNT_ID, "test-stack");
-    }
+        }
 
     private StackResource resource() {
         StackResource r = new StackResource();
@@ -364,4 +369,84 @@ class IamRoleCfnProvisionerTest {
         assertEquals("AccessDenied", failure.getErrorCode());
         verify(iam, never()).deleteRole("denied-role");
     }
+@Test
+void assumeRolePolicyIntrinsicsAreResolved() {
+    stubCreate("app-role");
+    StackResource r = resource();
+
+    CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+
+    when(engine.resolve(any())).thenAnswer(inv -> {
+        JsonNode node = inv.getArgument(0);
+        return node == null ? null : node.asText();
+    });
+
+    JsonNode assumeRolePolicy = props("""
+        {
+          "Version": "2012-10-17",
+          "Statement": [{
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": {
+                "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root"
+              }
+            },
+            "Action": "sts:AssumeRole"
+          }]
+        }
+        """);
+
+    when(engine.resolveJsonAttribute(any())).thenReturn(
+            "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\","
+            + "\"Principal\":{\"AWS\":\"arn:aws:iam::" + ACCOUNT_ID + ":root\"},"
+            + "\"Action\":\"sts:AssumeRole\"}]}"
+    );
+
+    ProvisionContext ctx = new ProvisionContext(
+            engine,
+            "us-east-1",
+            ACCOUNT_ID,
+            "test-stack"
+    );
+
+    JsonNode roleProps = props("""
+        {
+          "RoleName": "app-role",
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [{
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": {
+                  "Fn::Sub": "arn:aws:iam::${AWS::AccountId}:root"
+                }
+              },
+              "Action": "sts:AssumeRole"
+            }]
+          }
+        }
+        """);
+
+    provisioner.provision(r, roleProps, ctx);
+
+    ArgumentCaptor<String> docCaptor = ArgumentCaptor.forClass(String.class);
+
+    verify(iam).createRole(
+            eq("app-role"),
+            eq("/"),
+            docCaptor.capture(),
+            any(),
+            eq(3600),
+            eq(Map.of())
+    );
+
+    String storedDoc = docCaptor.getValue();
+
+    assertFalse(storedDoc.contains("Fn::Sub"));
+    assertFalse(storedDoc.contains("\"Ref\""));
+    assertTrue(storedDoc.contains(
+            "arn:aws:iam::" + ACCOUNT_ID + ":root"
+    ));
+}
+
 }


### PR DESCRIPTION
## Summary

Closes #2538

Resolve `AssumeRolePolicyDocument` through `CloudFormationTemplateEngine.resolveJsonAttribute` before storing it in `AWS::IAM::Role`.

Previously, the raw template node was serialized directly, causing intrinsics such as `Fn::Sub` and `Ref` to be stored as unresolved CloudFormation syntax.

Added a regression test to verify that the resolved trust policy is passed to `IamService.createRole` without unresolved intrinsic keys.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The IAM role `AssumeRolePolicyDocument` was previously stored with unresolved CloudFormation intrinsic functions such as `Fn::Sub`.

The fix resolves JSON-valued attributes using the existing `resolveJsonAttribute` helper before passing the policy to the IAM service.

## Checklist

- [x] `mvn -Dtest=IamRoleCfnProvisionerTest test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)