### PR TITLE
fix(ssm): validate SettingValue and require an account list on ModifyDocumentPermission

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
@@ -474,6 +474,12 @@ public class SsmJsonHandler {
         requireSharePermissionType(request);
         List<String> accountIdsToAdd = accountIds(request, "AccountIdsToAdd");
         List<String> accountIdsToRemove = accountIds(request, "AccountIdsToRemove");
+        if (accountIdsToAdd.isEmpty() && accountIdsToRemove.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "You must specify a value for the AccountIdsToAdd parameter or the "
+                            + "AccountIdsToRemove parameter.",
+                    400);
+        }
 
         ssmService.modifyDocumentPermission(name, accountIdsToAdd, accountIdsToRemove, region);
         return Response.ok(objectMapper.createObjectNode()).build();
@@ -601,6 +607,33 @@ public class SsmJsonHandler {
         return settingId;
     }
 
+    /**
+     * Reads the required {@code SettingValue} member of UpdateServiceSetting. Botocore models
+     * {@code ServiceSettingValue} as a string with {@code min: 1, max: 4096}; an absent or blank
+     * value silently stores an empty customized setting rather than failing, and an oversized one
+     * would sit in the store forever since GetServiceSetting just echoes it back.
+     */
+    private static final int MAX_SETTING_VALUE_LENGTH = 4096;
+
+    private String requireSettingValue(JsonNode request) {
+        JsonNode valueNode = request.path("SettingValue");
+        String settingValue = valueNode.asText();
+        if (!valueNode.isTextual() || settingValue.isBlank()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'settingValue' failed to satisfy "
+                            + "constraint: Member must not be null",
+                    400);
+        }
+        if (settingValue.length() > MAX_SETTING_VALUE_LENGTH) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'settingValue' failed to satisfy "
+                            + "constraint: Member must have length less than or equal to "
+                            + MAX_SETTING_VALUE_LENGTH,
+                    400);
+        }
+        return settingValue;
+    }
+
     private Response handleGetServiceSetting(JsonNode request, String region) {
         String settingId = requireSettingId(request);
         ServiceSetting setting = ssmService.getServiceSetting(settingId, region);
@@ -612,7 +645,7 @@ public class SsmJsonHandler {
 
     private Response handleUpdateServiceSetting(JsonNode request, String region) {
         String settingId = requireSettingId(request);
-        String settingValue = request.path("SettingValue").asText();
+        String settingValue = requireSettingValue(request);
         ssmService.updateServiceSetting(settingId, settingValue, region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmJsonHandler.java
@@ -383,8 +383,15 @@ public class SsmJsonHandler {
      * be reported back by DescribeDocumentPermission as though the share had happened.
      */
     private List<String> accountIds(JsonNode request, String field) {
+        JsonNode fieldNode = request.path(field);
+        if (!fieldNode.isMissingNode() && !fieldNode.isNull() && !fieldNode.isArray()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at '" + decapitalize(field) + "' failed to satisfy "
+                            + "constraint: Member must be a list",
+                    400);
+        }
         List<String> accountIds = new ArrayList<>();
-        request.path(field).forEach(node -> accountIds.add(node.asText()));
+        fieldNode.forEach(node -> accountIds.add(node.asText()));
         if (accountIds.size() > MAX_ACCOUNT_IDS) {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value at '" + decapitalize(field) + "' failed to satisfy "
@@ -476,8 +483,9 @@ public class SsmJsonHandler {
         List<String> accountIdsToRemove = accountIds(request, "AccountIdsToRemove");
         if (accountIdsToAdd.isEmpty() && accountIdsToRemove.isEmpty()) {
             throw new AwsException("ValidationException",
-                    "You must specify a value for the AccountIdsToAdd parameter or the "
-                            + "AccountIdsToRemove parameter.",
+                    "1 validation error detected: Value null at 'accountIdsToAdd' failed to satisfy "
+                            + "constraint: Member must not be null, or a value must be specified for "
+                            + "'accountIdsToRemove'",
                     400);
         }
 
@@ -618,7 +626,7 @@ public class SsmJsonHandler {
     private String requireSettingValue(JsonNode request) {
         JsonNode valueNode = request.path("SettingValue");
         String settingValue = valueNode.asText();
-        if (!valueNode.isTextual() || settingValue.isBlank()) {
+        if (!valueNode.isTextual() || settingValue.isEmpty()) {
             throw new AwsException("ValidationException",
                     "1 validation error detected: Value null at 'settingValue' failed to satisfy "
                             + "constraint: Member must not be null",

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -339,6 +339,35 @@ class SsmIntegrationTest {
     }
 
     @Test
+    void updateServiceSetting_whitespaceOnlySettingValueIsStoredVerbatim() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.UpdateServiceSetting")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "SettingId": "/ssm/parameter-store/default-parameter-tier",
+                    "SettingValue": " "
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetServiceSetting")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "SettingId": "/ssm/parameter-store/default-parameter-tier" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ServiceSetting.SettingValue", equalTo(" "));
+    }
+
+    @Test
     void updateServiceSetting_settingValueOverMaxLengthReturnsValidationException() {
         String tooLong = "x".repeat(4097);
         given()
@@ -1089,6 +1118,40 @@ class SsmIntegrationTest {
                 .statusCode(200)
                 .body("DocumentDescription.DocumentType", equalTo(documentTypes[i]));
         }
+    }
+
+    @Test
+    void modifyDocumentPermission_nonListAccountIdsToAddReturnsValidationException() {
+        createSharableDocument("Non-List-Account-Ids-Document");
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.ModifyDocumentPermission")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Name": "Non-List-Account-Ids-Document",
+                    "PermissionType": "Share",
+                    "AccountIdsToAdd": "444444444444"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        // Nothing may have been shared — the scalar must not be silently treated as empty.
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribeDocumentPermission")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Name": "Non-List-Account-Ids-Document", "PermissionType": "Share" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AccountIds", empty());
     }
 
     // ── AccountIdsToAdd/Remove (botocore: list max 20, member (?i)all|[0-9]{12}) ──

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -321,6 +321,42 @@ class SsmIntegrationTest {
             .body("__type", equalTo("ServiceSettingNotFound"));
     }
 
+    // ── SettingValue (botocore: ServiceSettingValue, required, min 1 / max 4096) ──
+
+    @Test
+    void updateServiceSetting_missingSettingValueReturnsValidationException() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.UpdateServiceSetting")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "SettingId": "/ssm/documents/console/public-sharing-permission" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void updateServiceSetting_settingValueOverMaxLengthReturnsValidationException() {
+        String tooLong = "x".repeat(4097);
+        given()
+            .header("X-Amz-Target", "AmazonSSM.UpdateServiceSetting")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "SettingId": "/ssm/documents/console/public-sharing-permission",
+                    "SettingValue": "%s"
+                }
+                """.formatted(tooLong))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
     @Test
     void serviceSettingOperations_missingSettingIdReturnsValidationException() {
         for (String target : new String[]{"GetServiceSetting", "UpdateServiceSetting", "ResetServiceSetting"}) {
@@ -1136,6 +1172,43 @@ class SsmIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("ValidationException"));
+    }
+
+    // ── ModifyDocumentPermission: at least one of AccountIdsToAdd/AccountIdsToRemove
+    // required (botocore: documented on both members, not a JSON `required` or shape
+    // constraint — "You must specify a value for this parameter or the
+    // AccountIdsToRemove/AccountIdsToAdd parameter.") ──
+
+    @Test
+    void modifyDocumentPermission_neitherAccountListSpecifiedReturnsValidationException() {
+        createSharableDocument("No-Account-Lists-Document");
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.ModifyDocumentPermission")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Name": "No-Account-Lists-Document",
+                    "PermissionType": "Share"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribeDocumentPermission")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Name": "No-Account-Lists-Document", "PermissionType": "Share" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AccountIds", empty());
     }
 
     private static void createSharableDocument(String name) {


### PR DESCRIPTION
## Summary

Proactive-fidelity-sweep-derived fix. The sweep flagged 4 findings in the SSM service (all landed via PR #2629, `feat(ssm): document lifecycle, share permissions, and account-scoped service settings`). Of those 4, 2 were already correctly handled by that PR and 2 are real gaps fixed here:

- **`DescribeDocumentPermission.PermissionType`** — already satisfied. `requireSharePermissionType(request)` validates it as required with the modeled single-value enum (`Share`), raising `ValidationException` when absent and `InvalidPermissionType` for any other value, matching botocore's `DocumentPermissionType` shape (`enum: ["Share"]`) and the operation's modeled `InvalidPermissionType` error. Already covered by `documentPermissionOperations_missingPermissionTypeIsRejected` and `documentPermissionOperations_rejectUnsupportedPermissionType`.
- **`ModifyDocumentPermission.AccountIdsToAdd` / `AccountIdsToRemove` (pattern/length)** — already satisfied. `accountIds()` enforces botocore's `AccountIdList` shape (`max: 20`) and `AccountId` pattern (`(?i)all|[0-9]{12}`), both as `ValidationException`. Already covered by `modifyDocumentPermission_rejectsAnAccountIdThatIsNotAnAccountId`, `modifyDocumentPermission_acceptsTheAllWildcard`, `modifyDocumentPermission_rejectsMoreThanTwentyAccountIds`.
- **`ModifyDocumentPermission.AccountIdsToAdd` / `AccountIdsToRemove` (at-least-one-required) — real gap, fixed.** Botocore's `service-2.json` documents (not a JSON `required` array entry, and not a shape constraint — a doc-string-derived constraint on both members) that at least one of the two must be specified. The handler previously built two empty lists when neither was sent and returned 200 having shared/unshared nothing.
- **`UpdateServiceSetting.SettingValue` — real gap, fixed.** `SettingValue` is in `UpdateServiceSettingRequest.required`, and its shape `ServiceSettingValue` is `{min: 1, max: 4096}`. The handler read it with a bare `request.path("SettingValue").asText()`, so an absent/blank value silently stored an empty customized setting, and the 4096 max was never enforced.

## Deliberate scope notes

- The "at least one account list required" constraint comes from `ModifyDocumentPermissionRequest`'s member documentation in botocore's `service-2.json`, not from the JSON `required` array or a shape-level constraint — flagging this explicitly since it's a different tier of fidelity evidence than the shape-derived guards already in this file.
- `DocumentPermissionLimit` (the 20-account-per-call error the model separately errors as `DocumentPermissionLimit`) documents the *cumulative* 1,000/5-account cap, not the per-call max of 20 — the existing `ValidationException` for exceeding 20 per call is the correct treatment (shape `max` constraint), left unchanged.
- Left unvalidated, deliberately out of scope for this fix since not in the 4 findings: `SettingId`'s `min:1/max:1000` shape bounds, `SharedDocumentVersion`, and `MaxResults`/pagination on `DescribeDocumentPermission`.

## Test plan

- [x] RED: added `updateServiceSetting_missingSettingValueReturnsValidationException`, `updateServiceSetting_settingValueOverMaxLengthReturnsValidationException`, `modifyDocumentPermission_neitherAccountListSpecifiedReturnsValidationException` to `SsmIntegrationTest`; confirmed all three failed (200 instead of 400) against the current merged code.
- [x] GREEN: `SsmIntegrationTest` — 47/47 passing.
- [x] `SsmIntegrationTest,SsmServiceTest,SsmCommandServiceDirectExecutionTest,SsmDirectCommandExecutorTest,SsmSendCommandIntegrationTest` — 113/113 passing.
- [x] `mvn clean test-compile` — full project compiles clean.
- [x] `make docs-check` — no-op (no changes to the operation dispatch table).