### PR TITLE
ci: restore ci.yml's maven cache in the compat native build

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -92,8 +92,27 @@ jobs:
         with:
           java-version: '25'
           distribution: 'mandrel'
-          cache: maven
+          # no `cache: maven` — it keys on setup-graalvm-Linux-maven-<hash>, which
+          # only this pull_request-only workflow ever writes. Actions caches are
+          # ref-scoped, so those writes land in refs/pull/N/merge and no run can
+          # read another's: it logged "maven cache is not found" on 6 of 6 sampled
+          # runs while dutifully saving 211 MB each time. Restore ci.yml's cache
+          # below instead, which push-to-main genuinely populates.
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore-only, and deliberately keyed identically to ci.yml:54-59 so this
+      # reads the ~/.m2 that ci.yml's shard 1 saves on every push to main. ci.yml
+      # stays the single owner of the save; a second writer would just race it.
+      # Two known partial-hit caveats, both cheap: `runner.os` is Linux for both
+      # but ci.yml runs x64 while this runs arm64 (Maven artifacts are
+      # arch-neutral, so only classifier-based natives re-download), and
+      # `-Dnative` pulls native-image plugins that ci.yml's `mvn test` never
+      # fetches. Expect most of the ~66s of cold resolution back, not all of it.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Build native executable (quick build)
         run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob"


### PR DESCRIPTION
## Summary

`build-native` logs `maven cache is not found` on **6 of 6** sampled runs while saving 211 MB every time, costing ~66s of cold dependency resolution (1,398 `Downloading from` lines) inside an 8.6m job that serially gates all eight compat legs.

Cause: `setup-graalvm`'s `cache: maven` keys on `setup-graalvm-Linux-maven-<hash>`, a key written only by this `pull_request`-only workflow. Actions caches are ref-scoped, so every write lands in `refs/pull/N/merge` where no other run can read it — the same class of defect #2503 fixed for `setup-java`.

Measured in run [33106349664](https://github.com/floci-io/floci/actions/runs/33106349664):

```
19:01:09  maven cache is not found
19:01:17 → 19:02:24   1,398 "Downloading from" lines    ~66s   <- what the miss costs
19:02:32 → 19:08:30   native-image compile            5m 55s   <- already -Ob, irreducible
```

`ci.yml` already saves `~/.m2/repository` on every push to main under `maven-<os>-<hash(pom.xml)>`, and `refs/heads/main` really does hold that entry. This restores that key instead, read-only so `ci.yml` remains the single writer and the two never race.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — CI workflow only (`ci:`), no runtime change

## AWS Compatibility

No wire-protocol impact. CI-only: no emulator source, request parsing, or response shape is touched.

## Checklist

- [x] `./mvnw test` passes locally — unaffected, no `src/` changes
- [ ] New or updated integration test added — **not applicable**, workflow-only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

**On verification:** expect *most* of the ~66s back, not all. `runner.os` is `Linux` on both sides but `ci.yml` runs x64 while this runs arm64 — Maven artifacts are arch-neutral so only classifier-based natives re-download — and `-Dnative` pulls native-image plugins that `mvn test` never fetches. Confirm post-merge by checking `build-native` logs for `Cache restored from key: maven-Linux-...` in place of `maven cache is not found`.

## Not included

`nightly.yml` carries the same `cache: maven` in two jobs and also misses — but for a different reason. It saves to a **main-scoped** key daily and is still evicted 24h later by the repo's 13.24 GB cache overrun, not by ref-scoping. That should recover once #2634 and its follow-up purge land, so changing it here would treat a symptom that is about to disappear and would blur which fix worked.

## Relation to #2634

Independent. Both touch `compatibility.yml`, but the hunks are ~100 lines apart and were verified to apply onto `main` together cleanly. Merge order does not matter.
