### PR TITLE
fix(kms): grant fidelity

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -154,6 +154,12 @@ public class KmsJsonHandler {
             entry.put("KeyId", (String) grant.get("KeyId"));
             entry.put("GranteePrincipal", (String) grant.get("GranteePrincipal"));
             entry.put("CreationDate", ((Number) grant.get("CreationDate")).longValue());
+            if (grant.get("Name") != null) {
+                entry.put("Name", (String) grant.get("Name"));
+            }
+            if (grant.get("Constraints") != null) {
+                entry.set("Constraints", objectMapper.valueToTree(grant.get("Constraints")));
+            }
             ArrayNode operations = entry.putArray("Operations");
             @SuppressWarnings("unchecked")
             List<String> operationValues = (List<String>) grant.get("Operations");
@@ -186,6 +192,12 @@ public class KmsJsonHandler {
             entry.put("KeyId", (String) grant.get("KeyId"));
             entry.put("GranteePrincipal", (String) grant.get("GranteePrincipal"));
             entry.put("CreationDate", ((Number) grant.get("CreationDate")).longValue());
+            if (grant.get("Name") != null) {
+                entry.put("Name", (String) grant.get("Name"));
+            }
+            if (grant.get("Constraints") != null) {
+                entry.set("Constraints", objectMapper.valueToTree(grant.get("Constraints")));
+            }
             ArrayNode operations = entry.putArray("Operations");
             @SuppressWarnings("unchecked")
             List<String> operationValues = (List<String>) grant.get("Operations");
@@ -208,8 +220,13 @@ public class KmsJsonHandler {
         request.path("Operations").forEach(operation -> operations.add(operation.asText()));
         String retiringPrincipal = request.path("RetiringPrincipal").isMissingNode()
                 ? null : request.path("RetiringPrincipal").asText(null);
+        String name = request.path("Name").isMissingNode() ? null : request.path("Name").asText(null);
+        Map<String, Object> constraints = request.path("Constraints").isObject()
+                ? objectMapper.convertValue(request.path("Constraints"), Map.class)
+                : null;
 
-        KmsGrant grant = service.createGrant(keyId, granteePrincipal, operations, retiringPrincipal, region);
+        KmsGrant grant = service.createGrant(
+                keyId, granteePrincipal, operations, retiringPrincipal, name, constraints, region);
         ObjectNode response = objectMapper.createObjectNode();
         response.put("GrantId", grant.getGrantId());
         response.put("GrantToken", grant.getGrantToken());

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsJsonHandler.java
@@ -221,8 +221,14 @@ public class KmsJsonHandler {
         String retiringPrincipal = request.path("RetiringPrincipal").isMissingNode()
                 ? null : request.path("RetiringPrincipal").asText(null);
         String name = request.path("Name").isMissingNode() ? null : request.path("Name").asText(null);
-        Map<String, Object> constraints = request.path("Constraints").isObject()
-                ? objectMapper.convertValue(request.path("Constraints"), Map.class)
+        JsonNode constraintsNode = request.path("Constraints");
+        if (!constraintsNode.isMissingNode() && !constraintsNode.isNull() && !constraintsNode.isObject()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value at 'constraints' failed to satisfy constraint: "
+                            + "Member must be a structure", 400);
+        }
+        Map<String, Object> constraints = constraintsNode.isObject()
+                ? objectMapper.convertValue(constraintsNode, Map.class)
                 : null;
 
         KmsGrant grant = service.createGrant(

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -273,11 +273,17 @@ public class KmsService implements ResourceProvider {
     }
 
     public KmsGrant createGrant(String keyId, String granteePrincipal, List<String> operations, String region) {
-        return createGrant(keyId, granteePrincipal, operations, null, region);
+        return createGrant(keyId, granteePrincipal, operations, null, null, null, region);
     }
 
     public KmsGrant createGrant(String keyId, String granteePrincipal, List<String> operations,
                                 String retiringPrincipal, String region) {
+        return createGrant(keyId, granteePrincipal, operations, retiringPrincipal, null, null, region);
+    }
+
+    public KmsGrant createGrant(String keyId, String granteePrincipal, List<String> operations,
+                                String retiringPrincipal, String name, Map<String, Object> constraints,
+                                String region) {
         if (keyId == null || keyId.isBlank()) {
             throw new AwsException("ValidationException", "KeyId is required", 400);
         }
@@ -296,11 +302,13 @@ public class KmsService implements ResourceProvider {
         KmsGrant grant = new KmsGrant();
         grant.setGrantId(grantId);
         grant.setGrantToken(Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes));
+        grant.setName(name);
         grant.setKeyId(key.getKeyId());
         grant.setKeyArn(key.getArn());
         grant.setGranteePrincipal(granteePrincipal);
         grant.setRetiringPrincipal(retiringPrincipal);
         grant.setOperations(new ArrayList<>(operations));
+        grant.setConstraints(constraints == null ? null : new HashMap<>(constraints));
 
         grantStore.put(region + "::" + grantId, grant);
         LOG.infov("Created KMS grant: {0} for key {1} in {2}", grantId, key.getKeyId(), region);
@@ -465,6 +473,12 @@ public class KmsService implements ResourceProvider {
         result.put("GranteePrincipal", grant.getGranteePrincipal());
         result.put("Operations", grant.getOperations());
         result.put("CreationDate", grant.getCreationDate());
+        if (grant.getName() != null) {
+            result.put("Name", grant.getName());
+        }
+        if (grant.getConstraints() != null) {
+            result.put("Constraints", grant.getConstraints());
+        }
         if (grant.getRetiringPrincipal() != null) {
             result.put("RetiringPrincipal", grant.getRetiringPrincipal());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -283,6 +283,56 @@ public class KmsService implements ResourceProvider {
     private static final java.util.regex.Pattern GRANT_NAME_PATTERN =
             java.util.regex.Pattern.compile("^[a-zA-Z0-9:/_-]+$");
 
+    /** GrantConstraintSourceArnType pattern from the KMS model (kms/2014-11-01/service-2.json). */
+    private static final java.util.regex.Pattern GRANT_CONSTRAINT_SOURCE_ARN_PATTERN =
+            java.util.regex.Pattern.compile("^arn:aws[a-z0-9-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]{12}:.+$");
+
+    private static final Set<String> GRANT_CONSTRAINT_MEMBERS =
+            Set.of("EncryptionContextSubset", "EncryptionContextEquals", "SourceArn");
+
+    /** Validates a CreateGrant Constraints map against the modeled GrantConstraints shape. */
+    private void validateGrantConstraints(Map<String, Object> constraints) {
+        if (constraints == null) {
+            return;
+        }
+        for (String member : constraints.keySet()) {
+            if (!GRANT_CONSTRAINT_MEMBERS.contains(member)) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Unknown parameter in 'constraints': \"" + member
+                                + "\", must be one of: " + String.join(", ", GRANT_CONSTRAINT_MEMBERS), 400);
+            }
+        }
+        for (String encryptionContextMember : List.of("EncryptionContextSubset", "EncryptionContextEquals")) {
+            Object value = constraints.get(encryptionContextMember);
+            if (value == null) {
+                continue;
+            }
+            if (!(value instanceof Map<?, ?> map)) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value at 'constraints." + encryptionContextMember
+                                + "' failed to satisfy constraint: Member must be a map of string to string", 400);
+            }
+            for (Map.Entry<?, ?> entry : map.entrySet()) {
+                if (!(entry.getKey() instanceof String) || !(entry.getValue() instanceof String)) {
+                    throw new AwsException("ValidationException",
+                            "1 validation error detected: Value at 'constraints." + encryptionContextMember
+                                    + "' failed to satisfy constraint: Member must be a map of string to string", 400);
+                }
+            }
+        }
+        Object sourceArn = constraints.get("SourceArn");
+        if (sourceArn != null) {
+            if (!(sourceArn instanceof String sourceArnValue)
+                    || sourceArnValue.length() < 20 || sourceArnValue.length() > 512
+                    || !GRANT_CONSTRAINT_SOURCE_ARN_PATTERN.matcher(sourceArnValue).matches()) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value at 'constraints.sourceArn' failed to satisfy "
+                                + "constraint: Member must satisfy regular expression pattern: "
+                                + "^arn:aws[a-z0-9-]*:[a-z0-9-]+:[a-z0-9-]*:[0-9]{12}:.+$", 400);
+            }
+        }
+    }
+
     public KmsGrant createGrant(String keyId, String granteePrincipal, List<String> operations, String region) {
         return createGrant(keyId, granteePrincipal, operations, null, null, null, region);
     }
@@ -313,7 +363,12 @@ public class KmsService implements ResourceProvider {
             }
         }
         if (name != null) {
-            if (name.isEmpty() || name.length() > 256) {
+            if (name.isEmpty()) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + name + "' at 'name' failed to satisfy "
+                                + "constraint: Member must have length greater than or equal to 1", 400);
+            }
+            if (name.length() > 256) {
                 throw new AwsException("ValidationException",
                         "1 validation error detected: Value '" + name + "' at 'name' failed to satisfy "
                                 + "constraint: Member must have length less than or equal to 256", 400);
@@ -325,6 +380,7 @@ public class KmsService implements ResourceProvider {
                                 + "^[a-zA-Z0-9:/_-]+$", 400);
             }
         }
+        validateGrantConstraints(constraints);
 
         KmsKey key = resolveKey(keyId, region);
         String grantId = UUID.randomUUID().toString();

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -272,6 +272,13 @@ public class KmsService implements ResourceProvider {
         return keyStore.scan(k -> k.startsWith(prefix));
     }
 
+    /** GrantOperation enum from the KMS model (kms/2014-11-01/service-2.json). */
+    private static final Set<String> GRANT_OPERATIONS = new LinkedHashSet<>(List.of(
+            "Decrypt", "Encrypt", "GenerateDataKey", "GenerateDataKeyWithoutPlaintext",
+            "ReEncryptFrom", "ReEncryptTo", "Sign", "Verify", "GetPublicKey", "CreateGrant",
+            "RetireGrant", "DescribeKey", "GenerateDataKeyPair", "GenerateDataKeyPairWithoutPlaintext",
+            "GenerateMac", "VerifyMac", "DeriveSharedSecret"));
+
     public KmsGrant createGrant(String keyId, String granteePrincipal, List<String> operations, String region) {
         return createGrant(keyId, granteePrincipal, operations, null, null, null, region);
     }
@@ -292,6 +299,14 @@ public class KmsService implements ResourceProvider {
         }
         if (operations == null || operations.isEmpty()) {
             throw new AwsException("ValidationException", "Operations is required", 400);
+        }
+        for (String operation : operations) {
+            if (!GRANT_OPERATIONS.contains(operation)) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + operation + "' at 'operations' failed to satisfy "
+                                + "constraint: Member must satisfy enum value set: ["
+                                + String.join(", ", GRANT_OPERATIONS) + "]", 400);
+            }
         }
 
         KmsKey key = resolveKey(keyId, region);

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -279,6 +279,10 @@ public class KmsService implements ResourceProvider {
             "RetireGrant", "DescribeKey", "GenerateDataKeyPair", "GenerateDataKeyPairWithoutPlaintext",
             "GenerateMac", "VerifyMac", "DeriveSharedSecret"));
 
+    /** GrantNameType pattern/length from the KMS model (kms/2014-11-01/service-2.json). */
+    private static final java.util.regex.Pattern GRANT_NAME_PATTERN =
+            java.util.regex.Pattern.compile("^[a-zA-Z0-9:/_-]+$");
+
     public KmsGrant createGrant(String keyId, String granteePrincipal, List<String> operations, String region) {
         return createGrant(keyId, granteePrincipal, operations, null, null, null, region);
     }
@@ -306,6 +310,19 @@ public class KmsService implements ResourceProvider {
                         "1 validation error detected: Value '" + operation + "' at 'operations' failed to satisfy "
                                 + "constraint: Member must satisfy enum value set: ["
                                 + String.join(", ", GRANT_OPERATIONS) + "]", 400);
+            }
+        }
+        if (name != null) {
+            if (name.isEmpty() || name.length() > 256) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + name + "' at 'name' failed to satisfy "
+                                + "constraint: Member must have length less than or equal to 256", 400);
+            }
+            if (!GRANT_NAME_PATTERN.matcher(name).matches()) {
+                throw new AwsException("ValidationException",
+                        "1 validation error detected: Value '" + name + "' at 'name' failed to satisfy "
+                                + "constraint: Member must satisfy regular expression pattern: "
+                                + "^[a-zA-Z0-9:/_-]+$", 400);
             }
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsGrant.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsGrant.java
@@ -6,17 +6,20 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class KmsGrant {
     private String grantId;
     private String grantToken;
+    private String name;
     private String keyId;
     private String keyArn;
     private String granteePrincipal;
     private String retiringPrincipal;
     private List<String> operations = new ArrayList<>();
+    private Map<String, Object> constraints;
     private long creationDate;
 
     public KmsGrant() {
@@ -28,6 +31,9 @@ public class KmsGrant {
 
     public String getGrantToken() { return grantToken; }
     public void setGrantToken(String grantToken) { this.grantToken = grantToken; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
 
     public String getKeyId() { return keyId; }
     public void setKeyId(String keyId) { this.keyId = keyId; }
@@ -43,6 +49,9 @@ public class KmsGrant {
 
     public List<String> getOperations() { return operations; }
     public void setOperations(List<String> operations) { this.operations = operations; }
+
+    public Map<String, Object> getConstraints() { return constraints; }
+    public void setConstraints(Map<String, Object> constraints) { this.constraints = constraints; }
 
     public long getCreationDate() { return creationDate; }
     public void setCreationDate(long creationDate) { this.creationDate = creationDate; }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -563,6 +563,8 @@ class KmsIntegrationTest {
                         {
                             "KeyId": "%s",
                             "GranteePrincipal": "arn:aws:iam::000000000000:user/grantee",
+                            "Name": "vellum-tenant-round-trip",
+                            "Constraints": {"EncryptionContextEquals": {"tenant_id": "tenant-001"}},
                             "Operations": ["Encrypt", "Decrypt"]
                         }
                         """.formatted(keyId))
@@ -587,6 +589,8 @@ class KmsIntegrationTest {
                 .body("Grants[0].GrantId", equalTo(grantId))
                 .body("Grants[0].KeyId", startsWith("arn:aws:kms:"))
                 .body("Grants[0].GranteePrincipal", equalTo("arn:aws:iam::000000000000:user/grantee"))
+                .body("Grants[0].Name", equalTo("vellum-tenant-round-trip"))
+                .body("Grants[0].Constraints.EncryptionContextEquals.tenant_id", equalTo("tenant-001"))
                 .body("Grants[0].Operations[0]", equalTo("Encrypt"))
                 .body("Grants[0].Operations[1]", equalTo("Decrypt"))
                 .body("Truncated", equalTo(false));

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -789,6 +789,36 @@ class KmsIntegrationTest {
     }
 
     @Test
+    void createGrantWithNonObjectConstraintsReturnsValidationException() {
+        // The handler previously converted any non-object Constraints (e.g. a raw string or
+        // array) to null before it reached KmsService, so a malformed request was silently
+        // treated as "no constraints" instead of rejected.
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"Description\":\"constraints-type-check\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.CreateGrant")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("""
+                        {
+                            "KeyId": "%s",
+                            "GranteePrincipal": "arn:aws:iam::000000000000:user/grantee",
+                            "Operations": ["Encrypt"],
+                            "Constraints": "not-an-object"
+                        }
+                        """.formatted(keyId))
+                .when().post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
     void revokeGrantReturnsNotFoundForUnknownGrant() {
         String keyId = given()
                 .header("X-Amz-Target", "TrentService.CreateKey")

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -176,6 +176,31 @@ class KmsServiceTest {
     }
 
     @Test
+    void createGrantInvalidNameCharacterThrowsValidation() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt"), null, "invalid name with spaces", null, REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("'name'"),
+                "message should name the rejected field, was: " + ex.getMessage());
+    }
+
+    @Test
+    void createGrantNameTooLongThrowsValidation() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+        String tooLong = "a".repeat(257);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt"), null, tooLong, null, REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
     void createGrantUnknownKeyThrowsNotFound() {
         AwsException ex = assertThrows(AwsException.class, () ->
                 kmsService.createGrant("non-existent-id", "arn:aws:iam::000000000000:user/grantee", List.of("Encrypt"), REGION));

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -163,6 +163,19 @@ class KmsServiceTest {
     }
 
     @Test
+    void createGrantUnknownOperationThrowsValidation() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt", "NotARealOperation"), REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("NotARealOperation"),
+                "message should name the rejected operation, was: " + ex.getMessage());
+    }
+
+    @Test
     void createGrantUnknownKeyThrowsNotFound() {
         AwsException ex = assertThrows(AwsException.class, () ->
                 kmsService.createGrant("non-existent-id", "arn:aws:iam::000000000000:user/grantee", List.of("Encrypt"), REGION));

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -198,6 +198,75 @@ class KmsServiceTest {
                         List.of("Encrypt"), null, tooLong, null, REGION));
 
         assertEquals("ValidationException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("less than or equal to 256"),
+                "too-long-name message should cite the max-length constraint, was: " + ex.getMessage());
+    }
+
+    @Test
+    void createGrantEmptyNameThrowsValidationWithMinLengthMessage() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt"), null, "", null, REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertTrue(ex.getMessage().contains("greater than or equal to 1"),
+                "empty-name message should cite the min-length constraint, was: " + ex.getMessage());
+    }
+
+    @Test
+    void createGrantConstraintsUnknownMemberThrowsValidation() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+        Map<String, Object> constraints = new LinkedHashMap<>();
+        constraints.put("NotARealConstraint", "value");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt"), null, null, constraints, REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void createGrantConstraintsStringValuedEncryptionContextEqualsThrowsValidation() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+        Map<String, Object> constraints = new LinkedHashMap<>();
+        constraints.put("EncryptionContextEquals", "not-a-map");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt"), null, null, constraints, REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void createGrantConstraintsInvalidSourceArnThrowsValidation() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+        Map<String, Object> constraints = new LinkedHashMap<>();
+        constraints.put("SourceArn", "not-an-arn");
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                        List.of("Encrypt"), null, null, constraints, REGION));
+
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void createGrantConstraintsValidEncryptionContextRoundTrips() {
+        KmsKey key = kmsService.createKey("grant key", REGION);
+        Map<String, Object> constraints = new LinkedHashMap<>();
+        Map<String, String> encryptionContext = new LinkedHashMap<>();
+        encryptionContext.put("purpose", "test");
+        constraints.put("EncryptionContextEquals", encryptionContext);
+        constraints.put("SourceArn", "arn:aws:iam::123456789012:role/test-role");
+
+        KmsGrant grant = kmsService.createGrant(key.getKeyId(), "arn:aws:iam::000000000000:user/grantee",
+                List.of("Encrypt"), null, null, constraints, REGION);
+
+        assertEquals(constraints, grant.getConstraints());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Three focused KMS `CreateGrant`/grant-metadata fidelity fixes, all botocore-derived (verified against `kms/2014-11-01/service-2.json`, no LZA pipeline run touches KMS grants):

- Preserve grant metadata (`Name`, `RetiringPrincipal`, `Constraints`) end to end through `KmsJsonHandler` and `KmsService` instead of silently dropping it.
- Reject `Operations` values that aren't in the modeled `GrantOperation` enum, instead of persisting and echoing back an operation AWS would have refused.
- Validate `Name` against `GrantNameType`'s constraint (`^[a-zA-Z0-9:/_-]+$`, 1-256 chars) instead of accepting any string.

## Wire-fidelity details

- **`Operations` enum enforcement**: `GrantOperation` in `kms/2014-11-01/service-2.json` is a closed enum (`Decrypt`, `Encrypt`, `GenerateDataKey`, `GenerateDataKeyWithoutPlaintext`, `ReEncryptFrom`, `ReEncryptTo`, `Sign`, `Verify`, `GetPublicKey`, `CreateGrant`, `RetireGrant`, `DescribeKey`, `GenerateDataKeyPair`, `GenerateDataKeyPairWithoutPlaintext`, `GenerateMac`, `VerifyMac`, `DeriveSharedSecret`). `CreateGrant` previously stored the caller-supplied list verbatim; a bogus operation would silently round-trip through `ListGrants`. Now validated with a `ValidationException` matching the existing `KeyId`/`GranteePrincipal`/`Operations`-required guards.
- **`Name` (`GrantNameType`) constraint**: the model shape is `{"type": "string", "max": 256, "min": 1, "pattern": "^[a-zA-Z0-9:/_-]+$"}`. `CreateGrant` now rejects names that violate either the length or pattern constraint, with the same `ValidationException` message shape (`"...failed to satisfy constraint: Member must satisfy regular expression pattern: ..."`) used elsewhere in this codebase (see `DynamoDbTableNames.validateTableNameForCreate`).
- **Grant metadata round-trip**: `Name`, `RetiringPrincipal`, and `Constraints` are now threaded from the JSON request through `KmsService.createGrant` into the stored `KmsGrant` and echoed back on `ListGrants`, instead of being read from the wire and discarded.

## Deliberate scope notes

- **`Name` is validated for format only, not used for idempotent-retry dedup.** Per the botocore documentation for `CreateGrantRequest.Name`, real AWS uses a supplied `Name` as a retry-idempotency key: a second `CreateGrant` call with an identical `Name` and identical other parameters returns the *original* `GrantId` instead of creating a duplicate grant. This PR does **not** implement that dedup behavior — it only enforces the format/length constraint AWS validates before considering a grant a duplicate. Implementing full idempotent-retry semantics (matching on `Name` + parameter equality, returning the prior `GrantId`) is a larger, separable change and is left for a follow-up if a caller is found to depend on it.
- Verified before fixing: audited whether `Name` has any read-side use in floci beyond echoing it back in the `ListGrants` response (`KmsService.java:491-492`, `result.put("Name", grant.getName())`). It does not — no lookup, no storage key, no state-mutation path keys off `Name`. The format/length validation is added purely for fidelity with real AWS's request-time validation, independent of any current internal risk.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## AWS Compatibility

- [x] Verified against botocore service model (`kms/2014-11-01/service-2.json`)
- [ ] Verified against a real LZA pipeline run
- [x] Added/updated tests covering the new behavior

## Checklist

- [x] `clean test-compile` passes
- [x] Targeted `KmsServiceTest` + `KmsIntegrationTest` suites pass (274/274)
- [x] `make docs-check` passes
- [x] Rebased onto current `upstream/main`
- [x] No file overlap with other open PRs (checked against #2635, #2637, and the full open-PR list)
