### PR TITLE
feat(ecs): rewrite ECR image URIs on RunTask like Lambda

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManager.java
@@ -47,6 +47,10 @@ public class EcrRegistryManager {
     private static final int CONTAINER_INTERNAL_PORT = 5000;
     private static final String NAMED_VOLUME = "floci-ecr-registry-data";
 
+    /** Matches an AWS-shaped ECR image URI: {@code <account>.dkr.ecr.<region>.amazonaws.com/<repo>[:tag]}. */
+    private static final java.util.regex.Pattern AWS_ECR_URI =
+            java.util.regex.Pattern.compile("^([0-9]{12})\\.dkr\\.ecr\\.([a-z0-9-]+)\\.amazonaws\\.com/(.+)$");
+
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
     private final ContainerLogStreamer logStreamer;
@@ -81,6 +85,30 @@ public class EcrRegistryManager {
         this.config = config;
         this.regionResolver = regionResolver;
         this.hostPort = config.services().ecr().registryBasePort();
+    }
+
+    /**
+     * Rewrites a real-AWS-shaped ECR image URI to point at Floci's loopback registry,
+     * starting the backing registry container on first use. Any image that doesn't
+     * match the AWS ECR URI shape (e.g. a plain Docker Hub reference or an image
+     * already pointing at Floci's registry) is returned unchanged, without starting
+     * the registry container.
+     */
+    public String rewriteImageUri(String image) {
+        if (image == null) {
+            return null;
+        }
+        java.util.regex.Matcher m = AWS_ECR_URI.matcher(image);
+        if (!m.matches()) {
+            return image;
+        }
+        String account = m.group(1);
+        String region = m.group(2);
+        String repoAndTag = m.group(3);
+        ensureStarted();
+        String rewritten = getRepositoryUri(account, region, repoAndTag);
+        LOG.infov("Rewriting ECR image URI {0} -> {1}", image, rewritten);
+        return rewritten;
     }
 
     /** Returns the docker-pullable repository URI for the given account/region/name. */

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManager.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.ecs.model.Container;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
@@ -60,6 +61,7 @@ public class EcsContainerManager {
     private final LaunchedContainerAwsEnv awsEnv;
     private final SsmService ssmService;
     private final SecretsManagerService secretsManagerService;
+    private final EcrRegistryManager ecrRegistryManager;
 
     @Inject
     public EcsContainerManager(ContainerBuilder containerBuilder,
@@ -70,7 +72,8 @@ public class EcsContainerManager {
                                RegionResolver regionResolver,
                                LaunchedContainerAwsEnv awsEnv,
                                SsmService ssmService,
-                               SecretsManagerService secretsManagerService) {
+                               SecretsManagerService secretsManagerService,
+                               EcrRegistryManager ecrRegistryManager) {
         this.containerBuilder = containerBuilder;
         this.lifecycleManager = lifecycleManager;
         this.logStreamer = logStreamer;
@@ -80,6 +83,7 @@ public class EcsContainerManager {
         this.awsEnv = awsEnv;
         this.ssmService = ssmService;
         this.secretsManagerService = secretsManagerService;
+        this.ecrRegistryManager = ecrRegistryManager;
     }
 
     /**
@@ -114,8 +118,11 @@ public class EcsContainerManager {
 
         Map<String, ContainerOverride> overridesByName = overridesByName(containerOverrides);
         Map<ContainerDefinition, List<String>> envVarsByContainer = new LinkedHashMap<>();
+        // Resolved before any container is created, so a registry-startup failure can't leak one already started.
+        Map<ContainerDefinition, String> imagesByContainer = new LinkedHashMap<>();
         for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
             envVarsByContainer.put(def, buildEnvVars(def, overridesByName.get(def.getName()), region));
+            imagesByContainer.put(def, ecrRegistryManager.rewriteImageUri(def.getImage()));
         }
 
         for (ContainerDefinition def : taskDef.getContainerDefinitions()) {
@@ -126,7 +133,7 @@ public class EcsContainerManager {
             ContainerOverride override = overridesByName.get(def.getName());
 
             // Build container spec
-            ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(def.getImage())
+            ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(imagesByContainer.get(def))
                     .withName(containerName)
                     .withEnv(envVarsByContainer.get(def))
                     .withDockerNetwork(config.services().ecs().dockerNetwork())

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -123,10 +123,6 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
     private final LaunchedContainerAwsEnv awsEnv;
     private final LambdaExecutionRoleCredentials executionRoleCredentials;
 
-    /** Matches an AWS-shaped ECR image URI: {@code <account>.dkr.ecr.<region>.amazonaws.com/<repo>[:tag]}. */
-    private static final java.util.regex.Pattern AWS_ECR_URI =
-            java.util.regex.Pattern.compile("^([0-9]{12})\\.dkr\\.ecr\\.([a-z0-9-]+)\\.amazonaws\\.com/(.+)$");
-
     @Inject
     public ContainerLauncher(ContainerBuilder containerBuilder,
                              ContainerLifecycleManager lifecycleManager,
@@ -161,28 +157,6 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
     @PreDestroy
     void shutdown() {
         volumeCleanupScheduler.shutdownNow();
-    }
-
-    /**
-     * Rewrites real-AWS-shaped ECR image URIs to point at Floci's loopback registry.
-     * Stored ImageUri is preserved (so describe-function returns the original);
-     * the rewrite is only applied immediately before the docker pull.
-     */
-    private String rewriteForEmulatedRegistry(String image) {
-        if (image == null) {
-            return null;
-        }
-        java.util.regex.Matcher m = AWS_ECR_URI.matcher(image);
-        if (!m.matches()) {
-            return image;
-        }
-        String account = m.group(1);
-        String region = m.group(2);
-        String repoAndTag = m.group(3);
-        ecrRegistryManager.ensureStarted();
-        String rewritten = ecrRegistryManager.getRepositoryUri(account, region, repoAndTag);
-        LOG.infov("Rewriting ECR image URI {0} -> {1}", image, rewritten);
-        return rewritten;
     }
 
     public ContainerHandle launch(LambdaFunction fn) {
@@ -236,7 +210,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
                 : imageResolver.resolve(fn.getRuntime());
 
         // If this is an AWS-shaped ECR URI, rewrite it to Floci's loopback registry
-        image = rewriteForEmulatedRegistry(image);
+        image = ecrRegistryManager.rewriteImageUri(image);
 
         // Determine host address reachable from container
         String hostAddress = dockerHostResolver.resolve();

--- a/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecr/registry/EcrRegistryManagerTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -43,6 +44,7 @@ class EcrRegistryManagerTest {
     private ContainerDetector containerDetector;
     private CurrentContainerNetworkResolver currentContainerNetworkResolver;
     private EmulatorConfig.DockerConfig docker;
+    private EmulatorConfig.EcrServiceConfig ecr;
     private ContainerBuilder.Builder builder;
     private EcrRegistryManager manager;
 
@@ -64,7 +66,7 @@ class EcrRegistryManagerTest {
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
-        EmulatorConfig.EcrServiceConfig ecr = Mockito.mock(EmulatorConfig.EcrServiceConfig.class);
+        ecr = Mockito.mock(EmulatorConfig.EcrServiceConfig.class);
         docker = Mockito.mock(EmulatorConfig.DockerConfig.class);
         EmulatorConfig.StorageConfig storage = Mockito.mock(EmulatorConfig.StorageConfig.class);
         when(config.services()).thenReturn(Mockito.mock(EmulatorConfig.ServicesConfig.class));
@@ -162,5 +164,40 @@ class EcrRegistryManagerTest {
         when(docker.resourceNamespace()).thenReturn(Optional.of("run/one"));
 
         assertEquals("http://floci-run-one-test-ecr-registry:5000", manager.httpClient().baseUrl());
+    }
+
+    @Test
+    void rewriteImageUri_matchesAwsEcrUri_rewritesToLocalRegistryAndStartsIt() {
+        when(lifecycleManager.createAndStart(any())).thenReturn(
+                new ContainerLifecycleManager.ContainerInfo("container-id", Map.of()));
+
+        String rewritten = manager.rewriteImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
+
+        assertEquals("123456789012.dkr.ecr.us-east-1.localhost:" + BASE_PORT + "/backend-user:1", rewritten);
+        verify(lifecycleManager).createAndStart(any());
+    }
+
+    @Test
+    void rewriteImageUri_pathStyleConfig_usesPathStyleUri() {
+        when(ecr.uriStyle()).thenReturn("path");
+        when(lifecycleManager.createAndStart(any())).thenReturn(
+                new ContainerLifecycleManager.ContainerInfo("container-id", Map.of()));
+
+        String rewritten = manager.rewriteImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
+
+        assertEquals("localhost:" + BASE_PORT + "/123456789012/us-east-1/backend-user:1", rewritten);
+    }
+
+    @Test
+    void rewriteImageUri_nonEcrImage_passesThroughWithoutStartingRegistry() {
+        String rewritten = manager.rewriteImageUri("nginx:latest");
+
+        assertEquals("nginx:latest", rewritten);
+        verify(lifecycleManager, Mockito.never()).createAndStart(any());
+    }
+
+    @Test
+    void rewriteImageUri_nullImage_returnsNull() {
+        assertNull(manager.rewriteImageUri(null));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerAwsBaselineTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerAwsBaselineTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
@@ -73,9 +74,12 @@ class EcsContainerManagerAwsBaselineTest {
                 "AWS_ACCESS_KEY_ID=test",
                 "AWS_ENDPOINT_URL=http://localhost:4566"));
 
+        EcrRegistryManager ecrRegistryManager = mock(EcrRegistryManager.class);
+        when(ecrRegistryManager.rewriteImageUri(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
                 containerDetector, config, regionResolver, awsEnv, mock(SsmService.class),
-                mock(SecretsManagerService.class));
+                mock(SecretsManagerService.class), ecrRegistryManager);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerEcrRewriteTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerEcrRewriteTest.java
@@ -1,0 +1,144 @@
+package io.github.hectorvent.floci.services.ecs.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
+import io.github.hectorvent.floci.services.ecs.model.Container;
+import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
+import io.github.hectorvent.floci.services.ecs.model.EcsTask;
+import io.github.hectorvent.floci.services.ecs.model.TaskDefinition;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.ssm.SsmService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the ECR image URI rewrite applied by {@link EcsContainerManager#startTask}
+ * (issue #2568): a real-AWS-shaped ECR URI in {@code containerDefinitions[].image} must be
+ * rewritten to Floci's emulated registry before the image is handed to Docker, the same way
+ * Lambda's {@code ContainerLauncher} already rewrites it via
+ * {@link EcrRegistryManager#rewriteImageUri}. The reported task/container image (RunTask,
+ * DescribeTasks) must keep the original, un-rewritten URI.
+ *
+ * <p>The container builder, lifecycle manager and {@link EcrRegistryManager} are mocked, so the
+ * test asserts the image that <em>would</em> be handed to Docker without launching one —
+ * runnable under {@code mvn test} (CI) with no Docker daemon.
+ */
+class EcsContainerManagerEcrRewriteTest {
+
+    private static final String ECR_IMAGE = "123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1";
+    private static final String REWRITTEN_IMAGE = "123456789012.dkr.ecr.us-east-1.localhost:5100/backend-user:1";
+
+    private ContainerBuilder containerBuilder;
+    private ContainerLifecycleManager lifecycleManager;
+    private EcrRegistryManager ecrRegistryManager;
+    private EcsContainerManager manager;
+
+    @BeforeEach
+    void setUp() {
+        ContainerBuilder.Builder builder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        containerBuilder = mock(ContainerBuilder.class);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+
+        lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any()))
+                .thenReturn(new ContainerInfo("docker-id", Map.of()));
+
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        LaunchedContainerAwsEnv awsEnv = mock(LaunchedContainerAwsEnv.class);
+        when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
+        SsmService ssmService = mock(SsmService.class);
+        SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
+
+        ecrRegistryManager = mock(EcrRegistryManager.class);
+        when(ecrRegistryManager.rewriteImageUri(ECR_IMAGE)).thenReturn(REWRITTEN_IMAGE);
+        when(ecrRegistryManager.rewriteImageUri("sidecar:latest")).thenReturn("sidecar:latest");
+
+        manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService,
+                ecrRegistryManager);
+    }
+
+    @Test
+    void ecrShapedImageIsRewrittenBeforeDockerPullButOriginalUriIsReported() {
+        ContainerDefinition app = new ContainerDefinition();
+        app.setName("app");
+        app.setImage(ECR_IMAGE);
+        ContainerDefinition sidecar = new ContainerDefinition();
+        sidecar.setName("sidecar");
+        sidecar.setImage("sidecar:latest");
+
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("test-family");
+        taskDef.setContainerDefinitions(List.of(app, sidecar));
+
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/abc123");
+
+        manager.startTask(task, taskDef, List.of(), "us-east-1");
+
+        // newContainer(...) is called once per container definition, in definition order.
+        ArgumentCaptor<String> imageCaptor = ArgumentCaptor.forClass(String.class);
+        verify(containerBuilder, org.mockito.Mockito.times(2)).newContainer(imageCaptor.capture());
+        List<String> images = imageCaptor.getAllValues();
+        assertEquals(REWRITTEN_IMAGE, images.get(0), "ECR-shaped image should be rewritten for the docker pull");
+        assertEquals("sidecar:latest", images.get(1), "non-ECR image should pass through unchanged");
+
+        // RunTask/DescribeTasks must keep reporting the original task-def image, not the rewrite.
+        List<Container> containers = task.getContainers();
+        assertEquals(ECR_IMAGE, containers.get(0).getImage(),
+                "reported container image must stay the original ECR URI, not the rewritten one");
+        assertEquals("sidecar:latest", containers.get(1).getImage());
+    }
+
+    @Test
+    void registryStartupFailureOnALaterContainerLeavesNoContainerCreated() {
+        ContainerDefinition sidecar = new ContainerDefinition();
+        sidecar.setName("sidecar");
+        sidecar.setImage("sidecar:latest");
+        ContainerDefinition app = new ContainerDefinition();
+        app.setName("app");
+        app.setImage(ECR_IMAGE);
+
+        when(ecrRegistryManager.rewriteImageUri(ECR_IMAGE))
+                .thenThrow(new RuntimeException("Cannot connect to the Docker daemon"));
+
+        TaskDefinition taskDef = new TaskDefinition();
+        taskDef.setFamily("test-family");
+        // "sidecar" (plain image) comes first, "app" (ECR image, fails to rewrite) comes second.
+        taskDef.setContainerDefinitions(List.of(sidecar, app));
+
+        EcsTask task = new EcsTask();
+        task.setTaskArn("arn:aws:ecs:us-east-1:000000000000:task/test-cluster/abc123");
+
+        assertThrows(RuntimeException.class,
+                () -> manager.startTask(task, taskDef, List.of(), "us-east-1"));
+
+        // The earlier "sidecar" container must never have been created.
+        verify(lifecycleManager, never()).createAndStart(any());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerLifecycleTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
 import io.github.hectorvent.floci.services.ssm.SsmService;
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,7 @@ class EcsContainerManagerLifecycleTest {
         return new EcsContainerManager(
                 mock(ContainerBuilder.class), lifecycleManager, mock(ContainerLogStreamer.class),
                 mock(ContainerDetector.class), mock(EmulatorConfig.class), mock(RegionResolver.class),
-                mock(LaunchedContainerAwsEnv.class), mock(SsmService.class), mock(SecretsManagerService.class));
+                mock(LaunchedContainerAwsEnv.class), mock(SsmService.class), mock(SecretsManagerService.class),
+                mock(EcrRegistryManager.class));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerOverridesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerOverridesTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
@@ -70,9 +71,12 @@ class EcsContainerManagerOverridesTest {
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
         SsmService ssmService = mock(SsmService.class);
         SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
+        EcrRegistryManager ecrRegistryManager = mock(EcrRegistryManager.class);
+        when(ecrRegistryManager.rewriteImageUri(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService,
+                ecrRegistryManager);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerPortMappingsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerPortMappingsTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.NetworkMode;
@@ -85,9 +86,12 @@ class EcsContainerManagerPortMappingsTest {
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
         SsmService ssmService = mock(SsmService.class);
         SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
+        EcrRegistryManager ecrRegistryManager = mock(EcrRegistryManager.class);
+        when(ecrRegistryManager.rewriteImageUri(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService,
+                ecrRegistryManager);
     }
 
     private void startWith(List<PortMapping> portMappings) {

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerSecretsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerSecretsTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.ContainerOverride;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
@@ -64,9 +65,12 @@ class EcsContainerManagerSecretsTest {
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
         ssmService = mock(SsmService.class);
         secretsManagerService = mock(SecretsManagerService.class);
+        EcrRegistryManager ecrRegistryManager = mock(EcrRegistryManager.class);
+        when(ecrRegistryManager.rewriteImageUri(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService,
+                ecrRegistryManager);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/container/EcsContainerManagerVolumesTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.LaunchedContainerAwsEnv;
+import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.ecs.model.ContainerDefinition;
 import io.github.hectorvent.floci.services.ecs.model.EcsTask;
 import io.github.hectorvent.floci.services.ecs.model.EfsVolumeConfiguration;
@@ -53,6 +54,7 @@ class EcsContainerManagerVolumesTest {
     private ContainerBuilder.Builder builder;
     private ContainerLifecycleManager lifecycleManager;
     private LaunchedContainerAwsEnv awsEnv;
+    private EcrRegistryManager ecrRegistryManager;
     private EcsContainerManager manager;
 
     @BeforeEach
@@ -73,9 +75,12 @@ class EcsContainerManagerVolumesTest {
         when(awsEnv.sdkBaselineEnv(any(), any())).thenReturn(List.of());
         SsmService ssmService = mock(SsmService.class);
         SecretsManagerService secretsManagerService = mock(SecretsManagerService.class);
+        ecrRegistryManager = mock(EcrRegistryManager.class);
+        when(ecrRegistryManager.rewriteImageUri(anyString())).thenAnswer(inv -> inv.getArgument(0));
 
         manager = new EcsContainerManager(containerBuilder, lifecycleManager, logStreamer,
-                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService);
+                containerDetector, config, regionResolver, awsEnv, ssmService, secretsManagerService,
+                ecrRegistryManager);
     }
 
     @Test
@@ -165,7 +170,7 @@ class EcsContainerManagerVolumesTest {
         EcsContainerManager configured = new EcsContainerManager(containerBuilder, lifecycleManager,
                 mock(ContainerLogStreamer.class), mock(ContainerDetector.class), cfg,
                 mock(RegionResolver.class), awsEnv, mock(SsmService.class),
-                mock(SecretsManagerService.class));
+                mock(SecretsManagerService.class), ecrRegistryManager);
 
         ContainerDefinition app = new ContainerDefinition();
         app.setName("app");
@@ -199,7 +204,7 @@ class EcsContainerManagerVolumesTest {
         EcsContainerManager configured = new EcsContainerManager(containerBuilder, lifecycleManager,
                 mock(ContainerLogStreamer.class), mock(ContainerDetector.class), cfg,
                 mock(RegionResolver.class), awsEnv, mock(SsmService.class),
-                mock(SecretsManagerService.class));
+                mock(SecretsManagerService.class), ecrRegistryManager);
 
         ContainerDefinition app = new ContainerDefinition();
         app.setName("app");

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -121,6 +121,10 @@ class ContainerLauncherTest {
         lenient().when(efs.mountGroupAdd()).thenReturn(OptionalInt.empty());
 
         when(embeddedDnsServer.getServerIp()).thenReturn(Optional.empty());
+        // Default: pass images through unchanged, matching the real EcrRegistryManager's
+        // behavior for non-ECR-shaped images. Individual ECR-rewrite tests override this.
+        lenient().when(ecrRegistryManager.rewriteImageUri(any()))
+                .thenAnswer(inv -> inv.getArgument(0));
 
         ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer);
         ContainerReachableEndpoint reachableEndpoint =
@@ -447,14 +451,13 @@ class ContainerLauncherTest {
         fn.setPackageType("Image");
         fn.setImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
 
-        when(ecrRegistryManager.getRepositoryUri("123456789012", "us-east-1", "backend-user:1"))
+        when(ecrRegistryManager.rewriteImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1"))
                 .thenReturn("123456789012.dkr.ecr.us-east-1.localhost:5100/backend-user:1");
 
         launcher.launch(fn);
 
         ContainerSpec spec = captureRealContainerSpec();
-        verify(ecrRegistryManager).ensureStarted();
-        verify(ecrRegistryManager).getRepositoryUri("123456789012", "us-east-1", "backend-user:1");
+        verify(ecrRegistryManager).rewriteImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
         assertEquals("123456789012.dkr.ecr.us-east-1.localhost:5100/backend-user:1",
                 spec.image());
     }
@@ -466,14 +469,13 @@ class ContainerLauncherTest {
         fn.setPackageType("Image");
         fn.setImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
 
-        when(ecrRegistryManager.getRepositoryUri("123456789012", "us-east-1", "backend-user:1"))
+        when(ecrRegistryManager.rewriteImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1"))
                 .thenReturn("localhost:5100/123456789012/us-east-1/backend-user:1");
 
         launcher.launch(fn);
 
         ContainerSpec spec = captureRealContainerSpec();
-        verify(ecrRegistryManager).ensureStarted();
-        verify(ecrRegistryManager).getRepositoryUri("123456789012", "us-east-1", "backend-user:1");
+        verify(ecrRegistryManager).rewriteImageUri("123456789012.dkr.ecr.us-east-1.amazonaws.com/backend-user:1");
         assertEquals("localhost:5100/123456789012/us-east-1/backend-user:1",
                 spec.image());
     }


### PR DESCRIPTION
## Summary

Adds ECS RunTask ECR image URI rewrite, mirroring what Lambda's `ContainerLauncher` already does: a `containerDefinitions[].image` shaped like a real AWS ECR URI (`<account>.dkr.ecr.<region>.amazonaws.com/...`) is now rewritten to Floci's emulated ECR registry before the Docker pull, instead of being handed straight to `docker.sock`. Closes #2568.

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

No wire-protocol/API surface change — `RunTask`/`DescribeTasks` still report the original, un-rewritten image URI (matching real ECS). This only changes which registry endpoint Floci's own Docker daemon pulls from locally when a task definition's image is ECR-shaped, so local HCL can point at the same ECR image URIs used in remote environments, the way Lambda functions already can.

## Checklist

- [x] `./mvnw test` passes locally — ran the targeted suites (`EcrRegistryManagerTest`, `EcsContainerManagerEcrRewriteTest` + the 6 other `EcsContainerManager*Test` classes, `ContainerLauncherTest`), all green. Did not run the full Docker-backed integration suite (API Gateway/WebSocket/Lambda scenarios) — unrelated to this change and very slow.
- [ ] New or updated integration test added — added a focused unit-level regression test (`EcsContainerManagerEcrRewriteTest`) at the same test level the Lambda side already uses for this exact behavior (`ContainerLauncherTest`'s ECR-rewrite cases); there's no `@QuarkusTest` end-to-end registry push/pull test for the Lambda precedent either, so this matches existing convention rather than introducing a new tier of coverage.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)