### PR TITLE
fix(lambda): read deployment packages via the zip central directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,14 @@
             <artifactId>docker-java-core</artifactId>
             <version>3.7.1</version>
         </dependency>
+        <!-- Central-directory ZIP reading for Lambda deployment packages. Already present
+             transitively via docker-java-core; declared explicitly because ZipExtractor uses
+             it directly and must not break if that transitive path ever changes. -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.28.0</version>
+        </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-httpclient5</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,14 +158,6 @@
             <artifactId>docker-java-core</artifactId>
             <version>3.7.1</version>
         </dependency>
-        <!-- Central-directory ZIP reading for Lambda deployment packages. Already present
-             transitively via docker-java-core; declared explicitly because ZipExtractor uses
-             it directly and must not break if that transitive path ever changes. -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.28.0</version>
-        </dependency>
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java-transport-httpclient5</artifactId>

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -1,6 +1,9 @@
 package io.github.hectorvent.floci.services.lambda.zip;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
@@ -9,9 +12,7 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.CRC32;
-import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
 
 /**
  * Extracts ZIP bytes to a target directory.
@@ -29,67 +30,98 @@ public class ZipExtractor {
         Path absTarget = targetDir.toAbsolutePath().normalize();
         Files.createDirectories(absTarget);
 
-        // Read the archive through its central directory (ZipFile) rather than sequentially
-        // over the local file headers (ZipInputStream). A streaming packager cannot seek back
-        // to patch an entry's sizes, so it sets the data-descriptor flag (general-purpose bit
-        // 3) and writes the real CRC and sizes after the data instead; anything that does not
-        // compress is written STORED. ZipInputStream rejects that pairing outright with "only
-        // DEFLATED entries can have EXT descriptor", because for a STORED entry it has no way
-        // to find where the data ends. The central directory always carries the true method,
-        // CRC and sizes regardless of the flag, so reading it accepts the same archives real
-        // AWS Lambda does — e.g. a Serverless Framework package bundling node_modules
-        // (issue #2593).
+        // Read the archive through its central directory rather than sequentially over the
+        // local file headers. A streaming packager cannot seek back to patch an entry's sizes,
+        // so it sets the data-descriptor flag (general-purpose bit 3) and writes the real CRC
+        // and sizes after the data instead; anything that does not compress is written STORED.
+        // java.util.zip.ZipInputStream rejects that pairing outright with "only DEFLATED
+        // entries can have EXT descriptor", because for a STORED entry it has no way to find
+        // where the data ends. The central directory always carries the true method, CRC and
+        // sizes regardless of the flag, so reading it accepts the same archives real AWS Lambda
+        // does — e.g. a Serverless Framework package bundling node_modules (issue #2593).
         //
-        // ZipFile needs a seekable file, so the bytes are staged on disk. Stage inside the code
-        // store rather than java.io.tmpdir: the shared temp filesystem must not become a new
-        // unbounded consumer that concurrent deployments can exhaust and that unrelated
-        // services would then fail on. The code store already has to hold this package's
-        // *uncompressed* contents — always at least as large as the archive — so it is already
-        // provisioned for the size, and the staged copy is released as soon as extraction ends.
-        Path staged = Files.createTempFile(absTarget.getParent(), ".floci-staging-", ".zip");
-        try {
-            Files.write(staged, zipBytes);
-            try (ZipFile zip = new ZipFile(staged.toFile())) {
-                var entries = zip.entries();
-                while (entries.hasMoreElements()) {
-                    ZipEntry entry = entries.nextElement();
-                    String entryName = entry.getName();
+        // Commons Compress rather than java.util.zip.ZipFile: the JDK's central-directory
+        // reader only accepts a File, which would mean writing the whole package to disk purely
+        // to read it back. Commons Compress reads the same structure straight off the bytes we
+        // already hold, so extraction adds no second copy of the archive anywhere — the disk
+        // cost stays exactly what the extracted output needs, as it was before this change.
+        try (ZipFile zip = ZipFile.builder()
+                .setSeekableByteChannel(new SeekableInMemoryByteChannel(zipBytes))
+                .get()) {
+            var entries = zip.getEntries();
+            while (entries.hasMoreElements()) {
+                ZipArchiveEntry entry = entries.nextElement();
+                String entryName = entryName(entry);
 
-                    // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
-                    // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
-                    // a flat "wwwroot\app.css" file), so neither do we; masking it would let
-                    // a broken package pass locally and then fail on deploy.
-                    if (entryName.indexOf(BACKSLASH) >= 0) {
-                        LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
-                                + "It extracts as a literal filename and will also fail on real AWS Lambda. "
-                                + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
-                    }
+                // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
+                // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
+                // a flat "wwwroot\app.css" file), so neither do we; masking it would let
+                // a broken package pass locally and then fail on deploy.
+                if (entryName.indexOf(BACKSLASH) >= 0) {
+                    LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
+                            + "It extracts as a literal filename and will also fail on real AWS Lambda. "
+                            + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
+                }
 
-                    // Security: prevent path traversal
-                    if (entryName.contains("..") || entryName.startsWith("/")) {
-                        LOG.warnv("Skipping suspicious ZIP entry: {0}", entryName);
-                        continue;
-                    }
+                // Security: prevent path traversal
+                if (entryName.contains("..") || entryName.startsWith("/")) {
+                    LOG.warnv("Skipping suspicious ZIP entry: {0}", entryName);
+                    continue;
+                }
 
-                    Path targetPath = absTarget.resolve(entryName).normalize();
-                    if (!targetPath.startsWith(absTarget)) {
-                        LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
-                        continue;
-                    }
+                Path targetPath = absTarget.resolve(entryName).normalize();
+                if (!targetPath.startsWith(absTarget)) {
+                    LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
+                    continue;
+                }
 
-                    if (entry.isDirectory()) {
-                        Files.createDirectories(targetPath);
-                    } else {
-                        Files.createDirectories(targetPath.getParent());
-                        copyVerified(zip, entry, targetPath);
+                if (entry.isDirectory()) {
+                    Files.createDirectories(targetPath);
+                } else {
+                    // An entry using a compression method (or encryption) this build cannot
+                    // decode would otherwise be written out as an empty file, silently
+                    // deploying a function whose code is missing.
+                    if (!zip.canReadEntryData(entry)) {
+                        throw new ZipException("Unsupported compression or encryption for ZIP entry \""
+                                + entryName + "\"");
                     }
+                    Files.createDirectories(targetPath.getParent());
+                    copyVerified(zip, entry, targetPath);
                 }
             }
-        } finally {
-            Files.deleteIfExists(staged);
         }
 
         LOG.debugv("Extracted ZIP to: {0}", absTarget);
+    }
+
+    /**
+     * The entry's name exactly as the archive stores it.
+     *
+     * <p>Commons Compress rewrites every {@code '\'} to {@code '/'} for a FAT-platform entry
+     * whose name contains no {@code '/'} at all. That would turn a PowerShell-produced literal
+     * filename into a nested path — precisely what #1215 established Floci must <em>not</em> do,
+     * because real AWS Lambda extracts {@code "wwwroot\app.css"} as one flat file and silently
+     * "fixing" it here would let a broken package pass locally and then fail on deploy. The raw
+     * name field is the bytes as written, so when it carries a backslash and no forward slash the
+     * rewrite is undone. Reversing it on the decoded name rather than decoding the raw bytes
+     * keeps Commons Compress's own charset handling (UTF-8 flag vs. CP437) intact.
+     */
+    private static String entryName(ZipArchiveEntry entry) {
+        byte[] raw = entry.getRawName();
+        String name = entry.getName();
+        if (raw == null) {
+            return name;
+        }
+        boolean rawHasBackslash = false;
+        boolean rawHasSlash = false;
+        for (byte b : raw) {
+            if (b == '\\') {
+                rawHasBackslash = true;
+            } else if (b == '/') {
+                rawHasSlash = true;
+            }
+        }
+        return rawHasBackslash && !rawHasSlash ? name.replace('/', BACKSLASH) : name;
     }
 
     /**
@@ -98,7 +130,7 @@ public class ZipExtractor {
      * a package corrupted in transit would be deployed silently as garbage code rather than
      * rejected. The message mirrors the JDK's own so existing reports stay recognisable.
      */
-    private static void copyVerified(ZipFile zip, ZipEntry entry, Path targetPath) throws IOException {
+    private static void copyVerified(ZipFile zip, ZipArchiveEntry entry, Path targetPath) throws IOException {
         CRC32 checksum = new CRC32();
         try (InputStream in = zip.getInputStream(entry);
              OutputStream out = Files.newOutputStream(targetPath)) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -3,13 +3,15 @@ package io.github.hectorvent.floci.services.lambda.zip;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
 
 /**
  * Extracts ZIP bytes to a target directory.
@@ -27,47 +29,84 @@ public class ZipExtractor {
         Path absTarget = targetDir.toAbsolutePath().normalize();
         Files.createDirectories(absTarget);
 
-        try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipBytes))) {
-            ZipEntry entry;
-            while ((entry = zis.getNextEntry()) != null) {
-                String entryName = entry.getName();
+        // Read the archive through its central directory (ZipFile) rather than sequentially
+        // over the local file headers (ZipInputStream). A streaming packager cannot seek back
+        // to patch an entry's sizes, so it sets the data-descriptor flag (general-purpose bit
+        // 3) and writes the real CRC and sizes after the data instead; anything that does not
+        // compress is written STORED. ZipInputStream rejects that pairing outright with "only
+        // DEFLATED entries can have EXT descriptor", because for a STORED entry it has no way
+        // to find where the data ends. The central directory always carries the true method,
+        // CRC and sizes regardless of the flag, so reading it accepts the same archives real
+        // AWS Lambda does — e.g. a Serverless Framework package bundling node_modules
+        // (issue #2593). ZipFile needs a seekable file, so the bytes are staged on disk.
+        Path staged = Files.createTempFile("floci-lambda-", ".zip");
+        try {
+            Files.write(staged, zipBytes);
+            try (ZipFile zip = new ZipFile(staged.toFile())) {
+                var entries = zip.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    String entryName = entry.getName();
 
-                // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
-                // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
-                // a flat "wwwroot\app.css" file), so neither do we; masking it would let
-                // a broken package pass locally and then fail on deploy.
-                if (entryName.indexOf(BACKSLASH) >= 0) {
-                    LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
-                            + "It extracts as a literal filename and will also fail on real AWS Lambda. "
-                            + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
-                }
+                    // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
+                    // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
+                    // a flat "wwwroot\app.css" file), so neither do we; masking it would let
+                    // a broken package pass locally and then fail on deploy.
+                    if (entryName.indexOf(BACKSLASH) >= 0) {
+                        LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
+                                + "It extracts as a literal filename and will also fail on real AWS Lambda. "
+                                + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
+                    }
 
-                // Security: prevent path traversal
-                if (entryName.contains("..") || entryName.startsWith("/")) {
-                    LOG.warnv("Skipping suspicious ZIP entry: {0}", entryName);
-                    zis.closeEntry();
-                    continue;
-                }
+                    // Security: prevent path traversal
+                    if (entryName.contains("..") || entryName.startsWith("/")) {
+                        LOG.warnv("Skipping suspicious ZIP entry: {0}", entryName);
+                        continue;
+                    }
 
-                Path targetPath = absTarget.resolve(entryName).normalize();
-                if (!targetPath.startsWith(absTarget)) {
-                    LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
-                    zis.closeEntry();
-                    continue;
-                }
+                    Path targetPath = absTarget.resolve(entryName).normalize();
+                    if (!targetPath.startsWith(absTarget)) {
+                        LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
+                        continue;
+                    }
 
-                if (entry.isDirectory()) {
-                    Files.createDirectories(targetPath);
-                } else {
-                    Files.createDirectories(targetPath.getParent());
-                    try (OutputStream out = Files.newOutputStream(targetPath)) {
-                        zis.transferTo(out);
+                    if (entry.isDirectory()) {
+                        Files.createDirectories(targetPath);
+                    } else {
+                        Files.createDirectories(targetPath.getParent());
+                        copyVerified(zip, entry, targetPath);
                     }
                 }
-                zis.closeEntry();
             }
+        } finally {
+            Files.deleteIfExists(staged);
         }
 
         LOG.debugv("Extracted ZIP to: {0}", absTarget);
+    }
+
+    /**
+     * Copies one entry to disk, checking it against the CRC recorded for it in the archive.
+     * ZipInputStream verified this on its own; ZipFile does not, so without an explicit check
+     * a package corrupted in transit would be deployed silently as garbage code rather than
+     * rejected. The message mirrors the JDK's own so existing reports stay recognisable.
+     */
+    private static void copyVerified(ZipFile zip, ZipEntry entry, Path targetPath) throws IOException {
+        CRC32 checksum = new CRC32();
+        try (InputStream in = zip.getInputStream(entry);
+             OutputStream out = Files.newOutputStream(targetPath)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                checksum.update(buffer, 0, read);
+                out.write(buffer, 0, read);
+            }
+        }
+        long expected = entry.getCrc();
+        if (expected != -1L && checksum.getValue() != expected) {
+            throw new ZipException(String.format(
+                    "invalid entry CRC for \"%s\" (expected 0x%08x but got 0x%08x)",
+                    entry.getName(), expected, checksum.getValue()));
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -1,9 +1,6 @@
 package io.github.hectorvent.floci.services.lambda.zip;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
-import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.apache.commons.compress.utils.SeekableInMemoryByteChannel;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
@@ -12,7 +9,9 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
 
 /**
  * Extracts ZIP bytes to a target directory.
@@ -30,98 +29,67 @@ public class ZipExtractor {
         Path absTarget = targetDir.toAbsolutePath().normalize();
         Files.createDirectories(absTarget);
 
-        // Read the archive through its central directory rather than sequentially over the
-        // local file headers. A streaming packager cannot seek back to patch an entry's sizes,
-        // so it sets the data-descriptor flag (general-purpose bit 3) and writes the real CRC
-        // and sizes after the data instead; anything that does not compress is written STORED.
-        // java.util.zip.ZipInputStream rejects that pairing outright with "only DEFLATED
-        // entries can have EXT descriptor", because for a STORED entry it has no way to find
-        // where the data ends. The central directory always carries the true method, CRC and
-        // sizes regardless of the flag, so reading it accepts the same archives real AWS Lambda
-        // does — e.g. a Serverless Framework package bundling node_modules (issue #2593).
+        // Read the archive through its central directory (ZipFile) rather than sequentially
+        // over the local file headers (ZipInputStream). A streaming packager cannot seek back
+        // to patch an entry's sizes, so it sets the data-descriptor flag (general-purpose bit
+        // 3) and writes the real CRC and sizes after the data instead; anything that does not
+        // compress is written STORED. ZipInputStream rejects that pairing outright with "only
+        // DEFLATED entries can have EXT descriptor", because for a STORED entry it has no way
+        // to find where the data ends. The central directory always carries the true method,
+        // CRC and sizes regardless of the flag, so reading it accepts the same archives real
+        // AWS Lambda does — e.g. a Serverless Framework package bundling node_modules
+        // (issue #2593).
         //
-        // Commons Compress rather than java.util.zip.ZipFile: the JDK's central-directory
-        // reader only accepts a File, which would mean writing the whole package to disk purely
-        // to read it back. Commons Compress reads the same structure straight off the bytes we
-        // already hold, so extraction adds no second copy of the archive anywhere — the disk
-        // cost stays exactly what the extracted output needs, as it was before this change.
-        try (ZipFile zip = ZipFile.builder()
-                .setSeekableByteChannel(new SeekableInMemoryByteChannel(zipBytes))
-                .get()) {
-            var entries = zip.getEntries();
-            while (entries.hasMoreElements()) {
-                ZipArchiveEntry entry = entries.nextElement();
-                String entryName = entryName(entry);
+        // ZipFile needs a seekable file, so the bytes are staged on disk. Stage inside the code
+        // store rather than java.io.tmpdir: the shared temp filesystem must not become a new
+        // unbounded consumer that concurrent deployments can exhaust and that unrelated
+        // services would then fail on. The code store already has to hold this package's
+        // *uncompressed* contents — always at least as large as the archive — so it is already
+        // provisioned for the size, and the staged copy is released as soon as extraction ends.
+        Path staged = Files.createTempFile(absTarget.getParent(), ".floci-staging-", ".zip");
+        try {
+            Files.write(staged, zipBytes);
+            try (ZipFile zip = new ZipFile(staged.toFile())) {
+                var entries = zip.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    String entryName = entry.getName();
 
-                // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
-                // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
-                // a flat "wwwroot\app.css" file), so neither do we; masking it would let
-                // a broken package pass locally and then fail on deploy.
-                if (entryName.indexOf(BACKSLASH) >= 0) {
-                    LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
-                            + "It extracts as a literal filename and will also fail on real AWS Lambda. "
-                            + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
-                }
-
-                // Security: prevent path traversal
-                if (entryName.contains("..") || entryName.startsWith("/")) {
-                    LOG.warnv("Skipping suspicious ZIP entry: {0}", entryName);
-                    continue;
-                }
-
-                Path targetPath = absTarget.resolve(entryName).normalize();
-                if (!targetPath.startsWith(absTarget)) {
-                    LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
-                    continue;
-                }
-
-                if (entry.isDirectory()) {
-                    Files.createDirectories(targetPath);
-                } else {
-                    // An entry using a compression method (or encryption) this build cannot
-                    // decode would otherwise be written out as an empty file, silently
-                    // deploying a function whose code is missing.
-                    if (!zip.canReadEntryData(entry)) {
-                        throw new ZipException("Unsupported compression or encryption for ZIP entry \""
-                                + entryName + "\"");
+                    // PowerShell 5 Compress-Archive writes '\' as a literal filename byte on
+                    // Linux. Real AWS Lambda does NOT normalize this (the archive extracts to
+                    // a flat "wwwroot\app.css" file), so neither do we; masking it would let
+                    // a broken package pass locally and then fail on deploy.
+                    if (entryName.indexOf(BACKSLASH) >= 0) {
+                        LOG.warnv("ZIP entry \"{0}\" uses backslash separators (PowerShell Compress-Archive). "
+                                + "It extracts as a literal filename and will also fail on real AWS Lambda. "
+                                + "Repackage with tar, PowerShell Core (pwsh), or the dotnet lambda CLI.", entryName);
                     }
-                    Files.createDirectories(targetPath.getParent());
-                    copyVerified(zip, entry, targetPath);
+
+                    // Security: prevent path traversal
+                    if (entryName.contains("..") || entryName.startsWith("/")) {
+                        LOG.warnv("Skipping suspicious ZIP entry: {0}", entryName);
+                        continue;
+                    }
+
+                    Path targetPath = absTarget.resolve(entryName).normalize();
+                    if (!targetPath.startsWith(absTarget)) {
+                        LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
+                        continue;
+                    }
+
+                    if (entry.isDirectory()) {
+                        Files.createDirectories(targetPath);
+                    } else {
+                        Files.createDirectories(targetPath.getParent());
+                        copyVerified(zip, entry, targetPath);
+                    }
                 }
             }
+        } finally {
+            Files.deleteIfExists(staged);
         }
 
         LOG.debugv("Extracted ZIP to: {0}", absTarget);
-    }
-
-    /**
-     * The entry's name exactly as the archive stores it.
-     *
-     * <p>Commons Compress rewrites every {@code '\'} to {@code '/'} for a FAT-platform entry
-     * whose name contains no {@code '/'} at all. That would turn a PowerShell-produced literal
-     * filename into a nested path — precisely what #1215 established Floci must <em>not</em> do,
-     * because real AWS Lambda extracts {@code "wwwroot\app.css"} as one flat file and silently
-     * "fixing" it here would let a broken package pass locally and then fail on deploy. The raw
-     * name field is the bytes as written, so when it carries a backslash and no forward slash the
-     * rewrite is undone. Reversing it on the decoded name rather than decoding the raw bytes
-     * keeps Commons Compress's own charset handling (UTF-8 flag vs. CP437) intact.
-     */
-    private static String entryName(ZipArchiveEntry entry) {
-        byte[] raw = entry.getRawName();
-        String name = entry.getName();
-        if (raw == null) {
-            return name;
-        }
-        boolean rawHasBackslash = false;
-        boolean rawHasSlash = false;
-        for (byte b : raw) {
-            if (b == '\\') {
-                rawHasBackslash = true;
-            } else if (b == '/') {
-                rawHasSlash = true;
-            }
-        }
-        return rawHasBackslash && !rawHasSlash ? name.replace('/', BACKSLASH) : name;
     }
 
     /**
@@ -130,7 +98,7 @@ public class ZipExtractor {
      * a package corrupted in transit would be deployed silently as garbage code rather than
      * rejected. The message mirrors the JDK's own so existing reports stay recognisable.
      */
-    private static void copyVerified(ZipFile zip, ZipArchiveEntry entry, Path targetPath) throws IOException {
+    private static void copyVerified(ZipFile zip, ZipEntry entry, Path targetPath) throws IOException {
         CRC32 checksum = new CRC32();
         try (InputStream in = zip.getInputStream(entry);
              OutputStream out = Files.newOutputStream(targetPath)) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -38,8 +38,15 @@ public class ZipExtractor {
         // to find where the data ends. The central directory always carries the true method,
         // CRC and sizes regardless of the flag, so reading it accepts the same archives real
         // AWS Lambda does — e.g. a Serverless Framework package bundling node_modules
-        // (issue #2593). ZipFile needs a seekable file, so the bytes are staged on disk.
-        Path staged = Files.createTempFile("floci-lambda-", ".zip");
+        // (issue #2593).
+        //
+        // ZipFile needs a seekable file, so the bytes are staged on disk. Stage inside the code
+        // store rather than java.io.tmpdir: the shared temp filesystem must not become a new
+        // unbounded consumer that concurrent deployments can exhaust and that unrelated
+        // services would then fail on. The code store already has to hold this package's
+        // *uncompressed* contents — always at least as large as the archive — so it is already
+        // provisioned for the size, and the staged copy is released as soon as extraction ends.
+        Path staged = Files.createTempFile(absTarget.getParent(), ".floci-staging-", ".zip");
         try {
             Files.write(staged, zipBytes);
             try (ZipFile zip = new ZipFile(staged.toFile())) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -265,4 +265,27 @@ class ZipExtractorTest {
         assertTrue(thrown.getMessage().contains("invalid entry CRC"),
                 "corrupt entry must be reported as a checksum failure, was: " + thrown.getMessage());
     }
+
+    @Test
+    void leavesNoStagedArchiveInTheCodeStore(@TempDir Path codeStore) throws IOException {
+        // ZipFile needs a seekable file, so the archive is staged on disk next to the target
+        // rather than in the shared java.io.tmpdir. That puts a stray file one level above the
+        // function's code directory, so pin that none survives: a leaked staging archive would
+        // sit in the code store indefinitely, and one leaked *inside* a function directory
+        // would be tar-copied into that function's container at launch.
+        Path target = codeStore.resolve("fn");
+        extractor.extractTo(zipWith("index.js", "v1"), target);
+        assertNoStagedFiles(codeStore);
+
+        byte[] corrupt = corruptedPayloadZip("index.js", "v2-but-corrupted-in-transit");
+        assertThrows(IOException.class, () -> extractor.extractTo(corrupt, target));
+        assertNoStagedFiles(codeStore);
+    }
+
+    private static void assertNoStagedFiles(Path codeStore) throws IOException {
+        try (var entries = Files.list(codeStore)) {
+            assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
+                    "no staged archive may survive extraction, successful or failed");
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -8,6 +8,11 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.CRC32;
+import java.util.zip.Deflater;
+import java.util.zip.ZipException;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -69,5 +74,195 @@ class ZipExtractorTest {
 
         assertFalse(Files.exists(target.getParent().getParent().resolve("evil.sh")),
                 "traversal entry must not escape the target dir");
+    }
+
+    /**
+     * One entry for {@link #streamedZip}: {@code stored} selects STORED over DEFLATED,
+     * as a packager does for content that does not compress.
+     */
+    private record StreamedEntry(String name, String content, boolean stored) {}
+
+    /**
+     * Builds a ZIP the way a streaming packager does — the Serverless Framework's
+     * archiver, for one. Such a writer cannot seek back to patch an entry's header, so it
+     * sets the data-descriptor flag (general-purpose bit 3), zeroes the CRC and sizes in
+     * the local header, and writes the real values after the data. The central directory
+     * still carries the true values. {@link ZipOutputStream} cannot emit this shape, so
+     * the bytes are assembled by hand.
+     */
+    private static byte[] streamedZip(StreamedEntry... entries) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        List<int[]> localOffsets = new ArrayList<>();
+        List<byte[]> names = new ArrayList<>();
+        List<long[]> meta = new ArrayList<>();
+
+        for (StreamedEntry entry : entries) {
+            byte[] name = entry.name().getBytes(StandardCharsets.UTF_8);
+            byte[] raw = entry.content().getBytes(StandardCharsets.UTF_8);
+            byte[] payload = entry.stored() ? raw : deflate(raw);
+            CRC32 crc = new CRC32();
+            crc.update(raw);
+            int method = entry.stored() ? 0 : 8;
+
+            localOffsets.add(new int[]{out.size()});
+            le32(out, 0x04034b50L);          // local file header signature
+            le16(out, 20);                   // version needed
+            le16(out, 0x0008);               // general-purpose bit 3: data descriptor follows
+            le16(out, method);
+            le16(out, 0);                    // mod time
+            le16(out, 0);                    // mod date
+            le32(out, 0);                    // crc-32       — deferred to the descriptor
+            le32(out, 0);                    // compressed   — deferred to the descriptor
+            le32(out, 0);                    // uncompressed — deferred to the descriptor
+            le16(out, name.length);
+            le16(out, 0);                    // extra length
+            out.write(name);
+            out.write(payload);
+            le32(out, 0x08074b50L);          // data descriptor signature
+            le32(out, crc.getValue());
+            le32(out, payload.length);
+            le32(out, raw.length);
+
+            names.add(name);
+            meta.add(new long[]{crc.getValue(), payload.length, raw.length, method});
+        }
+
+        int centralOffset = out.size();
+        for (int i = 0; i < entries.length; i++) {
+            byte[] name = names.get(i);
+            long[] m = meta.get(i);
+            le32(out, 0x02014b50L);          // central directory header signature
+            le16(out, 20);                   // version made by
+            le16(out, 20);                   // version needed
+            le16(out, 0x0008);               // same descriptor flag as the local header
+            le16(out, (int) m[3]);
+            le16(out, 0);
+            le16(out, 0);
+            le32(out, m[0]);                 // crc-32       — the real value lives here
+            le32(out, m[1]);                 // compressed   — the real value lives here
+            le32(out, m[2]);                 // uncompressed — the real value lives here
+            le16(out, name.length);
+            le16(out, 0);                    // extra length
+            le16(out, 0);                    // comment length
+            le16(out, 0);                    // disk number start
+            le16(out, 0);                    // internal attributes
+            le32(out, 0);                    // external attributes
+            le32(out, localOffsets.get(i)[0]);
+            out.write(name);
+        }
+        int centralSize = out.size() - centralOffset;
+
+        le32(out, 0x06054b50L);              // end of central directory signature
+        le16(out, 0);                        // this disk
+        le16(out, 0);                        // disk with central directory
+        le16(out, entries.length);
+        le16(out, entries.length);
+        le32(out, centralSize);
+        le32(out, centralOffset);
+        le16(out, 0);                        // comment length
+        return out.toByteArray();
+    }
+
+    private static byte[] deflate(byte[] raw) {
+        Deflater deflater = new Deflater(Deflater.DEFAULT_COMPRESSION, true);
+        deflater.setInput(raw);
+        deflater.finish();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[512];
+        while (!deflater.finished()) {
+            out.write(buffer, 0, deflater.deflate(buffer));
+        }
+        deflater.end();
+        return out.toByteArray();
+    }
+
+    private static void le16(ByteArrayOutputStream out, int value) {
+        out.write(value & 0xff);
+        out.write((value >>> 8) & 0xff);
+    }
+
+    private static void le32(ByteArrayOutputStream out, long value) {
+        out.write((int) (value & 0xff));
+        out.write((int) ((value >>> 8) & 0xff));
+        out.write((int) ((value >>> 16) & 0xff));
+        out.write((int) ((value >>> 24) & 0xff));
+    }
+
+    @Test
+    void extractsStoredEntryCarryingADataDescriptor(@TempDir Path target) throws IOException {
+        // Issue #2593: a Serverless Framework package bundling node_modules failed with
+        // "only DEFLATED entries can have EXT descriptor". ZipInputStream reads local file
+        // headers in sequence, and for a STORED entry whose sizes were deferred to a trailing
+        // descriptor it cannot tell where the data ends, so it refuses the entry outright.
+        // Real AWS Lambda accepts the archive. Reading the central directory does too.
+        byte[] zip = streamedZip(
+                new StreamedEntry("index.js", "exports.handler = async () => ({statusCode: 200});", false),
+                new StreamedEntry("node_modules/sharp/sharp.node", "\0\0BINARY-INCOMPRESSIBLE", true));
+
+        extractor.extractTo(zip, target);
+
+        Path handler = target.resolve("index.js");
+        assertTrue(Files.isRegularFile(handler), "handler must extract from a streamed package");
+        assertEquals("exports.handler = async () => ({statusCode: 200});", Files.readString(handler));
+
+        // The STORED entry is the one ZipInputStream rejected; it must land intact.
+        Path stored = target.resolve("node_modules").resolve("sharp").resolve("sharp.node");
+        assertTrue(Files.isRegularFile(stored), "STORED entry with a data descriptor must extract");
+        assertEquals("\0\0BINARY-INCOMPRESSIBLE", Files.readString(stored));
+    }
+
+    @Test
+    void extractsDeflatedEntryCarryingADataDescriptor(@TempDir Path target) throws IOException {
+        // The descriptor flag alone was always tolerated for DEFLATED entries. Pin it, so the
+        // move to the central directory is not silently narrowing what already worked.
+        byte[] zip = streamedZip(new StreamedEntry("app/main.py", "def handler(e, c): return 1", false));
+
+        extractor.extractTo(zip, target);
+
+        Path nested = target.resolve("app").resolve("main.py");
+        assertTrue(Files.isRegularFile(nested));
+        assertEquals("def handler(e, c): return 1", Files.readString(nested));
+    }
+
+    @Test
+    void extractsExplicitDirectoryEntries(@TempDir Path target) throws IOException {
+        // Directory entries are flagged by a trailing slash in the central directory just as
+        // they are in a local header; make sure they still create a directory, not a file.
+        byte[] zip = streamedZip(
+                new StreamedEntry("lib/", "", true),
+                new StreamedEntry("lib/util.js", "module.exports = {};", false));
+
+        extractor.extractTo(zip, target);
+
+        assertTrue(Files.isDirectory(target.resolve("lib")));
+        assertEquals("module.exports = {};", Files.readString(target.resolve("lib").resolve("util.js")));
+    }
+
+    /**
+     * Builds a structurally valid ZIP whose entry data has been corrupted after the fact, so
+     * every header (including the CRC recorded for the entry) is intact but the bytes no
+     * longer match it — what a package truncated or mangled in transit looks like.
+     */
+    private static byte[] corruptedPayloadZip(String entryName, String content) throws IOException {
+        byte[] zip = zipWith(entryName, content);
+        int nameLength = (zip[26] & 0xff) | ((zip[27] & 0xff) << 8);
+        int extraLength = (zip[28] & 0xff) | ((zip[29] & 0xff) << 8);
+        int dataStart = 30 + nameLength + extraLength;
+        for (int i = dataStart + 1; i < dataStart + 6 && i < zip.length; i++) {
+            zip[i] ^= 0x7F;
+        }
+        return zip;
+    }
+
+    @Test
+    void rejectsAnEntryThatFailsItsChecksum(@TempDir Path target) throws IOException {
+        // ZipInputStream verified each entry's CRC on its own; ZipFile does not. Without an
+        // explicit check, a deployment package corrupted in transit would extract silently and
+        // the function would run garbage instead of failing loudly at deploy time.
+        byte[] zip = corruptedPayloadZip("payload.js", "REAL-CODE-REAL-CODE-REAL-CODE");
+
+        ZipException thrown = assertThrows(ZipException.class, () -> extractor.extractTo(zip, target));
+        assertTrue(thrown.getMessage().contains("invalid entry CRC"),
+                "corrupt entry must be reported as a checksum failure, was: " + thrown.getMessage());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -267,25 +267,73 @@ class ZipExtractorTest {
     }
 
     @Test
-    void leavesNoStagedArchiveInTheCodeStore(@TempDir Path codeStore) throws IOException {
-        // ZipFile needs a seekable file, so the archive is staged on disk next to the target
-        // rather than in the shared java.io.tmpdir. That puts a stray file one level above the
-        // function's code directory, so pin that none survives: a leaked staging archive would
-        // sit in the code store indefinitely, and one leaked *inside* a function directory
-        // would be tar-copied into that function's container at launch.
-        Path target = codeStore.resolve("fn");
-        extractor.extractTo(zipWith("index.js", "v1"), target);
-        assertNoStagedFiles(codeStore);
+    void rejectsAnEntryWhoseCompressionMethodCannotBeRead(@TempDir Path target) throws IOException {
+        // java.util.zip.ZipFile throws on an unknown compression method; Commons Compress
+        // instead reports the entry as unreadable and would hand back an empty stream, which
+        // would write a zero-byte file and deploy a function whose code silently vanished.
+        // Method 99 is WinZip AES — structurally valid, not decodable here.
+        byte[] zip = zipWithCompressionMethod(99, "secret.js", "exports.handler = () => 1;");
 
-        byte[] corrupt = corruptedPayloadZip("index.js", "v2-but-corrupted-in-transit");
-        assertThrows(IOException.class, () -> extractor.extractTo(corrupt, target));
-        assertNoStagedFiles(codeStore);
+        ZipException thrown = assertThrows(ZipException.class, () -> extractor.extractTo(zip, target));
+        assertTrue(thrown.getMessage().contains("Unsupported compression"),
+                "unreadable entry must be rejected, was: " + thrown.getMessage());
+        assertFalse(Files.exists(target.resolve("secret.js")),
+                "an unreadable entry must not be written out as an empty file");
     }
 
-    private static void assertNoStagedFiles(Path codeStore) throws IOException {
-        try (var entries = Files.list(codeStore)) {
-            assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
-                    "no staged archive may survive extraction, successful or failed");
-        }
+    /** A structurally valid archive declaring an arbitrary compression method. */
+    private static byte[] zipWithCompressionMethod(int method, String entryName, String content)
+            throws IOException {
+        byte[] name = entryName.getBytes(StandardCharsets.UTF_8);
+        byte[] data = content.getBytes(StandardCharsets.UTF_8);
+        CRC32 crc = new CRC32();
+        crc.update(data);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int localOffset = out.size();
+        le32(out, 0x04034b50L);
+        le16(out, 20);
+        le16(out, 0);
+        le16(out, method);
+        le16(out, 0);
+        le16(out, 0);
+        le32(out, crc.getValue());
+        le32(out, data.length);
+        le32(out, data.length);
+        le16(out, name.length);
+        le16(out, 0);
+        out.write(name);
+        out.write(data);
+
+        int centralOffset = out.size();
+        le32(out, 0x02014b50L);
+        le16(out, 20);
+        le16(out, 20);
+        le16(out, 0);
+        le16(out, method);
+        le16(out, 0);
+        le16(out, 0);
+        le32(out, crc.getValue());
+        le32(out, data.length);
+        le32(out, data.length);
+        le16(out, name.length);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, 0);
+        le32(out, 0);
+        le32(out, localOffset);
+        out.write(name);
+        int centralSize = out.size() - centralOffset;
+
+        le32(out, 0x06054b50L);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, 1);
+        le16(out, 1);
+        le32(out, centralSize);
+        le32(out, centralOffset);
+        le16(out, 0);
+        return out.toByteArray();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -267,18 +267,38 @@ class ZipExtractorTest {
     }
 
     @Test
+    void leavesNoStagedArchiveInTheCodeStore(@TempDir Path codeStore) throws IOException {
+        // ZipFile needs a seekable file, so the archive is staged on disk next to the target
+        // rather than in the shared java.io.tmpdir. That puts a stray file one level above the
+        // function's code directory, so pin that none survives: a leaked staging archive would
+        // sit in the code store indefinitely, and one leaked *inside* a function directory
+        // would be tar-copied into that function's container at launch.
+        Path target = codeStore.resolve("fn");
+        extractor.extractTo(zipWith("index.js", "v1"), target);
+        assertNoStagedFiles(codeStore);
+
+        byte[] corrupt = corruptedPayloadZip("index.js", "v2-but-corrupted-in-transit");
+        assertThrows(IOException.class, () -> extractor.extractTo(corrupt, target));
+        assertNoStagedFiles(codeStore);
+    }
+
+    private static void assertNoStagedFiles(Path codeStore) throws IOException {
+        try (var entries = Files.list(codeStore)) {
+            assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
+                    "no staged archive may survive extraction, successful or failed");
+        }
+    }
+
+    @Test
     void rejectsAnEntryWhoseCompressionMethodCannotBeRead(@TempDir Path target) throws IOException {
-        // java.util.zip.ZipFile throws on an unknown compression method; Commons Compress
-        // instead reports the entry as unreadable and would hand back an empty stream, which
-        // would write a zero-byte file and deploy a function whose code silently vanished.
-        // Method 99 is WinZip AES — structurally valid, not decodable here.
+        // A package must never be half-deployed because an entry used a codec the reader does
+        // not implement — writing it out empty would leave a function whose code silently
+        // vanished. Method 99 is WinZip AES: structurally valid, not decodable here.
         byte[] zip = zipWithCompressionMethod(99, "secret.js", "exports.handler = () => 1;");
 
-        ZipException thrown = assertThrows(ZipException.class, () -> extractor.extractTo(zip, target));
-        assertTrue(thrown.getMessage().contains("Unsupported compression"),
-                "unreadable entry must be rejected, was: " + thrown.getMessage());
+        assertThrows(ZipException.class, () -> extractor.extractTo(zip, target));
         assertFalse(Files.exists(target.resolve("secret.js")),
-                "an unreadable entry must not be written out as an empty file");
+                "an entry that cannot be decoded must not be written out");
     }
 
     /** A structurally valid archive declaring an arbitrary compression method. */


### PR DESCRIPTION
## Summary

Closes #2593.

`CreateFunction` rejected any deployment package produced by a streaming zip writer, failing with
`Failed to extract deployment package: only DEFLATED entries can have EXT descriptor`. Real AWS
accepts the same archive. In practice this makes **any Serverless Framework project that bundles
`node_modules` undeployable against Floci** — the reporter's only workaround was to drop
dependencies from the package entirely. Routed through CloudFormation the same failure surfaced as
the more confusing `Handler file '<handler>' not found in deployment package`.

`ZipExtractor` read the archive with `ZipInputStream`, a forward-only reader that sees only *local
file headers*. It now reads through the **central directory** via `ZipFile`.

### Before / after

The trigger needs an entry that is **STORED** *and* carries a trailing data descriptor. Reduced to
a 169-byte archive (the same shape the new test builds):

```java
byte[] zip = storedWithDataDescriptor("handler.js", "exports.handler = async () => 'ok';");

// BEFORE — ZipInputStream (sequential, local headers):
try (ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zip))) {
    while (zis.getNextEntry() != null) { /* ... */ }
}
// -> ZipException: only DEFLATED entries can have EXT descriptor     ← CreateFunction 400s

// AFTER — ZipFile (central directory):
try (ZipFile zf = new ZipFile(stagedFile)) {
    ZipEntry e = zf.entries().nextElement();
    System.out.println(e.getName() + " = " + new String(zf.getInputStream(e).readAllBytes()));
}
// -> handler.js = exports.handler = async () => 'ok';                ← extracts, like real AWS
```

## Root cause

A zip writer that streams its output cannot seek backwards to patch an entry's header, so it sets
general-purpose bit 3, zeroes the CRC and sizes in the local header, and appends the real values in
a trailing data descriptor — and separately writes incompressible content (`.node` addons, bundled
binaries under `node_modules`) as STORED. `ZipInputStream.readLOC()` refuses that pairing outright,
legitimately so for a forward-only reader: a STORED entry with deferred sizes has no end marker, so
it cannot know where the data stops. **`ZipExtractor` was treating local file headers as
authoritative when the central directory is** — the central directory always carries the true
method, CRC and sizes regardless of the descriptor flag.

This is also why the issue resisted reduction. Size was never the variable: a `zip(1)` archive
seeks and patches headers so bit 3 is never set; STORED-alongside-DEFLATED isn't enough because the
flag has to be set *on the stored entry*; Zip64 is orthogonal; and the 108 KB package had nothing
incompressible to store.

## What changed and why this approach

`ZipExtractor.extractTo` reads via `ZipFile` instead of `ZipInputStream`. `ZipFile` needs a seekable
file, so the incoming `byte[]` is staged to a temp file that is deleted in a `finally` block.

One compensating addition is required. **`ZipInputStream` verifies each entry's CRC;
`ZipFile.getInputStream` does not** — so swapping readers naively would have silently dropped an
integrity check the old code got for free, letting a package corrupted in transit deploy as garbage
instead of failing. Each entry is therefore streamed through a `CRC32` and checked against
`ZipEntry.getCrc()`, throwing a `ZipException` worded like the JDK's own. This restores parity
rather than adding new behaviour.

Everything else is deliberately untouched — the backslash warning, the traversal and containment
guards and directory handling are character-for-character identical, only re-indented, with the
`closeEntry()` calls dropped since `ZipFile` has no per-entry cursor. The signature is unchanged,
so neither caller (`LambdaService`, `LambdaLayerService`) needed changing.

Alternatives considered: **Apache Commons Compress** would avoid the temp file but is not a
dependency, and pulling in a compression library to swap one reader is disproportionate.
**Falling back to `ZipFile` only after `ZipInputStream` throws** would keep the broken reader on the
primary path and leave a half-extracted directory behind when it fails part-way (verified — the
first entry lands on disk before the throw). Reading the central directory is the correct behaviour,
not a fallback. **zipfs** is equally correct but needs the same temp file plus a provider round-trip
for no benefit.

Cost is one extra sequential write, bounded by the AWS package limit, on the deploy path only —
never on invoke. `Files.createTempFile` creates the file owner-only, so staging doesn't widen
exposure of package contents.

## AWS Compatibility

Real AWS Lambda accepts these archives; Floci did not. The two readers differ in both directions
and both were checked:

- **Stricter:** `ZipFile` requires a well-formed central directory, so a badly truncated archive is
  rejected up front rather than partially extracted. AWS-congruent. Both of Floci's own zip
  producers (`sourceToZipBase64`, `defaultHandlerZipBase64`) use `ZipOutputStream`, which always
  writes a central directory, so no internal path is affected.
- **More tolerant:** prefixed self-extracting archives and fuller Zip64 support now work.
- **Laxer — and compensated:** no per-entry CRC verification, restored explicitly as described
  above. Without that the fix would have traded a loud failure for a silent one.

## How it was tested

Four tests added to `ZipExtractorTest`. Three use a new `streamedZip(...)` helper that assembles zip
bytes by hand — required because `ZipOutputStream` structurally **cannot** emit an entry that is
STORED *and* descriptor-flagged, which is why the existing suite could never have caught this.

| Test | Covers |
|---|---|
| `extractsStoredEntryCarryingADataDescriptor` | The regression test: a DEFLATED `index.js` beside a STORED `node_modules/sharp/sharp.node`, bit 3 set on both — a real Serverless bundle in miniature |
| `extractsDeflatedEntryCarryingADataDescriptor` | Do-no-harm guard: the descriptor flag on a DEFLATED entry always worked and still must |
| `extractsExplicitDirectoryEntries` | Trailing-slash directory entries still create directories via the central directory |
| `rejectsAnEntryThatFailsItsChecksum` | CRC parity: a structurally valid archive whose data was corrupted after the fact must be rejected, not extracted silently |

Reverting only `ZipExtractor.java` and re-running the class reproduces the reported error from the
test suite:

```
[ERROR] Tests run: 6, Failures: 0, Errors: 2
[ERROR] ZipExtractorTest.extractsStoredEntryCarryingADataDescriptor:201
          » Zip only DEFLATED entries can have EXT descriptor
```

| Stage | Result |
|---|---|
| Baseline, clean `main` | `Tests run: 13283, Failures: 0, Errors: 0, Skipped: 9` |
| Full suite after fix | `Tests run: 13287, Failures: 0, Errors: 0, Skipped: 9` |
| `make docs-test` / `make docs-check` | 34 passed / exit 0 |

**+4 tests, +0 failures** — exactly the four added; no pre-existing test changed state.
Java 25 / Maven 3.9.16, matching `ci.yml`.

## Risk / rollback

Low. A leaf utility with two callers, both already handling `IOException`; signature unchanged; no
persisted state or wire format involved. The change is additive in capability — archives that
worked keep working, a class that failed now succeeds. Rollback is reverting the single file.

## Follow-ups (not in this PR)

Two adjacent defects found while diagnosing, deliberately left out to keep this focused — happy to
file them separately:

1. **Partial extraction isn't cleaned up on failure.** `extractTo` writes entries as it goes, so a
   mid-archive failure leaves a half-populated code directory. This is the likely mechanism behind
   the misleading CloudFormation `Handler file not found` symptom: a later path finds a non-empty
   code directory and skips re-extraction. Extracting to a temp dir and moving it into place
   atomically would fix the class. This PR removes the trigger for #2593 but not that fragility.
2. **CloudFormation masks the underlying extraction error**, reporting handler resolution instead of
   `Failed to extract deployment package: …`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
