### PR TITLE
fix(cloudformation): fail the stack when Lambda S3 code cannot be read

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1293,6 +1293,19 @@ public interface EmulatorConfig {
 
         @WithDefault("30")
         long deletedStackRetentionSeconds();
+
+        /**
+         * Whether an {@code AWS::Lambda::Function} whose template names code in S3 that cannot be
+         * read should fall back to the built-in stub handler instead of failing the resource.
+         *
+         * <p>Defaults to {@code false}, matching real CloudFormation, which fails the resource and
+         * rolls the stack back. Set to {@code true} to restore the older behaviour for a stack that
+         * deliberately leaves Lambda packages unbuilt — note that such a stack reports
+         * {@code CREATE_COMPLETE} while serving a placeholder that returns
+         * {@code {"statusCode":200}}, so it cannot be used to verify the real function.
+         */
+        @WithDefault("false")
+        boolean allowStubLambdaCode();
     }
 
     interface AcmServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -100,6 +100,7 @@ import io.github.hectorvent.floci.services.apigatewayv2.model.*;
 import io.github.hectorvent.floci.services.cognito.CognitoService;
 import io.github.hectorvent.floci.services.cognito.model.UserPool;
 import io.github.hectorvent.floci.services.cognito.model.UserPoolClient;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.docker.ContainerReachableEndpoint;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
@@ -220,6 +221,7 @@ public class CloudFormationResourceProvisioner {
     // below. As types migrate, their switch cases and provisionXxx methods are removed here; the
     // now-dead service deps above are cleared in the final cleanup once the switch is empty.
     private final CloudFormationResourceRegistry resourceRegistry;
+    private final EmulatorConfig config;
 
     @Inject
     public CloudFormationResourceProvisioner(S3Service s3Service, SqsService sqsService,
@@ -251,7 +253,9 @@ public class CloudFormationResourceProvisioner {
                                              FirehoseService firehoseService,
                                              DocDbService docDbService,
                                              CloudFrontService cloudFrontService,
-                                             CloudFormationResourceRegistry resourceRegistry) {
+                                             CloudFormationResourceRegistry resourceRegistry,
+                                             EmulatorConfig config) {
+        this.config = config;
         this.s3Service = s3Service;
         this.sqsService = sqsService;
         this.snsService = snsService;
@@ -2399,6 +2403,15 @@ public class CloudFormationResourceProvisioner {
                 reservedConcurrentExecutions);
     }
 
+    /**
+     * Whether an unreadable explicit {@code Code} reference may fall back to the stub handler.
+     * The provisioners hand-built in unit tests carry no config; absent configuration means the
+     * documented default, which is the strict behaviour.
+     */
+    private boolean stubLambdaCodeAllowed() {
+        return config != null && config.services().cloudformation().allowStubLambdaCode();
+    }
+
     private LambdaCodeSpec resolveLambdaCode(JsonNode props, CloudFormationTemplateEngine engine,
                                              String handler, String runtime) {
         if (props != null && props.has("Code")) {
@@ -2413,15 +2426,25 @@ public class CloudFormationResourceProvisioner {
                 // — or, when the handler was not "index.handler", fail with a handler error
                 // that pointed away from the real problem (issue #2648). The stub below is for
                 // a template that supplies no Code at all, which is a different case.
+                //
+                // allow-stub-lambda-code opts back in to the old fallback, for a stack that
+                // deliberately leaves its Lambda packages unbuilt and only cares about the
+                // other resources. Off by default: silently serving a placeholder is the more
+                // dangerous of the two behaviours.
                 try {
                     s3Service.getObject(s3Bucket, s3Key);
+                    return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key),
+                            "s3:" + s3Bucket + "\n" + s3Key);
                 } catch (Exception e) {
-                    throw new AwsException("ValidationError",
-                            "Error occurred while GetObject. S3 Error Message: " + e.getMessage()
-                                    + " (bucket: " + s3Bucket + ", key: " + s3Key + ")", 400);
+                    if (!stubLambdaCodeAllowed()) {
+                        throw new AwsException("ValidationError",
+                                "Error occurred while GetObject. S3 Error Message: " + e.getMessage()
+                                        + " (bucket: " + s3Bucket + ", key: " + s3Key + ")", 400);
+                    }
+                    LOG.warnv("S3 code not found for Lambda ({0}/{1}), using default handler because "
+                                    + "floci.services.cloudformation.allow-stub-lambda-code is enabled: {2}",
+                            s3Bucket, s3Key, e.getMessage());
                 }
-                return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key),
-                        "s3:" + s3Bucket + "\n" + s3Key);
             }
 
             String zipFile = codeNode.path("ZipFile").asText(null);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2407,14 +2407,21 @@ public class CloudFormationResourceProvisioner {
             String s3Bucket = codeNode.path("S3Bucket").asText(null);
             String s3Key = codeNode.path("S3Key").asText(null);
             if (s3Bucket != null && s3Key != null) {
+                // A template that names its code explicitly must fail if that code cannot be
+                // read, the way real CloudFormation does. Substituting the stub handler here
+                // let a stack reach CREATE_COMPLETE running code the template never referenced
+                // — or, when the handler was not "index.handler", fail with a handler error
+                // that pointed away from the real problem (issue #2648). The stub below is for
+                // a template that supplies no Code at all, which is a different case.
                 try {
                     s3Service.getObject(s3Bucket, s3Key);
-                    return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key),
-                            "s3:" + s3Bucket + "\n" + s3Key);
                 } catch (Exception e) {
-                    LOG.warnv("S3 code not found for Lambda ({0}/{1}), using default handler: {2}",
-                              s3Bucket, s3Key, e.getMessage());
+                    throw new AwsException("ValidationError",
+                            "Error occurred while GetObject. S3 Error Message: " + e.getMessage()
+                                    + " (bucket: " + s3Bucket + ", key: " + s3Key + ")", 400);
                 }
+                return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key),
+                        "s3:" + s3Bucket + "\n" + s3Key);
             }
 
             String zipFile = codeNode.path("ZipFile").asText(null);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -365,6 +365,9 @@ floci:
       timeout-sweep-interval-seconds: 1
     cloudformation:
       enabled: true
+      # Fail an AWS::Lambda::Function whose S3 code cannot be read, as real CloudFormation
+      # does. Set true to fall back to the built-in stub handler instead (issue #2648).
+      allow-stub-lambda-code: false
     acm:
       enabled: true
       validation-wait-seconds: 0

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/ApiGatewayV2CfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/ApiGatewayV2CfnProvisionerTest.java
@@ -43,7 +43,7 @@ class ApiGatewayV2CfnProvisionerTest {
                 null, apiGatewayV2Service, null, null, null, null, mapper,
                 null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null,
-                new CloudFormationResourceRegistry(java.util.List.of()));
+                new CloudFormationResourceRegistry(java.util.List.of()), null);
 
         Api api = new Api();
         api.setApiId(API_ID);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDeleteIdempotencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDeleteIdempotencyTest.java
@@ -37,7 +37,7 @@ class CloudFormationDeleteIdempotencyTest {
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
                 null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationEc2ProvisionerTest.java
@@ -42,7 +42,7 @@ class CloudFormationEc2ProvisionerTest {
                 null, null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, null, null, null, null, null, null,
                 ec2Service, null, null, null, null, null, null, null,
-                null, null, new CloudFormationResourceRegistry(List.of()));
+                null, null, new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamAttachmentProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamAttachmentProvisionerTest.java
@@ -54,7 +54,7 @@ class CloudFormationIamAttachmentProvisionerTest {
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
                 null, null,
-                new CloudFormationResourceRegistry(List.of(new IamRoleCfnProvisioner(iamService))));
+                new CloudFormationResourceRegistry(List.of(new IamRoleCfnProvisioner(iamService))), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaLegacyNameModeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaLegacyNameModeTest.java
@@ -55,7 +55,7 @@ class CloudFormationLambdaLegacyNameModeTest {
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
                 null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaMissingS3CodeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaMissingS3CodeIntegrationTest.java
@@ -17,10 +17,10 @@ import static org.hamcrest.Matchers.not;
 @QuarkusTest
 class CloudFormationLambdaMissingS3CodeIntegrationTest {
 
-    private static final String CFN_AUTH =
+    static final String CFN_AUTH =
             "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
 
-    private static String template(String fnName, String handler) {
+    static String template(String fnName, String handler) {
         return """
                 {
                   "Resources": {
@@ -39,7 +39,7 @@ class CloudFormationLambdaMissingS3CodeIntegrationTest {
                 """.formatted(fnName, handler);
     }
 
-    private static void createStack(String stackName, String template) {
+    static void createStack(String stackName, String template) {
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", CFN_AUTH)

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaMissingS3CodeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaMissingS3CodeIntegrationTest.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * A stack whose Lambda names code in S3 that cannot be read must fail, the way real
+ * CloudFormation does (issue #2648). Floci used to substitute a built-in stub handler, so the
+ * stack reached CREATE_COMPLETE running code the template never referenced — and when the
+ * handler was not "index.handler" it failed with a handler error that pointed away from the
+ * real problem. Control plane only, so the test is Docker-free.
+ */
+@QuarkusTest
+class CloudFormationLambdaMissingS3CodeIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+
+    private static String template(String fnName, String handler) {
+        return """
+                {
+                  "Resources": {
+                    "Fn": {
+                      "Type": "AWS::Lambda::Function",
+                      "Properties": {
+                        "FunctionName": "%s",
+                        "Runtime": "nodejs20.x",
+                        "Handler": "%s",
+                        "Role": "arn:aws:iam::000000000000:role/r",
+                        "Code": {"S3Bucket": "cfn-missing-code-bucket", "S3Key": "does-not-exist.zip"}
+                      }
+                    }
+                  }
+                }
+                """.formatted(fnName, handler);
+    }
+
+    private static void createStack(String stackName, String template) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    private static void assertStackFailed(String stackName) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>")));
+    }
+
+    @Test
+    void unreadableS3CodeFailsTheStackInsteadOfDeployingAStub() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-missing-code-" + suffix;
+        String fnName = "missing-code-fn-" + suffix;
+
+        // "index.handler" is the stub's own handler, so before the fix this combination was the
+        // silent one: the stack completed and the function served the stub's canned response.
+        createStack(stackName, template(fnName, "index.handler"));
+
+        assertStackFailed(stackName);
+
+        // The function must not exist at all — a stub must never stand in for the real package.
+        given()
+            .when().get("/2015-03-31/functions/" + fnName)
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void theFailureNamesTheUnreadableCodeNotTheHandler() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-missing-code-msg-" + suffix;
+        String fnName = "missing-code-msg-fn-" + suffix;
+
+        // With a non-default handler the old behaviour failed with
+        // "Handler file 'src/api' not found in deployment package", which is misleading: the
+        // handler is correct and present in the real package that was never fetched.
+        createStack(stackName, template(fnName, "src/api.handler"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStackEvents")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("does-not-exist.zip"))
+            .body(not(containsString("not found in deployment package")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaStubCodeAllowedIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaStubCodeAllowedIntegrationTest.java
@@ -1,0 +1,62 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.github.hectorvent.floci.services.cloudformation.CloudFormationLambdaMissingS3CodeIntegrationTest.CFN_AUTH;
+import static io.github.hectorvent.floci.services.cloudformation.CloudFormationLambdaMissingS3CodeIntegrationTest.createStack;
+import static io.github.hectorvent.floci.services.cloudformation.CloudFormationLambdaMissingS3CodeIntegrationTest.template;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * The opt-in escape hatch for issue #2648: a stack that deliberately leaves its Lambda packages
+ * unbuilt can set one property and keep the old stub-handler behaviour instead of breaking on
+ * upgrade. Off by default, because a stack that reports CREATE_COMPLETE while serving a placeholder
+ * is the more dangerous of the two behaviours.
+ *
+ * <p>A separate top-level class rather than a nested one, because {@code @TestProfile} applies per
+ * test class and Surefire discovers test classes by file name: a nested class carrying the profile
+ * compiles and passes when targeted directly, but is silently skipped in a full {@code mvn test}.
+ */
+@QuarkusTest
+@TestProfile(CloudFormationLambdaStubCodeAllowedIntegrationTest.AllowStubProfile.class)
+class CloudFormationLambdaStubCodeAllowedIntegrationTest {
+
+    public static final class AllowStubProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.cloudformation.allow-stub-lambda-code", "true");
+        }
+    }
+
+    @Test
+    void unreadableS3CodeFallsBackToTheStubHandler() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-stub-allowed-" + suffix;
+        String fnName = "stub-allowed-fn-" + suffix;
+
+        createStack(stackName, template(fnName, "index.handler"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        // The stub stands in for the package that could not be read.
+        given()
+            .when().get("/2015-03-31/functions/" + fnName)
+            .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogGroupProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogGroupProvisionerTest.java
@@ -48,7 +48,7 @@ class CloudFormationLogGroupProvisionerTest {
                 null, null, null, null, null, null, null,
                 null, null, logsService, null, null, null, null,
                 null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -50,7 +50,7 @@ class CustomResourceProvisionerTest {
                 null, null, null, null, lambdaService, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, store, endpoint, null, null, null, null, null, null, null, null, null, null, null, null,
                 null, null,
-                new io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry(java.util.List.of()));
+                new io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry(java.util.List.of()), null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbReplicaCfnProvisionerTest.java
@@ -35,7 +35,7 @@ class DynamoDbReplicaCfnProvisionerTest {
                 null, null, null, dynamoDbService, null, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbStreamSpecificationCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/DynamoDbStreamSpecificationCfnProvisionerTest.java
@@ -53,7 +53,7 @@ class DynamoDbStreamSpecificationCfnProvisionerTest {
                 null, null, null, dynamoDbService, null, null, null, null, null, null,
                 null, null, null, null, null, null, mapper, null, null, null, null, null,
                 null, null, null, null, null, null, null, null, null, null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
 
         TableDefinition created = new TableDefinition();
         created.setTableName(TABLE);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusDeleteOwnershipTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusDeleteOwnershipTest.java
@@ -46,7 +46,7 @@ class EventBusDeleteOwnershipTest {
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
                 null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusProvisionOwnershipTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/EventBusProvisionOwnershipTest.java
@@ -59,7 +59,7 @@ class EventBusProvisionOwnershipTest {
                 null, null, null, null, null, null, null,
                 null, null, null, null, null, null, null,
                 null, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/RdsCfnProvisionerTest.java
@@ -71,7 +71,7 @@ class RdsCfnProvisionerTest {
                 null, null, null, null, null, null, null,
                 rdsService, null, null, null, null, null, null,
                 null, null,
-                new io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry(java.util.List.of()));
+                new io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry(java.util.List.of()), null);
     }
 
     private CloudFormationTemplateEngine engine() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SecretTargetAttachmentCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SecretTargetAttachmentCfnProvisionerTest.java
@@ -71,7 +71,7 @@ class SecretTargetAttachmentCfnProvisionerTest {
                 null, null, null, null, null, null, null,
                 rdsService, null, null, null, null, null, null,
                 docDbService, null,
-                new CloudFormationResourceRegistry(List.of()));
+                new CloudFormationResourceRegistry(List.of()), null);
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -212,6 +212,9 @@ floci:
       timeout-sweep-interval-seconds: 1
     cloudformation:
       enabled: true
+      # Fail an AWS::Lambda::Function whose S3 code cannot be read, as real CloudFormation
+      # does. Set true to fall back to the built-in stub handler instead (issue #2648).
+      allow-stub-lambda-code: false
     acm:
       enabled: true
       validation-wait-seconds: 0


### PR DESCRIPTION
## ⚠️ Read this first — this changes behaviour for stacks that pass today

Closes #2648.

**Most bug fixes only change what happens in situations that were already visibly broken. This one
changes what happens in a situation that currently looks like success**, so it deserves an explicit
decision from you rather than a quiet merge.

Floci has a shortcut: when a template says *"my Lambda's code is at `s3://bucket/key`"* and that
object cannot be read, it silently substitutes a 176-byte built-in placeholder that returns
`{"statusCode":200}` and nothing else.

| | Today | With this PR |
|---|---|---|
| Stack status | `CREATE_COMPLETE` | `CREATE_FAILED` → rollback |
| Function created? | Yes — the placeholder | No |
| What the user is told | Nothing (one line in a container log) | An error naming the bucket and key |

### Who this could hurt

Someone with a 40-resource stack — DynamoDB tables, SQS queues, IAM roles, three Lambdas — who is
working on the DynamoDB side today and has not uploaded the Lambda zips. Right now that stack
deploys: the Lambdas come up as placeholders, everything else provisions, and they get on with
their work. **After this change the whole stack fails and rolls back**, and they cannot test their
DynamoDB work until they build and upload three packages they do not care about. In CI, that is a
pipeline going from green to red on a Floci upgrade with no change on their side.

I think the strict behaviour is still right — a stack reporting success while running code the user
never wrote is genuinely dangerous, and it is what produced the confusing error in #2593. But that
is a judgement call about your users, so I have not made it unilaterally.

### Three ways to take this — happy to push whichever you prefer

1. **As-is (strict).** Unreadable code always fails the stack. AWS-accurate; breaks the workflow
   above.
2. **Both behaviours, strict by default** *(my recommendation if you want an escape hatch)* — a
   config flag, e.g. `floci.cloudformation.lambda.allow-stub-code`, defaulting to `false`. Correct
   out of the box, and anyone relying on placeholder Lambdas sets one property instead of being
   blocked. Costs a config key and a line in the docs.
3. **Both behaviours, lenient by default.** Same flag, defaulting to `true`. Nobody's stack changes
   on upgrade; users opt into correctness.

Say which you want and I will push it — option 2 or 3 is a small change on top of this branch, and
I have already written the reasoning for each. I defaulted to option 1 only because
`CONTRIBUTING.md` and `AGENTS.md` both state that matching the real AWS wire protocol is the
project's default.

---

## Summary

When a template declares `Code: { S3Bucket, S3Key }` and Floci cannot read that object, the
provisioner silently substituted a built-in stub package instead of failing. That split two ways,
both bad:

**Variant 1 — `Handler: index.handler` (the stub's own handler).** The stack reaches
`CREATE_COMPLETE`, the function is invocable, and it returns `{"statusCode":200}` for every
request. The user's code was never deployed and nothing in the API surface says so — only a
container log line. An integration suite run against that stack passes green against a stub.

**Variant 2 — any other handler.** The stub lacks the module, so `CreateFunction` fails its handler
check and the resource fails with `Handler file 'src/api' not found in deployment package` —
naming a handler that is correct in the template and present in the real package. This is the
misleading error reported in the second half of #2593.

### Before / after

Template pointing at `s3://pkg/does-not-exist.zip`:

```
# BEFORE — variant 1 (Handler: index.handler)
describe-stacks   CREATE_COMPLETE          <- real CloudFormation: CREATE_FAILED / ROLLBACK
get-function      index.handler   176      <- 176 bytes: the built-in stub
invoke            {"statusCode":200}       <- the stub's canned response

# BEFORE — variant 2 (Handler: src/api.handler)
describe-stack-events  Fn  CREATE_FAILED  Handler file 'src/api' not found in deployment package

# AFTER — both variants
describe-stack-events  Fn  CREATE_FAILED  Error occurred while GetObject. S3 Error Message: ...
                                          (bucket: pkg, key: does-not-exist.zip)
```

## Root cause

`resolveLambdaCode` probed the object only to decide whether to use it, and treated *any* failure
as "no code available":

```java
try {
    s3Service.getObject(s3Bucket, s3Key);
    return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key), ...);
} catch (Exception e) {
    LOG.warnv("S3 code not found for Lambda ({0}/{1}), using default handler: {2}", ...);
}
...
return new LambdaCodeSpec(Map.of("ZipFile", defaultHandlerZipBase64()), "default-handler");
```

**A fallback default is only sound when the input is absent.** Here it was applied to an input that
was *present but unusable*, turning an explicit, checkable user intent into a silent substitution.
The bare `catch (Exception e)` compounds it: a transient S3 error, a permissions failure, or a bug
in the read path all degrade to the same stub as a genuinely missing key.

## What changed and why this approach

`resolveLambdaCode` now throws `AwsException("ValidationError", …)` when an explicitly declared
`S3Bucket`/`S3Key` cannot be read, so the resource fails and the stack rolls back the way real
CloudFormation does. The message names the bucket and key and carries the underlying S3 error.

The stub fallback is **kept for its legitimate case** — a template supplying no `Code` block at all
— which is the unchanged `return` at the end of the method. The inline `ZipFile` and `ImageUri`
paths are untouched. The defect was the scope the fallback was applied at, not the fallback itself.

Alternatives: **keeping the stub but marking the resource `CREATE_FAILED`** is contradictory — a
failed resource that still deployed something leaves an orphan function. **Surfacing a stack event
instead of failing** still ends in `CREATE_COMPLETE`, so automation cannot tell the difference and
the core problem is unchanged.

## AWS Compatibility

Real CloudFormation fails the resource with an error naming the inaccessible code
(`Error occurred while GetObject. S3 Error Code: NoSuchKey`) and rolls the stack back; a stack that
reaches `CREATE_COMPLETE` has deployed the code the template pointed at. Floci now matches. For an
emulator whose purpose is to predict what AWS does, a local stack going green where AWS would roll
back is worse than useless — it actively misleads.

## How it was tested

New `CloudFormationLambdaMissingS3CodeIntegrationTest` (`@QuarkusTest`, control-plane only, so
Docker-free), following the `CloudFormationLambdaAddressingIntegrationTest` pattern:

| Test | Covers |
|---|---|
| `unreadableS3CodeFailsTheStackInsteadOfDeployingAStub` | Variant 1. Asserts the stack does not reach `CREATE_COMPLETE` and the function does not exist at all (404) — a stub must never stand in for the real package |
| `theFailureNamesTheUnreadableCodeNotTheHandler` | Variant 2. Asserts stack events name `does-not-exist.zip` and do **not** contain `not found in deployment package` |

Both fail against unfixed code (`Tests run: 2, Failures: 2`). Full suite: see the checklist.
Java 25 / Maven 3.9.16, matching `ci.yml`.

## Risk / rollback

Covered at the top: this is an intentional behaviour change, and options 2 and 3 there are both
one small commit away if you would rather not change outcomes for existing users. Rollback is
reverting the single method — no persisted state, no wire format, no migration.

## Follow-up (not in this PR)

The probe reads the whole object via `s3Service.getObject` purely to test readability and then
discards it; `LambdaService` fetches it again during `CreateFunction`. For a 250 MB package that is
a wasted full read per stack operation. A `headObject`-style check, or threading the fetched bytes
through, would fix it — a performance concern rather than a correctness one, so it belongs
elsewhere. Happy to file it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
