### PR TITLE
fix(s3): accept the log-delivery-write canned ACL

### DIFF
--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -337,3 +337,4 @@ Current limitations:
 - explicit ACL grant headers such as `x-amz-grant-read` and `x-amz-grant-full-control` are not modeled yet
 - cross-account canned ACL variants collapse to the emulator's single synthetic owner where Floci does not model a distinct second principal
 - `aws-exec-read` is accepted for compatibility, but Floci does not yet model a distinct EC2 bundle-reader grantee in `GetObjectAcl`
+- `log-delivery-write` is accepted on `PutBucketAcl`/`PutObjectAcl` and grants the well-known S3 log-delivery group (`http://acs.amazonaws.com/groups/s3/LogDelivery`) `WRITE` and `READ_ACP`, matching AWS

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -53,6 +53,7 @@ public class S3Service implements Resettable, ResourceProvider {
     private String ownerId() { return regionResolver != null ? regionResolver.getAccountId() : "000000000000"; }
     private static final String DEFAULT_OWNER_DISPLAY_NAME = "floci";
     private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
+    private static final String LOG_DELIVERY_GROUP_URI = "http://acs.amazonaws.com/groups/s3/LogDelivery";
     private static final String LEGACY_ACCESS_KEY_ID = "test";
     private static final Set<String> SUPPORTED_SERVER_SIDE_ENCRYPTION_VALUES = Set.of("AES256", "aws:kms", "aws:kms:dsse", "aws:fsx");
     private static final String SSE_C_ALGORITHM = "AES256";
@@ -2657,6 +2658,13 @@ public class S3Service implements Resettable, ResourceProvider {
             case "authenticated-read" -> objectAclXml(
                     ownerFullControlGrant(),
                     groupGrant(AUTHENTICATED_USERS_GROUP_URI, "READ"));
+            // Standard canned ACL used by S3 server-access-logging (and Terraform's
+            // aws_s3_bucket_acl / access-logging modules) to grant the S3 log-delivery service
+            // group permission to write log objects into this bucket and read their own ACL.
+            case "log-delivery-write" -> objectAclXml(
+                    ownerFullControlGrant(),
+                    groupGrant(LOG_DELIVERY_GROUP_URI, "WRITE"),
+                    groupGrant(LOG_DELIVERY_GROUP_URI, "READ_ACP"));
             default -> throw new AwsException("InvalidArgument",
                     "Unsupported x-amz-acl value: " + cannedAcl, 400);
         };

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AclIntegrationTest.java
@@ -17,6 +17,7 @@ class S3AclIntegrationTest {
     private static final String BUCKET = "acl-test-bucket";
     private static final String ALL_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AllUsers";
     private static final String AUTHENTICATED_USERS_GROUP_URI = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
+    private static final String LOG_DELIVERY_GROUP_URI = "http://acs.amazonaws.com/groups/s3/LogDelivery";
     private static String multipartUploadId;
 
     @Test
@@ -373,5 +374,31 @@ class S3AclIntegrationTest {
             .statusCode(200)
             .body(not(containsString(ALL_USERS_GROUP_URI)))
             .body(containsString("<Permission>FULL_CONTROL</Permission>"));
+    }
+
+    // Regression coverage for floci-3wz: PutBucketAcl rejected the "log-delivery-write" canned
+    // ACL, the standard value Terraform's aws_s3_bucket_acl / access-logging modules send to grant
+    // the S3 log-delivery service group permission to write access logs into a bucket.
+
+    @Test
+    @Order(17)
+    void putBucketAclAppliesLogDeliveryWriteCannedAcl() {
+        given()
+            .header("x-amz-acl", "log-delivery-write")
+        .when()
+            .put("/" + BUCKET + "?acl")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?acl")
+        .then()
+            .statusCode(200)
+            .body(containsString(LOG_DELIVERY_GROUP_URI))
+            .body(containsString("<Permission>WRITE</Permission>"))
+            .body(containsString("<Permission>READ_ACP</Permission>"))
+            .body(containsString("<Permission>FULL_CONTROL</Permission>"))
+            .body(not(containsString(ALL_USERS_GROUP_URI)));
     }
 }


### PR DESCRIPTION
## Summary

`PutBucketAcl`/`PutObjectAcl` rejected the `log-delivery-write` canned ACL with `InvalidArgument: Unsupported x-amz-acl value`, even though it's one of AWS's eight standard canned ACLs. Terraform's `aws_s3_bucket_acl` resource (and the access-logging modules that use it) send this value to grant the S3 log-delivery service group permission to write access logs into a bucket. This was the only canned ACL value missing from `cannedObjectAclXml`'s switch — the other seven (`private`, `public-read`, `public-read-write`, `authenticated-read`, `aws-exec-read`, `bucket-owner-read`, `bucket-owner-full-control`) were already implemented.

This PR adds the `log-delivery-write` case, translating it into `WRITE` and `READ_ACP` grants for the well-known LogDelivery group URI (`http://acs.amazonaws.com/groups/s3/LogDelivery`), following the same `groupGrant` pattern already used for `public-read`/`public-read-write`.

Found via the [floci-harness compatibility survey](https://github.com/allensanborn/floci-harness): 7 blocked roots across `terraform-aws-openvpn` and `terraform-aws-static-assets`, all failing on `PutBucketAcl` during S3 access-logging bucket setup.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real AWS's canned ACL list includes `log-delivery-write`, which grants the S3 log-delivery group `WRITE` and `READ_ACP` on the bucket (documented at `http://acs.amazonaws.com/groups/s3/LogDelivery`). floci previously threw `InvalidArgument` for this value instead of applying the grant, so any Terraform module that sets up S3 access logging via a canned ACL (rather than explicit grants) failed at plan/apply time against floci.

## Checklist

- [x] `./mvnw test` passes locally — ran the full S3 suite (`mvn -Dtest='io.github.hectorvent.floci.services.s3.**' test`) after rebasing onto current `upstream/main`: 937 tests, 0 failures, 0 errors.
- [x] New or updated integration test added — `S3AclIntegrationTest` gains coverage for `log-delivery-write`.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
