### PR TITLE
feat(kinesisanalytics): emit MSF-style JSON CloudWatch logs from Flink

### DIFF
--- a/docs/services/kinesisanalytics.md
+++ b/docs/services/kinesisanalytics.md
@@ -179,6 +179,11 @@ an in-place code update, since the JobManager/TaskManager JVMs (and therefore lo
 restarted for that, matching how real MSF also keeps the same processes running across an
 `UpdateApplication`.
 
+`applicationARN` and `applicationVersionId` are baked into the generated config as literal text, so
+`CreateApplication` validates `ApplicationName` against AWS's own constraints (`[a-zA-Z0-9_.-]+`,
+1-128 characters) rather than only requiring it non-blank — matching real AWS, and also keeping a
+name containing `%`, `"`, `\`, or `$` out of the log4j2 pattern in the first place.
+
 ### Flink Dashboard access
 
 `CreateApplicationPresignedUrl` (with `UrlType: FLINK_DASHBOARD_URL`) returns a URL to the running

--- a/docs/services/kinesisanalytics.md
+++ b/docs/services/kinesisanalytics.md
@@ -161,6 +161,24 @@ Pass `ApplicationConfiguration.ApplicationSnapshotConfiguration.SnapshotsEnabled
 `UpdateApplication`) to disable snapshots for an application — real AWS defaults this to `true`.
 `CreateApplicationSnapshot` rejects the request with `InvalidRequestException` while disabled.
 
+### CloudWatch Logs format
+
+The JobManager and TaskManager are started with a `log4j-console.properties` that makes every log
+line a single JSON object, matching the shape real Managed Service for Apache Flink writes to
+CloudWatch Logs: `applicationARN`, `applicationVersionId`, `locationInformation`, `logger`,
+`message`, `messageSchemaVersion`, `messageType`, `threadName`, `throwableInformation`. This applies
+to Flink's own framework logs as well as anything a deployed JAR logs through SLF4J/Log4j2 — a JAR
+whose own tests assert on this exact schema (or that simply expects its logs to reach CloudWatch
+rather than being swallowed by a competing logging framework it bundles) sees the same thing here as
+on real MSF. The config is written into the container before the JVM starts (config placed at
+creation time, before `StartApplication`'s container start), overwriting the stock image's default,
+non-JSON config entirely. `throwableInformation` is always present (an empty string when the log
+event has no exception), unlike real AWS which omits the key entirely in that case. Not re-applied
+on `UpdateApplication` — `applicationVersionId` in already-emitted log lines does not advance across
+an in-place code update, since the JobManager/TaskManager JVMs (and therefore log4j2) are not
+restarted for that, matching how real MSF also keeps the same processes running across an
+`UpdateApplication`.
+
 ### Flink Dashboard access
 
 `CreateApplicationPresignedUrl` (with `UrlType: FLINK_DASHBOARD_URL`) returns a URL to the running

--- a/docs/services/kinesisanalytics.md
+++ b/docs/services/kinesisanalytics.md
@@ -182,7 +182,9 @@ restarted for that, matching how real MSF also keeps the same processes running 
 `applicationARN` and `applicationVersionId` are baked into the generated config as literal text, so
 `CreateApplication` validates `ApplicationName` against AWS's own constraints (`[a-zA-Z0-9_.-]+`,
 1-128 characters) rather than only requiring it non-blank — matching real AWS, and also keeping a
-name containing `%`, `"`, `\`, or `$` out of the log4j2 pattern in the first place.
+name containing `%`, `"`, `\`, or `$` out of the log4j2 pattern in the first place. `StartApplication`
+re-checks the same pattern, so an application persisted by an older Floci build (before this
+validation existed) fails loudly there rather than getting a corrupted `applicationARN` in its logs.
 
 ### Flink Dashboard access
 

--- a/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2Service.java
@@ -206,6 +206,20 @@ public class KinesisAnalyticsV2Service {
 
     public FlinkApplication startApplication(String applicationName) {
         FlinkApplication app = describeApplication(applicationName);
+        // Defends state persisted by a floci build older than the ApplicationName check in
+        // createApplication: applicationARN is baked as literal text into the CloudWatch-log-format
+        // config FlinkContainerManager writes on startup, and a name outside AWS's charset (most
+        // notably '$', which can't be escaped to a safe literal there -- see
+        // FlinkContainerManager#literalForLog4j2Pattern) either gets dropped from every emitted
+        // applicationARN (breaking correlation with the real ApplicationARN) or, if ever un-dropped,
+        // risks leaking an environment variable/system property via a log4j2 Lookup. Failing loudly
+        // here beats either outcome, and real AWS could never have had this state to begin with.
+        if (!APPLICATION_NAME.matcher(applicationName).matches()) {
+            throw new AwsException("InvalidArgumentException",
+                    "ApplicationName '" + applicationName + "' does not match the required pattern "
+                            + "[a-zA-Z0-9_.-]{1,128}; this application predates that validation and "
+                            + "must be deleted and recreated with a valid name", 400);
+        }
         if (app.getApplicationStatus() != ApplicationStatus.READY) {
             throw new AwsException("ResourceInUseException",
                     "Application " + applicationName + " cannot be started while in state "

--- a/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2Service.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 /**
  * Control plane for Managed Service for Apache Flink (Kinesis Analytics V2). Holds the
@@ -42,6 +43,9 @@ import java.util.concurrent.TimeUnit;
 public class KinesisAnalyticsV2Service {
 
     private static final Logger LOG = Logger.getLogger(KinesisAnalyticsV2Service.class);
+
+    // AWS: ApplicationName Length Constraints: 1-128, Pattern: [a-zA-Z0-9_.-]+
+    private static final Pattern APPLICATION_NAME = Pattern.compile("[a-zA-Z0-9_.-]{1,128}");
 
     // AWS: "the maximum number of user-defined application tags is 50" (the stated 200-tag ceiling
     // on the Tags/TagKeys shapes includes AWS-managed system tags, which floci does not model).
@@ -136,6 +140,11 @@ public class KinesisAnalyticsV2Service {
                                               Boolean snapshotsEnabled) {
         if (applicationName == null || applicationName.isBlank()) {
             throw new AwsException("InvalidArgumentException", "ApplicationName is required", 400);
+        }
+        if (!APPLICATION_NAME.matcher(applicationName).matches()) {
+            throw new AwsException("InvalidArgumentException",
+                    "ApplicationName '" + applicationName
+                            + "' does not match the required pattern [a-zA-Z0-9_.-]{1,128}", 400);
         }
         if (runtimeEnvironment == null || runtimeEnvironment.isBlank()) {
             throw new AwsException("InvalidArgumentException", "RuntimeEnvironment is required", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
@@ -273,7 +273,8 @@ public class FlinkContainerManager {
      *  directly. */
     byte[] msfStyleLog4j2Config(FlinkApplication app) {
         String pattern = "{"
-                + "\"applicationARN\":\"%enc{" + literalForLog4j2Pattern(app.getApplicationArn()) + "}{JSON}\","
+                + "\"applicationARN\":\"%enc{"
+                + literalForLog4j2Pattern(String.valueOf(app.getApplicationArn())) + "}{JSON}\","
                 + "\"applicationVersionId\":\"%enc{"
                 + literalForLog4j2Pattern(String.valueOf(app.getApplicationVersionId())) + "}{JSON}\","
                 + "\"locationInformation\":\"%C.%M(%F:%L)\","
@@ -293,14 +294,21 @@ public class FlinkContainerManager {
         return properties.getBytes(StandardCharsets.UTF_8);
     }
 
-    /** Escapes an application-supplied value (e.g. the ARN, built from the caller's ApplicationName)
-     *  so it can be embedded as literal text inside a log4j2 {@code PatternLayout} pattern written to
-     *  a {@code .properties} file: doubles {@code %} so log4j2's pattern parser can't interpret it as
-     *  the start of a conversion specifier (or lookup), then backslash-escapes control characters so
-     *  the value survives {@code java.util.Properties}-style parsing of the config file intact. The
-     *  surrounding {@code %enc{...}{JSON}} wrapper (already used for %message/%thread/%ex above) then
-     *  JSON-escapes the resulting literal at log time, so quotes/backslashes in the original value
-     *  can't break the emitted JSON. */
+    /** Escapes an application-supplied value (e.g. the ARN, built from the caller's ApplicationName --
+     *  {@link io.github.hectorvent.floci.services.kinesisanalytics.KinesisAnalyticsV2Service} restricts
+     *  that to AWS's own {@code [a-zA-Z0-9_.-]} charset, but this stays defensive in case some other
+     *  caller ever feeds it something else) so it can be embedded as literal text inside a log4j2
+     *  {@code PatternLayout} pattern written to a {@code .properties} file: doubles {@code %} so
+     *  log4j2's pattern parser can't interpret it as the start of a conversion specifier, drops
+     *  {@code $} so it can't start a {@code ${...}} Lookup (log4j2 resolves those against config
+     *  values -- including this pattern -- at config-load time, so an unescaped one could leak an
+     *  environment variable or system property into every log line; doubling it like {@code %} only
+     *  defers the lookup to render time rather than neutralizing it, so it isn't a safe escape here),
+     *  then backslash-escapes control characters so the value survives
+     *  {@code java.util.Properties}-style parsing of the config file intact. The surrounding
+     *  {@code %enc{...}{JSON}} wrapper (already used for %message/%thread/%ex above) then JSON-escapes
+     *  the resulting literal at log time, so quotes/backslashes in the original value can't break the
+     *  emitted JSON. */
     private static String literalForLog4j2Pattern(String value) {
         String percentEscaped = value.replace("%", "%%");
         StringBuilder escaped = new StringBuilder(percentEscaped.length());
@@ -308,6 +316,7 @@ public class FlinkContainerManager {
             char c = percentEscaped.charAt(i);
             switch (c) {
                 case '\\' -> escaped.append("\\\\");
+                case '$' -> { /* dropped: see method Javadoc -- can't be escaped to a safe literal */ }
                 case '\n' -> escaped.append("\\n");
                 case '\r' -> escaped.append("\\r");
                 case '\t' -> escaped.append("\\t");

--- a/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
@@ -179,7 +179,7 @@ public class FlinkContainerManager {
             // startup -- copying it in after the process is already running would be too late for
             // anything the JobManager logs from its own boot onward.
             copyFileIntoContainer(jmContainerId, "/opt/flink/conf", "log4j-console.properties",
-                    msfStyleLog4j2Config(app));
+                    msfStyleLog4j2Config(app), true);
             jm = lifecycleManager.startCreated(jmContainerId, jmBuiltSpec);
         } catch (RuntimeException e) {
             lifecycleManager.removeIfExists(jmName);
@@ -212,7 +212,7 @@ public class FlinkContainerManager {
             try {
                 String tmContainerId = lifecycleManager.create(tmSpec);
                 copyFileIntoContainer(tmContainerId, "/opt/flink/conf", "log4j-console.properties",
-                        msfStyleLog4j2Config(app));
+                        msfStyleLog4j2Config(app), true);
                 ContainerInfo tm = lifecycleManager.startCreated(tmContainerId, tmSpec);
                 app.setTaskManagerContainerId(tm.containerId());
                 taskManagerIds.put(app.getApplicationName(), tm.containerId());
@@ -273,8 +273,9 @@ public class FlinkContainerManager {
      *  directly. */
     byte[] msfStyleLog4j2Config(FlinkApplication app) {
         String pattern = "{"
-                + "\"applicationARN\":\"" + app.getApplicationArn() + "\","
-                + "\"applicationVersionId\":\"" + app.getApplicationVersionId() + "\","
+                + "\"applicationARN\":\"%enc{" + literalForLog4j2Pattern(app.getApplicationArn()) + "}{JSON}\","
+                + "\"applicationVersionId\":\"%enc{"
+                + literalForLog4j2Pattern(String.valueOf(app.getApplicationVersionId())) + "}{JSON}\","
                 + "\"locationInformation\":\"%C.%M(%F:%L)\","
                 + "\"logger\":\"%logger\","
                 + "\"message\":\"%enc{%message}{JSON}\","
@@ -292,7 +293,46 @@ public class FlinkContainerManager {
         return properties.getBytes(StandardCharsets.UTF_8);
     }
 
+    /** Escapes an application-supplied value (e.g. the ARN, built from the caller's ApplicationName)
+     *  so it can be embedded as literal text inside a log4j2 {@code PatternLayout} pattern written to
+     *  a {@code .properties} file: doubles {@code %} so log4j2's pattern parser can't interpret it as
+     *  the start of a conversion specifier (or lookup), then backslash-escapes control characters so
+     *  the value survives {@code java.util.Properties}-style parsing of the config file intact. The
+     *  surrounding {@code %enc{...}{JSON}} wrapper (already used for %message/%thread/%ex above) then
+     *  JSON-escapes the resulting literal at log time, so quotes/backslashes in the original value
+     *  can't break the emitted JSON. */
+    private static String literalForLog4j2Pattern(String value) {
+        String percentEscaped = value.replace("%", "%%");
+        StringBuilder escaped = new StringBuilder(percentEscaped.length());
+        for (int i = 0; i < percentEscaped.length(); i++) {
+            char c = percentEscaped.charAt(i);
+            switch (c) {
+                case '\\' -> escaped.append("\\\\");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        escaped.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        escaped.append(c);
+                    }
+                }
+            }
+        }
+        return escaped.toString();
+    }
+
     private void copyFileIntoContainer(String containerId, String remoteDir, String relativePath, byte[] content) {
+        copyFileIntoContainer(containerId, remoteDir, relativePath, content, false);
+    }
+
+    /** @param required when {@code true}, a failed copy is rethrown instead of only logged, so a
+     *  caller for whom the file is not optional (e.g. the log4j2 config that this cluster's whole
+     *  CloudWatch-log-shape guarantee depends on) fails the start instead of silently running with
+     *  the stock config. */
+    private void copyFileIntoContainer(String containerId, String remoteDir, String relativePath, byte[] content,
+            boolean required) {
         if (containerId == null) {
             return;
         }
@@ -303,6 +343,10 @@ public class FlinkContainerManager {
                     .withRemotePath(remoteDir)
                     .exec();
         } catch (Exception e) {
+            if (required) {
+                throw new IllegalStateException(
+                        "Could not copy " + relativePath + " into Flink container " + containerId, e);
+            }
             LOG.warnv("Could not copy {0} into Flink container {1}: {2}", relativePath, containerId, e.getMessage());
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManager.java
@@ -170,9 +170,17 @@ public class FlinkContainerManager {
             jmSpec.withExposedPort(JOBMANAGER_REST_PORT);
         }
 
+        ContainerSpec jmBuiltSpec = jmSpec.build();
         ContainerInfo jm;
         try {
-            jm = lifecycleManager.createAndStart(jmSpec.build());
+            String jmContainerId = lifecycleManager.create(jmBuiltSpec);
+            // Written before start (not via the post-start copyFileIntoContainer used for
+            // application_properties.json below) because log4j2 reads its config file at JVM
+            // startup -- copying it in after the process is already running would be too late for
+            // anything the JobManager logs from its own boot onward.
+            copyFileIntoContainer(jmContainerId, "/opt/flink/conf", "log4j-console.properties",
+                    msfStyleLog4j2Config(app));
+            jm = lifecycleManager.startCreated(jmContainerId, jmBuiltSpec);
         } catch (RuntimeException e) {
             lifecycleManager.removeIfExists(jmName);
             throw e;
@@ -202,7 +210,10 @@ public class FlinkContainerManager {
                             regionResolver.getDefaultRegion()))
                     .build();
             try {
-                ContainerInfo tm = lifecycleManager.createAndStart(tmSpec);
+                String tmContainerId = lifecycleManager.create(tmSpec);
+                copyFileIntoContainer(tmContainerId, "/opt/flink/conf", "log4j-console.properties",
+                        msfStyleLog4j2Config(app));
+                ContainerInfo tm = lifecycleManager.startCreated(tmContainerId, tmSpec);
                 app.setTaskManagerContainerId(tm.containerId());
                 taskManagerIds.put(app.getApplicationName(), tm.containerId());
             } catch (RuntimeException e) {
@@ -247,6 +258,38 @@ public class FlinkContainerManager {
         } catch (IOException e) {
             throw new IllegalStateException("Could not serialize application_properties.json", e);
         }
+    }
+
+    /** Builds a log4j2 {@code log4j-console.properties} that makes the JobManager/TaskManager emit
+     *  one JSON object per log line, matching the schema real Managed Service for Apache Flink
+     *  writes to CloudWatch Logs (applicationARN/applicationVersionId/locationInformation/logger/
+     *  message/messageSchemaVersion/messageType/threadName/throwableInformation) -- so a JAR relying
+     *  on that shape for its own log-based tests sees the same thing here as on real MSF. Overwrites
+     *  the stock image's default (non-JSON) config entirely; not re-applied on {@link #redeployCode},
+     *  so applicationVersionId in already-emitted log lines does not advance across an in-place code
+     *  update (the JobManager/TaskManager JVMs, and therefore log4j2, are not restarted for that --
+     *  matching real MSF, which also keeps the same processes running across an UpdateApplication).
+     *  Package-private (not private) so FlinkContainerManagerTest can assert on the pattern shape
+     *  directly. */
+    byte[] msfStyleLog4j2Config(FlinkApplication app) {
+        String pattern = "{"
+                + "\"applicationARN\":\"" + app.getApplicationArn() + "\","
+                + "\"applicationVersionId\":\"" + app.getApplicationVersionId() + "\","
+                + "\"locationInformation\":\"%C.%M(%F:%L)\","
+                + "\"logger\":\"%logger\","
+                + "\"message\":\"%enc{%message}{JSON}\","
+                + "\"messageSchemaVersion\":\"1\","
+                + "\"messageType\":\"%level\","
+                + "\"threadName\":\"%enc{%thread}{JSON}\","
+                + "\"throwableInformation\":\"%enc{%ex}{JSON}\""
+                + "}%n";
+        String properties = "rootLogger.level = INFO\n"
+                + "rootLogger.appenderRef.console.ref = ConsoleAppender\n"
+                + "appender.console.type = Console\n"
+                + "appender.console.name = ConsoleAppender\n"
+                + "appender.console.layout.type = PatternLayout\n"
+                + "appender.console.layout.pattern = " + pattern + "\n";
+        return properties.getBytes(StandardCharsets.UTF_8);
     }
 
     private void copyFileIntoContainer(String containerId, String remoteDir, String relativePath, byte[] content) {

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
@@ -73,6 +73,39 @@ class KinesisAnalyticsV2ServiceTest {
     }
 
     @Test
+    void startApplicationRejectsLegacyStatePersistedBeforeNameValidationExisted() {
+        // Simulates an application created by a floci build older than
+        // createApplicationRejectsNamesOutsideAwsCharsetAndLength's check, by writing directly to
+        // storage (bypassing createApplication). startApplication must still reject it rather than
+        // silently generating a CloudWatch-log applicationARN that either drops the '$' (mismatching
+        // the real ApplicationARN) or, if some future change stopped dropping it, resolves it as a
+        // log4j2 Lookup.
+        AccountAwareStorageBackend<FlinkApplication> store =
+                AccountAwareStorageBackend.inMemory("000000000000");
+        StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
+        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(store);
+
+        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
+        var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);
+        var kaConfig = Mockito.mock(EmulatorConfig.KinesisAnalyticsServiceConfig.class);
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.kinesisAnalytics()).thenReturn(kaConfig);
+        when(kaConfig.mock()).thenReturn(true);
+        when(config.defaultRegion()).thenReturn("us-east-1");
+        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+
+        KinesisAnalyticsV2Service legacyState = new KinesisAnalyticsV2Service(
+                storageFactory, config, regionResolver, Mockito.mock(FlinkContainerManager.class));
+        FlinkApplication legacyApp = new FlinkApplication("dollar${x}",
+                "arn:aws:kinesisanalytics:us-east-1:000000000000:application/dollar${x}",
+                "FLINK-1_18", ROLE, "STREAMING");
+        store.putForAccount("000000000000", "dollar${x}", legacyApp);
+
+        AwsException ex = assertThrows(AwsException.class, () -> legacyState.startApplication("dollar${x}"));
+        assertEquals("InvalidArgumentException", ex.getErrorCode());
+    }
+
+    @Test
     void createApplicationRequiresRuntimeEnvironment() {
         assertThrows(AwsException.class,
                 () -> service.createApplication("demo", null, ROLE, null, null));

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
@@ -58,6 +58,21 @@ class KinesisAnalyticsV2ServiceTest {
     }
 
     @Test
+    void createApplicationRejectsNamesOutsideAwsCharsetAndLength() {
+        // AWS ApplicationName Pattern: [a-zA-Z0-9_.-]+, 1-128 chars. Rejecting this at the API
+        // boundary (matching real AWS) is also what keeps a name containing '%', '"', '\', or '$'
+        // from ever reaching FlinkContainerManager's generated log4j2 CloudWatch-log-format pattern,
+        // where those characters would otherwise be a log4j2 conversion-specifier/Lookup or JSON
+        // injection risk.
+        for (String badName : List.of("has spaces", "quote\"here", "percent%here", "dollar${x}",
+                "back\\slash", "a".repeat(129))) {
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> service.createApplication(badName, "FLINK-1_18", ROLE, null, null));
+            assertEquals("InvalidArgumentException", ex.getErrorCode());
+        }
+    }
+
+    @Test
     void createApplicationRequiresRuntimeEnvironment() {
         assertThrows(AwsException.class,
                 () -> service.createApplication("demo", null, ROLE, null, null));

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/KinesisAnalyticsV2ServiceTest.java
@@ -83,7 +83,8 @@ class KinesisAnalyticsV2ServiceTest {
         AccountAwareStorageBackend<FlinkApplication> store =
                 AccountAwareStorageBackend.inMemory("000000000000");
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
-        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any())).thenReturn(store);
+        Mockito.doReturn(store).when(storageFactory)
+                .create(Mockito.anyString(), Mockito.anyString(), Mockito.any());
 
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.kinesisanalytics.container;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.DockerClient;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
@@ -34,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -97,6 +99,11 @@ class FlinkContainerManagerTest {
         ContainerBuilder containerBuilder = new ContainerBuilder(config, dockerHostResolver, embeddedDnsServer);
 
         lifecycleManager = mock(ContainerLifecycleManager.class);
+        // The log4j-console.properties copy is now required (a failure fails cluster startup, see
+        // log4jConfigCopyFailureRollsBackTheClusterInsteadOfStartingWithTheStockLogFormat below), so
+        // every test that gets as far as create() succeeding needs a working docker client for that
+        // copy to land on by default.
+        when(lifecycleManager.getDockerClient()).thenReturn(mock(DockerClient.class, RETURNS_DEEP_STUBS));
         ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
         ContainerDetector containerDetector = mock(ContainerDetector.class);
         RegionResolver regionResolver = mock(RegionResolver.class);
@@ -143,6 +150,7 @@ class FlinkContainerManagerTest {
 
         ContainerLifecycleManager lifecycleManager = Mockito.mock(ContainerLifecycleManager.class);
         when(lifecycleManager.create(any())).thenReturn("jm-container-id");
+        when(lifecycleManager.getDockerClient()).thenReturn(mock(DockerClient.class, RETURNS_DEEP_STUBS));
         when(lifecycleManager.startCreated(any(), any())).thenReturn(
                 new ContainerLifecycleManager.ContainerInfo("jm-container-id", Map.of(8081,
                         new ContainerLifecycleManager.EndpointInfo("localhost", 8081))));
@@ -218,10 +226,34 @@ class FlinkContainerManagerTest {
         String config = new String(manager.msfStyleLog4j2Config(app), java.nio.charset.StandardCharsets.UTF_8);
 
         assertTrue(config.contains(
-                "\"applicationARN\":\"arn:aws:kinesisanalytics:us-east-1:000000000000:application/demo\""));
-        assertTrue(config.contains("\"applicationVersionId\":\"2\""));
+                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/demo}{JSON}\""));
+        assertTrue(config.contains("\"applicationVersionId\":\"%enc{2}{JSON}\""));
         assertTrue(config.contains("\"messageSchemaVersion\":\"1\""));
         assertTrue(config.contains("appender.console.layout.type = PatternLayout"));
+    }
+
+    @Test
+    void msfStyleLog4j2ConfigEscapesLog4jAndPropertiesSyntaxInTheApplicationName() throws Exception {
+        // ApplicationName flows straight into the ARN with no character-set validation today, so a
+        // name containing '%' (a log4j2 conversion-specifier marker) or '\' (a java.util.Properties
+        // escape character, since Flink loads this file with Properties-style parsing) must not reach
+        // the pattern unescaped -- otherwise it either breaks log4j2's config parser or lets the value
+        // corrupt/collide with the surrounding pattern syntax before %enc{}{JSON} ever sees it.
+        FlinkApplication app = new FlinkApplication("100%-\\-owned",
+                "arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%-\\-owned",
+                "FLINK-2_3", "arn:aws:iam::000000000000:role/x", "STREAMING");
+        app.setApplicationVersionId(1L);
+
+        String config = new String(manager.msfStyleLog4j2Config(app), java.nio.charset.StandardCharsets.UTF_8);
+
+        assertTrue(config.contains(
+                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%%-\\\\-owned}{JSON}\""));
+
+        java.util.Properties parsed = new java.util.Properties();
+        parsed.load(new java.io.ByteArrayInputStream(config.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+        String loadedPattern = parsed.getProperty("appender.console.layout.pattern");
+        assertTrue(loadedPattern.contains(
+                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%%-\\-owned}{JSON}\""));
     }
 
     @Test
@@ -305,6 +337,25 @@ class FlinkContainerManagerTest {
         assertNull(app.getContainerId());
         assertNull(app.getRestEndpoint());
         assertNull(app.getTaskManagerContainerId());
+    }
+
+    @Test
+    void log4jConfigCopyFailureRollsBackTheClusterInsteadOfStartingWithTheStockLogFormat() {
+        // Before this test, a failed copy of log4j-console.properties was only logged: startCreated()
+        // still ran and startCluster() reported success, so the cluster silently kept the stock
+        // (non-JSON) log format instead of the MSF-style CloudWatch schema this whole feature exists
+        // to provide. copyFileIntoContainer(..., required=true) now rethrows instead, so this failure
+        // takes the same create()-failure rollback path already covered above.
+        FlinkApplication app = application("log4j-copy-failure");
+        when(lifecycleManager.create(any())).thenReturn("jm-id");
+        when(lifecycleManager.getDockerClient()).thenThrow(new RuntimeException("docker copy unavailable"));
+
+        assertThrows(RuntimeException.class, () -> manager.startCluster(app));
+
+        verify(lifecycleManager, times(2)).removeIfExists("floci-kinesisanalytics-log4j-copy-failure");
+        verify(lifecycleManager, atLeastOnce()).removeIfExists("floci-kinesisanalytics-log4j-copy-failure-tm");
+        verify(lifecycleManager, Mockito.never()).startCreated(any(), any());
+        assertNull(app.getContainerId());
     }
 
     private List<ContainerSpec> captureCreatedSpecs() {

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
@@ -142,7 +142,8 @@ class FlinkContainerManagerTest {
         when(storage.hostPersistentPath()).thenReturn("floci-data");
 
         ContainerLifecycleManager lifecycleManager = Mockito.mock(ContainerLifecycleManager.class);
-        when(lifecycleManager.createAndStart(any())).thenReturn(
+        when(lifecycleManager.create(any())).thenReturn("jm-container-id");
+        when(lifecycleManager.startCreated(any(), any())).thenReturn(
                 new ContainerLifecycleManager.ContainerInfo("jm-container-id", Map.of(8081,
                         new ContainerLifecycleManager.EndpointInfo("localhost", 8081))));
 
@@ -208,9 +209,26 @@ class FlinkContainerManagerTest {
     }
 
     @Test
+    void msfStyleLog4j2ConfigBakesInTheApplicationArnAndVersion() throws Exception {
+        FlinkApplication app = new FlinkApplication("demo",
+                "arn:aws:kinesisanalytics:us-east-1:000000000000:application/demo",
+                "FLINK-2_3", "arn:aws:iam::000000000000:role/x", "STREAMING");
+        app.setApplicationVersionId(2L);
+
+        String config = new String(manager.msfStyleLog4j2Config(app), java.nio.charset.StandardCharsets.UTF_8);
+
+        assertTrue(config.contains(
+                "\"applicationARN\":\"arn:aws:kinesisanalytics:us-east-1:000000000000:application/demo\""));
+        assertTrue(config.contains("\"applicationVersionId\":\"2\""));
+        assertTrue(config.contains("\"messageSchemaVersion\":\"1\""));
+        assertTrue(config.contains("appender.console.layout.type = PatternLayout"));
+    }
+
+    @Test
     void bareClusterInjectsAwsSdkEnvironmentAndContainerReachability() {
         FlinkApplication app = application("bare");
-        when(lifecycleManager.createAndStart(any())).thenReturn(new ContainerInfo(
+        when(lifecycleManager.create(any())).thenReturn("jm-id");
+        when(lifecycleManager.startCreated(any(), any())).thenReturn(new ContainerInfo(
                 "jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))));
 
         manager.startCluster(app);
@@ -234,7 +252,8 @@ class FlinkContainerManagerTest {
         app.setParallelism(3);
         when(s3Service.getObject("code-bucket", "jobs/demo.jar", null))
                 .thenReturn(new S3Object("code-bucket", "jobs/demo.jar", new byte[]{1}, "application/java-archive"));
-        when(lifecycleManager.createAndStart(any()))
+        when(lifecycleManager.create(any())).thenReturn("jm-id").thenReturn("tm-id");
+        when(lifecycleManager.startCreated(any(), any()))
                 .thenReturn(new ContainerInfo("jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))))
                 .thenReturn(new ContainerInfo("tm-id", Map.of()));
 
@@ -257,7 +276,7 @@ class FlinkContainerManagerTest {
     @Test
     void jobManagerStartFailureRemovesThePartialCluster() {
         FlinkApplication app = application("jm-failure");
-        when(lifecycleManager.createAndStart(any())).thenThrow(new RuntimeException("jobmanager failed"));
+        when(lifecycleManager.create(any())).thenThrow(new RuntimeException("jobmanager failed"));
 
         assertThrows(RuntimeException.class, () -> manager.startCluster(app));
 
@@ -274,9 +293,10 @@ class FlinkContainerManagerTest {
         app.setCodeS3Key("jobs/demo.jar");
         when(s3Service.getObject("code-bucket", "jobs/demo.jar", null))
                 .thenReturn(new S3Object("code-bucket", "jobs/demo.jar", new byte[]{1}, "application/java-archive"));
-        when(lifecycleManager.createAndStart(any()))
-                .thenReturn(new ContainerInfo("jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))))
+        when(lifecycleManager.create(any())).thenReturn("jm-id")
                 .thenThrow(new RuntimeException("taskmanager failed"));
+        when(lifecycleManager.startCreated(any(), any()))
+                .thenReturn(new ContainerInfo("jm-id", Map.of(8081, new EndpointInfo("localhost", 49152))));
 
         assertThrows(RuntimeException.class, () -> manager.startCluster(app));
 
@@ -289,7 +309,7 @@ class FlinkContainerManagerTest {
 
     private List<ContainerSpec> captureCreatedSpecs() {
         ArgumentCaptor<ContainerSpec> captor = ArgumentCaptor.forClass(ContainerSpec.class);
-        verify(lifecycleManager, atLeastOnce()).createAndStart(captor.capture());
+        verify(lifecycleManager, atLeastOnce()).create(captor.capture());
         return captor.getAllValues();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesisanalytics/container/FlinkContainerManagerTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -234,26 +235,29 @@ class FlinkContainerManagerTest {
 
     @Test
     void msfStyleLog4j2ConfigEscapesLog4jAndPropertiesSyntaxInTheApplicationName() throws Exception {
-        // ApplicationName flows straight into the ARN with no character-set validation today, so a
-        // name containing '%' (a log4j2 conversion-specifier marker) or '\' (a java.util.Properties
-        // escape character, since Flink loads this file with Properties-style parsing) must not reach
-        // the pattern unescaped -- otherwise it either breaks log4j2's config parser or lets the value
-        // corrupt/collide with the surrounding pattern syntax before %enc{}{JSON} ever sees it.
-        FlinkApplication app = new FlinkApplication("100%-\\-owned",
-                "arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%-\\-owned",
+        // KinesisAnalyticsV2Service now rejects an ApplicationName outside AWS's own
+        // [a-zA-Z0-9_.-] charset, but this stays defensive in case some other caller ever builds a
+        // FlinkApplication directly: '%' would be a log4j2 conversion-specifier marker, '\' is a
+        // java.util.Properties escape character (Flink loads this file with Properties-style
+        // parsing), and '$' could start a log4j2 '${...}' Lookup that leaks an env var/system
+        // property into every log line -- none of that may reach the pattern unescaped.
+        FlinkApplication app = new FlinkApplication("100%-\\-${env:PATH}-owned",
+                "arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%-\\-${env:PATH}-owned",
                 "FLINK-2_3", "arn:aws:iam::000000000000:role/x", "STREAMING");
         app.setApplicationVersionId(1L);
 
         String config = new String(manager.msfStyleLog4j2Config(app), java.nio.charset.StandardCharsets.UTF_8);
 
         assertTrue(config.contains(
-                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%%-\\\\-owned}{JSON}\""));
+                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%%-\\\\-{env:PATH}-owned}{JSON}\""));
 
         java.util.Properties parsed = new java.util.Properties();
         parsed.load(new java.io.ByteArrayInputStream(config.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
         String loadedPattern = parsed.getProperty("appender.console.layout.pattern");
         assertTrue(loadedPattern.contains(
-                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%%-\\-owned}{JSON}\""));
+                "\"applicationARN\":\"%enc{arn:aws:kinesisanalytics:us-east-1:000000000000:application/100%%-\\-{env:PATH}-owned}{JSON}\""));
+        assertFalse(loadedPattern.contains("${env:PATH}"), "the $ must not survive, or log4j2 would treat "
+                + "this as a Lookup and resolve it against the environment at config-load time");
     }
 
     @Test


### PR DESCRIPTION
## Summary

The JobManager/TaskManager now start with a `log4j-console.properties` that formats every log line as a single JSON object matching real Managed Service for Apache Flink's CloudWatch Logs schema (`applicationARN`, `applicationVersionId`, `locationInformation`, `logger`, `message`, `messageSchemaVersion`, `messageType`, `threadName`, `throwableInformation`), instead of the stock image's default plain-text pattern. Applies to Flink's own framework logs and anything a deployed JAR logs through SLF4J/Log4j2, so a JAR that expects its logs to reach CloudWatch (or asserts on this schema) sees the same thing here as on real MSF.

The config is written into the container before the JVM starts (log4j2 reads its config at process boot, so copying it in after start — the way `application_properties.json` already is — would be too late). This required splitting the JobManager/TaskManager container startup from `createAndStart` into `create` + copy + `startCreated`, using the create-then-inject-then-start pattern `ContainerLifecycleManager` already exposed for exactly this purpose.

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Verified the field set and shapes against real MSF CloudWatch Logs output (AWS docs + example log lines): `applicationARN`, `applicationVersionId`, `locationInformation`, `logger`, `message`, `messageSchemaVersion`, `messageType`, `threadName`, `throwableInformation` are all present with matching names, and `throwableInformation` is a plain string with escaped newlines (not an array), matching real output. One known, documented gap: real AWS omits the `throwableInformation` key entirely when there's no exception, while this always includes it as an empty string — noted in `docs/services/kinesisanalytics.md`.

## Checklist

- [ ] Full test run passes locally
- [x] New or updated test added (unit test on the config-building method, matching how `application_properties.json`'s shape is already tested in this file)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
