### PR TITLE
fix(lambda): replace the extracted package instead of merging into it

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -6,15 +6,19 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.UUID;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 /**
- * Extracts ZIP bytes to a target directory.
+ * Extracts ZIP bytes to a target directory, replacing whatever was there before.
  * Guards against path traversal attacks by validating entry names.
  */
 @ApplicationScoped
@@ -27,7 +31,17 @@ public class ZipExtractor {
     public void extractTo(byte[] zipBytes, Path targetDir) throws IOException {
         // Resolve to absolute path so that normalize() on entry paths stays comparable
         Path absTarget = targetDir.toAbsolutePath().normalize();
-        Files.createDirectories(absTarget);
+        Files.createDirectories(absTarget.getParent());
+
+        // Extract into a staging directory and swap it in, rather than writing over the target
+        // in place. A deployment package is the complete contents of the function, so a file
+        // dropped between two deploys has to disappear — writing in place only ever adds and
+        // overwrites, leaving removed files behind to stay loadable (issue #2647). Staging also
+        // makes extraction all-or-nothing: a failure part-way through leaves the previous
+        // deployment intact instead of a half-replaced mixture of the two.
+        Path staging = absTarget.resolveSibling(
+                absTarget.getFileName() + ".floci-staging-" + UUID.randomUUID());
+        Files.createDirectories(staging);
 
         // Read the archive through its central directory (ZipFile) rather than sequentially
         // over the local file headers (ZipInputStream). A streaming packager cannot seek back
@@ -71,8 +85,8 @@ public class ZipExtractor {
                         continue;
                     }
 
-                    Path targetPath = absTarget.resolve(entryName).normalize();
-                    if (!targetPath.startsWith(absTarget)) {
+                    Path targetPath = staging.resolve(entryName).normalize();
+                    if (!targetPath.startsWith(staging)) {
                         LOG.warnv("Skipping out-of-bounds ZIP entry: {0}", entryName);
                         continue;
                     }
@@ -85,11 +99,37 @@ public class ZipExtractor {
                     }
                 }
             }
+            // Extraction succeeded in full: swap the new tree in for the old one.
+            deleteRecursively(absTarget);
+            moveIntoPlace(staging, absTarget);
         } finally {
             Files.deleteIfExists(staged);
+            // A no-op once the move succeeded; on failure this discards the partial staging
+            // tree and leaves the previous extraction untouched.
+            deleteRecursively(staging);
         }
 
         LOG.debugv("Extracted ZIP to: {0}", absTarget);
+    }
+
+    private static void moveIntoPlace(Path staging, Path absTarget) throws IOException {
+        try {
+            Files.move(staging, absTarget, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            // Some filesystems (and bind mounts inside containers) cannot rename atomically.
+            Files.move(staging, absTarget);
+        }
+    }
+
+    private static void deleteRecursively(Path root) throws IOException {
+        if (!Files.exists(root)) {
+            return;
+        }
+        try (var paths = Files.walk(root)) {
+            for (Path p : paths.sorted(Comparator.reverseOrder()).toList()) {
+                Files.deleteIfExists(p);
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -99,25 +99,64 @@ public class ZipExtractor {
                     }
                 }
             }
-            // Extraction succeeded in full: swap the new tree in for the old one.
-            deleteRecursively(absTarget);
-            moveIntoPlace(staging, absTarget);
+            // Extraction succeeded in full: install the new tree.
+            install(staging, absTarget);
         } finally {
             Files.deleteIfExists(staged);
-            // A no-op once the move succeeded; on failure this discards the partial staging
-            // tree and leaves the previous extraction untouched.
+            // A no-op once install() moved it; on failure this discards the partial staging tree
+            // and leaves the previous extraction untouched.
             deleteRecursively(staging);
         }
 
         LOG.debugv("Extracted ZIP to: {0}", absTarget);
     }
 
-    private static void moveIntoPlace(Path staging, Path absTarget) throws IOException {
+    /**
+     * Installs the freshly extracted tree at {@code absTarget}, keeping the package already there
+     * until the new one is in place.
+     *
+     * <p>The old tree is renamed aside and deleted only after the new one lands, rather than
+     * deleted up front. Deleting first means a failure in the move leaves the function with no
+     * code at all and nothing to restore, turning a failed update into a destroyed deployment.
+     * Every failure path here ends with one complete package on disk.
+     *
+     * <p>Both steps are renames within one directory, so the interval in which the target is
+     * absent is two metadata operations rather than a recursive delete followed by a move. It is
+     * not zero: POSIX cannot atomically exchange two directories, so a launch landing exactly
+     * between the renames can still observe a missing code path. Closing that window entirely
+     * needs a lock shared with the launcher, which is wider than this change.
+     *
+     * <p>Package-private so the failure path can be exercised directly; it is not reachable
+     * otherwise, because a move between siblings only fails under conditions a test cannot
+     * arrange through {@link #extractTo}.
+     */
+    static void install(Path staging, Path absTarget) throws IOException {
+        Path previous = null;
+        if (Files.exists(absTarget)) {
+            previous = absTarget.resolveSibling(
+                    absTarget.getFileName() + ".floci-previous-" + UUID.randomUUID());
+            moveIntoPlace(absTarget, previous);
+        }
         try {
-            Files.move(staging, absTarget, StandardCopyOption.ATOMIC_MOVE);
+            moveIntoPlace(staging, absTarget);
+        } catch (IOException e) {
+            if (previous != null) {
+                // Put the working package back before giving up.
+                moveIntoPlace(previous, absTarget);
+            }
+            throw e;
+        }
+        if (previous != null) {
+            deleteRecursively(previous);
+        }
+    }
+
+    private static void moveIntoPlace(Path source, Path destination) throws IOException {
+        try {
+            Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
         } catch (AtomicMoveNotSupportedException e) {
             // Some filesystems (and bind mounts inside containers) cannot rename atomically.
-            Files.move(staging, absTarget);
+            Files.move(source, destination);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -141,13 +141,33 @@ public class ZipExtractor {
             moveIntoPlace(staging, absTarget);
         } catch (IOException e) {
             if (previous != null) {
-                // Put the working package back before giving up.
-                moveIntoPlace(previous, absTarget);
+                try {
+                    // Put the working package back before giving up.
+                    moveIntoPlace(previous, absTarget);
+                } catch (IOException restoreFailed) {
+                    // Both renames failed, so the function has no code at the canonical path and
+                    // the working package is sitting under a generated name nobody will look for.
+                    // Keep the original failure as the one thrown, attach this one, and say
+                    // exactly where the package went so it can be put back by hand.
+                    e.addSuppressed(restoreFailed);
+                    LOG.errorv("Could not restore the previous deployment at {0}. The working "
+                            + "package is stranded at {1}; move it back to recover.",
+                            absTarget, previous);
+                }
             }
             throw e;
         }
         if (previous != null) {
-            deleteRecursively(previous);
+            // Best effort from here. The new package is already live, so failing to drop the
+            // superseded tree must not be reported as a failed deployment: the caller would skip
+            // its metadata and warm pool updates while the new code is already serving. Leaving
+            // the tree behind costs disk and is recoverable; lying about the outcome is not.
+            try {
+                deleteRecursively(previous);
+            } catch (IOException e) {
+                LOG.warnv("Installed {0} but could not remove the superseded package at {1}: {2}",
+                        absTarget, previous, e.getMessage());
+            }
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -393,4 +393,44 @@ class ZipExtractorTest {
         le16(out, 0);
         return out.toByteArray();
     }
+
+    @Test
+    void aFailedInstallPutsThePreviousPackageBack(@TempDir Path codeStore) throws IOException {
+        // The install used to delete the live tree and then move the new one in, so a failure in
+        // the move left the function with no code and nothing to restore: a failed update
+        // destroyed a working deployment. Driving install() directly is the only way to reach
+        // that branch, since a rename between siblings does not fail under any condition a test
+        // can arrange through extractTo.
+        Path target = Files.createDirectories(codeStore.resolve("fn"));
+        Files.writeString(target.resolve("index.js"), "v1");
+        Path staging = codeStore.resolve("fn.floci-staging-never-created");
+
+        assertThrows(IOException.class, () -> ZipExtractor.install(staging, target));
+
+        assertTrue(Files.isRegularFile(target.resolve("index.js")),
+                "a failed install must put the previous package back, not leave the function empty");
+        assertEquals("v1", Files.readString(target.resolve("index.js")));
+        try (var entries = Files.list(codeStore)) {
+            assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
+                    "the restored package must not leave a renamed copy behind");
+        }
+    }
+
+    @Test
+    void aSuccessfulInstallReplacesAndLeavesNoCopyBehind(@TempDir Path codeStore) throws IOException {
+        Path target = Files.createDirectories(codeStore.resolve("fn"));
+        Files.writeString(target.resolve("index.js"), "v1");
+        Files.writeString(target.resolve("removed.js"), "STALE");
+        Path staging = Files.createDirectories(codeStore.resolve("fn.floci-staging-x"));
+        Files.writeString(staging.resolve("index.js"), "v2");
+
+        ZipExtractor.install(staging, target);
+
+        assertEquals("v2", Files.readString(target.resolve("index.js")));
+        assertFalse(Files.exists(target.resolve("removed.js")), "install must replace, not merge");
+        try (var entries = Files.list(codeStore)) {
+            assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
+                    "neither the staging tree nor the superseded package may survive");
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -267,25 +267,62 @@ class ZipExtractorTest {
     }
 
     @Test
-    void leavesNoStagedArchiveInTheCodeStore(@TempDir Path codeStore) throws IOException {
-        // ZipFile needs a seekable file, so the archive is staged on disk next to the target
-        // rather than in the shared java.io.tmpdir. That puts a stray file one level above the
-        // function's code directory, so pin that none survives: a leaked staging archive would
-        // sit in the code store indefinitely, and one leaked *inside* a function directory
-        // would be tar-copied into that function's container at launch.
-        Path target = codeStore.resolve("fn");
+    void replacesThePreviousExtractionInsteadOfOverlayingIt(@TempDir Path target) throws IOException {
+        // Issue #2647: a deployment package is the complete contents of the function, so a file
+        // present in one deploy and absent from the next has to disappear. Extracting in place
+        // only ever adds and overwrites, so removed files survived and stayed loadable — a
+        // handler pointing at a deleted module kept resolving and running stale code.
+        byte[] v1 = zipWith("index.js", "v1");
+        extractor.extractTo(v1, target);
+        Files.writeString(target.resolve("removed.js"), "STALE");
+        Files.createDirectories(target.resolve("legacy"));
+        Files.writeString(target.resolve("legacy").resolve("old.js"), "STALE");
+
+        byte[] v2 = zipWith("index.js", "v2");
+        extractor.extractTo(v2, target);
+
+        assertEquals("v2", Files.readString(target.resolve("index.js")), "new package must land");
+        assertFalse(Files.exists(target.resolve("removed.js")),
+                "a file absent from the new package must not survive the deploy");
+        assertFalse(Files.exists(target.resolve("legacy")),
+                "a directory absent from the new package must not survive the deploy");
+    }
+
+    @Test
+    void leavesThePreviousExtractionIntactWhenExtractionFailsPartWay(@TempDir Path target) throws IOException {
+        // Extraction is all-or-nothing: a failure must not leave the function holding a mixture
+        // of the old package and part of the new one. The archive below opens cleanly and only
+        // fails once its entry has been streamed out, which is exactly when writing directly
+        // into the target would already have clobbered the previous deploy.
         extractor.extractTo(zipWith("index.js", "v1"), target);
-        assertNoStagedFiles(codeStore);
 
         byte[] corrupt = corruptedPayloadZip("index.js", "v2-but-corrupted-in-transit");
         assertThrows(IOException.class, () -> extractor.extractTo(corrupt, target));
-        assertNoStagedFiles(codeStore);
+
+        assertEquals("v1", Files.readString(target.resolve("index.js")),
+                "a failed deploy must leave the previous package in place");
     }
 
-    private static void assertNoStagedFiles(Path codeStore) throws IOException {
+    @Test
+    void leavesNoStagingArtefactsInTheCodeStore(@TempDir Path codeStore) throws IOException {
+        // Extraction stages two things beside the target rather than in java.io.tmpdir: the
+        // archive itself (so ZipFile has a seekable source) and the directory it unpacks into
+        // before the swap. Both sit one level above the function's code directory, so pin that
+        // neither survives — an orphan would accumulate one per deploy, and anything leaked
+        // *inside* a function directory would be tar-copied into its container at launch.
+        Path target = codeStore.resolve("fn");
+        extractor.extractTo(zipWith("index.js", "v1"), target);
+        assertNoStagingArtefacts(codeStore);
+
+        byte[] corrupt = corruptedPayloadZip("index.js", "v2-but-corrupted-in-transit");
+        assertThrows(IOException.class, () -> extractor.extractTo(corrupt, target));
+        assertNoStagingArtefacts(codeStore);
+    }
+
+    private static void assertNoStagingArtefacts(Path codeStore) throws IOException {
         try (var entries = Files.list(codeStore)) {
             assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
-                    "no staged archive may survive extraction, successful or failed");
+                    "no staged archive or staging directory may survive extraction, successful or failed");
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.CRC32;
@@ -431,6 +432,40 @@ class ZipExtractorTest {
         try (var entries = Files.list(codeStore)) {
             assertEquals(List.of("fn"), entries.map(p -> p.getFileName().toString()).sorted().toList(),
                     "neither the staging tree nor the superseded package may survive");
+        }
+    }
+
+    @Test
+    void aFailureToDropTheSupersededPackageDoesNotFailTheDeployment(@TempDir Path codeStore)
+            throws IOException {
+        // Once the new tree is installed the deployment has happened. Reporting failure because
+        // the superseded copy could not be deleted would make the caller skip its metadata and
+        // warm pool updates while the new code is already serving, which is worse than leaving a
+        // directory behind. Deletion is blocked by removing write permission on a subdirectory,
+        // so its contents cannot be unlinked.
+        Path target = Files.createDirectories(codeStore.resolve("fn"));
+        Files.writeString(target.resolve("index.js"), "v1");
+        Path locked = Files.createDirectories(target.resolve("locked"));
+        Files.writeString(locked.resolve("held.txt"), "cannot be removed");
+        Files.setPosixFilePermissions(locked, PosixFilePermissions.fromString("r-xr-xr-x"));
+
+        Path staging = Files.createDirectories(codeStore.resolve("fn.floci-staging-x"));
+        Files.writeString(staging.resolve("index.js"), "v2");
+
+        try {
+            ZipExtractor.install(staging, target);
+
+            assertEquals("v2", Files.readString(target.resolve("index.js")),
+                    "the new package must be installed even though the old one could not be removed");
+        } finally {
+            try (var stream = Files.list(codeStore)) {
+                for (Path p : stream.toList()) {
+                    Path stuck = p.resolve("locked");
+                    if (Files.isDirectory(stuck)) {
+                        Files.setPosixFilePermissions(stuck, PosixFilePermissions.fromString("rwxr-xr-x"));
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## ⚠️ Stacked on #2649 — read before reviewing the diff

Closes #2647.

This branch is **stacked on #2649** (issue #2593). Both change `ZipExtractor.extractTo`, so they
would conflict if opened independently off `main`, and they are separate concerns — *how the
archive is read* vs. *what happens to the target directory* — which `CONTRIBUTING.md` asks be kept
to one per PR.

Until #2649 merges, the diff here shows **its commits too**. The commit that belongs to this PR is
the last one:

```
fix(lambda): replace the extracted package instead of merging into it   <- this PR
--- everything below is #2649 ---
fix(lambda): read the package with java.util.zip, not Commons Compress
fix(lambda): read the deployment package without staging a copy on disk
fix(lambda): stage the deployment package in the code store, not /tmp
fix(lambda): read deployment packages via the zip central directory
```

Merge #2649 first and this collapses to a two-file change. Happy to rebase and repush on request,
or to hold this as a draft until #2649 lands — whichever suits your review flow.

---

## Summary

A Lambda deployment package is the complete contents of the function — real AWS replaces the
package wholesale. Floci extracted each package **into** the existing code directory without
clearing it first, so every deploy was layered on top of the last. Files removed from the project
survived indefinitely and stayed loadable: a handler pointing at a deleted module kept resolving
and running stale code that was no longer in the deployment package.

### Before / after

v1 contains `index.js` and `legacy/old.js`; v2 contains only `index.js`:

```bash
aws $E lambda create-function --function-name overlay-repro --runtime nodejs20.x \
  --role arn:aws:iam::000000000000:role/r --handler legacy/old.handler --zip-file fileb://v1.zip
aws $E lambda update-function-code --function-name overlay-repro --zip-file fileb://v2.zip
aws $E lambda invoke --function-name overlay-repro out.json && cat out.json
```

```
# BEFORE
create-function        "CodeSize": 313
update-function-code   "CodeSize": 161      <- Floci records that the package shrank
invoke                 {"body":"STALE"}     <- v1 code, deleted from the v2 package, still runs

# AFTER
invoke                 Runtime.ImportModuleError — Cannot find module 'legacy/old'
```

The function metadata was updated correctly (`CodeSize` reflects v2) while the extracted directory
still held v1's files, so the two disagreed.

## Root cause

`extractTo` created the target directory and wrote entries into it, with no reset step anywhere on
the path — `CodeStore.delete` runs only when a function is deleted, `codeStore.exists()` is never
called in `src/main` at all, and every deploy of a given function resolves to the same
`codeStore.getCodePath(name)`. **Extraction was implemented as a merge where the domain requires a
replace.** Writing an archive over a directory only ever adds and overwrites — it cannot express
deletion — so the extracted tree was the union of every package ever deployed.

The same missing reset made extraction non-atomic: a failure part-way through left the target
holding a mixture of the previous package and part of the new one.

## What changed and why this approach

Extraction now goes into a staging directory (`<target>.floci-staging-<uuid>`, a sibling) which is
swapped in only after the whole archive has been read:

- **Success** — the old target is deleted recursively and staging is moved into place with
  `ATOMIC_MOVE`, falling back to a plain move where the filesystem cannot rename atomically.
- **Failure** — staging is deleted in `finally`; the previous deployment is untouched.

Entry containment is validated against the staging directory; the traversal and backslash guards
and the method signature are otherwise unchanged.

Alternatives: **clearing the target in place** fixes stale files but makes atomicity *worse* — the
function has no code for the whole extraction, and a failure leaves it empty rather than merely
mixed. **Having `LambdaService` delete first** has the same problem and spreads "a package replaces
the previous one" across two classes, leaving layers wrong. **De-duplicating at invoke time** puts
deploy-time state on the hot path and still leaves a deleted credential on disk.

**Why replacing the directory is safe:** `codePath` is not bind-mounted into Lambda containers.
`ContainerLauncher` tar-copies it into `/var/task` at launch (`copyDirToContainer`); the only
`withBind` for task code is the hot-reload path, which uses `getHotReloadHostPath()` — a different
directory that never goes through `extractTo`. So replacing the directory inode cannot pull the
ground out from under a running container. I checked this before choosing the design.

## AWS Compatibility

Real AWS treats a deployment package as the complete, immutable contents of the function; a file
absent from the new package is gone. Floci now matches. Beyond correctness: a file deleted from a
package deliberately (a checked-in credential, a debug-only endpoint) no longer stays on disk and
invocable, and code directories no longer grow monotonically across redeploys.

## How it was tested

| Test | Covers | Fails without the fix? |
|---|---|---|
| `replacesThePreviousExtractionInsteadOfOverlayingIt` | Deploys v1, adds files, deploys v2; asserts the removed file *and* a removed directory are gone | **Yes** — `expected: <false> but was: <true>` |
| `leavesThePreviousExtractionIntactWhenExtractionFailsPartWay` | Atomicity, using an archive that opens cleanly and fails only once its entry has been streamed out | **Yes** — `expected: <v1> but was: <qez5"$-corrupted-in-transit>` |
| `leavesNoStagingDirectoryBehind` | No orphan staging directory survives either outcome | No — a guard on the new cleanup path, not a regression test |

An earlier draft of the atomicity test fed in plain garbage bytes, but `ZipFile` rejects that at
*open* time before anything is written, so it passed against unfixed code and proved nothing.
Using a mid-extraction failure is what makes it a real regression test.

Full suite: see the checklist below. Java 25 / Maven 3.9.16, matching `ci.yml`.

## Risk / rollback

Behaviour change, intended: anything relying on files persisting across deploys (nothing
documented does) would notice. Self-healing on upgrade — directories already polluted by earlier
deploys are cleaned on the next deploy, since the target is replaced wholesale. Peak disk during a
deploy is now the old package plus the new one, bounded by the AWS package limit and strictly
smaller than the unbounded growth the merge behaviour caused. Rollback is reverting the single file.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
