### PR TITLE
fix(dynamodb): hybrid persistence

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
@@ -64,6 +64,7 @@ public class GlobalSecondaryIndex {
     public long getIndexSizeBytes() { return indexSizeBytes; }
     public void setIndexSizeBytes(long indexSizeBytes) { this.indexSizeBytes = indexSizeBytes; }
 
+    @JsonIgnore
     public String getPartitionKeyName() {
         return keySchema.stream()
                 .filter(k -> "HASH".equals(k.getKeyType()))
@@ -72,6 +73,7 @@ public class GlobalSecondaryIndex {
                 .orElseThrow();
     }
 
+    @JsonIgnore
     public String getSortKeyName() {
         return keySchema.stream()
                 .filter(k -> "RANGE".equals(k.getKeyType()))

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/LocalSecondaryIndex.java
@@ -63,6 +63,7 @@ public class LocalSecondaryIndex {
     public long getItemCount() { return itemCount; }
     public void setItemCount(long itemCount) { this.itemCount = itemCount; }
 
+    @JsonIgnore
     public String getPartitionKeyName() {
         return keySchema.stream()
                 .filter(k -> "HASH".equals(k.getKeyType()))
@@ -71,6 +72,7 @@ public class LocalSecondaryIndex {
                 .orElseThrow();
     }
 
+    @JsonIgnore
     public String getSortKeyName() {
         return keySchema.stream()
                 .filter(k -> "RANGE".equals(k.getKeyType()))

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -207,6 +207,7 @@ public class TableDefinition {
     public Integer getOnDemandMaxWriteRequestUnits() { return onDemandMaxWriteRequestUnits; }
     public void setOnDemandMaxWriteRequestUnits(Integer v) { this.onDemandMaxWriteRequestUnits = v; }
 
+    @JsonIgnore
     public String getPartitionKeyName() {
         return keySchema.stream()
                 .filter(k -> "HASH".equals(k.getKeyType()))
@@ -216,6 +217,7 @@ public class TableDefinition {
     }
 
     /** Returns the sort key attribute name, or null if none. */
+    @JsonIgnore
     public String getSortKeyName() {
         return keySchema.stream()
                 .filter(k -> "RANGE".equals(k.getKeyType()))

--- a/src/test/java/io/github/hectorvent/floci/core/storage/HybridStorageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/HybridStorageTest.java
@@ -1,12 +1,17 @@
 package io.github.hectorvent.floci.core.storage;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
+import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
+import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -47,6 +52,29 @@ class HybridStorageTest {
         var store2 = new HybridStorage<>(filePath, new TypeReference<Map<String, String>>() {}, 60000);
         store2.load();
         assertEquals("value1", store2.get("key1").orElseThrow());
+        store2.shutdown();
+    }
+
+    @Test
+    void dynamoTableWithLocalSecondaryIndexSurvivesRestart() {
+        Path filePath = tempDir.resolve("dynamodb-tables.json");
+        TypeReference<Map<String, TableDefinition>> type = new TypeReference<>() {};
+        var table = new TableDefinition(
+                "ConfigTable",
+                List.of(new KeySchemaElement("pk", "HASH"), new KeySchemaElement("sk", "RANGE")),
+                List.of(new AttributeDefinition("pk", "S"), new AttributeDefinition("sk", "S")));
+        table.setLocalSecondaryIndexes(List.of(new LocalSecondaryIndex(
+                "lsi", List.of(new KeySchemaElement("pk", "HASH"),
+                        new KeySchemaElement("lsiSk", "RANGE")), null, "ALL")));
+
+        var store1 = new HybridStorage<String, TableDefinition>(filePath, type, 60000);
+        store1.put("000000000000/us-east-1::ConfigTable", table);
+        store1.shutdown();
+
+        var store2 = new HybridStorage<String, TableDefinition>(filePath, type, 60000);
+        store2.load();
+        TableDefinition restored = store2.get("000000000000/us-east-1::ConfigTable").orElseThrow();
+        assertEquals("lsiSk", restored.getLocalSecondaryIndexes().getFirst().getSortKeyName());
         store2.shutdown();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/core/storage/HybridStorageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/HybridStorageTest.java
@@ -62,7 +62,8 @@ class HybridStorageTest {
         var table = new TableDefinition(
                 "ConfigTable",
                 List.of(new KeySchemaElement("pk", "HASH"), new KeySchemaElement("sk", "RANGE")),
-                List.of(new AttributeDefinition("pk", "S"), new AttributeDefinition("sk", "S")));
+                List.of(new AttributeDefinition("pk", "S"), new AttributeDefinition("sk", "S"),
+                        new AttributeDefinition("lsiSk", "S")));
         table.setLocalSecondaryIndexes(List.of(new LocalSecondaryIndex(
                 "lsi", List.of(new KeySchemaElement("pk", "HASH"),
                         new KeySchemaElement("lsiSk", "RANGE")), null, "ALL")));


### PR DESCRIPTION
## Summary

DynamoDB table, GSI, and LSI definitions lose their partition/sort key names when a Floci instance restarts under hybrid (disk-backed) storage.

`TableDefinition`, `GlobalSecondaryIndex`, and `LocalSecondaryIndex` each expose derived getters — `getPartitionKeyName()` / `getSortKeyName()` — computed from the real `keySchema` list. Jackson treats any public no-arg getter as a serializable bean property by default, so these computed values were written into the persisted JSON as `partitionKeyName` / `sortKeyName` fields alongside the real `keySchema`. On deserialization there is no matching setter or constructor parameter for those synthetic fields, so Jackson silently drops them — but for `LocalSecondaryIndex` in particular, the round-trip left the index's derived sort key name unrecoverable after a restart, because the only source of truth (`keySchema`) round-trips fine but any code path relying on the *serialized* `sortKeyName` value found nothing to bind to.

Fix: annotate the four derived getters (`GlobalSecondaryIndex.getPartitionKeyName/getSortKeyName`, `LocalSecondaryIndex.getPartitionKeyName/getSortKeyName`, `TableDefinition.getPartitionKeyName/getSortKeyName`) with `@JsonIgnore` so only the real `keySchema` field is persisted, and the derived names are always recomputed from it — on every load, not just the first.

This was found by writing a `HybridStorage` round-trip test for a table with a local secondary index (`HybridStorageTest.dynamoTableWithLocalSecondaryIndexSurvivesRestart`) — RED before the `@JsonIgnore` annotations were added, GREEN after. Provenance: derived from observed hybrid-persistence behavior in this fork's `HybridStorage`, not from a specific botocore wire-shape gap — this is an internal serialization bug, not an API/request-response fidelity issue, so no botocore model changes apply here.

## Deliberate scope notes

- This is narrowly scoped to the four getters that were leaking into persisted JSON. I did not do a broader sweep of every derived/computed getter across other service models in this PR — that's tracked separately if it turns out to be a wider pattern.
- No wire-fidelity extractor pass was run against this branch: the diff touches no request/response shapes, operation members, or API-facing behavior — only internal Jackson serialization annotations on already-existing derived getters — so there is no new surface for the extractor to judge against the botocore model.
- No docs were touched; `make docs-check` is not applicable to this diff.

## Collision notes

- No file overlap with #1923 (`fix/dynamodb-sse-custom-kms-key`) — different DynamoDB subsystem (SSE/KMS handling vs. hybrid persistence).
- Minor overlap with #2250 (`fix/core-quarantine-hybrid-storage-2232`): both PRs add tests to `HybridStorageTest.java`, but touch different test methods with no logical dependency. Whichever merges second will need a trivial rebase; no functional conflict expected.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AWS compatibility

- [x] I have verified this change against real AWS behavior or documentation (hybrid persistence is a Floci-internal storage concern, not an AWS API-facing behavior; this fix does not change any request/response contract)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
