### PR TITLE
test(applicationautoscaling): cover the full delete-scaling-policy workflow

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/applicationautoscaling/ApplicationAutoScalingDeleteScalingPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/applicationautoscaling/ApplicationAutoScalingDeleteScalingPolicyIntegrationTest.java
@@ -1,0 +1,108 @@
+package io.github.hectorvent.floci.services.applicationautoscaling;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class ApplicationAutoScalingDeleteScalingPolicyIntegrationTest {
+
+    @BeforeAll
+    static void setUp() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void testDeleteScalingPolicyWorkflow() {
+        String resourceId = "service/delete-policy-cluster/delete-policy-service";
+
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("X-Amz-Target", "AnyScaleFrontendService.RegisterScalableTarget")
+                .body("""
+                        {
+                          "ServiceNamespace": "ecs",
+                          "ResourceId": "%s",
+                          "ScalableDimension": "ecs:service:DesiredCount",
+                          "MinCapacity": 1,
+                          "MaxCapacity": 5
+                        }
+                        """.formatted(resourceId))
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("ScalableTargetARN", notNullValue());
+
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("X-Amz-Target", "AnyScaleFrontendService.PutScalingPolicy")
+                .body("""
+                        {
+                          "PolicyName": "delete-policy",
+                          "PolicyType": "TargetTrackingScaling",
+                          "ServiceNamespace": "ecs",
+                          "ResourceId": "%s",
+                          "ScalableDimension": "ecs:service:DesiredCount",
+                          "TargetTrackingScalingPolicyConfiguration": {
+                            "TargetValue": 50.0,
+                            "PredefinedMetricSpecification": {
+                              "PredefinedMetricType": "ECSServiceAverageCPUUtilization"
+                            }
+                          }
+                        }
+                        """.formatted(resourceId))
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("PolicyARN", notNullValue());
+
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("X-Amz-Target", "AnyScaleFrontendService.DeleteScalingPolicy")
+                .body("""
+                        {
+                          "PolicyName": "delete-policy",
+                          "ServiceNamespace": "ecs",
+                          "ResourceId": "%s",
+                          "ScalableDimension": "ecs:service:DesiredCount"
+                        }
+                        """.formatted(resourceId))
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("X-Amz-Target", "AnyScaleFrontendService.DescribeScalingPolicies")
+                .body("""
+                        {
+                          "ServiceNamespace": "ecs",
+                          "ResourceId": "%s",
+                          "ScalableDimension": "ecs:service:DesiredCount"
+                        }
+                        """.formatted(resourceId))
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("ScalingPolicies", hasSize(0));
+
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("X-Amz-Target", "AnyScaleFrontendService.DeregisterScalableTarget")
+                .body("""
+                        {
+                          "ServiceNamespace": "ecs",
+                          "ResourceId": "%s",
+                          "ScalableDimension": "ecs:service:DesiredCount"
+                        }
+                        """.formatted(resourceId))
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/applicationautoscaling/ApplicationAutoScalingDeleteScalingPolicyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/applicationautoscaling/ApplicationAutoScalingDeleteScalingPolicyIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.applicationautoscaling;
 
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -12,14 +13,38 @@ import static org.hamcrest.Matchers.notNullValue;
 @QuarkusTest
 class ApplicationAutoScalingDeleteScalingPolicyIntegrationTest {
 
+    private static final String RESOURCE_ID = "service/delete-policy-cluster/delete-policy-service";
+    private static final String DIMENSION = "ecs:service:DesiredCount";
+
     @BeforeAll
     static void setUp() {
         RestAssuredJsonUtils.configureAwsContentTypes();
     }
 
+    @AfterEach
+    void tearDown() {
+        // Best-effort: if an assertion above fails mid-workflow, this still runs and prevents
+        // the scalable target from leaking into the shared @QuarkusTest JVM for later tests.
+        try {
+            given()
+                    .contentType("application/x-amz-json-1.1")
+                    .header("X-Amz-Target", "AnyScaleFrontendService.DeregisterScalableTarget")
+                    .body("""
+                            {
+                              "ServiceNamespace": "ecs",
+                              "ResourceId": "%s",
+                              "ScalableDimension": "%s"
+                            }
+                            """.formatted(RESOURCE_ID, DIMENSION))
+                    .post("/");
+        } catch (RuntimeException ignored) {
+            // Cleanup is best-effort; the test's own assertions are the source of truth.
+        }
+    }
+
     @Test
     void testDeleteScalingPolicyWorkflow() {
-        String resourceId = "service/delete-policy-cluster/delete-policy-service";
+        String resourceId = RESOURCE_ID;
 
         given()
                 .contentType("application/x-amz-json-1.1")


### PR DESCRIPTION
## Summary

Adds an over-the-wire integration test that exercises the full `DeleteScalingPolicy` lifecycle for Application Auto Scaling: `RegisterScalableTarget` → `PutScalingPolicy` → `DeleteScalingPolicy` → `DescribeScalingPolicies` (asserts zero remaining policies) → `DeregisterScalableTarget`.

Provenance: **botocore-derived**. The `DeleteScalingPolicy` handler itself (`ApplicationAutoScalingService.java`, `ApplicationAutoScalingJsonHandler.java`) already exists on `main` and was covered by a prior wire-fidelity audit. This PR adds the missing end-to-end integration coverage confirming the delete actually removes the policy (rather than only asserting a 200 status), and confirms the request/response shapes for all five actions round-trip correctly through Quarkus REST-assured.

## Wire-fidelity details

Prior audit passes over `ApplicationAutoScalingService.java` already produced corpus entries for `DeleteScalingPolicy`, confirming:

- `deleteScalingPolicy` calls `validateTriple` (`ApplicationAutoScalingService.java:275`, `408-421`), which calls `requireNamespace` and rejects any value not in `SERVICE_NAMESPACES` with `ValidationException` before any policy state is touched — matching the `ServiceNamespace` enum in botocore's `application-autoscaling/2016-02-06/service-2.json`.
- The same `validateTriple` call rejects any value not in `SCALABLE_DIMENSIONS` with `ValidationException` before the policy lookup/delete proceeds, matching the `ScalableDimension` enum in the same model.

No production code changed in this PR, so no new wire-fidelity extractor findings were generated — the touched surface (test-only) was diffed against `corpus.jsonl`'s existing `ApplicationAutoScaling|DeleteScalingPolicy|*` keys and no new packet keys were introduced.

## Deliberate scope notes

- This PR is test-only. It does not modify `ApplicationAutoScalingService.java` or the JSON handler — those already implement `DeleteScalingPolicy` and were reviewed in a prior wave.
- The test asserts `DescribeScalingPolicies` returns an empty list after delete, which is the behavioral assertion the prior coverage (over-the-wire happy path only) was missing.
- Resource cleanup (`DeregisterScalableTarget`) is included in the same test for hygiene, not as new coverage of that operation.

## Type of change

- [x] Test coverage addition
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## AWS compatibility

- [x] Request/response shapes verified against botocore's `application-autoscaling` service model
- [x] No new operations or fields introduced

## Checklist

- [x] `mvn clean test-compile` passes
- [x] Targeted suite (`ApplicationAutoScaling*Test`, 33 tests) passes
- [x] Rebased cleanly onto current `upstream/main`
- [x] No file overlap with other open PRs (checked against #2673, `feature/autoscaling` — different AWS service, zero overlapping files)
