### PR TITLE
fix(rds): grant the MySQL/MariaDB master user RDS-master-equivalent privileges

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -171,7 +171,7 @@ public class RdsContainerManager {
             EndpointInfo endpoint = info.getEndpoint(enginePort);
 
             LOG.infov("RDS backend for instance {0}: {1}", instanceId, endpoint);
-            initializeEngine(containerName, info.containerId(), engine, masterUsername);
+            initializeEngine(containerName, info.containerId(), engine, masterUsername, masterPassword);
 
             handle = new RdsContainerHandle(
                     info.containerId(), effectiveRuntimeId, instanceId,
@@ -371,9 +371,13 @@ public class RdsContainerManager {
         return Integer.parseInt(tag.substring(0, end));
     }
 
-    private void initializeEngine(String containerName, String containerId, DatabaseEngine engine, String masterUsername) {
+    private void initializeEngine(String containerName, String containerId, DatabaseEngine engine,
+                                  String masterUsername, String masterPassword) {
         if (engine == DatabaseEngine.POSTGRES) {
             initializePostgresIamRole(containerName, containerId, masterUsername);
+        } else if (needsMasterGrant(engine, masterUsername)) {
+            execUntilSuccess(containerName, containerId,
+                    masterGrantCommand(engine, masterUsername, masterPassword), "master-user grants");
         }
     }
 
@@ -398,13 +402,41 @@ public class RdsContainerManager {
                 "-d", "postgres",
                 "-c", postgresIamRoleInitSql()
         };
+        execUntilSuccess(containerName, containerId, cmd, "PostgreSQL IAM role");
+    }
+
+    /**
+     * The stock mysql/mariadb images grant {@code MYSQL_USER} only {@code ALL} on
+     * {@code MYSQL_DATABASE}, so a master user cannot {@code CREATE DATABASE}, {@code CREATE USER}
+     * or {@code GRANT} — operations real RDS master users perform routinely. A root master needs
+     * nothing (and the images create no separate user for it).
+     */
+    static boolean needsMasterGrant(DatabaseEngine engine, String masterUsername) {
+        return (engine == DatabaseEngine.MYSQL || engine == DatabaseEngine.MARIADB)
+                && masterUsername != null && !masterUsername.isBlank() && !"root".equals(masterUsername);
+    }
+
+    static String[] masterGrantCommand(DatabaseEngine engine, String masterUsername, String masterPassword) {
+        // MariaDB images ≥10.4 (Floci's floor is 10.11) ship only the `mariadb` client binary.
+        String client = engine == DatabaseEngine.MARIADB ? "mariadb" : "mysql";
+        return new String[]{client, "-uroot", "-p" + masterPassword, "-e", mysqlMasterGrantSql(masterUsername)};
+    }
+
+    static String mysqlMasterGrantSql(String masterUsername) {
+        // Real RDS grants the master user a near-global privilege list (withholding SUPER, FILE
+        // and SHUTDOWN); the emulator grants ALL for simplicity, mirroring how POSTGRES_USER is
+        // already a superuser. MasterUsername is API-constrained to word characters, safe to inline.
+        return "GRANT ALL PRIVILEGES ON *.* TO '" + masterUsername + "'@'%' WITH GRANT OPTION;";
+    }
+
+    private void execUntilSuccess(String containerName, String containerId, String[] cmd, String description) {
         String lastOutput = "";
         for (int attempt = 1; attempt <= 60; attempt++) {
             try {
                 ContainerExecResult result = execInContainer(containerId, cmd, 5);
                 lastOutput = result.output();
                 if (result.exitCode() == 0) {
-                    LOG.infov("Initialized PostgreSQL IAM role in RDS container {0}", containerName);
+                    LOG.infov("Initialized {0} in RDS container {1}", description, containerName);
                     return;
                 }
             } catch (Exception e) {
@@ -414,10 +446,10 @@ public class RdsContainerManager {
                 TimeUnit.SECONDS.sleep(1);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                throw new IllegalStateException("Interrupted initializing PostgreSQL IAM role in " + containerName, e);
+                throw new IllegalStateException("Interrupted initializing " + description + " in " + containerName, e);
             }
         }
-        throw new IllegalStateException("Timed out initializing PostgreSQL IAM role in " + containerName + ": " + lastOutput);
+        throw new IllegalStateException("Timed out initializing " + description + " in " + containerName + ": " + lastOutput);
     }
 
     private ContainerExecResult execInContainer(String containerId, String[] cmd, int timeoutSeconds) throws Exception {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -17,8 +17,11 @@ import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
 import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.jboss.logging.Logger;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -167,11 +170,14 @@ public class RdsContainerManager {
             cleanupContainerId = containerName;
             String createdContainerId = lifecycleManager.create(spec);
             cleanupContainerId = createdContainerId;
+            if (needsMasterGrant(engine, masterUsername)) {
+                installMasterGrantInitScript(createdContainerId, masterUsername);
+            }
             ContainerInfo info = lifecycleManager.startCreated(createdContainerId, spec);
             EndpointInfo endpoint = info.getEndpoint(enginePort);
 
             LOG.infov("RDS backend for instance {0}: {1}", instanceId, endpoint);
-            initializeEngine(containerName, info.containerId(), engine, masterUsername, masterPassword);
+            initializeEngine(containerName, info.containerId(), engine, masterUsername);
 
             handle = new RdsContainerHandle(
                     info.containerId(), effectiveRuntimeId, instanceId,
@@ -371,13 +377,9 @@ public class RdsContainerManager {
         return Integer.parseInt(tag.substring(0, end));
     }
 
-    private void initializeEngine(String containerName, String containerId, DatabaseEngine engine,
-                                  String masterUsername, String masterPassword) {
+    private void initializeEngine(String containerName, String containerId, DatabaseEngine engine, String masterUsername) {
         if (engine == DatabaseEngine.POSTGRES) {
             initializePostgresIamRole(containerName, containerId, masterUsername);
-        } else if (needsMasterGrant(engine, masterUsername)) {
-            execUntilSuccess(containerName, containerId,
-                    masterGrantCommand(engine, masterUsername, masterPassword), "master-user grants");
         }
     }
 
@@ -416,17 +418,42 @@ public class RdsContainerManager {
                 && masterUsername != null && !masterUsername.isBlank() && !"root".equals(masterUsername);
     }
 
-    static String[] masterGrantCommand(DatabaseEngine engine, String masterUsername, String masterPassword) {
-        // MariaDB images ≥10.4 (Floci's floor is 10.11) ship only the `mariadb` client binary.
-        String client = engine == DatabaseEngine.MARIADB ? "mariadb" : "mysql";
-        return new String[]{client, "-uroot", "-p" + masterPassword, "-e", mysqlMasterGrantSql(masterUsername)};
-    }
-
     static String mysqlMasterGrantSql(String masterUsername) {
         // Real RDS grants the master user a near-global privilege list (withholding SUPER, FILE
         // and SHUTDOWN); the emulator grants ALL for simplicity, mirroring how POSTGRES_USER is
-        // already a superuser. MasterUsername is API-constrained to word characters, safe to inline.
-        return "GRANT ALL PRIVILEGES ON *.* TO '" + masterUsername + "'@'%' WITH GRANT OPTION;";
+        // already a superuser. Floci does not enforce AWS's MasterUsername charset, so the name
+        // is escaped rather than trusted — this SQL runs as root inside the container.
+        String escaped = masterUsername.replace("\\", "\\\\").replace("'", "\\'");
+        return "GRANT ALL PRIVILEGES ON *.* TO '" + escaped + "'@'%' WITH GRANT OPTION;";
+    }
+
+    /**
+     * Delivered as a {@code /docker-entrypoint-initdb.d} script installed between container create
+     * and start, rather than a post-start root exec: the images run init scripts exactly once —
+     * against an empty data directory, as root, after creating the master user. A reboot on a
+     * reused volume therefore never re-runs it, which matters because the volume's real root
+     * password survives a ModifyDBInstance master-password rotation (MYSQL_ROOT_PASSWORD only
+     * takes effect on first initialization), so any post-start root exec would fail there.
+     */
+    private void installMasterGrantInitScript(String containerId, String masterUsername) {
+        byte[] sql = mysqlMasterGrantSql(masterUsername).getBytes(StandardCharsets.UTF_8);
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            try (TarArchiveOutputStream tar = new TarArchiveOutputStream(bos)) {
+                TarArchiveEntry entry = new TarArchiveEntry("floci-master-grants.sql");
+                entry.setSize(sql.length);
+                entry.setMode(0644);
+                tar.putArchiveEntry(entry);
+                tar.write(sql);
+                tar.closeArchiveEntry();
+            }
+            lifecycleManager.getDockerClient().copyArchiveToContainerCmd(containerId)
+                    .withRemotePath("/docker-entrypoint-initdb.d")
+                    .withTarInputStream(new ByteArrayInputStream(bos.toByteArray()))
+                    .exec();
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Failed to install the master-grant init script into container " + containerId, e);
+        }
     }
 
     private void execUntilSuccess(String containerName, String containerId, String[] cmd, String description) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -55,6 +55,52 @@ class RdsContainerManagerTest {
     }
 
     @Test
+    void mysqlMasterGrantSqlGrantsGlobalPrivilegesWithGrantOption() {
+        String sql = RdsContainerManager.mysqlMasterGrantSql("admin");
+
+        assertTrue(sql.contains("GRANT ALL PRIVILEGES ON *.*"));
+        assertTrue(sql.contains("'admin'@'%'"));
+        assertTrue(sql.contains("WITH GRANT OPTION"));
+    }
+
+    @Test
+    void masterGrantCommandUsesTheEngineClientBinary() {
+        assertEquals("mysql",
+                RdsContainerManager.masterGrantCommand(DatabaseEngine.MYSQL, "admin", "pw")[0]);
+        assertEquals("mariadb",
+                RdsContainerManager.masterGrantCommand(DatabaseEngine.MARIADB, "admin", "pw")[0]);
+    }
+
+    @Test
+    void needsMasterGrantSkipsRootAndPostgres() {
+        assertTrue(RdsContainerManager.needsMasterGrant(DatabaseEngine.MYSQL, "admin"));
+        assertTrue(RdsContainerManager.needsMasterGrant(DatabaseEngine.MARIADB, "admin"));
+        assertFalse(RdsContainerManager.needsMasterGrant(DatabaseEngine.MYSQL, "root"));
+        assertFalse(RdsContainerManager.needsMasterGrant(DatabaseEngine.POSTGRES, "admin"));
+        assertFalse(RdsContainerManager.needsMasterGrant(DatabaseEngine.MYSQL, null));
+    }
+
+    @Test
+    void mysqlRootMasterStartDoesNotExecIntoTheContainer() {
+        EmulatorConfig config = config(tempDir.resolve("host-root"));
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        stubStarts(lifecycleManager, new ContainerLifecycleManager.ContainerInfo(
+                "container-id", Map.of(3306, new ContainerLifecycleManager.EndpointInfo("db1", 3306))));
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        lenient().when(logStreamer.generateLogStreamName(any())).thenReturn("log-stream");
+
+        RdsContainerManager manager = new RdsContainerManager(
+                new ContainerBuilder(config, mock(DockerHostResolver.class), mock(EmbeddedDnsServer.class)),
+                lifecycleManager, logStreamer, mock(ContainerDetector.class), config,
+                new RegionResolver("us-east-1", "000000000000"),
+                mock(ServiceConfigAccess.class));
+
+        manager.start("db1", "vol1", DatabaseEngine.MYSQL, "mysql:8.0", "root", "password", "db");
+
+        verify(lifecycleManager, never()).getDockerClient();
+    }
+
+    @Test
     void postgres18UsesParentDataMount() {
         assertEquals("/var/lib/postgresql",
                 RdsContainerManager.engineDefaultDataPath(DatabaseEngine.POSTGRES, "postgres:18.4-alpine"));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CopyArchiveToContainerCmd;
 import com.github.dockerjava.api.model.Bind;
 import io.github.hectorvent.floci.services.rds.model.DatabaseEngine;
 
@@ -64,11 +66,11 @@ class RdsContainerManagerTest {
     }
 
     @Test
-    void masterGrantCommandUsesTheEngineClientBinary() {
-        assertEquals("mysql",
-                RdsContainerManager.masterGrantCommand(DatabaseEngine.MYSQL, "admin", "pw")[0]);
-        assertEquals("mariadb",
-                RdsContainerManager.masterGrantCommand(DatabaseEngine.MARIADB, "admin", "pw")[0]);
+    void mysqlMasterGrantSqlEscapesQuotesAndBackslashes() {
+        // Floci does not enforce AWS's MasterUsername charset, so a quote must not be able to
+        // break out of the string literal in SQL executed as root.
+        assertEquals("GRANT ALL PRIVILEGES ON *.* TO 'we\\'ird\\\\'@'%' WITH GRANT OPTION;",
+                RdsContainerManager.mysqlMasterGrantSql("we'ird\\"));
     }
 
     @Test
@@ -81,7 +83,7 @@ class RdsContainerManagerTest {
     }
 
     @Test
-    void mysqlRootMasterStartDoesNotExecIntoTheContainer() {
+    void mysqlRootMasterStartDoesNotInstallAnInitScript() {
         EmulatorConfig config = config(tempDir.resolve("host-root"));
         ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
         stubStarts(lifecycleManager, new ContainerLifecycleManager.ContainerInfo(
@@ -98,6 +100,45 @@ class RdsContainerManagerTest {
         manager.start("db1", "vol1", DatabaseEngine.MYSQL, "mysql:8.0", "root", "password", "db");
 
         verify(lifecycleManager, never()).getDockerClient();
+    }
+
+    @Test
+    void mysqlNonRootMasterStartInstallsGrantInitScriptBeforeStart() throws Exception {
+        EmulatorConfig config = config(tempDir.resolve("host-root"));
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        stubStarts(lifecycleManager, new ContainerLifecycleManager.ContainerInfo(
+                "container-id", Map.of(3306, new ContainerLifecycleManager.EndpointInfo("db1", 3306))));
+        DockerClient dockerClient = mock(DockerClient.class);
+        when(lifecycleManager.getDockerClient()).thenReturn(dockerClient);
+        CopyArchiveToContainerCmd copyCmd = mock(CopyArchiveToContainerCmd.class);
+        when(dockerClient.copyArchiveToContainerCmd(any())).thenReturn(copyCmd);
+        when(copyCmd.withRemotePath(any())).thenReturn(copyCmd);
+        when(copyCmd.withTarInputStream(any())).thenReturn(copyCmd);
+        ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+        lenient().when(logStreamer.generateLogStreamName(any())).thenReturn("log-stream");
+
+        RdsContainerManager manager = new RdsContainerManager(
+                new ContainerBuilder(config, mock(DockerHostResolver.class), mock(EmbeddedDnsServer.class)),
+                lifecycleManager, logStreamer, mock(ContainerDetector.class), config,
+                new RegionResolver("us-east-1", "000000000000"),
+                mock(ServiceConfigAccess.class));
+
+        manager.start("db1", "vol1", DatabaseEngine.MYSQL, "mysql:8.0", "admin", "password", "db");
+
+        verify(copyCmd).withRemotePath("/docker-entrypoint-initdb.d");
+        var tarCaptor = org.mockito.ArgumentCaptor.forClass(java.io.InputStream.class);
+        verify(copyCmd).withTarInputStream(tarCaptor.capture());
+        try (var tar = new org.apache.commons.compress.archivers.tar.TarArchiveInputStream(tarCaptor.getValue())) {
+            var entry = tar.getNextEntry();
+            assertEquals("floci-master-grants.sql", entry.getName());
+            assertEquals(RdsContainerManager.mysqlMasterGrantSql("admin"),
+                    new String(tar.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
+        }
+        // The script lands on the created container before it starts, so the entrypoint's
+        // one-time init phase is the thing that runs it.
+        var order = org.mockito.Mockito.inOrder(dockerClient, lifecycleManager);
+        order.verify(dockerClient).copyArchiveToContainerCmd("container-id");
+        order.verify(lifecycleManager).startCreated(org.mockito.ArgumentMatchers.eq("container-id"), any());
     }
 
     @Test


### PR DESCRIPTION
## Problem

A non-root MySQL/MariaDB master user cannot run the operations real RDS master users perform routinely. The stock `mysql`/`mariadb` images grant `MYSQL_USER` only `ALL` on `MYSQL_DATABASE` plus global `USAGE`:

```
GRANT USAGE ON *.* TO `admin`@`%`
GRANT ALL PRIVILEGES ON `admin`.* TO `admin`@`%`
```

so `CREATE DATABASE`, `CREATE USER` and `GRANT` all fail:

```
$ mysql -h localhost -P 7001 -uadmin -p*** -e "CREATE DATABASE spike_db;"
ERROR 1044 (42000): Access denied for user 'admin'@'%' to database 'spike_db'
```

On real RDS the master user holds a near-global privilege list, and the terraform/pulumi `mysql` providers depend on it: they connect to the instance endpoint during apply and immediately create schemas, users and grants. Against Floci those applies fail today.

## Fix

After the DB container starts, exec a root `GRANT ALL PRIVILEGES ON *.* TO '<master>'@'%' WITH GRANT OPTION` into it, reusing the exec-with-retry machinery the PostgreSQL `rds_iam` init already uses (extracted into a shared `execUntilSuccess`, with the PostgreSQL log/error text unchanged). The retry loop also absorbs the image's init window: the grant only succeeds once the entrypoint has created the master user.

Notes on the shape:

- **Root master is skipped.** The images create no separate user for `MasterUsername=root` and root already holds every privilege.
- **`GRANT ALL` is a disclosed deviation.** Real RDS withholds `SUPER`, `FILE` and `SHUTDOWN` from its master grant list. The emulator grants `ALL` for simplicity, mirroring how `POSTGRES_USER` is already a full superuser on the postgres side.
- **MariaDB uses the `mariadb` client binary.** Images at Floci's supported floor (10.11+) no longer ship a `mysql` symlink.
- **Runs where the postgres `rds_iam` init already runs**, so the blocking behavior matches the existing engine-init precedent (provisioning is async per #2525, the CreateDBInstance response is unaffected).
- PostgreSQL master users are unaffected and need nothing: `POSTGRES_USER` is a superuser.

## Tests

- `mysqlMasterGrantSqlGrantsGlobalPrivilegesWithGrantOption`, `masterGrantCommandUsesTheEngineClientBinary`, `needsMasterGrantSkipsRootAndPostgres`: the statement, the per-engine client binary, and the dispatch rule (extending the `postgresIamRoleInitSql` static-method test pattern).
- `mysqlRootMasterStartDoesNotExecIntoTheContainer`: a root-master start never touches the Docker exec API.
- All 27 `RdsContainerManagerTest` and 235 `RdsServiceTest` tests pass.

## Verified end-to-end

Ran the patched build in a container with `/var/run/docker.sock` and created instances with `--master-username admin` for both engines:

```
INFO [RdsContainerManager] Initialized master-user grants in RDS container floci-rds-db-F5C0659E...   (mysql:8.0.36)
INFO [RdsContainerManager] Initialized master-user grants in RDS container floci-rds-db-2DDCB9B4...   (mariadb:11)
```

Through the auth proxy as `admin`, the previously failing operations now succeed on both engines:

```
mysql> SHOW GRANTS FOR CURRENT_USER();
GRANT SELECT, INSERT, ..., CREATE USER, ... ON *.* TO `admin`@`%` WITH GRANT OPTION
mysql> CREATE DATABASE fixtest_db;            -- was ERROR 1044
mysql> CREATE USER 'appuser'@'%' IDENTIFIED BY '***';
mysql> GRANT ALL ON fixtest_db.* TO 'appuser'@'%';
```
