### PR TITLE
fix(docdb): refuse an engine version a live account does not list

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -220,6 +220,19 @@ teardown() {
     aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
 }
 
+@test "docdb: an engine version a live account does not list is refused" {
+    CLUSTER_ID="bats-docdb-version-$(unique_name)"
+    run aws_cmd docdb create-db-cluster --db-cluster-identifier "$CLUSTER_ID" --engine docdb \
+        --engine-version 9.9.9 --master-username u --master-user-password pw12345678
+    assert_failure
+    assert_output --partial 'InvalidParameterCombination'
+    assert_output --partial 'Cannot find version 9.9.9 for docdb'
+
+    run aws_cmd docdb describe-db-clusters --db-cluster-identifier "$CLUSTER_ID"
+    assert_failure
+    assert_output --partial 'DBClusterNotFoundFault'
+}
+
 @test "docdb: cluster settings given on create are returned by describe" {
     CLUSTER_ID="bats-docdb-settings-$(unique_name)"
     run aws_cmd kms create-key --description "$CLUSTER_ID"

--- a/docs/services/docdb.md
+++ b/docs/services/docdb.md
@@ -43,7 +43,9 @@ and so are the windows (30-minute minimum, no overlap). Omitted values take the 
 `default`, `default.docdb<family>`, the VPC's default security group, one day of backups — with
 deterministic windows `04:00-06:00` / `mon:00:00-mon:03:00` where AWS picks random ones.
 `CreateDBInstance` keeps `AutoMinorVersionUpgrade`, `PreferredMaintenanceWindow`,
-`CopyTagsToSnapshot`, `PromotionTier` and `Tags`.
+`CopyTagsToSnapshot`, `PromotionTier` and `Tags`. `EngineVersion` must be one a live account lists
+(`3.6.0`, `4.0.0`, `5.0.0`, `5.0.1`, `8.0.0`, `8.0.1`, or the `major.minor` form of one); any other
+is refused with `Cannot find version X for docdb`, on create and on modify.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -40,6 +40,15 @@ public class DocDbService {
 
     private static final Logger LOG = Logger.getLogger(DocDbService.class);
     private static final String ENGINE_VERSION_DEFAULT = "5.0.0";
+
+    /** The engine versions a live account lists for docdb, each with its parameter group family. */
+    static final Map<String, String> ENGINE_VERSION_FAMILIES = Map.of(
+            "3.6.0", "docdb3.6",
+            "4.0.0", "docdb4.0",
+            "5.0.0", "docdb5.0",
+            "5.0.1", "docdb5.0",
+            "8.0.0", "docdb8.0",
+            "8.0.1", "docdb8.0");
     private static final int MONGO_PORT = 27017;
 
     private final StorageBackend<String, DocDbCluster> clusters;
@@ -195,7 +204,7 @@ public class DocDbService {
                                         Map<String, String> tags) {
         String region = regionResolver.getRegion();
         settings.validate();
-        String effectiveEngineVersion = engineVersion != null ? engineVersion : ENGINE_VERSION_DEFAULT;
+        String effectiveEngineVersion = requireKnownEngineVersion(engineVersion);
         // every reference checked and every default chosen before a container is started
         DocDbClusterSettings resolved = resolveClusterSettings(settings, null, effectiveEngineVersion, region);
         synchronized (lockFor("cluster:" + key(region, id))) {
@@ -207,7 +216,7 @@ public class DocDbService {
             DocDbCluster cluster = new DocDbCluster();
             cluster.setDbClusterIdentifier(id);
             cluster.setStatus("available");
-            cluster.setEngineVersion(engineVersion != null ? engineVersion : ENGINE_VERSION_DEFAULT);
+            cluster.setEngineVersion(effectiveEngineVersion);
             cluster.setMasterUsername(masterUsername);
             cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
             cluster.setDbClusterArn(regionResolver.buildArn("rds", region, "cluster:" + id));
@@ -388,9 +397,33 @@ public class DocDbService {
         }
     }
 
-    /** The parameter group family an engine version belongs to: {@code 5.0.0} is {@code docdb5.0}. */
+    /**
+     * The version a request names, refused as a live account refuses one it does not list. The
+     * {@code major.minor} form of a listed version is accepted as given.
+     */
+    static String requireKnownEngineVersion(String engineVersion) {
+        if (engineVersion == null || engineVersion.isBlank()) {
+            return ENGINE_VERSION_DEFAULT;
+        }
+        if (ENGINE_VERSION_FAMILIES.containsKey(engineVersion)
+                || ENGINE_VERSION_FAMILIES.containsValue("docdb" + engineVersion)) {
+            return engineVersion;
+        }
+        throw new AwsException("InvalidParameterCombination",
+                "Cannot find version " + engineVersion + " for docdb", 400);
+    }
+
+    /**
+     * The parameter group family an engine version belongs to: {@code 5.0.0} is {@code docdb5.0}.
+     * A version outside the catalogue can only come from a record persisted before versions were
+     * checked; its family is still derived so the record keeps describing the way it always has.
+     */
     static String parameterGroupFamily(String engineVersion) {
         String version = engineVersion == null || engineVersion.isBlank() ? ENGINE_VERSION_DEFAULT : engineVersion;
+        String known = ENGINE_VERSION_FAMILIES.get(version);
+        if (known != null) {
+            return known;
+        }
         String[] parts = version.split("\\.");
         return "docdb" + parts[0] + "." + (parts.length > 1 ? parts[1] : "0");
     }
@@ -573,7 +606,7 @@ public class DocDbService {
             DocDbCluster cluster = getDbCluster(id);
             // every check before any change: the store hands out its own object
             String effectiveEngineVersion = engineVersion != null && !engineVersion.isBlank()
-                    ? engineVersion : cluster.getEngineVersion();
+                    ? requireKnownEngineVersion(engineVersion) : cluster.getEngineVersion();
             DocDbClusterSettings resolved = resolveClusterSettings(settings, cluster, effectiveEngineVersion, region);
             cluster.setEngineVersion(effectiveEngineVersion);
             if (iamEnabled != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -95,7 +95,8 @@ public class RdsService implements Resettable, ResourceProvider {
             // versions map to); DocDbService validates a cluster's parameter group here
             managedDefault("docdb3.6"),
             managedDefault("docdb4.0"),
-            managedDefault("docdb5.0"));
+            managedDefault("docdb5.0"),
+            managedDefault("docdb8.0"));
 
     /**
      * Engines AWS accepts for {@code EngineName} on an option group. Floci can only run

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbIntegrationTest.java
@@ -117,12 +117,12 @@ class DocDbIntegrationTest {
             .contentType(FORM)
             .formParam("Action", "ModifyDBCluster")
             .formParam("DBClusterIdentifier", CLUSTER_ID)
-            .formParam("EngineVersion", "6.0.0")
+            .formParam("EngineVersion", "8.0.0")
         .when().post("/")
         .then()
             .statusCode(200)
             .body(containsString(CLUSTER_ID))
-            .body(containsString("6.0.0"));
+            .body(containsString("8.0.0"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbServiceTest.java
@@ -67,7 +67,7 @@ class DocDbServiceTest {
         kmsService = Mockito.mock(KmsService.class);
         when(kmsService.describeKey(any(), any())).thenThrow(new AwsException("NotFoundException", "Key not found", 404));
         when(rdsService.isManagedClusterParameterGroup(any())).thenAnswer(inv ->
-                List.of("default.docdb3.6", "default.docdb4.0", "default.docdb5.0").contains(inv.<String>getArgument(0)));
+                List.of("default.docdb3.6", "default.docdb4.0", "default.docdb5.0", "default.docdb8.0").contains(inv.<String>getArgument(0)));
         docDbService = new DocDbService(config, regionResolver, containerManager, storageFactory,
                 rdsService, ec2Service, kmsService);
     }
@@ -457,6 +457,30 @@ class DocDbServiceTest {
         DocDbCluster stored = docDbService.getDbCluster("c1");
         assertEquals("22:00-23:50", stored.getPreferredBackupWindow());
         assertFalse(BackupWindows.overlap(stored.getPreferredBackupWindow(), stored.getPreferredMaintenanceWindow()));
+    }
+
+    @Test
+    void engineVersionsOutsideTheCatalogueAreRefusedBeforeAnythingChanges() {
+        for (String version : List.of("9.9.9", "5", "abc", "5.0.2")) {
+            AwsException e = assertThrows(AwsException.class, () -> docDbService.createDbCluster(
+                    "c1", version, "u", "pw", false, DocDbClusterSettings.unchanged(), Map.of()));
+            assertEquals("InvalidParameterCombination", e.getErrorCode());
+            assertEquals("Cannot find version " + version + " for docdb", e.getMessage());
+            assertThrows(AwsException.class, () -> docDbService.getDbCluster("c1"));
+        }
+
+        docDbService.createDbCluster("c1", "8.0.1", "u", "pw", false);
+        assertEquals("default.docdb8.0", docDbService.getDbCluster("c1").getDbClusterParameterGroupName());
+        docDbService.createDbCluster("c2", "5.0", "u", "pw", false);
+        assertEquals("5.0", docDbService.getDbCluster("c2").getEngineVersion());
+        assertEquals("default.docdb5.0", docDbService.getDbCluster("c2").getDbClusterParameterGroupName());
+        docDbService.createDbCluster("c3", null, "u", "pw", false);
+        assertEquals("5.0.0", docDbService.getDbCluster("c3").getEngineVersion());
+
+        AwsException e = assertThrows(AwsException.class, () -> docDbService.modifyDbCluster("c1", "9.9.9", null));
+        assertEquals("Cannot find version 9.9.9 for docdb", e.getMessage());
+        assertEquals("8.0.1", docDbService.getDbCluster("c1").getEngineVersion());
+        assertEquals("default.docdb8.0", docDbService.getDbCluster("c1").getDbClusterParameterGroupName());
     }
 
     private AwsException refused(DocDbClusterSettings settings) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -96,7 +96,8 @@ class RdsServiceTest {
             "postgres18",
             "docdb3.6",
             "docdb4.0",
-            "docdb5.0");
+            "docdb5.0",
+            "docdb8.0");
 
     private RdsService rdsService;
     private RdsContainerManager containerManager;


### PR DESCRIPTION
Closes #2681

### What was wrong
`parameterGroupFamily(engineVersion)` derived `docdb<major>.<minor>` from any string, and both `CreateDBCluster` (no group given) and the engine-version branch of `ModifyDBCluster` assigned `default.<family>` without checking that such a group exists — a cluster on `9.9.9` ended up on `default.docdb9.9`, which RDS has no record of.

### What changes
- `DocDbService` carries the versions a live account lists for docdb, with their families: `3.6.0→docdb3.6`, `4.0.0→docdb4.0`, `5.0.0`/`5.0.1→docdb5.0`, `8.0.0`/`8.0.1→docdb8.0`. A version outside it is refused before any change, on create and on modify, with the live answer: `InvalidParameterCombination: Cannot find version 9.9.9 for docdb`. The `major.minor` form of a listed version is accepted, as it is live (`5.0` passes, `5` does not).
- `parameterGroupFamily` reads the catalogue first; the derivation stays only for records persisted before versions were checked, so they keep describing as they always have.
- `default.docdb8.0` joins RDS's managed cluster parameter groups — the family floci was missing.
- `DocDbIntegrationTest.modifyCluster` modified to `6.0.0`, a version that does not exist; it now uses `8.0.0`.

### Stated deviation
A version given as `5.0` is stored as given; what a live cluster reports for that form after create was not observed.

### Evidence
Live account: `9.9.9`, `5`, `abc` refused with the wording above ahead of every other check; `3.6.0`, `4.0.0`, `5.0`, `5.0.1` pass version validation; `DescribeDBEngineVersions` gives the six versions and families.

### Tests
`DocDbServiceTest.engineVersionsOutsideTheCatalogueAreRefusedBeforeAnythingChanges` (four bad versions on create leave no record; `8.0.1 → default.docdb8.0`; `5.0` kept; null → `5.0.0`; bad version on modify leaves version and group untouched). `RdsServiceTest` managed-group list updated. DocDb* and RdsServiceTest: 310/310.
