### PR TITLE
fix(stepfunctions): keep a JSONata expression's explicit null in the output

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -66,6 +66,22 @@ uniformly between zero and the computed delay, as on AWS. One deviation. The del
 between attempts is capped at 30 seconds, the same cap Floci applies to `Wait` states,
 so emulated runs stay fast.
 
+## JSONata nulls
+
+An expression that evaluates to JSON `null` produces a value, not a missing one. It keeps its key
+in `Output`, in `Assign` and in a Task's `Arguments`, at any nesting depth, and it stays in place as
+an array element:
+
+```
+"Output": {"v": "{% $states.input.bar %}"}   on input {"bar": null}   ->   {"v": null}
+```
+
+The same `null` is a value inside the expression too: `$exists()` on it is true and `$type()` on it
+is `"null"`. Only an expression that returns nothing loses its key, which is what
+`$states.input.absent` and the functions listed below that evaluate to undefined do.
+
+One deviation. `$count()` on a JSON null answers `0`; AWS answers `1`.
+
 ## JSONata functions
 
 State machines with `"QueryLanguage": "JSONata"` reach the six functions Step Functions adds on

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -80,7 +80,10 @@ The same `null` is a value inside the expression too: `$exists()` on it is true 
 is `"null"`. Only an expression that returns nothing loses its key, which is what
 `$states.input.absent` and the functions listed below that evaluate to undefined do.
 
-One deviation. `$count()` on a JSON null answers `0`; AWS answers `1`.
+Two deviations. `$count()` on a JSON null answers `0`; AWS answers `1`. And dropping the key of an
+expression that returned nothing is Floci's own behaviour: AWS fails the state instead, with
+`States.QueryEvaluationError` and `The JSONata expression '$states.input.absent' specified for the
+field 'Output/v' returned nothing (undefined).`
 
 ## JSONata functions
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -125,6 +126,11 @@ public class JsonataEvaluator {
         String expr = isExpression(expression) ? unwrap(expression) : expression;
         try {
             Jsonata jsonataExpr = jsonata(expr);
+            // Off, the library keeps JSONata's null marker in the result instead of flattening it
+            // into a Java null. On, an expression that evaluated to JSON null and one that returned
+            // nothing both arrive here as a Java null, and AWS keeps the first while dropping the
+            // second.
+            jsonataExpr.setOutputConvertNulls(false);
             Jsonata.Frame frame = jsonataExpr.createFrame();
             stepFunctionsExtensions.forEach(frame::bind);
             // Workflow variables (the Assign field) are referenced as top-level $name in AWS's
@@ -220,7 +226,7 @@ public class JsonataEvaluator {
     }
 
     JsonNode resolveTemplate(JsonNode template, JsonNode statesVar, JsonNode variables) {
-        if (template == null || template.isNull() || template.isMissingNode()) {
+        if (template == null || template.isMissingNode()) {
             return template;
         }
         if (template.isTextual()) {
@@ -236,9 +242,10 @@ public class JsonataEvaluator {
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
                 JsonNode value = resolveTemplate(entry.getValue(), statesVar, variables);
-                // Per JSONata spec: undefined (null) values are omitted from object output,
-                // matching real AWS Step Functions behavior.
-                if (value != null && !value.isNull() && !value.isMissingNode()) {
+                // Per JSONata spec: an expression that returned nothing is omitted from object
+                // output, matching real AWS Step Functions behavior. A JSON null is a value and
+                // keeps its key: AWS answers {"v":null} to Output {"v":"{% null %}"}.
+                if (value != null && !value.isMissingNode()) {
                     resolved.set(entry.getKey(), value);
                 }
             }
@@ -249,9 +256,10 @@ public class JsonataEvaluator {
             for (int i = 0; i < template.size(); i++) {
                 JsonNode element = template.get(i);
                 JsonNode value = resolveTemplate(element, statesVar, variables);
-                // Per real AWS behavior: undefined array elements fail the execution.
+                // Per real AWS behavior: an array element that returned nothing fails the execution.
                 // Unlike object fields (which are omitted), undefined in an array is a runtime error.
-                if (value == null || value.isNull() || value.isMissingNode()) {
+                // A JSON null is a value and stays: AWS answers [null,1] to ["{% null %}",1].
+                if (value == null || value.isMissingNode()) {
                     String expr = element.isTextual() ? element.asText() : element.toString();
                     throw new FailStateException("States.Runtime",
                             "The JSONata expression '" + expr + "' at array index " + i + " returned nothing (undefined).");
@@ -264,16 +272,41 @@ public class JsonataEvaluator {
         return template;
     }
 
-    private Object toObject(JsonNode node) {
-        if (node == null || node.isNull() || node.isMissingNode()) {
+    /**
+     * Binds $states and the workflow variables as JSONata values, so a JSON null inside them stays
+     * a null the expression can see: $exists() on it is true and $type() on it is "null", as on
+     * AWS. Only an absent node is undefined.
+     */
+    private static Object toObject(JsonNode node) {
+        if (node == null || node.isMissingNode()) {
             return null;
         }
-        return objectMapper.convertValue(node, Object.class);
+        return toJsonataValue(node);
     }
 
+    /**
+     * The evaluation result. A Java null is the expression returning nothing, which
+     * {@link #resolveTemplate} drops from an object; the JSONata null marker is a JSON null, which
+     * it keeps. Nested inside an object or an array there is no undefined, so every null there is
+     * a JSON null.
+     */
     private JsonNode toJsonNode(Object value) {
-        if (value == null) {
+        return value == null ? MissingNode.getInstance() : fromJsonataValue(value);
+    }
+
+    private JsonNode fromJsonataValue(Object value) {
+        if (value == null || value == Jsonata.NULL_VALUE) {
             return NullNode.getInstance();
+        }
+        if (value instanceof Map<?, ?> map) {
+            ObjectNode object = objectMapper.createObjectNode();
+            map.forEach((key, element) -> object.set(String.valueOf(key), fromJsonataValue(element)));
+            return object;
+        }
+        if (value instanceof List<?> list) {
+            ArrayNode array = objectMapper.createArrayNode();
+            list.forEach(element -> array.add(fromJsonataValue(element)));
+            return array;
         }
         return objectMapper.valueToTree(value);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -229,6 +229,15 @@ public class JsonataEvaluator {
         if (template == null || template.isMissingNode()) {
             return template;
         }
+        JsonNode resolved = resolveTemplateNode(template, statesVar, variables);
+        // A resolved Output or Arguments is serialized as it stands, and a missing node writes
+        // itself as the empty string, which no client can parse. "Returned nothing" is a value only
+        // in the positions resolveTemplateNode reads it in: an object field it drops, an array
+        // element it fails the state on. As the whole field there is nothing to drop it from.
+        return resolved.isMissingNode() ? NullNode.getInstance() : resolved;
+    }
+
+    private JsonNode resolveTemplateNode(JsonNode template, JsonNode statesVar, JsonNode variables) {
         if (template.isTextual()) {
             String text = template.asText();
             if (isExpression(text)) {
@@ -241,11 +250,11 @@ public class JsonataEvaluator {
             Iterator<Map.Entry<String, JsonNode>> fields = template.fields();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
-                JsonNode value = resolveTemplate(entry.getValue(), statesVar, variables);
+                JsonNode value = resolveTemplateNode(entry.getValue(), statesVar, variables);
                 // Per JSONata spec: an expression that returned nothing is omitted from object
                 // output, matching real AWS Step Functions behavior. A JSON null is a value and
                 // keeps its key: AWS answers {"v":null} to Output {"v":"{% null %}"}.
-                if (value != null && !value.isMissingNode()) {
+                if (!value.isMissingNode()) {
                     resolved.set(entry.getKey(), value);
                 }
             }
@@ -255,11 +264,11 @@ public class JsonataEvaluator {
             ArrayNode resolved = objectMapper.createArrayNode();
             for (int i = 0; i < template.size(); i++) {
                 JsonNode element = template.get(i);
-                JsonNode value = resolveTemplate(element, statesVar, variables);
+                JsonNode value = resolveTemplateNode(element, statesVar, variables);
                 // Per real AWS behavior: an array element that returned nothing fails the execution.
                 // Unlike object fields (which are omitted), undefined in an array is a runtime error.
                 // A JSON null is a value and stays: AWS answers [null,1] to ["{% null %}",1].
-                if (value == null || value.isMissingNode()) {
+                if (value.isMissingNode()) {
                     String expr = element.isTextual() ? element.asText() : element.toString();
                     throw new FailStateException("States.Runtime",
                             "The JSONata expression '" + expr + "' at array index " + i + " returned nothing (undefined).");
@@ -268,7 +277,7 @@ public class JsonataEvaluator {
             }
             return resolved;
         }
-        // Primitives (number, boolean) pass through
+        // Primitives (number, boolean, null) pass through
         return template;
     }
 
@@ -286,9 +295,9 @@ public class JsonataEvaluator {
 
     /**
      * The evaluation result. A Java null is the expression returning nothing, which
-     * {@link #resolveTemplate} drops from an object; the JSONata null marker is a JSON null, which
-     * it keeps. Nested inside an object or an array there is no undefined, so every null there is
-     * a JSON null.
+     * {@link #resolveTemplateNode} drops from an object; the JSONata null marker is a JSON null,
+     * which it keeps. Nested inside an object or an array there is no undefined, so every null
+     * there is a JSON null.
      */
     private JsonNode toJsonNode(Object value) {
         return value == null ? MissingNode.getInstance() : fromJsonataValue(value);

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHttpInvokeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHttpInvokeTest.java
@@ -285,6 +285,47 @@ class AslExecutorHttpInvokeTest {
     }
 
     @Test
+    void jsonataArgumentsSendAnExplicitNullAndOmitOnlyWhatReturnedNothing() throws Exception {
+        // AWS keeps the null in the arguments a Task is invoked with: TestState TRACE reports
+        // afterArguments {"FunctionName":"nope","Payload":{"v":null}} for Payload {"v":"{% null %}"}.
+        Execution execution = run("""
+                {
+                  "QueryLanguage": "JSONata",
+                  "StartAt": "CallHttp",
+                  "States": {
+                    "CallHttp": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::http:invoke",
+                      "Arguments": {
+                        "ApiEndpoint": "%s/text",
+                        "Method": "POST",
+                        "Authentication": {
+                          "ConnectionArn": "%s"
+                        },
+                        "RequestBody": {
+                          "fromInput": "{%% $lookup($states.input, 'customerId') %%}",
+                          "returnedNothing": "{%% $states.input.absent %%}",
+                          "active": true
+                        }
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(baseUrl, CONNECTION_ARN), """
+                {
+                  "customerId": null
+                }
+                """);
+
+        assertEquals("SUCCEEDED", execution.getStatus(), execution.getCause());
+        JsonNode body = objectMapper.readTree(onlyRequest().body());
+        assertTrue(body.path("fromInput").isNull(), body.toString());
+        assertTrue(body.path("returnedNothing").isMissingNode(), body.toString());
+        assertTrue(body.path("active").asBoolean());
+    }
+
+    @Test
     void nonSuccessStatusFailsWithStatesHttpStatusCodeError() throws Exception {
         Execution execution = run("""
                 {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -84,12 +84,12 @@ class JsonataEvaluatorTest {
     }
 
     @Test
-    void evaluate_returnsNullForMissingField() throws Exception {
+    void evaluate_returnsNothingForMissingField() throws Exception {
         JsonNode statesVar = objectMapper.readTree("""
                 {"input": {"name": "Alice"}}
                 """);
         JsonNode result = evaluator.evaluate("{% $states.input.missing %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
@@ -215,7 +215,7 @@ class JsonataEvaluatorTest {
     void parse_noArgumentReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $parse() %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
@@ -259,14 +259,14 @@ class JsonataEvaluatorTest {
     void partition_emptyArrayReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $partition([], 2) %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
     void partition_chunkSizeZeroReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $partition([1,2,3], 0) %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
@@ -318,21 +318,21 @@ class JsonataEvaluatorTest {
     void range_wrongSignStepReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $range(5, 1, 1) %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
     void range_stepZeroReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $range(1, 5, 0) %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
     void range_missingStepReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $range(1, 5) %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
@@ -374,7 +374,7 @@ class JsonataEvaluatorTest {
     void hash_missingAlgorithmReturnsUndefined() {
         JsonNode statesVar = objectMapper.createObjectNode();
         JsonNode result = evaluator.evaluate("{% $hash('Hello') %}", statesVar);
-        assertTrue(result.isNull());
+        assertTrue(result.isMissingNode());
     }
 
     @Test
@@ -449,7 +449,7 @@ class JsonataEvaluatorTest {
         assertEquals("[-2,-1,0]", evaluator.evaluate("{% $range(-2.9, 0, 1) %}", statesVar).toString());
         assertEquals("[5,4,3,2,1]", evaluator.evaluate("{% $range(5, 1, -1.5) %}", statesVar).toString());
         // -0.5 rounds to 0, which is undefined, while -2 stays negative and is an error.
-        assertTrue(evaluator.evaluate("{% $partition([1,2,3,4], -0.5) %}", statesVar).isNull());
+        assertTrue(evaluator.evaluate("{% $partition([1,2,3,4], -0.5) %}", statesVar).isMissingNode());
     }
 
     @Test
@@ -479,7 +479,7 @@ class JsonataEvaluatorTest {
     @Test
     void hash_missingAlgorithmIsUndefinedButNonStringOneIsASignatureError() {
         JsonNode statesVar = objectMapper.createObjectNode();
-        assertTrue(evaluator.evaluate("{% $hash('a') %}", statesVar).isNull());
+        assertTrue(evaluator.evaluate("{% $hash('a') %}", statesVar).isMissingNode());
         AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
                 () -> evaluator.evaluate("{% $hash('a', 5) %}", statesVar));
         assertTrue(ex.cause.contains("T0410"));
@@ -730,5 +730,85 @@ class JsonataEvaluatorTest {
                 () -> evaluator.evaluate("{% $toMillis('nope') %}", statesVar));
         assertEquals("States.QueryEvaluationError", ex.error);
         assertTrue(ex.cause.contains("nope"), ex.cause);
+    }
+
+    @Test
+    void anExplicitNullKeepsItsKeyAndOnlyWhatReturnedNothingIsDropped() throws Exception {
+        JsonNode statesVar = objectMapper.readTree("""
+                {"input": {"bar": null}}
+                """);
+        JsonNode template = objectMapper.readTree("""
+                {"fromInput": "{% $lookup($states.input, 'bar') %}",
+                 "returnedNothing": "{% $states.input.absent %}",
+                 "kept": 1}
+                """);
+
+        assertEquals("{\"fromInput\":null,\"kept\":1}",
+                evaluator.resolveTemplate(template, statesVar).toString());
+    }
+
+    @Test
+    void anExplicitNullSurvivesInsideANestedObject() throws Exception {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        JsonNode template = objectMapper.readTree("""
+                {"outer": {"fromExpression": "{% null %}", "kept": 1}}
+                """);
+
+        assertEquals("{\"outer\":{\"fromExpression\":null,\"kept\":1}}",
+                evaluator.resolveTemplate(template, statesVar).toString());
+    }
+
+    @Test
+    void aWholeTemplateEvaluatingToNullIsANullWhileNothingIsAMissingNode() throws Exception {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% null %}\""), statesVar).isNull());
+        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% $states.input.absent %}\""), statesVar)
+                .isMissingNode());
+    }
+
+    @Test
+    void anExplicitNullIsAnArrayElementWhileNothingStillFailsTheState() throws Exception {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals("{\"values\":[null,1]}", evaluator.resolveTemplate(objectMapper.readTree("""
+                {"values": ["{% null %}", 1]}
+                """), statesVar).toString());
+
+        AslExecutor.FailStateException failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.resolveTemplate(objectMapper.readTree("""
+                        {"values": ["{% $states.input.absent %}"]}
+                        """), statesVar));
+        assertTrue(failure.cause.contains("returned nothing (undefined)"), failure.cause);
+    }
+
+    @Test
+    void aLiteralNullInTheTemplateKeepsItsKey() throws Exception {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals("{\"literal\":null,\"kept\":1}", evaluator.resolveTemplate(objectMapper.readTree("""
+                {"literal": null, "kept": 1}
+                """), statesVar).toString());
+    }
+
+    @Test
+    void anInputNullIsAValueForExistsAndType() throws Exception {
+        JsonNode statesVar = objectMapper.readTree("""
+                {"input": {"bar": null}}
+                """);
+
+        assertTrue(evaluator.evaluate("{% $exists($states.input.bar) %}", statesVar).asBoolean());
+        assertEquals("null", evaluator.evaluate("{% $type($states.input.bar) %}", statesVar).asText());
+    }
+
+    @Test
+    void anAssignedNullReadsBackAsANull() throws Exception {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        JsonNode variables = objectMapper.readTree("""
+                {"nullVariable": null}
+                """);
+
+        assertTrue(evaluator.evaluate("{% $nullVariable %}", statesVar, variables).isNull());
+        assertTrue(evaluator.evaluate("{% $exists($nullVariable) %}", statesVar, variables).asBoolean());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -759,12 +759,15 @@ class JsonataEvaluatorTest {
     }
 
     @Test
-    void aWholeTemplateEvaluatingToNullIsANullWhileNothingIsAMissingNode() throws Exception {
+    void aWholeTemplateIsANullWhetherItEvaluatedToNullOrReturnedNothing() throws Exception {
         JsonNode statesVar = objectMapper.createObjectNode();
 
         assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% null %}\""), statesVar).isNull());
+        // AWS fails the second one with States.QueryEvaluationError, which #2665 covers. Until then
+        // it is a null and not a missing node: an Output or Arguments is serialized as it stands,
+        // and a missing node writes itself as the empty string rather than as JSON.
         assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% $states.input.absent %}\""), statesVar)
-                .isMissingNode());
+                .isNull());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -614,7 +614,9 @@ class JsonataEvaluatorTest {
         assertEquals("abc", evaluator.evaluate("{% $string('abc') %}", statesVar).asText());
         assertEquals("null", evaluator.evaluate("{% $string(null) %}", statesVar).asText());
         assertEquals("{\n  \"a\": 1\n}", evaluator.evaluate("{% $string({'a': 1}, true) %}", statesVar).asText());
-        assertTrue(evaluator.evaluate("{% $string() %}", statesVar).isNull());
+        // $string() with no argument returns nothing, which this change stops reporting as an
+        // explicit null. AWS fails the state on it, which is #2665's subject and not this one's.
+        assertTrue(evaluator.evaluate("{% $string() %}", statesVar).isMissingNode());
         assertEquals("[\"100000000000000000000\",\"1e+21\"]",
                 evaluator.evaluate("{% $map([1e20, 1e21], $string) %}", statesVar).toString());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1298,6 +1298,32 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void aWholeOutputThatReturnedNothingStaysReadableJson() throws Exception {
+        // AWS fails this state with States.QueryEvaluationError, which #2665 covers. Until then the
+        // execution succeeds, and what DescribeExecution hands back has to parse: an output field
+        // holding the empty string is not JSON any client can read.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Transform",
+                    "States": {
+                        "Transform": {
+                            "Type": "Pass",
+                            "Output": "{% $states.input.absent %}",
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-whole-output-nothing-test", definition);
+        String execArn = startExecution(smArn, "{}");
+        String output = waitForExecution(execArn);
+
+        assertTrue(objectMapper.readTree(output).isNull(), output);
+    }
+
+    @Test
     void assignedVariablesSurviveBeyondNextStateOutput() throws Exception {
         // Variables set via Assign persist across states even after a later state replaces the output.
         String definition = """

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1226,6 +1226,78 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void outputKeepsAnExplicitNullInEveryPositionAndDropsOnlyWhatReturnedNothing() throws Exception {
+        // AWS returns {"v":null} for an expression that evaluates to JSON null, in an object field,
+        // nested, as an array element and as a literal. Only an expression that returned nothing
+        // loses its key.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Transform",
+                    "States": {
+                        "Transform": {
+                            "Type": "Pass",
+                            "Output": {
+                                "fromInput": "{% $lookup($states.input, 'bar') %}",
+                                "fromLiteralExpression": "{% null %}",
+                                "literal": null,
+                                "nested": {"inner": "{% null %}", "kept": 1},
+                                "values": ["{% null %}", 1],
+                                "returnedNothing": "{% $states.input.absent %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-explicit-null-test", definition);
+        String execArn = startExecution(smArn, "{\"bar\": null}");
+        JsonNode output = objectMapper.readTree(waitForExecution(execArn));
+
+        assertTrue(output.path("fromInput").isNull(), output.toString());
+        assertTrue(output.path("fromLiteralExpression").isNull(), output.toString());
+        assertTrue(output.path("literal").isNull(), output.toString());
+        assertTrue(output.path("nested").path("inner").isNull(), output.toString());
+        assertEquals("[null,1]", output.path("values").toString());
+        assertTrue(output.path("returnedNothing").isMissingNode(), output.toString());
+    }
+
+    @Test
+    void anAssignedNullReadsBackAsANullInTheNextState() throws Exception {
+        // AWS keeps the null in the variables map: TestState TRACE reports {"x":null} for
+        // Assign {"x": "{% null %}"}. A state never sees its own Assign, so the read is one state on.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "AssignNull",
+                    "States": {
+                        "AssignNull": {
+                            "Type": "Pass",
+                            "Assign": {"nullVariable": "{% $states.input.bar %}"},
+                            "Next": "ReadItBack"
+                        },
+                        "ReadItBack": {
+                            "Type": "Pass",
+                            "Output": {
+                                "fromVariable": "{% $nullVariable %}",
+                                "exists": "{% $exists($nullVariable) %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-null-test", definition);
+        String execArn = startExecution(smArn, "{\"bar\": null}");
+        JsonNode output = objectMapper.readTree(waitForExecution(execArn));
+
+        assertTrue(output.path("fromVariable").isNull(), output.toString());
+        assertTrue(output.path("exists").asBoolean(), output.toString());
+    }
+
+    @Test
     void assignedVariablesSurviveBeyondNextStateOutput() throws Exception {
         // Variables set via Assign persist across states even after a later state replaces the output.
         String definition = """


### PR DESCRIPTION
## Summary

A JSONata expression that evaluates to JSON `null` lost its key, exactly as an expression that returned nothing did. The two were indistinguishable in the output and inside the evaluator. Closes #2664, which carries the one-container reproduction.

- **Root cause:** dashjoin flattens JSONata's null marker into a Java `null` unless `outputConvertNulls` is off, and Floci never changed it (`JsonataEvaluator.java:112`). `toJsonNode` then mapped that Java `null` to a `NullNode`, and `resolveTemplate` dropped every `NullNode`.
- **Both halves of the conversion move.** `$states` and the workflow variables bind through the existing `toJsonataValue`, so an input null reaches the expression as a null rather than as undefined. The result is walked back by `fromJsonataValue`, which maps the marker to a JSON null at any depth; a top-level Java `null` becomes a `MissingNode`, now the single representation of "returned nothing".
- **`resolveTemplate` drops only the missing node**, in objects and in arrays. A literal `null` written straight into an `Output` template is kept too, which it was not before.
- **The missing node does not leave the template walk.** `resolveTemplate` is the boundary for `Output`, `Assign` and `Arguments`, and it answers a JSON value: a whole field that is one expression returning nothing resolves to a `null`, as it did before this PR. The private `resolveTemplateNode` is where "returned nothing" is still itself, in the two positions that read it — an object field it drops, an array element it fails the state on. Without that split a top-level `Output` would reach `exec.setOutput(output.toString())` as a `MissingNode`, and `DescribeExecution` would hand back `""` instead of JSON.
- **`AslExecutor` also calls `evaluate` directly, and five of those six sites are unaffected.** A `Choice` condition reads the result through `isBoolean`, `Wait` `Seconds` through `asInt`, `MaxConcurrency` through `isIntegralNumber`, `Map` `Items` through `isArray`; all four answer the same for a `NullNode` and a `MissingNode`, so those paths keep the behaviour they had. The sixth is `Fail`, which reads `Error` and `Cause` through `asText()`: an expression that returned nothing now yields `""` where it yielded `"null"`. AWS answers neither — it fails the state with `States.QueryEvaluationError`, `The JSONata expression '$states.input.absent' specified for the field 'Error' returned nothing (undefined).` — so this is #2665's ground and no test here blesses either string.
- **Docs:** a new `## JSONata nulls` section in `docs/services/step-functions.md`, outside the generated action-table markers, recording both deviations: `$count()` on a JSON null, and the key that Floci drops where AWS fails the state.

## Wire-fidelity details (AWS CLI 2.33.7, `test-state` against `us-east-1`)

```bash
aws stepfunctions test-state --role-arn "$ROLE" --query '[status,output]' --output json \
  --definition '{"Type":"Pass","QueryLanguage":"JSONata","Output":{"v":"{% null %}"},"End":true}' --input '{}'
# [ "SUCCEEDED", "{\"v\":null}" ]
```

| Position, as sent to AWS | AWS returns | Pinned by |
| --- | --- | --- |
| `Output {"v":"{% $lookup($states.input,\"bar\") %}"}` on `{"bar":null}` | `{"v":null}` | `anExplicitNullKeepsItsKeyAndOnlyWhatReturnedNothingIsDropped` |
| `Output {"a":{"b":"{% null %}","c":1}}` | `{"a":{"b":null,"c":1}}` | `anExplicitNullSurvivesInsideANestedObject` |
| `Output "{% null %}"`, the whole field one expression | `null` | `aWholeTemplateIsANullWhetherItEvaluatedToNullOrReturnedNothing` |
| `Output {"a":["{% null %}",1]}` | `{"a":[null,1]}` | `anExplicitNullIsAnArrayElementWhileNothingStillFailsTheState` |
| `Output {"v":null,"k":1}`, a literal null in the template | `{"v":null,"k":1}` | `aLiteralNullInTheTemplateKeepsItsKey` |
| `$exists($states.input.bar)` and `$type($states.input.bar)` on `{"bar":null}` | `true`, `"null"` | `anInputNullIsAValueForExistsAndType` |
| `Assign {"x":"{% null %}"}`, TRACE | variables `{"x":null}` | `anAssignedNullReadsBackAsANullInTheNextState` |
| Task `Arguments {"Payload":{"v":"{% null %}"}}`, TRACE | `afterArguments` `{"Payload":{"v":null}}` | `jsonataArgumentsSendAnExplicitNullAndOmitOnlyWhatReturnedNothing` |

The last two rows are observed differently on each side. `test-state` runs one state and AWS never shows a state its own `Assign`, so the AWS side there is the variables map TRACE reports while the Floci test reads the variable back in the next state; the Task row is `afterArguments` on AWS and the request body an `http:invoke` Task actually sends on Floci.

## Deliberate scope notes

- **#2665 is still open and untouched.** AWS fails the state on an expression that returned nothing: `Output {"v":"{% $states.input.absent %}"}` answers `States.QueryEvaluationError`, `The JSONata expression '$states.input.absent' specified for the field 'Output/v' returned nothing (undefined).` Floci still drops that key, and the new docs section now names that as a deviation rather than leaving it to read as parity. This PR only makes the two cases distinguishable, which is what #2665 needs before it can fail the right one.
- **`$count` on a JSON null answers `0` here and `1` on AWS.** That is dashjoin, not this code: `$count(null)` is `0` straight out of the library with the marker in place. It is one line in the new docs section as a deviation, and no test blesses it.
- **`AslExecutorResultWriterTest.jsonataDestinationNullsAreTypeErrorsRatherThanMissingValues` is unchanged and green.** The issue reports it going red under `setOutputConvertNulls(false)` alone, and that reproduces: 411 tests, 1 failure, at the `Arguments {"Bucket":"{% null %}"}` block. The cause is not a behavioural disagreement. With only that line the marker reaches Jackson unconverted and `valueToTree` throws `No serializer found for class com.dashjoin.jsonata.Jsonata$2`, which `evaluate`'s catch turns into a `States.QueryEvaluationError` carrying that message instead of `ResultWriter Bucket must resolve to a string`. Adding the `toJsonNode` half restores the message: `Bucket` is now a `NullNode` rather than an absent key, and it still is not textual, so the error and its message match `main`. I did not settle what AWS writes on the distributed `Map` `ResultWriter` S3 export path, because this PR does not move it; that stays open for whoever changes that behaviour.
- **Eleven existing tests moved from `assertTrue(result.isNull())` to `assertTrue(result.isMissingNode())`.** `evaluate_returnsNothingForMissingField`, `parse_noArgumentReturnsUndefined`, `partition_emptyArrayReturnsUndefined`, `partition_chunkSizeZeroReturnsUndefined`, `range_missingStepReturnsUndefined`, `range_stepZeroReturnsUndefined`, `range_wrongSignStepReturnsUndefined`, `hash_missingAlgorithmReturnsUndefined`, `hash_missingAlgorithmIsUndefinedButNonStringOneIsASignatureError`, `roundingGoesTowardsZeroNotDownwards` and `string_leavesEveryOtherValueToTheBuiltIn`. Each is named `...ReturnsUndefined` or asserts a missing field, so the assertion now matches the name instead of the representation that made undefined and null the same thing. No test deleted, no expectation weakened.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- [x] Every row above is a captured `test-state` response from `us-east-1`, not a value derived from the documentation. `test-state` creates nothing, and nothing was created on AWS for this PR
- [x] `$exists`, `$type` and `$count` were measured on both sides, AWS through `test-state` and dashjoin 0.9.10 directly
- [x] No wire-protocol or botocore model work: this is expression evaluation

## Checklist

- [x] Targeted Step Functions suites green: 435 tests, 0 failures, 0 errors, 0 skipped (`mvnw test -Dtest='io.github.hectorvent.floci.services.stepfunctions.*Test'`). The merge base is 424 on the same command, and the 11 new tests are the difference
- [x] Red proved before the fix: with the 10 new tests written and `JsonataEvaluator` still at `main`, all 10 fail on the null they expected to survive, for example `expected: <{"fromInput":null,"kept":1}> but was: <{"kept":1}>` and `States.Runtime: The JSONata expression '{% null %}' at array index 0 returned nothing (undefined).`
- [x] 7 new unit tests in `JsonataEvaluatorTest`, 3 new integration tests in `StepFunctionsJsonataIntegrationTest` through `CreateStateMachine` and `StartExecution`, 1 new Task-`Arguments` test in `AslExecutorHttpInvokeTest`
- [x] `aWholeOutputThatReturnedNothingStaysReadableJson` was red before the boundary split: `Output "{% $states.input.absent %}"` came back from `DescribeExecution` as `""`, and it passes with `JsonataEvaluator` reverted to `main`, so the empty output was this PR's own regression and not a pre-existing one
- [x] `make docs-check` passes and the generated action table is untouched. `make docs-test` fails on this machine with `No module named pytest`; through `uvx --with pytest --with pyyaml pytest tools/docs -q` it is 34 passed
- [x] Merge base with `origin/main` is `acf88794`, Conventional Commits
- [ ] The full `./mvnw test` run was not executed on this branch; the diff is one class under `services/stepfunctions`

