### PR TITLE
fix(stepfunctions): resolve the substitutions in a JSONata error cause

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -62,6 +62,18 @@ public class JsonataEvaluator {
      */
     private static final double SMALLEST_EXPONENT_NOTATION = 1e21;
 
+    /** What dashjoin prefixes to an error whose code is not in its message catalog. */
+    private static final String UNKNOWN_CODE_PREFIX = "JSonataException ";
+
+    /** Stand-ins for the two values dashjoin substitutes; no catalog template contains them. */
+    private static final String CURRENT_MARKER = "{{floci-current}}";
+    private static final String EXPECTED_MARKER = "{{floci-expected}}";
+
+    /** The name jsonata-js gives each element type a function signature can ask an array for. */
+    private static final Map<Object, String> ARRAY_ELEMENT_TYPES = Map.of(
+            "a", "arrays", "b", "booleans", "f", "functions",
+            "n", "numbers", "o", "objects", "s", "strings");
+
     private final ObjectMapper objectMapper;
     private final ObjectReader strictJsonReader;
     private final Map<String, Jsonata.JFunction> stepFunctionsExtensions;
@@ -131,7 +143,68 @@ public class JsonataEvaluator {
             Object result = jsonataExpr.evaluate(null, frame);
             return toJsonNode(result);
         } catch (Exception e) {
-            throw new AslExecutor.FailStateException("States.QueryEvaluationError", e.getMessage());
+            throw new AslExecutor.FailStateException("States.QueryEvaluationError", queryEvaluationCause(e));
+        }
+    }
+
+    /**
+     * The cause AWS reports for a failed JSONata expression: the error code, then the message
+     * jsonata-js renders for it, as in {@code T0412: Argument 1 of function "sum" must be an array
+     * of "numbers"}. AWS puts a sentence naming the expression and the field in front of that,
+     * which needs the field path {@link #resolveTemplate} does not thread today (#2665).
+     *
+     * <p>The dashjoin port renders the message itself, and three things go wrong on the way. Its
+     * copy of the catalog has the word "function" replaced by "Object" throughout; its substituter
+     * fills the first two placeholders of a template and leaves a third one standing; and it quotes
+     * every value it inserts, where jsonata-js JSON-renders it. So the message is composed here
+     * from the code and the values {@link JException} carries instead.
+     */
+    private String queryEvaluationCause(Exception e) {
+        if (!(e instanceof JException jsonataError) || jsonataError.getError() == null) {
+            return e.getMessage();
+        }
+        String code = jsonataError.getError();
+        Object current = jsonataError.getCurrent();
+        Object expected = jsonataError.getExpected();
+        // Both this class's own functions and a few library call sites throw with the whole
+        // message in the code slot. The catalog lookup then misses and dashjoin prefixes its own
+        // class name, which AWS never emits; the message is the code slot itself.
+        if ((UNKNOWN_CODE_PREFIX + code).equals(jsonataError.getMessage())) {
+            return code;
+        }
+        return switch (code) {
+            // The only two templates in the catalog with a third placeholder. Neither third value
+            // reaches the exception: T0412 carries the offending argument and the element type it
+            // wanted but not the argument index nor the function name, and T2009 carries the two
+            // compared values but not the operator. Both sentences state what is carried.
+            case "T0412" -> "T0412: Argument " + json(current) + " must be an array of "
+                    + json(ARRAY_ELEMENT_TYPES.getOrDefault(expected, String.valueOf(expected)));
+            case "T2009" -> "T2009: The values " + json(current) + " and " + json(expected)
+                    + " either side of the operator must be of the same data type";
+            default -> code + ": " + renderTemplate(code, current, expected);
+        };
+    }
+
+    /**
+     * The catalog template for a code with its values substituted. Rendering it once with markers
+     * in the value slots is what keeps the template's own words apart from a value that happens to
+     * contain them, so restoring "function" cannot reach into a value. A marker comes back quoted
+     * where jsonata-js JSON-renders the value and bare where it inserts it raw.
+     */
+    private String renderTemplate(String code, Object current, Object expected) {
+        return JException.msg(code, -1, CURRENT_MARKER, EXPECTED_MARKER)
+                .replace("Object", "function")
+                .replace('"' + CURRENT_MARKER + '"', json(current))
+                .replace('"' + EXPECTED_MARKER + '"', json(expected))
+                .replace(CURRENT_MARKER, String.valueOf(current))
+                .replace(EXPECTED_MARKER, String.valueOf(expected));
+    }
+
+    private String json(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            return String.valueOf(value);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -618,4 +618,117 @@ class JsonataEvaluatorTest {
         assertEquals("[\"100000000000000000000\",\"1e+21\"]",
                 evaluator.evaluate("{% $map([1e20, 1e21], $string) %}", statesVar).toString());
     }
+
+    // ---- the cause of a States.QueryEvaluationError (#2668) ----
+    // Every expected string below was captured from real AWS through test-state, minus the
+    // "The JSONata expression '...' specified for the field '...' threw an error during
+    // evaluation." prefix AWS puts in front of it, which needs the field path #2665 threads.
+
+    @Test
+    void theCauseCarriesTheJsonataErrorCode() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate("{% $split('a','b',-1) %}", statesVar));
+        assertEquals("D3020: Third argument of split function must evaluate to a positive number",
+                ex.cause);
+    }
+
+    @Test
+    void theErrorNameStaysQueryEvaluationErrorSoACatchStillMatchesIt() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        for (String expression : new String[]{"$sum(['a'])", "1 < 'a'", "$sqrt(-1)",
+                "$each('x', function($v){$v})", "$parse(null)"}) {
+            AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                    () -> evaluator.evaluate("{% " + expression + " %}", statesVar),
+                    "expected " + expression + " to fail");
+            assertEquals("States.QueryEvaluationError", ex.error,
+                    "wrong error name for " + expression);
+        }
+    }
+
+    @Test
+    void aFunctionNameIsNamedAsAFunctionAndNotAsAnObject() {
+        // dashjoin ships jsonata-js's message catalog with the word "function" replaced by
+        // "Object" throughout, which is 116 of the 117 malformed causes in #2668.
+        JsonNode statesVar = objectMapper.createObjectNode();
+        assertEquals("T0410: Argument 1 of function \"each\" does not match function signature",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $each('x', function($v){$v}) %}", statesVar)).cause);
+        assertEquals("D3050: The second argument of reduce function must be a function"
+                        + " with at least two arguments",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $reduce([1,2], function($a){$a}) %}", statesVar)).cause);
+        assertEquals("D3138: The $single() function expected exactly 1 matching result. "
+                        + " Instead it matched more.",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $single([1,2], function($x){true}) %}", statesVar)).cause);
+    }
+
+    @Test
+    void anArrayElementTypeIsNamedInsteadOfLeftAsATypePlaceholder() {
+        // T0412 is the one code in the catalog carrying both defects: the "Object" word and a
+        // third placeholder that dashjoin's two-slot substituter never reaches. It also carries
+        // neither the argument index nor the function name AWS names, so the cause states what
+        // the library does hand over: the offending argument and the element type it wanted.
+        JsonNode statesVar = objectMapper.createObjectNode();
+        assertEquals("T0412: Argument [\"a\"] must be an array of \"numbers\"",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $sum(['a']) %}", statesVar)).cause);
+        assertEquals("T0412: Argument [\"a\",\"b\"] must be an array of \"numbers\"",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $average(['a','b']) %}", statesVar)).cause);
+    }
+
+    @Test
+    void bothComparedValuesAreNamedInsteadOfLeftAsATokenPlaceholder() {
+        // T2009 is the other three-placeholder code, and the only one of the 117 whose leftover
+        // is {{token}}. The operator is not carried either, so the cause names the two values.
+        JsonNode statesVar = objectMapper.createObjectNode();
+        assertEquals("T2009: The values 1 and \"a\" either side of the operator"
+                        + " must be of the same data type",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% 1 < 'a' %}", statesVar)).cause);
+        assertEquals("T2009: The values \"a\" and 1 either side of the operator"
+                        + " must be of the same data type",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% 'a' < 1 %}", statesVar)).cause);
+    }
+
+    @Test
+    void aMessageThrownInPlaceOfACodeIsNotPrefixedWithJSonataException() {
+        // dashjoin's own catalog lookup falls back to "JSonataException " + code, and both this
+        // class's six functions and a handful of library call sites throw with the whole message
+        // in the code slot. AWS emits neither that prefix nor the class name.
+        JsonNode statesVar = objectMapper.createObjectNode();
+        assertEquals("T0410: Argument 1 of function \"parse\" does not match function signature",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $parse(null) %}", statesVar)).cause);
+        assertEquals("Second argument of replace function cannot be an empty string",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $replace('a','','b') %}", statesVar)).cause);
+    }
+
+    @Test
+    void aValueSubstitutedIntoTheMessageIsRenderedAsJson() {
+        // dashjoin quotes every value it substitutes; jsonata-js and AWS JSON-render it, so a
+        // number stays bare and an array keeps its brackets.
+        JsonNode statesVar = objectMapper.createObjectNode();
+        assertEquals("D3060: The sqrt function cannot be applied to a negative number: -1",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% $sqrt(-1) %}", statesVar)).cause);
+        assertEquals("T2002: The right side of the \"+\" operator must evaluate to a number",
+                assertThrows(AslExecutor.FailStateException.class,
+                        () -> evaluator.evaluate("{% 1 + {} %}", statesVar)).cause);
+    }
+
+    @Test
+    void aNonJsonataFailureKeepsTheMessageItCameWith() {
+        // dashjoin lets a plain Java exception out of a few functions. There is no code and no
+        // template to render, and swallowing the message would lose the only diagnosis there is.
+        JsonNode statesVar = objectMapper.createObjectNode();
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate("{% $toMillis('nope') %}", statesVar));
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertTrue(ex.cause.contains("nope"), ex.cause);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataFunctionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataFunctionsIntegrationTest.java
@@ -223,6 +223,34 @@ class StepFunctionsJsonataFunctionsIntegrationTest {
                 "cause does not name the rejected algorithm: " + resp.jsonPath().getString("cause"));
     }
 
+    @Test
+    void aFailedJsonataExpressionReportsTheErrorCodeAndTheTypeItWanted() throws Exception {
+        // The reproduction in #2668, end to end: DescribeExecution is where a caller reads the
+        // cause, and the malformed one there said Object "n" and {{type}}.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Sum",
+                    "States": {
+                        "Sum": {
+                            "Type": "Pass",
+                            "Output": {
+                                "v": "{% $sum(['a']) %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-error-cause", definition);
+        Response resp = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", resp.jsonPath().getString("error"));
+        assertEquals("T0412: Argument [\"a\"] must be an array of \"numbers\"",
+                resp.jsonPath().getString("cause"));
+    }
+
     // ---- helpers ----
 
     private String createStateMachine(String name, String definition) {


### PR DESCRIPTION
## Summary

`JsonataEvaluator` built the cause of a `States.QueryEvaluationError` from `e.getMessage()`, dashjoin's already-rendered template. That template is wrong in three separate ways, and #2668 counts what reaches a caller: a function named as the literal `Object`, a sentence ending in `{{type}}` or `{{token}}`, and no error code anywhere. The cause is now composed from `JException`'s own pieces, so it reads the way jsonata-js and AWS write it. Closes #2668.

- **The root cause is dashjoin's catalog, not its call sites.** Diffing `Jsonata.errorCodes` against jsonata-js v2.2.2 shows 21 templates in which the word `function` was replaced by `Object`. Of the 118 malformed causes I measured, 116 come from one of those templates, so restoring that one word is most of the fix.
- **A third placeholder is never reached, and its value is not in the exception either.** `JException.msg` rewrites the first two `{{...}}` of a template into `%1$s` and `%2$s` from `getCurrent()` and `getExpected()`. Exactly two templates have a third: `T0412` (`{{type}}`, 13 cases) and `T2009` (`{{token}}`, 1 case), the remaining 14. `Signature.validate` throws `T0412` with `(arg, param.subtype)` rather than the argument index and function name jsonata-js passes, and the `T2009` site drops the operator, so both sentences now state what is carried and claim nothing else.
- **The code is prefixed and dashjoin's class name is not.** `JSonataException ` is what dashjoin prepends when the code is not in its catalog, which happens for this class's own six functions and for a few library sites that throw with the whole message in the code slot. Values are JSON-rendered too: dashjoin quotes everything it inserts, so `$sqrt(-1)` reported `: "-1"` where AWS reports `: -1`.

## Wire-fidelity details (AWS CLI 2.33.7, `test-state` against `us-east-1`)

`test-state` creates nothing, so every row is re-checkable in one call. AWS prefixes each cause with `The JSONata expression '...' specified for the field '...' threw an error during evaluation.` and the code sits after it; the table drops that prefix, and the next section says why.

```bash
ROLE=arn:aws:iam::<account>:role/<any-role>

aws stepfunctions test-state --role-arn "$ROLE" --query 'cause' --output text \
  --definition '{"Type":"Pass","QueryLanguage":"JSONata","Output":{"v":"{% $sum([\"a\"]) %}"},"End":true}'
# ... threw an error during evaluation. T0412: Argument 1 of function "sum" must be an array of "numbers"
```

| Expression | Floci now | AWS | Pinned by |
| --- | --- | --- | --- |
| `$each('x', function($v){$v})` | `T0410: Argument 1 of function "each" does not match function signature` | identical | `aFunctionNameIsNamedAsAFunctionAndNotAsAnObject` |
| `$single([1,2], function($x){true})` | `D3138: The $single() function expected exactly 1 matching result.  Instead it matched more.` | identical | `aFunctionNameIsNamedAsAFunctionAndNotAsAnObject` |
| `$split('a','b',-1)` | `D3020: Third argument of split function must evaluate to a positive number` | identical | `theCauseCarriesTheJsonataErrorCode` |
| `$sqrt(-1)` | `D3060: The sqrt function cannot be applied to a negative number: -1` | identical | `aValueSubstitutedIntoTheMessageIsRenderedAsJson` |
| `1 + {}` | `T2002: The right side of the "+" operator must evaluate to a number` | identical | `aValueSubstitutedIntoTheMessageIsRenderedAsJson` |
| `$parse(null)` | `T0410: Argument 1 of function "parse" does not match function signature` | identical | `aMessageThrownInPlaceOfACodeIsNotPrefixedWithJSonataException` |
| `$replace('a','','b')` | `Second argument of replace function cannot be an empty string` | prefixes `D3010: ` | `aMessageThrownInPlaceOfACodeIsNotPrefixedWithJSonataException` |
| `$sum(['a'])` | `T0412: Argument ["a"] must be an array of "numbers"` | says `Argument 1 of function "sum"` | `anArrayElementTypeIsNamedInsteadOfLeftAsATypePlaceholder`, `aFailedJsonataExpressionReportsTheErrorCodeAndTheTypeItWanted` |
| `$average(['a','b'])` | `T0412: Argument ["a","b"] must be an array of "numbers"` | says `Argument 1 of function "average"` | `anArrayElementTypeIsNamedInsteadOfLeftAsATypePlaceholder` |
| `1 < 'a'` | `T2009: The values 1 and "a" either side of the operator must be of the same data type` | says `operator "<"` | `bothComparedValuesAreNamedInsteadOfLeftAsATokenPlaceholder` |
| `'a' < 1` | `T2009: The values "a" and 1 either side of the operator must be of the same data type` | says `operator "<"` | `bothComparedValuesAreNamedInsteadOfLeftAsATokenPlaceholder` |

I re-ran the corpus the issue used: 1674 expressions from the jsonata-js v2.2.2 groups minus `function-eval`, each on its dataset, 285 of which raise here. **Causes carrying an unresolved substitution go from 118 to 1, and causes carrying a `T####`/`D####`/`S####` code from 0 to 220.** The one survivor is a raw `NullPointerException` from a path that builds no message from a template (`Cannot invoke "java.util.Map.get(Object)" because "item" is null`); the word `Object` there is a Java signature, not a substitution.

## Deliberate scope notes

- **The sentence AWS puts in front of the cause is #2665, not this PR.** The field path is not available inside `resolveTemplate`, which walks a template without carrying where it is. Threading it here would put the interesting half of #2665 inside a diagnosability fix.
- **The argument index, the function name and the operator are not in the exception, so they are not invented.** Writing `of function "n"` after restoring the word would call a signature type letter a function name, which is worse than the placeholder it replaces. Both messages are shorter than AWS's and every word in them is carried.
- **`T0410`'s argument number is dashjoin's, and it is not always AWS's.** For `$sum([1],2)` AWS says `Argument 2` and the library says `Argument 1`, because `throwValidationError` walks its regex with `matches()` where jsonata-js uses a prefix test. That is a signature-validation defect rather than a substitution one, and fixing it means reimplementing the validator, so the table only claims rows where the two agree.
- **Value rendering came with the placeholders, not instead of them.** Half-repairing `The sqrt Object ... : "-1"` into `The sqrt function ... : "-1"` leaves a cause that still is not the AWS string, for a reason nobody would guess. `json()` is four lines and it is what makes six of the eleven rows above exact.
- **Restoring `function` runs on the template, never on the message.** Rendering once with markers in the value slots keeps a value that contains the word `Object` out of the replacement; replacing on the rendered string would silently corrupt `Syntax error: "Object"`.
- **Behaviour is unchanged.** `error` is still `States.QueryEvaluationError` on every path, including the non-`JException` failures dashjoin lets out of `$toMillis` and `$number`, which keep the message they came with.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- [x] Verified against real Step Functions in `us-east-1` with AWS CLI 2.33.7, through `test-state`, which creates nothing and left nothing behind
- [x] Every "AWS" cell above is a captured response, not a value derived from the documentation or from jsonata-js
- [x] Catalog diff against jsonata-js v2.2.2 `src/jsonata.js`: 21 templates differ only by `function` becoming `Object`, and exactly 2 have a third placeholder
- [x] No botocore model work: this is expression evaluation, not the wire protocol

## Checklist

- [x] Targeted Step Functions suites green: `./mvnw test -Dtest='io.github.hectorvent.floci.services.stepfunctions.*Test'` is 433 tests, 0 failures, 0 errors, 0 skipped (424 before this PR)
- [x] 8 new unit tests in `JsonataEvaluatorTest`, plus 1 integration test in `StepFunctionsJsonataFunctionsIntegrationTest` that reproduces #2668 through `CreateStateMachine`, `StartExecution` and `DescribeExecution`
- [x] Red proof: with `JsonataEvaluator.java` reverted to `main` and the tests untouched, the 9 run as `Tests run: 9, Failures: 7`, for instance `expected: <T0412: Argument ["a"] must be an array of "numbers"> but was: <Argument "[a]" of Object "n" must be an array of {{type}}>`. The two that stay green are the behaviour-preservation pins, `theErrorNameStaysQueryEvaluationErrorSoACatchStillMatchesIt` and `aNonJsonataFailureKeepsTheMessageItCameWith`
- [x] No docs change: nothing under `docs/` documents a JSONata cause, and the generated action table is untouched
- [x] Rebased onto `main` at acf88794, after #2683; the branch merges into current `origin/main` with no conflict
- [x] Commit message follows [Conventional Commits](https://www.conventionalcommits.org/)

