### PR TITLE
fix(stepfunctions): fail the state when a JSONata expression returns nothing

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -79,10 +79,7 @@ an array element:
 The same `null` is a value inside the expression too: `$exists()` on it is true and `$type()` on it
 is `"null"`.
 
-Two deviations. `$count()` on a JSON null answers `0`; AWS answers `1`. And dropping the key of an
-expression that returned nothing is Floci's own behaviour: AWS fails the state instead, with
-`States.QueryEvaluationError` and `The JSONata expression '$states.input.absent' specified for the
-field 'Output/v' returned nothing (undefined).`
+One deviation. `$count()` on a JSON null answers `0`; AWS answers `1`.
 
 ## An expression that returns nothing fails the state
 
@@ -129,8 +126,8 @@ Three behaviours are worth knowing before reading an unexpected result, and all 
   `$partition(items, 2.9)` chunks by 2.
 - Several arguments evaluate to undefined rather than failing: a chunk size of zero, an empty
   array, a `$range` with no `step` or with a step whose sign disagrees with the direction, and a
-  `$hash` with no algorithm. An undefined value is then dropped from the surrounding `Output`
-  object, so the field goes missing instead of the state failing.
+  `$hash` with no algorithm. The argument itself does not fail; the field the expression was
+  written in does, under `States.QueryEvaluationError`, as the section above records.
 - `$range` collapses a single-element range to the bare number, not a one-element array.
 
 JSONata's own `$string` follows AWS's number notation: a whole number is written out in full below

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -100,8 +100,10 @@ that error fires:
 
 The field is named relative to the state, with `/` before each object key and `[i]` for each array
 index: `Output`, `Output/a/b[0]`, `Assign/x`, `Arguments/MessageGroupId`, `Choices[1]/Condition`,
-`Seconds`, `Error`, `Cause`, `Items`, `MaxConcurrency`. A `Choice` stops at the first rule that
-matches, so an undefined condition in a later rule is never evaluated.
+`Seconds`, `Error`, `Cause`, `Items`, `MaxConcurrency`. A matched `Choice` rule and a matching
+`Catch` clause carry their own `Assign` and `Output`, which are named under the rule or clause:
+`Choices[1]/Output/v`, `Choices[0]/Assign/x`, `Catch[1]/Output/v`. A `Choice` stops at the first rule
+that matches, so an undefined condition in a later rule is never evaluated.
 
 One deviation. AWS prefixes the cause of a real execution with
 `An error occurred while executing the state '<name>' (entered at the event id #<n>).`; Floci

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -77,13 +77,35 @@ an array element:
 ```
 
 The same `null` is a value inside the expression too: `$exists()` on it is true and `$type()` on it
-is `"null"`. Only an expression that returns nothing loses its key, which is what
-`$states.input.absent` and the functions listed below that evaluate to undefined do.
+is `"null"`.
 
 Two deviations. `$count()` on a JSON null answers `0`; AWS answers `1`. And dropping the key of an
 expression that returned nothing is Floci's own behaviour: AWS fails the state instead, with
 `States.QueryEvaluationError` and `The JSONata expression '$states.input.absent' specified for the
 field 'Output/v' returned nothing (undefined).`
+
+## An expression that returns nothing fails the state
+
+An expression that returns nothing, which is what `$states.input.absent` and the functions listed
+below that evaluate to undefined do, is not a missing value the state carries on without. It fails
+the state with `States.QueryEvaluationError`, naming the field it was written in, and a `Catch` on
+that error fires:
+
+```
+"Output": {"v": "{% $states.input.absent %}"}
+  ->  States.QueryEvaluationError
+      The JSONata expression '$states.input.absent' specified for the field 'Output/v'
+      returned nothing (undefined).
+```
+
+The field is named relative to the state, with `/` before each object key and `[i]` for each array
+index: `Output`, `Output/a/b[0]`, `Assign/x`, `Arguments/MessageGroupId`, `Choices[1]/Condition`,
+`Seconds`, `Error`, `Cause`, `Items`, `MaxConcurrency`. A `Choice` stops at the first rule that
+matches, so an undefined condition in a later rule is never evaluated.
+
+One deviation. AWS prefixes the cause of a real execution with
+`An error occurred while executing the state '<name>' (entered at the event id #<n>).`; Floci
+returns the cause without it, which is the form AWS's own `TestState` returns.
 
 ## JSONata functions
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -593,7 +593,8 @@ public class AslExecutor {
             var effectiveInput = input;
             if (stateDef.has("Arguments")) {
                 var statesVar = buildStatesVar(input, null, context);
-                effectiveInput = jsonataEvaluator.resolveTemplate(stateDef.get("Arguments"), statesVar, variables);
+                effectiveInput = jsonataEvaluator.resolveTemplate(
+                        stateDef.get("Arguments"), "Arguments", statesVar, variables);
             }
             taskResult = mockedSteps != null
                     ? mockedTaskResult(mockedSteps, stateName, attempt)
@@ -1650,10 +1651,12 @@ public class AslExecutor {
         if (jsonata) {
             JsonNode statesVar = buildStatesVar(input, null, context);
             JsonNode choices = stateDef.path("Choices");
-            for (JsonNode choice : choices) {
+            for (int i = 0; i < choices.size(); i++) {
+                JsonNode choice = choices.get(i);
                 String condition = choice.path("Condition").asText(null);
                 if (condition != null) {
-                    JsonNode result = jsonataEvaluator.evaluate(condition, statesVar, variables);
+                    JsonNode result = jsonataEvaluator.evaluateField(
+                            condition, "Choices[" + i + "]/Condition", statesVar, variables);
                     if (result.isBoolean() && result.asBoolean()) {
                         // A matched rule carries its own Assign and Output; the state-level ones
                         // belong to the Default path and do not run here.
@@ -1777,7 +1780,8 @@ public class AslExecutor {
                 JsonNode secondsNode = stateDef.get("Seconds");
                 if (secondsNode.isTextual() && JsonataEvaluator.isExpression(secondsNode.asText())) {
                     JsonNode statesVar = buildStatesVar(input, null, context);
-                    JsonNode result = jsonataEvaluator.evaluate(secondsNode.asText(), statesVar, variables);
+                    JsonNode result = jsonataEvaluator.evaluateField(
+                            secondsNode.asText(), "Seconds", statesVar, variables);
                     seconds = Math.min(result.asInt(), MAX_WAIT_SECONDS);
                 } else {
                     seconds = Math.min(secondsNode.asInt(), MAX_WAIT_SECONDS);
@@ -1818,10 +1822,10 @@ public class AslExecutor {
         if (jsonata) {
             JsonNode statesVar = buildStatesVar(input, null, context);
             if (error != null && JsonataEvaluator.isExpression(error)) {
-                error = jsonataEvaluator.evaluate(error, statesVar, variables).asText();
+                error = jsonataEvaluator.evaluateField(error, "Error", statesVar, variables).asText();
             }
             if (cause != null && JsonataEvaluator.isExpression(cause)) {
-                cause = jsonataEvaluator.evaluate(cause, statesVar, variables).asText();
+                cause = jsonataEvaluator.evaluateField(cause, "Cause", statesVar, variables).asText();
             }
         }
         throw new FailStateException(error, cause);
@@ -2031,7 +2035,7 @@ public class AslExecutor {
             if (jsonata && value.isTextual() && JsonataEvaluator.isExpression(value.asText())) {
                 jsonataExpression = true;
                 JsonNode statesVar = buildStatesVar(mapInput, null, context);
-                value = jsonataEvaluator.evaluate(value.asText(), statesVar, variables);
+                value = jsonataEvaluator.evaluateField(value.asText(), "MaxConcurrency", statesVar, variables);
             }
         } else {
             return 0;
@@ -2118,19 +2122,8 @@ public class AslExecutor {
             // InputPath, which is supplied by executeMapState.
             JsonNode loc;
             if (jsonata && writer.has("Arguments")) {
-                JsonNode arguments = writer.get("Arguments");
-                loc = jsonataEvaluator.resolveTemplate(
-                        arguments, buildStatesVar(input, null, context), variables);
-                if (arguments.isObject()) {
-                    if (arguments.has("Bucket") && !loc.has("Bucket")) {
-                        throw new FailStateException("States.QueryEvaluationError",
-                                "ResultWriter Bucket must resolve to a string");
-                    }
-                    if (arguments.has("Prefix") && !loc.has("Prefix")) {
-                        throw new FailStateException("States.QueryEvaluationError",
-                                "ResultWriter Prefix must resolve to a string");
-                    }
-                }
+                loc = jsonataEvaluator.resolveTemplate(writer.get("Arguments"), "ResultWriter/Arguments",
+                        buildStatesVar(input, null, context), variables);
             } else if (writer.has("Parameters")) {
                 loc = resolveParameters(writer.get("Parameters"), input, context);
             } else {
@@ -2287,7 +2280,8 @@ public class AslExecutor {
             JsonNode itemsNode = stateDef.get("Items");
             if (itemsNode.isTextual() && JsonataEvaluator.isExpression(itemsNode.asText())) {
                 JsonNode statesVar = buildStatesVar(input, null, context);
-                return new ResolvedMapItems(jsonataEvaluator.evaluate(itemsNode.asText(), statesVar, variables),
+                return new ResolvedMapItems(
+                        jsonataEvaluator.evaluateField(itemsNode.asText(), "Items", statesVar, variables),
                         MapItemsSource.DEFAULT);
             }
             return new ResolvedMapItems(itemsNode, MapItemsSource.DEFAULT);
@@ -2323,7 +2317,8 @@ public class AslExecutor {
         JsonNode resolvedParameters;
         if (jsonata && itemReader.has("Arguments")) {
             JsonNode statesVar = buildStatesVar(input, null, context);
-            resolvedParameters = jsonataEvaluator.resolveTemplate(itemReader.get("Arguments"), statesVar, variables);
+            resolvedParameters = jsonataEvaluator.resolveTemplate(
+                    itemReader.get("Arguments"), "ItemReader/Arguments", statesVar, variables);
         } else {
             JsonNode parameters = itemReader.path("Parameters");
             resolvedParameters = resolveParameters(parameters, input, context);
@@ -2530,7 +2525,7 @@ public class AslExecutor {
                                                  ObjectNode variables) {
         JsonNode assigned = evaluateJsonataAssign(holder, statesVar, variables);
         JsonNode output = holder.has("Output")
-                ? jsonataEvaluator.resolveTemplate(holder.get("Output"), statesVar, variables)
+                ? jsonataEvaluator.resolveTemplate(holder.get("Output"), "Output", statesVar, variables)
                 : fallbackOutput;
         commitJsonataAssign(assigned, variables);
         return output;
@@ -2540,7 +2535,7 @@ public class AslExecutor {
         if (!holder.has("Assign")) {
             return null;
         }
-        JsonNode assigned = jsonataEvaluator.resolveTemplate(holder.get("Assign"), statesVar, variables);
+        JsonNode assigned = jsonataEvaluator.resolveTemplate(holder.get("Assign"), "Assign", statesVar, variables);
         if (assigned == null || !assigned.isObject()) {
             throw new FailStateException("States.Runtime", "Assign must evaluate to an object");
         }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -391,7 +391,16 @@ public class AslExecutor {
                         currentStateName = null;
                     }
                 } catch (FailStateException e) {
-                    StateResult caught = handleCatch(stateDef, currentInput, e, jsonata, execContext, variables);
+                    StateResult caught = null;
+                    FailStateException failure = e;
+                    try {
+                        caught = handleCatch(stateDef, currentInput, e, jsonata, execContext, variables);
+                    } catch (FailStateException catchClauseFailure) {
+                        // A matching Catch clause carries its own Assign and Output, and an
+                        // expression there can fail. AWS reports that failure, not the error the
+                        // clause was catching, and no later clause catches it.
+                        failure = catchClauseFailure;
+                    }
                     if (caught != null) {
                         addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
                                 Map.of("name", currentStateName, "output", caught.output().toString()));
@@ -399,7 +408,7 @@ public class AslExecutor {
                         currentStateName = caught.nextState();
                         continue;
                     }
-                    failExecution(exec, history, eventId, e);
+                    failExecution(exec, history, eventId, failure);
                     onUpdate.accept(exec, history);
                     return;
                 }
@@ -1660,7 +1669,8 @@ public class AslExecutor {
                     if (result.isBoolean() && result.asBoolean()) {
                         // A matched rule carries its own Assign and Output; the state-level ones
                         // belong to the Default path and do not run here.
-                        JsonNode output = applyJsonataAssignAndOutput(choice, statesVar, input, variables);
+                        JsonNode output = applyJsonataAssignAndOutput(
+                                choice, "Choices[" + i + "]/", statesVar, input, variables);
                         return new StateResult(output, choice.path("Next").asText());
                     }
                 }
@@ -1668,7 +1678,7 @@ public class AslExecutor {
             String defaultState = stateDef.path("Default").asText(null);
             if (defaultState != null) {
                 // No rule matched: the state-level Assign and Output apply on the Default path.
-                JsonNode output = applyJsonataAssignAndOutput(stateDef, statesVar, input, variables);
+                JsonNode output = applyJsonataAssignAndOutput(stateDef, "", statesVar, input, variables);
                 return new StateResult(output, defaultState);
             }
             throw new FailStateException("States.NoChoiceMatched", "No choice rule matched and no default state");
@@ -2514,28 +2524,35 @@ public class AslExecutor {
     private JsonNode applyJsonataOutput(JsonNode holder, JsonNode input, JsonNode result, JsonNode context,
                                         ObjectNode variables) {
         JsonNode statesVar = buildStatesVar(input, result, context);
-        return applyJsonataAssignAndOutput(holder, statesVar, result != null ? result : input, variables);
+        return applyJsonataAssignAndOutput(holder, "", statesVar, result != null ? result : input, variables);
     }
 
     /**
      * Apply the Assign and Output fields of anything that can carry them: a state, a Choice rule, or
-     * a Catch block. {@code fallbackOutput} is the value that becomes the output when Output is absent.
+     * a Catch clause. {@code fallbackOutput} is the value that becomes the output when Output is absent.
+     *
+     * <p>{@code holderPrefix} is what AWS puts before the holder's own field names in the cause of a
+     * States.QueryEvaluationError: empty for a state, {@code "Choices[1]/"} for the second Choice
+     * rule, {@code "Catch[1]/"} for the second Catch clause. AWS names a rule's own Output
+     * {@code Choices[1]/Output/v}, not {@code Output/v}.
      */
-    private JsonNode applyJsonataAssignAndOutput(JsonNode holder, JsonNode statesVar, JsonNode fallbackOutput,
-                                                 ObjectNode variables) {
-        JsonNode assigned = evaluateJsonataAssign(holder, statesVar, variables);
+    private JsonNode applyJsonataAssignAndOutput(JsonNode holder, String holderPrefix, JsonNode statesVar,
+                                                 JsonNode fallbackOutput, ObjectNode variables) {
+        JsonNode assigned = evaluateJsonataAssign(holder, holderPrefix, statesVar, variables);
         JsonNode output = holder.has("Output")
-                ? jsonataEvaluator.resolveTemplate(holder.get("Output"), "Output", statesVar, variables)
+                ? jsonataEvaluator.resolveTemplate(holder.get("Output"), holderPrefix + "Output", statesVar, variables)
                 : fallbackOutput;
         commitJsonataAssign(assigned, variables);
         return output;
     }
 
-    private JsonNode evaluateJsonataAssign(JsonNode holder, JsonNode statesVar, ObjectNode variables) {
+    private JsonNode evaluateJsonataAssign(JsonNode holder, String holderPrefix, JsonNode statesVar,
+                                           ObjectNode variables) {
         if (!holder.has("Assign")) {
             return null;
         }
-        JsonNode assigned = jsonataEvaluator.resolveTemplate(holder.get("Assign"), "Assign", statesVar, variables);
+        JsonNode assigned = jsonataEvaluator.resolveTemplate(
+                holder.get("Assign"), holderPrefix + "Assign", statesVar, variables);
         if (assigned == null || !assigned.isObject()) {
             throw new FailStateException("States.Runtime", "Assign must evaluate to an object");
         }
@@ -3380,7 +3397,8 @@ public class AslExecutor {
         }
         String error = failure.error != null ? failure.error : "States.Runtime";
         String cause = failure.cause != null ? failure.cause : "";
-        for (JsonNode catcher : catchers) {
+        for (int i = 0; i < catchers.size(); i++) {
+            JsonNode catcher = catchers.get(i);
             if (!catchMatches(catcher, error)) {
                 continue;
             }
@@ -3396,7 +3414,8 @@ public class AslExecutor {
                 // scope the catching state lives in — so for a Parallel or Map it lands in the outer
                 // scope, not the branch scope that failed.
                 JsonNode statesVar = buildCatchStatesVar(input, errorOutput, context);
-                JsonNode output = applyJsonataAssignAndOutput(catcher, statesVar, errorOutput, variables);
+                JsonNode output = applyJsonataAssignAndOutput(
+                        catcher, "Catch[" + i + "]/", statesVar, errorOutput, variables);
                 return new StateResult(output, next);
             }
             return new StateResult(mergeResult(catcher, input, errorOutput), next);

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -256,33 +256,46 @@ public class JsonataEvaluator {
     }
 
     /**
-     * Walk a JSON template (Arguments or Output), evaluating any {% %} strings found.
+     * Evaluate the single expression an ASL field holds, failing the state when it returns nothing.
+     * AWS names the field in the cause and a {@code Catch} on States.QueryEvaluationError fires:
+     * a Wait whose Seconds returned nothing does not wait zero seconds, it fails.
+     *
+     * <p>{@code field} is the field's path relative to the state, as AWS writes it: {@code Seconds},
+     * {@code Choices[1]/Condition}, {@code Output/a/b}.
+     */
+    JsonNode evaluateField(String expression, String field, JsonNode statesVar, JsonNode variables) {
+        JsonNode value = evaluate(expression, statesVar, variables);
+        if (value.isMissingNode()) {
+            throw new FailStateException("States.QueryEvaluationError",
+                    "The JSONata expression '" + (isExpression(expression) ? unwrap(expression) : expression)
+                            + "' specified for the field '" + field + "' returned nothing (undefined).");
+        }
+        return value;
+    }
+
+    /**
+     * Walk a JSON template (Arguments, Output or Assign), evaluating any {% %} strings found.
      * Non-expression values pass through unchanged.
      *
      * Only pure {% expression %} strings are evaluated (can return any JSON type).
      * All other strings pass through unchanged.
+     *
+     * <p>{@code field} is the template's own field name, which the walk extends with {@code /key}
+     * per object key and {@code [i]} per array index so a failing expression is named the way AWS
+     * names it: {@code Output/a/b[0][1]}.
      */
-    JsonNode resolveTemplate(JsonNode template, JsonNode statesVar) {
-        return resolveTemplate(template, statesVar, null);
+    JsonNode resolveTemplate(JsonNode template, String field, JsonNode statesVar) {
+        return resolveTemplate(template, field, statesVar, null);
     }
 
-    JsonNode resolveTemplate(JsonNode template, JsonNode statesVar, JsonNode variables) {
+    JsonNode resolveTemplate(JsonNode template, String field, JsonNode statesVar, JsonNode variables) {
         if (template == null || template.isMissingNode()) {
             return template;
         }
-        JsonNode resolved = resolveTemplateNode(template, statesVar, variables);
-        // A resolved Output or Arguments is serialized as it stands, and a missing node writes
-        // itself as the empty string, which no client can parse. "Returned nothing" is a value only
-        // in the positions resolveTemplateNode reads it in: an object field it drops, an array
-        // element it fails the state on. As the whole field there is nothing to drop it from.
-        return resolved.isMissingNode() ? NullNode.getInstance() : resolved;
-    }
-
-    private JsonNode resolveTemplateNode(JsonNode template, JsonNode statesVar, JsonNode variables) {
         if (template.isTextual()) {
             String text = template.asText();
             if (isExpression(text)) {
-                return evaluate(text, statesVar, variables);
+                return evaluateField(text, field, statesVar, variables);
             }
             return template;
         }
@@ -291,30 +304,15 @@ public class JsonataEvaluator {
             Iterator<Map.Entry<String, JsonNode>> fields = template.fields();
             while (fields.hasNext()) {
                 Map.Entry<String, JsonNode> entry = fields.next();
-                JsonNode value = resolveTemplateNode(entry.getValue(), statesVar, variables);
-                // Per JSONata spec: an expression that returned nothing is omitted from object
-                // output, matching real AWS Step Functions behavior. A JSON null is a value and
-                // keeps its key: AWS answers {"v":null} to Output {"v":"{% null %}"}.
-                if (!value.isMissingNode()) {
-                    resolved.set(entry.getKey(), value);
-                }
+                resolved.set(entry.getKey(),
+                        resolveTemplate(entry.getValue(), field + "/" + entry.getKey(), statesVar, variables));
             }
             return resolved;
         }
         if (template.isArray()) {
             ArrayNode resolved = objectMapper.createArrayNode();
             for (int i = 0; i < template.size(); i++) {
-                JsonNode element = template.get(i);
-                JsonNode value = resolveTemplateNode(element, statesVar, variables);
-                // Per real AWS behavior: an array element that returned nothing fails the execution.
-                // Unlike object fields (which are omitted), undefined in an array is a runtime error.
-                // A JSON null is a value and stays: AWS answers [null,1] to ["{% null %}",1].
-                if (value.isMissingNode()) {
-                    String expr = element.isTextual() ? element.asText() : element.toString();
-                    throw new FailStateException("States.Runtime",
-                            "The JSONata expression '" + expr + "' at array index " + i + " returned nothing (undefined).");
-                }
-                resolved.add(value);
+                resolved.add(resolveTemplate(template.get(i), field + "[" + i + "]", statesVar, variables));
             }
             return resolved;
         }
@@ -336,9 +334,9 @@ public class JsonataEvaluator {
 
     /**
      * The evaluation result. A Java null is the expression returning nothing, which
-     * {@link #resolveTemplateNode} drops from an object; the JSONata null marker is a JSON null,
-     * which it keeps. Nested inside an object or an array there is no undefined, so every null
-     * there is a JSON null.
+     * {@link #evaluateField} fails the state on; the JSONata null marker is a JSON null, which is a
+     * value like any other. Nested inside an object or an array there is no undefined, so every
+     * null there is a JSON null.
      */
     private JsonNode toJsonNode(Object value) {
         return value == null ? MissingNode.getInstance() : fromJsonataValue(value);

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorErrorTerminationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorErrorTerminationTest.java
@@ -64,7 +64,7 @@ class AslExecutorErrorTerminationTest {
         }
 
         @Override
-        JsonNode resolveTemplate(JsonNode template, JsonNode statesVar, JsonNode variables) {
+        JsonNode resolveTemplate(JsonNode template, String field, JsonNode statesVar, JsonNode variables) {
             throw new LinkageError(ERROR_MESSAGE);
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHttpInvokeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHttpInvokeTest.java
@@ -288,7 +288,7 @@ class AslExecutorHttpInvokeTest {
     }
 
     @Test
-    void jsonataArgumentsSendAnExplicitNullAndOmitOnlyWhatReturnedNothing() throws Exception {
+    void jsonataArgumentsSendAnExplicitNull() throws Exception {
         // AWS keeps the null in the arguments a Task is invoked with: TestState TRACE reports
         // afterArguments {"FunctionName":"nope","Payload":{"v":null}} for Payload {"v":"{% null %}"}.
         Execution execution = run("""
@@ -307,7 +307,6 @@ class AslExecutorHttpInvokeTest {
                         },
                         "RequestBody": {
                           "fromInput": "{%% $lookup($states.input, 'customerId') %%}",
-                          "returnedNothing": "{%% $states.input.absent %%}",
                           "active": true
                         }
                       },
@@ -324,7 +323,6 @@ class AslExecutorHttpInvokeTest {
         assertEquals("SUCCEEDED", execution.getStatus(), execution.getCause());
         JsonNode body = objectMapper.readTree(onlyRequest().body());
         assertTrue(body.path("fromInput").isNull(), body.toString());
-        assertTrue(body.path("returnedNothing").isMissingNode(), body.toString());
         assertTrue(body.path("active").asBoolean());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultWriterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultWriterTest.java
@@ -402,19 +402,27 @@ class AslExecutorResultWriterTest {
         assertEquals("States.QueryEvaluationError", nestedBucketFailure.error);
         assertTrue(nestedBucketFailure.getMessage().contains("Bucket must resolve to a string"));
 
-        JsonNode nestedPrefixStateDef = mapper.readTree("""
+        verify(s3Service, org.mockito.Mockito.never())
+                .putObject(anyString(), anyString(), any(byte[].class), anyString(), any());
+    }
+
+    @Test
+    void aDestinationExpressionReturningNothingFailsBeforeWriting() throws Exception {
+        JsonNode stateDef = mapper.readTree("""
                 {"Type":"Map",
                  "ResultWriter":{"Resource":"arn:aws:states:::s3:putObject",
                    "Arguments":{"Bucket":"b","Prefix":"{% $states.input.missing %}"}}}
                 """);
-        AslExecutor.FailStateException nestedPrefixFailure = assertThrows(
+
+        AslExecutor.FailStateException failure = assertThrows(
                 AslExecutor.FailStateException.class,
-                () -> executor.applyResultWriter("Process", nestedPrefixStateDef, mapper.createObjectNode(),
+                () -> executor.applyResultWriter("Process", stateDef, mapper.createObjectNode(),
                         arr("{\"ok\":true}"), mapper.createArrayNode(), List.of(),
                         sm, context, true));
-        assertEquals("States.QueryEvaluationError", nestedPrefixFailure.error);
-        assertTrue(nestedPrefixFailure.getMessage().contains("Prefix must resolve to a string"));
 
+        assertEquals("States.QueryEvaluationError", failure.error);
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'ResultWriter/Arguments/Prefix' returned nothing (undefined).", failure.cause);
         verify(s3Service, org.mockito.Mockito.never())
                 .putObject(anyString(), anyString(), any(byte[].class), anyString(), any());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -6,6 +6,11 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -97,7 +102,7 @@ class JsonataEvaluatorTest {
     void resolveTemplate_nonExpressionStringPassesThrough() throws Exception {
         JsonNode template = objectMapper.readTree("\"plain text\"");
         JsonNode statesVar = objectMapper.createObjectNode();
-        JsonNode result = evaluator.resolveTemplate(template, statesVar);
+        JsonNode result = evaluator.resolveTemplate(template, "Output", statesVar);
         assertEquals("plain text", result.asText());
     }
 
@@ -105,7 +110,7 @@ class JsonataEvaluatorTest {
     void resolveTemplate_evaluatesExpressionInString() throws Exception {
         JsonNode template = objectMapper.readTree("\"{% 1 + 1 %}\"");
         JsonNode statesVar = objectMapper.createObjectNode();
-        JsonNode result = evaluator.resolveTemplate(template, statesVar);
+        JsonNode result = evaluator.resolveTemplate(template, "Output", statesVar);
         assertEquals(2, result.asInt());
     }
 
@@ -121,7 +126,7 @@ class JsonataEvaluatorTest {
         JsonNode statesVar = objectMapper.readTree("""
                 {"input": {"name": "Bob"}}
                 """);
-        JsonNode result = evaluator.resolveTemplate(template, statesVar);
+        JsonNode result = evaluator.resolveTemplate(template, "Output", statesVar);
         assertTrue(result.isObject());
         assertEquals("Hello Bob", result.get("greeting").asText());
         assertEquals("unchanged", result.get("static").asText());
@@ -136,7 +141,7 @@ class JsonataEvaluatorTest {
         JsonNode statesVar = objectMapper.readTree("""
                 {"input": {"a": 1, "b": 2}}
                 """);
-        JsonNode result = evaluator.resolveTemplate(template, statesVar);
+        JsonNode result = evaluator.resolveTemplate(template, "Output", statesVar);
         assertTrue(result.isArray());
         assertEquals(1, result.get(0).asInt());
         assertEquals("static", result.get(1).asText());
@@ -150,7 +155,7 @@ class JsonataEvaluatorTest {
         JsonNode statesVar = objectMapper.readTree("""
                 {"input": {"name": "Alice", "age": 30}}
                 """);
-        JsonNode result = evaluator.resolveTemplate(template, statesVar);
+        JsonNode result = evaluator.resolveTemplate(template, "Output", statesVar);
         assertTrue(result.isTextual());
         assertEquals("Hello {% $states.input.name %}, you are {% $states.input.age %} years old", result.asText());
     }
@@ -161,7 +166,7 @@ class JsonataEvaluatorTest {
         JsonNode statesVar = objectMapper.readTree("""
                 {"input": {"name": "Alice", "age": 30}}
                 """);
-        JsonNode result = evaluator.resolveTemplate(template, statesVar);
+        JsonNode result = evaluator.resolveTemplate(template, "Output", statesVar);
         assertTrue(result.isObject());
         assertEquals("Alice", result.get("name").asText());
     }
@@ -170,9 +175,9 @@ class JsonataEvaluatorTest {
     void resolveTemplate_primitivesPassThrough() throws Exception {
         JsonNode statesVar = objectMapper.createObjectNode();
 
-        assertEquals(42, evaluator.resolveTemplate(objectMapper.readTree("42"), statesVar).asInt());
-        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("true"), statesVar).asBoolean());
-        assertTrue(evaluator.resolveTemplate(NullNode.getInstance(), statesVar).isNull());
+        assertEquals(42, evaluator.resolveTemplate(objectMapper.readTree("42"), "Output", statesVar).asInt());
+        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("true"), "Output", statesVar).asBoolean());
+        assertTrue(evaluator.resolveTemplate(NullNode.getInstance(), "Output", statesVar).isNull());
     }
 
     @Test
@@ -804,18 +809,17 @@ class JsonataEvaluatorTest {
     }
 
     @Test
-    void anExplicitNullKeepsItsKeyAndOnlyWhatReturnedNothingIsDropped() throws Exception {
+    void anExplicitNullKeepsItsKey() throws Exception {
         JsonNode statesVar = objectMapper.readTree("""
                 {"input": {"bar": null}}
                 """);
         JsonNode template = objectMapper.readTree("""
                 {"fromInput": "{% $lookup($states.input, 'bar') %}",
-                 "returnedNothing": "{% $states.input.absent %}",
                  "kept": 1}
                 """);
 
         assertEquals("{\"fromInput\":null,\"kept\":1}",
-                evaluator.resolveTemplate(template, statesVar).toString());
+                evaluator.resolveTemplate(template, "Output", statesVar).toString());
     }
 
     @Test
@@ -826,34 +830,23 @@ class JsonataEvaluatorTest {
                 """);
 
         assertEquals("{\"outer\":{\"fromExpression\":null,\"kept\":1}}",
-                evaluator.resolveTemplate(template, statesVar).toString());
+                evaluator.resolveTemplate(template, "Output", statesVar).toString());
     }
 
     @Test
-    void aWholeTemplateIsANullWhetherItEvaluatedToNullOrReturnedNothing() throws Exception {
+    void aWholeTemplateEvaluatingToNullIsANull() throws Exception {
         JsonNode statesVar = objectMapper.createObjectNode();
 
-        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% null %}\""), statesVar).isNull());
-        // AWS fails the second one with States.QueryEvaluationError, which #2665 covers. Until then
-        // it is a null and not a missing node: an Output or Arguments is serialized as it stands,
-        // and a missing node writes itself as the empty string rather than as JSON.
-        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% $states.input.absent %}\""), statesVar)
-                .isNull());
+        assertTrue(evaluator.resolveTemplate(objectMapper.readTree("\"{% null %}\""), "Output", statesVar).isNull());
     }
 
     @Test
-    void anExplicitNullIsAnArrayElementWhileNothingStillFailsTheState() throws Exception {
+    void anExplicitNullIsAnArrayElement() throws Exception {
         JsonNode statesVar = objectMapper.createObjectNode();
 
         assertEquals("{\"values\":[null,1]}", evaluator.resolveTemplate(objectMapper.readTree("""
                 {"values": ["{% null %}", 1]}
-                """), statesVar).toString());
-
-        AslExecutor.FailStateException failure = assertThrows(AslExecutor.FailStateException.class,
-                () -> evaluator.resolveTemplate(objectMapper.readTree("""
-                        {"values": ["{% $states.input.absent %}"]}
-                        """), statesVar));
-        assertTrue(failure.cause.contains("returned nothing (undefined)"), failure.cause);
+                """), "Output", statesVar).toString());
     }
 
     @Test
@@ -862,7 +855,7 @@ class JsonataEvaluatorTest {
 
         assertEquals("{\"literal\":null,\"kept\":1}", evaluator.resolveTemplate(objectMapper.readTree("""
                 {"literal": null, "kept": 1}
-                """), statesVar).toString());
+                """), "Output", statesVar).toString());
     }
 
     @Test
@@ -884,5 +877,55 @@ class JsonataEvaluatorTest {
 
         assertTrue(evaluator.evaluate("{% $nullVariable %}", statesVar, variables).isNull());
         assertTrue(evaluator.evaluate("{% $exists($nullVariable) %}", statesVar, variables).asBoolean());
+    }
+
+    /**
+     * The field path AWS names in the cause: the ASL field the template came from, a {@code /}
+     * before every object key below it and {@code [i]} appended for every array index. Measured on
+     * TestState, one Pass or one Assign per row.
+     */
+    static Stream<Arguments> templatesWhoseExpressionReturnsNothing() {
+        return Stream.of(
+                Arguments.of("{\"v\": \"{% $states.input.missing %}\"}", "Output", "Output/v"),
+                Arguments.of("{\"a\": {\"b\": \"{% $states.input.missing %}\"}}", "Output", "Output/a/b"),
+                Arguments.of("\"{% $states.input.missing %}\"", "Output", "Output"),
+                Arguments.of("{\"values\": [\"{% $states.input.missing %}\", 1]}", "Output", "Output/values[0]"),
+                Arguments.of("{\"a\": {\"b\": [[1, \"{% $states.input.missing %}\"]]}}", "Output", "Output/a/b[0][1]"),
+                Arguments.of("{\"x\": {\"y\": \"{% $states.input.missing %}\"}}", "Assign", "Assign/x/y"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("templatesWhoseExpressionReturnsNothing")
+    void anExpressionReturningNothingFailsTheStateNamingTheFieldPath(String template, String field,
+                                                                     String expectedFieldPath) throws Exception {
+        JsonNode statesVar = objectMapper.readTree("{\"input\": {}}");
+
+        AslExecutor.FailStateException failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.resolveTemplate(objectMapper.readTree(template), field, statesVar));
+
+        assertEquals("States.QueryEvaluationError", failure.error);
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field '"
+                + expectedFieldPath + "' returned nothing (undefined).", failure.cause);
+    }
+
+    @Test
+    void evaluateFieldNamesTheFieldOfAPositionThatHoldsASingleExpression() throws Exception {
+        JsonNode statesVar = objectMapper.readTree("{\"input\": {}}");
+
+        AslExecutor.FailStateException failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluateField("{% $states.input.missing %}", "Seconds", statesVar, null));
+
+        assertEquals("States.QueryEvaluationError", failure.error);
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Seconds' "
+                + "returned nothing (undefined).", failure.cause);
+    }
+
+    @Test
+    void anExplicitNullIsAValueAndKeepsEveryPositionEvaluating() throws Exception {
+        JsonNode statesVar = objectMapper.readTree("{\"input\": {\"bar\": null}}");
+
+        assertTrue(evaluator.evaluateField("{% null %}", "Seconds", statesVar, null).isNull());
+        assertEquals("{\"v\":null}", evaluator.resolveTemplate(
+                objectMapper.readTree("{\"v\": \"{% $states.input.bar %}\"}"), "Output", statesVar).toString());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1487,22 +1487,28 @@ class StepFunctionsJsonataIntegrationTest {
     void aCatchClauseNamesItsOwnOutputUnderTheClauseIndex() throws Exception {
         // Real AWS names 'Catch[1]/Output/v': a clause's own Output is a field of the clause, and the
         // index is its position in Catch, not its position among the clauses that matched. Measured
-        // with a real execution, since TestState stops at CAUGHT_ERROR and never evaluates a Catch
-        // Output. The state below fails on its own Output first, which is the error being caught.
+        // with a real execution: TestState answers CAUGHT_ERROR and omits the output rather than
+        // failing. Catch belongs to a Task, which AWS rejects on a Pass, so the state below fails on
+        // its own Arguments and the clause catches that.
         String definition = """
                 {
                     "QueryLanguage": "JSONata",
                     "StartAt": "Boom",
                     "States": {
                         "Boom": {
-                            "Type": "Pass",
-                            "Output": {"first": "{% $states.input.missing %}"},
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::sqs:sendMessage",
+                            "Arguments": {
+                                "QueueUrl": "http://localhost:4566/000000000000/absent-queue",
+                                "MessageBody": "m",
+                                "MessageGroupId": "{% $states.input.missing %}"
+                            },
                             "Catch": [
                                 {"ErrorEquals": ["States.Timeout"], "Next": "Caught"},
                                 {"ErrorEquals": ["States.QueryEvaluationError"],
                                  "Output": {"v": "{% $states.input.missing %}"}, "Next": "Caught"}
                             ],
-                            "Next": "Caught"
+                            "End": true
                         },
                         "Caught": {"Type": "Pass", "End": true}
                     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1226,10 +1226,9 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
-    void outputKeepsAnExplicitNullInEveryPositionAndDropsOnlyWhatReturnedNothing() throws Exception {
+    void outputKeepsAnExplicitNullInEveryPosition() throws Exception {
         // AWS returns {"v":null} for an expression that evaluates to JSON null, in an object field,
-        // nested, as an array element and as a literal. Only an expression that returned nothing
-        // loses its key.
+        // nested, as an array element and as a literal.
         String definition = """
                 {
                     "QueryLanguage": "JSONata",
@@ -1242,8 +1241,7 @@ class StepFunctionsJsonataIntegrationTest {
                                 "fromLiteralExpression": "{% null %}",
                                 "literal": null,
                                 "nested": {"inner": "{% null %}", "kept": 1},
-                                "values": ["{% null %}", 1],
-                                "returnedNothing": "{% $states.input.absent %}"
+                                "values": ["{% null %}", 1]
                             },
                             "End": true
                         }
@@ -1260,7 +1258,279 @@ class StepFunctionsJsonataIntegrationTest {
         assertTrue(output.path("literal").isNull(), output.toString());
         assertTrue(output.path("nested").path("inner").isNull(), output.toString());
         assertEquals("[null,1]", output.path("values").toString());
-        assertTrue(output.path("returnedNothing").isMissingNode(), output.toString());
+    }
+
+    @Test
+    void outputExpressionReturningNothingFailsTheStateAndIsCatchable() throws Exception {
+        // Real AWS on the same definition: States.QueryEvaluationError, "An error occurred while
+        // executing the state 'Transform' (entered at the event id #2). The JSONata expression
+        // '$states.input.missing' specified for the field 'Output/v' returned nothing (undefined)."
+        // Floci does not yet render the "An error occurred while executing the state" prefix (#2668).
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Transform",
+                    "States": {
+                        "Transform": {
+                            "Type": "Pass",
+                            "Output": {"v": "{% $states.input.missing %}"},
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-output-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
+                + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
+
+        String catching = definition.replace("\"End\": true",
+                """
+                        "Catch": [{"ErrorEquals": ["States.QueryEvaluationError"], "Next": "Caught"}],
+                        "Next": "Unreached"
+                    },
+                    "Unreached": {"Type": "Fail", "Error": "UnexpectedSuccess"},
+                    "Caught": {"Type": "Pass", "Output": {"caught": true}, "End": true""");
+        String catchingArn = createStateMachine("jsonata-output-returned-nothing-catch-test", catching);
+        JsonNode caught = objectMapper.readTree(waitForExecution(startExecution(catchingArn, "{}")));
+
+        assertTrue(caught.path("caught").asBoolean(), caught.toString());
+    }
+
+    @Test
+    void assignExpressionReturningNothingFailsTheState() throws Exception {
+        // Real AWS names 'Assign/x' for this definition; before this guard the variable was never
+        // bound and the next state read it as missing.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Bind",
+                    "States": {
+                        "Bind": {
+                            "Type": "Pass",
+                            "Assign": {"x": "{% $states.input.missing %}"},
+                            "Next": "Read"
+                        },
+                        "Read": {"Type": "Pass", "Output": {"got": "{% $x %}"}, "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-assign-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Assign/x' "
+                + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void taskArgumentReturningNothingFailsTheStateBeforeTheRequestIsSent() throws Exception {
+        // Real AWS names 'Arguments/MessageGroupId' and fails before reaching SQS, which is why the
+        // queue url below never has to exist. Before this guard Floci sent the message without it.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Send",
+                    "States": {
+                        "Send": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::sqs:sendMessage",
+                            "Arguments": {
+                                "QueueUrl": "http://localhost:4566/000000000000/absent-queue",
+                                "MessageBody": "m",
+                                "MessageGroupId": "{% $states.input.missing %}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-arguments-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'Arguments/MessageGroupId' returned nothing (undefined).",
+                failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void choiceConditionReturningNothingFailsTheStateInsteadOfTakingDefault() throws Exception {
+        // Real AWS names the rule by its index, 'Choices[1]/Condition', and evaluates the rules in
+        // order, so the first rule being false is what makes the second one run.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Pick",
+                    "States": {
+                        "Pick": {
+                            "Type": "Choice",
+                            "Choices": [
+                                {"Condition": "{% false %}", "Next": "First"},
+                                {"Condition": "{% $states.input.missing %}", "Next": "Second"}
+                            ],
+                            "Default": "Fallback"
+                        },
+                        "First": {"Type": "Pass", "Output": {"went": "First"}, "End": true},
+                        "Second": {"Type": "Pass", "Output": {"went": "Second"}, "End": true},
+                        "Fallback": {"Type": "Pass", "Output": {"went": "Fallback"}, "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-condition-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'Choices[1]/Condition' returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void aChoiceRuleAfterTheMatchingOneIsNeverEvaluated() throws Exception {
+        // AWS succeeds on this definition: the first rule matches, so the undefined condition in the
+        // second one is never reached. The guard must not turn rule order into a failure.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Pick",
+                    "States": {
+                        "Pick": {
+                            "Type": "Choice",
+                            "Choices": [
+                                {"Condition": "{% true %}", "Next": "First"},
+                                {"Condition": "{% $states.input.missing %}", "Next": "Second"}
+                            ],
+                            "Default": "Fallback"
+                        },
+                        "First": {"Type": "Pass", "Output": {"went": "First"}, "End": true},
+                        "Second": {"Type": "Pass", "Output": {"went": "Second"}, "End": true},
+                        "Fallback": {"Type": "Pass", "Output": {"went": "Fallback"}, "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-condition-short-circuit-test", definition);
+        JsonNode output = objectMapper.readTree(waitForExecution(startExecution(smArn, "{}")));
+
+        assertEquals("First", output.path("went").asText(), output.toString());
+    }
+
+    @Test
+    void waitSecondsReturningNothingFailsTheStateInsteadOfNotWaiting() throws Exception {
+        // Real AWS names 'Seconds'. Before this guard the expression resolved to zero and the state
+        // did not wait at all.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Pause",
+                    "States": {
+                        "Pause": {"Type": "Wait", "Seconds": "{% $states.input.missing %}", "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-wait-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Seconds' "
+                + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void failErrorAndCauseReturningNothingFailTheStateWithTheQueryEvaluationError() throws Exception {
+        // Real AWS names 'Error' and 'Cause'. The Fail state's own error is replaced by the
+        // evaluation failure, so a Catch on States.QueryEvaluationError fires instead of one on the
+        // error the definition meant to raise.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Stop",
+                    "States": {
+                        "Stop": {"Type": "Fail", "Error": "%s", "Cause": "%s"}
+                    }
+                }
+                """;
+
+        Response errorFailure = waitForExecutionFailure(startExecution(
+                createStateMachine("jsonata-fail-error-returned-nothing-test",
+                        definition.formatted("{% $states.input.missing %}", "boom")), "{}"));
+        assertEquals("States.QueryEvaluationError", errorFailure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Error' "
+                + "returned nothing (undefined).", errorFailure.jsonPath().getString("cause"));
+
+        Response causeFailure = waitForExecutionFailure(startExecution(
+                createStateMachine("jsonata-fail-cause-returned-nothing-test",
+                        definition.formatted("Boom", "{% $states.input.missing %}")), "{}"));
+        assertEquals("States.QueryEvaluationError", causeFailure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Cause' "
+                + "returned nothing (undefined).", causeFailure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void mapItemsReturningNothingFailsTheStateInsteadOfIteratingNothing() throws Exception {
+        // Real AWS names 'Items'.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Fan",
+                    "States": {
+                        "Fan": {
+                            "Type": "Map",
+                            "Items": "{% $states.input.missing %}",
+                            "ItemProcessor": {
+                                "StartAt": "P",
+                                "States": {"P": {"Type": "Pass", "End": true}}
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-map-items-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Items' "
+                + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void mapMaxConcurrencyReturningNothingFailsTheStateNamingTheField() throws Exception {
+        // Real AWS names 'MaxConcurrency'. Before this guard the undefined value reached the
+        // non-negative-integer check and failed with Floci's own wording instead of AWS's.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Fan",
+                    "States": {
+                        "Fan": {
+                            "Type": "Map",
+                            "Items": [1, 2],
+                            "MaxConcurrency": "{% $states.input.missing %}",
+                            "ItemProcessor": {
+                                "StartAt": "P",
+                                "States": {"P": {"Type": "Pass", "End": true}}
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-map-maxconcurrency-returned-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'MaxConcurrency' returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
     @Test
@@ -1298,10 +1568,9 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
-    void aWholeOutputThatReturnedNothingStaysReadableJson() throws Exception {
-        // AWS fails this state with States.QueryEvaluationError, which #2665 covers. Until then the
-        // execution succeeds, and what DescribeExecution hands back has to parse: an output field
-        // holding the empty string is not JSON any client can read.
+    void aWholeOutputThatReturnedNothingFailsTheState() throws Exception {
+        // Real AWS names the whole field, 'Output', with no path below it. There is no output to
+        // serialize once the state fails, which is what the null this used to resolve to stood in for.
         String definition = """
                 {
                     "QueryLanguage": "JSONata",
@@ -1309,7 +1578,7 @@ class StepFunctionsJsonataIntegrationTest {
                     "States": {
                         "Transform": {
                             "Type": "Pass",
-                            "Output": "{% $states.input.absent %}",
+                            "Output": "{% $states.input.missing %}",
                             "End": true
                         }
                     }
@@ -1317,10 +1586,11 @@ class StepFunctionsJsonataIntegrationTest {
                 """;
 
         String smArn = createStateMachine("jsonata-whole-output-nothing-test", definition);
-        String execArn = startExecution(smArn, "{}");
-        String output = waitForExecution(execArn);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
-        assertTrue(objectMapper.readTree(output).isNull(), output);
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Output' "
+                + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1422,6 +1422,102 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void aMatchedChoiceRuleNamesItsOwnOutputUnderTheRuleIndex() throws Exception {
+        // Real AWS names 'Choices[1]/Output/v': a rule's own Output is a field of the rule, not the
+        // state-level Output, and the index is the rule's position in Choices.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Pick",
+                    "States": {
+                        "Pick": {
+                            "Type": "Choice",
+                            "Choices": [
+                                {"Condition": "{% false %}", "Next": "First"},
+                                {"Condition": "{% true %}",
+                                 "Output": {"v": "{% $states.input.missing %}"}, "Next": "First"}
+                            ],
+                            "Default": "Fallback"
+                        },
+                        "First": {"Type": "Pass", "End": true},
+                        "Fallback": {"Type": "Pass", "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-choice-rule-output-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'Choices[1]/Output/v' returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void aMatchedChoiceRuleNamesItsOwnAssignUnderTheRuleIndex() throws Exception {
+        // Real AWS names 'Choices[0]/Assign/x' for a rule's own Assign.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Pick",
+                    "States": {
+                        "Pick": {
+                            "Type": "Choice",
+                            "Choices": [
+                                {"Condition": "{% true %}",
+                                 "Assign": {"x": "{% $states.input.missing %}"}, "Next": "First"}
+                            ],
+                            "Default": "Fallback"
+                        },
+                        "First": {"Type": "Pass", "End": true},
+                        "Fallback": {"Type": "Pass", "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-choice-rule-assign-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'Choices[0]/Assign/x' returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void aCatchClauseNamesItsOwnOutputUnderTheClauseIndex() throws Exception {
+        // Real AWS names 'Catch[1]/Output/v': a clause's own Output is a field of the clause, and the
+        // index is its position in Catch, not its position among the clauses that matched. Measured
+        // with a real execution, since TestState stops at CAUGHT_ERROR and never evaluates a Catch
+        // Output. The state below fails on its own Output first, which is the error being caught.
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Boom",
+                    "States": {
+                        "Boom": {
+                            "Type": "Pass",
+                            "Output": {"first": "{% $states.input.missing %}"},
+                            "Catch": [
+                                {"ErrorEquals": ["States.Timeout"], "Next": "Caught"},
+                                {"ErrorEquals": ["States.QueryEvaluationError"],
+                                 "Output": {"v": "{% $states.input.missing %}"}, "Next": "Caught"}
+                            ],
+                            "Next": "Caught"
+                        },
+                        "Caught": {"Type": "Pass", "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-catch-output-nothing-test", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+                + "'Catch[1]/Output/v' returned nothing (undefined).", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
     void waitSecondsReturningNothingFailsTheStateInsteadOfNotWaiting() throws Exception {
         // Real AWS names 'Seconds'. Before this guard the expression resolved to zero and the state
         // did not wait at all.


### PR DESCRIPTION
#2684 has merged, so this is no longer stacked: the branch is rebased onto `origin/main` and the diff is this PR's change alone, five commits from `1359bb9b` to `b5b3b6f5`.

## Summary

A JSONata expression that returns nothing is not a missing value a state carries on without. Real AWS fails the state with `States.QueryEvaluationError`, names the field the expression was written in, and a `Catch` on that error fires. Floci succeeded and dropped the key, so the execution kept going down the happy path with a field that is not there. Closes #2665, which carries the reproduction and the seven positions.

- **One guard, eleven positions.** `evaluateField` (`JsonataEvaluator.java:152`) evaluates one expression and fails the state when it comes back as nothing. `resolveTemplate` calls it at every leaf, carrying the field it is inside and extending it with `/key` per object key and `[i]` per array index, which covers `Output`, `Assign`, a Task's `Arguments`, `ItemReader/Arguments` and `ResultWriter/Arguments`. The six positions that called `evaluate` directly (`Choices[n]/Condition`, `Seconds`, `Error`, `Cause`, `MaxConcurrency`, `Items`) call it themselves.
- **A matched `Choice` rule and a matching `Catch` clause name their own fields under their index.** `Choices[1]/Output/v`, `Choices[0]/Assign/x`, `Catch[1]/Output/v` and `Catch[0]/Assign/x`, all four measured on the account; the index is the position in `Choices` or `Catch`, not the position among the entries that matched. `applyJsonataAssignAndOutput` had one hardcoded `Output` and `Assign` for all four of its holders. The `Catch` label was unobservable until this: `doExecute` calls `handleCatch` from inside its own `catch (FailStateException)`, so a failure raised while resolving the clause's own `Output` escaped to the method-level handler and came back as `States.Runtime` with the raw message. The execution now fails with the clause's own error, and no later clause catches it, which is what AWS does.
- **This is a behaviour change, and it makes previously green runs red.** A run of the jsonata-js v2.2.2 suite as one `Pass` state per expression found 108 cases the suite marks `undefinedResult`; 106 succeeded on Floci and dropped the key. All 106 now fail the state, as AWS does with each. Any state machine relying on the silent drop stops working, and that is the point: today it runs on Floci and fails on AWS.
- **Three of the seven positions changed control flow, not data.** `Choice` silently took `Default`, `Wait` did not wait, and a `Task` sent its request with the argument omitted. The red proof below catches the SQS Task actually reaching the queue.
- **Docs**: a new `## An expression that returns nothing fails the state` section in `docs/services/step-functions.md`, and the `## JSONata nulls` section from #2684 loses both the sentence saying an undefined expression only loses its key and the deviation #2684 added for it, which this change removes. The `## JSONata functions` section also loses the sentence saying an undefined argument leaves the field missing instead of failing the state, measured on AWS for all three shapes it lists: `$hash("x")`, `$partition([1,2],0)` and `$range(1,5)` each answer `States.QueryEvaluationError` with `... specified for the field 'Output/v' returned nothing (undefined).`

## Wire-fidelity details (AWS CLI 2.33.7, `test-state` and real executions against `us-east-1`)

Every cause below is a captured AWS response, and `test-state` creates nothing, so an unmarked row is re-checkable in one call:

```bash
aws stepfunctions test-state --role-arn "$ANY_ROLE" --input '{}' --query 'cause' --output text \
  --definition '{"Type":"Pass","QueryLanguage":"JSONata","Output":{"a":{"b":[[1,"{% $states.input.missing %}"]]}},"End":true}'
# The JSONata expression '$states.input.missing' specified for the field 'Output/a/b[0][1]' returned nothing (undefined).
```

Each row uses `{% $states.input.missing %}` on input `{}` and each error is `States.QueryEvaluationError`. The middle column is what AWS puts in `... specified for the field '<here>' returned nothing (undefined).`

| Position | AWS names the field | Pinned by |
| --- | --- | --- |
| `Pass` `Output: {"v": ...}` | `Output/v` | `outputExpressionReturningNothingFailsTheStateAndIsCatchable` |
| `Pass` `Output: {"a": {"b": ...}}` | `Output/a/b` | `anExpressionReturningNothingFailsTheStateNamingTheFieldPath` |
| `Pass` `Output: ...` (whole field) | `Output` | same test, and `aWholeOutputThatReturnedNothingFailsTheState` |
| `Pass` `Output: {"values": [..., 1]}` | `Output/values[0]` | same test |
| `Pass` `Output: {"a": {"b": [[1, ...]]}}` | `Output/a/b[0][1]` | same test |
| `Pass` `Assign: {"x": {"y": ...}}` | `Assign/x/y` | same test |
| `Pass` `Assign: {"x": ...}` | `Assign/x` | `assignExpressionReturningNothingFailsTheState` |
| `Task` `sqs:sendMessage` `Arguments` | `Arguments/MessageGroupId` | `taskArgumentReturningNothingFailsTheStateBeforeTheRequestIsSent` |
| `Choice` first rule | `Choices[0]/Condition` | no test: the same `Choices[i]` literal as the row below |
| `Choice` second rule, first one false | `Choices[1]/Condition` | `choiceConditionReturningNothingFailsTheStateInsteadOfTakingDefault` |
| `Choice` matched rule's own `Output` | `Choices[1]/Output/v` | `aMatchedChoiceRuleNamesItsOwnOutputUnderTheRuleIndex` |
| `Choice` matched rule's own `Assign` | `Choices[0]/Assign/x` | `aMatchedChoiceRuleNamesItsOwnAssignUnderTheRuleIndex` |
| `Catch` matching clause's own `Output` (real execution) | `Catch[1]/Output/v` | `aCatchClauseNamesItsOwnOutputUnderTheClauseIndex` |
| `Catch` matching clause's own `Assign` (real execution) | `Catch[0]/Assign/x` | no test: the same `applyJsonataAssignAndOutput` call as the row above |
| `Wait` `Seconds` | `Seconds` | `waitSecondsReturningNothingFailsTheStateInsteadOfNotWaiting` |
| `Fail` `Error` | `Error` | `failErrorAndCauseReturningNothingFailTheStateWithTheQueryEvaluationError` |
| `Fail` `Cause` | `Cause` | same test |
| `Map` `Items` (real execution) | `Items` | `mapItemsReturningNothingFailsTheStateInsteadOfIteratingNothing` |
| `Map` `MaxConcurrency` (real execution) | `MaxConcurrency` | `mapMaxConcurrencyReturningNothingFailsTheStateNamingTheField` |
| DISTRIBUTED `Map` `ItemReader` `Arguments` (real execution) | `ItemReader/Arguments/Key` | no test: needs a distributed run |
| DISTRIBUTED `Map` `ResultWriter` `Arguments` (real execution) | `ResultWriter/Arguments/Prefix` | `aDestinationExpressionReturningNothingFailsBeforeWriting` |

Four things the table cannot show:

- **A `Choice` stops at the first rule that matches.** With `Choices[0]` at `{% true %}` and `Choices[1]` undefined, AWS answers `SUCCEEDED`. `aChoiceRuleAfterTheMatchingOneIsNeverEvaluated` pins it: a guard over every rule up front would break it.
- **No later `Catch` clause catches what an earlier matching one raised.** A state with `Catch[0]` on `States.QueryEvaluationError` whose own `Output` returns nothing and `Catch[1]` on `States.ALL` ends `FAILED` on AWS with `Catch[0]/Output/v`, not caught by the second clause.
- **An explicit `null` still succeeds.** `Output {"v": "{% null %}"}` is `SUCCEEDED` on AWS. That distinction is what #2684 buys, and `anExplicitNullIsAValueAndKeepsEveryPositionEvaluating` keeps it from being undone here.
- **`test-state` does not reach the `Catch` and `Map` rows.** It supports neither `Map` nor `Parallel`, and on a caught error it answers `CAUGHT_ERROR` and simply omits the output when a `Catch` clause's own `Output` returned nothing, rather than failing. Those rows came from `create-state-machine` plus `start-execution`. Every state machine created was deleted.

## Deliberate scope notes

- **I threaded the field path rather than shipping a guard with no field name.** The smaller option fixes the `Catch`, the behavioural half, and the issue offers it as a first step. Threading costs one `String` parameter on `resolveTemplate` and one literal at each call site, and the measured rows agree on one rule: the ASL field relative to the state, `/` per object key, `[i]` per array index. That is an accumulator, not a mechanism, and a nameless cause would have to be replaced later by exactly this change.
- **The `An error occurred while executing the state '<name>' (entered at the event id #<n>).` prefix belongs to #2668.** Floci returns the bare cause, the form `TestState` returns; a real execution adds the prefix. This PR does not touch the cause-building code #2668 owns, and the docs section records the missing prefix as this change's one deviation.
- **An undefined array element stopped being a `States.Runtime` special case.** `resolveTemplate` threw its own error there, with a different code and the wording `at array index 0`. AWS answers `States.QueryEvaluationError` and `Output/values[0]`, the same shape as every other position, so the leaf guard covers it. A second behaviour change, smaller: that state already failed, with the wrong code and message.
- **`resolveTemplateNode` is gone and `resolveTemplate` is one method again.** `36db065e` split it so a whole field returning nothing could be coerced to a `NullNode` before serialization, a missing node writing itself as the empty string no client can parse; its comment says that stands `until #2665`. Once the state fails there is no output to serialize, and the walk's only source of a missing node was the leaf the guard throws at, so coercion and wrapper are both unreachable.
- **Two `ResultWriter` guards were deleted as dead, not as cleanup.** `ResultWriter Bucket must resolve to a string` and its `Prefix` twin fired only on a key `resolveTemplate` had dropped, which can no longer happen. The type checks below them still cover a non-string value, `{% null %}` included, and `jsonataDestinationNullsAreTypeErrorsRatherThanMissingValues` passes unchanged. `ItemReader/Arguments/Key` and `ResultWriter/Arguments/Prefix` were the two labels this PR first shipped extrapolated; both are now measured on a DISTRIBUTED `Map` execution against a bucket that does not exist, since AWS evaluates the arguments before it reaches S3, and both match what the code emits.
- **`MaxConcurrency` keeps its own non-negative-integer check.** The guard removes only the undefined case; `true`, `-1` and `1.5` still reach it, and `invalidJsonataMaxConcurrencyIsCatchableAsQueryEvaluationError` still covers all four.
- **Every state-machine definition in the new tests is one AWS accepts.** All fourteen pass `validate-state-machine-definition` with `result: OK`. `0706fee3` moved the `Catch` clause under test off a `Pass` state, which AWS refuses with `SCHEMA_VALIDATION_FAILED`, `Field 'Catch' is not supported`, onto the `Task` the measurement used.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [x] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

The commit is `fix:`, not `fix!:`: the repository has no `!` subject and no `BREAKING CHANGE` footer in its history, and forcing a major bump on a fidelity fix is a maintainer's call. The box is ticked so the decision is visible.

## AWS Compatibility

- [x] Verified in `us-east-1` with AWS CLI 2.33.7: the `Pass`, `Task`, `Choice`, `Wait` and `Fail` rows through `test-state`, the `Catch`, `Map`, `ItemReader` and `ResultWriter` rows through `create-state-machine` plus `start-execution`, every state machine deleted afterwards
- [x] Every field name and cause here and in the tests is a captured AWS response, not a value read off the documentation
- [x] `Catch` on `States.QueryEvaluationError` confirmed to fire on AWS, and pinned here by `outputExpressionReturningNothingFailsTheStateAndIsCatchable`
- [x] No botocore model work: this is expression evaluation, not the wire protocol

## Checklist

- [x] Step Functions suite green: `-Dtest='io.github.hectorvent.floci.services.stepfunctions.*Test'` is 468 tests, 0 failures, 0 errors, 0 skipped
- [x] 21 new tests: 12 in `StepFunctionsJsonataIntegrationTest`, 8 in `JsonataEvaluatorTest` (one parameterized over the six measured path shapes), 1 in `AslExecutorResultWriterTest`
- [x] Red proof. With the `isMissingNode` throw removed from `evaluateField` and the drop, the array throw and the top-level null coercion restored in `resolveTemplate`, tests untouched, the same 468-test run is 20 failures, each for the reason claimed: six `nothing was thrown`, eight `Execution SUCCEEDED`, three `but was: <States.Runtime>` (the two array rows and `Map` `Items`), `MaxConcurrency must resolve to a non-negative integer`, `but was: <>` (a `Fail` whose `Error` came back empty) and `but was: <SQS.AWS.SimpleQueueService.NonExistentQueue>`, which is Floci reaching SQS with `MessageGroupId` omitted
- [x] Seven existing tests changed, none deleted. Six because AWS disagrees with what they asserted: the three `...AndDropsOnlyWhatReturnedNothing` / `...AndOmitOnlyWhatReturnedNothing` tests keep the explicit-null half AWS confirms and lose the dropped-key half, which is the bug; `aWholeTemplateIsANullWhetherItEvaluatedToNullOrReturnedNothing` and `aWholeOutputThatReturnedNothingStaysReadableJson` are the stopgap `36db065e` marked `until #2665`; in `AslExecutorResultWriterTest` the `Prefix` block moved into its own test. The seventh is the crashing evaluator stub in `AslExecutorErrorTerminationTest`, which follows the new `resolveTemplate` signature
- [x] `make docs-check` passes; `make docs-test` is 34 passed through `uvx --with pytest --with pyyaml pytest tools/docs -q`, because this machine's python3 has no pytest module
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/); `CHANGELOG.md` untouched
- [x] Caught up with `origin/main` by merge (`31c3625e`); the branch sits on #2684 until that PR merges


