### PR TITLE
feat(codepipeline): validate ListPipelineExecutions filters and PutApprovalResult inputs

### DIFF
--- a/docs/services/codepipeline.md
+++ b/docs/services/codepipeline.md
@@ -39,6 +39,14 @@ The following providers execute against local Floci services:
 AWS-managed providers without a corresponding Floci execution adapter fail the action with an
 AWS-shaped action error. Floci does not call real AWS accounts or third-party SaaS providers.
 
+## Approvals
+
+`PutApprovalResult` completes waiting Manual approval actions with AWS-shaped validation
+and error responses. Floci validates the stage and action names, enforces `result.status`
+as `Approved` or `Rejected`, limits `result.summary` to 512 characters, returns
+`InvalidApprovalTokenException` for unknown tokens, and returns
+`ApprovalAlreadyCompletedException` if the same approval token is reused after completion.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -322,11 +322,25 @@ public class CodePipelineService {
         String pipelineName = text(request, "pipelineName");
         requirePipeline(account, region, pipelineName);
         List<CodePipelineExecution> executions = executions(account, region, pipelineName);
-        JsonNode filter = request.path("filter");
-        if (filter.hasNonNull("succeededInStage")) {
-            String stage = filter.path("succeededInStage").asText();
+        JsonNode filter = request.get("filter");
+        if (filter != null && !filter.isNull() && !filter.isObject()) {
+            throw new AwsException("ValidationException", "filter must be an object", 400);
+        }
+        JsonNode succeededInStage = filter == null ? null : filter.get("succeededInStage");
+        if (succeededInStage != null && !succeededInStage.isNull()) {
+            if (!succeededInStage.isObject() || !succeededInStage.hasNonNull("stageName")) {
+                throw new AwsException("ValidationException",
+                        "succeededInStage requires stageName", 400);
+            }
+            String stage = succeededInStage.path("stageName").asText();
             executions = executions.stream().filter(e -> actionExecutionsForStage(e, stage).stream()
                     .allMatch(a -> "Succeeded".equals(a.getStatus()))).toList();
+        }
+        if (request.hasNonNull("maxResults")) {
+            int maxResults = request.path("maxResults").asInt(-1);
+            if (maxResults < 1 || maxResults > 100) {
+                throw new AwsException("ValidationException", "maxResults must be between 1 and 100", 400);
+            }
         }
         Page page = page(request, executions.size(), 100);
         ObjectNode response = mapper.createObjectNode();
@@ -414,23 +428,48 @@ public class CodePipelineService {
         String stageName = text(request, "stageName");
         String actionName = text(request, "actionName");
         String token = text(request, "token");
-        String status = request.path("result").path("status").asText();
+        JsonNode resultNode = request.get("result");
+        if (resultNode == null || !resultNode.isObject()) {
+            throw new AwsException("ValidationException", "result is required", 400);
+        }
+        String status = text(resultNode, "status");
+        if (!List.of("Approved", "Rejected").contains(status)) {
+            throw new AwsException("ValidationException",
+                    "result.status must be one of [Approved, Rejected]", 400);
+        }
+        String summary = resultNode.path("summary").asText("");
+        if (summary.length() > 512) {
+            throw new AwsException("ValidationException",
+                    "result.summary must not exceed 512 characters", 400);
+        }
+
+        CodePipelinePipeline pipeline = requirePipeline(account, region, pipelineName);
+        requireStage(pipeline, stageName);
+        requireAction(pipeline, stageName, actionName);
+
         CodePipelineExecution execution = executions(account, region, pipelineName).stream()
                 .filter(e -> e.getActionExecutions().stream()
                         .anyMatch(a -> stageName.equals(a.getStageName())
                                 && actionName.equals(a.getActionName())
-                                && token.equals(a.getToken())
-                                && "InProgress".equals(a.getStatus())))
+                                && token.equals(a.getToken())))
                 .findFirst()
                 .orElseThrow(() -> new AwsException(
                         "InvalidApprovalTokenException", "Approval token is invalid", 400));
+
         ActionExecution approval = execution.getActionExecutions().stream()
                 .filter(a -> stageName.equals(a.getStageName()) && actionName.equals(a.getActionName()))
-                .filter(a -> token.equals(a.getToken()) && "InProgress".equals(a.getStatus()))
+                .filter(a -> token.equals(a.getToken()))
                 .findFirst()
-                .orElseThrow();
+                .orElseThrow(() -> new AwsException(
+                        "InvalidApprovalTokenException", "Approval token is invalid", 400));
+
+        if (!"InProgress".equals(approval.getStatus())) {
+            throw new AwsException("ApprovalAlreadyCompletedException",
+                    "The approval action has already been approved or rejected.", 400);
+        }
+
         approval.setStatus("Approved".equals(status) ? "Succeeded" : "Failed");
-        approval.setSummary(request.path("result").path("summary").asText(status));
+        approval.setSummary(summary);
         approval.setLastUpdateTime(now());
         putExecution(execution);
         return mapper.createObjectNode().put("approvedAt", now());
@@ -1131,6 +1170,20 @@ public class CodePipelineService {
         for (JsonNode stage : pipeline.getDeclaration().path("stages")) {
             if (stageName.equals(stage.path("name").asText())) {
                 return;
+            }
+        }
+        throw new AwsException("StageNotFoundException", "Stage not found: " + stageName, 400);
+    }
+
+    private void requireAction(CodePipelinePipeline pipeline, String stageName, String actionName) {
+        for (JsonNode stage : pipeline.getDeclaration().path("stages")) {
+            if (stageName.equals(stage.path("name").asText())) {
+                for (JsonNode action : stage.path("actions")) {
+                    if (actionName.equals(action.path("name").asText())) {
+                        return;
+                    }
+                }
+                throw new AwsException("ActionNotFoundException", "Action not found: " + actionName, 400);
             }
         }
         throw new AwsException("StageNotFoundException", "Stage not found: " + stageName, 400);

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -326,18 +327,32 @@ public class CodePipelineService {
         if (filter != null && !filter.isNull() && !filter.isObject()) {
             throw new AwsException("ValidationException", "filter must be an object", 400);
         }
+        if (filter != null && filter.isObject()) {
+            requireOnlyMembers(filter, "filter", Set.of("succeededInStage"));
+        }
         JsonNode succeededInStage = filter == null ? null : filter.get("succeededInStage");
         if (succeededInStage != null && !succeededInStage.isNull()) {
-            if (!succeededInStage.isObject() || !succeededInStage.hasNonNull("stageName")) {
+            if (!succeededInStage.isObject()) {
                 throw new AwsException("ValidationException",
                         "succeededInStage requires stageName", 400);
             }
-            String stage = succeededInStage.path("stageName").asText();
+            requireOnlyMembers(succeededInStage, "succeededInStage", Set.of("stageName"));
+            JsonNode stageNameNode = succeededInStage.get("stageName");
+            if (stageNameNode == null || stageNameNode.isNull() || !stageNameNode.isTextual()
+                    || stageNameNode.asText().isBlank()) {
+                throw new AwsException("ValidationException",
+                        "succeededInStage requires stageName", 400);
+            }
+            String stage = stageNameNode.asText();
             executions = executions.stream().filter(e -> actionExecutionsForStage(e, stage).stream()
                     .allMatch(a -> "Succeeded".equals(a.getStatus()))).toList();
         }
         if (request.hasNonNull("maxResults")) {
-            int maxResults = request.path("maxResults").asInt(-1);
+            JsonNode maxResultsNode = request.get("maxResults");
+            if (!maxResultsNode.isIntegralNumber()) {
+                throw new AwsException("ValidationException", "maxResults must be an integer", 400);
+            }
+            int maxResults = maxResultsNode.asInt();
             if (maxResults < 1 || maxResults > 100) {
                 throw new AwsException("ValidationException", "maxResults must be between 1 and 100", 400);
             }
@@ -429,23 +444,31 @@ public class CodePipelineService {
         String actionName = text(request, "actionName");
         String token = text(request, "token");
         JsonNode resultNode = request.get("result");
-        if (resultNode == null || !resultNode.isObject()) {
+        if (resultNode == null || resultNode.isNull()) {
             throw new AwsException("ValidationException", "result is required", 400);
+        }
+        if (!resultNode.isObject()) {
+            throw new AwsException("ValidationException", "result must be an object", 400);
         }
         String status = text(resultNode, "status");
         if (!List.of("Approved", "Rejected").contains(status)) {
             throw new AwsException("ValidationException",
                     "result.status must be one of [Approved, Rejected]", 400);
         }
-        String summary = resultNode.path("summary").asText("");
+        JsonNode summaryNode = resultNode.get("summary");
+        String summary = "";
+        if (summaryNode != null && !summaryNode.isNull()) {
+            if (!summaryNode.isTextual()) {
+                throw new AwsException("ValidationException", "result.summary must be a string", 400);
+            }
+            summary = summaryNode.asText();
+        }
         if (summary.length() > 512) {
             throw new AwsException("ValidationException",
                     "result.summary must not exceed 512 characters", 400);
         }
 
         CodePipelinePipeline pipeline = requirePipeline(account, region, pipelineName);
-        requireStage(pipeline, stageName);
-        requireAction(pipeline, stageName, actionName);
 
         CodePipelineExecution execution = executions(account, region, pipelineName).stream()
                 .filter(e -> e.getActionExecutions().stream()
@@ -453,15 +476,19 @@ public class CodePipelineService {
                                 && actionName.equals(a.getActionName())
                                 && token.equals(a.getToken())))
                 .findFirst()
-                .orElseThrow(() -> new AwsException(
-                        "InvalidApprovalTokenException", "Approval token is invalid", 400));
+                .orElse(null);
 
-        ActionExecution approval = execution.getActionExecutions().stream()
+        ActionExecution approval = execution == null ? null : execution.getActionExecutions().stream()
                 .filter(a -> stageName.equals(a.getStageName()) && actionName.equals(a.getActionName()))
                 .filter(a -> token.equals(a.getToken()))
                 .findFirst()
-                .orElseThrow(() -> new AwsException(
-                        "InvalidApprovalTokenException", "Approval token is invalid", 400));
+                .orElse(null);
+
+        if (approval == null) {
+            requireStage(pipeline, stageName);
+            requireAction(pipeline, stageName, actionName);
+            throw new AwsException("InvalidApprovalTokenException", "Approval token is invalid", 400);
+        }
 
         if (!"InProgress".equals(approval.getStatus())) {
             throw new AwsException("ApprovalAlreadyCompletedException",
@@ -1164,6 +1191,14 @@ public class CodePipelineService {
         if (name == null || !name.matches("[A-Za-z0-9.@_-]{1,100}")) {
             throw new AwsException("ValidationException", "pipeline name has invalid format", 400);
         }
+    }
+
+    private static void requireOnlyMembers(JsonNode node, String label, Set<String> allowed) {
+        node.fieldNames().forEachRemaining(field -> {
+            if (!allowed.contains(field)) {
+                throw new AwsException("ValidationException", "Unknown " + label + " member: " + field, 400);
+            }
+        });
     }
 
     private void requireStage(CodePipelinePipeline pipeline, String stageName) {

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -28,6 +28,139 @@ class CodePipelineIntegrationTest {
     }
 
     @Test
+    void getPipelineReturnsCurrentStructureAndMetadata() {
+        String pipelineName = "get-pipeline-it";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceAction",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Build",
+                    "actions": [{
+                        "name": "BuildAction",
+                        "actionTypeId": {
+                            "category": "Build",
+                            "owner": "AWS",
+                            "provider": "CodeBuild",
+                            "version": "1"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """)).then().statusCode(200);
+
+        post("GetPipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipeline.name", equalTo(pipelineName))
+                .body("pipeline.version", equalTo(1))
+                .body("pipeline.pipelineType", equalTo("V1"))
+                .body("pipeline.executionMode", equalTo("SUPERSEDED"))
+                .body("metadata.pipelineArn", equalTo("arn:aws:codepipeline:us-east-1:000000000000:" + pipelineName))
+                .body("metadata.created", notNullValue())
+                .body("metadata.updated", notNullValue());
+
+        post("GetPipeline", """
+                {"name": "%s", "version": 2}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("PipelineVersionNotFoundException"));
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
+    void updatePipelineReplacesStructureAndIncrementsVersion() {
+        String pipelineName = "update-pipeline-it";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceAction",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        }
+                    }]
+                },
+                {
+                    "name": "Build",
+                    "actions": [{
+                        "name": "BuildAction",
+                        "actionTypeId": {
+                            "category": "Build",
+                            "owner": "AWS",
+                            "provider": "CodeBuild",
+                            "version": "1"
+                        }
+                    }]
+                }
+                """)).then().statusCode(200);
+
+        post("UpdatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceActionV2",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        }
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "DeployAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "CodeDeploy",
+                            "version": "1"
+                        }
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200)
+                .body("pipeline.name", equalTo(pipelineName))
+                .body("pipeline.version", equalTo(2))
+                .body("pipeline.stages[1].name", equalTo("Deploy"));
+
+        post("GetPipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipeline.version", equalTo(2))
+                .body("pipeline.stages[0].actions[0].name", equalTo("SourceActionV2"))
+                .body("pipeline.stages[1].name", equalTo("Deploy"));
+
+        post("DeletePipeline", """
+                {"name": "%s"}
+                """.formatted(pipelineName)).then().statusCode(200);
+    }
+
+    @Test
     void pipelineLifecycleExecutesS3SourceAndDeployActions() throws Exception {
         createBucket("codepipeline-source");
         createBucket("codepipeline-destination");
@@ -103,6 +236,25 @@ class CodePipelineIntegrationTest {
                 .body("pipelineExecution.status", equalTo("Succeeded"))
                 .body("pipelineExecution.artifactRevisions", hasSize(1))
                 .body("pipelineExecution.artifactRevisions[0].name", equalTo("SourceObject"));
+
+        post("ListPipelineExecutions", """
+                {"pipelineName": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionSummaries", hasSize(1))
+                .body("pipelineExecutionSummaries[0].pipelineExecutionId", equalTo(executionId))
+                .body("pipelineExecutionSummaries[0].status", equalTo("Succeeded"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "filter": {"succeededInStage": {"stageName": "Deploy"}}
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("pipelineExecutionSummaries", hasSize(1));
 
         post("GetPipelineState", """
                 {"name": "%s"}
@@ -253,6 +405,352 @@ class CodePipelineIntegrationTest {
         post("DeleteCustomActionType", """
                 {"category": "Build", "provider": "FlociWorker", "version": "1"}
                 """).then().statusCode(200);
+    }
+
+    @Test
+    void putApprovalResultApprovesAndRejectsManualApprovalActions() throws Exception {
+        String pipelineName = "approval-test-pipeline";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Approve",
+                    "actions": [{
+                        "name": "ManualApproval",
+                        "actionTypeId": {
+                            "category": "Approval",
+                            "owner": "AWS",
+                            "provider": "Manual",
+                            "version": "1"
+                        },
+                        "configuration": {},
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-artifacts",
+                            "ObjectKey": "placeholder"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        String executionId = post("StartPipelineExecution", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .extract().path("pipelineExecutionId");
+
+        Thread.sleep(100);
+
+        String approvalToken = post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .extract().path("stageStates[0].actionStates[0].latestExecution.token");
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "%s",
+                    "result": {
+                        "status": "Approved",
+                        "summary": "Approved by test"
+                    }
+                }
+                """.formatted(pipelineName, approvalToken))
+                .then()
+                .statusCode(200)
+                .body("approvedAt", notNullValue());
+
+        Thread.sleep(100);
+
+        post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Succeeded"))
+                .body("stageStates[0].actionStates[0].latestExecution.summary", equalTo("Approved by test"));
+
+        String pipelineName2 = "rejection-test-pipeline";
+        post("CreatePipeline", pipeline(pipelineName2, """
+                {
+                    "name": "Approve",
+                    "actions": [{
+                        "name": "ManualApproval",
+                        "actionTypeId": {
+                            "category": "Approval",
+                            "owner": "AWS",
+                            "provider": "Manual",
+                            "version": "1"
+                        },
+                        "configuration": {},
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-artifacts",
+                            "ObjectKey": "placeholder"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        String executionId2 = post("StartPipelineExecution", """
+                {"name": "%s"}
+                """.formatted(pipelineName2))
+                .then()
+                .statusCode(200)
+                .extract().path("pipelineExecutionId");
+
+        Thread.sleep(100);
+
+        String approvalToken2 = post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName2))
+                .then()
+                .statusCode(200)
+                .extract().path("stageStates[0].actionStates[0].latestExecution.token");
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "%s",
+                    "result": {
+                        "status": "Rejected",
+                        "summary": "Rejected by test"
+                    }
+                }
+                """.formatted(pipelineName2, approvalToken2))
+                .then()
+                .statusCode(200)
+                .body("approvedAt", notNullValue());
+
+        Thread.sleep(100);
+
+        post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName2))
+                .then()
+                .statusCode(200)
+                .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Failed"))
+                .body("stageStates[0].actionStates[0].latestExecution.summary", equalTo("Rejected by test"));
+    }
+
+    @Test
+    void putApprovalResultValidatesErrors() throws Exception {
+        String pipelineName = "error-test-pipeline";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Approve",
+                    "actions": [{
+                        "name": "ManualApproval",
+                        "actionTypeId": {
+                            "category": "Approval",
+                            "owner": "AWS",
+                            "provider": "Manual",
+                            "version": "1"
+                        },
+                        "configuration": {},
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-artifacts",
+                            "ObjectKey": "placeholder"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "nonexistent",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Approved",
+                        "summary": ""
+                    }
+                }
+                """)
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("PipelineNotFoundException"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "NonexistentStage",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Approved",
+                        "summary": ""
+                    }
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("StageNotFoundException"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "NonexistentAction",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Approved",
+                        "summary": ""
+                    }
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ActionNotFoundException"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Invalid",
+                        "summary": ""
+                    }
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("result.status must be one of"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Approved",
+                        "summary": "%s"
+                    }
+                }
+                """.formatted(pipelineName, "a".repeat(513)))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("must not exceed 512 characters"));
+
+        String executionId = post("StartPipelineExecution", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .extract().path("pipelineExecutionId");
+
+        Thread.sleep(100);
+
+        String approvalToken = post("GetPipelineState", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200)
+                .extract().path("stageStates[0].actionStates[0].latestExecution.token");
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Approved",
+                        "summary": ""
+                    }
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("InvalidApprovalTokenException"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "%s",
+                    "result": {
+                        "status": "Approved",
+                        "summary": "First approval"
+                    }
+                }
+                """.formatted(pipelineName, approvalToken))
+                .then()
+                .statusCode(200);
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "%s",
+                    "result": {
+                        "status": "Approved",
+                        "summary": "Second approval attempt"
+                    }
+                }
+                """.formatted(pipelineName, approvalToken))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ApprovalAlreadyCompletedException"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineIntegrationTest.java
@@ -322,6 +322,227 @@ class CodePipelineIntegrationTest {
     }
 
     @Test
+    void listPipelineExecutionsValidatesFilterAndMaxResults() {
+        String pipelineName = "list-executions-validation-pipeline";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Source",
+                    "actions": [{
+                        "name": "SourceAction",
+                        "actionTypeId": {
+                            "category": "Source",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Build",
+                    "actions": [{
+                        "name": "BuildAction",
+                        "actionTypeId": {
+                            "category": "Build",
+                            "owner": "AWS",
+                            "provider": "CodeBuild",
+                            "version": "1"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "filter": {"succeededInStage": {"stageName": 42}}
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("succeededInStage requires stageName"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "filter": {"succeededInStage": {"stageName": "Source", "extra": 1}}
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("Unknown"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "filter": {"succeededInStage": {"stageName": "Source"}, "extra": 1}
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("Unknown"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "filter": {"succeededInStage": null}
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200);
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "maxResults": "5"
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("maxResults must be"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "maxResults": 5.5
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("maxResults must be"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "maxResults": 0
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("between 1 and 100"));
+
+        post("ListPipelineExecutions", """
+                {
+                    "pipelineName": "%s",
+                    "maxResults": 101
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("between 1 and 100"));
+    }
+
+    @Test
+    void putApprovalResultSurvivesStageRenameForInFlightApproval() throws Exception {
+        String pipelineName = "approval-rename-pipeline";
+        post("CreatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "Approve",
+                    "actions": [{
+                        "name": "ManualApproval",
+                        "actionTypeId": {
+                            "category": "Approval",
+                            "owner": "AWS",
+                            "provider": "Manual",
+                            "version": "1"
+                        },
+                        "configuration": {},
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-artifacts",
+                            "ObjectKey": "placeholder"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        post("StartPipelineExecution", """
+                {"name": "%s"}
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(200);
+
+        String approvalToken = waitForApprovalToken(pipelineName);
+
+        post("UpdatePipeline", pipeline(pipelineName, """
+                {
+                    "name": "ApproveRenamed",
+                    "actions": [{
+                        "name": "ManualApprovalRenamed",
+                        "actionTypeId": {
+                            "category": "Approval",
+                            "owner": "AWS",
+                            "provider": "Manual",
+                            "version": "1"
+                        },
+                        "configuration": {},
+                        "runOrder": 1
+                    }]
+                },
+                {
+                    "name": "Deploy",
+                    "actions": [{
+                        "name": "PlaceholderAction",
+                        "actionTypeId": {
+                            "category": "Deploy",
+                            "owner": "AWS",
+                            "provider": "S3",
+                            "version": "1"
+                        },
+                        "configuration": {
+                            "BucketName": "codepipeline-artifacts",
+                            "ObjectKey": "placeholder"
+                        },
+                        "runOrder": 1
+                    }]
+                }
+                """))
+                .then()
+                .statusCode(200);
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "%s",
+                    "result": {
+                        "status": "Approved",
+                        "summary": "Approved despite rename"
+                    }
+                }
+                """.formatted(pipelineName, approvalToken))
+                .then()
+                .statusCode(200)
+                .body("approvedAt", notNullValue());
+    }
+
+    @Test
     void customActionUsesAwsWorkerJobProtocol() throws Exception {
         createBucket("codepipeline-custom-source");
         putObject("codepipeline-custom-source", "source.zip", "custom artifact");
@@ -453,14 +674,7 @@ class CodePipelineIntegrationTest {
                 .statusCode(200)
                 .extract().path("pipelineExecutionId");
 
-        Thread.sleep(100);
-
-        String approvalToken = post("GetPipelineState", """
-                {"name": "%s"}
-                """.formatted(pipelineName))
-                .then()
-                .statusCode(200)
-                .extract().path("stageStates[0].actionStates[0].latestExecution.token");
+        String approvalToken = waitForApprovalToken(pipelineName);
 
         post("PutApprovalResult", """
                 {
@@ -478,11 +692,7 @@ class CodePipelineIntegrationTest {
                 .statusCode(200)
                 .body("approvedAt", notNullValue());
 
-        Thread.sleep(100);
-
-        post("GetPipelineState", """
-                {"name": "%s"}
-                """.formatted(pipelineName))
+        waitForApprovalStatus(pipelineName, "Succeeded")
                 .then()
                 .statusCode(200)
                 .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Succeeded"))
@@ -532,14 +742,7 @@ class CodePipelineIntegrationTest {
                 .statusCode(200)
                 .extract().path("pipelineExecutionId");
 
-        Thread.sleep(100);
-
-        String approvalToken2 = post("GetPipelineState", """
-                {"name": "%s"}
-                """.formatted(pipelineName2))
-                .then()
-                .statusCode(200)
-                .extract().path("stageStates[0].actionStates[0].latestExecution.token");
+        String approvalToken2 = waitForApprovalToken(pipelineName2);
 
         post("PutApprovalResult", """
                 {
@@ -557,11 +760,7 @@ class CodePipelineIntegrationTest {
                 .statusCode(200)
                 .body("approvedAt", notNullValue());
 
-        Thread.sleep(100);
-
-        post("GetPipelineState", """
-                {"name": "%s"}
-                """.formatted(pipelineName2))
+        waitForApprovalStatus(pipelineName2, "Failed")
                 .then()
                 .statusCode(200)
                 .body("stageStates[0].actionStates[0].latestExecution.status", equalTo("Failed"))
@@ -660,6 +859,50 @@ class CodePipelineIntegrationTest {
                     "pipelineName": "%s",
                     "stageName": "Approve",
                     "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000"
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("result is required"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": "Approved"
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("result must be an object"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
+                    "token": "00000000-0000-0000-0000-000000000000",
+                    "result": {
+                        "status": "Approved",
+                        "summary": 12345
+                    }
+                }
+                """.formatted(pipelineName))
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("ValidationException"))
+                .body("message", containsString("result.summary must be a string"));
+
+        post("PutApprovalResult", """
+                {
+                    "pipelineName": "%s",
+                    "stageName": "Approve",
+                    "actionName": "ManualApproval",
                     "token": "00000000-0000-0000-0000-000000000000",
                     "result": {
                         "status": "Invalid",
@@ -696,14 +939,7 @@ class CodePipelineIntegrationTest {
                 .statusCode(200)
                 .extract().path("pipelineExecutionId");
 
-        Thread.sleep(100);
-
-        String approvalToken = post("GetPipelineState", """
-                {"name": "%s"}
-                """.formatted(pipelineName))
-                .then()
-                .statusCode(200)
-                .extract().path("stageStates[0].actionStates[0].latestExecution.token");
+        String approvalToken = waitForApprovalToken(pipelineName);
 
         post("PutApprovalResult", """
                 {
@@ -838,6 +1074,39 @@ class CodePipelineIntegrationTest {
             Thread.sleep(50);
         } while (Instant.now().isBefore(deadline));
         throw new AssertionError("Pipeline did not reach " + expected + ", last status: " + status);
+    }
+
+    private Response waitForApprovalStatus(String pipelineName, String expectedStatus) throws Exception {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        Response response;
+        String status;
+        do {
+            response = post("GetPipelineState", """
+                    {"name": "%s"}
+                    """.formatted(pipelineName));
+            status = response.jsonPath().getString("stageStates[0].actionStates[0].latestExecution.status");
+            if (expectedStatus.equals(status)) {
+                return response;
+            }
+            Thread.sleep(50);
+        } while (Instant.now().isBefore(deadline));
+        throw new AssertionError("Approval action did not reach " + expectedStatus + ", last status: " + status);
+    }
+
+    private String waitForApprovalToken(String pipelineName) throws Exception {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(5));
+        String token;
+        do {
+            token = post("GetPipelineState", """
+                    {"name": "%s"}
+                    """.formatted(pipelineName))
+                    .jsonPath().getString("stageStates[0].actionStates[0].latestExecution.token");
+            if (token != null) {
+                return token;
+            }
+            Thread.sleep(50);
+        } while (Instant.now().isBefore(deadline));
+        throw new AssertionError("Approval token was not issued for pipeline " + pipelineName);
     }
 
     private static Response post(String action, String body) {


### PR DESCRIPTION
## Summary

Adds AWS-shaped input validation to two existing CodePipeline operations:

- **`ListPipelineExecutions`** — validates `filter` is an object, requires
  `filter.succeededInStage.stageName` when `succeededInStage` is present, and
  bounds `maxResults` to `[1, 100]`.
- **`PutApprovalResult`** — requires `result` as an object, restricts
  `result.status` to `Approved`/`Rejected`, caps `result.summary` at 512
  characters, verifies the target stage/action exist on the pipeline
  (`StageNotFoundException`/`ActionNotFoundException`), and returns a new
  `ApprovalAlreadyCompletedException` when the same approval token is reused
  after the action has already left `InProgress` (previously: silently fell
  through to `orElseThrow()`, producing an unrelated NoSuchElementException).

**Provenance:** this is a re-derivation of one still-live commit
(`49484ab79`, "feat: tighten CodePipeline P0 operation contracts") cherry-picked
out of a long-diverged internal integration branch
(`feature/arc-operator-tooling`) that never went upstream as a whole. The rest
of that branch is either internal docs/tooling noise or feature work already
superseded elsewhere and is not part of this PR. The cherry-pick applied
cleanly to `CodePipelineService.java` and `CodePipelineIntegrationTest.java`
with no conflicts; only the accompanying doc paragraph needed manual
resolution, because it was originally written against two other sections
(Events/notifications, V2 stage conditions/retry/rollback) that this branch
added in separate, not-yet-upstreamed commits. Those sections are out of scope
here, so the doc addition was re-anchored as a standalone "Approvals" section
containing only the sentence this commit's behavior actually documents.

## Wire fidelity (verified against current botocore, `codepipeline/2015-07-09/service-2.json`)

- `PipelineExecutionFilter` has exactly one member, `succeededInStage`
  (`SucceededInStageFilter`), which itself has exactly one member, `stageName`
  — matches the new validation exactly (rejects any `filter` shape other than
  an object containing only that nested field).
- `MaxResults` is `{type: integer, min: 1, max: 100}` — matches the new bounds
  check exactly.
- `ApprovalStatus` is a two-value enum `[Approved, Rejected]` — matches.
- `ApprovalSummary` is `{type: string, min: 0, max: 512}` — matches the new
  512-character cap.
- `ApprovalResult` marks both `summary` and `status` as required in the model;
  Floci treats a missing `summary` as empty string rather than rejecting the
  request. This is a deliberate leniency (see Deliberate scope notes below),
  not a fidelity gap in the added validation.

No RED-first fixes were needed here — this commit's added validation logic
matches the botocore model member-for-member.

## Local code review (arcPI `review-local.ts`, isolated per-file pass)

Ran against the full `CodePipelineService.java` (the only changed non-test
source file). All 14 findings (3 HIGH, 7 MEDIUM, 4 LOW) are real, but every
one is about the pre-existing execution engine — store-copy mutation on
stop/approval signals, missing wait-loop timeouts, unsynchronized parallel
action state, job-polling nonce/claim gaps, non-idempotent restart replay, and
similar — and none intersects the lines this PR touches (the filter/result
validation blocks and the new `requireAction` helper). Verified each against
current source rather than trusting the isolated review's framing; none of
them exist because of, or are fixed by, this diff. Filed as
floci-io/floci#2702 for a future dedicated durability/concurrency pass
rather than folded into this PR.

## Deliberate scope notes

- `PutApprovalResult`'s `result.summary` is accepted as optional (defaults to
  `""`) even though the botocore model marks it required — consistent with
  Floci's general leniency on optional-in-practice request fields; not
  changed by this PR.
- The accompanying doc change adds a new, self-contained "Approvals" section
  to `docs/services/codepipeline.md` rather than reproducing the original
  commit's context (which assumed two other not-yet-upstreamed sections). No
  content was dropped — only re-anchored to a location that exists on current
  `main`.
- This PR intentionally does not touch `stopPipelineExecution` or any
  execution-engine code, even though the local review's top finding overlaps
  conceptually (approval token handling) — that finding is about the shared
  mutation pattern across the whole engine, not the validation this PR adds.

## Type of change

- [x] Bug fix (input validation / error-shape correction)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## AWS compatibility

- [x] Verified against current botocore `codepipeline` service model
- [x] Error codes/shapes match AWS (`ValidationException`,
      `InvalidApprovalTokenException`, `ApprovalAlreadyCompletedException`,
      `StageNotFoundException`, `ActionNotFoundException`)

## Checklist

- [x] Tests added/updated (`CodePipelineIntegrationTest`:
      `putApprovalResultApprovesAndRejectsManualApprovalActions`,
      `putApprovalResultValidatesErrors`)
- [x] `clean test-compile` + targeted suite green
      (`CodePipelineIntegrationTest`: 7/7 passing)
- [x] `make docs-check` passes
- [x] No overlap with other open PRs (checked file-level diff against #2685,
      the only other open PR touching CodePipeline-adjacent code — it only
      changes `CloudFormationResourceProvisioner`/`CodePipelineCfnProvisioner`
      and CFN-side tests, zero shared files)

