### PR TITLE
fix(rds): clear CLIENT_SSL before forwarding the TLS-terminated handshake response to the backend

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandler.java
@@ -125,6 +125,12 @@ public class MySqlProtocolHandler {
             // permanently one behind the client's for the rest of the connection phase.
             sequenceOffset = 1;
             clientResponseRaw[3] = (byte) (clientResponseRaw[3] - sequenceOffset);
+            // Real clients keep CLIENT_SSL set in the HandshakeResponse they send over the
+            // now-encrypted stream. The backend connection stays plaintext, and a MySQL server
+            // treats any first packet with CLIENT_SSL as an SSLRequest — it would sit waiting for
+            // a TLS ClientHello that never comes while the proxy waits for its auth verdict,
+            // deadlocking the connection. Clear the bit (the mirror of forceClientSslCapability).
+            clearClientSslCapability(clientResponseRaw);
         } else {
             clientResponseRaw = clientFirstRaw;
             if (clientResponseRaw.length < 40) {
@@ -257,6 +263,15 @@ public class MySqlProtocolHandler {
         } catch (Exception e) {
             throw new IOException("Unable to negotiate MySQL SSL", e);
         }
+    }
+
+    /**
+     * Clears the {@code CLIENT_SSL} bit in a raw HandshakeResponse41 packet's capability flags.
+     * The client capabilities are the first 4 payload bytes, little-endian; {@code CLIENT_SSL}
+     * (0x0800) lives in the second byte.
+     */
+    private static void clearClientSslCapability(byte[] raw) {
+        raw[5] &= (byte) ~(CLIENT_SSL >> 8);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandlerTest.java
@@ -153,8 +153,11 @@ class MySqlProtocolHandlerTest {
 
                 byte[] scramble = scrambleNativePassword("secret", nonce);
                 // Real clients send this at sequence 2 after the TLS upgrade — the proxy must
-                // rewrite it to 1 before forwarding to the (plaintext-only) backend.
-                byte[] response = buildHandshakeResponse41("admin", scramble, (byte) 2);
+                // rewrite it to 1 before forwarding to the (plaintext-only) backend. They also
+                // keep CLIENT_SSL set in it; a real backend would treat a first packet carrying
+                // that bit as an SSLRequest and hang waiting for a TLS handshake.
+                byte[] response = buildHandshakeResponse41("admin", scramble, (byte) 2,
+                        CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_SSL);
                 tlsOut.write(response);
                 tlsOut.flush();
 
@@ -178,6 +181,11 @@ class MySqlProtocolHandlerTest {
         assertEquals((byte) 1, backendResponseSeq.get(),
                 "backend never saw the SSLRequest, so it must receive the real response at sequence 1");
         assertEquals("admin", extractUsername(backendResponsePayload.get()));
+        int backendCaps = (backendResponsePayload.get()[0] & 0xFF)
+                | ((backendResponsePayload.get()[1] & 0xFF) << 8);
+        assertEquals(0, backendCaps & CLIENT_SSL,
+                "the plaintext backend must not see CLIENT_SSL, or it treats the response as an "
+                        + "SSLRequest and waits forever for a TLS handshake");
     }
 
     @Test
@@ -238,7 +246,8 @@ class MySqlProtocolHandlerTest {
                 OutputStream tlsOut = sslClient.getOutputStream();
 
                 byte[] scramble = scrambleNativePassword("secret", nonce);
-                byte[] response = buildHandshakeResponse41("admin", scramble, (byte) 2);
+                byte[] response = buildHandshakeResponse41("admin", scramble, (byte) 2,
+                        CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION | CLIENT_SSL);
                 tlsOut.write(response);
                 tlsOut.flush();
 
@@ -352,8 +361,14 @@ class MySqlProtocolHandlerTest {
 
     private static byte[] buildHandshakeResponse41(String username, byte[] scramble, byte sequence)
             throws IOException {
+        return buildHandshakeResponse41(username, scramble, sequence,
+                CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION);
+    }
+
+    private static byte[] buildHandshakeResponse41(String username, byte[] scramble, byte sequence,
+                                                   int capabilities) throws IOException {
         ByteArrayOutputStream payload = new ByteArrayOutputStream();
-        writeInt32LE(payload, CLIENT_PROTOCOL_41 | CLIENT_SECURE_CONNECTION);
+        writeInt32LE(payload, capabilities);
         writeInt32LE(payload, 0); // max packet size
         payload.write(0x21); // charset
         payload.write(new byte[23]); // reserved


### PR DESCRIPTION
## Summary

Every TLS connection to a MySQL RDS instance through the auth proxy hangs until the client times out. mysql's default `--ssl-mode=PREFERRED` is enough to hit it, so out of the box a stock client cannot connect at all; only `--ssl-mode=DISABLED` works.

A virtual-thread dump during the hang shows the proxy parked in the connection-phase relay, waiting for a backend verdict that never arrives:

```
#103 "rds-proxy-conn-rds-resource:arn:aws:rds:...:db:tls-check" virtual WAITING
    at MySqlProtocolHandler.readMysqlPacketRaw(MySqlProtocolHandler.java:441)
    at MySqlProtocolHandler.relayConnectionPhase(MySqlProtocolHandler.java:200)
    at MySqlProtocolHandler.handleAuth(MySqlProtocolHandler.java:178)
```

**Root cause:** real clients keep `CLIENT_SSL` set in the `HandshakeResponse41` they send over the now-encrypted stream after the `SSLRequest`. The proxy terminates TLS itself and forwards that response to the **plaintext** backend verbatim (only renumbering the sequence). A MySQL server treats any first packet carrying `CLIENT_SSL` as an SSLRequest: it switches into TLS-accept mode and waits for a ClientHello that never comes, while the proxy waits for the auth verdict. Both sides block forever. The existing TLS test missed this because its synthetic client built the post-upgrade response without `CLIENT_SSL`, which no real client does.

**Fix:** clear the `CLIENT_SSL` bit in the client's response before it reaches the backend — the mirror image of the existing `forceClientSslCapability` on the server handshake. One bit in one byte; the sequence-renumber logic is untouched.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: real RDS accepts TLS connections (and `rds.force_ssl` even requires them); Floci's proxy deadlocked on every TLS attempt, mysql's default `--ssl-mode=PREFERRED` included:

```
$ timeout 20 mysql -h <endpoint> -P 7001 -uadmin -p*** --ssl-mode=REQUIRED -e "SELECT 1"
(no output, exit 124)
```

Verified end-to-end against a JVM build with a real `mysql:8.0.36` backend container, all through the proxy as the master user (mysql client 8.0.36):

```
--ssl-mode=REQUIRED   → SELECT succeeds   (hung before the fix)
default (PREFERRED)   → SELECT succeeds   (hung before the fix)
--ssl-mode=DISABLED   → SELECT succeeds   (unchanged)
```

`Ssl_cipher` reads empty by design: it reports the backend leg, which intentionally stays plaintext — TLS terminates at the proxy. `REQUIRED` succeeding is the proof the client leg negotiated TLS.

## Checklist

- [x] `./mvnw test` passes locally (`MySqlProtocolHandlerTest`, `PostgresProtocolHandlerTest`, `RdsProxyManagerTest`)
- [x] New or updated integration test added — the TLS handler tests now build real-client-shaped responses (`CLIENT_SSL` set) and assert the backend-received packet has the bit cleared; without the fix the assertion fails: `expected: <0> but was: <2048>`
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
