### PR TITLE
feat(stepfunctions): emit task history events and chain previousEventId

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsExecutionHistoryTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsExecutionHistoryTest.java
@@ -1,0 +1,139 @@
+package com.floci.test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import software.amazon.awssdk.services.sfn.SfnClient;
+import software.amazon.awssdk.services.sfn.model.*;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteQueueRequest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * Compatibility test for issue #2520: a Task state backed by a service integration must emit
+ * TaskScheduled/TaskStarted/TaskSucceeded around TaskStateEntered/TaskStateExited, and every
+ * event's previousEventId must chain to the id of the event immediately before it, with the
+ * first state's Entered event pointing to 0.
+ *
+ * Shapes pinned against real AWS: see taskScheduledEventDetails assertions below for the
+ * exact fields AWS returns for the "arn:aws:states:::sqs:sendMessage" optimized integration.
+ */
+@DisplayName("SFN GetExecutionHistory task events and previousEventId chaining")
+class StepFunctionsExecutionHistoryTest {
+
+    private static final String ROLE_ARN = System.getenv("SFN_ROLE_ARN") != null
+            ? System.getenv("SFN_ROLE_ARN")
+            : "arn:aws:iam::000000000000:role/service-role/test-role";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static SfnClient sfn;
+    private static SqsClient sqs;
+
+    @BeforeAll
+    static void setup() {
+        sfn = TestFixtures.sfnClient();
+        sqs = TestFixtures.sqsClient();
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (sfn != null) {
+            sfn.close();
+        }
+        if (sqs != null) {
+            sqs.close();
+        }
+    }
+
+    @Test
+    void taskEventsAreEmittedInOrderWithChainedPreviousEventId() throws Exception {
+        var queueUrl = sqs.createQueue(b -> b.queueName(TestFixtures.uniqueName("sfn-history-queue")))
+                .queueUrl();
+
+        var smDef = """
+                {
+                  "StartAt": "Send",
+                  "States": {
+                    "Send": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::sqs:sendMessage",
+                      "Parameters": {
+                        "QueueUrl": "%s",
+                        "MessageBody": "hello"
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(queueUrl);
+
+        var smArn = sfn.createStateMachine(b -> b
+                .name(TestFixtures.uniqueName("sfn-history-sm"))
+                .definition(smDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            var execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(smArn)
+                    .input("{}")).executionArn();
+
+            var execution = pollUntilDone(execArn);
+            assertThat(execution.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+
+            var history = sfn.getExecutionHistory(b -> b
+                    .executionArn(execArn)
+                    .includeExecutionData(true));
+            var events = history.events();
+
+            var types = events.stream().map(HistoryEvent::type).toList();
+            assertThat(types).containsExactly(
+                    HistoryEventType.EXECUTION_STARTED,
+                    HistoryEventType.TASK_STATE_ENTERED,
+                    HistoryEventType.TASK_SCHEDULED,
+                    HistoryEventType.TASK_STARTED,
+                    HistoryEventType.TASK_SUCCEEDED,
+                    HistoryEventType.TASK_STATE_EXITED,
+                    HistoryEventType.EXECUTION_SUCCEEDED);
+
+            var expectedPreviousEventIds = List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L);
+            for (var i = 0; i < events.size(); i++) {
+                var event = events.get(i);
+                assertThat(event.id()).isEqualTo(i + 1L);
+                assertThat(event.previousEventId()).isEqualTo(expectedPreviousEventIds.get(i));
+            }
+
+            var scheduled = events.get(2).taskScheduledEventDetails();
+            assertThat(scheduled.resourceType()).isEqualTo("sqs");
+            assertThat(scheduled.resource()).isEqualTo("sendMessage");
+            assertThat(scheduled.region()).isNotBlank();
+            var parameters = MAPPER.readTree(scheduled.parameters());
+            assertThat(parameters.path("QueueUrl").asText()).isEqualTo(queueUrl);
+            assertThat(parameters.path("MessageBody").asText()).isEqualTo("hello");
+
+            var started = events.get(3).taskStartedEventDetails();
+            assertThat(started.resourceType()).isEqualTo("sqs");
+            assertThat(started.resource()).isEqualTo("sendMessage");
+
+            var succeeded = events.get(4).taskSucceededEventDetails();
+            assertThat(succeeded.resourceType()).isEqualTo("sqs");
+            assertThat(succeeded.resource()).isEqualTo("sendMessage");
+            assertThat(succeeded.output()).contains("MessageId");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(smArn)); } catch (Exception ignored) {}
+            try { sqs.deleteQueue(DeleteQueueRequest.builder().queueUrl(queueUrl).build()); } catch (Exception ignored) {}
+        }
+    }
+
+    private DescribeExecutionResponse pollUntilDone(String execArn) throws InterruptedException {
+        for (var i = 0; i < 120; i++) {
+            var resp = sfn.describeExecution(b -> b.executionArn(execArn));
+            if (resp.status() != ExecutionStatus.RUNNING) {
+                return resp;
+            }
+            Thread.sleep(500);
+        }
+        throw new AssertionError("Execution did not complete within 60s: " + execArn);
+    }
+}

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -40,6 +40,45 @@
 definition, role, logging, tracing, encryption, and tags without replacing the state machine;
 changes to `StateMachineName` or `StateMachineType` use replacement semantics.
 
+## Execution history events
+
+`GetExecutionHistory` emits an event family around a Task state's `TaskStateEntered` and
+`TaskStateExited` pair. Which family depends on the resource type.
+
+- A service integration ARN (`arn:aws:states:::...`) emits `TaskScheduled`, `TaskStarted`,
+  and then `TaskSucceeded` or `TaskFailed`. `taskScheduledEventDetails` carries
+  `resourceType`, `resource`, `region`, and `parameters`. `parameters` is the resolved
+  `Parameters` or `Arguments` payload, serialized as a JSON string. `timeoutInSeconds` and
+  `heartbeatInSeconds` appear only when the state sets `TimeoutSeconds` or
+  `HeartbeatSeconds` as a literal number.
+- A direct Lambda function ARN emits `LambdaFunctionScheduled`, `LambdaFunctionStarted`,
+  and then `LambdaFunctionSucceeded` or `LambdaFunctionFailed`. `LambdaFunctionScheduled`
+  carries `resource` and `input`. `resource` holds the full function ARN. `LambdaFunctionStarted`
+  carries no details at all. This matches AWS.
+- An activity ARN emits the equivalent `Activity*` family.
+
+A `Retry` re-entry emits its own Scheduled, Started, and Failed triple for each attempt. A
+mocked Task (`SFN_MOCK_CONFIG`) emits the same events as a real one, because Step Functions
+Local does the same.
+
+Every event's `previousEventId` points to the id of the event right before it. The one
+exception is the first state's `*StateEntered` event. Its `previousEventId` is `0`. That
+matches `ExecutionStarted`, which is always `id: 1, previousEventId: 0`.
+
+`inputDetails` appears on `ExecutionStarted`, on `stateEnteredEventDetails`, and on
+`LambdaFunctionScheduled`/`ActivityScheduled`. `outputDetails` appears on
+`stateExitedEventDetails`, on `executionSucceededEventDetails`, and on
+`taskSucceededEventDetails`/`lambdaFunctionSucceededEventDetails`. Both are always
+`{"truncated": false}`. Floci never truncates a payload, so the value never changes.
+When the request sets `includeExecutionData` to false, the details objects stay but lose
+`input`, `inputDetails`, `output`, and `outputDetails`. Every other field stays, including
+`taskScheduledEventDetails.parameters`. This matches AWS.
+
+A few gaps remain. `TaskStarted`, `LambdaFunctionStarted`, and `ActivityStarted` fire at
+scheduling time, not when a worker actually picks up the task. Events inside a `Parallel` or
+`Map` branch are not recorded in the parent execution's history. `TaskSubmitted`, which real
+AWS emits for `.sync` and `.waitForTaskToken` integrations, is not emitted yet.
+
 ## Map concurrency
 
 Map states honor `MaxConcurrency` and, for JSONPath state machines, `MaxConcurrencyPath`.

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -352,6 +352,7 @@ public class AslExecutor {
         // Declared outside the try so the terminal handlers below can keep numbering the history
         // where the execution left it.
         AtomicLong eventId = new AtomicLong(history.size());
+        var firstState = true;
         try {
             JsonNode definition = objectMapper.readTree(sm.getDefinition());
             JsonNode states = definition.path("States");
@@ -371,8 +372,10 @@ public class AslExecutor {
                 }
 
                 String type = stateDef.path("Type").asText();
-                addEvent(history, eventId, stateEnteredEventType(type), null,
-                        Map.of("name", currentStateName, "input", currentInput.toString()));
+                addEvent(history, eventId, stateEnteredEventType(type), firstState ? 0L : eventId.get(),
+                        Map.of("name", currentStateName, "input", currentInput.toString(),
+                               "inputDetails", Map.of("truncated", false)));
+                firstState = false;
 
                 // Update per-state context fields
                 updateStateContext(execContext, currentStateName);
@@ -381,8 +384,9 @@ public class AslExecutor {
                 try {
                     var stateResult = executeStateWithRetry(currentStateName, type, stateDef, currentInput,
                             history, eventId, sm, jsonata, topLevelQueryLanguage, execContext, variables);
-                    addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
-                            Map.of("name", currentStateName, "output", stateResult.output().toString()));
+                    addEvent(history, eventId, stateExitedEventType(type),
+                            Map.of("name", currentStateName, "output", stateResult.output().toString(),
+                                   "outputDetails", Map.of("truncated", false)));
 
                     currentInput = stateResult.output();
                     currentStateName = stateResult.nextState();
@@ -393,8 +397,9 @@ public class AslExecutor {
                 } catch (FailStateException e) {
                     StateResult caught = handleCatch(stateDef, currentInput, e, jsonata, execContext, variables);
                     if (caught != null) {
-                        addEvent(history, eventId, stateExitedEventType(type), eventId.get() - 1,
-                                Map.of("name", currentStateName, "output", caught.output().toString()));
+                        addEvent(history, eventId, stateExitedEventType(type),
+                                Map.of("name", currentStateName, "output", caught.output().toString(),
+                                       "outputDetails", Map.of("truncated", false)));
                         currentInput = caught.output();
                         currentStateName = caught.nextState();
                         continue;
@@ -412,8 +417,8 @@ public class AslExecutor {
             exec.setOutput(currentInput.toString());
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
             exec.setStatus("SUCCEEDED");
-            addEvent(history, eventId, "ExecutionSucceeded", null,
-                    Map.of("output", currentInput.toString()));
+            addEvent(history, eventId, "ExecutionSucceeded",
+                    Map.of("output", currentInput.toString(), "outputDetails", Map.of("truncated", false)));
             onUpdate.accept(exec, history);
 
         } catch (Exception e) {
@@ -588,29 +593,40 @@ public class AslExecutor {
             tokenFuture = sfnService.get().registerPendingToken(taskToken);
         }
 
-        JsonNode taskResult;
+        JsonNode effectiveInput;
         if (jsonata) {
-            var effectiveInput = input;
+            effectiveInput = input;
             if (stateDef.has("Arguments")) {
                 var statesVar = buildStatesVar(input, null, context);
                 effectiveInput = jsonataEvaluator.resolveTemplate(stateDef.get("Arguments"), statesVar, variables);
             }
-            taskResult = mockedSteps != null
-                    ? mockedTaskResult(mockedSteps, stateName, attempt)
-                    : invokeResource(effectiveResource, effectiveInput, sm, taskToken);
         } else {
-            var effectiveInput = applyInputPath(stateDef, input);
+            effectiveInput = applyInputPath(stateDef, input);
             if (stateDef.has("Parameters")) {
                 effectiveInput = resolveParameters(stateDef.get("Parameters"), effectiveInput, context);
             }
+        }
+
+        var profile = taskEventProfile(resource, isActivity);
+        addTaskScheduledEvent(history, eventId, profile, stateDef, effectiveInput, sm);
+        addTaskStartedEvent(history, eventId, profile);
+
+        JsonNode taskResult;
+        try {
             taskResult = mockedSteps != null
                     ? mockedTaskResult(mockedSteps, stateName, attempt)
                     : invokeResource(effectiveResource, effectiveInput, sm, taskToken);
+            if (tokenFuture != null) {
+                taskResult = awaitToken(tokenFuture, stateDef);
+            }
+        } catch (Exception e) {
+            var failure = e instanceof FailStateException f ? f : null;
+            addTaskFailedEvent(history, eventId, profile,
+                    failure != null && failure.error != null ? failure.error : "States.Runtime",
+                    failure != null ? failure.cause : e.getMessage());
+            throw e;
         }
-
-        if (tokenFuture != null) {
-            taskResult = awaitToken(tokenFuture, stateDef);
-        }
+        addTaskSucceededEvent(history, eventId, profile, taskResult);
 
         if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, taskResult, context, variables);
@@ -3347,14 +3363,99 @@ public class AslExecutor {
 
     // ──────────────────────────── History helpers ────────────────────────────
 
-    private void addEvent(List<HistoryEvent> history, AtomicLong counter, String type,
-                          Long prevId, Map<String, Object> details) {
-        HistoryEvent event = new HistoryEvent();
+    private void addEvent(List<HistoryEvent> history, AtomicLong counter, String type, Map<String, Object> details) {
+        addEvent(history, counter, type, counter.get(), details);
+    }
+
+    private void addEvent(List<HistoryEvent> history, AtomicLong counter, String type, long previousEventId,
+                          Map<String, Object> details) {
+        var event = new HistoryEvent();
         event.setId(counter.incrementAndGet());
+        event.setPreviousEventId(previousEventId);
         event.setType(type);
-        event.setPreviousEventId(prevId);
         event.setDetails(details);
         history.add(event);
+    }
+
+    private record TaskEventProfile(String prefix, String resourceType, String resource) {}
+
+    private TaskEventProfile taskEventProfile(String resource, boolean isActivity) {
+        if (isActivity) {
+            return new TaskEventProfile("Activity", null, resource);
+        }
+        if (resource.contains(":lambda:") && resource.contains(":function:")) {
+            return new TaskEventProfile("LambdaFunction", null, resource);
+        }
+        if (resource.startsWith("arn:aws:states:::")) {
+            var tail = resource.substring("arn:aws:states:::".length());
+            var idx = tail.lastIndexOf(':');
+            if (idx < 0) {
+                return new TaskEventProfile("Task", tail, tail);
+            }
+            return new TaskEventProfile("Task", tail.substring(0, idx), tail.substring(idx + 1));
+        }
+        return new TaskEventProfile("Task", resource, resource);
+    }
+
+    private void addTaskScheduledEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile,
+                                       JsonNode stateDef, JsonNode effectiveInput, StateMachine sm) {
+        var details = new LinkedHashMap<String, Object>();
+        if (profile.resourceType() != null) {
+            details.put("resourceType", profile.resourceType());
+        }
+        details.put("resource", profile.resource());
+        if ("Task".equals(profile.prefix())) {
+            details.put("region", extractRegionFromArn(sm.getStateMachineArn()));
+            details.put("parameters", effectiveInput.toString());
+        } else {
+            details.put("input", effectiveInput.toString());
+            details.put("inputDetails", Map.of("truncated", false));
+        }
+        if (stateDef.path("TimeoutSeconds").isNumber()) {
+            details.put("timeoutInSeconds", stateDef.path("TimeoutSeconds").asLong());
+        }
+        if (stateDef.path("HeartbeatSeconds").isNumber()) {
+            details.put("heartbeatInSeconds", stateDef.path("HeartbeatSeconds").asLong());
+        }
+        addEvent(history, eventId, profile.prefix() + "Scheduled", details);
+    }
+
+    private void addTaskStartedEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile) {
+        if ("Task".equals(profile.prefix())) {
+            addEvent(history, eventId, profile.prefix() + "Started",
+                    Map.of("resourceType", profile.resourceType(), "resource", profile.resource()));
+        } else {
+            addEvent(history, eventId, profile.prefix() + "Started", null);
+        }
+    }
+
+    private void addTaskSucceededEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile,
+                                       JsonNode taskResult) {
+        var output = taskResult.toString();
+        if ("Task".equals(profile.prefix())) {
+            addEvent(history, eventId, profile.prefix() + "Succeeded",
+                    Map.of("resourceType", profile.resourceType(), "resource", profile.resource(),
+                           "output", output, "outputDetails", Map.of("truncated", false)));
+        } else {
+            addEvent(history, eventId, profile.prefix() + "Succeeded",
+                    Map.of("output", output, "outputDetails", Map.of("truncated", false)));
+        }
+    }
+
+    private void addTaskFailedEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile,
+                                    String error, String cause) {
+        var details = new LinkedHashMap<String, Object>();
+        if ("Task".equals(profile.prefix())) {
+            details.put("resourceType", profile.resourceType());
+            details.put("resource", profile.resource());
+        }
+        if (error != null) {
+            details.put("error", error);
+        }
+        if (cause != null) {
+            details.put("cause", cause);
+        }
+        addEvent(history, eventId, profile.prefix() + "Failed", details);
     }
 
     private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId, FailStateException e) {
@@ -3373,7 +3474,7 @@ public class AslExecutor {
         exec.setCause(cause);
         exec.setStopDate(System.currentTimeMillis() / 1000.0);
         exec.setStatus("FAILED");
-        addEvent(history, eventId, "ExecutionFailed", null,
+        addEvent(history, eventId, "ExecutionFailed",
                 Map.of("error", error, "cause", cause));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -16,8 +16,10 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @ApplicationScoped
 public class StepFunctionsJsonHandler {
@@ -327,12 +329,21 @@ public class StepFunctionsJsonHandler {
             item.put("timestamp", e.getTimestamp());
             item.put("type", e.getType());
             if (e.getPreviousEventId() != null) item.put("previousEventId", e.getPreviousEventId());
-            if (includeExecutionData && e.getDetails() != null) {
-                item.set(historyEventDetailsField(e.getType()), objectMapper.valueToTree(e.getDetails()));
+            if (e.getDetails() != null) {
+                var details = e.getDetails();
+                if (!includeExecutionData) {
+                    var filtered = new LinkedHashMap<>(details);
+                    filtered.keySet().removeAll(EXECUTION_DATA_FIELDS);
+                    details = filtered;
+                }
+                item.set(historyEventDetailsField(e.getType()), objectMapper.valueToTree(details));
             }
         }
         return Response.ok(response).build();
     }
+
+    private static final Set<String> EXECUTION_DATA_FIELDS =
+            Set.of("input", "inputDetails", "output", "outputDetails");
 
     static String historyEventDetailsField(String type) {
         if (type.endsWith("StateEntered")) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -510,9 +510,11 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         var history = new ArrayList<HistoryEvent>();
         var startEvent = new HistoryEvent();
         startEvent.setId(1L);
+        startEvent.setPreviousEventId(0L);
         startEvent.setType("ExecutionStarted");
         startEvent.setDetails(Map.of("input", input != null ? input : "{}",
-                                     "roleArn", sm.getRoleArn() != null ? sm.getRoleArn() : ""));
+                                     "roleArn", sm.getRoleArn() != null ? sm.getRoleArn() : "",
+                                     "inputDetails", Map.of("truncated", false)));
         history.add(startEvent);
         historyCache.put(arn, history);
 
@@ -562,9 +564,11 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         var history = new ArrayList<HistoryEvent>();
         var startEvent = new HistoryEvent();
         startEvent.setId(1L);
+        startEvent.setPreviousEventId(0L);
         startEvent.setType("ExecutionStarted");
         startEvent.setDetails(Map.of("input", input != null ? input : "{}",
-                                     "roleArn", sm.getRoleArn() != null ? sm.getRoleArn() : ""));
+                                     "roleArn", sm.getRoleArn() != null ? sm.getRoleArn() : "",
+                                     "inputDetails", Map.of("truncated", false)));
         history.add(startEvent);
 
         aslExecutor.executeSync(sm, exec, history, (updatedExec, updatedHistory) -> {
@@ -651,6 +655,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         List<HistoryEvent> history = historyCache.getOrDefault(arn, new ArrayList<>());
         HistoryEvent event = new HistoryEvent();
         event.setId(history.size() + 1L);
+        event.setPreviousEventId((long) history.size());
         event.setType("ExecutionAborted");
         Map<String, Object> details = new HashMap<>();
         if (error != null) details.put("error", error);

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -1,0 +1,309 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.MockedResponseStep;
+import io.github.hectorvent.floci.services.stepfunctions.model.MockedTestCase;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.Vertx;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression tests for issue #2520: a Task state must emit the AWS event family
+ * (Task/LambdaFunction/Activity Scheduled/Started/Succeeded/Failed) around
+ * TaskStateEntered/Exited, and every event's previousEventId must chain to the id of the
+ * event immediately before it, with the first state's Entered event pointing to 0.
+ */
+@QuarkusTest
+class AslExecutorTaskHistoryEventsTest {
+
+    private static final String REGION = "us-east-2";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private LambdaExecutorService lambdaExecutor;
+    private LambdaFunctionStore functionStore;
+    private AslExecutor executor;
+
+    @Inject
+    Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        lambdaExecutor = mock(LambdaExecutorService.class);
+        functionStore = mock(LambdaFunctionStore.class);
+
+        executor = new AslExecutor(
+                lambdaExecutor,
+                functionStore,
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
+                mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
+                mock(S3Service.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerService.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
+                objectMapper,
+                new JsonataEvaluator(objectMapper),
+                mock(Instance.class), mock(EmulatorConfig.class), vertx);
+    }
+
+    @Test
+    void mockedTaskEmitsScheduledStartedSucceededInOrder() throws Exception {
+        var mocks = testCase(Map.of("Send", List.of(
+                returnStep(0, 0, "{\"MessageId\":\"abc\"}"))));
+
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Send",
+                  "States": {
+                    "Send": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::aws-sdk:sqs:sendMessage",
+                      "Parameters": {
+                        "QueueUrl": "https://sqs.us-east-2.amazonaws.com/000000000000/q",
+                        "MessageBody.$": "$.msg"
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """, "{\"msg\":\"hello\"}", mocks, history);
+
+        assertEquals("SUCCEEDED", execution.getStatus(), "history: " + typesOf(history));
+        assertEquals(
+                List.of("TaskStateEntered", "TaskScheduled", "TaskStarted", "TaskSucceeded",
+                        "TaskStateExited", "ExecutionSucceeded"),
+                typesOf(history));
+        assertChain(history);
+
+        var scheduled = eventOfType(history, "TaskScheduled");
+        assertEquals("aws-sdk:sqs", scheduled.getDetails().get("resourceType"));
+        assertEquals("sendMessage", scheduled.getDetails().get("resource"));
+        assertEquals(REGION, scheduled.getDetails().get("region"));
+        var parameters = objectMapper.readTree((String) scheduled.getDetails().get("parameters"));
+        assertEquals("https://sqs.us-east-2.amazonaws.com/000000000000/q", parameters.path("QueueUrl").asText());
+        assertEquals("hello", parameters.path("MessageBody").asText());
+    }
+
+    @Test
+    void retriedMockEmitsTaskEventsPerAttempt() throws Exception {
+        var mocks = testCase(Map.of("Send", List.of(
+                throwStep(0, 1, "ApiGateway.500", "boom"),
+                returnStep(2, 2, "{\"ok\":true}"))));
+
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Send",
+                  "States": {
+                    "Send": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::aws-sdk:sqs:sendMessage",
+                      "Parameters": {"QueueUrl": "https://sqs.us-east-2.amazonaws.com/000000000000/q", "MessageBody": "x"},
+                      "End": true,
+                      "Retry": [{
+                        "ErrorEquals": ["ApiGateway.500"],
+                        "IntervalSeconds": 0,
+                        "BackoffRate": 1.0,
+                        "MaxAttempts": 2
+                      }]
+                    }
+                  }
+                }
+                """, "{}", mocks, history);
+
+        assertEquals("SUCCEEDED", execution.getStatus(), "history: " + typesOf(history));
+        assertEquals(
+                List.of("TaskStateEntered",
+                        "TaskScheduled", "TaskStarted", "TaskFailed",
+                        "TaskScheduled", "TaskStarted", "TaskFailed",
+                        "TaskScheduled", "TaskStarted", "TaskSucceeded",
+                        "TaskStateExited", "ExecutionSucceeded"),
+                typesOf(history));
+        assertChain(history);
+    }
+
+    @Test
+    void taskFailedToleratesNullCause() throws Exception {
+        var mocks = testCase(Map.of("Send", List.of(
+                throwStep(0, 0, "My.Error", null))));
+
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Send",
+                  "States": {
+                    "Send": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::aws-sdk:sqs:sendMessage",
+                      "Parameters": {"QueueUrl": "https://sqs.us-east-2.amazonaws.com/000000000000/q", "MessageBody": "x"},
+                      "End": true
+                    }
+                  }
+                }
+                """, "{}", mocks, history);
+
+        assertEquals("FAILED", execution.getStatus(), "history: " + typesOf(history));
+        var failed = eventOfType(history, "TaskFailed");
+        assertEquals("My.Error", failed.getDetails().get("error"));
+        assertFalse(failed.getDetails().containsKey("cause"));
+    }
+
+    @Test
+    void jsonataArgumentsAppearResolvedInTaskScheduledParameters() throws Exception {
+        var mocks = testCase(Map.of("Send", List.of(
+                returnStep(0, 0, "{\"ok\":true}"))));
+
+        var history = new ArrayList<HistoryEvent>();
+        run("""
+                {
+                  "QueryLanguage": "JSONata",
+                  "StartAt": "Send",
+                  "States": {
+                    "Send": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::aws-sdk:sqs:sendMessage",
+                      "Arguments": "{% $states.input %}",
+                      "End": true
+                    }
+                  }
+                }
+                """, "{\"msg\":\"hi\"}", mocks, history);
+
+        var scheduled = eventOfType(history, "TaskScheduled");
+        var parameters = objectMapper.readTree((String) scheduled.getDetails().get("parameters"));
+        assertEquals("hi", parameters.path("msg").asText());
+    }
+
+    @Test
+    void directLambdaArnEmitsLambdaFunctionEvents() throws Exception {
+        var functionName = "echo-lambda";
+        var functionArn = "arn:aws:lambda:%s:%s:function:%s".formatted(REGION, ACCOUNT, functionName);
+        var function = new LambdaFunction();
+        function.setFunctionName(functionName);
+        function.setFunctionArn(functionArn);
+
+        when(functionStore.get(REGION, functionName)).thenReturn(Optional.of(function));
+        when(lambdaExecutor.invoke(eq(function), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenAnswer(invocation -> {
+                    var event = objectMapper.readTree((byte[]) invocation.getArgument(1));
+                    var output = objectMapper.writeValueAsBytes(event);
+                    return new InvokeResult(200, null, output, null, "echo-request");
+                });
+
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Call",
+                  "States": {
+                    "Call": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(functionArn), "{\"msg\":\"hello\"}", null, history);
+
+        assertEquals("SUCCEEDED", execution.getStatus(), "history: " + typesOf(history));
+        assertEquals(
+                List.of("TaskStateEntered", "LambdaFunctionScheduled", "LambdaFunctionStarted",
+                        "LambdaFunctionSucceeded", "TaskStateExited", "ExecutionSucceeded"),
+                typesOf(history));
+        assertChain(history);
+
+        var scheduled = eventOfType(history, "LambdaFunctionScheduled");
+        assertEquals(functionArn, scheduled.getDetails().get("resource"));
+        assertFalse(scheduled.getDetails().containsKey("resourceType"));
+        var input = objectMapper.readTree((String) scheduled.getDetails().get("input"));
+        assertEquals("hello", input.path("msg").asText());
+
+        var started = eventOfType(history, "LambdaFunctionStarted");
+        assertNull(started.getDetails());
+    }
+
+    private static List<String> typesOf(List<HistoryEvent> history) {
+        return history.stream().map(HistoryEvent::getType).toList();
+    }
+
+    private static HistoryEvent eventOfType(List<HistoryEvent> history, String type) {
+        return history.stream()
+                .filter(event -> type.equals(event.getType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "history has no " + type + " event: " + typesOf(history)));
+    }
+
+    private static void assertChain(List<HistoryEvent> history) {
+        for (var i = 0; i < history.size(); i++) {
+            var event = history.get(i);
+            assertEquals(i + 1L, event.getId(), "unexpected id at index " + i);
+            assertEquals((long) i, event.getPreviousEventId(), "unexpected previousEventId at index " + i);
+        }
+    }
+
+    private MockedTestCase testCase(Map<String, List<MockedResponseStep>> stateResponses) {
+        return new MockedTestCase("history-events-test", "Case", stateResponses);
+    }
+
+    private MockedResponseStep returnStep(int from, int to, String json) throws Exception {
+        return new MockedResponseStep(from, to, objectMapper.readTree(json), null, null);
+    }
+
+    private MockedResponseStep throwStep(int from, int to, String error, String cause) {
+        return new MockedResponseStep(from, to, null, error, cause);
+    }
+
+    private Execution run(String definition, String input, MockedTestCase mocks, List<HistoryEvent> history) {
+        var stateMachine = new StateMachine();
+        stateMachine.setName("history-events-test");
+        stateMachine.setStateMachineArn("arn:aws:states:%s:%s:stateMachine:history-events-test".formatted(REGION, ACCOUNT));
+        stateMachine.setRoleArn("arn:aws:iam::%s:role/test-role".formatted(ACCOUNT));
+        stateMachine.setDefinition(definition);
+
+        var execution = new Execution();
+        execution.setName("history-events-execution");
+        execution.setExecutionArn(
+                "arn:aws:states:%s:%s:execution:history-events-test:history-events-execution".formatted(REGION, ACCOUNT));
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput(input);
+
+        executor.executeSync(stateMachine, execution, history, mocks, (updated, events) -> {
+        });
+        return execution;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsExecutionHistoryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsExecutionHistoryIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.stepfunctions;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
@@ -7,19 +8,26 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 @QuarkusTest
 class StepFunctionsExecutionHistoryIntegrationTest {
 
     private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String SQS_CONTENT_TYPE = "application/x-amz-json-1.0";
     private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     @BeforeAll
     static void configureRestAssured() {
@@ -84,7 +92,7 @@ class StepFunctionsExecutionHistoryIntegrationTest {
     }
 
     @Test
-    void getExecutionHistory_omitsExecutionSucceededEventDetailsWhenIncludeExecutionDataIsFalse() throws Exception {
+    void getExecutionHistory_omitsExecutionDataWhenIncludeExecutionDataIsFalse() throws Exception {
         String definition = """
                 {
                   "StartAt": "Set Output",
@@ -117,10 +125,125 @@ class StepFunctionsExecutionHistoryIntegrationTest {
                 .post("/")
                 .then()
                 .statusCode(200)
-                .body("events.find { it.type == 'PassStateEntered' }.stateEnteredEventDetails", nullValue())
-                .body("events.find { it.type == 'PassStateExited' }.stateExitedEventDetails", nullValue())
-                .body("events.find { it.type == 'ExecutionSucceeded' }.type", equalTo("ExecutionSucceeded"))
-                .body("events.find { it.type == 'ExecutionSucceeded' }.executionSucceededEventDetails", nullValue());
+                .body("events.find { it.type == 'PassStateEntered' }.stateEnteredEventDetails.name",
+                        equalTo("Set Output"))
+                .body("events.find { it.type == 'PassStateEntered' }.stateEnteredEventDetails.input", nullValue())
+                .body("events.find { it.type == 'PassStateEntered' }.stateEnteredEventDetails.inputDetails",
+                        nullValue())
+                .body("events.find { it.type == 'PassStateExited' }.stateExitedEventDetails.name",
+                        equalTo("Set Output"))
+                .body("events.find { it.type == 'PassStateExited' }.stateExitedEventDetails.output", nullValue())
+                .body("events.find { it.type == 'PassStateExited' }.stateExitedEventDetails.outputDetails",
+                        nullValue())
+                .body("events.find { it.type == 'ExecutionSucceeded' }.executionSucceededEventDetails",
+                        notNullValue())
+                .body("events.find { it.type == 'ExecutionSucceeded' }.executionSucceededEventDetails.output",
+                        nullValue());
+    }
+
+    @Test
+    void getExecutionHistory_emitsTaskScheduledStartedSucceededWithChainedPreviousEventId() throws Exception {
+        var queueUrl = createQueue("execution-history-sqs-queue");
+        try {
+            var definition = """
+                    {
+                      "StartAt": "Send",
+                      "States": {
+                        "Send": {
+                          "Type": "Task",
+                          "Resource": "arn:aws:states:::sqs:sendMessage",
+                          "Parameters": {
+                            "QueueUrl": "%s",
+                            "MessageBody": "hello"
+                          },
+                          "End": true
+                        }
+                      }
+                    }
+                    """.formatted(queueUrl);
+
+            var stateMachineArn = createStateMachine("execution-history-task-events-test", definition);
+            var executionArn = startExecution(stateMachineArn);
+            waitForExecution(executionArn);
+
+            var response = given()
+                    .header("X-Amz-Target", "AWSStepFunctions.GetExecutionHistory")
+                    .contentType(SFN_CONTENT_TYPE)
+                    .body(String.format("""
+                            {
+                                "executionArn": "%s",
+                                "includeExecutionData": true
+                            }
+                            """, executionArn))
+                    .when()
+                    .post("/");
+            response.then().statusCode(200);
+
+            var events = MAPPER.readTree(response.body().asString()).path("events");
+            var types = new ArrayList<String>();
+            events.forEach(event -> types.add(event.path("type").asText()));
+            assertEquals(List.of("ExecutionStarted", "TaskStateEntered", "TaskScheduled", "TaskStarted",
+                    "TaskSucceeded", "TaskStateExited", "ExecutionSucceeded"), types);
+
+            var expectedPreviousEventIds = List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L);
+            for (var i = 0; i < events.size(); i++) {
+                var event = events.get(i);
+                assertEquals(i + 1L, event.path("id").asLong());
+                assertEquals(expectedPreviousEventIds.get(i), event.path("previousEventId").asLong());
+            }
+
+            var scheduled = events.get(2).path("taskScheduledEventDetails");
+            assertFalse(scheduled.has("inputDetails"));
+            assertEquals("sqs", scheduled.path("resourceType").asText());
+            assertEquals("sendMessage", scheduled.path("resource").asText());
+            assertEquals(stateMachineArn.split(":")[3], scheduled.path("region").asText());
+            var parameters = MAPPER.readTree(scheduled.path("parameters").asText());
+            assertEquals(queueUrl, parameters.path("QueueUrl").asText());
+            assertEquals("hello", parameters.path("MessageBody").asText());
+
+            var started = events.get(3).path("taskStartedEventDetails");
+            assertEquals("sqs", started.path("resourceType").asText());
+            assertEquals("sendMessage", started.path("resource").asText());
+
+            var succeeded = events.get(4).path("taskSucceededEventDetails");
+            var succeededOutputDetails = succeeded.path("outputDetails");
+            assertTrue(succeededOutputDetails.isObject());
+            assertFalse(succeededOutputDetails.path("truncated").asBoolean(true));
+            assertTrue(succeeded.path("output").asText().contains("MessageId"));
+
+            var entered = events.get(1).path("stateEnteredEventDetails");
+            var enteredInputDetails = entered.path("inputDetails");
+            assertTrue(enteredInputDetails.isObject());
+            assertFalse(enteredInputDetails.path("truncated").asBoolean(true));
+        } finally {
+            deleteQueue(queueUrl);
+        }
+    }
+
+    private static String createQueue(String queueName) {
+        var response = given()
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueName":"%s"}
+                        """.formatted(queueName))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response.jsonPath().getString("QueueUrl");
+    }
+
+    private static void deleteQueue(String queueUrl) {
+        given()
+                .header("X-Amz-Target", "AmazonSQS.DeleteQueue")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s"}
+                        """.formatted(queueUrl))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
     }
 
     private String createStateMachine(String name, String definition) {


### PR DESCRIPTION
## Summary

Closes #2520

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

This changes improves what `GetExecutionHistory` returns.

- Event shapes were captured from real AWS (us-east-1) with AWS CLI 2.36.34.
- Captured cases: `sqs:sendMessage`, `aws-sdk:sqs:sendMessage`, a direct Lambda ARN, and a two-state machine.
- The captures pinned the event order, the `previousEventId` chain, the first `*StateEntered` pointing to 0, the `aws-sdk:sqs` resourceType format, `timeoutInSeconds`, and `inputDetails`/`outputDetails`.
- A new compat test (AWS SDK for Java) asserts the typed response against the emulator and passes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
