### PR TITLE
fix(rds): propagate ModifyDBInstance master-password rotations to the backend and proxy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1078,7 +1078,20 @@ public class RdsService implements Resettable, ResourceProvider {
                     instance.getEngineVersion(), effectiveRegion);
             instance.setOptionGroupName(optionGroupName);
         }
+        boolean passwordRotated = false;
         if (newPassword != null && !newPassword.isBlank()) {
+            String oldPassword = instance.getMasterPassword();
+            boolean backendRunning = !config.services().rds().mock()
+                    && instance.getDbClusterIdentifier() == null && instance.getContainerId() != null;
+            passwordRotated = backendRunning && !newPassword.equals(oldPassword);
+            // Propagate the rotation into the running backend DB before overwriting the stored
+            // password — this is the last moment the old credential (which the backend still
+            // holds) is known. Without it every later connection fails: the proxy dials the
+            // backend with the rotated password against a database still holding the original.
+            if (passwordRotated) {
+                containerManager.rotateMasterPassword(id, instance.getContainerId(),
+                        instance.getEngine(), instance.getMasterUsername(), oldPassword, newPassword);
+            }
             instance.setMasterPassword(newPassword);
         }
         if (iamEnabled != null) {
@@ -1096,6 +1109,26 @@ public class RdsService implements Resettable, ResourceProvider {
         }
         effective.applyTo(instance);
         putInstanceForScope(currentAccountId(), effectiveRegion, id, instance);
+
+        // The running auth proxy validates the master scramble against the password it was
+        // started with, so restart it on the rotated credential (the same stop/start the
+        // reboot path uses).
+        if (passwordRotated) {
+            String effectiveMasterUser = instance.getMasterUsername() != null
+                    ? instance.getMasterUsername() : "root";
+            final String accountId = accountIdFromArn(instance.getDbInstanceArn());
+            final String instanceRegion = regionFromArn(instance.getDbInstanceArn());
+            proxyManager.stopProxy(rdsResourceRelayKey(instance.getDbInstanceArn(), id));
+            proxyManager.startProxy(rdsResourceRelayKey(instance.getDbInstanceArn(), id),
+                    instance.getEngine(),
+                    instance.isIamDatabaseAuthenticationEnabled(),
+                    instance.getProxyPort(), instance.getContainerHost(), instance.getContainerPort(),
+                    instance.getEndpoint().address(),
+                    effectiveMasterUser, instance.getMasterPassword(), instance.getDbName(),
+                    (user, pw) -> validateDbPasswordForScope(
+                            accountId, instanceRegion, id, user, pw));
+        }
+
         LOG.infov("DB instance {0} modified", id);
         return instance;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1110,23 +1110,12 @@ public class RdsService implements Resettable, ResourceProvider {
         effective.applyTo(instance);
         putInstanceForScope(currentAccountId(), effectiveRegion, id, instance);
 
-        // The running auth proxy validates the master scramble against the password it was
-        // started with, so restart it on the rotated credential (the same stop/start the
-        // reboot path uses).
+        // The running auth proxy holds a password snapshot from start time, so swap it in place
+        // (a stop/start here races the listener rebind while relay connections are still open,
+        // and would drop live connections rotation shouldn't touch).
         if (passwordRotated) {
-            String effectiveMasterUser = instance.getMasterUsername() != null
-                    ? instance.getMasterUsername() : "root";
-            final String accountId = accountIdFromArn(instance.getDbInstanceArn());
-            final String instanceRegion = regionFromArn(instance.getDbInstanceArn());
-            proxyManager.stopProxy(rdsResourceRelayKey(instance.getDbInstanceArn(), id));
-            proxyManager.startProxy(rdsResourceRelayKey(instance.getDbInstanceArn(), id),
-                    instance.getEngine(),
-                    instance.isIamDatabaseAuthenticationEnabled(),
-                    instance.getProxyPort(), instance.getContainerHost(), instance.getContainerPort(),
-                    instance.getEndpoint().address(),
-                    effectiveMasterUser, instance.getMasterPassword(), instance.getDbName(),
-                    (user, pw) -> validateDbPasswordForScope(
-                            accountId, instanceRegion, id, user, pw));
+            proxyManager.updateMasterPassword(
+                    rdsResourceRelayKey(instance.getDbInstanceArn(), id), instance.getMasterPassword());
         }
 
         LOG.infov("DB instance {0} modified", id);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -408,6 +408,52 @@ public class RdsContainerManager {
     }
 
     /**
+     * Propagates a ModifyDBInstance master-password rotation into the running DB container, so
+     * the backend's stored credential matches what clients (and the auth proxy) use from now on.
+     * For MySQL/MariaDB this runs as the master user itself with the old password — changing your
+     * own password needs no extra privileges, and the container's root password is the
+     * creation-time one, not reliably known after earlier rotations. PostgreSQL's official image
+     * trusts local socket connections, so psql needs no password at all.
+     */
+    public void rotateMasterPassword(String instanceId, String containerId, DatabaseEngine engine,
+                                     String masterUsername, String oldPassword, String newPassword) {
+        execUntilSuccess(instanceId, containerId,
+                passwordRotationCommand(engine, masterUsername, oldPassword, newPassword),
+                "master-password rotation");
+    }
+
+    static String[] passwordRotationCommand(DatabaseEngine engine, String masterUsername,
+                                            String oldPassword, String newPassword) {
+        if (engine == DatabaseEngine.POSTGRES) {
+            String effectiveUser = (masterUsername != null && !masterUsername.isBlank())
+                    ? masterUsername : "postgres";
+            return new String[]{"psql", "-v", "ON_ERROR_STOP=1", "-U", effectiveUser, "-d", "postgres",
+                    "-c", postgresPasswordRotationSql(effectiveUser, newPassword)};
+        }
+        String effectiveUser = (masterUsername != null && !masterUsername.isBlank())
+                ? masterUsername : "root";
+        // MariaDB images ≥10.4 (Floci's floor is 10.11) ship only the `mariadb` client binary.
+        String client = engine == DatabaseEngine.MARIADB ? "mariadb" : "mysql";
+        return new String[]{client, "-u" + effectiveUser, "-p" + oldPassword,
+                "-e", mysqlPasswordRotationSql(engine, newPassword)};
+    }
+
+    static String mysqlPasswordRotationSql(DatabaseEngine engine, String newPassword) {
+        String escaped = newPassword.replace("\\", "\\\\").replace("'", "\\'");
+        // MariaDB only accepts the PASSWORD() form; MySQL 8 only the plain literal.
+        return engine == DatabaseEngine.MARIADB
+                ? "SET PASSWORD = PASSWORD('" + escaped + "');"
+                : "SET PASSWORD = '" + escaped + "';";
+    }
+
+    static String postgresPasswordRotationSql(String masterUsername, String newPassword) {
+        // Identifier quoted with doubled double-quotes, literal with doubled single-quotes.
+        String role = masterUsername.replace("\"", "\"\"");
+        String password = newPassword.replace("'", "''");
+        return "ALTER ROLE \"" + role + "\" WITH PASSWORD '" + password + "';";
+    }
+
+    /**
      * The stock mysql/mariadb images grant {@code MYSQL_USER} only {@code ALL} on
      * {@code MYSQL_DATABASE}, so a master user cannot {@code CREATE DATABASE}, {@code CREATE USER}
      * or {@code GRANT} — operations real RDS master users perform routinely. A root master needs

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
@@ -22,7 +22,7 @@ public class RdsAuthProxy {
     private final String instanceId;
     private final String backendHost;
     private final String masterUsername;
-    private final String masterPassword;
+    private volatile String masterPassword;
     private final String dbName;
     private final DatabaseEngine engine;
     private final RdsSigV4Validator sigV4;
@@ -58,6 +58,11 @@ public class RdsAuthProxy {
         Thread.ofVirtual().name("rds-proxy-accept-" + instanceId).start(this::acceptLoop);
         LOG.infov("RDS proxy started for instance {0} on port {1} → {2}:{3}",
                 instanceId, String.valueOf(proxyPort), backendHost, String.valueOf(backendPort));
+    }
+
+    /** Swap the master-password snapshot after a rotation; new connections authenticate against it. */
+    public void updateMasterPassword(String newPassword) {
+        this.masterPassword = newPassword;
     }
 
     public void stop() {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsProxyManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsProxyManager.java
@@ -73,6 +73,14 @@ public class RdsProxyManager {
         }
     }
 
+    public synchronized void updateMasterPassword(String instanceId, String newPassword) {
+        RdsAuthProxy proxy = proxies.get(instanceId);
+        if (proxy != null) {
+            proxy.updateMasterPassword(newPassword);
+            LOG.infov("Updated RDS proxy master password for instance {0}", instanceId);
+        }
+    }
+
     public synchronized void stopProxy(String instanceId) {
         RdsAuthProxy proxy = proxies.get(instanceId);
         if (proxy != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -740,7 +740,7 @@ class RdsServiceTest {
     }
 
     @Test
-    void modifyDbInstancePasswordRotationPropagatesToBackendAndRestartsProxy() {
+    void modifyDbInstancePasswordRotationPropagatesToBackendAndProxy() {
         DbInstance instance = rdsService.createDbInstance("mydb", "mysql", "8.0",
                 "admin", "original-password", "dbname", "db.t3.micro",
                 20, false, null, null, null, null, false);
@@ -754,11 +754,10 @@ class RdsServiceTest {
         // The backend learns the new credential while the old one is still known...
         verify(containerManager).rotateMasterPassword("mydb", "container-1",
                 DatabaseEngine.MYSQL, "admin", "original-password", "rotated-password");
-        // ...and the proxy restarts so its master-scramble check uses the rotated password.
-        verify(proxyManager).stopProxy(anyString());
-        verify(proxyManager).startProxy(anyString(), any(), anyBoolean(), anyInt(),
-                anyString(), anyInt(), anyString(), anyString(), eq("rotated-password"),
-                anyString(), any());
+        // ...and the running proxy's password snapshot is swapped in place, without a restart
+        // (a stop/start would race the listener rebind and drop live connections).
+        verify(proxyManager).updateMasterPassword(anyString(), eq("rotated-password"));
+        verify(proxyManager, never()).stopProxy(anyString());
     }
 
     @Test
@@ -772,7 +771,7 @@ class RdsServiceTest {
 
         verify(containerManager, never()).rotateMasterPassword(
                 anyString(), anyString(), any(), anyString(), anyString(), anyString());
-        verify(proxyManager, never()).stopProxy(anyString());
+        verify(proxyManager, never()).updateMasterPassword(anyString(), anyString());
     }
 
     @Test
@@ -787,6 +786,7 @@ class RdsServiceTest {
         assertEquals("rotated-password", modified.getMasterPassword());
         verify(containerManager, never()).rotateMasterPassword(
                 anyString(), anyString(), any(), anyString(), anyString(), anyString());
+        verify(proxyManager, never()).updateMasterPassword(anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -58,6 +58,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -736,6 +737,56 @@ class RdsServiceTest {
 
         assertEquals("original-password", modified.getMasterPassword());
         assertFalse(modified.isIamDatabaseAuthenticationEnabled());
+    }
+
+    @Test
+    void modifyDbInstancePasswordRotationPropagatesToBackendAndRestartsProxy() {
+        DbInstance instance = rdsService.createDbInstance("mydb", "mysql", "8.0",
+                "admin", "original-password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+        instance.setContainerId("container-1");
+        instance.setContainerHost("10.0.0.5");
+        instance.setContainerPort(3306);
+
+        DbInstance modified = rdsService.modifyDbInstance("mydb", "rotated-password", null, null);
+
+        assertEquals("rotated-password", modified.getMasterPassword());
+        // The backend learns the new credential while the old one is still known...
+        verify(containerManager).rotateMasterPassword("mydb", "container-1",
+                DatabaseEngine.MYSQL, "admin", "original-password", "rotated-password");
+        // ...and the proxy restarts so its master-scramble check uses the rotated password.
+        verify(proxyManager).stopProxy(anyString());
+        verify(proxyManager).startProxy(anyString(), any(), anyBoolean(), anyInt(),
+                anyString(), anyInt(), anyString(), anyString(), eq("rotated-password"),
+                anyString(), any());
+    }
+
+    @Test
+    void modifyDbInstanceSamePasswordDoesNotTouchBackendOrProxy() {
+        DbInstance instance = rdsService.createDbInstance("mydb", "mysql", "8.0",
+                "admin", "original-password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+        instance.setContainerId("container-1");
+
+        rdsService.modifyDbInstance("mydb", "original-password", null, null);
+
+        verify(containerManager, never()).rotateMasterPassword(
+                anyString(), anyString(), any(), anyString(), anyString(), anyString());
+        verify(proxyManager, never()).stopProxy(anyString());
+    }
+
+    @Test
+    void modifyDbInstancePasswordRotationSkipsBackendInMockMode() {
+        when(config.services().rds().mock()).thenReturn(true);
+        rdsService.createDbInstance("mydb", "mysql", "8.0",
+                "admin", "original-password", "dbname", "db.t3.micro",
+                20, false, null, null, null, null, false);
+
+        DbInstance modified = rdsService.modifyDbInstance("mydb", "rotated-password", null, null);
+
+        assertEquals("rotated-password", modified.getMasterPassword());
+        verify(containerManager, never()).rotateMasterPassword(
+                anyString(), anyString(), any(), anyString(), anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerTest.java
@@ -74,6 +74,36 @@ class RdsContainerManagerTest {
     }
 
     @Test
+    void passwordRotationCommandRunsAsTheMasterUserWithTheOldPassword() {
+        String[] mysql = RdsContainerManager.passwordRotationCommand(
+                DatabaseEngine.MYSQL, "admin", "old-pass", "new-pass");
+        assertEquals("mysql", mysql[0]);
+        assertEquals("-uadmin", mysql[1]);
+        assertEquals("-pold-pass", mysql[2]);
+        assertEquals("SET PASSWORD = 'new-pass';", mysql[4]);
+
+        assertEquals("mariadb", RdsContainerManager.passwordRotationCommand(
+                DatabaseEngine.MARIADB, "admin", "old-pass", "new-pass")[0]);
+
+        // PostgreSQL: local socket connections are trusted, so no old password appears at all.
+        String[] postgres = RdsContainerManager.passwordRotationCommand(
+                DatabaseEngine.POSTGRES, "admin", "old-pass", "new-pass");
+        assertEquals("psql", postgres[0]);
+        assertEquals("ALTER ROLE \"admin\" WITH PASSWORD 'new-pass';", postgres[postgres.length - 1]);
+    }
+
+    @Test
+    void passwordRotationSqlUsesEngineSyntaxAndEscapes() {
+        assertEquals("SET PASSWORD = 'a\\'b';",
+                RdsContainerManager.mysqlPasswordRotationSql(DatabaseEngine.MYSQL, "a'b"));
+        // MariaDB only accepts the PASSWORD() form.
+        assertEquals("SET PASSWORD = PASSWORD('a\\'b');",
+                RdsContainerManager.mysqlPasswordRotationSql(DatabaseEngine.MARIADB, "a'b"));
+        assertEquals("ALTER ROLE \"we\"\"ird\" WITH PASSWORD 'a''b';",
+                RdsContainerManager.postgresPasswordRotationSql("we\"ird", "a'b"));
+    }
+
+    @Test
     void needsMasterGrantSkipsRootAndPostgres() {
         assertTrue(RdsContainerManager.needsMasterGrant(DatabaseEngine.MYSQL, "admin"));
         assertTrue(RdsContainerManager.needsMasterGrant(DatabaseEngine.MARIADB, "admin"));

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/RdsProxyManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/RdsProxyManagerTest.java
@@ -10,6 +10,7 @@ import java.net.ServerSocket;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -72,6 +73,31 @@ class RdsProxyManagerTest {
         } finally {
             manager.stopAll();
         }
+    }
+
+    @Test
+    void updateMasterPasswordSwapsTheRunningProxySnapshotWithoutARestart() throws Exception {
+        RdsProxyManager manager = new RdsProxyManager(
+                mock(RdsSigV4Validator.class), mock(RdsProxyTlsCertificates.class));
+        int proxyPort = availablePort();
+        try {
+            start(manager, "proxy", proxyPort);
+
+            manager.updateMasterPassword("proxy", "rotated");
+
+            assertEquals("rotated", masterPassword(registry(manager).get("proxy")));
+            assertPortUnavailable(proxyPort);
+        } finally {
+            manager.stopAll();
+        }
+    }
+
+    @Test
+    void updateMasterPasswordForUnknownInstanceIsANoOp() {
+        RdsProxyManager manager = new RdsProxyManager(
+                mock(RdsSigV4Validator.class), mock(RdsProxyTlsCertificates.class));
+
+        assertDoesNotThrow(() -> manager.updateMasterPassword("missing", "rotated"));
     }
 
     @Test
@@ -157,6 +183,12 @@ class RdsProxyManagerTest {
         return new RdsAuthProxy(key, "localhost", 1, DatabaseEngine.POSTGRES, false,
                 "admin", "secret", "app", mock(RdsSigV4Validator.class),
                 mock(RdsProxyTlsCertificates.class), (user, password) -> true);
+    }
+
+    private static String masterPassword(RdsAuthProxy proxy) throws Exception {
+        Field field = RdsAuthProxy.class.getDeclaredField("masterPassword");
+        field.setAccessible(true);
+        return (String) field.get(proxy);
     }
 
     private static void setServerSocket(RdsAuthProxy proxy, ServerSocket socket) throws Exception {


### PR DESCRIPTION
## Summary

After `ModifyDBInstance` rotates the master password, no client can connect to the instance at all. Rotation only updated Floci's stored state, leaving two layers stale:

1. The backend DB container keeps the original credential (`MYSQL_ROOT_PASSWORD`/`MYSQL_PASSWORD` only take effect on first initialization), so a connection carrying the rotated password fails there.
2. The running auth proxy validates the master scramble against the password it was **started** with, so the rotated password fails proxy-side too until something restarts the proxy.

Either way the user is locked out: old password fails the proxy's live validator, new password fails one of the two stale layers. First disclosed on #2679.

The fix acts at rotation time, the last moment the old credential is still known:

- **Backend:** exec into the DB container and change the password there. MySQL/MariaDB run `SET PASSWORD` **as the master user itself with the old password**: changing your own password needs no privileges, and root's password is the creation-time one, not reliably known after earlier rotations. PostgreSQL runs `ALTER ROLE` over the trusted local socket. Engine-specific syntax (`SET PASSWORD = '...'` vs MariaDB's `PASSWORD('...')` form), passwords and role names escaped.
- **Proxy:** swap the password snapshot on the running proxy in place. A stop/start here races the listener rebind (closing the server socket defers the port release while relay connections are still draining, so the immediate rebind hits EADDRINUSE, which is what the first CI run caught in `RdsJdbcCompatTest`), and it would also drop live connections that rotation shouldn't touch.

Mock mode, cluster members, and instances without a running container are unaffected (cluster password rotation has the same gap and is intentionally not covered here, can follow up separately).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: on real RDS, `ModifyDBInstance --master-user-password` makes the new password usable (asynchronously, usually within seconds) and invalidates the old one. On Floci the rotated password never became usable:

```
$ aws rds modify-db-instance --db-instance-identifier mydb --master-user-password new... --apply-immediately
$ mysql -h <endpoint> -uadmin -p<new> ...
ERROR 1045 (HY000): Access denied for user 'admin'@'localhost' (using password: YES)
```

Verified against a JVM build with real backend containers, all through the auth proxy:

| Engine | rotate → connect with new password | old password | connection open across the rotation | rotate → reboot → new password |
|---|---|---|---|---|
| mysql:8.0.36 | works (failed before) | rejected (1045) | stays connected | works |
| mariadb:11 | works (failed before) | rejected | n/a | n/a |
| postgres:16 | works (failed before) | rejected | stays connected | n/a |

## Checklist

- [x] `./mvnw test` passes locally (`RdsServiceTest` 249, `RdsContainerManagerTest` 30, `RdsProxyManagerTest` 9)
- [x] New or updated integration test added: `modifyDbInstancePasswordRotationPropagatesToBackendAndProxy` (backend exec with old+new credentials, in-place proxy snapshot update, no restart), same-password and mock-mode no-op tests, `updateMasterPassword` manager tests, and per-engine command/SQL builder tests including escaping
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
