### PR TITLE
feat(lambda): bound physical execution environments

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -195,6 +195,8 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 | `FLOCI_SERVICES_LAMBDA_CODE_PATH` | `./data/lambda-code` | Container path where Lambda deployment ZIPs are stored |
 | `FLOCI_SERVICES_LAMBDA_POLL_INTERVAL_MS` | `1000` | How often (ms) the SQS and Kinesis event source pollers check for new messages |
 | `FLOCI_SERVICES_LAMBDA_CONTAINER_IDLE_TIMEOUT_SECONDS` | `300` | Seconds of inactivity before an idle Lambda container is removed |
+| `FLOCI_SERVICES_LAMBDA_MAX_PHYSICAL_ENVIRONMENTS` | _(unset)_ | Optional cap on concurrently running Lambda execution environments; unset preserves the historical behavior |
+| `FLOCI_SERVICES_LAMBDA_PHYSICAL_ENVIRONMENT_WAIT_TIMEOUT_SECONDS` | `15` | Maximum fair-queue wait (seconds) for a physical environment slot when the cap is enabled |
 | `FLOCI_SERVICES_LAMBDA_REGION_CONCURRENCY_LIMIT` | `1000` | Maximum concurrent Lambda invocations across all functions in a region |
 | `FLOCI_SERVICES_LAMBDA_UNRESERVED_CONCURRENCY_MIN` | `100` | Minimum unreserved concurrency pool |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED` | `false` | Watch Lambda code directories for changes and reload without redeployment |

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -199,6 +199,8 @@ These AWS Lambda operations have no handler in Floci. Calls will return `404` or
 | `FLOCI_SERVICES_LAMBDA_CODE_PATH` | `./data/lambda-code` | Directory where Lambda ZIP files are stored |
 | `FLOCI_SERVICES_LAMBDA_POLL_INTERVAL_MS` | `1000` | Event-source mapping poll interval (milliseconds) |
 | `FLOCI_SERVICES_LAMBDA_CONTAINER_IDLE_TIMEOUT_SECONDS` | `300` | Idle container shutdown timeout (seconds) |
+| `FLOCI_SERVICES_LAMBDA_MAX_PHYSICAL_ENVIRONMENTS` | *(unset)* | Optional cap on concurrently running Docker execution environments. When unset, the historical unbounded behavior is preserved |
+| `FLOCI_SERVICES_LAMBDA_PHYSICAL_ENVIRONMENT_WAIT_TIMEOUT_SECONDS` | `15` | Maximum fair-queue wait for a physical environment slot when the cap is enabled; this wait is separate from the function timeout |
 | `FLOCI_SERVICES_LAMBDA_REGION_CONCURRENCY_LIMIT` | `1000` | Maximum concurrent executions per region |
 | `FLOCI_SERVICES_LAMBDA_UNRESERVED_CONCURRENCY_MIN` | `100` | Minimum unreserved capacity `PutFunctionConcurrency` must leave |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED` | `false` | Enable bind-mount hot-reload via `S3Bucket=hot-reload` |

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1740,6 +1740,27 @@ public interface EmulatorConfig {
         @WithDefault("300")
         int containerIdleTimeoutSeconds();
 
+        /**
+         * Optional hard ceiling for physical Lambda execution environments. When absent,
+         * Floci keeps its historical unbounded Docker-environment behavior; when present,
+         * invocation admission is queued fairly behind this number of concurrently running
+         * environments. The logical Lambda concurrency limit remains independent.
+         *
+         * <p>Env var: FLOCI_SERVICES_LAMBDA_MAX_PHYSICAL_ENVIRONMENTS
+         */
+        OptionalInt maxPhysicalEnvironments();
+
+        /**
+         * Maximum time an invocation waits for a physical execution-environment slot when
+         * {@link #maxPhysicalEnvironments()} is configured. This is intentionally separate
+         * from the function timeout: AWS starts the function timeout after the runtime receives
+         * the invocation. The constrained Samva profile uses the 15-second default.
+         *
+         * <p>Env var: FLOCI_SERVICES_LAMBDA_PHYSICAL_ENVIRONMENT_WAIT_TIMEOUT_SECONDS
+         */
+        @WithDefault("15")
+        int physicalEnvironmentWaitTimeoutSeconds();
+
         /** Docker network to attach Lambda containers to. Empty = default bridge. */
         Optional<String> dockerNetwork();
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaEnvironmentLimiter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaEnvironmentLimiter.java
@@ -1,0 +1,370 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayDeque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Admits physical Lambda execution environments independently from Lambda's logical
+ * concurrency limiter.
+ *
+ * <p>The limiter is disabled when {@code max-physical-environments} is absent. In that
+ * mode every acquisition still has a close-once permit and contributes to status, but
+ * no caller waits and the existing AWS-like emulator behavior is unchanged.
+ *
+ * <p>When enabled, waiters are admitted in FIFO order. A waiter has one bounded,
+ * interruptible wait; timed-out or interrupted waiters are removed before returning so
+ * a later release cannot accidentally grant a permit to a cancelled invocation.
+ */
+@ApplicationScoped
+public class LambdaEnvironmentLimiter implements AutoCloseable {
+
+    /** A non-positive configured value means that the physical cap is disabled. */
+    private static final int UNBOUNDED = 0;
+    private static final int DEFAULT_WAIT_SECONDS = 15;
+
+    private final int maxPhysicalEnvironments;
+    private final long waitNanos;
+    private final ReentrantLock lock = new ReentrantLock(true);
+    private final Condition changed = lock.newCondition();
+    private final ArrayDeque<Waiter> waiters = new ArrayDeque<>();
+    private final Map<String, Integer> inFlightByKey = new HashMap<>();
+    private final Map<String, Integer> queuedByKey = new HashMap<>();
+    private long granted;
+    private long timedOut;
+    private long interrupted;
+    private int inFlight;
+    private boolean closed;
+
+    private static final class Waiter {
+        private final String key;
+
+        private Waiter(String key) {
+            this.key = key;
+        }
+    }
+
+    @Inject
+    public LambdaEnvironmentLimiter(EmulatorConfig config) {
+        this(configuredLimit(config), configuredWaitSeconds(config));
+    }
+
+    /** Test-only constructor. A non-positive limit disables the physical cap. */
+    LambdaEnvironmentLimiter(int maxPhysicalEnvironments, int waitSeconds) {
+        this.maxPhysicalEnvironments = Math.max(UNBOUNDED, maxPhysicalEnvironments);
+        this.waitNanos = TimeUnit.SECONDS.toNanos(Math.max(0, waitSeconds));
+    }
+
+    /** Test-only constructor for the unchanged, unbounded default behavior. */
+    LambdaEnvironmentLimiter() {
+        this(UNBOUNDED, DEFAULT_WAIT_SECONDS);
+    }
+
+    /**
+     * Acquires a physical execution-environment slot for {@code environmentKey}.
+     *
+     * <p>The public method preserves the existing no-checked-exception shape used by
+     * Lambda services. If an invocation thread is interrupted while waiting, the
+     * interrupt flag is restored and an {@link AdmissionInterruptedException} is
+     * thrown so the caller can return a bounded invocation failure.
+     */
+    public Permit acquire(String environmentKey) {
+        // Keep the opt-in nature of this limiter observable: without a physical cap there is
+        // no wait to interrupt, so retain the historical non-blocking acquisition semantics
+        // even if a caller arrives with a stale interrupt flag.
+        if (!bounded()) {
+            String key = normalizeKey(environmentKey);
+            lock.lock();
+            try {
+                ensureOpen(key);
+                return grant(key);
+            } finally {
+                lock.unlock();
+            }
+        }
+        try {
+            return acquireInterruptibly(environmentKey);
+        } catch (java.lang.InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AdmissionInterruptedException(normalizeKey(environmentKey), e);
+        }
+    }
+
+    /**
+     * Interruptible form used by tests and by callers that already expose checked
+     * interruption.
+     */
+    public Permit acquireInterruptibly(String environmentKey) throws java.lang.InterruptedException {
+        String key = normalizeKey(environmentKey);
+        lock.lockInterruptibly();
+        try {
+            ensureOpen(key);
+            if (!bounded() && waiters.isEmpty()) {
+                return grant(key);
+            }
+
+            Waiter waiter = new Waiter(key);
+            waiters.addLast(waiter);
+            increment(queuedByKey, key);
+            long startedAt = System.nanoTime();
+            while (true) {
+                if (waiter == waiters.peekFirst() && (!bounded() || inFlight < maxPhysicalEnvironments)) {
+                    waiters.removeFirst();
+                    decrement(queuedByKey, key);
+                    return grant(key);
+                }
+
+                long remaining = waitNanos - (System.nanoTime() - startedAt);
+                if (remaining <= 0) {
+                    removeWaiter(waiter);
+                    timedOut++;
+                    changed.signalAll();
+                    throw new AdmissionTimeoutException(key, maxPhysicalEnvironments, waitNanos);
+                }
+                try {
+                    changed.awaitNanos(remaining);
+                } catch (java.lang.InterruptedException e) {
+                    removeWaiter(waiter);
+                    interrupted++;
+                    changed.signalAll();
+                    throw e;
+                }
+                try {
+                    ensureOpen(key);
+                } catch (RuntimeException e) {
+                    removeWaiter(waiter);
+                    changed.signalAll();
+                    throw e;
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private Permit grant(String key) {
+        inFlight++;
+        increment(inFlightByKey, key);
+        granted++;
+        return new PermitImpl(this, key);
+    }
+
+    private void release(String key) {
+        lock.lock();
+        try {
+            // A close-once Permit should make this branch impossible. Keep it
+            // defensive so a malformed caller cannot make status negative.
+            if (inFlight <= 0) {
+                return;
+            }
+            inFlight--;
+            decrement(inFlightByKey, key);
+            changed.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void ensureOpen(String key) {
+        if (closed) {
+            throw new AdmissionClosedException(key);
+        }
+    }
+
+    private void removeWaiter(Waiter waiter) {
+        if (waiters.remove(waiter)) {
+            decrement(queuedByKey, waiter.key);
+        }
+    }
+
+    /**
+     * Returns a point-in-time readback of physical admission. The returned object is
+     * immutable and safe to log or expose to a status endpoint.
+     */
+    public Status status() {
+        lock.lock();
+        try {
+            return new Status(maxPhysicalEnvironments, inFlight, waiters.size(),
+                    availableUnsafe(), granted, timedOut, interrupted, closed);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Returns status scoped to one account/function/version identity. */
+    public KeyStatus status(String environmentKey) {
+        String key = normalizeKey(environmentKey);
+        lock.lock();
+        try {
+            return new KeyStatus(key, inFlightByKey.getOrDefault(key, 0), queuedByKey.getOrDefault(key, 0));
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public int configuredLimit() {
+        return maxPhysicalEnvironments;
+    }
+
+    public int inFlightCount() {
+        lock.lock();
+        try {
+            return inFlight;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public int queuedCount() {
+        lock.lock();
+        try {
+            return waiters.size();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public boolean bounded() {
+        return maxPhysicalEnvironments > UNBOUNDED;
+    }
+
+    @Override
+    public void close() {
+        lock.lock();
+        try {
+            if (!closed) {
+                closed = true;
+                changed.signalAll();
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private int availableUnsafe() {
+        return bounded() ? Math.max(0, maxPhysicalEnvironments - inFlight) : Integer.MAX_VALUE;
+    }
+
+    private static String normalizeKey(String key) {
+        return key == null || key.isBlank() ? "unknown" : key;
+    }
+
+    private static void increment(Map<String, Integer> counts, String key) {
+        counts.merge(key, 1, Integer::sum);
+    }
+
+    private static void decrement(Map<String, Integer> counts, String key) {
+        counts.computeIfPresent(key, (ignored, count) -> count <= 1 ? null : count - 1);
+    }
+
+    private static int configuredLimit(EmulatorConfig config) {
+        if (config == null || config.services() == null || config.services().lambda() == null) {
+            return UNBOUNDED;
+        }
+        OptionalInt configured = config.services().lambda().maxPhysicalEnvironments();
+        return configured == null || configured.isEmpty() ? UNBOUNDED : configured.getAsInt();
+    }
+
+    private static int configuredWaitSeconds(EmulatorConfig config) {
+        if (config == null || config.services() == null || config.services().lambda() == null) {
+            return DEFAULT_WAIT_SECONDS;
+        }
+        return Math.max(0, config.services().lambda().physicalEnvironmentWaitTimeoutSeconds());
+    }
+
+    @FunctionalInterface
+    public interface Permit extends AutoCloseable {
+        @Override
+        void close();
+    }
+
+    private static final class PermitImpl implements Permit {
+        private final LambdaEnvironmentLimiter owner;
+        private final String key;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private PermitImpl(LambdaEnvironmentLimiter owner, String key) {
+            this.owner = owner;
+            this.key = key;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                owner.release(key);
+            }
+        }
+    }
+
+    public record Status(int configuredLimit,
+                         int inFlight,
+                         int queued,
+                         int available,
+                         long granted,
+                         long timedOut,
+                         long interrupted,
+                         boolean closed) {
+        public boolean bounded() {
+            return configuredLimit > UNBOUNDED;
+        }
+    }
+
+    public record KeyStatus(String environmentKey, int inFlight, int queued) {
+    }
+
+    public static class AdmissionTimeoutException extends RuntimeException {
+        private final String environmentKey;
+        private final int configuredLimit;
+
+        public AdmissionTimeoutException(String environmentKey, int configuredLimit, long waitNanos) {
+            super("Timed out waiting for a Lambda execution environment for " + environmentKey
+                    + " after " + TimeUnit.NANOSECONDS.toMillis(waitNanos) + "ms"
+                    + " (configured limit=" + configuredLimit + ")");
+            this.environmentKey = environmentKey;
+            this.configuredLimit = configuredLimit;
+        }
+
+        public String environmentKey() {
+            return environmentKey;
+        }
+
+        public int configuredLimit() {
+            return configuredLimit;
+        }
+    }
+
+    public static class AdmissionInterruptedException extends RuntimeException {
+        private final String environmentKey;
+
+        public AdmissionInterruptedException(String environmentKey, Throwable cause) {
+            super("Interrupted waiting for a Lambda execution environment for " + environmentKey, cause);
+            this.environmentKey = environmentKey;
+        }
+
+        public String environmentKey() {
+            return environmentKey;
+        }
+    }
+
+    public static class AdmissionClosedException extends RuntimeException {
+        private final String environmentKey;
+
+        public AdmissionClosedException(String environmentKey) {
+            super("Lambda execution-environment admission is closed for " + environmentKey);
+            this.environmentKey = environmentKey;
+        }
+
+        public String environmentKey() {
+            return environmentKey;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorService.java
@@ -85,6 +85,25 @@ public class LambdaExecutorService {
         ContainerHandle handle;
         try {
             handle = warmPool.acquire(fn);
+        } catch (LambdaEnvironmentLimiter.AdmissionTimeoutException e) {
+            LOG.warnv("Physical environment admission timed out for function {0}: {1}",
+                    fn.getFunctionName(), e.getMessage());
+            return new InvokeResult(200, "Unhandled",
+                    buildErrorPayload(e.getMessage(), "Lambda.EnvironmentTimeout"),
+                    null, requestId);
+        } catch (LambdaEnvironmentLimiter.AdmissionInterruptedException e) {
+            // LambdaEnvironmentLimiter restores the interrupted flag before exposing this
+            // unchecked exception, so preserve it while returning a bounded invocation error.
+            LOG.warnv("Physical environment admission interrupted for function {0}", fn.getFunctionName());
+            return new InvokeResult(200, "Unhandled",
+                    buildErrorPayload("Invocation interrupted while waiting for a Lambda execution environment",
+                            "Interrupted"),
+                    null, requestId);
+        } catch (LambdaEnvironmentLimiter.AdmissionClosedException e) {
+            LOG.warnv("Physical environment admission is closed for function {0}", fn.getFunctionName());
+            return new InvokeResult(200, "Unhandled",
+                    buildErrorPayload(e.getMessage(), "Lambda.EnvironmentUnavailable"),
+                    null, requestId);
         } catch (Exception e) {
             LOG.warnv("Failed to acquire container for function {0}: {1}", fn.getFunctionName(), e.getMessage());
             return new InvokeResult(200, "Unhandled",

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -698,7 +698,9 @@ public class LambdaService implements ResourceProvider {
         LambdaFunction fn = getFunction(region, functionName); // throws 404 if not found
         functionName = fn.getFunctionName();
         String arn = fn.getFunctionArn();
-        warmPool.drainFunction(functionName);
+        // Include the owner account so deleting one tenant's function cannot drain
+        // an identically named warm environment belonging to another tenant.
+        warmPool.drainFunction(fn);
         // Take the same per-function lock used by Put/DeleteFunctionConcurrency
         // so a concurrent concurrency mutation cannot interleave with the
         // limiter reset and store delete and leave the two views out of sync.

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/WarmPool.java
@@ -17,12 +17,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Manages a pool of warm Lambda containers per function.
@@ -32,6 +34,10 @@ import java.util.concurrent.TimeUnit;
  *    after {@code container-idle-timeout-seconds} of inactivity.
  *  - {@code true}: each invocation gets a fresh container that is stopped immediately
  *    after the invocation completes.
+ *
+ * <p>When a physical-environment cap is configured, each acquired handle also owns one
+ * close-once admission permit. The permit spans the invocation (including warm reuse and
+ * container teardown) and is released on every terminal path.
  */
 @ApplicationScoped
 public class WarmPool implements ContainerTeardown {
@@ -42,31 +48,48 @@ public class WarmPool implements ContainerTeardown {
 
     private final LambdaRuntimeLauncher lambdaRuntimeLauncher;
     private final EmulatorConfig config;
+    private final LambdaEnvironmentLimiter environmentLimiter;
     private final int maxPoolSizePerFunction;
-    private final ConcurrentHashMap<String, PoolState> poolStates = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<FunctionPoolKey, PoolState> poolStates = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<ContainerHandle, Lease> activeLeases = new ConcurrentHashMap<>();
+    private final AtomicInteger idleContainerCount = new AtomicInteger();
     private final ScheduledExecutorService evictionScheduler = Executors.newSingleThreadScheduledExecutor(
             r -> { Thread t = new Thread(r, "warm-pool-evictor"); t.setDaemon(true); return t; });
+
+    private record FunctionPoolKey(String accountId, String region, String functionName) {
+    }
 
     private static final class PoolState {
         private final Map<String, ArrayDeque<ContainerHandle>> idleByEnvironment = new HashMap<>();
         private final Map<String, Long> epochByEnvironment = new HashMap<>();
     }
 
-    private record Lease(PoolState poolState, long epoch, String environmentKey) {
+    private record Lease(PoolState poolState,
+                         long epoch,
+                         String environmentKey,
+                         LambdaEnvironmentLimiter.Permit environmentPermit) {
     }
 
     @Inject
-    public WarmPool(LambdaRuntimeLauncher lambdaRuntimeLauncher, EmulatorConfig config) {
+    public WarmPool(LambdaRuntimeLauncher lambdaRuntimeLauncher,
+                    EmulatorConfig config,
+                    LambdaEnvironmentLimiter environmentLimiter) {
         this.lambdaRuntimeLauncher = lambdaRuntimeLauncher;
         this.config = config;
-        this.maxPoolSizePerFunction = DEFAULT_MAX_POOL_SIZE;
+        this.environmentLimiter = environmentLimiter;
+        this.maxPoolSizePerFunction = maxPoolSize(config);
+    }
+
+    /** Constructor retained for focused tests and embedders that do not use CDI. */
+    public WarmPool(LambdaRuntimeLauncher lambdaRuntimeLauncher, EmulatorConfig config) {
+        this(lambdaRuntimeLauncher, config, new LambdaEnvironmentLimiter(config));
     }
 
     /** Package-private constructor for testing (empty pool, no containers to drain). */
     WarmPool() {
         this.lambdaRuntimeLauncher = null;
         this.config = null;
+        this.environmentLimiter = new LambdaEnvironmentLimiter();
         this.maxPoolSizePerFunction = DEFAULT_MAX_POOL_SIZE;
     }
 
@@ -98,12 +121,14 @@ public class WarmPool implements ContainerTeardown {
      */
     @Override
     public void stopManagedContainers() {
+        environmentLimiter.close();
         drainAll();
     }
 
     @PreDestroy
     void shutdown() {
         evictionScheduler.shutdownNow();
+        environmentLimiter.close();
         drainAll();
     }
 
@@ -113,14 +138,27 @@ public class WarmPool implements ContainerTeardown {
      * Otherwise returns a warm container from the pool, or cold-starts a new one.
      */
     public ContainerHandle acquire(LambdaFunction fn) {
+        String environmentKey = executionEnvironmentKey(fn);
+        LambdaEnvironmentLimiter.Permit environmentPermit = environmentLimiter.acquire(environmentKey);
+        try {
+            return acquireLeased(fn, environmentKey, environmentPermit);
+        } catch (RuntimeException | Error e) {
+            environmentPermit.close();
+            throw e;
+        }
+    }
+
+    private ContainerHandle acquireLeased(LambdaFunction fn,
+                                          String environmentKey,
+                                          LambdaEnvironmentLimiter.Permit environmentPermit) {
         boolean ephemeral = config != null && config.services().lambda().ephemeral();
         ContainerHandle handle = null;
         PoolState poolState = null;
         long leaseEpoch = 0;
-        String environmentKey = executionEnvironmentKey(fn);
 
         if (!ephemeral) {
-            poolState = poolStates.computeIfAbsent(fn.getFunctionName(), ignored -> new PoolState());
+            FunctionPoolKey poolKey = functionPoolKey(fn);
+            poolState = poolStates.computeIfAbsent(poolKey, ignored -> new PoolState());
             synchronized (poolState) {
                 leaseEpoch = poolState.epochByEnvironment.computeIfAbsent(environmentKey, ignored -> 0L);
             }
@@ -131,6 +169,12 @@ public class WarmPool implements ContainerTeardown {
                 synchronized (poolState) {
                     ArrayDeque<ContainerHandle> idle = poolState.idleByEnvironment.get(environmentKey);
                     candidate = idle == null ? null : idle.pollFirst();
+                    if (candidate != null) {
+                        idleContainerCount.decrementAndGet();
+                        if (idle.isEmpty()) {
+                            poolState.idleByEnvironment.remove(environmentKey);
+                        }
+                    }
                 }
                 if (candidate == null) {
                     break;
@@ -138,13 +182,27 @@ public class WarmPool implements ContainerTeardown {
                 // A container whose extension reported a fatal error is still *running*, so the
                 // liveness probe alone would hand it back out. Skip it for the same reason a dead
                 // one is skipped: it can no longer serve invocations correctly.
-                if (candidate.isFaulted()) {
+                boolean faulted;
+                try {
+                    faulted = candidate.isFaulted();
+                } catch (RuntimeException | Error e) {
+                    stopQuietly(candidate);
+                    throw e;
+                }
+                if (faulted) {
                     LOG.infov("Discarding pooled container {0} for function {1}: an extension reported a fatal error",
                             candidate.getContainerId(), fn.getFunctionName());
                     stopQuietly(candidate);
                     continue;
                 }
-                if (lambdaRuntimeLauncher.isAlive(candidate)) {
+                boolean alive;
+                try {
+                    alive = lambdaRuntimeLauncher.isAlive(candidate);
+                } catch (RuntimeException | Error e) {
+                    stopQuietly(candidate);
+                    throw e;
+                }
+                if (alive) {
                     handle = candidate;
                     break;
                 }
@@ -161,9 +219,7 @@ public class WarmPool implements ContainerTeardown {
         } else {
             LOG.debugv("Reusing warm container for function: {0}", fn.getFunctionName());
         }
-        if (!ephemeral) {
-            activeLeases.put(handle, new Lease(poolState, leaseEpoch, environmentKey));
-        }
+        activeLeases.put(handle, new Lease(poolState, leaseEpoch, environmentKey, environmentPermit));
         handle.setState(ContainerState.BUSY);
         return handle;
     }
@@ -176,53 +232,67 @@ public class WarmPool implements ContainerTeardown {
     public void release(ContainerHandle handle) {
         Lease lease = activeLeases.remove(handle);
         boolean ephemeral = config != null && config.services().lambda().ephemeral();
-        // An extension reporting an init/exit error is fatal to the execution environment in real
-        // AWS. RuntimeApiServer already refuses new work at that point; the container is torn down
-        // here rather than at fault time so the invocation that was in flight when the extension
-        // failed still completes normally through the runtime.
-        if (handle.isFaulted()) {
-            LOG.infov("Retiring container {0} for function {1}: an extension reported a fatal error",
-                    handle.getContainerId(), handle.getFunctionName());
-            stopQuietly(handle);
-            return;
-        }
-        if (ephemeral || handle.isHotReload()) {
-            LOG.debugv("{0}: stopping container {1} after invocation",
-                    handle.isHotReload() ? "Hot-reload" : "Ephemeral", handle.getContainerId());
-            stopQuietly(handle);
-            return;
-        }
-
-        if (lease == null) {
-            LOG.warnv("Container {0} for function {1} has no active warm-pool lease; stopping it",
-                    handle.getContainerId(), handle.getFunctionName());
-            stopQuietly(handle);
-            return;
-        }
-
-        boolean stale;
-        boolean returned;
-        synchronized (lease.poolState()) {
-            stale = lease.epoch() != lease.poolState().epochByEnvironment
-                    .getOrDefault(lease.environmentKey(), 0L);
-            returned = !stale && idleSize(lease.poolState()) < maxPoolSizePerFunction;
-            if (returned) {
-                handle.setState(ContainerState.WARM);
-                handle.touchLastUsed();
-                lease.poolState().idleByEnvironment
-                        .computeIfAbsent(lease.environmentKey(), ignored -> new ArrayDeque<>())
-                        .addFirst(handle);
+        try {
+            // An extension reporting an init/exit error is fatal to the execution environment in real
+            // AWS. RuntimeApiServer already refuses new work at that point; the container is torn down
+            // here rather than at fault time so the invocation that was in flight when the extension
+            // failed still completes normally through the runtime.
+            boolean faulted;
+            try {
+                faulted = handle.isFaulted();
+            } catch (RuntimeException | Error e) {
+                stopQuietly(handle);
+                throw e;
             }
-        }
-        if (stale) {
-            LOG.debugv("Pool was invalidated while container {0} was busy; stopping it",
-                    handle.getContainerId());
-            stopQuietly(handle);
-        } else if (returned) {
-            LOG.debugv("Released container back to pool for function: {0}", handle.getFunctionName());
-        } else {
-            LOG.debugv("Pool full for function {0}, stopping excess container", handle.getFunctionName());
-            stopQuietly(handle);
+            if (faulted) {
+                LOG.infov("Retiring container {0} for function {1}: an extension reported a fatal error",
+                        handle.getContainerId(), handle.getFunctionName());
+                stopQuietly(handle);
+                return;
+            }
+            if (ephemeral || handle.isHotReload()) {
+                LOG.debugv("{0}: stopping container {1} after invocation",
+                        handle.isHotReload() ? "Hot-reload" : "Ephemeral", handle.getContainerId());
+                stopQuietly(handle);
+                return;
+            }
+
+            if (lease == null) {
+                LOG.warnv("Container {0} for function {1} has no active warm-pool lease; stopping it",
+                        handle.getContainerId(), handle.getFunctionName());
+                stopQuietly(handle);
+                return;
+            }
+
+            boolean stale;
+            boolean returned;
+            synchronized (lease.poolState()) {
+                stale = lease.epoch() != lease.poolState().epochByEnvironment
+                        .getOrDefault(lease.environmentKey(), 0L);
+                returned = !stale && idleSize(lease.poolState()) < maxPoolSizePerFunction
+                        && reserveIdleSlot();
+                if (returned) {
+                    handle.setState(ContainerState.WARM);
+                    handle.touchLastUsed();
+                    lease.poolState().idleByEnvironment
+                            .computeIfAbsent(lease.environmentKey(), ignored -> new ArrayDeque<>())
+                            .addFirst(handle);
+                }
+            }
+            if (stale) {
+                LOG.debugv("Pool was invalidated while container {0} was busy; stopping it",
+                        handle.getContainerId());
+                stopQuietly(handle);
+            } else if (returned) {
+                LOG.debugv("Released container back to pool for function: {0}", handle.getFunctionName());
+            } else {
+                LOG.debugv("Pool full for function {0}, stopping excess container", handle.getFunctionName());
+                stopQuietly(handle);
+            }
+        } finally {
+            if (lease != null) {
+                lease.environmentPermit().close();
+            }
         }
     }
 
@@ -242,10 +312,16 @@ public class WarmPool implements ContainerTeardown {
      * stop is needed — no pool bookkeeping required.
      */
     public void destroyHandle(ContainerHandle handle) {
-        activeLeases.remove(handle);
         LOG.debugv("Destroying timed-out container {0} for function {1}",
                 handle.getContainerId(), handle.getFunctionName());
-        stopQuietly(handle);
+        Lease lease = activeLeases.remove(handle);
+        try {
+            stopQuietly(handle);
+        } finally {
+            if (lease != null) {
+                lease.environmentPermit().close();
+            }
+        }
     }
 
     /**
@@ -253,14 +329,15 @@ public class WarmPool implements ContainerTeardown {
      * {@code $LATEST}. Published versions keep their independently keyed warm containers.
      */
     public void drainEnvironment(LambdaFunction fn) {
-        String functionName = fn.getFunctionName();
         String environmentKey = executionEnvironmentKey(fn);
-        PoolState poolState = poolStates.computeIfAbsent(functionName, ignored -> new PoolState());
+        FunctionPoolKey poolKey = functionPoolKey(fn);
+        PoolState poolState = poolStates.computeIfAbsent(poolKey, ignored -> new PoolState());
         List<ContainerHandle> toStop;
         synchronized (poolState) {
             poolState.epochByEnvironment.merge(environmentKey, 1L, Long::sum);
             ArrayDeque<ContainerHandle> idle = poolState.idleByEnvironment.remove(environmentKey);
             toStop = idle == null ? List.of() : new ArrayList<>(idle);
+            idleContainerCount.addAndGet(-toStop.size());
         }
         LOG.infov("Draining {0} container(s) for Lambda environment: {1}",
                 toStop.size(), environmentKey);
@@ -272,15 +349,25 @@ public class WarmPool implements ContainerTeardown {
      * Called on function deletion and emulator shutdown.
      */
     public void drainFunction(String functionName) {
-        PoolState poolState = poolStates.computeIfAbsent(functionName, ignored -> new PoolState());
-        List<ContainerHandle> toStop;
-        synchronized (poolState) {
-            poolState.epochByEnvironment.replaceAll((ignored, epoch) -> epoch + 1);
-            toStop = new ArrayList<>();
-            poolState.idleByEnvironment.values().forEach(toStop::addAll);
-            poolState.idleByEnvironment.clear();
+        List<ContainerHandle> toStop = new ArrayList<>();
+        for (var entry : poolStates.entrySet()) {
+            if (!entry.getKey().functionName().equals(functionName)) {
+                continue;
+            }
+            toStop.addAll(drainPoolState(entry.getValue()));
         }
         LOG.infov("Draining {0} container(s) for function: {1}", toStop.size(), functionName);
+        stopInParallel(toStop);
+    }
+
+    /**
+     * Stops and invalidates every warm environment for one account/region/function identity.
+     * The name-only overload above remains for callers that intentionally drain all accounts.
+     */
+    public void drainFunction(LambdaFunction fn) {
+        PoolState poolState = poolStates.computeIfAbsent(functionPoolKey(fn), ignored -> new PoolState());
+        List<ContainerHandle> toStop = drainPoolState(poolState);
+        LOG.infov("Draining {0} container(s) for function: {1}", toStop.size(), fn.getFunctionName());
         stopInParallel(toStop);
     }
 
@@ -309,8 +396,8 @@ public class WarmPool implements ContainerTeardown {
     }
 
     private void drainAll() {
-        for (String functionName : new ArrayList<>(poolStates.keySet())) {
-            drainFunction(functionName);
+        for (PoolState poolState : new ArrayList<>(poolStates.values())) {
+            stopInParallel(drainPoolState(poolState));
         }
     }
 
@@ -322,7 +409,7 @@ public class WarmPool implements ContainerTeardown {
         long now = System.currentTimeMillis();
 
         for (var entry : poolStates.entrySet()) {
-            String functionName = entry.getKey();
+            String functionName = entry.getKey().functionName();
             PoolState poolState = entry.getValue();
             List<ContainerHandle> toEvict = new ArrayList<>();
 
@@ -338,6 +425,7 @@ public class WarmPool implements ContainerTeardown {
                     });
                 }
                 poolState.idleByEnvironment.values().removeIf(ArrayDeque::isEmpty);
+                idleContainerCount.addAndGet(-toEvict.size());
             }
 
             if (!toEvict.isEmpty()) {
@@ -354,7 +442,91 @@ public class WarmPool implements ContainerTeardown {
         if (functionArn != null && !functionArn.isBlank()) {
             return functionArn;
         }
-        return fn.getFunctionName() + ":" + fn.getVersion();
+        return accountId(fn) + ":" + fn.getFunctionName() + ":" + fn.getVersion();
+    }
+
+    private static FunctionPoolKey functionPoolKey(LambdaFunction fn) {
+        return new FunctionPoolKey(accountId(fn), regionId(fn), fn.getFunctionName());
+    }
+
+    private static String regionId(LambdaFunction fn) {
+        String functionArn = fn.getFunctionArn();
+        if (functionArn != null && !functionArn.isBlank()) {
+            String[] segments = functionArn.split(":", 6);
+            if (segments.length >= 4 && !segments[3].isBlank()) {
+                return segments[3];
+            }
+        }
+        return "unknown";
+    }
+
+    private static String accountId(LambdaFunction fn) {
+        String accountId = fn.getAccountId();
+        if (accountId != null && !accountId.isBlank()) {
+            return accountId;
+        }
+        String functionArn = fn.getFunctionArn();
+        if (functionArn != null && !functionArn.isBlank()) {
+            String[] segments = functionArn.split(":", 6);
+            if (segments.length >= 5 && !segments[4].isBlank()) {
+                return segments[4];
+            }
+        }
+        return "000000000000";
+    }
+
+    private List<ContainerHandle> drainPoolState(PoolState poolState) {
+        List<ContainerHandle> toStop = new ArrayList<>();
+        synchronized (poolState) {
+            poolState.epochByEnvironment.replaceAll((ignored, epoch) -> epoch + 1);
+            poolState.idleByEnvironment.values().forEach(toStop::addAll);
+            poolState.idleByEnvironment.clear();
+            idleContainerCount.addAndGet(-toStop.size());
+        }
+        return toStop;
+    }
+
+    /**
+     * Reserves one global warm-container slot. A bounded physical profile must not
+     * retain more idle Docker environments than its configured cap across all accounts
+     * and functions; the historical unbounded profile keeps the old per-function bound.
+     */
+    private boolean reserveIdleSlot() {
+        if (!environmentLimiter.bounded()) {
+            idleContainerCount.incrementAndGet();
+            return true;
+        }
+        int cap = environmentLimiter.configuredLimit();
+        while (true) {
+            int current = idleContainerCount.get();
+            if (current >= cap) {
+                return false;
+            }
+            if (idleContainerCount.compareAndSet(current, current + 1)) {
+                return true;
+            }
+        }
+    }
+
+    /** Status/readback for physical environment admission. */
+    public LambdaEnvironmentLimiter.Status status() {
+        return environmentLimiter.status();
+    }
+
+    /** Number of currently idle warm containers retained by this pool. */
+    public int idleContainerCount() {
+        return idleContainerCount.get();
+    }
+
+    private static int maxPoolSize(EmulatorConfig config) {
+        if (config == null || config.services() == null || config.services().lambda() == null) {
+            return DEFAULT_MAX_POOL_SIZE;
+        }
+        var configured = config.services().lambda().maxPhysicalEnvironments();
+        if (configured == null || configured.isEmpty() || configured.getAsInt() <= 0) {
+            return DEFAULT_MAX_POOL_SIZE;
+        }
+        return Math.min(DEFAULT_MAX_POOL_SIZE, configured.getAsInt());
     }
 
     private static int idleSize(PoolState poolState) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -258,6 +258,8 @@ floci:
       code-path: ./data/lambda-code
       poll-interval-ms: 1000
       container-idle-timeout-seconds: 300
+      # max-physical-environments: 4            # Optional cap for concurrently running Docker environments; unset preserves the historical behavior
+      physical-environment-wait-timeout-seconds: 15 # FLOCI_SERVICES_LAMBDA_PHYSICAL_ENVIRONMENT_WAIT_TIMEOUT_SECONDS
       region-concurrency-limit: 1000
       unreserved-concurrency-min: 100
       # aws-config-path:                      # Host path to bind-mount (read-only) at /opt/aws-config for real credential discovery

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaEnvironmentLimiterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaEnvironmentLimiterTest.java
@@ -1,0 +1,215 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LambdaEnvironmentLimiterTest {
+
+    @Test
+    void twentyLogicalInvocationsShareFourPhysicalSlots() throws Exception {
+        LambdaEnvironmentLimiter limiter = new LambdaEnvironmentLimiter(4, 10);
+        List<LambdaEnvironmentLimiter.Permit> held = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            held.add(limiter.acquire("arn:aws:lambda:us-east-1:000000000000:function:fn:" + i));
+        }
+
+        ExecutorService workers = Executors.newFixedThreadPool(16);
+        CountDownLatch started = new CountDownLatch(16);
+        List<Future<LambdaEnvironmentLimiter.Permit>> waiting = new ArrayList<>();
+        try {
+            for (int i = 0; i < 16; i++) {
+                waiting.add(workers.submit(() -> {
+                    started.countDown();
+                    return limiter.acquire("arn:aws:lambda:us-east-1:000000000000:function:fn:burst");
+                }));
+            }
+            assertTrue(started.await(2, TimeUnit.SECONDS), "all logical invocations did not start");
+            awaitQueued(limiter, 16);
+            assertEquals(4, limiter.status().inFlight());
+            assertEquals(16, limiter.status().queued());
+            assertEquals(0, limiter.status().available());
+
+            held.forEach(LambdaEnvironmentLimiter.Permit::close);
+            held.clear();
+            for (Future<LambdaEnvironmentLimiter.Permit> future : waiting) {
+                LambdaEnvironmentLimiter.Permit permit = future.get(5, TimeUnit.SECONDS);
+                assertNotNull(permit);
+                permit.close();
+            }
+            assertEquals(20, limiter.status().granted());
+            assertEquals(0, limiter.status().inFlight());
+            assertEquals(0, limiter.status().queued());
+        } finally {
+            held.forEach(LambdaEnvironmentLimiter.Permit::close);
+            workers.shutdownNow();
+        }
+        assertEquals(0, limiter.status().inFlight());
+        assertEquals(0, limiter.status().queued());
+    }
+
+    @Test
+    void waitersAreGrantedInFifoOrder() throws Exception {
+        LambdaEnvironmentLimiter limiter = new LambdaEnvironmentLimiter(1, 10);
+        LambdaEnvironmentLimiter.Permit holder = limiter.acquire("holder");
+        ExecutorService workers = Executors.newFixedThreadPool(2);
+        CountDownLatch firstGranted = new CountDownLatch(1);
+        CountDownLatch allowFirstToFinish = new CountDownLatch(1);
+        List<String> order = new ArrayList<>();
+        try {
+            Future<?> first = workers.submit(() -> {
+                try (LambdaEnvironmentLimiter.Permit ignored = limiter.acquireInterruptibly("first")) {
+                    synchronized (order) {
+                        order.add("first");
+                    }
+                    firstGranted.countDown();
+                    assertTrue(allowFirstToFinish.await(5, TimeUnit.SECONDS));
+                }
+                return null;
+            });
+            awaitQueued(limiter, 1);
+
+            Future<?> second = workers.submit(() -> {
+                try (LambdaEnvironmentLimiter.Permit ignored = limiter.acquireInterruptibly("second")) {
+                    synchronized (order) {
+                        order.add("second");
+                    }
+                }
+                return null;
+            });
+            awaitQueued(limiter, 2);
+
+            holder.close();
+            assertTrue(firstGranted.await(2, TimeUnit.SECONDS), "first waiter was not granted");
+            assertFalse(second.isDone(), "second waiter bypassed the FIFO waiter");
+            synchronized (order) {
+                assertEquals(List.of("first"), order);
+            }
+            allowFirstToFinish.countDown();
+            first.get(2, TimeUnit.SECONDS);
+            second.get(2, TimeUnit.SECONDS);
+            synchronized (order) {
+                assertEquals(List.of("first", "second"), order);
+            }
+        } finally {
+            holder.close();
+            workers.shutdownNow();
+        }
+    }
+
+    @Test
+    void timeoutRemovesWaiterAndDoesNotLeakPermit() {
+        LambdaEnvironmentLimiter limiter = new LambdaEnvironmentLimiter(1, 0);
+        LambdaEnvironmentLimiter.Permit holder = limiter.acquire("held");
+        try {
+            LambdaEnvironmentLimiter.AdmissionTimeoutException exception = assertThrows(
+                    LambdaEnvironmentLimiter.AdmissionTimeoutException.class,
+                    () -> limiter.acquireInterruptibly("timed-out"));
+            assertEquals("timed-out", exception.environmentKey());
+            assertEquals(0, limiter.status().queued());
+            assertEquals(1, limiter.status().timedOut());
+            assertEquals(1, limiter.status().inFlight());
+        } finally {
+            holder.close();
+        }
+        assertEquals(0, limiter.status().inFlight());
+    }
+
+    @Test
+    void interruptionRemovesWaiterAndRestoresInterruptAtPublicBoundary() throws Exception {
+        LambdaEnvironmentLimiter limiter = new LambdaEnvironmentLimiter(1, 10);
+        LambdaEnvironmentLimiter.Permit holder = limiter.acquire("held");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicReference<Boolean> interrupted = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            try {
+                limiter.acquire("interrupted");
+                failure.set(new AssertionError("acquire unexpectedly succeeded"));
+            } catch (LambdaEnvironmentLimiter.AdmissionInterruptedException expected) {
+                interrupted.set(Thread.currentThread().isInterrupted());
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+        waiter.start();
+        awaitQueued(limiter, 1);
+        waiter.interrupt();
+        waiter.join(2_000);
+        try {
+            assertFalse(waiter.isAlive(), "interrupted waiter did not exit");
+            assertNull(failure.get());
+            assertEquals(Boolean.TRUE, interrupted.get());
+            assertEquals(0, limiter.status().queued());
+            assertEquals(1, limiter.status().interrupted());
+        } finally {
+            holder.close();
+        }
+    }
+
+    @Test
+    void closeWakesAndRejectsQueuedAcquisition() throws Exception {
+        LambdaEnvironmentLimiter limiter = new LambdaEnvironmentLimiter(1, 10);
+        LambdaEnvironmentLimiter.Permit holder = limiter.acquire("held");
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        Thread waiter = new Thread(() -> {
+            try {
+                limiter.acquire("closed");
+                failure.set(new AssertionError("acquire unexpectedly succeeded"));
+            } catch (LambdaEnvironmentLimiter.AdmissionClosedException expected) {
+                // expected
+            } catch (Throwable unexpected) {
+                failure.set(unexpected);
+            }
+        });
+        waiter.start();
+        awaitQueued(limiter, 1);
+        limiter.close();
+        waiter.join(2_000);
+        try {
+            assertFalse(waiter.isAlive(), "closed waiter did not exit");
+            assertNull(failure.get());
+            assertEquals(0, limiter.status().queued());
+            assertTrue(limiter.status().closed());
+        } finally {
+            holder.close();
+        }
+    }
+
+    @Test
+    void statusIsolatedByExecutionEnvironmentIdentity() {
+        LambdaEnvironmentLimiter limiter = new LambdaEnvironmentLimiter(2, 1);
+        LambdaEnvironmentLimiter.Permit first = limiter.acquire("account-a/function-a:$LATEST");
+        LambdaEnvironmentLimiter.Permit second = limiter.acquire("account-b/function-a:$LATEST");
+        try {
+            assertEquals(1, limiter.status("account-a/function-a:$LATEST").inFlight());
+            assertEquals(1, limiter.status("account-b/function-a:$LATEST").inFlight());
+            assertEquals(0, limiter.status("account-c/function-a:$LATEST").inFlight());
+            assertEquals(2, limiter.status().inFlight());
+        } finally {
+            first.close();
+            second.close();
+        }
+    }
+
+    private static void awaitQueued(LambdaEnvironmentLimiter limiter, int expected) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (limiter.queuedCount() < expected && System.nanoTime() < deadline) {
+            Thread.sleep(1);
+        }
+        assertEquals(expected, limiter.queuedCount(), "expected waiters were not queued");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaExecutorServiceTest.java
@@ -174,4 +174,38 @@ class LambdaExecutorServiceTest {
         assertEquals("Unhandled", result.getFunctionError());
         assertTrue(new String(result.getPayload()).contains("InvocationError"));
     }
+
+    @Test
+    void physicalAdmissionTimeoutReturnsBoundedErrorAndReleasesLogicalPermit() {
+        LambdaConcurrencyLimiter.Permit logicalPermit = mock(LambdaConcurrencyLimiter.Permit.class);
+        when(concurrencyLimiter.acquire(any())).thenReturn(logicalPermit);
+        when(warmPool.acquire(any())).thenThrow(new LambdaEnvironmentLimiter.AdmissionTimeoutException(
+                fn.getFunctionArn(), 4, 0));
+
+        InvokeResult result = executor.invoke(fn, "{}".getBytes(), InvocationType.RequestResponse);
+
+        verify(logicalPermit).close();
+        verify(warmPool, never()).release(any());
+        verify(warmPool, never()).destroyHandle(any());
+        assertEquals(200, result.getStatusCode());
+        assertEquals("Unhandled", result.getFunctionError());
+        assertTrue(new String(result.getPayload()).contains("Lambda.EnvironmentTimeout"));
+    }
+
+    @Test
+    void physicalAdmissionInterruptionReturnsBoundedErrorAndReleasesLogicalPermit() {
+        LambdaConcurrencyLimiter.Permit logicalPermit = mock(LambdaConcurrencyLimiter.Permit.class);
+        when(concurrencyLimiter.acquire(any())).thenReturn(logicalPermit);
+        when(warmPool.acquire(any())).thenThrow(new LambdaEnvironmentLimiter.AdmissionInterruptedException(
+                fn.getFunctionArn(), new InterruptedException()));
+
+        InvokeResult result = executor.invoke(fn, "{}".getBytes(), InvocationType.RequestResponse);
+
+        verify(logicalPermit).close();
+        verify(warmPool, never()).release(any());
+        verify(warmPool, never()).destroyHandle(any());
+        assertEquals(200, result.getStatusCode());
+        assertEquals("Unhandled", result.getFunctionError());
+        assertTrue(new String(result.getPayload()).contains("Invocation interrupted"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/WarmPoolTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.OptionalInt;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -43,6 +44,18 @@ class WarmPoolTest {
         when(lambda.ephemeral()).thenReturn(false);
         when(lambda.containerIdleTimeoutSeconds()).thenReturn(0);
         return new WarmPool(containerLauncher, config);
+    }
+
+    private WarmPool buildBoundedPool(int maxPhysicalEnvironments) {
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.LambdaServiceConfig lambda = mock(EmulatorConfig.LambdaServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.lambda()).thenReturn(lambda);
+        when(lambda.ephemeral()).thenReturn(false);
+        when(lambda.containerIdleTimeoutSeconds()).thenReturn(0);
+        when(lambda.maxPhysicalEnvironments()).thenReturn(OptionalInt.of(maxPhysicalEnvironments));
+        return new WarmPool(containerLauncher, config,
+                new LambdaEnvironmentLimiter(maxPhysicalEnvironments, 1));
     }
 
     @Test
@@ -276,6 +289,86 @@ class WarmPoolTest {
 
         pool.release(reacquiredLatest);
         pool.release(reacquiredVersion);
+        pool.shutdown();
+    }
+
+    @Test
+    void accountsUseSeparateWarmPoolsForIdenticallyNamedFunctions() {
+        WarmPool pool = buildPool();
+        pool.init();
+
+        LambdaFunction accountA = mock(LambdaFunction.class);
+        LambdaFunction accountB = mock(LambdaFunction.class);
+        when(accountA.getFunctionName()).thenReturn("shared-name");
+        when(accountB.getFunctionName()).thenReturn("shared-name");
+        when(accountA.getFunctionArn())
+                .thenReturn("arn:aws:lambda:us-east-1:111111111111:function:shared-name");
+        when(accountB.getFunctionArn())
+                .thenReturn("arn:aws:lambda:us-east-1:222222222222:function:shared-name");
+
+        ContainerHandle handleA = new ContainerHandle("cid-account-a", "shared-name", null, ContainerState.WARM);
+        ContainerHandle handleB = new ContainerHandle("cid-account-b", "shared-name", null, ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(handleA, handleB);
+        when(containerLauncher.isAlive(any())).thenReturn(true);
+
+        pool.release(pool.acquire(accountA));
+        pool.release(pool.acquire(accountB));
+
+        assertSame(handleA, pool.acquire(accountA));
+        assertSame(handleB, pool.acquire(accountB));
+        verify(containerLauncher, times(2)).launch(any());
+
+        pool.release(handleA);
+        pool.release(handleB);
+        pool.shutdown();
+    }
+
+    @Test
+    void boundedProfileRetainsAtMostConfiguredIdleEnvironmentsAcrossFunctions() {
+        WarmPool pool = buildBoundedPool(1);
+        pool.init();
+
+        LambdaFunction accountA = mock(LambdaFunction.class);
+        LambdaFunction accountB = mock(LambdaFunction.class);
+        when(accountA.getFunctionName()).thenReturn("first");
+        when(accountB.getFunctionName()).thenReturn("second");
+        when(accountA.getFunctionArn())
+                .thenReturn("arn:aws:lambda:us-east-1:111111111111:function:first");
+        when(accountB.getFunctionArn())
+                .thenReturn("arn:aws:lambda:us-east-1:222222222222:function:second");
+
+        ContainerHandle first = new ContainerHandle("cid-first", "first", null, ContainerState.WARM);
+        ContainerHandle second = new ContainerHandle("cid-second", "second", null, ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(first, second);
+
+        pool.release(pool.acquire(accountA));
+        assertEquals(1, pool.idleContainerCount());
+        pool.release(pool.acquire(accountB));
+
+        assertEquals(1, pool.idleContainerCount());
+        verify(containerLauncher).stop(second);
+        assertEquals(1, pool.status().configuredLimit());
+        assertEquals(0, pool.status().inFlight());
+        pool.shutdown();
+    }
+
+    @Test
+    void destroyHandleReleasesPhysicalAdmissionPermit() {
+        WarmPool pool = buildBoundedPool(1);
+        pool.init();
+        LambdaFunction fn = mock(LambdaFunction.class);
+        when(fn.getFunctionName()).thenReturn("destroy-permit");
+        when(fn.getFunctionArn())
+                .thenReturn("arn:aws:lambda:us-east-1:000000000000:function:destroy-permit");
+        ContainerHandle handle = new ContainerHandle("cid-destroy-permit", "destroy-permit", null,
+                ContainerState.WARM);
+        when(containerLauncher.launch(any())).thenReturn(handle);
+
+        assertSame(handle, pool.acquire(fn));
+        assertEquals(1, pool.status().inFlight());
+        pool.destroyHandle(handle);
+        assertEquals(0, pool.status().inFlight());
+        verify(containerLauncher).stop(handle);
         pool.shutdown();
     }
 


### PR DESCRIPTION
## Summary

Add an opt-in physical Lambda environment cap with fair, bounded admission waits while preserving the historical behavior when no cap is configured. Logical Lambda concurrency remains a separate limiter.

## Configuration

```yaml
floci:
  services:
    lambda:
      max-physical-environments: 4
      physical-environment-wait-timeout-seconds: 15
```

Leaving `max-physical-environments` unset preserves the existing unbounded mode.

## Lifecycle

```text
invoke
  -> logical LambdaConcurrencyLimiter
  -> fair physical LambdaEnvironmentLimiter
  -> WarmPool acquire/reuse
  -> release, destroy, timeout, failure, or code-update drain
  -> close the physical permit
```

Account, region, function, and version identities use independent warm-pool keys; constrained warm retention is capped separately from logical admission.

## Validation

- `./mvnw -Dtest=WarmPoolTest,LambdaExecutorServiceTest,LambdaConcurrencyLimiterTest,LambdaEnvironmentLimiterTest test` — 48 passed
- `./mvnw test` — 13,985 run; unrelated `EcrIntegrationTest.createRepository` duplicate-repository failure and `ResourceExplorer2IntegrationTest` resource/tag timeout/failure remain
- `git diff --check`

## Follow-up Scope

Samva profile selection and distribution remain consumer-owned.
