### PR TITLE
ci: save the maven cache from main only, not from every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,20 @@ jobs:
           -Dsurefire.includesFile="$GITHUB_WORKSPACE/shard.txt"
           -Dsurefire.failIfNoTests=true
 
+      # Save from main only, and from shard 1 only. Actions caches are ref-scoped:
+      # a pull_request run's write lands in refs/pull/N/merge where no other PR can
+      # read it, so every open PR was storing a ~201 MB byte-identical duplicate of
+      # the copy main already publishes under this exact key — 1.61 GB across 8 PRs
+      # when measured, against a 10 GB repo budget. PRs restore main's copy instead
+      # (verified: four sampled PR runs all restored maven-Linux-a80d20aaec, the key
+      # main holds), and main gets ~15 qualifying pushes a day so it stays fresh.
+      #
+      # Trade-off: a PR that edits pom.xml misses this exact key, falls back to the
+      # restore-keys prefix for the bulk, and re-downloads its delta on each re-run
+      # rather than caching it. pom.xml changed 21 times in 30 days, so that is a
+      # small minority of PRs paying a small delta.
       - uses: actions/cache/save@v6.1.0
-        if: always() && matrix.shard == 1
+        if: always() && matrix.shard == 1 && github.event_name == 'push'
         with:
           path: ~/.m2/repository
           key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}


### PR DESCRIPTION
## Summary

`ci.yml` saved `~/.m2/repository` on **every** run, including pull requests. Actions caches are ref-scoped, so a PR's write lands in `refs/pull/N/merge` where no other PR can read it — every open PR was storing a **~201 MB byte-identical duplicate** of the copy `main` already publishes under the same key.

Measured: **1.61 GB across 8 open PRs**, against a 10 GB repo-wide budget that #2634 and its follow-up purge had just brought back under control. Cache usage returned from 3.09 GB to 7.56 GB within hours of the purge, and this is one of the two remaining sources.

PRs already restore `main`'s copy — four sampled PR runs all logged:

```
Cache restored from key: maven-Linux-a80d20aaec
```

which is the exact key `main` holds. Their own save adds nothing, and `main` sees ~15 qualifying pushes a day so its copy stays fresh.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — CI workflow only (`ci:`), no runtime change

## AWS Compatibility

No wire-protocol impact. CI-only: no emulator source, request parsing, or response shape is touched.

## Checklist

- [x] `./mvnw test` passes locally — unaffected, no `src/` changes
- [ ] New or updated integration test added — **not applicable**, workflow-only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Trade-off

**Restore is untouched** and still runs on every shard of every event; only the save is gated to `github.event_name == 'push'`.

A PR that edits `pom.xml` now misses this exact key, falls back to the `restore-keys` prefix for the bulk of the repository, and re-downloads its delta on each re-run instead of caching it. `pom.xml` changed 21 times in the last 30 days, so that is a small minority of PRs paying a small delta — against ~200 MB reclaimed per active PR.

## Verification

Post-merge, PR runs should still log `Cache restored from key: maven-Linux-…`, and no new `maven-*` entries should appear under `refs/pull/*`:

```bash
gh api 'repos/floci-io/floci/actions/caches?per_page=100' --paginate \
  | grep -o '"key": "maven-[^"]*"'          # expect main-scoped only
```

## Context

Fourth instance of one root cause — ref-scoped caches with no shared producer. Previously: #2503 (`setup-java`), #2634 (compat test images), #2636 (`build-native`).
