### PR TITLE
fix(apigatewayv2): propagate Lambda REQUEST authorizer context to HTTP API backends

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1479,9 +1479,12 @@ public class ApiGatewayExecuteController {
             jwtScopes = jwtResult.scopes();
         }
 
+        ObjectNode lambdaAuthorizerContext = null;
         if ("CUSTOM".equalsIgnoreCase(route.getAuthorizationType()) && route.getAuthorizerId() != null) {
-            Response authError = enforceRequestAuthorizerV2(region, apiId, stageName, route, httpMethod, path, headers, uriInfo);
-            if (authError != null) return authError;
+            RequestAuthorizerResult requestResult =
+                    enforceRequestAuthorizerV2(region, apiId, stageName, route, httpMethod, path, headers, uriInfo);
+            if (requestResult.errorResponse() != null) return requestResult.errorResponse();
+            lambdaAuthorizerContext = requestResult.context();
         }
 
         if (route.getTarget() == null) {
@@ -1520,7 +1523,8 @@ public class ApiGatewayExecuteController {
 
         String requestId = UUID.randomUUID().toString();
         String eventJson = buildV2ProxyEvent(httpMethod, path, route.getRouteKey(),
-                apiId, region, stageName, headers, uriInfo, body, requestId, jwtClaims, jwtScopes);
+                apiId, region, stageName, headers, uriInfo, body, requestId, jwtClaims, jwtScopes,
+                lambdaAuthorizerContext);
 
         LOG.debugv("execute-api v2: {0} {1}/{2}{3} → Lambda {4}", httpMethod, apiId, stageName, path, functionName);
 
@@ -1786,26 +1790,33 @@ public class ApiGatewayExecuteController {
 
     // ──────────────────────────── HTTP API v2 Lambda REQUEST authorizer ────────────────────────────
 
+    // Mirrors JwtAuthorizerResult's shape (and the v1/REST AuthorizerResult's) for the same
+    // reason: a null errorResponse means "authorized, proceed", and context (when non-null) is
+    // the authorizer response's `context` object, which the caller threads through to
+    // buildV2ProxyEvent so requestContext.authorizer.lambda is populated for the backend.
+    private record RequestAuthorizerResult(Response errorResponse, ObjectNode context) {}
+
     /**
      * Enforces a Lambda REQUEST authorizer on an HTTP API (v2) route.
      * Supports both payload format versions (1.0 and 2.0) and simple responses.
      *
-     * @return null if authorized, or an error Response if denied/unauthorized
+     * @return a result whose errorResponse is null if authorized, or carries the error Response
+     *         if denied/unauthorized
      */
-    private Response enforceRequestAuthorizerV2(String region, String apiId, String stageName,
+    private RequestAuthorizerResult enforceRequestAuthorizerV2(String region, String apiId, String stageName,
                                                 Route route, String httpMethod, String path,
                                                 HttpHeaders headers, UriInfo uriInfo) {
         Authorizer authorizer;
         try {
             authorizer = apiGatewayV2Service.getAuthorizer(region, apiId, route.getAuthorizerId());
         } catch (AwsException e) {
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Authorizer not found"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         if (!"REQUEST".equalsIgnoreCase(authorizer.getAuthorizerType())) {
-            return null; // Not a REQUEST authorizer — skip
+            return new RequestAuthorizerResult(null, null); // Not a REQUEST authorizer — skip
         }
 
         // Validate identity sources — if any configured source is missing, return 401 without invoking Lambda
@@ -1817,17 +1828,17 @@ public class ApiGatewayExecuteController {
                     String headerName = expression.substring("$request.header.".length());
                     String value = headers.getHeaderString(headerName);
                     if (value == null || value.isEmpty()) {
-                        return Response.status(401)
+                        return new RequestAuthorizerResult(Response.status(401)
                                 .entity(jsonMessage("Unauthorized"))
-                                .type(MediaType.APPLICATION_JSON).build();
+                                .type(MediaType.APPLICATION_JSON).build(), null);
                     }
                 } else if (expression.startsWith("$request.querystring.")) {
                     String paramName = expression.substring("$request.querystring.".length());
                     String value = queryParams.getFirst(paramName);
                     if (value == null || value.isEmpty()) {
-                        return Response.status(401)
+                        return new RequestAuthorizerResult(Response.status(401)
                                 .entity(jsonMessage("Unauthorized"))
-                                .type(MediaType.APPLICATION_JSON).build();
+                                .type(MediaType.APPLICATION_JSON).build(), null);
                     }
                 }
                 // $context.* identity sources are always present — no validation needed
@@ -1849,9 +1860,9 @@ public class ApiGatewayExecuteController {
         String functionName = functionNameFromUri(authorizer.getAuthorizerUri());
         if (functionName == null) {
             LOG.warnv("Cannot extract function name from authorizer URI: {0}", authorizer.getAuthorizerUri());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         // Invoke the authorizer Lambda
@@ -1861,26 +1872,26 @@ public class ApiGatewayExecuteController {
                     eventJson.getBytes(StandardCharsets.UTF_8), InvocationType.RequestResponse);
         } catch (Exception e) {
             LOG.warnv("Lambda REQUEST authorizer invocation failed for API {0}: {1}", apiId, e.getMessage());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         // Check for function error (Lambda threw an exception)
         if (invokeResult.getFunctionError() != null) {
             LOG.warnv("Lambda REQUEST authorizer returned function error for API {0}: {1}",
                     apiId, invokeResult.getFunctionError());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         byte[] payload = invokeResult.getPayload();
         if (payload == null || payload.length == 0) {
             LOG.warnv("Lambda REQUEST authorizer returned empty payload for API {0}", apiId);
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         // Parse the authorizer response
@@ -1894,57 +1905,71 @@ public class ApiGatewayExecuteController {
                 JsonNode isAuthorized = response.path("isAuthorized");
                 if (isAuthorized.isMissingNode() || isAuthorized.isNull()) {
                     LOG.warnv("Lambda REQUEST authorizer simple response missing isAuthorized for API {0}", apiId);
-                    return Response.status(500)
+                    return new RequestAuthorizerResult(Response.status(500)
                             .entity(jsonMessage("Internal Server Error"))
-                            .type(MediaType.APPLICATION_JSON).build();
+                            .type(MediaType.APPLICATION_JSON).build(), null);
                 }
                 if (!isAuthorized.asBoolean(false)) {
-                    return Response.status(403)
+                    return new RequestAuthorizerResult(Response.status(403)
                             .entity(jsonMessage("Forbidden"))
-                            .type(MediaType.APPLICATION_JSON).build();
+                            .type(MediaType.APPLICATION_JSON).build(), null);
                 }
-                return null; // authorized
+                return new RequestAuthorizerResult(null, requestAuthorizerContext(response));
             }
 
             // IAM policy document format
             JsonNode policyDocument = response.path("policyDocument");
             if (policyDocument.isMissingNode() || policyDocument.isNull()) {
                 LOG.warnv("Authorizer response missing policyDocument for API {0}", apiId);
-                return Response.status(500)
+                return new RequestAuthorizerResult(Response.status(500)
                         .entity(jsonMessage("Internal Server Error"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
             JsonNode statements = policyDocument.path("Statement");
             if (statements.isMissingNode() || statements.isNull()
                     || !statements.isArray() || statements.isEmpty()) {
                 LOG.warnv("Authorizer response missing or empty Statement array for API {0}", apiId);
-                return Response.status(500)
+                return new RequestAuthorizerResult(Response.status(500)
                         .entity(jsonMessage("Internal Server Error"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
             String effect = statements.get(0).path("Effect").asText("Deny");
             if ("Deny".equalsIgnoreCase(effect)) {
-                return Response.status(403)
+                return new RequestAuthorizerResult(Response.status(403)
                         .entity(jsonMessage("User is not authorized to access this resource"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
             if (!"Allow".equalsIgnoreCase(effect)) {
                 LOG.warnv("Authorizer response has unrecognized Effect '{0}' for API {1}", effect, apiId);
-                return Response.status(500)
+                return new RequestAuthorizerResult(Response.status(500)
                         .entity(jsonMessage("Internal Server Error"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
-            return null; // authorized
+            return new RequestAuthorizerResult(null, requestAuthorizerContext(response));
         } catch (Exception e) {
             LOG.warnv("Failed to parse authorizer response for API {0}: {1}", apiId, e.getMessage());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
+    }
+
+    /**
+     * The {@code context} an authorizer response carries, or null when it carries none.
+     *
+     * <p>Unlike the v1/REST path (see extractAuthorizerContext), values are NOT flattened to
+     * strings: an HTTP API hands the context to the backend as JSON under
+     * requestContext.authorizer.lambda, so a nested object — the shape a verifier-style
+     * authorizer uses to pass claims down — survives intact. Anything that is not a JSON object
+     * is treated as absent, as AWS rejects those.
+     */
+    private ObjectNode requestAuthorizerContext(JsonNode response) {
+        JsonNode context = response.path("context");
+        return context.isObject() && !context.isEmpty() ? (ObjectNode) context : null;
     }
 
     /**
@@ -1952,8 +1977,9 @@ public class ApiGatewayExecuteController {
      * Compatible with REST API (v1) REQUEST authorizer shape.
      *
      * <p>Package-private so the shape can be asserted directly, the way {@code buildV2ProxyEvent}
-     * is: a REQUEST authorizer's context never reaches the v2 proxy event, so these fields are
-     * not observable end to end.
+     * is. The context an authorizer returns does now reach the v2 proxy event, so these fields
+     * are observable end to end by round-tripping them through an echo authorizer's context -
+     * asserting the built event directly stays the clearer test.
      */
     String buildRequestAuthorizerEventV1(String httpMethod, String path,
                                          String apiId, String stageName, String region,
@@ -2203,15 +2229,26 @@ public class ApiGatewayExecuteController {
     // jwtClaims is non-null only when the route's authorizer is JWT-type and verification
     // succeeded (see dispatchV2/enforceJwtAuthorizer) - null means either no authorizer on this
     // route (Auth: NONE) or a CUSTOM/REQUEST authorizer. jwtScopes is non-null only when that
-    // route additionally carries authorizationScopes (see JwtAuthorizerResult). Unlike the
-    // v1/REST CUSTOM-authorizer path (buildV1ProxyEvent's principalId/context handling), a v2
-    // CUSTOM/REQUEST authorizer's response context is not currently threaded into
-    // requestContext.authorizer here at all.
+    // route additionally carries authorizationScopes (see JwtAuthorizerResult).
     String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
                                      String apiId, String region, String stageName,
                                      HttpHeaders headers, UriInfo uriInfo,
                                      byte[] body, String requestId, Map<String, String> jwtClaims,
                                      List<String> jwtScopes) {
+        return buildV2ProxyEvent(httpMethod, path, routeKey, apiId, region, stageName,
+                headers, uriInfo, body, requestId, jwtClaims, jwtScopes, null);
+    }
+
+    // lambdaAuthorizerContext is the context a CUSTOM/REQUEST authorizer returned (see
+    // enforceRequestAuthorizerV2) and is mutually exclusive with jwtClaims - a route carries one
+    // authorizer, not both. Previously it was discarded rather than reaching here, so a backend
+    // behind a Lambda authorizer saw no requestContext.authorizer at all; the v1/REST path has
+    // threaded its equivalent through buildProxyEvent's principalId/context since before this.
+    String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
+                                     String apiId, String region, String stageName,
+                                     HttpHeaders headers, UriInfo uriInfo,
+                                     byte[] body, String requestId, Map<String, String> jwtClaims,
+                                     List<String> jwtScopes, ObjectNode lambdaAuthorizerContext) {
         // The JAX-RS {proxy} binding strips a trailing slash, but rawPath is by contract the
         // raw path and routers treat /x and /x/ as distinct routes. Recover it from the raw
         // request URI for the event path fields. Route matching in dispatchV2 and the
@@ -2287,6 +2324,19 @@ public class ApiGatewayExecuteController {
                 ArrayNode scopesNode = jwtNode.putArray("scopes");
                 jwtScopes.forEach(scopesNode::add);
             }
+        } else if (lambdaAuthorizerContext != null) {
+            // AWS's HTTP API Lambda-authorizer shape: the authorizer's context object lands
+            // verbatim under requestContext.authorizer.lambda, nesting included (unlike a REST
+            // API, which flattens it to a string map under requestContext.authorizer).
+            // principalId is deliberately not surfaced here: a policy-document response's
+            // principalId reaches $context.authorizer.principalId for access logging and
+            // parameter mapping, and where AWS places it in the 2.0 proxy event (if anywhere)
+            // was not measured, so inventing a field is worse than omitting one.
+            //
+            // An authorizer that allows with no context leaves the authorizer node absent
+            // entirely rather than rendering "lambda": null - also unmeasured, and absent and
+            // null read identically to a backend that navigates the event defensively.
+            ctx.putObject("authorizer").set("lambda", lambdaAuthorizerContext);
         }
 
         if (body != null && body.length > 0) {

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1483,7 +1483,9 @@ public class ApiGatewayExecuteController {
         if ("CUSTOM".equalsIgnoreCase(route.getAuthorizationType()) && route.getAuthorizerId() != null) {
             RequestAuthorizerResult requestResult =
                     enforceRequestAuthorizerV2(region, apiId, stageName, route, httpMethod, path, headers, uriInfo);
-            if (requestResult.errorResponse() != null) return requestResult.errorResponse();
+            if (requestResult.errorResponse() != null) {
+                return requestResult.errorResponse();
+            }
             lambdaAuthorizerContext = requestResult.context();
         }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1790,18 +1790,14 @@ public class ApiGatewayExecuteController {
 
     // ──────────────────────────── HTTP API v2 Lambda REQUEST authorizer ────────────────────────────
 
-    // Mirrors JwtAuthorizerResult's shape (and the v1/REST AuthorizerResult's) for the same
-    // reason: a null errorResponse means "authorized, proceed", and context (when non-null) is
-    // the authorizer response's `context` object, which the caller threads through to
-    // buildV2ProxyEvent so requestContext.authorizer.lambda is populated for the backend.
+    // A null errorResponse means authorized, as in JwtAuthorizerResult.
     private record RequestAuthorizerResult(Response errorResponse, ObjectNode context) {}
 
     /**
      * Enforces a Lambda REQUEST authorizer on an HTTP API (v2) route.
      * Supports both payload format versions (1.0 and 2.0) and simple responses.
      *
-     * @return a result whose errorResponse is null if authorized, or carries the error Response
-     *         if denied/unauthorized
+     * @return a result whose errorResponse is null when authorized
      */
     private RequestAuthorizerResult enforceRequestAuthorizerV2(String region, String apiId, String stageName,
                                                 Route route, String httpMethod, String path,
@@ -1961,11 +1957,9 @@ public class ApiGatewayExecuteController {
     /**
      * The {@code context} an authorizer response carries, or null when it carries none.
      *
-     * <p>Unlike the v1/REST path (see extractAuthorizerContext), values are NOT flattened to
-     * strings: an HTTP API hands the context to the backend as JSON under
-     * requestContext.authorizer.lambda, so a nested object — the shape a verifier-style
-     * authorizer uses to pass claims down — survives intact. Anything that is not a JSON object
-     * is treated as absent, as AWS rejects those.
+     * <p>Values are not flattened to strings the way the v1/REST path flattens them
+     * (extractAuthorizerContext): an HTTP API delivers the context to the backend as JSON, so
+     * nested objects survive. A non-object context is treated as absent, as AWS rejects those.
      */
     private ObjectNode requestAuthorizerContext(JsonNode response) {
         JsonNode context = response.path("context");
@@ -1977,9 +1971,7 @@ public class ApiGatewayExecuteController {
      * Compatible with REST API (v1) REQUEST authorizer shape.
      *
      * <p>Package-private so the shape can be asserted directly, the way {@code buildV2ProxyEvent}
-     * is. The context an authorizer returns does now reach the v2 proxy event, so these fields
-     * are observable end to end by round-tripping them through an echo authorizer's context -
-     * asserting the built event directly stays the clearer test.
+     * is.
      */
     String buildRequestAuthorizerEventV1(String httpMethod, String path,
                                          String apiId, String stageName, String region,
@@ -2239,11 +2231,9 @@ public class ApiGatewayExecuteController {
                 headers, uriInfo, body, requestId, jwtClaims, jwtScopes, null);
     }
 
-    // lambdaAuthorizerContext is the context a CUSTOM/REQUEST authorizer returned (see
-    // enforceRequestAuthorizerV2) and is mutually exclusive with jwtClaims - a route carries one
-    // authorizer, not both. Previously it was discarded rather than reaching here, so a backend
-    // behind a Lambda authorizer saw no requestContext.authorizer at all; the v1/REST path has
-    // threaded its equivalent through buildProxyEvent's principalId/context since before this.
+    // lambdaAuthorizerContext is what a CUSTOM/REQUEST authorizer returned (see
+    // enforceRequestAuthorizerV2). It is mutually exclusive with jwtClaims: a route carries one
+    // authorizer, not both.
     String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
                                      String apiId, String region, String stageName,
                                      HttpHeaders headers, UriInfo uriInfo,
@@ -2325,17 +2315,12 @@ public class ApiGatewayExecuteController {
                 jwtScopes.forEach(scopesNode::add);
             }
         } else if (lambdaAuthorizerContext != null) {
-            // AWS's HTTP API Lambda-authorizer shape: the authorizer's context object lands
-            // verbatim under requestContext.authorizer.lambda, nesting included (unlike a REST
-            // API, which flattens it to a string map under requestContext.authorizer).
-            // principalId is deliberately not surfaced here: a policy-document response's
-            // principalId reaches $context.authorizer.principalId for access logging and
-            // parameter mapping, and where AWS places it in the 2.0 proxy event (if anywhere)
-            // was not measured, so inventing a field is worse than omitting one.
+            // AWS delivers the context verbatim under requestContext.authorizer.lambda, nesting
+            // included, unlike a REST API's flattened string map.
             //
-            // An authorizer that allows with no context leaves the authorizer node absent
-            // entirely rather than rendering "lambda": null - also unmeasured, and absent and
-            // null read identically to a backend that navigates the event defensively.
+            // Two omissions, both because the AWS behaviour could not be measured: principalId
+            // is not surfaced here, and a context-less allow leaves the authorizer node absent
+            // rather than rendering "lambda": null.
             ctx.putObject("authorizer").set("lambda", lambdaAuthorizerContext);
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventJwtClaimsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventJwtClaimsTest.java
@@ -117,7 +117,7 @@ class BuildV2ProxyEventJwtClaimsTest {
         JsonNode event = new ObjectMapper().readTree(json);
 
         assertFalse(event.get("requestContext").has("authorizer"),
-                "requestContext.authorizer must be absent for routes with no JWT authorizer claims (Auth: NONE or CUSTOM)");
+                "requestContext.authorizer must be absent for routes with no JWT claims and no Lambda authorizer context");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventLambdaAuthorizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventLambdaAuthorizerTest.java
@@ -1,0 +1,137 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that {@link ApiGatewayExecuteController#buildV2ProxyEvent} populates
+ * {@code requestContext.authorizer.lambda} for HTTP API (V2) routes behind a Lambda
+ * REQUEST authorizer - previously enforceRequestAuthorizerV2 parsed the authorizer's context
+ * only to decide allow/deny and then discarded it, so the backend saw no authorizer node at all.
+ *
+ * <p>The end-to-end path is covered by HttpApiRequestAuthorizerTest; these assertions pin the
+ * rendered shape without needing a Lambda container.
+ */
+class BuildV2ProxyEventLambdaAuthorizerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ApiGatewayExecuteController controller;
+    private HttpHeaders headers;
+    private UriInfo uriInfo;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+
+        headers = mock(HttpHeaders.class);
+        when(headers.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+        when(headers.getHeaderString("User-Agent")).thenReturn(null);
+
+        uriInfo = mock(UriInfo.class);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/v1/things"));
+
+        controller = new ApiGatewayExecuteController(
+                null, null, null,
+                regionResolver, MAPPER, null,
+                null, null, null, null, new ApiGatewayExecuteRouteContext(), null, null
+        );
+    }
+
+    @Test
+    void populatesAuthorizerLambdaContext() throws Exception {
+        ObjectNode context = MAPPER.createObjectNode();
+        context.put("userId", "user123");
+        context.put("role", "admin");
+
+        String json = controller.buildV2ProxyEvent(
+                "POST", "/v1/things", "$default",
+                "abc123", "us-east-2", "$default", headers, uriInfo, null, "req-1", null, null,
+                context);
+        JsonNode event = MAPPER.readTree(json);
+
+        JsonNode lambda = event.at("/requestContext/authorizer/lambda");
+        assertFalse(lambda.isMissingNode(), "requestContext.authorizer.lambda must be present");
+        assertEquals("user123", lambda.get("userId").asText());
+        assertEquals("admin", lambda.get("role").asText());
+        assertFalse(event.at("/requestContext/authorizer").has("jwt"),
+                "a Lambda authorizer must not render the JWT-authorizer node");
+    }
+
+    @Test
+    void keepsNestedObjectsAndScalarTypes() throws Exception {
+        // An HTTP API hands the context to the backend as JSON, unlike a REST API, which
+        // flattens it to a string map (see buildProxyEvent's authorizerContext handling). The
+        // developer guide's own simple-response example returns a string, a number, a boolean,
+        // an array and a map, so all five have to survive.
+        ObjectNode context = MAPPER.createObjectNode();
+        ObjectNode claims = context.putObject("jwt").putObject("claims");
+        claims.put("sub", "user-abc");
+        context.put("tenantId", "CONDO_1");
+        context.put("requestCount", 3);
+        context.put("active", true);
+        context.putArray("groups").add("admin").add("auditor");
+
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/v1/things", "$default",
+                "abc123", "us-east-2", "$default", headers, uriInfo, null, "req-2", null, null,
+                context);
+        JsonNode lambda = MAPPER.readTree(json).at("/requestContext/authorizer/lambda");
+
+        assertEquals("user-abc", lambda.at("/jwt/claims/sub").asText(),
+                "nested objects must survive rather than being stringified");
+        assertEquals("CONDO_1", lambda.get("tenantId").asText());
+        assertTrue(lambda.get("requestCount").isNumber(), "a number must stay a number");
+        assertTrue(lambda.get("active").isBoolean(), "a boolean must stay a boolean");
+        assertTrue(lambda.get("groups").isArray(), "an array must stay an array");
+        assertEquals("auditor", lambda.get("groups").get(1).asText());
+    }
+
+    @Test
+    void omitsAuthorizerNodeWhenNoContextWasReturned() throws Exception {
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/v1/things", "$default",
+                "abc123", "us-east-2", "$default", headers, uriInfo, null, "req-3", null, null,
+                null);
+        JsonNode event = MAPPER.readTree(json);
+
+        assertFalse(event.get("requestContext").has("authorizer"),
+                "an authorizer that allows without a context leaves the node absent");
+    }
+
+    @Test
+    void jwtClaimsWinOverLambdaContext() throws Exception {
+        // A route carries one authorizer, so dispatchV2 can never hand over both. Pinned so the
+        // event never grows two mutually exclusive authorizer nodes if that ever changes.
+        Map<String, String> claims = new LinkedHashMap<>();
+        claims.put("sub", "user_01ABC");
+        ObjectNode context = MAPPER.createObjectNode();
+        context.put("userId", "user123");
+
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/v1/things", "$default",
+                "abc123", "us-east-2", "$default", headers, uriInfo, null, "req-4", claims, null,
+                context);
+        JsonNode authorizer = MAPPER.readTree(json).at("/requestContext/authorizer");
+
+        assertEquals("user_01ABC", authorizer.at("/jwt/claims/sub").asText());
+        assertFalse(authorizer.has("lambda"), "the two authorizer shapes are mutually exclusive");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventLambdaAuthorizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventLambdaAuthorizerTest.java
@@ -20,9 +20,8 @@ import static org.mockito.Mockito.when;
 
 /**
  * Verifies that {@link ApiGatewayExecuteController#buildV2ProxyEvent} populates
- * {@code requestContext.authorizer.lambda} for HTTP API (V2) routes behind a Lambda
- * REQUEST authorizer - previously enforceRequestAuthorizerV2 parsed the authorizer's context
- * only to decide allow/deny and then discarded it, so the backend saw no authorizer node at all.
+ * {@code requestContext.authorizer.lambda} for HTTP API (V2) routes behind a Lambda REQUEST
+ * authorizer.
  *
  * <p>The end-to-end path is covered by HttpApiRequestAuthorizerTest; these assertions pin the
  * rendered shape without needing a Lambda container.
@@ -77,9 +76,7 @@ class BuildV2ProxyEventLambdaAuthorizerTest {
 
     @Test
     void keepsNestedObjectsAndScalarTypes() throws Exception {
-        // An HTTP API hands the context to the backend as JSON, unlike a REST API, which
-        // flattens it to a string map (see buildProxyEvent's authorizerContext handling). The
-        // developer guide's own simple-response example returns a string, a number, a boolean,
+        // The developer guide's simple-response example returns a string, a number, a boolean,
         // an array and a map, so all five have to survive.
         ObjectNode context = MAPPER.createObjectNode();
         ObjectNode claims = context.putObject("jwt").putObject("claims");
@@ -118,8 +115,8 @@ class BuildV2ProxyEventLambdaAuthorizerTest {
 
     @Test
     void jwtClaimsWinOverLambdaContext() throws Exception {
-        // A route carries one authorizer, so dispatchV2 can never hand over both. Pinned so the
-        // event never grows two mutually exclusive authorizer nodes if that ever changes.
+        // dispatchV2 can never hand over both; pinned so the event never grows two authorizer
+        // nodes if that changes.
         Map<String, String> claims = new LinkedHashMap<>();
         claims.put("sub", "user_01ABC");
         ObjectNode context = MAPPER.createObjectNode();

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/HttpApiRequestAuthorizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/HttpApiRequestAuthorizerTest.java
@@ -86,9 +86,8 @@ class HttpApiRequestAuthorizerTest {
     @Order(2)
     void setupLambdaFunctions() throws Exception {
         // Backend Lambda
-        // Echoes requestContext.authorizer back so the authorizer context the gateway
-        // delivers is assertable end to end. JSON.stringify drops the key entirely when the
-        // event carries no authorizer, which is what the contextless case asserts.
+        // Echoes requestContext.authorizer back. JSON.stringify drops the key entirely when the
+        // event carries none, which is what the contextless case asserts.
         createNodeLambda(BACKEND_FN, """
                 exports.handler = async (event) => ({
                     statusCode: 200,
@@ -143,9 +142,8 @@ class HttpApiRequestAuthorizerTest {
                 });
                 """);
 
-        // Simple-response authorizer whose context nests objects — the shape a verifier-style
-        // authorizer uses to hand verified claims to the backend. An HTTP API delivers it as
-        // JSON, so the nesting has to survive rather than being flattened to strings.
+        // Simple-response authorizer whose context nests objects — an HTTP API delivers the
+        // context as JSON, so the nesting has to survive.
         createNodeLambda(NESTED_CTX_FN, """
                 exports.handler = async (event) => ({
                     isAuthorized: true,
@@ -337,8 +335,7 @@ class HttpApiRequestAuthorizerTest {
 
     /**
      * The context an IAM-policy authorizer returns alongside its policy document reaches the
-     * backend under requestContext.authorizer.lambda. It used to be parsed for the Effect and
-     * then dropped, so a backend behind a Lambda authorizer saw no authorizer node at all.
+     * backend under requestContext.authorizer.lambda.
      */
     @Test
     @Order(15)
@@ -426,8 +423,7 @@ class HttpApiRequestAuthorizerTest {
 
     /**
      * An HTTP API delivers the authorizer context as JSON, so nested objects and non-string
-     * scalars survive to the backend — unlike a REST API, which flattens the context to a string
-     * map. A verifier-style authorizer passing claims down depends on this.
+     * scalars survive to the backend, unlike a REST API's flattened string map.
      */
     @Test
     @Order(46)
@@ -577,11 +573,8 @@ class HttpApiRequestAuthorizerTest {
                 .when().patch("/v2/apis/" + httpApiId + "/routes/" + routeId)
                 .then().statusCode(200);
 
-        // The echo authorizer allows the request and embeds the received event in its context.
-        // That context does reach the backend (see iamPolicyContextReachesBackend), but the
-        // event it describes is the one the AUTHORIZER received, so assert the shape by
-        // invoking the echo function directly with a realistic event instead of unwrapping it
-        // through two hops.
+        // The echo authorizer embeds the event it received in its context, so assert that shape
+        // by invoking the echo function directly rather than unwrapping it through two hops.
         String response = given()
                 .header("X-Custom-Header", "test-value")
                 .queryParam("foo", "bar")

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/HttpApiRequestAuthorizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/HttpApiRequestAuthorizerTest.java
@@ -43,6 +43,8 @@ class HttpApiRequestAuthorizerTest {
     private static String identitySourceAuthorizerId;
     private static String echoV1AuthorizerId;
     private static String echoV2AuthorizerId;
+    private static String nestedContextAuthorizerId;
+    private static String contextlessAuthorizerId;
 
     private static final String ALLOW_FN = "httpv2-auth-allow-fn";
     private static final String DENY_FN = "httpv2-auth-deny-fn";
@@ -51,6 +53,8 @@ class HttpApiRequestAuthorizerTest {
     private static final String SIMPLE_DENY_FN = "httpv2-auth-simple-deny-fn";
     private static final String ECHO_FN = "httpv2-auth-echo-fn";
     private static final String BACKEND_FN = "httpv2-auth-backend-fn";
+    private static final String NESTED_CTX_FN = "httpv2-auth-nested-ctx-fn";
+    private static final String CONTEXTLESS_FN = "httpv2-auth-contextless-fn";
 
     // ──────────────────────────── Setup ────────────────────────────
 
@@ -82,10 +86,17 @@ class HttpApiRequestAuthorizerTest {
     @Order(2)
     void setupLambdaFunctions() throws Exception {
         // Backend Lambda
+        // Echoes requestContext.authorizer back so the authorizer context the gateway
+        // delivers is assertable end to end. JSON.stringify drops the key entirely when the
+        // event carries no authorizer, which is what the contextless case asserts.
         createNodeLambda(BACKEND_FN, """
                 exports.handler = async (event) => ({
                     statusCode: 200,
-                    body: JSON.stringify({ message: "Hello from backend", path: event.rawPath })
+                    body: JSON.stringify({
+                        message: "Hello from backend",
+                        path: event.rawPath,
+                        authorizer: event.requestContext ? event.requestContext.authorizer : undefined
+                    })
                 });
                 """);
 
@@ -132,6 +143,28 @@ class HttpApiRequestAuthorizerTest {
                 });
                 """);
 
+        // Simple-response authorizer whose context nests objects — the shape a verifier-style
+        // authorizer uses to hand verified claims to the backend. An HTTP API delivers it as
+        // JSON, so the nesting has to survive rather than being flattened to strings.
+        createNodeLambda(NESTED_CTX_FN, """
+                exports.handler = async (event) => ({
+                    isAuthorized: true,
+                    context: {
+                        jwt: { claims: { sub: "user-abc", scope: "condo/read" } },
+                        tenantId: "CONDO_1",
+                        licenseTier: "PRO",
+                        requestCount: 3,
+                        active: true,
+                        groups: ["admin", "auditor"]
+                    }
+                });
+                """);
+
+        // Simple-response authorizer that allows without returning any context
+        createNodeLambda(CONTEXTLESS_FN, """
+                exports.handler = async (event) => ({ isAuthorized: true });
+                """);
+
         // Echo authorizer that returns the event payload in context
         createNodeLambda(ECHO_FN, """
                 exports.handler = async (event) => ({
@@ -148,7 +181,8 @@ class HttpApiRequestAuthorizerTest {
     @Test
     @Order(3)
     void prewarmLambdaFunctions() {
-        for (String fn : new String[]{BACKEND_FN, ALLOW_FN, DENY_FN, ERROR_FN, SIMPLE_ALLOW_FN, SIMPLE_DENY_FN, ECHO_FN}) {
+        for (String fn : new String[]{BACKEND_FN, ALLOW_FN, DENY_FN, ERROR_FN, SIMPLE_ALLOW_FN,
+                SIMPLE_DENY_FN, ECHO_FN, NESTED_CTX_FN, CONTEXTLESS_FN}) {
             given().contentType(ContentType.JSON).body("{}")
                     .when().post("/2015-03-31/functions/" + fn + "/invocations")
                     .then().statusCode(200);
@@ -242,6 +276,26 @@ class HttpApiRequestAuthorizerTest {
                 .then().statusCode(201)
                 .extract().path("authorizerId");
 
+        // Nested-context authorizer (format 2.0 with enableSimpleResponses)
+        nestedContextAuthorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"nested-ctx-auth","authorizerType":"REQUEST","authorizerPayloadFormatVersion":"2.0","enableSimpleResponses":true,"authorizerUri":"arn:aws:lambda:us-east-1:000000000000:function:%s/invocations"}
+                        """.formatted(NESTED_CTX_FN))
+                .when().post("/v2/apis/" + httpApiId + "/authorizers")
+                .then().statusCode(201)
+                .extract().path("authorizerId");
+
+        // Contextless simple-allow authorizer (format 2.0 with enableSimpleResponses)
+        contextlessAuthorizerId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"contextless-auth","authorizerType":"REQUEST","authorizerPayloadFormatVersion":"2.0","enableSimpleResponses":true,"authorizerUri":"arn:aws:lambda:us-east-1:000000000000:function:%s/invocations"}
+                        """.formatted(CONTEXTLESS_FN))
+                .when().post("/v2/apis/" + httpApiId + "/authorizers")
+                .then().statusCode(201)
+                .extract().path("authorizerId");
+
         // Echo authorizer (format 1.0)
         echoV1AuthorizerId = given()
                 .contentType(ContentType.JSON)
@@ -279,6 +333,25 @@ class HttpApiRequestAuthorizerTest {
         given()
                 .when().get("/execute-api/" + httpApiId + "/test/hello")
                 .then().statusCode(200);
+    }
+
+    /**
+     * The context an IAM-policy authorizer returns alongside its policy document reaches the
+     * backend under requestContext.authorizer.lambda. It used to be parsed for the Effect and
+     * then dropped, so a backend behind a Lambda authorizer saw no authorizer node at all.
+     */
+    @Test
+    @Order(15)
+    void iamPolicyContextReachesBackend() throws Exception {
+        // Route still carries allowAuthorizerId from the previous test.
+        String body = given()
+                .when().get("/execute-api/" + httpApiId + "/test/hello")
+                .then().statusCode(200)
+                .extract().asString();
+
+        JsonNode lambda = MAPPER.readTree(body).path("authorizer").path("lambda");
+        assertEquals("user123", lambda.path("userId").asText());
+        assertEquals("admin", lambda.path("role").asText());
     }
 
     // ──────────────────────────── Test: Deny with IAM policy (format 1.0) ────────────────────────────
@@ -333,6 +406,79 @@ class HttpApiRequestAuthorizerTest {
         given()
                 .when().get("/execute-api/" + httpApiId + "/test/hello")
                 .then().statusCode(200);
+    }
+
+    @Test
+    @Order(45)
+    void simpleResponseContextReachesBackend() throws Exception {
+        // Route still carries simpleAllowAuthorizerId from the previous test.
+        String body = given()
+                .when().get("/execute-api/" + httpApiId + "/test/hello")
+                .then().statusCode(200)
+                .extract().asString();
+
+        JsonNode lambda = MAPPER.readTree(body).path("authorizer").path("lambda");
+        assertEquals("simple-user", lambda.path("userId").asText());
+        assertEquals("premium", lambda.path("plan").asText());
+        assertTrue(MAPPER.readTree(body).path("authorizer").path("jwt").isMissingNode(),
+                "A Lambda authorizer must not render the JWT-authorizer node");
+    }
+
+    /**
+     * An HTTP API delivers the authorizer context as JSON, so nested objects and non-string
+     * scalars survive to the backend — unlike a REST API, which flattens the context to a string
+     * map. A verifier-style authorizer passing claims down depends on this.
+     */
+    @Test
+    @Order(46)
+    void nestedContextSurvivesToBackend() throws Exception {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"authorizationType":"CUSTOM","authorizerId":"%s"}
+                        """.formatted(nestedContextAuthorizerId))
+                .when().patch("/v2/apis/" + httpApiId + "/routes/" + routeId)
+                .then().statusCode(200);
+
+        String body = given()
+                .when().get("/execute-api/" + httpApiId + "/test/hello")
+                .then().statusCode(200)
+                .extract().asString();
+
+        JsonNode lambda = MAPPER.readTree(body).path("authorizer").path("lambda");
+        assertEquals("user-abc", lambda.path("jwt").path("claims").path("sub").asText(),
+                "Nested objects must not be flattened or stringified");
+        assertEquals("condo/read", lambda.path("jwt").path("claims").path("scope").asText());
+        assertEquals("CONDO_1", lambda.path("tenantId").asText());
+        assertEquals("PRO", lambda.path("licenseTier").asText());
+        assertTrue(lambda.path("requestCount").isNumber(), "A number must stay a number");
+        assertEquals(3, lambda.path("requestCount").asInt());
+        assertTrue(lambda.path("active").isBoolean(), "A boolean must stay a boolean");
+        assertTrue(lambda.path("groups").isArray(), "An array must stay an array");
+        assertEquals("auditor", lambda.path("groups").get(1).asText());
+    }
+
+    /** An authorizer that allows without returning a context leaves the authorizer node absent. */
+    @Test
+    @Order(47)
+    void contextlessAllowLeavesAuthorizerNodeAbsent() throws Exception {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"authorizationType":"CUSTOM","authorizerId":"%s"}
+                        """.formatted(contextlessAuthorizerId))
+                .when().patch("/v2/apis/" + httpApiId + "/routes/" + routeId)
+                .then().statusCode(200);
+
+        String body = given()
+                .when().get("/execute-api/" + httpApiId + "/test/hello")
+                .then().statusCode(200)
+                .extract().asString();
+
+        JsonNode response = MAPPER.readTree(body);
+        assertEquals("Hello from backend", response.path("message").asText());
+        assertTrue(response.path("authorizer").isMissingNode(),
+                "No context returned means no authorizer node on the proxy event");
     }
 
     // ──────────────────────────── Test: Simple response Deny (format 2.0) ────────────────────────────
@@ -432,9 +578,10 @@ class HttpApiRequestAuthorizerTest {
                 .then().statusCode(200);
 
         // The echo authorizer allows the request and embeds the received event in its context.
-        // The backend Lambda receives the proxy event which does NOT include authorizer context
-        // in the v2 proxy event format. So we verify the authorizer was invoked (200 response)
-        // and then invoke the echo function directly with a realistic event to verify format.
+        // That context does reach the backend (see iamPolicyContextReachesBackend), but the
+        // event it describes is the one the AUTHORIZER received, so assert the shape by
+        // invoking the echo function directly with a realistic event instead of unwrapping it
+        // through two hops.
         String response = given()
                 .header("X-Custom-Header", "test-value")
                 .queryParam("foo", "bar")
@@ -571,7 +718,8 @@ class HttpApiRequestAuthorizerTest {
     void cleanup() {
         if (routeId != null) given().when().delete("/v2/apis/" + httpApiId + "/routes/" + routeId);
         if (httpApiId != null) given().when().delete("/v2/apis/" + httpApiId);
-        for (String fn : new String[]{BACKEND_FN, ALLOW_FN, DENY_FN, ERROR_FN, SIMPLE_ALLOW_FN, SIMPLE_DENY_FN, ECHO_FN}) {
+        for (String fn : new String[]{BACKEND_FN, ALLOW_FN, DENY_FN, ERROR_FN, SIMPLE_ALLOW_FN,
+                SIMPLE_DENY_FN, ECHO_FN, NESTED_CTX_FN, CONTEXTLESS_FN}) {
             deleteFunction(fn);
         }
     }


### PR DESCRIPTION
## Summary

Floci invokes a Lambda REQUEST authorizer on an HTTP API route, but discards the `context` the authorizer returns. `enforceRequestAuthorizerV2` returns a bare `Response` (null meaning "allowed"), so there is nothing to carry the context to `buildV2ProxyEvent`, and the backend Lambda receives no `requestContext.authorizer` at all.

Real API Gateway delivers it under `requestContext.authorizer.lambda` — that is how an authorizer hands verified identity to the integration — so a backend that reads it sees an empty object and rejects requests the authorizer has just allowed.

This completes #1011 (issue #812), which added REQUEST authorizer invocation for HTTP APIs but wired only the allow/deny decision, and brings v2 in line with #581, which propagated the authorizer context on the v1/REST path. The WebSocket `$connect` path already does the same via `WebSocketProxyEventBuilder`, so HTTP APIs were the last of the three to drop it.

The gap had been written down as though it were AWS's format — an existing comment in `HttpApiRequestAuthorizerTest` read *"the backend Lambda receives the proxy event which does NOT include authorizer context in the v2 proxy event format"*, which is not true of AWS. Corrected here.

### What changed

- `enforceRequestAuthorizerV2` returns a `RequestAuthorizerResult` carrying the context — mirroring the `JwtAuthorizerResult` the JWT path already threads through — instead of a bare `Response`.
- `buildV2ProxyEvent` renders it as `requestContext.authorizer.lambda`.

Values are **not** flattened to strings the way the v1/REST path flattens its authorizer context: an HTTP API hands the context to the integration as JSON. The [developer guide's simple-response example](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html) returns a string, a number, a boolean, an array and a map, and all five now survive to the backend.

### Deliberate omissions

Both because I could not measure the real AWS behaviour — happy to change either if a maintainer knows the answer:

- `principalId` is not surfaced on the proxy event. A policy-document response's `principalId` reaches `$context.authorizer.principalId` for access logging and parameter mapping; where AWS places it in the 2.0 proxy event, if anywhere, I could not confirm.
- An authorizer that allows without returning a context leaves the `authorizer` node absent rather than rendering `"lambda": null`.

Not covered: `HTTP_PROXY` integrations behind a Lambda authorizer — `dispatchHttpProxyV2` still receives only JWT claims.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** a route with `authorizationType: CUSTOM` invoked its authorizer and honoured the allow/deny decision, but the integration Lambda received no `requestContext.authorizer` node, so every context value the authorizer returned was lost.

Verified against the documented payload-format-2.0 shapes in [Control access to HTTP APIs with AWS Lambda authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-lambda-authorizer.html), for both the simple-response and IAM-policy response formats.

Also exercised end to end outside the test suite, against a real 2529-line OpenAPI document (132 routes, 132 integrations, one REQUEST authorizer with `enableSimpleResponses` and `identitySource: $request.header.Authorization,$context.routeKey`): an authorized request now reaches the backend with the authorizer's nested context intact, a missing identity source still returns 401 without invoking the authorizer, and a denial still returns 403.

## Checklist

- [x] `./mvnw test` passes locally — 13952 tests, 0 failures, 0 errors, 12 skipped
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Tests: 4 cases added to `HttpApiRequestAuthorizerTest` (IAM-policy context, simple-response context, nesting and scalar types, context-less allow) and a new `BuildV2ProxyEventLambdaAuthorizerTest` (4 cases) pinning the rendered shape without needing a Lambda container.
