### PR TITLE
fix(firehose): use request region in delivery stream ARN

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseJsonHandler.java
@@ -67,7 +67,8 @@ public class FirehoseJsonHandler {
                 KinesisStreamSource source = request.has("KinesisStreamSourceConfiguration")
                         ? mapper.treeToValue(request.get("KinesisStreamSourceConfiguration"), KinesisStreamSource.class)
                         : null;
-                String arn = firehoseService.createDeliveryStream(name, s3, tags, deliveryStreamType, source);
+                String arn = firehoseService.createDeliveryStream(
+                        region, name, s3, tags, deliveryStreamType, source);
                 yield Response.ok(Map.of("DeliveryStreamARN", arn)).build();
             }
             case "UpdateDestination" -> {

--- a/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/firehose/FirehoseService.java
@@ -201,6 +201,13 @@ public class FirehoseService implements ResourceProvider {
 
     public String createDeliveryStream(String name, S3Destination s3Config, List<DeliveryStreamDescription.Tag> tags,
                                        String deliveryStreamType, KinesisStreamSource source) {
+        return createDeliveryStream(regionResolver.getDefaultRegion(), name, s3Config, tags, deliveryStreamType,
+                source);
+    }
+
+    public String createDeliveryStream(String region, String name, S3Destination s3Config,
+                                       List<DeliveryStreamDescription.Tag> tags, String deliveryStreamType,
+                                       KinesisStreamSource source) {
         if (name == null || name.isEmpty() || name.length() > 64 || !name.matches("[a-zA-Z0-9_.-]+")) {
             throw new AwsException("InvalidArgumentException",
                     "Delivery stream name must be between 1 and 64 characters and contain only letters, numbers, underscores, hyphens, or periods.", 400);
@@ -212,7 +219,8 @@ public class FirehoseService implements ResourceProvider {
         }
 
         validateBufferingHints(s3Config);
-        String arn = AwsArnUtils.Arn.of("firehose", regionResolver.getDefaultRegion(), regionResolver.getAccountId(), "deliverystream/" + name).toString();
+        String arn = AwsArnUtils.Arn.of("firehose", region, regionResolver.getAccountId(),
+                "deliverystream/" + name).toString();
         // CreateDeliveryStream's KinesisStreamSourceConfiguration carries only the ARN and
         // role -- DeliveryStartTimestamp exists only on the Description shape, which AWS
         // fills in at creation. Stamping it here, at creation time, is what makes the first

--- a/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/firehose/FirehoseIntegrationTest.java
@@ -19,6 +19,9 @@ class FirehoseIntegrationTest {
     private static final String KINESIS_SOURCE_STREAM_NAME = "kinesis-source-delivery-stream";
     private static final String KINESIS_STREAM_ARN = "arn:aws:kinesis:us-east-1:000000000000:stream/events";
     private static final String SOURCE_ROLE_ARN = "arn:aws:iam::000000000000:role/firehose-role";
+    private static final String EU_WEST_1_AUTH = "AWS4-HMAC-SHA256 "
+            + "Credential=test/20260829/eu-west-1/firehose/aws4_request, "
+            + "SignedHeaders=host;x-amz-date, Signature=test";
 
     @BeforeAll
     static void configureRestAssured() {
@@ -509,5 +512,34 @@ class FirehoseIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("InvalidArgumentException"));
+    }
+
+    @Test
+    @Order(17)
+    void deliveryStreamArnUsesRequestRegion() {
+        String streamName = "regional-delivery-stream";
+        String expectedArn = "arn:aws:firehose:eu-west-1:000000000000:deliverystream/" + streamName;
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("Authorization", EU_WEST_1_AUTH)
+            .header("X-Amz-Target", "Firehose_20150804.CreateDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + streamName + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeliveryStreamARN", equalTo(expectedArn));
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("Authorization", EU_WEST_1_AUTH)
+            .header("X-Amz-Target", "Firehose_20150804.DescribeDeliveryStream")
+            .body("{ \"DeliveryStreamName\": \"" + streamName + "\" }")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DeliveryStreamDescription.DeliveryStreamARN", equalTo(expectedArn));
     }
 }


### PR DESCRIPTION
## Summary

- build `DeliveryStreamARN` from the request signing region passed to the Firehose handler
- preserve the default-region overload for internal service callers
- verify both CreateDeliveryStream and DescribeDeliveryStream return the persisted regional ARN

## Testing

- `./mvnw test -Dtest=FirehoseIntegrationTest,FirehoseServiceTest` (50 tests passed)

Closes #2658