### PR TITLE
fix(apigateway): support underscores in v2 path parameters

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1678,7 +1678,8 @@ public class ApiGatewayExecuteController {
             new ConcurrentHashMap<>();
 
     /** Extracts parameter names from a route template; the pattern itself is constant. */
-    private static final Pattern ROUTE_PARAM_NAMES = Pattern.compile("\\{([a-zA-Z_]+)\\+?\\}");
+    private static final Pattern ROUTE_PARAM_NAMES =
+            Pattern.compile("\\{([a-zA-Z_][a-zA-Z0-9_]*)\\+?\\}");
 
     private static CompiledRouteTemplate compileRouteTemplate(String template) {
         List<String> parameterNames = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1661,27 +1661,41 @@ public class ApiGatewayExecuteController {
         if (parts.length != 2) return Map.of();
         String template = parts[1];
 
-        Pattern p = ROUTE_TEMPLATE_PATTERNS.computeIfAbsent(template, t -> {
-            String regex = t.replaceAll("\\{([a-zA-Z_]+)\\+\\}", "(?<$1>.+)")
-                            .replaceAll("\\{([a-zA-Z_]+)\\}", "(?<$1>[^/]+)");
-            return Pattern.compile("^" + regex + "$");
-        });
-        Matcher m = p.matcher(actualPath);
+        CompiledRouteTemplate compiled = ROUTE_TEMPLATE_PATTERNS.computeIfAbsent(
+                template, ApiGatewayExecuteController::compileRouteTemplate);
+        Matcher m = compiled.pattern().matcher(actualPath);
         if (!m.matches()) return Map.of();
 
         Map<String, String> result = new java.util.LinkedHashMap<>();
-        Matcher names = ROUTE_PARAM_NAMES.matcher(template);
-        while (names.find()) {
-            try { result.put(names.group(1), m.group(names.group(1))); } catch (Exception ignored) {}
+        for (int i = 0; i < compiled.parameterNames().size(); i++) {
+            result.put(compiled.parameterNames().get(i), m.group(i + 1));
         }
         return result;
     }
 
     /** Cache of compiled route-template patterns keyed by the raw template (e.g. {@code "/wallet/{proxy+}"}). */
-    private static final ConcurrentHashMap<String, Pattern> ROUTE_TEMPLATE_PATTERNS = new ConcurrentHashMap<>();
+    private static final ConcurrentHashMap<String, CompiledRouteTemplate> ROUTE_TEMPLATE_PATTERNS =
+            new ConcurrentHashMap<>();
 
     /** Extracts parameter names from a route template; the pattern itself is constant. */
     private static final Pattern ROUTE_PARAM_NAMES = Pattern.compile("\\{([a-zA-Z_]+)\\+?\\}");
+
+    private static CompiledRouteTemplate compileRouteTemplate(String template) {
+        List<String> parameterNames = new ArrayList<>();
+        StringBuilder regex = new StringBuilder("^");
+        Matcher parameters = ROUTE_PARAM_NAMES.matcher(template);
+        int literalStart = 0;
+        while (parameters.find()) {
+            regex.append(Pattern.quote(template.substring(literalStart, parameters.start())));
+            regex.append(parameters.group().endsWith("+}") ? "(.+)" : "([^/]+)");
+            parameterNames.add(parameters.group(1));
+            literalStart = parameters.end();
+        }
+        regex.append(Pattern.quote(template.substring(literalStart))).append('$');
+        return new CompiledRouteTemplate(Pattern.compile(regex.toString()), List.copyOf(parameterNames));
+    }
+
+    private record CompiledRouteTemplate(Pattern pattern, List<String> parameterNames) {}
 
     // Mirrors AuthorizerResult's shape (used by the v1/REST CUSTOM-authorizer path) for the same
     // reason: a null errorResponse means "authorized, proceed", and claims (when non-null) is what

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -70,6 +70,13 @@ class ApiGatewayExecuteControllerTest {
     }
 
     @Test
+    void capturesNamedParamsContainingDigits() {
+        Map<String, String> p = ApiGatewayExecuteController.extractV2PathParams(
+                "GET /items/{item1}", "/items/value-1");
+        assertEquals("value-1", p.get("item1"));
+    }
+
+    @Test
     void capturesMixedGreedyAndNamedParams() {
         Map<String, String> p = ApiGatewayExecuteController.extractV2PathParams(
                 "ANY /users/{user}/files/{path+}", "/users/u-1/files/a/b/c");

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteControllerTest.java
@@ -61,6 +61,15 @@ class ApiGatewayExecuteControllerTest {
     }
 
     @Test
+    void capturesNamedParamsContainingUnderscores() {
+        Map<String, String> p = ApiGatewayExecuteController.extractV2PathParams(
+                "GET /api/v1/key-ids/{key_id}/jobs/{job_id}",
+                "/api/v1/key-ids/key-123/jobs/job-456");
+        assertEquals("key-123", p.get("key_id"));
+        assertEquals("job-456", p.get("job_id"));
+    }
+
+    @Test
     void capturesMixedGreedyAndNamedParams() {
         Map<String, String> p = ApiGatewayExecuteController.extractV2PathParams(
                 "ANY /users/{user}/files/{path+}", "/users/u-1/files/a/b/c");

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
@@ -72,10 +72,10 @@ class BuildV2ProxyEventPathParametersTest {
     void underscoredParamNameIsPreservedInPathParameters() throws Exception {
         when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/key-ids/key-42"));
         String json = controller.buildV2ProxyEvent(
-                "GET", "/key-ids/key-42", "GET /key-ids/{key_id}",
+                "GET", "/key-ids/key-42", "GET /key-ids/{key_id1}",
                 "abc123", "us-east-2", "$default", headers, uriInfo, null, "req-underscore");
         JsonNode event = new ObjectMapper().readTree(json);
-        assertEquals("key-42", event.get("pathParameters").get("key_id").asText());
+        assertEquals("key-42", event.get("pathParameters").get("key_id1").asText());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventPathParametersTest.java
@@ -69,6 +69,16 @@ class BuildV2ProxyEventPathParametersTest {
     }
 
     @Test
+    void underscoredParamNameIsPreservedInPathParameters() throws Exception {
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/key-ids/key-42"));
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/key-ids/key-42", "GET /key-ids/{key_id}",
+                "abc123", "us-east-2", "$default", headers, uriInfo, null, "req-underscore");
+        JsonNode event = new ObjectMapper().readTree(json);
+        assertEquals("key-42", event.get("pathParameters").get("key_id").asText());
+    }
+
+    @Test
     void defaultRouteOmitsPathParameters() throws Exception {
         when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/anything"));
         String json = controller.buildV2ProxyEvent(


### PR DESCRIPTION
## Summary

- compile HTTP API v2 route templates with indexed capture groups instead of Java named groups
- preserve original parameter names such as `key_id`, `job_id`, and `item1` in Lambda `pathParameters`
- quote literal route segments while retaining greedy `{proxy+}` matching
- align extraction with the parameter grammar used by integration URI templates

## Testing

- `./mvnw test -Dtest=ApiGatewayExecuteControllerTest,BuildV2ProxyEventPathParametersTest,BuildV2ProxyEventTrailingSlashTest` (32 tests passed)

Closes #2599