### PR TITLE
ci: give the nightly native builds a maven cache that can actually hit

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,8 +54,25 @@ jobs:
         with:
           java-version: '25'
           distribution: 'mandrel'
-          cache: maven
+          # no `cache: maven` — it could never hit here. Its restore hashes the
+          # pristine pom.xml, but its post-job save runs *after* `versions:set`
+          # below has rewritten that pom, so the two keys never match. Worse, the
+          # nightly version embeds the date, so the save key changed every night:
+          # 08-28 saved ...0d0497deb231, 08-29 saved ...476d856e99e8. Nightly was
+          # writing 222 MB per job per night under a key nothing would ever read.
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore-only, keyed identically to ci.yml so this reads the ~/.m2 that
+      # ci.yml's shard 1 saves on every push to main. This job checks out `ref:
+      # main`, so the pristine pom hashed here matches the one ci.yml hashed —
+      # and restoring before `versions:set` keeps it that way. Nothing is saved:
+      # ci.yml is the single writer, and a save here would recreate the mutated-
+      # key garbage described above.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Set nightly version
         run: mvn versions:set -DnewVersion="nightly-${{ needs.prepare.outputs.version }}" -DgenerateBackupPoms=false -q
@@ -89,8 +106,25 @@ jobs:
         with:
           java-version: '25'
           distribution: 'mandrel'
-          cache: maven
+          # no `cache: maven` — it could never hit here. Its restore hashes the
+          # pristine pom.xml, but its post-job save runs *after* `versions:set`
+          # below has rewritten that pom, so the two keys never match. Worse, the
+          # nightly version embeds the date, so the save key changed every night:
+          # 08-28 saved ...0d0497deb231, 08-29 saved ...476d856e99e8. Nightly was
+          # writing 222 MB per job per night under a key nothing would ever read.
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Restore-only, keyed identically to ci.yml so this reads the ~/.m2 that
+      # ci.yml's shard 1 saves on every push to main. This job checks out `ref:
+      # main`, so the pristine pom hashed here matches the one ci.yml hashed —
+      # and restoring before `versions:set` keeps it that way. Nothing is saved:
+      # ci.yml is the single writer, and a save here would recreate the mutated-
+      # key garbage described above.
+      - uses: actions/cache/restore@v6.1.0
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ runner.os }}-${{ hashFiles('pom.xml') }}
+          restore-keys: maven-${{ runner.os }}-
 
       - name: Set nightly version
         run: mvn versions:set -DnewVersion="nightly-${{ needs.prepare.outputs.version }}" -DgenerateBackupPoms=false -q


### PR DESCRIPTION
## Summary

Both nightly native-build jobs used `setup-graalvm`'s `cache: maven`, which **could never hit here**. Two compounding faults:

1. The restore hashes the pristine `pom.xml`, but the post-job save runs **after** `mvn versions:set` has rewritten that pom — so the restore key and the save key never match.
2. The nightly version embeds the date, so the save key changed every night regardless:

```
nightly 08-28 saved:  setup-graalvm-Linux-maven-0d0497deb231...
nightly 08-29 saved:  setup-graalvm-Linux-maven-476d856e99e8...
```

Both jobs logged `maven cache is not found` on **every** run sampled, while writing **222 MB per job per night** under a key nothing would ever read, and paying ~66s of cold dependency resolution each time.

## The fix

Drop `cache: maven`; restore `ci.yml`'s key explicitly instead.

Both jobs `checkout` with `ref: main`, so the pristine pom hashed here is the same one `ci.yml` hashed when it saved from a push to main — the keys match exactly. Placing the restore **before** `versions:set` is what keeps it that way.

**Restore-only.** `ci.yml` is the single writer, and saving here would recreate the mutated-key garbage. This composes with #2713, which just made `main` the sole producer of that key.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — CI workflow only (`ci:`), no runtime change

## AWS Compatibility

No wire-protocol impact. CI-only: no emulator source, request parsing, or response shape is touched.

## Checklist

- [x] `./mvnw test` passes locally — unaffected, no `src/` changes
- [ ] New or updated integration test added — **not applicable**, workflow-only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Verification

The next scheduled nightly should log `Cache restored from key: maven-Linux-…` in place of `maven cache is not found`, in both the amd64 and arm64 jobs, and should no longer create a `setup-graalvm-Linux-maven-*` entry at all.

Expect *most* of the ~66s per job rather than all of it: `-Dnative` pulls native-image plugins that `ci.yml`'s `mvn test` never fetches, and the arm64 job restores an x64-populated `~/.m2` (Maven artifacts are arch-neutral, so only classifier-based natives re-download).

## Context

Fifth instance of one root cause — caches whose producer and consumer keys don't line up. Previously: #2503 (`setup-java` save broken), #2634 (compat images, ref-scoped with no main producer), #2636 (`build-native`, same), #2713 (maven duplicated per-PR).

Deliberately **not** included: `release.yml` and `release-cut.yml` carry related defects (`release-cut` has the same mutated-pom problem via semantic-release; `release.yml`'s caches are tag-scoped so nothing reads them). Both run rarely and are release-critical infrastructure, so the fix value does not justify the risk. `build-images.yml` has two more `cache: maven` uses but has no callers and no run history.
