### PR TITLE
ci: stop the compat jobs writing per-PR image caches

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -38,8 +38,12 @@ jobs:
           build-args: VERSION=latest
           load: true
           tags: floci-compat-shim-test
+          # Read-only; warm-compat-caches.yml produces this scope on main. Unlike
+          # floci-native above, these layers are worth caching: the image builds
+          # FROM a published floci/floci tag and its cost is a microdnf install
+          # that changes only when the Dockerfile does. Writing from here would
+          # put a per-PR copy no other PR can read back into the budget.
           cache-from: type=gha,scope=compat-shim
-          cache-to: type=gha,scope=compat-shim,mode=max
 
       - name: Unflagged aws sqs call routes to AWS_ENDPOINT_URL
         run: |
@@ -133,8 +137,14 @@ jobs:
           file: docker/Dockerfile.native-package
           tags: floci:test-native
           outputs: type=docker,dest=/tmp/floci-native-image.tar
-          cache-from: type=gha,scope=floci-native
-          cache-to: type=gha,scope=floci-native,mode=max
+          # No layer cache here, deliberately. The `COPY native/$TARGETARCH/`
+          # below brings in a binary that changes every commit, and Docker layer
+          # reuse is sequential, so nothing after it can ever be reused. Measured:
+          # the build imported a cache manifest but reported **zero CACHED
+          # layers** — it was write-only. `mode=max` still stored the whole image
+          # including that volatile multi-hundred-MB binary layer, per PR ref,
+          # which was the largest single consumer of the repo's 10 GB budget.
+          # The step costs ~19-28s either way.
 
       - name: Compress native image
         run: gzip /tmp/floci-native-image.tar

--- a/.github/workflows/warm-compat-caches.yml
+++ b/.github/workflows/warm-compat-caches.yml
@@ -34,6 +34,9 @@ on:
       # (go.sum is gitignored, so filtering on it would match nothing.) Only 8
       # commits in 90 days touch this directory, so watching all of it is cheap.
       - 'compatibility-tests/sdk-test-go/**'
+      # compat-shim's inputs (see the `shim` job below)
+      - 'docker/Dockerfile.compat'
+      - 'bin/awslocal'
       # No *.tf entry: compat-terraform and compat-opentofu resolve nothing at
       # build time — `COPY . .` is their final layer, after the yum install and
       # bats clones — so .tf changes invalidate no cached work.
@@ -93,3 +96,31 @@ jobs:
           # No `load:` — the image itself is discarded; only the cache is wanted.
           cache-from: type=gha,scope=${{ matrix.test }}
           cache-to: type=gha,scope=${{ matrix.test }},mode=max
+
+  shim:
+    name: warm / compat-shim
+    # Produces the scope that compatibility.yml's compat-aws-cli-shim job reads.
+    # Worth warming, unlike floci-native: this image builds FROM a published
+    # floci/floci tag and its cost is a microdnf install of python3/pip/unzip that
+    # changes only when the Dockerfile does — genuinely stable layers, with nothing
+    # volatile above them.
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build and cache compat shim image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile.compat
+          # Must match the consumer's build-args, or the layers key differently
+          # and the warm is silently useless (compatibility.yml:38).
+          build-args: VERSION=latest
+          # No `load:` — the image is discarded; only the cache is wanted.
+          cache-from: type=gha,scope=compat-shim
+          cache-to: type=gha,scope=compat-shim,mode=max


### PR DESCRIPTION
## Summary

`compat-shim` and `floci-native` were the two buildx scopes still writing from `pull_request` runs after #2634, and they had become **the largest single consumer of the repo's 10 GB Actions cache budget**:

```
5.57 GB   compat-shim + floci-native   across 19 open PR refs
2.49 GB   main
```

Actions caches are ref-scoped, so none of that 5.57 GB was readable by any other PR. The repo went from 3.09 GB (after the #2634 purge) back to **10.68 GB within ~20 hours**, and this was the bulk of it.

The two scopes needed **different** fixes, which is why they are handled separately below rather than as one change.

## `floci-native` — cache removed entirely

The image `COPY`s a natively compiled binary that changes every commit. Docker layer reuse is sequential, so nothing after that `COPY` can ever be reused — only the `ubi9-minimal` base and a gosu download sit above it.

Measured on a real run, the build **imported a cache manifest and then reported zero `CACHED` layers**. It was write-only. Meanwhile `mode=max` stored the entire image *including* the volatile multi-hundred-MB binary layer, on every PR ref.

The step costs **~19–28s with or without the cache**, so nothing is lost.

## `compat-shim` — cache kept, production moved to main

This one is worth caching: it builds `FROM` a published `floci/floci` tag, and its cost is a `microdnf install` of python3/pip/unzip that changes only when the Dockerfile does. Genuinely stable layers, nothing volatile above them.

The defect was only that **no producer existed on `main`**, so a PR's first run could never hit — exactly what #2634 fixed for the eight test-image scopes. `warm-compat-caches.yml` gains a `shim` job mirroring the consumer's `context`, `file` and `build-args` (a mismatch there would key the layers differently and make the warm silently useless), and the consumer becomes read-only.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore — CI workflow only (`ci:`), no runtime change

## AWS Compatibility

No wire-protocol impact. CI-only: no emulator source, request parsing, or response shape is touched.

## Checklist

- [x] `./mvnw test` passes locally — unaffected, no `src/` changes
- [ ] New or updated integration test added — **not applicable**, workflow-only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Follow-up required after merge

As with #2634, this **stops the writes but does not reclaim what is already stored**. A one-off purge of the `refs/pull/*` entries is needed, or they will keep evicting the main-scoped caches:

```bash
gh api 'repos/floci-io/floci/actions/caches?per_page=100' --paginate \
  | grep -o 'refs/pull/[0-9]*/merge' | sort -u        # re-derive; it changes daily
gh cache delete --all --ref "refs/pull/<N>/merge" --succeed-on-no-caches
```

Note `gh api .../actions/cache/usage` lags deletions badly — trust a full paginated enumeration of `.../actions/caches` instead.

## Context

Completes the cache work started in #2634. Related: #2503, #2636, #2713, #2724 — all instances of one root cause, a cache whose producer and consumer keys don't line up.
