### PR TITLE
fix(rds): propagate ModifyDBCluster master-password rotations to the backend and every proxy

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1089,7 +1089,8 @@ public class RdsService implements Resettable, ResourceProvider {
             // holds) is known. Without it every later connection fails: the proxy dials the
             // backend with the rotated password against a database still holding the original.
             if (passwordRotated) {
-                containerManager.rotateMasterPassword(id, instance.getContainerId(),
+                containerManager.rotateMasterPassword(
+                        instance.getDockerVolumeName(), instance.getContainerId(),
                         instance.getEngine(), instance.getMasterUsername(), oldPassword, newPassword);
             }
             instance.setMasterPassword(newPassword);
@@ -1648,7 +1649,7 @@ public class RdsService implements Resettable, ResourceProvider {
         return modifyDbCluster(id, newPassword, iamEnabled, null, null, null, region);
     }
 
-    public DbCluster modifyDbCluster(String id, String newPassword, Boolean iamEnabled,
+    public synchronized DbCluster modifyDbCluster(String id, String newPassword, Boolean iamEnabled,
                                      Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
                                      Integer serverlessV2SecondsUntilAutoPause, String region) {
         String effectiveRegion = effectiveRegion(region);
@@ -1677,7 +1678,20 @@ public class RdsService implements Resettable, ResourceProvider {
             effectiveAutoPauseSeconds = validateServerlessV2ScalingConfiguration(
                     effectiveMinCapacity, effectiveMaxCapacity, requestedOrExistingAutoPause);
         }
+        boolean passwordRotated = false;
         if (newPassword != null && !newPassword.isBlank()) {
+            String oldPassword = cluster.getMasterPassword();
+            boolean backendRunning = !config.services().rds().mock()
+                    && cluster.getContainerId() != null;
+            passwordRotated = backendRunning && !newPassword.equals(oldPassword);
+            // Propagate the rotation into the running backend DB before overwriting the stored
+            // password — the last moment the old credential (which the backend still holds) is
+            // known — mirroring the ModifyDBInstance path.
+            if (passwordRotated) {
+                containerManager.rotateMasterPassword(
+                        cluster.getDockerVolumeName(), cluster.getContainerId(),
+                        cluster.getEngine(), cluster.getMasterUsername(), oldPassword, newPassword);
+            }
             cluster.setMasterPassword(newPassword);
         }
         if (iamEnabled != null) {
@@ -1689,6 +1703,27 @@ public class RdsService implements Resettable, ResourceProvider {
             cluster.setServerlessV2SecondsUntilAutoPause(effectiveAutoPauseSeconds);
         }
         putClusterForScope(currentAccountId(), effectiveRegion, id, cluster);
+
+        // A cluster rotation applies to every endpoint: the cluster's own proxy and each member
+        // instance's proxy hold start-time password snapshots, and member endpoints validate
+        // against the member's stored password, so propagate the rotated credential to all of
+        // them (AWS applies the cluster master password to every member endpoint).
+        if (passwordRotated) {
+            proxyManager.updateMasterPassword(
+                    rdsResourceRelayKey(cluster.getDbClusterArn(), id), newPassword);
+            for (String memberId : cluster.getDbClusterMembers()) {
+                DbInstance member = findInstanceForScope(
+                        currentAccountId(), effectiveRegion, memberId);
+                if (member == null) {
+                    continue;
+                }
+                member.setMasterPassword(newPassword);
+                putInstanceForScope(currentAccountId(), effectiveRegion, memberId, member);
+                proxyManager.updateMasterPassword(
+                        rdsResourceRelayKey(member.getDbInstanceArn(), memberId), newPassword);
+            }
+        }
+
         LOG.infov("DB cluster {0} modified", id);
         return cluster;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -408,16 +408,16 @@ public class RdsContainerManager {
     }
 
     /**
-     * Propagates a ModifyDBInstance master-password rotation into the running DB container, so
-     * the backend's stored credential matches what clients (and the auth proxy) use from now on.
-     * For MySQL/MariaDB this runs as the master user itself with the old password — changing your
-     * own password needs no extra privileges, and the container's root password is the
-     * creation-time one, not reliably known after earlier rotations. PostgreSQL's official image
-     * trusts local socket connections, so psql needs no password at all.
+     * Propagates a ModifyDBInstance/ModifyDBCluster master-password rotation into the running DB
+     * container, so the backend's stored credential matches what clients (and the auth proxy) use
+     * from now on. For MySQL/MariaDB this runs as the master user itself with the old password —
+     * changing your own password needs no extra privileges, and the container's root password is
+     * the creation-time one, not reliably known after earlier rotations. PostgreSQL's official
+     * image trusts local socket connections, so psql needs no password at all.
      */
-    public void rotateMasterPassword(String instanceId, String containerId, DatabaseEngine engine,
+    public void rotateMasterPassword(String containerName, String containerId, DatabaseEngine engine,
                                      String masterUsername, String oldPassword, String newPassword) {
-        execUntilSuccess(instanceId, containerId,
+        execUntilSuccess(containerName, containerId,
                 passwordRotationCommand(engine, masterUsername, oldPassword, newPassword),
                 "master-password rotation");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -747,12 +747,13 @@ class RdsServiceTest {
         instance.setContainerId("container-1");
         instance.setContainerHost("10.0.0.5");
         instance.setContainerPort(3306);
+        instance.setDockerVolumeName("volume-1");
 
         DbInstance modified = rdsService.modifyDbInstance("mydb", "rotated-password", null, null);
 
         assertEquals("rotated-password", modified.getMasterPassword());
         // The backend learns the new credential while the old one is still known...
-        verify(containerManager).rotateMasterPassword("mydb", "container-1",
+        verify(containerManager).rotateMasterPassword("volume-1", "container-1",
                 DatabaseEngine.MYSQL, "admin", "original-password", "rotated-password");
         // ...and the running proxy's password snapshot is swapped in place, without a restart
         // (a stop/start would race the listener rebind and drop live connections).
@@ -782,6 +783,59 @@ class RdsServiceTest {
                 20, false, null, null, null, null, false);
 
         DbInstance modified = rdsService.modifyDbInstance("mydb", "rotated-password", null, null);
+
+        assertEquals("rotated-password", modified.getMasterPassword());
+        verify(containerManager, never()).rotateMasterPassword(
+                anyString(), anyString(), any(), anyString(), anyString(), anyString());
+        verify(proxyManager, never()).updateMasterPassword(anyString(), anyString());
+    }
+
+    @Test
+    void modifyDbClusterPasswordRotationPropagatesToBackendAndEveryProxy() {
+        DbCluster cluster = rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "original-password", "dbname", false, null);
+        cluster.setContainerId("container-1");
+        cluster.setDockerVolumeName("volume-1");
+        DbInstance member = rdsService.createDbInstance("member-1", "aurora-postgresql", "16.3",
+                "admin", "original-password", "dbname", "db.r5.large",
+                20, false, null, null, "cluster1");
+
+        DbCluster modified = rdsService.modifyDbCluster("cluster1", "rotated-password", null);
+
+        assertEquals("rotated-password", modified.getMasterPassword());
+        // The backend learns the new credential while the old one is still known...
+        verify(containerManager).rotateMasterPassword("volume-1", "container-1",
+                DatabaseEngine.POSTGRES, "admin", "original-password", "rotated-password");
+        // ...and the cluster proxy AND every member endpoint's proxy swap their snapshots,
+        // with the member's stored password updated so its validator accepts the new one.
+        verify(proxyManager).updateMasterPassword(
+                eq("rds-resource:" + cluster.getDbClusterArn()), eq("rotated-password"));
+        verify(proxyManager).updateMasterPassword(
+                eq("rds-resource:" + member.getDbInstanceArn()), eq("rotated-password"));
+        assertEquals("rotated-password", member.getMasterPassword());
+        verify(proxyManager, never()).stopProxy(anyString());
+    }
+
+    @Test
+    void modifyDbClusterSamePasswordDoesNotTouchBackendOrProxy() {
+        DbCluster cluster = rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "original-password", "dbname", false, null);
+        cluster.setContainerId("container-1");
+
+        rdsService.modifyDbCluster("cluster1", "original-password", null);
+
+        verify(containerManager, never()).rotateMasterPassword(
+                anyString(), anyString(), any(), anyString(), anyString(), anyString());
+        verify(proxyManager, never()).updateMasterPassword(anyString(), anyString());
+    }
+
+    @Test
+    void modifyDbClusterPasswordRotationSkipsBackendInMockMode() {
+        when(config.services().rds().mock()).thenReturn(true);
+        rdsService.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "original-password", "dbname", false, null);
+
+        DbCluster modified = rdsService.modifyDbCluster("cluster1", "rotated-password", null);
 
         assertEquals("rotated-password", modified.getMasterPassword());
         verify(containerManager, never()).rotateMasterPassword(


### PR DESCRIPTION
## Summary

Follow-up to #2709, which fixed master-password rotation for standalone instances and disclosed that clusters have the same gap. `ModifyDBCluster --master-user-password` only updated Floci's stored state, leaving three layers stale:

1. The backend DB container keeps the original credential.
2. The cluster endpoint's auth proxy holds a start-time password snapshot.
3. Every member endpoint's auth proxy holds its own start-time snapshot, and member instances validate against the member's stored password.

So after a cluster rotation no endpoint accepted the new password. The fix reuses the #2709 mechanism at rotation time, while the old credential is still known:

- **Backend:** exec the password change into the cluster's container (`SET PASSWORD` as the master user for MySQL/MariaDB, `ALTER ROLE` over the trusted socket for PostgreSQL).
- **Proxies:** swap the password snapshot in place on the cluster proxy AND on each member instance's proxy, updating the members' stored passwords to match. AWS applies the cluster master password to every member endpoint, and the in-place swap keeps live connections open (rotation causes no outage).

`modifyDbCluster` is now `synchronized` like `modifyDbInstance` and `deleteDbCluster`, protecting the read-old-credential-then-exec window. Mock mode and clusters without a running container are unaffected.

Also addresses the #2709 review note: `rotateMasterPassword` now receives the Docker container name (not the instance id) for `execUntilSuccess` log lines, matching the other call sites.

Note: current `main` fails `testCompile` on an unrelated cross-PR conflict (#2703 + #2688); fix in #2726. This PR's CI needs that to land first.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: on real Aurora, `ModifyDBCluster --master-user-password` makes the new password usable on the cluster endpoint and every instance endpoint, without an outage. On Floci the rotated password never became usable anywhere:

```
$ aws rds modify-db-cluster --db-cluster-identifier mycluster --master-user-password new... --apply-immediately
$ psql "postgresql://admin:<new>@<cluster-endpoint>/db"
FATAL:  password authentication failed for user "admin"
```

Verified against a JVM build with a real backend container (aurora-postgresql cluster + one member instance, postgres:16), all through the auth proxies:

| Endpoint | rotate → new password | old password | connection open across the rotation |
|---|---|---|---|
| cluster (writer) | works (failed before) | rejected | stays connected |
| member instance | works (failed before) | rejected | n/a |

One observed difference in error shape: a member created without `MasterUsername` gets the "root" default, so connections as the cluster's master user take the member proxy's non-master path (backend is the authority) and the old password fails with `Backend database authentication failed` instead of the proxy-side `password authentication failed`. Members created with the master username engage the validator/snapshot paths this PR updates.

## Checklist

- [x] `./mvnw test` passes locally (`RdsServiceTest` 252, `RdsContainerManagerTest` 30, `RdsProxyManagerTest` 9)
- [x] New or updated integration test added: `modifyDbClusterPasswordRotationPropagatesToBackendAndEveryProxy` (backend exec with old+new credentials, snapshot swap on the cluster proxy and the member proxy, member stored password updated, no proxy restart), plus same-password and mock-mode no-op tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
