### PR TITLE
perf(cloudformation): probe Lambda S3 code with headObject, not getObject

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -2502,8 +2502,16 @@ public class CloudFormationResourceProvisioner {
                 // deliberately leaves its Lambda packages unbuilt and only cares about the
                 // other resources. Off by default: silently serving a placeholder is the more
                 // dangerous of the two behaviours.
+                //
+                // headObject, not getObject: this only needs to know whether the code is
+                // readable. getObject additionally reads the whole body, which is then thrown
+                // away, and LambdaService reads it again for real during CreateFunction. That
+                // is a second full copy of the package per Lambda per stack operation, for a
+                // question a metadata lookup answers (issue #2675). Both resolve the object
+                // through the same getObjectMetadata call, so a missing key or bucket still
+                // fails here exactly as before.
                 try {
-                    s3Service.getObject(s3Bucket, s3Key);
+                    s3Service.headObject(s3Bucket, s3Key);
                     return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key),
                             "s3:" + s3Bucket + "\n" + s3Key);
                 } catch (Exception e) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaS3CodeProbeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLambdaS3CodeProbeTest.java
@@ -1,0 +1,125 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Issue #2675: resolving an AWS::Lambda::Function whose Code points at S3 checked the object by
+ * calling getObject and discarding the result, so the package was read in full twice per stack
+ * operation, once here and once by LambdaService during CreateFunction. The check only needs to
+ * know whether the object is readable, which headObject answers without reading the body.
+ *
+ * <p>Uses the mocked-service provisioner approach of CloudFormationLambdaLegacyNameModeTest,
+ * because how many times a service is called is not observable through the HTTP integration tests.
+ */
+class CloudFormationLambdaS3CodeProbeTest {
+
+    private static final String ACCOUNT_ID = "000000000000";
+    private static final String REGION = "us-east-1";
+    private static final String STACK_NAME = "test-stack";
+    private static final String BUCKET = "pkg";
+    private static final String KEY = "fn.zip";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private S3Service s3Service;
+    private LambdaService lambdaService;
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        s3Service = mock(S3Service.class);
+        lambdaService = mock(LambdaService.class);
+        when(lambdaService.createFunction(anyString(), anyMap()))
+                .thenAnswer(inv -> lambdaFunction((String) ((Map<?, ?>) inv.getArgument(1)).get("FunctionName")));
+        // Built through the fixture rather than by positional nulls: AWS::Lambda::Function is
+        // still served by the provisioner's own switch, so an empty registry is correct here.
+        provisioner = CfnProvisionerFixture.builder()
+                .s3(s3Service)
+                .lambda(lambdaService)
+                .objectMapper(mapper)
+                .build();
+    }
+
+    @Test
+    void theCodeProbeReadsMetadataOnlyAndNeverTheBody() {
+        when(s3Service.headObject(BUCKET, KEY)).thenReturn(new S3Object());
+
+        StackResource result = provision();
+
+        assertEquals("CREATE_COMPLETE", result.getStatus());
+        verify(s3Service).headObject(BUCKET, KEY);
+        // The body is LambdaService's to read during CreateFunction. Reading it here too is a
+        // second full copy of the package per Lambda per stack operation.
+        verify(s3Service, never()).getObject(anyString(), anyString());
+        verify(s3Service, never()).getObject(anyString(), anyString(), any());
+    }
+
+    @Test
+    void anUnreadableObjectStillFailsTheResource() {
+        // The probe changed from getObject to headObject, but both resolve the object through the
+        // same metadata lookup, so the failure behaviour established in #2648 must be unchanged.
+        when(s3Service.headObject(BUCKET, KEY))
+                .thenThrow(new AwsException("NoSuchKey", "The specified key does not exist.", 404));
+
+        StackResource result = provision();
+
+        assertEquals("CREATE_FAILED", result.getStatus());
+        verify(lambdaService, never()).createFunction(anyString(), anyMap());
+    }
+
+    private StackResource provision() {
+        String props = """
+                {
+                  "FunctionName": "probe-fn",
+                  "Runtime": "nodejs20.x",
+                  "Handler": "index.handler",
+                  "Role": "arn:aws:iam::000000000000:role/r",
+                  "Code": {"S3Bucket": "%s", "S3Key": "%s"}
+                }
+                """.formatted(BUCKET, KEY);
+        return provisioner.provision("Function", "AWS::Lambda::Function", props(props), engine(),
+                REGION, ACCOUNT_ID, STACK_NAME, null, Map.of());
+    }
+
+    private CloudFormationTemplateEngine engine() {
+        return new CloudFormationTemplateEngine(
+                ACCOUNT_ID, REGION, STACK_NAME, "stack/id",
+                Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), mapper,
+                (Function<String, String>) name -> null);
+    }
+
+    private JsonNode props(String json) {
+        try {
+            return mapper.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static LambdaFunction lambdaFunction(String name) {
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName(name);
+        fn.setFunctionArn("arn:aws:lambda:" + REGION + ":" + ACCOUNT_ID + ":function:" + name);
+        return fn;
+    }
+}


### PR DESCRIPTION
## ⚠️ CI on this PR will fail for a reason unrelated to the change

`main` does not currently compile its test sources, and has not since `08e532ab`. Every branch cut
from it inherits that, so the shards here die before running anything:

```
AslExecutorTaskHistoryEventsTest.java:[64,20]
  constructor AslExecutor cannot be applied to given types
  reason: actual and formal argument lists differ in length
```

That is a semantic merge conflict between #2688, which added a `CustomResourceLiveness` constructor
parameter, and #2703, which added a test constructing `AslExecutor` directly. I have opened a
separate one line PR to restore compilation; once that merges this branch will go green on a rebase.
Nothing here touches Step Functions.

I verified this change locally by applying that one line fix uncommitted, purely so the module would
build. Full suite on this branch with that in place:
`Tests run: 14235, Failures: 0, Errors: 0, Skipped: 9`.

---

## Summary

Closes #2675.

Resolving an `AWS::Lambda::Function` whose `Code` points at S3 checked the object by calling
`getObject` and throwing the result away. `S3Object.getData()` is a materialised byte array, so that
read the whole package into memory only to answer whether it was readable, and `LambdaService` then
read the same object again for real during `CreateFunction`. Every stack create or update paid for
two full copies of every Lambda package in the template.

## Root cause

The probe asked an existence question with a method that also fetches the body:

```java
try {
    s3Service.getObject(s3Bucket, s3Key);          // result discarded
    return new LambdaCodeSpec(Map.of("S3Bucket", s3Bucket, "S3Key", s3Key), ...);
} catch (Exception e) {
    ...
}
```

and `LambdaService.extractZipCodeFromS3` then does the real read:

```java
obj = s3Service.getObject(s3Bucket, s3Key);
extractZipCodeBytes(fn, obj.getData(), region);
```

## What changed and why this approach

One call:

```java
- s3Service.getObject(s3Bucket, s3Key);
+ s3Service.headObject(s3Bucket, s3Key);
```

This is safe because of how `S3Service` is layered. `getObject` is `getObjectMetadata` plus
`readFile`; `headObject` is `getObjectMetadata` alone. Both resolve the object through the same
metadata lookup, so a missing key or bucket still throws at the same point and the resource still
fails exactly as #2648 established. Only the discarded body read goes away.

The issue also offered a second option, threading the fetched bytes through `LambdaCodeSpec` so the
object is read once end to end. I did not take it: it removes the second read as well, but it puts
the package payload into a structure that currently carries only a request map and an identity
string, and it couples the provisioner's data flow to `LambdaService`'s. The metadata probe removes
the duplicated read while leaving that layering alone. Happy to switch if maintainers prefer the
other shape.

## AWS Compatibility

No wire behaviour change. A template whose `Code` is unreadable still fails the resource with the
same error, and the `allow-stub-lambda-code` opt in from #2650 still works the same way.

## How it was tested

New `CloudFormationLambdaS3CodeProbeTest`, using the mocked service provisioner approach of
`CloudFormationLambdaLegacyNameModeTest`, because call counts are not observable through the HTTP
integration tests:

| Test | Covers |
|---|---|
| `theCodeProbeReadsMetadataOnlyAndNeverTheBody` | `headObject` is called and `getObject` never is |
| `anUnreadableObjectStillFailsTheResource` | the #2648 failure behaviour is unchanged |

Reverting only the probe makes both fail, so they are real regression tests:

```
anUnreadableObjectStillFailsTheResource:89  expected: <CREATE_FAILED> but was: <CREATE_COMPLETE>
theCodeProbeReadsMetadataOnlyAndNeverTheBody:73
```

## Risk / rollback

Low. One call in one method, no signature or config change, no persisted state. Rollback is
reverting the single line.

One behavioural nuance worth stating rather than leaving to be discovered: if an object's metadata
exists but its backing file cannot be read, `getObject` used to surface that here, and now it
surfaces from `LambdaService` as `Unable to fetch code from s3://...`. The stack still fails either
way, and the message from the layer that actually does the read is the more accurate of the two.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
