### PR TITLE
test(stepfunctions): restore AslExecutorTaskHistoryEventsTest compilation

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -77,7 +77,8 @@ class AslExecutorTaskHistoryEventsTest {
                 mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
                 objectMapper,
                 new JsonataEvaluator(objectMapper),
-                mock(Instance.class), mock(EmulatorConfig.class), vertx);
+                mock(Instance.class), mock(EmulatorConfig.class), vertx,
+                mock(io.github.hectorvent.floci.core.common.CustomResourceLiveness.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`main` does not compile its test sources, and has not since `08e532ab` landed. This adds the one
missing constructor argument.

```
AslExecutorTaskHistoryEventsTest.java:[64,20]
  constructor AslExecutor in class AslExecutor cannot be applied to given types;
  required: ..., io.vertx.mutiny.core.Vertx, io.github.hectorvent.floci.core.common.CustomResourceLiveness
  found:    ..., io.vertx.mutiny.core.Vertx
  reason: actual and formal argument lists differ in length
```

## Root cause

A semantic merge conflict between two changes that were each green on their own branch.

`08e532ab` (#2688) added a `CustomResourceLiveness` parameter to the `AslExecutor` constructor and
updated the call sites that existed at the time. `5600d21f` (#2703) added
`AslExecutorTaskHistoryEventsTest`, which constructs `AslExecutor` directly. Neither branch touched
the other's file, so neither PR could see the conflict, and merging them in sequence broke the
build.

## What changed

The test now passes the same mock its siblings already do. `AslExecutorErrorTerminationTest` and
`AslExecutorCustomResourceLivenessTest` construct `AslExecutor` this way already, so this brings the
new test in line rather than inventing anything:

```java
mock(Instance.class), mock(EmulatorConfig.class), vertx,
mock(io.github.hectorvent.floci.core.common.CustomResourceLiveness.class));
```

## Why the tracker looks green

Worth flagging, because the breakage is easy to miss from the PR list. Open PRs whose checks ran
before `08e532ab` merged still display green: GitHub does not re-run a PR's checks when the base
branch advances. For example #2723's checks completed at 16:52 UTC, while the breaking commit merged
at 19:01 UTC. Anything opened or pushed after that point fails, and `main`'s own CI has been failing
for three commits.

## How it was tested

`./mvnw clean test-compile` fails on `main` at `8a705d0a` and succeeds with this change.
`AslExecutorTaskHistoryEventsTest` then runs and passes.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

No new test: this restores compilation of an existing one. The suite could not run at all before it.
