### PR TITLE
fix(stepfunctions): pass CustomResourceLiveness to AslExecutor in task-history test

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -77,7 +77,8 @@ class AslExecutorTaskHistoryEventsTest {
                 mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
                 objectMapper,
                 new JsonataEvaluator(objectMapper),
-                mock(Instance.class), mock(EmulatorConfig.class), vertx);
+                mock(Instance.class), mock(EmulatorConfig.class), vertx,
+                mock(io.github.hectorvent.floci.core.common.CustomResourceLiveness.class));
     }
 
     @Test


### PR DESCRIPTION
Test compilation has been failing on `main` since `08e532ab`, so every CI run on the branch (and on any PR opened against it) fails before a single test executes.

## Cause

Two PRs landed in sequence and conflicted semantically, not textually:

- #2703 (`5600d21f`) added `AslExecutorTaskHistoryEventsTest`, constructing `AslExecutor` with 18 arguments.
- #2688 (`08e532ab`) added a 19th constructor parameter, `CustomResourceLiveness`, and updated every call site it could see. Its branch predated #2703, so the new test file was never in its tree.

Each PR was green on its own; the breakage only exists in the merged result.

```
constructor AslExecutor in class AslExecutor cannot be applied to given types;
  required: ..., Instance<StepFunctionsService>, EmulatorConfig, Vertx, CustomResourceLiveness
  found:    ..., Instance, EmulatorConfig, Vertx
  reason: actual and formal argument lists differ in length
```

## Fix

Passes the missing mock, matching how the sibling `AslExecutorErrorTerminationTest` already supplies it.

## Verification

`./mvnw test-compile` succeeds again, and `-Dtest='AslExecutor*'` runs **105 tests, 0 failures** — including the 5 in this file that could not run at all before.

---

**Unrelated pre-existing failure:** `native / sdk-test-java` fails here, but it fails the same way on `main` itself (e.g. run `33255141648`): the `floci-native-image` artifact download reports `digest-mismatch`, so the emulator never starts and every SDK call hits `Connection refused` on `localhost:4566`. That is independent of this one-line test change, which does not affect the native image.
