### PR TITLE
fix(ec2): honour documented Describe* filters and stop ENIs inheriting instance tags

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -615,17 +615,25 @@ public class Ec2QueryHandler {
 
         String iamInstanceProfileArn = resolveIamInstanceProfileArn(p);
 
-        // Parse TagSpecifications
+        // Parse TagSpecifications. AWS applies each specification to exactly the resource
+        // type it names, so the interfaces RunInstances creates are tagged only by a
+        // ResourceType=network-interface specification - never by the instance's own tags.
         List<Tag> instanceTags = new ArrayList<>();
+        List<Tag> networkInterfaceTags = new ArrayList<>();
         for (int i = 1; ; i++) {
             String resType = p.getFirst("TagSpecification." + i + ".ResourceType");
             if (resType == null) break;
-            if ("instance".equals(resType)) {
+            List<Tag> target = switch (resType) {
+                case "instance" -> instanceTags;
+                case "network-interface" -> networkInterfaceTags;
+                default -> null;
+            };
+            if (target != null) {
                 for (int j = 1; ; j++) {
                     String k = p.getFirst("TagSpecification." + i + ".Tag." + j + ".Key");
                     if (k == null) break;
                     String v = p.getFirst("TagSpecification." + i + ".Tag." + j + ".Value");
-                    instanceTags.add(new Tag(k, v));
+                    target.add(new Tag(k, v));
                 }
             }
         }
@@ -652,6 +660,16 @@ public class Ec2QueryHandler {
         Reservation res = service.runInstances(region, imageId, instanceType, minCount, maxCount,
                 keyName, sgIds, subnetId, clientToken, instanceTags, userData, iamInstanceProfileArn,
                 associatePublicIp);
+
+        if (!networkInterfaceTags.isEmpty()) {
+            List<String> eniIds = new ArrayList<>();
+            for (Instance inst : res.getInstances()) {
+                inst.getNetworkInterfaces().forEach(eni -> eniIds.add(eni.getNetworkInterfaceId()));
+            }
+            if (!eniIds.isEmpty()) {
+                service.createTags(region, eniIds, networkInterfaceTags);
+            }
+        }
 
         XmlBuilder xml = new XmlBuilder()
                 .start("RunInstancesResponse", AwsNamespaces.EC2)

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4417,6 +4417,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         if (resourceId.startsWith("sgr-")) {
             return "security-group-rule";
         }
+        if (resourceId.startsWith("eni-")) {
+            return "network-interface";
+        }
         if (resourceId.startsWith("sg-")) {
             return "security-group";
         }
@@ -4970,19 +4973,17 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
 
     public List<Address> describeAddresses(String region, List<String> allocationIds, Map<String, List<String>> filters) {
         ensureDefaultResources(region);
-        List<Address> matched = addresses.scan(k -> true).stream()
+        List<Address> candidates = addresses.scan(k -> true).stream()
                 .filter(a -> a.getRegion().equals(region))
                 .filter(a -> allocationIds.isEmpty() || allocationIds.contains(a.getAllocationId()))
-                // The filters parameter was previously accepted and never applied: every
-                // DescribeAddresses filter, including the generic tag: family that works
-                // against every other resource here, was a silent no-op.
-                .filter(a -> matchesFilters(a, filters, region))
                 .collect(Collectors.toList());
         // An EIP can be associated before its instance has a container, and Docker hands out a
         // different bridge IP after a stop/start, either of which would leave the association
-        // reporting an address that no longer answers. Re-resolve on read: this is the call
-        // Terraform refreshes public_ip from, so it is the last chance to be right.
-        for (Address addr : matched) {
+        // reporting an address that no longer answers. Re-resolve BEFORE filtering: a public-ip
+        // or association filter must be judged against the address the response will carry, not
+        // the one persisted before the restart. This is also the call Terraform refreshes
+        // public_ip from, so it is the last chance to be right.
+        for (Address addr : candidates) {
             if (addr.getInstanceId() != null) {
                 String before = addr.getPublicIp();
                 pointAddressAtInstance(addr, region, addr.getInstanceId());
@@ -4991,7 +4992,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 }
             }
         }
-        return matched;
+        // The filters parameter was previously accepted and never applied: every
+        // DescribeAddresses filter, including the generic tag: family that works
+        // against every other resource here, was a silent no-op.
+        return candidates.stream()
+                .filter(a -> matchesFilters(a, filters, region))
+                .collect(Collectors.toList());
     }
 
     // ─── Availability Zones & Regions ─────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4973,6 +4973,10 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         List<Address> matched = addresses.scan(k -> true).stream()
                 .filter(a -> a.getRegion().equals(region))
                 .filter(a -> allocationIds.isEmpty() || allocationIds.contains(a.getAllocationId()))
+                // The filters parameter was previously accepted and never applied: every
+                // DescribeAddresses filter, including the generic tag: family that works
+                // against every other resource here, was a silent no-op.
+                .filter(a -> matchesFilters(a, filters, region))
                 .collect(Collectors.toList());
         // An EIP can be associated before its instance has a container, and Docker hands out a
         // different bridge IP after a stop/start, either of which would leave the association
@@ -5153,7 +5157,11 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "vpc-id" -> matchesValue(values, vpc.getVpcId());
                 case "state" -> matchesValue(values, vpc.getState());
                 case "isDefault", "is-default" -> matchesValue(values, String.valueOf(vpc.isDefault()));
-                case "cidr" -> matchesValue(values, vpc.getCidrBlock());
+                // "cidr" is the documented filter name for a VPC's primary CIDR block; real EC2
+                // also accepts the undocumented alias "cidr-block" (confirmed against live AWS
+                // 2026-08-25: it matches only the primary block, not a secondary
+                // cidr-block-association entry).
+                case "cidr", "cidr-block" -> matchesValue(values, vpc.getCidrBlock());
                 default -> true;
             };
         }
@@ -5208,6 +5216,11 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "group-id" -> matchesValue(values, sg.getGroupId());
                 case "group-name" -> matchesValue(values, sg.getGroupName());
                 case "vpc-id" -> matchesValue(values, sg.getVpcId());
+                // "description" is a documented DescribeSecurityGroups filter matching the
+                // group's description exactly (wildcards allowed). Without this case the
+                // default arm silently matched every group regardless of value, which is
+                // indistinguishable from "no filter" for the caller.
+                case "description" -> matchesValue(values, sg.getDescription());
                 default -> true;
             };
         }
@@ -5220,6 +5233,10 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "subnet-id" -> matchesValue(values, inst.getSubnetId());
                 case "availabilityZone", "availability-zone" -> inst.getPlacement() != null
                         && matchesValue(values, inst.getPlacement().getAvailabilityZone());
+                // "image-id" is a documented DescribeInstances filter matching the AMI the
+                // instance was launched from; it previously fell through the default arm and
+                // matched every instance regardless of value.
+                case "image-id" -> matchesValue(values, inst.getImageId());
                 default -> true;
             };
         }
@@ -5265,7 +5282,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "vpc-endpoint-id" -> matchesValue(values, endpoint.getVpcEndpointId());
                 case "vpc-endpoint-type" -> matchesValue(values, endpoint.getVpcEndpointType());
                 case "vpc-id" -> matchesValue(values, endpoint.getVpcId());
-                case "state" -> matchesValue(values, endpoint.getState());
+                // AWS documents this filter as "vpc-endpoint-state", not "state" (see
+                // DescribeVpcEndpoints in the EC2 API reference). The old key was a silent
+                // rename: a caller sending the documented name fell through the default arm
+                // and got every endpoint back unfiltered. Renamed rather than aliased -
+                // there is no evidence real AWS accepts "state" here.
+                case "vpc-endpoint-state" -> matchesValue(values, endpoint.getState());
                 case "route-table-id" -> endpoint.getRouteTableIds().stream()
                         .anyMatch(routeTableId -> matchesValue(values, routeTableId));
                 case "subnet-id" -> endpoint.getSubnetIds().stream()
@@ -5290,6 +5312,19 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "volume-type" -> matchesValue(values, vol.getVolumeType());
                 case "availability-zone" -> matchesValue(values, vol.getAvailabilityZone());
                 case "encrypted" -> matchesValue(values, String.valueOf(vol.isEncrypted()));
+                // attachment.* was previously unhandled and fell through to the default arm,
+                // so DescribeVolumes --filters attachment.instance-id/attachment.device
+                // matched every volume in the region instead of the attached one; Volumes[0]
+                // then depended on iteration order, which reads as nondeterminism but is a
+                // plain missing-filter bug.
+                case "attachment.instance-id" -> vol.getAttachments().stream()
+                        .anyMatch(a -> matchesValue(values, a.getInstanceId()));
+                case "attachment.device" -> vol.getAttachments().stream()
+                        .anyMatch(a -> matchesValue(values, a.getDevice()));
+                case "attachment.status" -> vol.getAttachments().stream()
+                        .anyMatch(a -> matchesValue(values, a.getState()));
+                case "attachment.delete-on-termination" -> vol.getAttachments().stream()
+                        .anyMatch(a -> matchesValue(values, String.valueOf(a.isDeleteOnTermination())));
                 default -> true;
             };
         }
@@ -5311,6 +5346,26 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "owner-id" -> matchesValue(values, ni.getOwnerId());
                 case "mac-address" -> matchesValue(values, ni.getMacAddress());
                 case "private-dns-name" -> matchesValue(values, ni.getPrivateDnsName());
+                default -> true;
+            };
+        }
+        // These are the AWS-documented DescribeAddresses filters this store can back with
+        // real data; two documented filters (network-border-group,
+        // network-interface-owner-id) are omitted because Address has no such field and
+        // fabricating one would be its own wrong answer.
+        if (resource instanceof Address addr) {
+            return switch (filterName) {
+                case "allocation-id" -> matchesValue(values, addr.getAllocationId());
+                case "public-ip" -> matchesValue(values, addr.getPublicIp());
+                case "domain" -> matchesValue(values, addr.getDomain());
+                case "association-id" -> addr.getAssociationId() != null
+                        && matchesValue(values, addr.getAssociationId());
+                case "instance-id" -> addr.getInstanceId() != null
+                        && matchesValue(values, addr.getInstanceId());
+                case "network-interface-id" -> addr.getNetworkInterfaceId() != null
+                        && matchesValue(values, addr.getNetworkInterfaceId());
+                case "private-ip-address" -> addr.getPrivateIpAddress() != null
+                        && matchesValue(values, addr.getPrivateIpAddress());
                 default -> true;
             };
         }
@@ -5548,7 +5603,16 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 if (inst.getPlacement() != null) {
                     ni.setAvailabilityZone(inst.getPlacement().getAvailabilityZone());
                 }
-                ni.getTagSet().addAll(inst.getTags());
+                // A network interface's tags are its OWN, never the instance's. AWS tags
+                // exactly the resource types a RunInstances TagSpecification names, so an
+                // interface created for an instance whose specification said
+                // ResourceType=instance carries no tags until something tags the eni- id
+                // itself - and DescribeTags never listed these copied tags either, so
+                // DescribeNetworkInterfaces disagreed with DescribeTags about the same
+                // resource. Read the interface's own entry in the tag store instead:
+                // CreateTags on the eni- id writes it, and so does a RunInstances
+                // TagSpecification with ResourceType=network-interface.
+                ni.getTagSet().addAll(tags.get(eni.getNetworkInterfaceId()).orElse(List.of()));
 
                 NetworkInterfaceAttachment att = new NetworkInterfaceAttachment();
                 att.setAttachmentId(eni.getAttachmentId());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1421,6 +1421,409 @@ class Ec2IntegrationTest {
             .body(containsString("<ipProtocol>-1</ipProtocol>"));
     }
 
+    @Test
+    @Order(37)
+    void describeSecurityGroupsFiltersByDescription() {
+        // Issue #150: DescribeSecurityGroups' "description" filter (a real, AWS-documented
+        // filter) must actually narrow the result set to groups whose description matches
+        // the given value, not merely accept the filter name and return every group
+        // unconditionally. A permissive no-op would still pass a check that only asserts
+        // "my group is somewhere in the results", so this asserts an exact result set for
+        // both a matching and (crucially) a non-matching value: the negative case is what a
+        // no-op filter fails, since it has no way to return fewer groups than an unfiltered
+        // call would.
+        //
+        // Self-contained (own VPC, not the class's shared `vpcId`/`securityGroupId`): this
+        // lets the test run in isolation (`-Dtest=...#describeSecurityGroupsFiltersByDescription`)
+        // without depending on createVpc/createSecurityGroup at @Order(10)/@Order(30) having
+        // already populated those static fields, and it is how this test was proven
+        // load-bearing against the unfixed code.
+        String testVpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.99.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String targetGroupId = given()
+            .formParam("Action", "CreateSecurityGroup")
+            .formParam("GroupName", "description-filter-target")
+            .formParam("GroupDescription", "A security group")
+            .formParam("VpcId", testVpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateSecurityGroupResponse.groupId");
+
+        given()
+            .formParam("Action", "CreateSecurityGroup")
+            .formParam("GroupName", "description-filter-decoy")
+            .formParam("GroupDescription", "A totally different description")
+            .formParam("VpcId", testVpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        // Positive case: filtering by the exact description of `targetGroupId` returns
+        // exactly that one group out of the three now in this VPC (its own default group,
+        // the decoy, and the target) - not the decoy, and not the default group.
+        given()
+            .formParam("Action", "DescribeSecurityGroups")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", testVpcId)
+            .formParam("Filter.2.Name", "description")
+            .formParam("Filter.2.Value.1", "A security group")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.size()", equalTo(1))
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.groupId",
+                    equalTo(targetGroupId));
+
+        // Negative case: a description value that cannot match anything in the store must
+        // return zero groups. An unimplemented filter (falling through to a "default ->
+        // true" arm) gets exactly this case wrong: it returns every group in the vpc
+        // regardless of the value asked for, including one guaranteed not to match anything.
+        given()
+            .formParam("Action", "DescribeSecurityGroups")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", testVpcId)
+            .formParam("Filter.2.Name", "description")
+            .formParam("Filter.2.Value.1", "nonexistent-string-xyz")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeSecurityGroupsResponse.securityGroupInfo.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DeleteVpc")
+            .formParam("VpcId", testVpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(38)
+    void describeAddressesFiltersByTagAndPublicIp() {
+        // Issue #151: Ec2Service.describeAddresses took a `filters` parameter and never
+        // referenced it anywhere in its body - not a missing case in a switch (like #150,
+        // #152, #153) but the whole parameter dropped before any filtering could happen. This
+        // asserts both halves of the fix: the generic "tag:" family (which needed nothing but
+        // the parameter actually reaching matchesFilters()) and a resource-specific field
+        // filter this fix adds ("public-ip"), each with its positive and negative case. A
+        // no-op filter cannot produce the negative case - it has no way to return fewer
+        // addresses than an unfiltered call would.
+        //
+        // Self-contained: allocates and releases its own two addresses rather than touching
+        // the class's shared `allocationId` static field, and scopes every query with a
+        // per-test tag so pre-existing addresses from other tests can't change the counts.
+        String suiteTag = "eip-filter-suite-151";
+
+        String targetAllocationId = given()
+            .formParam("Action", "AllocateAddress")
+            .formParam("Domain", "vpc")
+            .formParam("TagSpecification.1.ResourceType", "elastic-ip")
+            .formParam("TagSpecification.1.Tag.1.Key", "Role")
+            .formParam("TagSpecification.1.Tag.1.Value", "target")
+            .formParam("TagSpecification.1.Tag.2.Key", "Suite")
+            .formParam("TagSpecification.1.Tag.2.Value", suiteTag)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("AllocateAddressResponse.allocationId");
+
+        String targetPublicIp = given()
+            .formParam("Action", "DescribeAddresses")
+            .formParam("AllocationId.1", targetAllocationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("DescribeAddressesResponse.addressesSet.item.publicIp");
+
+        String decoyAllocationId = given()
+            .formParam("Action", "AllocateAddress")
+            .formParam("Domain", "vpc")
+            .formParam("TagSpecification.1.ResourceType", "elastic-ip")
+            .formParam("TagSpecification.1.Tag.1.Key", "Role")
+            .formParam("TagSpecification.1.Tag.1.Value", "decoy")
+            .formParam("TagSpecification.1.Tag.2.Key", "Suite")
+            .formParam("TagSpecification.1.Tag.2.Value", suiteTag)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("AllocateAddressResponse.allocationId");
+
+        // Positive, tag: family: narrowed to this suite (Suite=<suiteTag>), then further
+        // narrowed to Role=target, returns exactly the target address.
+        given()
+            .formParam("Action", "DescribeAddresses")
+            .formParam("Filter.1.Name", "tag:Suite")
+            .formParam("Filter.1.Value.1", suiteTag)
+            .formParam("Filter.2.Name", "tag:Role")
+            .formParam("Filter.2.Value.1", "target")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeAddressesResponse.addressesSet.item.size()", equalTo(1))
+            .body("DescribeAddressesResponse.addressesSet.item.allocationId", equalTo(targetAllocationId));
+
+        // Negative, tag: family: a Role value that cannot match anything in this suite must
+        // return zero addresses, not both of them (or all addresses in the account, which is
+        // what the unpatched code returned regardless of any filter).
+        given()
+            .formParam("Action", "DescribeAddresses")
+            .formParam("Filter.1.Name", "tag:Suite")
+            .formParam("Filter.1.Value.1", suiteTag)
+            .formParam("Filter.2.Name", "tag:Role")
+            .formParam("Filter.2.Value.1", "nonexistent-role-xyz")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeAddressesResponse.addressesSet.item.size()", equalTo(0));
+
+        // Positive, resource-specific field filter: "public-ip" narrows to exactly the
+        // address with that public IP.
+        given()
+            .formParam("Action", "DescribeAddresses")
+            .formParam("Filter.1.Name", "tag:Suite")
+            .formParam("Filter.1.Value.1", suiteTag)
+            .formParam("Filter.2.Name", "public-ip")
+            .formParam("Filter.2.Value.1", targetPublicIp)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeAddressesResponse.addressesSet.item.size()", equalTo(1))
+            .body("DescribeAddressesResponse.addressesSet.item.allocationId", equalTo(targetAllocationId));
+
+        // Negative, resource-specific field filter: floci's synthesized public IPs always
+        // start with "54." (Ec2Service.allocateAddress), so an RFC 5737 TEST-NET-3 address is
+        // guaranteed not to match anything this test (or any other) could have allocated.
+        given()
+            .formParam("Action", "DescribeAddresses")
+            .formParam("Filter.1.Name", "tag:Suite")
+            .formParam("Filter.1.Value.1", suiteTag)
+            .formParam("Filter.2.Name", "public-ip")
+            .formParam("Filter.2.Value.1", "203.0.113.99")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeAddressesResponse.addressesSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "ReleaseAddress")
+            .formParam("AllocationId", targetAllocationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "ReleaseAddress")
+            .formParam("AllocationId", decoyAllocationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(38)
+    void describeInstancesFiltersByImageId() {
+        // Issue #152: DescribeInstances' "image-id" filter (a real, AWS-documented filter -
+        // "The ID of the image used to launch the instance") fell through matchesFilter's
+        // Instance arm's `default -> true`, so it matched every instance in the region
+        // regardless of the AMI it was launched from. Same shape as #150: positive case plus
+        // the negative case a permissive no-op filter cannot pass.
+        //
+        // Self-contained: launches its own two instances with made-up ImageIds unique to this
+        // test (so no other fixture's instances can be mistaken for a match) and terminates
+        // both at the end, rather than touching the class's shared `instanceId` static field.
+        String targetInstanceId = given()
+            .formParam("Action", "RunInstances")
+            .formParam("ImageId", "ami-filter-target-152")
+            .formParam("InstanceType", "t3.micro")
+            .formParam("MinCount", "1")
+            .formParam("MaxCount", "1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+
+        String decoyInstanceId = given()
+            .formParam("Action", "RunInstances")
+            .formParam("ImageId", "ami-filter-decoy-152")
+            .formParam("InstanceType", "t3.micro")
+            .formParam("MinCount", "1")
+            .formParam("MaxCount", "1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+
+        // Positive: filtering by the target's exact image-id returns exactly that instance,
+        // not the decoy (launched from a different image-id) and not any other instance
+        // already running from earlier tests in this suite.
+        given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("Filter.1.Name", "image-id")
+            .formParam("Filter.1.Value.1", "ami-filter-target-152")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstancesResponse.reservationSet.item.instancesSet.item.instanceId",
+                    equalTo(targetInstanceId));
+
+        // Negative: an image-id that was never used to launch anything must return zero
+        // instances. An unimplemented filter (falling through to `default -> true`) gets
+        // exactly this case wrong: it returns every instance in the region regardless of the
+        // value asked for.
+        given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("Filter.1.Name", "image-id")
+            .formParam("Filter.1.Value.1", "ami-does-not-exist-anywhere-152")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeInstancesResponse.reservationSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "TerminateInstances")
+            .formParam("InstanceId.1", targetInstanceId)
+            .formParam("InstanceId.2", decoyInstanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(38)
+    void describeVpcEndpointsFiltersByVpcEndpointState() {
+        // Issue #153: DescribeVpcEndpoints implemented a filter under the key "state", but
+        // AWS documents this filter as "vpc-endpoint-state". That made it a silent rename
+        // rather than a missing case: a real caller sending the AWS-documented name fell
+        // through the default arm and got every endpoint back regardless of its actual state.
+        // This is what the negative case here catches - filtering by a state ("pending") that
+        // this emulator's one synthesized endpoint (always "available") can never be in must
+        // return zero endpoints, not the endpoint anyway.
+        //
+        // Self-contained: its own VPC and its own Gateway endpoint (no RouteTableId needed -
+        // createVpcEndpoint only validates route table ids that are actually supplied), rather
+        // than the class's shared `vpcId`/`vpcEndpointId`.
+        String testVpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.98.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String testEndpointId = given()
+            .formParam("Action", "CreateVpcEndpoint")
+            .formParam("VpcId", testVpcId)
+            .formParam("ServiceName", "com.amazonaws.us-east-1.s3")
+            .formParam("VpcEndpointType", "Gateway")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcEndpointResponse.vpcEndpoint.vpcEndpointId");
+
+        // Positive: the endpoint is (and can only ever be, in this emulator) "available", so
+        // filtering this VPC's endpoints by vpc-endpoint-state=available returns exactly it.
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", testVpcId)
+            .formParam("Filter.2.Name", "vpc-endpoint-state")
+            .formParam("Filter.2.Value.1", "available")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item.size()", equalTo(1))
+            .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item.vpcEndpointId",
+                    equalTo(testEndpointId));
+
+        // Negative: a real AWS endpoint state ("pending") that no endpoint in this VPC is
+        // actually in must return zero endpoints. Under the old "state" key with the wrong
+        // documented name, or under any unimplemented filter name, this returns the endpoint
+        // anyway because the default arm ignores the value entirely.
+        given()
+            .formParam("Action", "DescribeVpcEndpoints")
+            .formParam("Filter.1.Name", "vpc-id")
+            .formParam("Filter.1.Value.1", testVpcId)
+            .formParam("Filter.2.Name", "vpc-endpoint-state")
+            .formParam("Filter.2.Value.1", "pending")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcEndpointsResponse.vpcEndpointSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DeleteVpcEndpoints")
+            .formParam("VpcEndpointId.1", testEndpointId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DeleteVpc")
+            .formParam("VpcId", testVpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
     // =========================================================================
     // Key Pairs
     // =========================================================================
@@ -2316,6 +2719,41 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(84)
+    void describeVolumesAttachmentFiltersMatchOnlyTheirOwnInstance() {
+        // attachment.* previously fell through matchesFilter's default arm, so
+        // DescribeVolumes --filters attachment.instance-id=<id> matched every volume in
+        // the region and Volumes[0] depended on iteration order, not on the filter.
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("Filter.1.Name", "attachment.instance-id")
+            .formParam("Filter.1.Value.1", instanceId)
+            .formParam("Filter.2.Name", "attachment.device")
+            .formParam("Filter.2.Value.1", "/dev/xvda")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVolumesResponse.volumeSet.item.size()", equalTo(1))
+            .body("DescribeVolumesResponse.volumeSet.item.attachmentSet.item.instanceId",
+                    equalTo(instanceId));
+
+        // The negative case an unimplemented filter gets wrong: an instance id that
+        // nothing is attached to must return zero volumes, not every volume.
+        given()
+            .formParam("Action", "DescribeVolumes")
+            .formParam("Filter.1.Name", "attachment.instance-id")
+            .formParam("Filter.1.Value.1", "i-00000000000000000")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVolumesResponse.volumeSet.item.size()", equalTo(0));
+    }
+
+    @Test
     @Order(85)
     void describeInstanceAttributeDisableApiStop() {
         given()
@@ -2605,11 +3043,13 @@ class Ec2IntegrationTest {
             // availabilityZone from instance placement
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].availabilityZone",
                     startsWith("us-east-1"))
-            // tagSet propagated from instance tags (created at Order 90)
-            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].key",
-                    equalTo("Name"))
-            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].value",
-                    equalTo("test-instance"))
+            // The interface's tagSet is its OWN, never the instance's. The instance
+            // carries Name=test-instance (CreateTags at Order 90) and nothing has
+            // tagged this eni- id, so AWS answers with an empty tagSet here: a
+            // RunInstances TagSpecification tags exactly the resource types it names,
+            // and ec2:DescribeTags never listed these tags for the interface either,
+            // so copying them made two calls disagree about one resource.
+            .body(not(containsString("test-instance")))
             // attachment: attachTime (from instance launchTime) and deleteOnTermination
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].attachment.attachTime",
                     notNullValue())
@@ -2706,6 +3146,62 @@ class Ec2IntegrationTest {
     @Test
     @Order(92)
     void describeNetworkInterfacesFilterByTag() {
+        // A tag:N filter matches the interface's own tags, so the interface is tagged
+        // here first. Filtering on the INSTANCE's tags used to match, which is what
+        // describeNetworkInterfacesDoNotInheritInstanceTags now pins the other way.
+        given()
+            .formParam("Action", "CreateTags")
+            .formParam("ResourceId.1", networkInterfaceId)
+            .formParam("Tag.1.Key", "FilterProbe")
+            .formParam("Tag.1.Value", "eni-own-tag")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "tag:FilterProbe")
+            .formParam("Filter.1.Value.1", "eni-own-tag")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
+                    equalTo(1))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId",
+                    equalTo(networkInterfaceId))
+            .body(containsString("FilterProbe"));
+    }
+
+    /**
+     * Issue: DescribeNetworkInterfaces answered with the ATTACHED INSTANCE's tags as
+     * the interface's own tagSet, which AWS never does - RunInstances applies each
+     * TagSpecification to exactly the resource type it names, and this emulator's own
+     * ec2:DescribeTags never listed those tags for the eni- id either, so the two
+     * calls disagreed about one resource.
+     *
+     * <p>Read the promise, not the implementation: the instance carries
+     * Name=test-instance (Order 90) and must still carry it, while no interface in the
+     * account answers a tag:Name filter for it. Before the fix this filter returned the
+     * instance's own interface.
+     */
+    @Test
+    @Order(92)
+    void describeNetworkInterfacesDoNotInheritInstanceTags() {
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "resource-id")
+            .formParam("Filter.1.Value.1", instanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("test-instance"));
+
         given()
             .formParam("Action", "DescribeNetworkInterfaces")
             .formParam("Filter.1.Name", "tag:Name")
@@ -2716,7 +3212,7 @@ class Ec2IntegrationTest {
         .then()
             .statusCode(200)
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()",
-                    greaterThanOrEqualTo(1));
+                    equalTo(0));
     }
 
     @Test
@@ -3478,6 +3974,77 @@ class Ec2IntegrationTest {
     }
 
     @Test
+    @Order(302)
+    void describeVpcsWithCidrBlockFilterAlias() {
+        // "cidr" is the documented DescribeVpcs filter name for a VPC's primary CIDR block, but
+        // real EC2 also honours the undocumented alias "cidr-block" (confirmed against live AWS
+        // 2026-08-25: a filter naming an unrelated CIDR returns zero VPCs rather than every VPC,
+        // so the service is genuinely filtering, not ignoring the name). Before this fix floci's
+        // Vpc filter switch fell through its `default -> true` arm for "cidr-block" and matched
+        // every VPC regardless of the requested value.
+        String matching = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "172.16.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String other = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.9.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        // Filtering on the matching VPC's own primary CIDR returns exactly that VPC, not the
+        // whole account (which, thanks to describeDefaultVpc's default VPC and "other" above,
+        // has at least two others in scope).
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "cidr-block")
+            .formParam("Filter.1.Value.1", "172.16.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item[0].vpcId", equalTo(matching));
+
+        // A "cidr-block" value that matches no VPC's primary CIDR must return none, not "the
+        // filter was ignored, return everything".
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "cidr-block")
+            .formParam("Filter.1.Value.1", "203.0.113.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(0));
+
+        given()
+            .formParam("Action", "DeleteVpc")
+            .formParam("VpcId", matching)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/");
+        given()
+            .formParam("Action", "DeleteVpc")
+            .formParam("VpcId", other)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/");
+    }
+
+    @Test
     @Order(150)
     void spotInstanceLifecycle() {
         // Per-invocation tag value: DescribeSpotInstanceRequests has no owner scoping beyond
@@ -4138,4 +4705,73 @@ class Ec2IntegrationTest {
             .when().post("/").then().statusCode(200);
     }
 
+
+    /**
+     * The other half of "an interface's tags are its own": AWS DOES tag the interfaces
+     * RunInstances creates when the request carries a TagSpecification naming
+     * ResourceType=network-interface, and only then. This launches one instance with
+     * both specifications and asserts each landed on its own resource.
+     *
+     * <p>Runs last, like the other tests that launch extra instances: the
+     * DescribeNetworkInterfaces pagination tests at @Order(92) assert on exact ENI
+     * counts, so the instance is terminated before this returns.
+     */
+    @Test
+    @Order(323)
+    void runInstancesTagsTheInterfaceOnlyWhenTheSpecificationNamesIt() {
+        String taggedInstanceId = given()
+            .formParam("Action", "RunInstances")
+            .formParam("ImageId", "ami-12345678")
+            .formParam("InstanceType", "t3.micro")
+            .formParam("MinCount", "1")
+            .formParam("MaxCount", "1")
+            .formParam("TagSpecification.1.ResourceType", "instance")
+            .formParam("TagSpecification.1.Tag.1.Key", "Name")
+            .formParam("TagSpecification.1.Tag.1.Value", "eni-tagspec-instance")
+            .formParam("TagSpecification.2.ResourceType", "network-interface")
+            .formParam("TagSpecification.2.Tag.1.Key", "Name")
+            .formParam("TagSpecification.2.Tag.1.Value", "eni-tagspec-interface")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
+
+        given()
+            .formParam("Action", "DescribeNetworkInterfaces")
+            .formParam("Filter.1.Name", "attachment.instance-id")
+            .formParam("Filter.1.Value.1", taggedInstanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item.size()", equalTo(1))
+            // the interface's own specification, and not the instance's
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].key",
+                    equalTo("Name"))
+            .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].value",
+                    equalTo("eni-tagspec-interface"))
+            .body(not(containsString("eni-tagspec-instance")));
+
+        given()
+            .formParam("Action", "DescribeInstances")
+            .formParam("InstanceId.1", taggedInstanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("eni-tagspec-instance"));
+
+        given()
+            .formParam("Action", "TerminateInstances")
+            .formParam("InstanceId.1", taggedInstanceId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -4755,6 +4755,21 @@ class Ec2IntegrationTest {
                     equalTo("eni-tagspec-interface"))
             .body(not(containsString("eni-tagspec-instance")));
 
+        // The launch-time interface tag must also surface through DescribeTags under its own
+        // resource type: eni- ids classify as network-interface, not as an unknown type the
+        // resource-type filter then drops.
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "resource-type")
+            .formParam("Filter.1.Value.1", "network-interface")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'Name' && it.value == 'eni-tagspec-interface' }.resourceType",
+                    equalTo("network-interface"));
+
         given()
             .formParam("Action", "DescribeInstances")
             .formParam("InstanceId.1", taggedInstanceId)

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -4738,7 +4738,7 @@ class Ec2IntegrationTest {
             .statusCode(200)
             .extract().path("RunInstancesResponse.instancesSet.item.instanceId");
 
-        given()
+        String eniId = given()
             .formParam("Action", "DescribeNetworkInterfaces")
             .formParam("Filter.1.Name", "attachment.instance-id")
             .formParam("Filter.1.Value.1", taggedInstanceId)
@@ -4753,11 +4753,13 @@ class Ec2IntegrationTest {
                     equalTo("Name"))
             .body("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].tagSet.item[0].value",
                     equalTo("eni-tagspec-interface"))
-            .body(not(containsString("eni-tagspec-instance")));
+            .body(not(containsString("eni-tagspec-instance")))
+            .extract().path("DescribeNetworkInterfacesResponse.networkInterfaceSet.item[0].networkInterfaceId");
 
         // The launch-time interface tag must also surface through DescribeTags under its own
         // resource type: eni- ids classify as network-interface, not as an unknown type the
-        // resource-type filter then drops.
+        // resource-type filter then drops. Pinned to the interface's id, not just the tag pair,
+        // so the whole RunInstances -> createTags -> DescribeTags path is exercised.
         given()
             .formParam("Action", "DescribeTags")
             .formParam("Filter.1.Name", "resource-type")
@@ -4767,7 +4769,11 @@ class Ec2IntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("DescribeTagsResponse.tagSet.item.find { it.key == 'Name' && it.value == 'eni-tagspec-interface' }.resourceType",
+            .body("DescribeTagsResponse.tagSet.item.find { it.resourceId == '" + eniId + "' }.key",
+                    equalTo("Name"))
+            .body("DescribeTagsResponse.tagSet.item.find { it.resourceId == '" + eniId + "' }.value",
+                    equalTo("eni-tagspec-interface"))
+            .body("DescribeTagsResponse.tagSet.item.find { it.resourceId == '" + eniId + "' }.resourceType",
                     equalTo("network-interface"));
 
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -2844,6 +2844,33 @@ class Ec2ServiceTest {
         assertEquals("192.168.215.42", refreshed.getPublicIp());
     }
 
+    /**
+     * The re-resolution must run BEFORE the filter pass: a public-ip filter is judged against
+     * the address the response will carry, not the one persisted before the restart. A
+     * regression back to filter-before-refresh makes the current IP miss and the stale IP hit.
+     */
+    @Test
+    void describeAddressesFiltersOnTheRefreshedAssociationState() {
+        Ec2ContainerManager containerManager = mock(Ec2ContainerManager.class);
+        when(containerManager.reachablePublicAddress(argThat(i -> i != null))).thenReturn("192.168.215.9");
+        Ec2Service service = eipService(containerManager);
+        String instanceId = launchOne(service);
+        Address allocated = service.allocateAddress("us-east-1");
+        service.associateAddress("us-east-1", allocated.getAllocationId(), instanceId);
+
+        // The container restarts and Docker hands the instance a different bridge IP.
+        when(containerManager.reachablePublicAddress(argThat(i -> i != null))).thenReturn("192.168.215.42");
+
+        List<Address> byCurrentIp = service.describeAddresses("us-east-1", List.of(),
+                Map.of("public-ip", List.of("192.168.215.42")));
+        assertEquals(1, byCurrentIp.size());
+        assertEquals(allocated.getAllocationId(), byCurrentIp.getFirst().getAllocationId());
+        assertEquals("192.168.215.42", byCurrentIp.getFirst().getPublicIp());
+
+        assertTrue(service.describeAddresses("us-east-1", List.of(),
+                Map.of("public-ip", List.of("192.168.215.9"))).isEmpty());
+    }
+
     /** With no instance behind it there is nothing reachable left, so the allocation is restored. */
     @Test
     void disassociateAddressRestoresTheAllocatedAddress() {


### PR DESCRIPTION
Several EC2 Describe* calls accepted a documented filter name and returned
the unfiltered list anyway, because the unhandled name fell through
matchesFilter's default arm (DescribeAddresses never applied its filters
parameter at all). A caller reading Volumes[0] or Vpcs[0] then got whichever
resource iteration order produced, which looks nondeterministic but is a
plain missing-filter bug.

The fix covers six calls. DescribeSecurityGroups gains its description
filter; DescribeVpcs accepts cidr-block (verified against live AWS
2026-08-25 as an accepted alias for cidr, primary CIDR only);
DescribeVpcEndpoints filters by the documented vpc-endpoint-state name
instead of the undocumented "state"; DescribeVolumes gains the attachment.*
family; DescribeInstances gains image-id; and DescribeAddresses now applies
every documented filter its store can back plus the generic tag: family.

Also, DescribeNetworkInterfaces no longer copies the attached instance's
tags into an ENI's tagSet: an interface's tags are its own, and
RunInstances now honours a TagSpecification with
ResourceType=network-interface, the way AWS actually tags launch-created
interfaces.

Each fix carries a regression test asserting the negative case an
unimplemented filter gets wrong, where a value matching nothing must return
zero resources rather than everything. The full local EC2 suite passes with
649 tests and 0 failures.

