### PR TITLE
fix(apigateway): forward v2 request authorizer context

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -1472,6 +1472,7 @@ public class ApiGatewayExecuteController {
 
         Map<String, String> jwtClaims = null;
         List<String> jwtScopes = null;
+        JsonNode requestAuthorizerContext = null;
         if ("JWT".equalsIgnoreCase(route.getAuthorizationType()) && route.getAuthorizerId() != null) {
             JwtAuthorizerResult jwtResult = enforceJwtAuthorizer(region, apiId, route, headers, uriInfo);
             if (jwtResult.errorResponse() != null) return jwtResult.errorResponse();
@@ -1480,8 +1481,12 @@ public class ApiGatewayExecuteController {
         }
 
         if ("CUSTOM".equalsIgnoreCase(route.getAuthorizationType()) && route.getAuthorizerId() != null) {
-            Response authError = enforceRequestAuthorizerV2(region, apiId, stageName, route, httpMethod, path, headers, uriInfo);
-            if (authError != null) return authError;
+            RequestAuthorizerResult authorizerResult = enforceRequestAuthorizerV2(
+                    region, apiId, stageName, route, httpMethod, path, headers, uriInfo);
+            if (authorizerResult.errorResponse() != null) {
+                return authorizerResult.errorResponse();
+            }
+            requestAuthorizerContext = authorizerResult.context();
         }
 
         if (route.getTarget() == null) {
@@ -1520,7 +1525,8 @@ public class ApiGatewayExecuteController {
 
         String requestId = UUID.randomUUID().toString();
         String eventJson = buildV2ProxyEvent(httpMethod, path, route.getRouteKey(),
-                apiId, region, stageName, headers, uriInfo, body, requestId, jwtClaims, jwtScopes);
+                apiId, region, stageName, headers, uriInfo, body, requestId,
+                jwtClaims, jwtScopes, requestAuthorizerContext);
 
         LOG.debugv("execute-api v2: {0} {1}/{2}{3} → Lambda {4}", httpMethod, apiId, stageName, path, functionName);
 
@@ -1696,6 +1702,9 @@ public class ApiGatewayExecuteController {
         }
     }
 
+    private record RequestAuthorizerResult(Response errorResponse, JsonNode context) {
+    }
+
     private JwtAuthorizerResult enforceJwtAuthorizer(String region, String apiId, Route route, HttpHeaders headers,
                                           UriInfo uriInfo) {
         Authorizer authorizer;
@@ -1790,22 +1799,22 @@ public class ApiGatewayExecuteController {
      * Enforces a Lambda REQUEST authorizer on an HTTP API (v2) route.
      * Supports both payload format versions (1.0 and 2.0) and simple responses.
      *
-     * @return null if authorized, or an error Response if denied/unauthorized
+     * @return the authorizer context when authorized, or an error response when denied/unauthorized
      */
-    private Response enforceRequestAuthorizerV2(String region, String apiId, String stageName,
-                                                Route route, String httpMethod, String path,
-                                                HttpHeaders headers, UriInfo uriInfo) {
+    private RequestAuthorizerResult enforceRequestAuthorizerV2(String region, String apiId, String stageName,
+                                                               Route route, String httpMethod, String path,
+                                                               HttpHeaders headers, UriInfo uriInfo) {
         Authorizer authorizer;
         try {
             authorizer = apiGatewayV2Service.getAuthorizer(region, apiId, route.getAuthorizerId());
         } catch (AwsException e) {
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Authorizer not found"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         if (!"REQUEST".equalsIgnoreCase(authorizer.getAuthorizerType())) {
-            return null; // Not a REQUEST authorizer — skip
+            return new RequestAuthorizerResult(null, null); // Not a REQUEST authorizer — skip
         }
 
         // Validate identity sources — if any configured source is missing, return 401 without invoking Lambda
@@ -1817,17 +1826,17 @@ public class ApiGatewayExecuteController {
                     String headerName = expression.substring("$request.header.".length());
                     String value = headers.getHeaderString(headerName);
                     if (value == null || value.isEmpty()) {
-                        return Response.status(401)
+                        return new RequestAuthorizerResult(Response.status(401)
                                 .entity(jsonMessage("Unauthorized"))
-                                .type(MediaType.APPLICATION_JSON).build();
+                                .type(MediaType.APPLICATION_JSON).build(), null);
                     }
                 } else if (expression.startsWith("$request.querystring.")) {
                     String paramName = expression.substring("$request.querystring.".length());
                     String value = queryParams.getFirst(paramName);
                     if (value == null || value.isEmpty()) {
-                        return Response.status(401)
+                        return new RequestAuthorizerResult(Response.status(401)
                                 .entity(jsonMessage("Unauthorized"))
-                                .type(MediaType.APPLICATION_JSON).build();
+                                .type(MediaType.APPLICATION_JSON).build(), null);
                     }
                 }
                 // $context.* identity sources are always present — no validation needed
@@ -1849,9 +1858,9 @@ public class ApiGatewayExecuteController {
         String functionName = functionNameFromUri(authorizer.getAuthorizerUri());
         if (functionName == null) {
             LOG.warnv("Cannot extract function name from authorizer URI: {0}", authorizer.getAuthorizerUri());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         // Invoke the authorizer Lambda
@@ -1861,26 +1870,26 @@ public class ApiGatewayExecuteController {
                     eventJson.getBytes(StandardCharsets.UTF_8), InvocationType.RequestResponse);
         } catch (Exception e) {
             LOG.warnv("Lambda REQUEST authorizer invocation failed for API {0}: {1}", apiId, e.getMessage());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         // Check for function error (Lambda threw an exception)
         if (invokeResult.getFunctionError() != null) {
             LOG.warnv("Lambda REQUEST authorizer returned function error for API {0}: {1}",
                     apiId, invokeResult.getFunctionError());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         byte[] payload = invokeResult.getPayload();
         if (payload == null || payload.length == 0) {
             LOG.warnv("Lambda REQUEST authorizer returned empty payload for API {0}", apiId);
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
 
         // Parse the authorizer response
@@ -1894,57 +1903,62 @@ public class ApiGatewayExecuteController {
                 JsonNode isAuthorized = response.path("isAuthorized");
                 if (isAuthorized.isMissingNode() || isAuthorized.isNull()) {
                     LOG.warnv("Lambda REQUEST authorizer simple response missing isAuthorized for API {0}", apiId);
-                    return Response.status(500)
+                    return new RequestAuthorizerResult(Response.status(500)
                             .entity(jsonMessage("Internal Server Error"))
-                            .type(MediaType.APPLICATION_JSON).build();
+                            .type(MediaType.APPLICATION_JSON).build(), null);
                 }
                 if (!isAuthorized.asBoolean(false)) {
-                    return Response.status(403)
+                    return new RequestAuthorizerResult(Response.status(403)
                             .entity(jsonMessage("Forbidden"))
-                            .type(MediaType.APPLICATION_JSON).build();
+                            .type(MediaType.APPLICATION_JSON).build(), null);
                 }
-                return null; // authorized
+                return new RequestAuthorizerResult(null, requestAuthorizerContext(response));
             }
 
             // IAM policy document format
             JsonNode policyDocument = response.path("policyDocument");
             if (policyDocument.isMissingNode() || policyDocument.isNull()) {
                 LOG.warnv("Authorizer response missing policyDocument for API {0}", apiId);
-                return Response.status(500)
+                return new RequestAuthorizerResult(Response.status(500)
                         .entity(jsonMessage("Internal Server Error"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
             JsonNode statements = policyDocument.path("Statement");
             if (statements.isMissingNode() || statements.isNull()
                     || !statements.isArray() || statements.isEmpty()) {
                 LOG.warnv("Authorizer response missing or empty Statement array for API {0}", apiId);
-                return Response.status(500)
+                return new RequestAuthorizerResult(Response.status(500)
                         .entity(jsonMessage("Internal Server Error"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
             String effect = statements.get(0).path("Effect").asText("Deny");
             if ("Deny".equalsIgnoreCase(effect)) {
-                return Response.status(403)
+                return new RequestAuthorizerResult(Response.status(403)
                         .entity(jsonMessage("User is not authorized to access this resource"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
             if (!"Allow".equalsIgnoreCase(effect)) {
                 LOG.warnv("Authorizer response has unrecognized Effect '{0}' for API {1}", effect, apiId);
-                return Response.status(500)
+                return new RequestAuthorizerResult(Response.status(500)
                         .entity(jsonMessage("Internal Server Error"))
-                        .type(MediaType.APPLICATION_JSON).build();
+                        .type(MediaType.APPLICATION_JSON).build(), null);
             }
 
-            return null; // authorized
+            return new RequestAuthorizerResult(null, requestAuthorizerContext(response));
         } catch (Exception e) {
             LOG.warnv("Failed to parse authorizer response for API {0}: {1}", apiId, e.getMessage());
-            return Response.status(500)
+            return new RequestAuthorizerResult(Response.status(500)
                     .entity(jsonMessage("Internal Server Error"))
-                    .type(MediaType.APPLICATION_JSON).build();
+                    .type(MediaType.APPLICATION_JSON).build(), null);
         }
+    }
+
+    private JsonNode requestAuthorizerContext(JsonNode response) {
+        JsonNode context = response.get("context");
+        return context != null && context.isObject() ? context.deepCopy() : null;
     }
 
     /**
@@ -2197,21 +2211,23 @@ public class ApiGatewayExecuteController {
                                      HttpHeaders headers, UriInfo uriInfo,
                                      byte[] body, String requestId) {
         return buildV2ProxyEvent(httpMethod, path, routeKey, apiId, region, stageName,
-                headers, uriInfo, body, requestId, null, null);
+                headers, uriInfo, body, requestId, null, null, null);
     }
 
-    // jwtClaims is non-null only when the route's authorizer is JWT-type and verification
-    // succeeded (see dispatchV2/enforceJwtAuthorizer) - null means either no authorizer on this
-    // route (Auth: NONE) or a CUSTOM/REQUEST authorizer. jwtScopes is non-null only when that
-    // route additionally carries authorizationScopes (see JwtAuthorizerResult). Unlike the
-    // v1/REST CUSTOM-authorizer path (buildV1ProxyEvent's principalId/context handling), a v2
-    // CUSTOM/REQUEST authorizer's response context is not currently threaded into
-    // requestContext.authorizer here at all.
     String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
                                      String apiId, String region, String stageName,
                                      HttpHeaders headers, UriInfo uriInfo,
                                      byte[] body, String requestId, Map<String, String> jwtClaims,
                                      List<String> jwtScopes) {
+        return buildV2ProxyEvent(httpMethod, path, routeKey, apiId, region, stageName,
+                headers, uriInfo, body, requestId, jwtClaims, jwtScopes, null);
+    }
+
+    String buildV2ProxyEvent(String httpMethod, String path, String routeKey,
+                                     String apiId, String region, String stageName,
+                                     HttpHeaders headers, UriInfo uriInfo,
+                                     byte[] body, String requestId, Map<String, String> jwtClaims,
+                                     List<String> jwtScopes, JsonNode requestAuthorizerContext) {
         // The JAX-RS {proxy} binding strips a trailing slash, but rawPath is by contract the
         // raw path and routers treat /x and /x/ as distinct routes. Recover it from the raw
         // request URI for the event path fields. Route matching in dispatchV2 and the
@@ -2287,6 +2303,9 @@ public class ApiGatewayExecuteController {
                 ArrayNode scopesNode = jwtNode.putArray("scopes");
                 jwtScopes.forEach(scopesNode::add);
             }
+        } else if (requestAuthorizerContext != null) {
+            ObjectNode authorizerNode = ctx.putObject("authorizer");
+            authorizerNode.set("lambda", requestAuthorizerContext);
         }
 
         if (body != null && body.length > 0) {

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventRequestAuthorizerContextTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/BuildV2ProxyEventRequestAuthorizerContextTest.java
@@ -1,0 +1,80 @@
+package io.github.hectorvent.floci.services.apigateway;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Verifies that an HTTP API Lambda REQUEST authorizer's response context is forwarded to the
+ * integration event at {@code requestContext.authorizer.lambda}.
+ */
+class BuildV2ProxyEventRequestAuthorizerContextTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ApiGatewayExecuteController controller;
+    private HttpHeaders headers;
+    private UriInfo uriInfo;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+
+        headers = mock(HttpHeaders.class);
+        when(headers.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+        when(headers.getHeaderString("User-Agent")).thenReturn(null);
+
+        uriInfo = mock(UriInfo.class);
+        when(uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+        when(uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:4566/api/stage/hello"));
+
+        controller = new ApiGatewayExecuteController(
+                null, null, null,
+                regionResolver, MAPPER, null,
+                null, null, null, null, new ApiGatewayExecuteRouteContext(), null, null
+        );
+    }
+
+    @Test
+    void forwardsRequestAuthorizerContextUnderLambda() throws Exception {
+        JsonNode authorizerContext = MAPPER.readTree("""
+                {
+                  "userId": "user123",
+                  "role": "admin",
+                  "limits": {"requests": 25}
+                }
+                """);
+
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/hello", "GET /hello",
+                "abc123", "us-east-1", "stage", headers, uriInfo, null, "req-1",
+                null, null, authorizerContext);
+        JsonNode event = MAPPER.readTree(json);
+
+        assertEquals(authorizerContext, event.at("/requestContext/authorizer/lambda"));
+    }
+
+    @Test
+    void omitsAuthorizerWhenNoContextWasReturned() throws Exception {
+        String json = controller.buildV2ProxyEvent(
+                "GET", "/hello", "GET /hello",
+                "abc123", "us-east-1", "stage", headers, uriInfo, null, "req-2",
+                null, null, null);
+        JsonNode event = MAPPER.readTree(json);
+
+        assertFalse(event.at("/requestContext").has("authorizer"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/HttpApiRequestAuthorizerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/HttpApiRequestAuthorizerTest.java
@@ -85,7 +85,11 @@ class HttpApiRequestAuthorizerTest {
         createNodeLambda(BACKEND_FN, """
                 exports.handler = async (event) => ({
                     statusCode: 200,
-                    body: JSON.stringify({ message: "Hello from backend", path: event.rawPath })
+                    body: JSON.stringify({
+                        message: "Hello from backend",
+                        path: event.rawPath,
+                        authorizer: event.requestContext?.authorizer ?? null
+                    })
                 });
                 """);
 
@@ -267,7 +271,7 @@ class HttpApiRequestAuthorizerTest {
 
     @Test
     @Order(10)
-    void requestAuthorizerAllowsWithIamPolicy() {
+    void requestAuthorizerAllowsWithIamPolicy() throws Exception {
         given()
                 .contentType(ContentType.JSON)
                 .body("""
@@ -276,9 +280,14 @@ class HttpApiRequestAuthorizerTest {
                 .when().patch("/v2/apis/" + httpApiId + "/routes/" + routeId)
                 .then().statusCode(200);
 
-        given()
+        String body = given()
                 .when().get("/execute-api/" + httpApiId + "/test/hello")
-                .then().statusCode(200);
+                .then().statusCode(200)
+                .extract().body().asString();
+
+        JsonNode authorizer = MAPPER.readTree(body).path("authorizer").path("lambda");
+        assertEquals("user123", authorizer.path("userId").asText());
+        assertEquals("admin", authorizer.path("role").asText());
     }
 
     // ──────────────────────────── Test: Deny with IAM policy (format 1.0) ────────────────────────────
@@ -321,7 +330,7 @@ class HttpApiRequestAuthorizerTest {
 
     @Test
     @Order(40)
-    void simpleResponseAllows() {
+    void simpleResponseAllowsAndForwardsContext() throws Exception {
         given()
                 .contentType(ContentType.JSON)
                 .body("""
@@ -330,9 +339,14 @@ class HttpApiRequestAuthorizerTest {
                 .when().patch("/v2/apis/" + httpApiId + "/routes/" + routeId)
                 .then().statusCode(200);
 
-        given()
+        String body = given()
                 .when().get("/execute-api/" + httpApiId + "/test/hello")
-                .then().statusCode(200);
+                .then().statusCode(200)
+                .extract().body().asString();
+
+        JsonNode authorizer = MAPPER.readTree(body).path("authorizer").path("lambda");
+        assertEquals("simple-user", authorizer.path("userId").asText());
+        assertEquals("premium", authorizer.path("plan").asText());
     }
 
     // ──────────────────────────── Test: Simple response Deny (format 2.0) ────────────────────────────
@@ -431,10 +445,8 @@ class HttpApiRequestAuthorizerTest {
                 .when().patch("/v2/apis/" + httpApiId + "/routes/" + routeId)
                 .then().statusCode(200);
 
-        // The echo authorizer allows the request and embeds the received event in its context.
-        // The backend Lambda receives the proxy event which does NOT include authorizer context
-        // in the v2 proxy event format. So we verify the authorizer was invoked (200 response)
-        // and then invoke the echo function directly with a realistic event to verify format.
+        // The echo authorizer allows the request and embeds the actual event it received in its
+        // context. The backend must receive that context in its proxy event.
         String response = given()
                 .header("X-Custom-Header", "test-value")
                 .queryParam("foo", "bar")
@@ -442,23 +454,9 @@ class HttpApiRequestAuthorizerTest {
                 .then().statusCode(200)
                 .extract().body().asString();
 
-        // Backend received the request — authorizer allowed it
         JsonNode backendResponse = MAPPER.readTree(response);
         assertEquals("Hello from backend", backendResponse.path("message").asText());
-
-        // Verify format by invoking echo function with a v1-shaped event
-        String testEvent = """
-                {"version":"1.0","type":"REQUEST","methodArn":"arn:aws:execute-api:us-east-1:000000000000:%s/test/GET/hello","resource":"/hello","path":"/hello","httpMethod":"GET","headers":{"X-Custom-Header":"test-value"},"queryStringParameters":{"foo":"bar"}}
-                """.formatted(httpApiId);
-        String echoResponse = given()
-                .contentType(ContentType.JSON)
-                .body(testEvent)
-                .when().post("/2015-03-31/functions/" + ECHO_FN + "/invocations")
-                .then().statusCode(200)
-                .extract().body().asString();
-
-        JsonNode echoResult = MAPPER.readTree(echoResponse);
-        String authEventStr = echoResult.path("context").path("receivedEvent").asText(null);
+        String authEventStr = backendResponse.at("/authorizer/lambda/receivedEvent").asText(null);
         assertNotNull(authEventStr, "Echo authorizer should embed receivedEvent in context");
         JsonNode authEvent = MAPPER.readTree(authEventStr);
 
@@ -489,23 +487,10 @@ class HttpApiRequestAuthorizerTest {
                 .then().statusCode(200)
                 .extract().body().asString();
 
-        // Backend received the request — authorizer allowed it
+        // The authorizer's context carries the actual event it received through to the backend.
         JsonNode backendResponse = MAPPER.readTree(response);
         assertEquals("Hello from backend", backendResponse.path("message").asText());
-
-        // Verify format by invoking echo function with a v2-shaped event
-        String testEvent = """
-                {"version":"2.0","type":"REQUEST","routeArn":"arn:aws:execute-api:us-east-1:000000000000:%s/test/GET/hello","routeKey":"GET /hello","rawPath":"/hello","rawQueryString":"key=value","headers":{"x-custom-header":"test-value-v2"},"queryStringParameters":{"key":"value"},"requestContext":{"accountId":"000000000000","apiId":"%s","http":{"method":"GET","path":"/hello"}}}
-                """.formatted(httpApiId, httpApiId);
-        String echoResponse = given()
-                .contentType(ContentType.JSON)
-                .body(testEvent)
-                .when().post("/2015-03-31/functions/" + ECHO_FN + "/invocations")
-                .then().statusCode(200)
-                .extract().body().asString();
-
-        JsonNode echoResult = MAPPER.readTree(echoResponse);
-        String authEventStr = echoResult.path("context").path("receivedEvent").asText(null);
+        String authEventStr = backendResponse.at("/authorizer/lambda/receivedEvent").asText(null);
         assertNotNull(authEventStr, "Echo authorizer should embed receivedEvent in context");
         JsonNode authEvent = MAPPER.readTree(authEventStr);
 


### PR DESCRIPTION
## Summary

- carry successful HTTP API Lambda REQUEST authorizer context through request dispatch
- expose IAM-policy and simple-response context at `requestContext.authorizer.lambda`
- verify the proxy-event shape directly and through the existing backend Lambda integration flow

## Testing

- `./mvnw test -Dtest=BuildV2ProxyEventRequestAuthorizerContextTest,BuildV2ProxyEventJwtClaimsTest,BuildV2AuthorizerEventTrailingSlashTest` (11 tests passed)
- full main and test source compilation completed successfully
- `HttpApiRequestAuthorizerTest` requires an available Docker socket for its Lambda containers; local execution was blocked by the unavailable socket

Fixes #2652
