### PR TITLE
fix(ui): verify Floci connectivity in readiness probe

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -11,6 +11,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
@@ -47,6 +49,7 @@ public class FlociUiManager {
     private static final int CONTAINER_INTERNAL_PORT = 4500;
     private static final String FLOCI_ENDPOINT_ENV = "FLOCI_ENDPOINT";
     private static final Pattern IPV4_LITERAL = Pattern.compile("^\\d{1,3}(\\.\\d{1,3}){3}$");
+    private static final String RUNTIME_STATUS_PATH = "/api/clouds/aws/status";
 
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
@@ -56,6 +59,7 @@ public class FlociUiManager {
     private final DockerHostResolver dockerHostResolver;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
 
     private volatile boolean started;
     private volatile int hostPort;
@@ -87,7 +91,8 @@ public class FlociUiManager {
                           CurrentContainerNetworkResolver currentContainerNetworkResolver,
                           DockerHostResolver dockerHostResolver,
                           EmulatorConfig config,
-                          RegionResolver regionResolver) {
+                          RegionResolver regionResolver,
+                          ObjectMapper objectMapper) {
         this.containerBuilder = containerBuilder;
         this.lifecycleManager = lifecycleManager;
         this.logStreamer = logStreamer;
@@ -96,6 +101,7 @@ public class FlociUiManager {
         this.dockerHostResolver = dockerHostResolver;
         this.config = config;
         this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
     }
 
     /** Snapshot of the sidecar state for the interstitial page. */
@@ -203,8 +209,11 @@ public class FlociUiManager {
         if (lastError != null) {
             return new UiStatus(started, false, hostPort, lastError);
         }
-        boolean ready = started && probeReady();
-        if (started && !ready && shouldReArm(lifecycleManager.presenceOf(containerId))) {
+        if (!started) {
+            return new UiStatus(false, false, hostPort, null);
+        }
+        RuntimeProbe probe = probeRuntime();
+        if (!probe.ready() && shouldReArm(lifecycleManager.presenceOf(containerId))) {
             LOG.infov("floci-ui sidecar {0} is gone — starting it again so the dashboard "
                     + "recovers without Floci being restarted", containerId);
             this.started = false;
@@ -214,7 +223,7 @@ public class FlociUiManager {
             this.kicked.set(false);
             ensureStartedAsync();
         }
-        return new UiStatus(started, ready, hostPort, null);
+        return new UiStatus(started, probe.ready(), hostPort, probe.error());
     }
 
     /** Host port the UI is published on. Valid once {@link #ensureStarted()} succeeds. */
@@ -438,8 +447,8 @@ public class FlociUiManager {
     }
 
     /**
-     * Resolves the URL the readiness probe should connect to from the sidecar's
-     * resolved endpoint. {@link EndpointInfo} already returns a Floci-reachable
+     * Resolves the sidecar runtime-status URL that the readiness probe should query.
+     * {@link EndpointInfo} already returns a Floci-reachable
      * address — {@code localhost:hostPort} when Floci runs natively, or the
      * sidecar's container IP on the shared Docker network when Floci runs in a
      * container (where the published host port is not reachable from inside).
@@ -447,26 +456,47 @@ public class FlociUiManager {
      */
     String resolveProbeUrl(EndpointInfo endpoint, int fallbackHostPort) {
         if (endpoint != null) {
-            return "http://" + endpoint.host() + ":" + endpoint.port() + "/";
+            return "http://" + endpoint.host() + ":" + endpoint.port() + RUNTIME_STATUS_PATH;
         }
-        return "http://localhost:" + fallbackHostPort + "/";
+        return "http://localhost:" + fallbackHostPort + RUNTIME_STATUS_PATH;
     }
 
-    private boolean probeReady() {
+    private record RuntimeProbe(boolean ready, String error) {
+    }
+
+    private RuntimeProbe probeRuntime() {
         String url = probeUrl;
         if (url == null) {
-            return false;
+            return new RuntimeProbe(false, null);
         }
+        HttpURLConnection conn = null;
         try {
-            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
             conn.setConnectTimeout(800);
             conn.setReadTimeout(800);
             conn.setRequestMethod("GET");
             int code = conn.getResponseCode();
-            conn.disconnect();
-            return code > 0;
+            if (code != HttpURLConnection.HTTP_OK) {
+                return new RuntimeProbe(false, null);
+            }
+            JsonNode status;
+            try (var input = conn.getInputStream()) {
+                status = objectMapper.readTree(input);
+            }
+            String runtime = status.path("runtime").asText("");
+            if ("reachable".equalsIgnoreCase(runtime)) {
+                return new RuntimeProbe(true, null);
+            }
+            if ("unavailable".equalsIgnoreCase(runtime)) {
+                return new RuntimeProbe(false, runtimeUnavailableMessage(status));
+            }
+            return new RuntimeProbe(false, null);
         } catch (Exception e) {
-            return false;
+            return new RuntimeProbe(false, null);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
         }
     }
 
@@ -505,6 +535,19 @@ public class FlociUiManager {
                     existing.getId(), e.getMessage());
             return false;
         }
+    }
+
+    private static String runtimeUnavailableMessage(JsonNode status) {
+        String endpoint = status.path("endpoint").asText("");
+        String error = status.path("error").asText("");
+        StringBuilder message = new StringBuilder("The Floci UI cannot reach Floci");
+        if (!endpoint.isBlank()) {
+            message.append(" at ").append(endpoint);
+        }
+        if (!error.isBlank()) {
+            message.append(": ").append(error);
+        }
+        return message.append('.').toString();
     }
 
     private void adoptExisting(Container existing) {

--- a/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManager.java
@@ -492,6 +492,7 @@ public class FlociUiManager {
             }
             return new RuntimeProbe(false, null);
         } catch (Exception e) {
+            LOG.debugv(e, "Failed to probe floci-ui runtime at {0}", url);
             return new RuntimeProbe(false, null);
         } finally {
             if (conn != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
@@ -50,7 +50,6 @@ class FlociUiManagerTest {
     private final EmulatorConfig.TlsConfig tls = mock(EmulatorConfig.TlsConfig.class);
     private final EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
     private final EmulatorConfig.UiServiceConfig ui = mock(EmulatorConfig.UiServiceConfig.class);
-    private final RegionResolver regionResolver = mock(RegionResolver.class);
 
     /** Wires config.services().ui() with the defaults every UI test starts from. */
     private void withUiConfig() {
@@ -608,6 +607,7 @@ class FlociUiManagerTest {
         when(ui.enabled()).thenReturn(true);
         when(ui.containerName()).thenReturn("floci-ui");
         when(ui.port()).thenReturn(port);
+        when(ui.endpoint()).thenReturn(Optional.of("http://custom:4566"));
 
         Container existing = mock(Container.class);
         when(existing.getId()).thenReturn("ui-container");

--- a/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/floci/ui/FlociUiManagerTest.java
@@ -1,11 +1,14 @@
 package io.github.hectorvent.floci.services.floci.ui;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerPresence;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import io.github.hectorvent.floci.core.common.docker.CurrentContainerNetworkResolver;
@@ -15,7 +18,10 @@ import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Container;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,6 +31,7 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
@@ -36,6 +43,9 @@ class FlociUiManagerTest {
 
     private final ContainerDetector containerDetector = mock(ContainerDetector.class);
     private final DockerHostResolver dockerHostResolver = mock(DockerHostResolver.class);
+    private final ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+    private final ContainerLogStreamer logStreamer = mock(ContainerLogStreamer.class);
+    private final RegionResolver regionResolver = mock(RegionResolver.class);
     private final EmulatorConfig config = mock(EmulatorConfig.class);
     private final EmulatorConfig.TlsConfig tls = mock(EmulatorConfig.TlsConfig.class);
     private final EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
@@ -53,13 +63,14 @@ class FlociUiManagerTest {
     private FlociUiManager newManager() {
         return new FlociUiManager(
                 mock(ContainerBuilder.class),
-                mock(ContainerLifecycleManager.class),
-                mock(ContainerLogStreamer.class),
+                lifecycleManager,
+                logStreamer,
                 containerDetector,
                 mock(CurrentContainerNetworkResolver.class),
                 dockerHostResolver,
                 config,
-                regionResolver);
+                regionResolver,
+                new ObjectMapper());
     }
 
     @Test
@@ -164,19 +175,63 @@ class FlociUiManagerTest {
         // probe must target the sidecar's container IP on the shared Docker network.
         EndpointInfo endpoint = new EndpointInfo("10.88.0.20", 4500);
 
-        assertEquals("http://10.88.0.20:4500/", newManager().resolveProbeUrl(endpoint, 4500));
+        assertEquals("http://10.88.0.20:4500/api/clouds/aws/status",
+                newManager().resolveProbeUrl(endpoint, 4500));
     }
 
     @Test
     void probeUsesLocalhostHostPortNatively() {
         EndpointInfo endpoint = new EndpointInfo("localhost", 4500);
 
-        assertEquals("http://localhost:4500/", newManager().resolveProbeUrl(endpoint, 4500));
+        assertEquals("http://localhost:4500/api/clouds/aws/status",
+                newManager().resolveProbeUrl(endpoint, 4500));
     }
 
     @Test
     void probeFallsBackToLocalhostWhenEndpointMissing() {
-        assertEquals("http://localhost:4500/", newManager().resolveProbeUrl(null, 4500));
+        assertEquals("http://localhost:4500/api/clouds/aws/status",
+                newManager().resolveProbeUrl(null, 4500));
+    }
+
+    @Test
+    void statusIsReadyWhenSidecarCanReachFloci() throws Exception {
+        HttpServer server = startRuntimeStatusServer("""
+                {"runtime":"reachable","endpoint":"http://host.docker.internal:4566"}
+                """);
+        try {
+            FlociUiManager manager = adoptSidecar(server.getAddress().getPort());
+
+            FlociUiManager.UiStatus status = manager.status();
+
+            assertTrue(status.started());
+            assertTrue(status.ready());
+            assertNull(status.error());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void statusSurfacesSidecarRuntimeFailure() throws Exception {
+        HttpServer server = startRuntimeStatusServer("""
+                {
+                  "runtime":"unavailable",
+                  "endpoint":"http://10.88.4.98:4566",
+                  "error":"ECONNREFUSED"
+                }
+                """);
+        try {
+            FlociUiManager manager = adoptSidecar(server.getAddress().getPort());
+
+            FlociUiManager.UiStatus status = manager.status();
+
+            assertTrue(status.started());
+            assertFalse(status.ready());
+            assertTrue(status.error().contains("http://10.88.4.98:4566"), status.error());
+            assertTrue(status.error().contains("ECONNREFUSED"), status.error());
+        } finally {
+            server.stop(0);
+        }
     }
 
     @Test
@@ -442,7 +497,8 @@ class FlociUiManagerTest {
                 mock(CurrentContainerNetworkResolver.class),
                 dockerHostResolver,
                 config,
-                regionResolver);
+                regionResolver,
+                new ObjectMapper());
 
         manager.ensureStartedAsync();
         await().atMost(2, TimeUnit.SECONDS)
@@ -480,7 +536,8 @@ class FlociUiManagerTest {
                 mock(CurrentContainerNetworkResolver.class),
                 dockerHostResolver,
                 config,
-                regionResolver);
+                regionResolver,
+                new ObjectMapper());
 
         manager.ensureStarted();
 
@@ -532,7 +589,8 @@ class FlociUiManagerTest {
                 mock(CurrentContainerNetworkResolver.class),
                 dockerHostResolver,
                 config,
-                regionResolver);
+                regionResolver,
+                new ObjectMapper());
 
         manager.ensureStarted();
 
@@ -540,5 +598,39 @@ class FlociUiManagerTest {
         assertTrue(manager.status().error() != null && manager.status().error().contains("http://"),
                 "expected a captured error mentioning the required http:// scheme, was: "
                         + manager.status().error());
+    }
+
+    private FlociUiManager adoptSidecar(int port) {
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.UiServiceConfig ui = mock(EmulatorConfig.UiServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.ui()).thenReturn(ui);
+        when(ui.enabled()).thenReturn(true);
+        when(ui.containerName()).thenReturn("floci-ui");
+        when(ui.port()).thenReturn(port);
+
+        Container existing = mock(Container.class);
+        when(existing.getId()).thenReturn("ui-container");
+        when(lifecycleManager.findByName("floci-ui")).thenReturn(Optional.of(existing));
+        when(lifecycleManager.adopt("ui-container", List.of(4500))).thenReturn(
+                new ContainerInfo("ui-container", Map.of(4500, new EndpointInfo("127.0.0.1", port))));
+
+        FlociUiManager manager = newManager();
+        manager.ensureStarted();
+        return manager;
+    }
+
+    private static HttpServer startRuntimeStatusServer(String response) throws IOException {
+        byte[] body = response.getBytes(StandardCharsets.UTF_8);
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/api/clouds/aws/status", exchange -> {
+            exchange.getResponseHeaders().set("Content-Type", "application/json");
+            exchange.sendResponseHeaders(200, body.length);
+            try (var output = exchange.getResponseBody()) {
+                output.write(body);
+            }
+        });
+        server.start();
+        return server;
     }
 }


### PR DESCRIPTION
## Summary

- probe the UI sidecar's `/api/clouds/aws/status` endpoint instead of treating any root response as ready
- require `runtime: reachable` before redirecting users to the dashboard
- surface the sidecar-reported Floci endpoint and connection error when `runtime: unavailable`
- keep transient probe failures in the polling state while the sidecar starts

## Testing

- `./mvnw test -Dtest=FlociUiManagerTest,UiLandingIntegrationTest` (20 tests passed)

Fixes #2217
