### PR TITLE
fix(s3): prevent compliance retention downgrade

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1859,7 +1859,14 @@ public class S3Service implements Resettable, ResourceProvider {
                 .orElseThrow(() -> new AwsException("NoSuchKey",
                         "The specified key does not exist.", 404));
 
-        // COMPLIANCE mode: retainUntil cannot be shortened
+        // COMPLIANCE mode cannot be changed or removed, even when the retention date
+        // is unchanged or extended.
+        if ("COMPLIANCE".equals(obj.getObjectLockMode()) && !"COMPLIANCE".equals(mode)) {
+            throw new AwsException("AccessDenied",
+                    "COMPLIANCE retention mode cannot be changed", 403);
+        }
+
+        // COMPLIANCE mode: retainUntil cannot be shortened.
         if ("COMPLIANCE".equals(obj.getObjectLockMode())
                 && obj.getRetainUntilDate() != null
                 && retainUntil != null

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1859,16 +1859,19 @@ public class S3Service implements Resettable, ResourceProvider {
                 .orElseThrow(() -> new AwsException("NoSuchKey",
                         "The specified key does not exist.", 404));
 
-        // COMPLIANCE mode cannot be changed or removed, even when the retention date
-        // is unchanged or extended.
-        if ("COMPLIANCE".equals(obj.getObjectLockMode()) && !"COMPLIANCE".equals(mode)) {
+        boolean activeComplianceRetention = "COMPLIANCE".equals(obj.getObjectLockMode())
+                && obj.getRetainUntilDate() != null
+                && Instant.now().isBefore(obj.getRetainUntilDate());
+
+        // Active COMPLIANCE mode cannot be changed or removed, even when the
+        // retention date is unchanged or extended.
+        if (activeComplianceRetention && !"COMPLIANCE".equals(mode)) {
             throw new AwsException("AccessDenied",
                     "COMPLIANCE retention mode cannot be changed", 403);
         }
 
-        // COMPLIANCE mode: retainUntil cannot be shortened.
-        if ("COMPLIANCE".equals(obj.getObjectLockMode())
-                && obj.getRetainUntilDate() != null
+        // Active COMPLIANCE mode: retainUntil cannot be shortened.
+        if (activeComplianceRetention
                 && retainUntil != null
                 && retainUntil.isBefore(obj.getRetainUntilDate())) {
             throw new AwsException("AccessDenied",

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
@@ -143,7 +143,7 @@ class S3ObjectLockIntegrationTest {
         String body = """
                 <?xml version="1.0" encoding="UTF-8"?>
                 <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-                  <Mode>GOVERNANCE</Mode>
+                  <Mode>COMPLIANCE</Mode>
                   <RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate>
                 </Retention>
                 """;
@@ -199,6 +199,70 @@ class S3ObjectLockIntegrationTest {
 
     @Test
     @Order(14)
+    void putGovernanceObjectForRetentionUpgrade() {
+        given()
+            .header("x-amz-object-lock-mode", "GOVERNANCE")
+            .header("x-amz-object-lock-retain-until-date", "2030-01-01T00:00:00Z")
+            .body("governance object")
+        .when()
+            .put("/" + LOCK_BUCKET + "/governance-object.txt")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(15)
+    void governanceRetentionCanBeUpgradedToCompliance() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Mode>COMPLIANCE</Mode>
+                  <RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate>
+                </Retention>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "/governance-object.txt?retention")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + LOCK_BUCKET + "/governance-object.txt?retention")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Mode>COMPLIANCE</Mode>"));
+    }
+
+    @Test
+    @Order(16)
+    void complianceRetentionCannotBeDowngradedToGovernance() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Mode>GOVERNANCE</Mode>
+                  <RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate>
+                </Retention>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "/" + RETENTION_KEY + "?retention")
+        .then()
+            .statusCode(403)
+            .body(containsString("AccessDenied"));
+
+        given()
+        .when()
+            .get("/" + LOCK_BUCKET + "/" + RETENTION_KEY + "?retention")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Mode>COMPLIANCE</Mode>"));
+    }
+
+    @Test
+    @Order(17)
     void nonExistentBucketReturnsNoSuchBucket() {
         given()
         .when()

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ObjectLockIntegrationTest.java
@@ -263,6 +263,44 @@ class S3ObjectLockIntegrationTest {
 
     @Test
     @Order(17)
+    void putObjectWithExpiredComplianceRetention() {
+        given()
+            .header("x-amz-object-lock-mode", "COMPLIANCE")
+            .header("x-amz-object-lock-retain-until-date", "2020-01-01T00:00:00Z")
+            .body("expired compliance object")
+        .when()
+            .put("/" + LOCK_BUCKET + "/expired-compliance-object.txt")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(18)
+    void expiredComplianceRetentionCanChangeMode() {
+        String body = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <Retention xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                  <Mode>GOVERNANCE</Mode>
+                  <RetainUntilDate>2030-01-01T00:00:00Z</RetainUntilDate>
+                </Retention>
+                """;
+        given()
+            .body(body)
+        .when()
+            .put("/" + LOCK_BUCKET + "/expired-compliance-object.txt?retention")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + LOCK_BUCKET + "/expired-compliance-object.txt?retention")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Mode>GOVERNANCE</Mode>"));
+    }
+
+    @Test
+    @Order(19)
     void nonExistentBucketReturnsNoSuchBucket() {
         given()
         .when()


### PR DESCRIPTION
## Summary

- reject attempts to change or remove an active S3 COMPLIANCE retention mode
- preserve the allowed GOVERNANCE-to-COMPLIANCE transition
- add end-to-end coverage for active and expired COMPLIANCE retention transitions

## Testing

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=S3ObjectLockIntegrationTest` (18 tests passed)

Fixes #2598
