### PR TITLE
refactor(cloudformation): move AWS::Logs::LogGroup into its own provisioner

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -139,7 +139,7 @@ public class CloudFormationResourceProvisioner {
     private static final String LAMBDA_CODE_IDENTITY_ATTR = "FlociLambdaCodeIdentity";
     private static final String LAMBDA_NAME_MODE_ATTR = "FlociLambdaFunctionNameMode";
     private static final String LAMBDA_PACKAGE_TYPE_ATTR = "FlociLambdaPackageType";
-    static final String UPDATE_ROLLBACK_RESTORED_ATTR = "__FlociUpdateRollbackRestored";
+    static final String UPDATE_ROLLBACK_RESTORED_ATTR = CfnRollback.UPDATE_ROLLBACK_RESTORED_ATTR;
     static final String UPDATE_ROLLBACK_FAILURE_ATTR = "__FlociUpdateRollbackFailure";
     private static final String INLINE_CLEANUP_POLICY_NAME_ATTR = "__FlociInlineCleanupPolicyName";
     private static final String INLINE_CLEANUP_ROLE_TARGETS_ATTR = "__FlociInlineCleanupRoleTargets";
@@ -158,7 +158,6 @@ public class CloudFormationResourceProvisioner {
     private static final String NAME_MODE_GENERATED = "generated";
     private static final int GENERATED_NAME_SUFFIX_LENGTH = 12;
     private static final int STEP_FUNCTIONS_NAME_MAX_LENGTH = 80;
-    private static final String LOG_GROUP_NAME_MODE_ATTR = "FlociLogGroupNameMode";
     private static final String SECRET_TARGET_MANAGED_KEYS_ATTR = "__FlociSecretTargetManagedKeys";
     private static final String SECRET_TARGET_OWNER_ATTR = "__FlociSecretTargetOwner";
     private static final String DDB_REPLICA_TABLE_NAME_ATTR = "TableName";
@@ -261,7 +260,6 @@ public class CloudFormationResourceProvisioner {
             "AWS::Lambda::EventSourceMapping",
             "AWS::Lambda::Function",
             "AWS::Lambda::LayerVersion",
-            "AWS::Logs::LogGroup",
             "AWS::RDS::DBCluster",
             "AWS::RDS::DBClusterParameterGroup",
             "AWS::RDS::DBInstance",
@@ -309,7 +307,6 @@ public class CloudFormationResourceProvisioner {
     private final Ec2Service ec2Service;
     private final RdsService rdsService;
     private final EksService eksService;
-    private final CloudWatchLogsService logsService;
     private final KinesisService kinesisService;
     private final CloudWatchMetricsService cloudWatchMetricsService;
     private final AutoScalingService autoScalingService;
@@ -377,7 +374,6 @@ public class CloudFormationResourceProvisioner {
         this.ec2Service = ec2Service;
         this.rdsService = rdsService;
         this.eksService = eksService;
-        this.logsService = logsService;
         this.kinesisService = kinesisService;
         this.cloudWatchMetricsService = cloudWatchMetricsService;
         this.autoScalingService = autoScalingService;
@@ -517,7 +513,6 @@ public class CloudFormationResourceProvisioner {
                         provisionDbProxyTargetGroup(resource, properties, engine, region);
                 case "AWS::EKS::Cluster" -> provisionEksCluster(resource, properties, engine, stackName);
                 case "AWS::EKS::Nodegroup" -> provisionEksNodegroup(resource, properties, engine, stackName);
-                case "AWS::Logs::LogGroup" -> provisionLogGroup(resource, properties, engine, region, accountId, stackName);
                 case "AWS::Kinesis::Stream" ->
                         provisionKinesisStream(resource, properties, engine, region, stackName);
                 case "AWS::CloudWatch::Alarm" ->
@@ -755,7 +750,6 @@ public class CloudFormationResourceProvisioner {
             case "AWS::RDS::DBClusterParameterGroup" ->
                     rdsService.deleteDbClusterParameterGroup(physicalId, region);
             case "AWS::EKS::Cluster" -> eksService.deleteCluster(physicalId);
-            case "AWS::Logs::LogGroup" -> logsService.deleteLogGroup(physicalId, region);
             case "AWS::Kinesis::Stream" -> kinesisService.deleteStream(physicalId, region);
             case "AWS::CloudWatch::Alarm" ->
                     cloudWatchMetricsService.deleteAlarms(List.of(physicalId), region);
@@ -890,89 +884,6 @@ public class CloudFormationResourceProvisioner {
 
     // ── CloudWatch Logs ─────────────────────────────────────────────────────────
 
-    private void provisionLogGroup(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                   String region, String accountId, String stackName) {
-        String explicitName = resolveOptional(props, "LogGroupName", engine);
-        boolean hasExplicitName = explicitName != null && !explicitName.isBlank();
-        String previousNameMode = r.getAttributes().get(LOG_GROUP_NAME_MODE_ATTR);
-        if (previousNameMode == null && r.getPhysicalId() != null) {
-            // Stacks persisted before FlociLogGroupNameMode existed have no recorded mode, but an
-            // auto-generated name always has the deterministic shape generatePhysicalName produces,
-            // so anything else must have been explicit.
-            previousNameMode = isGeneratedName(r.getPhysicalId(), stackName, r.getLogicalId(), 512)
-                    ? NAME_MODE_GENERATED
-                    : NAME_MODE_EXPLICIT;
-        }
-        // Going from an explicit name to none is itself a replacement-worthy change on real AWS, not
-        // something to silently keep reconciling under the old explicit name (mirrors the same check
-        // for Lambda's FunctionName above).
-        boolean explicitNameRemoved = r.getPhysicalId() != null && !hasExplicitName
-                && NAME_MODE_EXPLICIT.equals(previousNameMode);
-
-        String name;
-        if (hasExplicitName) {
-            name = explicitName;
-        } else if (r.getPhysicalId() != null && !explicitNameRemoved) {
-            // No explicit name and the prior name was itself auto-generated: keep it across updates
-            // instead of generating a fresh random one each time, so the log group is reconciled in
-            // place rather than replaced on every no-op update.
-            name = r.getPhysicalId();
-        } else {
-            name = generatePhysicalName(stackName, r.getLogicalId(), 512, false);
-        }
-        Integer retentionInDays = null;
-        String retention = resolveOptional(props, "RetentionInDays", engine);
-        if (retention != null && !retention.isBlank()) {
-            try {
-                retentionInDays = Integer.valueOf(retention.trim());
-            } catch (NumberFormatException ignored) {
-                // leave unset
-            }
-        }
-        Map<String, String> tags = new HashMap<>();
-        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
-            for (JsonNode tag : props.get("Tags")) {
-                String key = engine.resolve(tag.path("Key"));
-                if (!key.isEmpty()) {
-                    tags.put(key, engine.resolve(tag.path("Value")));
-                }
-            }
-        }
-
-        // LogGroupName isn't updatable in place on real AWS (a change replaces the resource), so only
-        // reconcile in place when the name is unchanged and the group is still there; otherwise this is
-        // either a first create or a rename, both of which need a fresh createLogGroup call. On a rename,
-        // create the new group before deleting the old one: if the new name collides with something else
-        // and createLogGroup throws, the update rolls back without touching the old group, since rollback
-        // does not restore a resource this method already deleted.
-        String priorPhysicalId = r.getPhysicalId();
-        if (priorPhysicalId != null && priorPhysicalId.equals(name) && logsService.logGroupExists(name, region)) {
-            reconcileLogGroup(name, retentionInDays, tags, region);
-        } else {
-            boolean preservedPriorGroup = priorPhysicalId != null
-                    && !priorPhysicalId.equals(name)
-                    && logsService.logGroupExists(priorPhysicalId, region);
-            try {
-                logsService.createLogGroup(name, retentionInDays, tags, region);
-            } catch (RuntimeException failure) {
-                if (preservedPriorGroup) {
-                    r.getAttributes().put(UPDATE_ROLLBACK_RESTORED_ATTR, "true");
-                }
-                throw failure;
-            }
-            if (preservedPriorGroup) {
-                logsService.deleteLogGroup(priorPhysicalId, region);
-            }
-        }
-
-        // Ref returns the log group name; GetAtt Arn is arn:aws:logs:<region>:<account>:log-group:<name>:*
-        r.setPhysicalId(name);
-        r.getAttributes().put("Arn",
-                AwsArnUtils.Arn.of("logs", region, accountId, "log-group:" + name + ":*").toString());
-        r.getAttributes().put(LOG_GROUP_NAME_MODE_ATTR,
-                hasExplicitName ? NAME_MODE_EXPLICIT : NAME_MODE_GENERATED);
-    }
-
     /**
      * Whether {@code physicalId} matches the exact shape {@link #generatePhysicalName} produces for
      * this stack/logical id/maxLength: its base-and-truncation logic (minus the random suffix itself)
@@ -1015,24 +926,6 @@ public class CloudFormationResourceProvisioner {
             prefix = prefix.substring(0, prefix.length() - 1);
         }
         return prefix;
-    }
-
-    private void reconcileLogGroup(String name, Integer retentionInDays, Map<String, String> tags, String region) {
-        if (retentionInDays != null) {
-            logsService.putRetentionPolicy(name, retentionInDays, region);
-        } else {
-            logsService.deleteRetentionPolicy(name, region);
-        }
-        Map<String, String> existingTags = logsService.listTagsLogGroup(name, region);
-        List<String> tagsToRemove = existingTags.keySet().stream()
-                .filter(key -> !tags.containsKey(key))
-                .toList();
-        if (!tagsToRemove.isEmpty()) {
-            logsService.untagLogGroup(name, tagsToRemove, region);
-        }
-        if (!tags.isEmpty()) {
-            logsService.tagLogGroup(name, tags, region);
-        }
     }
 
     // ── Kinesis ─────────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -271,8 +271,6 @@ public class CloudFormationResourceProvisioner {
             "AWS::RDS::DBSubnetGroup",
             "AWS::Route53::HostedZone",
             "AWS::Route53::RecordSet",
-            "AWS::S3::Bucket",
-            "AWS::S3::BucketPolicy",
             "AWS::SNS::Subscription",
             "AWS::SNS::Topic",
             "AWS::SecretsManager::Secret",
@@ -425,7 +423,6 @@ public class CloudFormationResourceProvisioner {
                 return resource;
             }
             switch (resourceType) {
-                case "AWS::S3::Bucket" -> provisionS3Bucket(resource, properties, engine, region, accountId, stackName);
                 case "AWS::SNS::Topic" -> provisionSnsTopic(resource, properties, engine, region, accountId, stackName);
                 case "AWS::SNS::Subscription" -> provisionSnsSubscription(resource, properties, engine, region);
                 case "AWS::DynamoDB::Table", "AWS::DynamoDB::GlobalTable" ->
@@ -442,7 +439,6 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::SecretsManager::Secret" -> provisionSecret(resource, properties, engine, region, accountId, stackName);
                 case "AWS::SecretsManager::SecretTargetAttachment" ->
                         provisionSecretTargetAttachment(resource, properties, engine, region, stackName);
-                case "AWS::S3::BucketPolicy" -> provisionS3BucketPolicy(resource, properties, engine);
                 case "AWS::Route53::HostedZone" -> provisionRoute53HostedZone(resource, properties, engine);
                 case "AWS::Route53::RecordSet" -> provisionRoute53RecordSet(resource, properties, engine);
                 case "AWS::Events::Rule" -> provisionEventBridgeRule(resource, properties, engine, region, stackName);
@@ -713,7 +709,6 @@ public class CloudFormationResourceProvisioner {
             return;
         }
         switch (resourceType) {
-            case "AWS::S3::Bucket" -> s3Service.deleteBucket(physicalId);
             case "AWS::SNS::Topic" -> snsService.deleteTopic(physicalId, region);
             case "AWS::SNS::Subscription" -> snsService.unsubscribe(physicalId, region);
             case "AWS::DynamoDB::Table" -> deleteDynamoTableSafe(physicalId, region);
@@ -775,23 +770,6 @@ public class CloudFormationResourceProvisioner {
 
     // ── S3 ────────────────────────────────────────────────────────────────────
 
-    private void provisionS3Bucket(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                   String region, String accountId, String stackName) {
-        String bucketName = resolveOptional(props, "BucketName", engine);
-        if (bucketName == null || bucketName.isBlank()) {
-            bucketName = generatePhysicalName(stackName, r.getLogicalId(), 63, true);
-        }
-        s3Service.createBucket(bucketName, region);
-        applyBucketCorsConfiguration(bucketName, props, engine);
-        applyBucketVersioningConfiguration(bucketName, props, engine);
-        r.setPhysicalId(bucketName);
-        r.getAttributes().put("Arn", AwsArnUtils.Arn.of("s3", "", "", bucketName).toString());
-        r.getAttributes().put("DomainName", bucketName + ".s3.amazonaws.com");
-        r.getAttributes().put("RegionalDomainName", bucketName + ".s3." + region + ".amazonaws.com");
-        r.getAttributes().put("WebsiteURL", "http://" + bucketName + ".s3-website." + region + ".amazonaws.com");
-        r.getAttributes().put("BucketName", bucketName);
-    }
-
     /**
      * Applies the optional {@code CorsConfiguration} property of {@code AWS::S3::Bucket} by translating
      * the CloudFormation {@code CorsRules} list into the S3 CORS XML document the bucket stores and
@@ -801,61 +779,6 @@ public class CloudFormationResourceProvisioner {
      * absent or has no rules, any existing CORS configuration is cleared so the bucket matches the
      * template. Clearing is a harmless no-op on create since a freshly created bucket has none.
      */
-    private void applyBucketCorsConfiguration(String bucketName, JsonNode props,
-                                              CloudFormationTemplateEngine engine) {
-        JsonNode corsRules = null;
-        if (props != null && props.has("CorsConfiguration") && !props.get("CorsConfiguration").isNull()) {
-            corsRules = props.get("CorsConfiguration").get("CorsRules");
-        }
-        if (corsRules == null || !corsRules.isArray() || corsRules.isEmpty()) {
-            s3Service.deleteBucketCors(bucketName);
-            return;
-        }
-        XmlBuilder xml = new XmlBuilder().start("CORSConfiguration", AwsNamespaces.S3);
-        for (JsonNode rule : corsRules) {
-            xml.start("CORSRule");
-            xml.elem("ID", resolveOptional(rule, "Id", engine));
-            appendCorsRuleElements(xml, rule.get("AllowedHeaders"), "AllowedHeader", engine);
-            appendCorsRuleElements(xml, rule.get("AllowedMethods"), "AllowedMethod", engine);
-            appendCorsRuleElements(xml, rule.get("AllowedOrigins"), "AllowedOrigin", engine);
-            appendCorsRuleElements(xml, rule.get("ExposedHeaders"), "ExposeHeader", engine);
-            String maxAge = resolveOptional(rule, "MaxAge", engine);
-            if (maxAge != null && !maxAge.isBlank()) {
-                xml.elem("MaxAgeSeconds", maxAge);
-            }
-            xml.end("CORSRule");
-        }
-        xml.end("CORSConfiguration");
-        s3Service.putBucketCors(bucketName, xml.build());
-    }
-
-    private void applyBucketVersioningConfiguration(String bucketName, JsonNode props,
-                                                     CloudFormationTemplateEngine engine) {
-        if (props == null || !props.has("VersioningConfiguration")
-                || props.get("VersioningConfiguration").isNull()) {
-            return;
-        }
-        String status = resolveOptional(props.get("VersioningConfiguration"), "Status", engine);
-        if (status != null && !status.isBlank()) {
-            s3Service.putBucketVersioning(bucketName, status);
-        }
-    }
-
-    private void appendCorsRuleElements(XmlBuilder xml, JsonNode values, String elementName,
-                                        CloudFormationTemplateEngine engine) {
-        if (values == null || !values.isArray()) {
-            return;
-        }
-        for (JsonNode value : values) {
-            if (value != null && !value.isNull()) {
-                String resolved = engine.resolve(value);
-                if (resolved != null && !resolved.isBlank()) {
-                    xml.elem(elementName, resolved);
-                }
-            }
-        }
-    }
-
 
     // ── EC2 networking ─────────────────────────────────────────────────────────
     // Each method delegates to Ec2Service so the resource really exists (describe-subnets,
@@ -5128,10 +5051,6 @@ public class CloudFormationResourceProvisioner {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
-
-    private void provisionS3BucketPolicy(StackResource r, JsonNode props, CloudFormationTemplateEngine engine) {
-        r.setPhysicalId("bucket-policy-" + UUID.randomUUID().toString().substring(0, 8));
-    }
 
 
     private void provisionIamUser(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/CfnRollback.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/CfnRollback.java
@@ -19,6 +19,15 @@ public final class CfnRollback {
      */
     public static final String ROLLBACK_OWNED_ATTR = "__FlociRollbackOwned";
 
+    /**
+     * Marks a resource whose prior physical entity is still intact after a failed update, so the
+     * rollback must not try to restore it. Set by a provisioner that creates the replacement before
+     * deleting the original; read by {@code CloudFormationService} when deciding what a rollback
+     * owes. Lives here rather than on {@code CloudFormationResourceProvisioner} so extracted
+     * provisioners in this package can set it.
+     */
+    public static final String UPDATE_ROLLBACK_RESTORED_ATTR = "__FlociUpdateRollbackRestored";
+
     private CfnRollback() {
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LogsCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LogsCfnProvisioner.java
@@ -1,0 +1,182 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Provisions {@code AWS::Logs::LogGroup}. */
+@ApplicationScoped
+public class LogsCfnProvisioner implements CfnResourceProvisioner {
+
+    /**
+     * Records whether the log group's name came from the template or was generated, so a later
+     * update can tell a rename from a no-op. Read back off the resource's stored attributes.
+     */
+    private static final String LOG_GROUP_NAME_MODE_ATTR = "FlociLogGroupNameMode";
+    private static final String NAME_MODE_EXPLICIT = "explicit";
+    private static final String NAME_MODE_GENERATED = "generated";
+    private static final int LOG_GROUP_NAME_MAX_LENGTH = 512;
+    private static final int GENERATED_NAME_SUFFIX_LENGTH = 12;
+
+    private final CloudWatchLogsService logsService;
+
+    public LogsCfnProvisioner(CloudWatchLogsService logsService) {
+        this.logsService = logsService;
+    }
+
+    @Override
+    public Set<String> resourceTypes() {
+        return Set.of("AWS::Logs::LogGroup");
+    }
+
+    @Override
+    public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String explicitName = ctx.resolveOptional(props, "LogGroupName");
+        boolean hasExplicitName = explicitName != null && !explicitName.isBlank();
+        String priorPhysicalId = ctx.priorPhysicalId();
+
+        String previousNameMode = r.getAttributes().get(LOG_GROUP_NAME_MODE_ATTR);
+        if (previousNameMode == null && priorPhysicalId != null) {
+            // Stacks persisted before FlociLogGroupNameMode existed have no recorded mode, but an
+            // auto-generated name always has the deterministic shape generatePhysicalName produces,
+            // so anything else must have been explicit.
+            previousNameMode = isGeneratedName(priorPhysicalId, ctx.stackName(), r.getLogicalId(),
+                    LOG_GROUP_NAME_MAX_LENGTH) ? NAME_MODE_GENERATED : NAME_MODE_EXPLICIT;
+        }
+        // Going from an explicit name to none is itself a replacement-worthy change on real AWS, not
+        // something to silently keep reconciling under the old explicit name.
+        boolean explicitNameRemoved = priorPhysicalId != null && !hasExplicitName
+                && NAME_MODE_EXPLICIT.equals(previousNameMode);
+
+        String name;
+        if (hasExplicitName) {
+            name = explicitName;
+        } else if (priorPhysicalId != null && !explicitNameRemoved) {
+            // No explicit name and the prior name was itself auto-generated: keep it across updates
+            // instead of generating a fresh random one each time, so the log group is reconciled in
+            // place rather than replaced on every no-op update.
+            name = priorPhysicalId;
+        } else {
+            name = ctx.generatePhysicalName(r.getLogicalId(), LOG_GROUP_NAME_MAX_LENGTH, false);
+        }
+
+        Integer retentionInDays = null;
+        String retention = ctx.resolveOptional(props, "RetentionInDays");
+        if (retention != null && !retention.isBlank()) {
+            try {
+                retentionInDays = Integer.valueOf(retention.trim());
+            } catch (NumberFormatException ignored) {
+                // leave unset
+            }
+        }
+        Map<String, String> tags = new HashMap<>();
+        if (props != null && props.has("Tags") && props.get("Tags").isArray()) {
+            for (JsonNode tag : props.get("Tags")) {
+                String key = ctx.engine().resolve(tag.path("Key"));
+                if (!key.isEmpty()) {
+                    tags.put(key, ctx.engine().resolve(tag.path("Value")));
+                }
+            }
+        }
+
+        // LogGroupName isn't updatable in place on real AWS (a change replaces the resource), so only
+        // reconcile in place when the name is unchanged and the group is still there; otherwise this is
+        // either a first create or a rename, both of which need a fresh createLogGroup call. On a rename,
+        // create the new group before deleting the old one: if the new name collides with something else
+        // and createLogGroup throws, the update rolls back without touching the old group, since rollback
+        // does not restore a resource this method already deleted.
+        if (priorPhysicalId != null && priorPhysicalId.equals(name)
+                && logsService.logGroupExists(name, ctx.region())) {
+            reconcileLogGroup(name, retentionInDays, tags, ctx.region());
+        } else {
+            boolean preservedPriorGroup = priorPhysicalId != null
+                    && !priorPhysicalId.equals(name)
+                    && logsService.logGroupExists(priorPhysicalId, ctx.region());
+            try {
+                logsService.createLogGroup(name, retentionInDays, tags, ctx.region());
+            } catch (RuntimeException failure) {
+                if (preservedPriorGroup) {
+                    r.getAttributes().put(CfnRollback.UPDATE_ROLLBACK_RESTORED_ATTR, "true");
+                }
+                throw failure;
+            }
+            if (preservedPriorGroup) {
+                logsService.deleteLogGroup(priorPhysicalId, ctx.region());
+            }
+        }
+
+        // Ref returns the log group name; GetAtt Arn is arn:aws:logs:<region>:<account>:log-group:<name>:*
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", AwsArnUtils.Arn
+                .of("logs", ctx.region(), ctx.accountId(), "log-group:" + name + ":*").toString());
+        r.getAttributes().put(LOG_GROUP_NAME_MODE_ATTR,
+                hasExplicitName ? NAME_MODE_EXPLICIT : NAME_MODE_GENERATED);
+    }
+
+    private void reconcileLogGroup(String name, Integer retentionInDays, Map<String, String> tags,
+                                   String region) {
+        if (retentionInDays != null) {
+            logsService.putRetentionPolicy(name, retentionInDays, region);
+        } else {
+            logsService.deleteRetentionPolicy(name, region);
+        }
+        Map<String, String> existingTags = logsService.listTagsLogGroup(name, region);
+        List<String> tagsToRemove = existingTags.keySet().stream()
+                .filter(key -> !tags.containsKey(key))
+                .toList();
+        if (!tagsToRemove.isEmpty()) {
+            logsService.untagLogGroup(name, tagsToRemove, region);
+        }
+        if (!tags.isEmpty()) {
+            logsService.tagLogGroup(name, tags, region);
+        }
+    }
+
+    /**
+     * Whether a physical id has the exact shape {@code generatePhysicalName} produces. Copied from
+     * the monolith, which still needs it for a type that has not migrated yet.
+     */
+    private boolean isGeneratedName(String physicalId, String stackName, String logicalId, int maxLength) {
+        if (physicalId == null || physicalId.length() < GENERATED_NAME_SUFFIX_LENGTH + 1) {
+            return false;
+        }
+        String suffix = physicalId.substring(physicalId.length() - GENERATED_NAME_SUFFIX_LENGTH);
+        for (int i = 0; i < suffix.length(); i++) {
+            char c = suffix.charAt(i);
+            boolean hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+            if (!hex) {
+                return false;
+            }
+        }
+        if (physicalId.charAt(physicalId.length() - GENERATED_NAME_SUFFIX_LENGTH - 1) != '-') {
+            return false;
+        }
+        String actualPrefix = physicalId.substring(0, physicalId.length() - GENERATED_NAME_SUFFIX_LENGTH - 1);
+        return actualPrefix.equals(expectedGeneratedNamePrefix(stackName, logicalId, maxLength));
+    }
+
+    private String expectedGeneratedNamePrefix(String stackName, String logicalId, int maxLength) {
+        String base = stackName + "-" + logicalId;
+        if (maxLength <= 0 || base.length() + 1 + GENERATED_NAME_SUFFIX_LENGTH <= maxLength) {
+            return base;
+        }
+        int keep = Math.max(0, maxLength - GENERATED_NAME_SUFFIX_LENGTH - 1);
+        String prefix = base.length() > keep ? base.substring(0, keep) : base;
+        while (prefix.endsWith("-")) {
+            prefix = prefix.substring(0, prefix.length() - 1);
+        }
+        return prefix;
+    }
+
+    @Override
+    public void delete(String resourceType, String physicalId, String region) {
+        logsService.deleteLogGroup(physicalId, region);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisioner.java
@@ -1,0 +1,128 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsNamespaces;
+import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Provisions {@code AWS::S3::Bucket} and {@code AWS::S3::BucketPolicy}.
+ *
+ * <p>The bucket policy is accepted and given a physical id but not enforced: Floci does not
+ * evaluate S3 policies, and failing the resource would break every template that attaches one.
+ */
+@ApplicationScoped
+public class S3CfnProvisioner implements CfnResourceProvisioner {
+
+    private static final String BUCKET = "AWS::S3::Bucket";
+    private static final String BUCKET_POLICY = "AWS::S3::BucketPolicy";
+    private static final int BUCKET_NAME_MAX_LENGTH = 63;
+
+    private final S3Service s3Service;
+
+    public S3CfnProvisioner(S3Service s3Service) {
+        this.s3Service = s3Service;
+    }
+
+    @Override
+    public Set<String> resourceTypes() {
+        return Set.of(BUCKET, BUCKET_POLICY);
+    }
+
+    @Override
+    public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+        switch (r.getResourceType()) {
+            case BUCKET -> provisionBucket(r, props, ctx);
+            case BUCKET_POLICY ->
+                    r.setPhysicalId("bucket-policy-" + UUID.randomUUID().toString().substring(0, 8));
+            default -> throw new IllegalStateException(
+                    "S3CfnProvisioner cannot provision " + r.getResourceType());
+        }
+    }
+
+    private void provisionBucket(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String bucketName = ctx.resolveOptional(props, "BucketName");
+        if (bucketName == null || bucketName.isBlank()) {
+            bucketName = ctx.generatePhysicalName(r.getLogicalId(), BUCKET_NAME_MAX_LENGTH, true);
+        }
+        s3Service.createBucket(bucketName, ctx.region());
+        applyBucketCorsConfiguration(bucketName, props, ctx);
+        applyBucketVersioningConfiguration(bucketName, props, ctx);
+        r.setPhysicalId(bucketName);
+        r.getAttributes().put("Arn", AwsArnUtils.Arn.of("s3", "", "", bucketName).toString());
+        r.getAttributes().put("DomainName", bucketName + ".s3.amazonaws.com");
+        r.getAttributes().put("RegionalDomainName", bucketName + ".s3." + ctx.region() + ".amazonaws.com");
+        r.getAttributes().put("WebsiteURL",
+                "http://" + bucketName + ".s3-website." + ctx.region() + ".amazonaws.com");
+        r.getAttributes().put("BucketName", bucketName);
+    }
+
+    private void applyBucketCorsConfiguration(String bucketName, JsonNode props, ProvisionContext ctx) {
+        JsonNode corsRules = null;
+        if (props != null && props.has("CorsConfiguration") && !props.get("CorsConfiguration").isNull()) {
+            corsRules = props.get("CorsConfiguration").get("CorsRules");
+        }
+        if (corsRules == null || !corsRules.isArray() || corsRules.isEmpty()) {
+            s3Service.deleteBucketCors(bucketName);
+            return;
+        }
+        XmlBuilder xml = new XmlBuilder().start("CORSConfiguration", AwsNamespaces.S3);
+        for (JsonNode rule : corsRules) {
+            xml.start("CORSRule");
+            xml.elem("ID", ctx.resolveOptional(rule, "Id"));
+            appendCorsRuleElements(xml, rule.get("AllowedHeaders"), "AllowedHeader", ctx);
+            appendCorsRuleElements(xml, rule.get("AllowedMethods"), "AllowedMethod", ctx);
+            appendCorsRuleElements(xml, rule.get("AllowedOrigins"), "AllowedOrigin", ctx);
+            appendCorsRuleElements(xml, rule.get("ExposedHeaders"), "ExposeHeader", ctx);
+            String maxAge = ctx.resolveOptional(rule, "MaxAge");
+            if (maxAge != null && !maxAge.isBlank()) {
+                xml.elem("MaxAgeSeconds", maxAge);
+            }
+            xml.end("CORSRule");
+        }
+        xml.end("CORSConfiguration");
+        s3Service.putBucketCors(bucketName, xml.build());
+    }
+
+    private void appendCorsRuleElements(XmlBuilder xml, JsonNode values, String elementName,
+                                        ProvisionContext ctx) {
+        if (values == null || !values.isArray()) {
+            return;
+        }
+        for (JsonNode value : values) {
+            if (value != null && !value.isNull()) {
+                String resolved = ctx.engine().resolve(value);
+                if (resolved != null && !resolved.isBlank()) {
+                    xml.elem(elementName, resolved);
+                }
+            }
+        }
+    }
+
+    private void applyBucketVersioningConfiguration(String bucketName, JsonNode props,
+                                                    ProvisionContext ctx) {
+        if (props == null || !props.has("VersioningConfiguration")
+                || props.get("VersioningConfiguration").isNull()) {
+            return;
+        }
+        String status = ctx.resolveOptional(props.get("VersioningConfiguration"), "Status");
+        if (status != null && !status.isBlank()) {
+            s3Service.putBucketVersioning(bucketName, status);
+        }
+    }
+
+    @Override
+    public void delete(String resourceType, String physicalId, String region) {
+        // A bucket policy has no backing resource to remove. Deleting a non-empty bucket raises
+        // BucketNotEmpty, which propagates so the stack reports DELETE_FAILED as AWS does.
+        if (BUCKET.equals(resourceType)) {
+            s3Service.deleteBucket(physicalId);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogGroupProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogGroupProvisionerTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.cloudformation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.LogsCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,9 +40,14 @@ class CloudFormationLogGroupProvisionerTest {
     @BeforeEach
     void setUp() {
         logsService = mock(CloudWatchLogsService.class);
+        // Registering the provisioner is load-bearing, not decoration: AWS::Logs::LogGroup now lives
+        // in LogsCfnProvisioner, so with an empty registry these calls would fall through to the
+        // dispatcher's stub arm and assert against a synthetic id instead of the real logic. Going
+        // through the dispatcher rather than the provisioner directly also covers the plumbing this
+        // migration changed, that existingPhysicalId and existingAttributes reach ProvisionContext.
         provisioner = CfnProvisionerFixture.builder()
                 .objectMapper(mapper)
-                .logs(logsService)
+                .provisioners(new LogsCfnProvisioner(logsService))
                 .build();
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LogsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LogsCfnProvisionerTest.java
@@ -1,0 +1,218 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationTemplateEngine;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code AWS::Logs::LogGroup}, whose provision body is also its update path: it decides between
+ * reconciling in place and replacing, from the prior physical id and the recorded name mode.
+ */
+class LogsCfnProvisionerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT_ID = "000000000000";
+    private static final String STACK = "my-stack";
+
+    private CloudWatchLogsService logs;
+    private LogsCfnProvisioner provisioner;
+    private CloudFormationTemplateEngine engine;
+
+    @BeforeEach
+    void setUp() {
+        logs = mock(CloudWatchLogsService.class);
+        provisioner = new LogsCfnProvisioner(logs);
+        engine = mock(CloudFormationTemplateEngine.class);
+        when(engine.resolve(any())).thenAnswer(i -> {
+            JsonNode node = i.getArgument(0);
+            return node == null || node.isMissingNode() || node.isNull() ? null : node.asText();
+        });
+        when(engine.resolveNode(any())).thenAnswer(i -> i.getArgument(0));
+        when(logs.listTagsLogGroup(anyString(), anyString())).thenReturn(Map.of());
+    }
+
+    private static JsonNode props(String json) {
+        try {
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /** Provisions as a create (no prior physical id) or an update (prior id and attributes). */
+    private StackResource provision(String json, String priorPhysicalId, Map<String, String> attrs) {
+        StackResource r = new StackResource();
+        r.setLogicalId("LogGroup");
+        r.setResourceType("AWS::Logs::LogGroup");
+        r.setPhysicalId(priorPhysicalId);
+        r.setAttributes(new HashMap<>(attrs));
+        provisioner.provision(r, props(json),
+                new ProvisionContext(engine, REGION, ACCOUNT_ID, STACK, priorPhysicalId));
+        return r;
+    }
+
+    @Test
+    void createUsesTheExplicitNameAndSetsTheArn() {
+        StackResource r = provision("""
+                {"LogGroupName": "/aws/app"}
+                """, null, Map.of());
+
+        verify(logs).createLogGroup(eq("/aws/app"), isNull(), anyMap(), eq(REGION));
+        assertEquals("/aws/app", r.getPhysicalId(), "Ref is the log group name");
+        assertEquals("arn:aws:logs:us-east-1:000000000000:log-group:/aws/app:*",
+                r.getAttributes().get("Arn"));
+        assertEquals("explicit", r.getAttributes().get("FlociLogGroupNameMode"));
+    }
+
+    @Test
+    void anUnnamedGroupGetsAGeneratedNameRecordedAsGenerated() {
+        StackResource r = provision("{}", null, Map.of());
+
+        assertTrue(r.getPhysicalId().startsWith("my-stack-LogGroup-"), r.getPhysicalId());
+        assertEquals("generated", r.getAttributes().get("FlociLogGroupNameMode"));
+    }
+
+    @Test
+    void retentionAndTagsReachTheService() {
+        ArgumentCaptor<Map<String, String>> tags = ArgumentCaptor.forClass(Map.class);
+
+        provision("""
+                {"LogGroupName": "g", "RetentionInDays": "14",
+                 "Tags": [{"Key": "env", "Value": "dev"}]}
+                """, null, Map.of());
+
+        verify(logs).createLogGroup(eq("g"), eq(14), tags.capture(), eq(REGION));
+        assertEquals(Map.of("env", "dev"), tags.getValue());
+    }
+
+    /** A non-numeric RetentionInDays leaves retention unset rather than failing the resource. */
+    @Test
+    void anUnparseableRetentionIsIgnored() {
+        provision("""
+                {"LogGroupName": "g", "RetentionInDays": "forever"}
+                """, null, Map.of());
+
+        verify(logs).createLogGroup(eq("g"), isNull(), anyMap(), eq(REGION));
+    }
+
+    @Test
+    void anUnchangedNameReconcilesInPlaceInsteadOfRecreating() {
+        when(logs.logGroupExists("g", REGION)).thenReturn(true);
+        when(logs.listTagsLogGroup("g", REGION)).thenReturn(Map.of("stale", "1"));
+
+        provision("""
+                {"LogGroupName": "g", "RetentionInDays": "7"}
+                """, "g", Map.of("FlociLogGroupNameMode", "explicit"));
+
+        verify(logs, never()).createLogGroup(anyString(), any(), anyMap(), anyString());
+        verify(logs).putRetentionPolicy("g", 7, REGION);
+        // A tag dropped from the template is removed from the live group, not just left behind.
+        verify(logs).untagLogGroup("g", List.of("stale"), REGION);
+    }
+
+    @Test
+    void reconcileClearsRetentionWhenTheTemplateDropsIt() {
+        when(logs.logGroupExists("g", REGION)).thenReturn(true);
+
+        provision("""
+                {"LogGroupName": "g"}
+                """, "g", Map.of("FlociLogGroupNameMode", "explicit"));
+
+        verify(logs).deleteRetentionPolicy("g", REGION);
+        verify(logs, never()).putRetentionPolicy(anyString(), anyInt(), anyString());
+    }
+
+    @Test
+    void arenameCreatesTheNewGroupBeforeDeletingTheOld() {
+        when(logs.logGroupExists("old", REGION)).thenReturn(true);
+
+        StackResource r = provision("""
+                {"LogGroupName": "new"}
+                """, "old", Map.of("FlociLogGroupNameMode", "explicit"));
+
+        assertEquals("new", r.getPhysicalId());
+        verify(logs).createLogGroup(eq("new"), isNull(), anyMap(), eq(REGION));
+        verify(logs).deleteLogGroup("old", REGION);
+    }
+
+    /**
+     * If creating the replacement fails, the original must survive and the resource must say so, or
+     * rollback would try to restore a group that was never deleted.
+     */
+    @Test
+    void aFailedRenameLeavesTheOriginalAndFlagsTheRollback() {
+        when(logs.logGroupExists("old", REGION)).thenReturn(true);
+        doThrow(new RuntimeException("name taken"))
+                .when(logs).createLogGroup(eq("new"), any(), anyMap(), anyString());
+
+        StackResource r = new StackResource();
+        r.setLogicalId("LogGroup");
+        r.setResourceType("AWS::Logs::LogGroup");
+        r.setPhysicalId("old");
+        r.setAttributes(new HashMap<>(Map.of("FlociLogGroupNameMode", "explicit")));
+
+        assertThrows(RuntimeException.class, () -> provisioner.provision(r, props("""
+                {"LogGroupName": "new"}
+                """), new ProvisionContext(engine, REGION, ACCOUNT_ID, STACK, "old")));
+
+        verify(logs, never()).deleteLogGroup("old", REGION);
+        assertEquals("true", r.getAttributes().get(CfnRollback.UPDATE_ROLLBACK_RESTORED_ATTR));
+    }
+
+    /**
+     * Dropping an explicit LogGroupName is a replacement on real AWS, so it must not keep
+     * reconciling under the old explicit name.
+     */
+    @Test
+    void removingAnExplicitNameReplacesTheGroup() {
+        when(logs.logGroupExists("chosen", REGION)).thenReturn(true);
+
+        StackResource r = provision("{}", "chosen", Map.of("FlociLogGroupNameMode", "explicit"));
+
+        assertTrue(r.getPhysicalId().startsWith("my-stack-LogGroup-"), r.getPhysicalId());
+        verify(logs).deleteLogGroup("chosen", REGION);
+    }
+
+    /** A generated name is kept across updates so a no-op update does not churn the group. */
+    @Test
+    void aGeneratedNameIsKeptAcrossUpdates() {
+        String generated = "my-stack-LogGroup-abc123def456";
+        when(logs.logGroupExists(generated, REGION)).thenReturn(true);
+
+        StackResource r = provision("{}", generated, Map.of("FlociLogGroupNameMode", "generated"));
+
+        assertEquals(generated, r.getPhysicalId());
+        verify(logs, never()).createLogGroup(anyString(), any(), anyMap(), anyString());
+    }
+
+    @Test
+    void deleteReachesTheService() {
+        provisioner.delete("AWS::Logs::LogGroup", "g", REGION);
+        verify(logs).deleteLogGroup("g", REGION);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisionerTest.java
@@ -1,0 +1,184 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationTemplateEngine;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** {@code AWS::S3::Bucket} and {@code AWS::S3::BucketPolicy}. */
+class S3CfnProvisionerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String REGION = "us-east-1";
+
+    private S3Service s3;
+    private S3CfnProvisioner provisioner;
+    private ProvisionContext ctx;
+
+    @BeforeEach
+    void setUp() {
+        s3 = mock(S3Service.class);
+        provisioner = new S3CfnProvisioner(s3);
+        CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+        when(engine.resolve(any())).thenAnswer(i -> {
+            JsonNode node = i.getArgument(0);
+            return node == null || node.isMissingNode() || node.isNull() ? null : node.asText();
+        });
+        when(engine.resolveNode(any())).thenAnswer(i -> i.getArgument(0));
+        ctx = new ProvisionContext(engine, REGION, "000000000000", "my-stack");
+    }
+
+    private static JsonNode props(String json) {
+        try {
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static StackResource resource(String logicalId, String type) {
+        StackResource r = new StackResource();
+        r.setLogicalId(logicalId);
+        r.setResourceType(type);
+        return r;
+    }
+
+    private StackResource provisionBucket(String json) {
+        StackResource r = resource("Bucket", "AWS::S3::Bucket");
+        provisioner.provision(r, props(json), ctx);
+        return r;
+    }
+
+    @Test
+    void refIsTheBucketNameAndGetAttExposesTheDocumentedAttributes() {
+        StackResource r = provisionBucket("""
+                {"BucketName": "my-bucket"}
+                """);
+
+        verify(s3).createBucket("my-bucket", REGION);
+        assertEquals("my-bucket", r.getPhysicalId(), "Ref is the bucket name");
+        // aws-s3-bucket.json readOnlyProperties, minus DualStackDomainName (see the PR follow-up),
+        // plus BucketName which the template engine resolves for Fn::GetAtt.
+        assertEquals(Map.of(
+                "Arn", "arn:aws:s3:::my-bucket",
+                "DomainName", "my-bucket.s3.amazonaws.com",
+                "RegionalDomainName", "my-bucket.s3.us-east-1.amazonaws.com",
+                "WebsiteURL", "http://my-bucket.s3-website.us-east-1.amazonaws.com",
+                "BucketName", "my-bucket"), r.getAttributes());
+    }
+
+    @Test
+    void anUnnamedBucketGetsALowerCasedStackScopedName() {
+        StackResource r = provisionBucket("{}");
+
+        String name = r.getPhysicalId();
+        assertTrue(name.startsWith("my-stack-bucket-"), name);
+        assertEquals(name.toLowerCase(), name, "S3 bucket names must be lower case");
+        assertTrue(name.length() <= 63, "bucket names cap at 63 characters: " + name);
+    }
+
+    /**
+     * A bucket with no CORS block has its configuration cleared rather than left alone, so an
+     * update that removes CorsConfiguration actually removes it from the bucket.
+     */
+    @Test
+    void absentCorsConfigurationClearsAnyExistingRules() {
+        provisionBucket("""
+                {"BucketName": "b"}
+                """);
+
+        verify(s3).deleteBucketCors("b");
+        verify(s3, never()).putBucketCors(anyString(), anyString());
+    }
+
+    @Test
+    void corsRulesBecomeS3CorsConfigurationXml() {
+        ArgumentCaptor<String> xml = ArgumentCaptor.forClass(String.class);
+
+        provisionBucket("""
+                {
+                  "BucketName": "b",
+                  "CorsConfiguration": {
+                    "CorsRules": [
+                      {
+                        "Id": "rule-1",
+                        "AllowedHeaders": ["*"],
+                        "AllowedMethods": ["GET", "PUT"],
+                        "AllowedOrigins": ["https://example.com"],
+                        "ExposedHeaders": ["ETag"],
+                        "MaxAge": "3600"
+                      }
+                    ]
+                  }
+                }
+                """);
+
+        verify(s3).putBucketCors(anyString(), xml.capture());
+        String body = xml.getValue();
+        assertTrue(body.contains("<ID>rule-1</ID>"), body);
+        assertTrue(body.contains("<AllowedMethod>GET</AllowedMethod>"), body);
+        assertTrue(body.contains("<AllowedMethod>PUT</AllowedMethod>"), body);
+        assertTrue(body.contains("<AllowedOrigin>https://example.com</AllowedOrigin>"), body);
+        // The CFN property is ExposedHeaders but the S3 XML element is ExposeHeader.
+        assertTrue(body.contains("<ExposeHeader>ETag</ExposeHeader>"), body);
+        assertTrue(body.contains("<MaxAgeSeconds>3600</MaxAgeSeconds>"), body);
+    }
+
+    @Test
+    void anEmptyCorsRuleListIsTreatedAsNoCors() {
+        provisionBucket("""
+                {"BucketName": "b", "CorsConfiguration": {"CorsRules": []}}
+                """);
+
+        verify(s3).deleteBucketCors("b");
+        verify(s3, never()).putBucketCors(anyString(), anyString());
+    }
+
+    @Test
+    void versioningIsAppliedOnlyWhenAStatusIsGiven() {
+        provisionBucket("""
+                {"BucketName": "b", "VersioningConfiguration": {"Status": "Enabled"}}
+                """);
+        verify(s3).putBucketVersioning("b", "Enabled");
+
+        provisionBucket("""
+                {"BucketName": "c"}
+                """);
+        verify(s3, never()).putBucketVersioning("c", null);
+    }
+
+    @Test
+    void bucketPolicyIsAcceptedWithAPhysicalIdAndNoAttributes() {
+        StackResource r = resource("Policy", "AWS::S3::BucketPolicy");
+        provisioner.provision(r, props("""
+                {"Bucket": "b", "PolicyDocument": {"Version": "2012-10-17"}}
+                """), ctx);
+
+        assertTrue(r.getPhysicalId().startsWith("bucket-policy-"), r.getPhysicalId());
+        assertTrue(r.getAttributes().isEmpty());
+    }
+
+    @Test
+    void deletingABucketReachesTheServiceButAPolicyHasNothingToDelete() {
+        provisioner.delete("AWS::S3::Bucket", "b", REGION);
+        verify(s3).deleteBucket("b");
+
+        provisioner.delete("AWS::S3::BucketPolicy", "bucket-policy-abc", REGION);
+        verify(s3, never()).deleteBucket("bucket-policy-abc");
+    }
+}

--- a/src/test/resources/cloudformation/supported-resource-types.tsv
+++ b/src/test/resources/cloudformation/supported-resource-types.tsv
@@ -82,7 +82,7 @@ AWS::Lambda::MicrovmImage	LambdaMicrovmsCfnProvisioner
 AWS::Lambda::NetworkConnector	LambdaMicrovmsCfnProvisioner
 AWS::Lambda::Permission	LambdaAddressingCfnProvisioner
 AWS::Lambda::Version	LambdaVersionAliasCfnProvisioner
-AWS::Logs::LogGroup	LEGACY_SWITCH
+AWS::Logs::LogGroup	LogsCfnProvisioner
 AWS::Organizations::Account	OrganizationsCfnProvisioner
 AWS::Organizations::Organization	OrganizationsCfnProvisioner
 AWS::Organizations::OrganizationalUnit	OrganizationsCfnProvisioner

--- a/src/test/resources/cloudformation/supported-resource-types.tsv
+++ b/src/test/resources/cloudformation/supported-resource-types.tsv
@@ -98,8 +98,8 @@ AWS::RDS::DBProxyTargetGroup	LEGACY_SWITCH
 AWS::RDS::DBSubnetGroup	LEGACY_SWITCH
 AWS::Route53::HostedZone	LEGACY_SWITCH
 AWS::Route53::RecordSet	LEGACY_SWITCH
-AWS::S3::Bucket	LEGACY_SWITCH
-AWS::S3::BucketPolicy	LEGACY_SWITCH
+AWS::S3::Bucket	S3CfnProvisioner
+AWS::S3::BucketPolicy	S3CfnProvisioner
 AWS::SNS::Subscription	LEGACY_SWITCH
 AWS::SNS::Topic	LEGACY_SWITCH
 AWS::SQS::Queue	SqsCfnProvisioner


### PR DESCRIPTION
## Summary

Migrates `AWS::Logs::LogGroup` into `LogsCfnProvisioner`. Behaviour-preserving, but this is the
first slice carrying a **real update path**: the body decides between reconciling in place and
replacing, based on the prior physical id and the recorded `FlociLogGroupNameMode`, and infers that
mode from the physical id's shape for stacks persisted before the attribute existed.

Monolith **7,315 → 7,208 lines**; legacy switch 70 → 69 types. Docs table unchanged, as expected.

**Stacked on #2754 → #2744 → #2739.** Review those first.

### Three things this slice needed that earlier ones did not

**`UPDATE_ROLLBACK_RESTORED_ATTR` moved to `CfnRollback`.** It was package-private on the monolith,
so unreachable from the `provisioners` package. `CfnRollback` exists for exactly this (it was added
to solve the same problem for the IAM role rollback constants). The monolith's constant now
delegates there, so `CloudFormationService`'s two references are untouched.

**Uses `ctx.priorPhysicalId()` rather than reading it back off the `StackResource`.** The two are
equal on entry, but the method assigns the new physical id before it finishes, so a
context-captured value cannot later be invalidated by an edit to the body. This is the first real
use of the accessor added in #2732.

**The existing regression test stays pointed at the dispatcher**, now with the provisioner
registered. That is load-bearing, not decoration, and I verified it by mutation: dropping the
registration makes both tests fail with

```
expected: <test-stack-LogGroup-abc123def456> but was: <LogGroup-8df62014>
```

which is the dispatcher's stub arm answering instead of the provisioner. Testing through the
dispatcher also covers the plumbing this migration changes, that `existingPhysicalId` and
`existingAttributes` reach `ProvisionContext`.

`reconcileLogGroup` moves with the slice; `isGeneratedName` and its prefix helper are copied,
because a not-yet-migrated type still calls them. `logsService` leaves the monolith entirely (its
constructor parameter stays, unused, until the endgame).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A for the wire protocol. `aws-logs-loggroup.json` gives `primaryIdentifier` `LogGroupName` and
read-only `Arn`; both are asserted, `Arn` in the exact
`arn:aws:logs:<region>:<account>:log-group:<name>:*` form AWS uses.

The AWS behaviour this preserves is that `LogGroupName` is not updatable in place: a rename creates
the replacement *before* deleting the original, so a colliding name fails the update without
destroying the existing group.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

CloudFormation + Cloud Control: **854 tests, 0 failures, 0 errors**. `LogsCfnProvisionerTest` adds
11 covering both update branches, retention set and cleared, tag removal on reconcile, an
unparseable `RetentionInDays`, the explicit-name-removed replacement, the generated-name-kept
no-op, and the failed-rename case that must leave the original intact and flag the rollback. The
#1965 legacy-name-mode regression test is preserved unchanged apart from the registration line.
