### PR TITLE
test(cloudformation): wire fixture provisioners from the named services

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
@@ -161,7 +161,8 @@ final class CfnProvisionerFixture {
         }
 
         /**
-         * The provisioners CDI would discover for the services this test named.
+         * The provisioners inferred from the services this test named, not everything CDI would
+         * discover: a service the test did not name contributes nothing here.
          *
          * <p>Inferring these is what keeps a test honest across a migration. A test that names a
          * service and provisions one of its types used to keep passing when that type moved to a
@@ -410,6 +411,36 @@ final class CfnProvisionerFixture {
 
         public Builder cloudFront(CloudFrontService v) {
             this.cloudFrontService = v;
+            return this;
+        }
+
+        public Builder flowLog(FlowLogService v) {
+            this.flowLogService = v;
+            return this;
+        }
+
+        public Builder lambdaMicrovms(LambdaMicrovmsService v) {
+            this.lambdaMicrovmsService = v;
+            return this;
+        }
+
+        public Builder awsConfig(AwsConfigService v) {
+            this.awsConfigService = v;
+            return this;
+        }
+
+        public Builder organizations(OrganizationsService v) {
+            this.organizationsService = v;
+            return this;
+        }
+
+        public Builder sqs(SqsService v) {
+            this.sqsService = v;
+            return this;
+        }
+
+        public Builder wafV2(WafV2Service v) {
+            this.wafV2Service = v;
             return this;
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
@@ -8,6 +8,41 @@ import io.github.hectorvent.floci.services.apigatewayv2.ApiGatewayV2Service;
 import io.github.hectorvent.floci.services.autoscaling.AutoScalingService;
 import io.github.hectorvent.floci.services.batch.BatchService;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnDynamicReferences;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.ConfigCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2FlowLogCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.LambdaMicrovmsCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.OrganizationsCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.SqsCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.WafV2CfnProvisioner;
+import io.github.hectorvent.floci.services.configservice.AwsConfigService;
+import io.github.hectorvent.floci.services.ec2.FlowLogService;
+import io.github.hectorvent.floci.services.lambdamicrovms.LambdaMicrovmsService;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import io.github.hectorvent.floci.services.wafv2.WafV2Service;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.ApiGatewayAccountCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.AutoScalingLifecycleHookCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CdkMetadataCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudWatchCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2LaunchTemplateCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2NetworkAclCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2SecurityGroupRuleCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2VpcCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2VpcEndpointCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.Ec2VpcGatewayAttachmentCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.EcrCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.EcsCapacityCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.FirehoseCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.IamRoleCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.KinesisCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.KmsCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.LambdaAddressingCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.LambdaVersionAliasCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.LogsCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.PipesCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.S3CfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.SnsCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.SsmCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnResourceProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry;
 import io.github.hectorvent.floci.services.cloudfront.CloudFrontService;
@@ -36,6 +71,7 @@ import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.ssm.SsmService;
 import io.github.hectorvent.floci.services.stepfunctions.StepFunctionsService;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -96,19 +132,125 @@ final class CfnProvisionerFixture {
         private FirehoseService firehoseService;
         private DocDbService docDbService;
         private CloudFrontService cloudFrontService;
+        // Services that back a provisioner without being a constructor argument of the
+        // dispatcher. They exist only so inferredProvisioners() can wire their provisioner.
+        private FlowLogService flowLogService;
+        private LambdaMicrovmsService lambdaMicrovmsService;
+        private AwsConfigService awsConfigService;
+        private OrganizationsService organizationsService;
+        private SqsService sqsService;
+        private WafV2Service wafV2Service;
         private CloudFormationResourceRegistry resourceRegistry;
+        private boolean registryChosenByTest;
         private CfnDynamicReferences dynamicReferences;
         private EmulatorConfig config;
 
         private Builder() {
             this.objectMapper = new ObjectMapper();
-            this.resourceRegistry = new CloudFormationResourceRegistry(List.of());
         }
 
-        /** Registers extracted provisioners, the way production CDI discovery would. */
+        /**
+         * Registers an explicit provisioner set, replacing the ones inferred from the named
+         * services. Needed only for a provisioner this fixture cannot build itself, such as one
+         * taking collaborators beyond a single service.
+         */
         public Builder provisioners(CfnResourceProvisioner... provisioners) {
             this.resourceRegistry = new CloudFormationResourceRegistry(Arrays.asList(provisioners));
+            this.registryChosenByTest = true;
             return this;
+        }
+
+        /**
+         * The provisioners CDI would discover for the services this test named.
+         *
+         * <p>Inferring these is what keeps a test honest across a migration. A test that names a
+         * service and provisions one of its types used to keep passing when that type moved to a
+         * provisioner: the empty registry sent it to the dispatcher's stub arm, which reports
+         * CREATE_COMPLETE with a synthetic id, so the assertions ran against nothing. Wiring the
+         * provisioner from the service means the test follows the type instead.
+         *
+         * <p>Covers every provisioner that takes a single service. The two that take more
+         * ({@code CodeBuildCfnProvisioner}, {@code CodePipelineCfnProvisioner}) must be passed to
+         * {@link Builder#provisioners} explicitly. {@code CfnProvisionerFixtureTest} fails if a new
+         * provisioner is neither wired here nor listed as an exemption there, so this cannot fall
+         * behind silently.
+         */
+        private List<CfnResourceProvisioner> inferredProvisioners() {
+            List<CfnResourceProvisioner> discovered = new ArrayList<>();
+            discovered.add(new CdkMetadataCfnProvisioner());
+            if (s3Service != null) {
+                discovered.add(new S3CfnProvisioner(s3Service));
+            }
+            if (snsService != null) {
+                discovered.add(new SnsCfnProvisioner(snsService));
+            }
+            if (ssmService != null) {
+                discovered.add(new SsmCfnProvisioner(ssmService));
+            }
+            if (kmsService != null) {
+                discovered.add(new KmsCfnProvisioner(kmsService));
+            }
+            if (ecrService != null) {
+                discovered.add(new EcrCfnProvisioner(ecrService));
+            }
+            if (pipesService != null) {
+                discovered.add(new PipesCfnProvisioner(pipesService));
+            }
+            if (firehoseService != null) {
+                discovered.add(new FirehoseCfnProvisioner(firehoseService));
+            }
+            if (logsService != null) {
+                discovered.add(new LogsCfnProvisioner(logsService));
+            }
+            if (kinesisService != null) {
+                discovered.add(new KinesisCfnProvisioner(kinesisService));
+            }
+            if (cloudWatchMetricsService != null) {
+                discovered.add(new CloudWatchCfnProvisioner(cloudWatchMetricsService));
+            }
+            if (iamService != null) {
+                discovered.add(new IamRoleCfnProvisioner(iamService));
+            }
+            if (ecsService != null) {
+                discovered.add(new EcsCapacityCfnProvisioner(ecsService));
+            }
+            if (apiGatewayService != null) {
+                discovered.add(new ApiGatewayAccountCfnProvisioner(apiGatewayService));
+            }
+            if (autoScalingService != null) {
+                discovered.add(new AutoScalingLifecycleHookCfnProvisioner(autoScalingService));
+            }
+            if (lambdaService != null) {
+                discovered.add(new LambdaAddressingCfnProvisioner(lambdaService));
+                discovered.add(new LambdaVersionAliasCfnProvisioner(lambdaService));
+            }
+            if (flowLogService != null) {
+                discovered.add(new Ec2FlowLogCfnProvisioner(flowLogService));
+            }
+            if (lambdaMicrovmsService != null) {
+                discovered.add(new LambdaMicrovmsCfnProvisioner(lambdaMicrovmsService));
+            }
+            if (awsConfigService != null) {
+                discovered.add(new ConfigCfnProvisioner(awsConfigService));
+            }
+            if (organizationsService != null) {
+                discovered.add(new OrganizationsCfnProvisioner(organizationsService));
+            }
+            if (sqsService != null) {
+                discovered.add(new SqsCfnProvisioner(sqsService));
+            }
+            if (wafV2Service != null) {
+                discovered.add(new WafV2CfnProvisioner(wafV2Service));
+            }
+            if (ec2Service != null) {
+                discovered.add(new Ec2VpcCfnProvisioner(ec2Service));
+                discovered.add(new Ec2VpcEndpointCfnProvisioner(ec2Service));
+                discovered.add(new Ec2VpcGatewayAttachmentCfnProvisioner(ec2Service));
+                discovered.add(new Ec2NetworkAclCfnProvisioner(ec2Service));
+                discovered.add(new Ec2SecurityGroupRuleCfnProvisioner(ec2Service));
+                discovered.add(new Ec2LaunchTemplateCfnProvisioner(ec2Service));
+            }
+            return discovered;
         }
 
         public Builder s3(S3Service v) {
@@ -273,6 +415,7 @@ final class CfnProvisionerFixture {
 
         public Builder registry(CloudFormationResourceRegistry v) {
             this.resourceRegistry = v;
+            this.registryChosenByTest = true;
             return this;
         }
 
@@ -286,7 +429,17 @@ final class CfnProvisionerFixture {
             return this;
         }
 
+        /** The registry {@link #build()} would use: explicit if the test chose one, else inferred. */
+        CloudFormationResourceRegistry buildRegistry() {
+            return registryChosenByTest
+                    ? resourceRegistry
+                    : new CloudFormationResourceRegistry(inferredProvisioners());
+        }
+
         public CloudFormationResourceProvisioner build() {
+            if (!registryChosenByTest) {
+                resourceRegistry = buildRegistry();
+            }
             if (dynamicReferences == null) {
                 // Wire it from the services already named, the way CDI does in production, so a
                 // test resolving {{resolve:ssm:...}} or {{resolve:secretsmanager:...}} does not

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixtureTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixtureTest.java
@@ -1,0 +1,150 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnResourceProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.ProvisionContext;
+import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.sns.SnsService;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The fixture wires provisioners from the services a test names.
+ *
+ * <p>This is what keeps a test honest across a migration. Before it, a test that named a service
+ * and provisioned one of its types silently kept passing when that type moved into a provisioner:
+ * the empty registry sent it to the dispatcher's stub arm, which reports CREATE_COMPLETE with a
+ * synthetic physical id, so every assertion ran against a resource nothing had provisioned.
+ */
+class CfnProvisionerFixtureTest {
+
+    /**
+     * Provisioners the fixture cannot build from a single service, so they must be passed to
+     * {@code provisioners(...)} explicitly. Both take collaborators beyond one service
+     * ({@code RegionResolver} and an {@code ObjectMapper}), which the Builder does not model.
+     */
+    private static final Set<String> NOT_INFERABLE =
+            Set.of("CodeBuildCfnProvisioner", "CodePipelineCfnProvisioner");
+
+    /** Reaches the registry the same way the dispatcher does. */
+    private static boolean serves(CfnProvisionerFixture.Builder builder, String type) {
+        return builder.buildRegistry().forType(type).isPresent();
+    }
+
+    @Test
+    void namingAServiceWiresItsProvisioner() {
+        CfnProvisionerFixture.Builder fixture = CfnProvisionerFixture.builder()
+                .logs(mock(CloudWatchLogsService.class));
+
+        assertTrue(serves(fixture, "AWS::Logs::LogGroup"));
+    }
+
+    @Test
+    void anUnnamedServiceIsNotWired() {
+        CfnProvisionerFixture.Builder fixture = CfnProvisionerFixture.builder()
+                .logs(mock(CloudWatchLogsService.class));
+
+        assertFalse(serves(fixture, "AWS::SNS::Topic"),
+                "a test that never named SNS should not get its provisioner");
+    }
+
+    /** One service can back several provisioners, as it does under CDI. */
+    @Test
+    void oneServiceCanWireSeveralProvisioners() {
+        CfnProvisionerFixture.Builder fixture = CfnProvisionerFixture.builder()
+                .ec2(mock(Ec2Service.class));
+
+        for (String type : Set.of("AWS::EC2::VPC", "AWS::EC2::VPCEndpoint", "AWS::EC2::NetworkAcl",
+                "AWS::EC2::LaunchTemplate", "AWS::EC2::SecurityGroupIngress")) {
+            assertTrue(serves(fixture, type), type + " should be wired from Ec2Service");
+        }
+    }
+
+    /** CDK::Metadata backs no service, so it is always available. */
+    @Test
+    void theServicelessProvisionerIsAlwaysWired() {
+        assertTrue(serves(CfnProvisionerFixture.builder(), "AWS::CDK::Metadata"));
+    }
+
+    /**
+     * Every provisioner is either wirable from a named service or listed as an exemption.
+     *
+     * <p>Without this the fixture reproduces the very problem it exists to prevent. A provisioner
+     * added later and never wired here is silently absent from every fixture-based test, so those
+     * tests fall through to the dispatcher's stub arm and assert against a synthetic id. The other
+     * assertions in this class cannot catch it: they check the types that *are* wired, never that
+     * the set is complete, so a gap looks exactly like a passing suite.
+     */
+    @Test
+    void everyProvisionerIsWirableOrExplicitlyExempt() throws Exception {
+        Path provisioners = Path.of(
+                "src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners");
+        Set<String> onDisk;
+        try (var files = Files.list(provisioners)) {
+            onDisk = files.map(f -> f.getFileName().toString())
+                    .filter(n -> n.endsWith("CfnProvisioner.java"))
+                    .map(n -> n.replace(".java", ""))
+                    .collect(Collectors.toCollection(TreeSet::new));
+        }
+
+        String source = Files.readString(
+                Path.of("src/test/java/io/github/hectorvent/floci/services/cloudformation/"
+                        + "CfnProvisionerFixture.java"));
+        Set<String> wired = new TreeSet<>();
+        Matcher matcher = Pattern.compile("new (\\w+CfnProvisioner)\\(").matcher(source);
+        while (matcher.find()) {
+            wired.add(matcher.group(1));
+        }
+
+        Set<String> unaccounted = new TreeSet<>(onDisk);
+        unaccounted.removeAll(wired);
+        unaccounted.removeAll(NOT_INFERABLE);
+
+        assertTrue(unaccounted.isEmpty(),
+                "These provisioners are neither wired from a service nor exempt, so a fixture test "
+                        + "naming their service would silently hit the stub arm. Wire them in "
+                        + "inferredProvisioners(), or add them to NOT_INFERABLE with a reason: "
+                        + unaccounted);
+
+        Set<String> staleExemptions = new TreeSet<>(NOT_INFERABLE);
+        staleExemptions.removeAll(onDisk);
+        assertTrue(staleExemptions.isEmpty(),
+                "NOT_INFERABLE names provisioners that no longer exist: " + staleExemptions);
+    }
+
+    @Test
+    void anExplicitProvisionerSetReplacesTheInferredOne() {
+        CfnResourceProvisioner only = new CfnResourceProvisioner() {
+            @Override
+            public Set<String> resourceTypes() {
+                return Set.of("AWS::Test::Only");
+            }
+
+            @Override
+            public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+            }
+        };
+
+        CfnProvisionerFixture.Builder fixture = CfnProvisionerFixture.builder()
+                .sns(mock(SnsService.class))
+                .provisioners(only);
+
+        assertTrue(serves(fixture, "AWS::Test::Only"));
+        assertFalse(serves(fixture, "AWS::SNS::Topic"),
+                "an explicit set replaces inference rather than adding to it");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixtureTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixtureTest.java
@@ -3,18 +3,19 @@ package io.github.hectorvent.floci.services.cloudformation;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnResourceProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CloudFormationResourceRegistry;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.ProvisionContext;
 import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.sns.SnsService;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.TreeSet;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,6 +40,12 @@ class CfnProvisionerFixtureTest {
      */
     private static final Set<String> NOT_INFERABLE =
             Set.of("CodeBuildCfnProvisioner", "CodePipelineCfnProvisioner");
+
+    /**
+     * Builder setters that replace the inferred registry outright rather than naming a service.
+     * Driving them in the sweep below would discard everything inference produced.
+     */
+    private static final Set<String> REGISTRY_OVERRIDES = Set.of("registry", "provisioners");
 
     /** Reaches the registry the same way the dispatcher does. */
     private static boolean serves(CfnProvisionerFixture.Builder builder, String type) {
@@ -81,16 +88,21 @@ class CfnProvisionerFixtureTest {
     }
 
     /**
-     * Every provisioner is either wirable from a named service or listed as an exemption.
+     * Every provisioner on disk is reachable by driving the Builder's own public setters, or is
+     * explicitly exempt.
      *
-     * <p>Without this the fixture reproduces the very problem it exists to prevent. A provisioner
-     * added later and never wired here is silently absent from every fixture-based test, so those
-     * tests fall through to the dispatcher's stub arm and assert against a synthetic id. The other
-     * assertions in this class cannot catch it: they check the types that *are* wired, never that
-     * the set is complete, so a gap looks exactly like a passing suite.
+     * <p>Deliberately behavioural rather than textual. An earlier version of this gate matched
+     * {@code new XCfnProvisioner(} against the fixture's source, which scored a construction arm as
+     * wired even when its field had no setter and could never be non-null. That is the same silent
+     * gap this fixture exists to close, so the check has to run the wiring instead of reading it:
+     * everything below reaches the registry only through the public API a test has, which means a
+     * field no setter assigns cannot be satisfied and shows up here as unreachable.
+     *
+     * <p>Mirrors {@code CfnResourceInventoryTest}, which compares the CDI-resolved production
+     * registry for the same reason.
      */
     @Test
-    void everyProvisionerIsWirableOrExplicitlyExempt() throws Exception {
+    void everyProvisionerIsReachableThroughThePublicBuilderOrExplicitlyExempt() throws Exception {
         Path provisioners = Path.of(
                 "src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners");
         Set<String> onDisk;
@@ -101,24 +113,32 @@ class CfnProvisionerFixtureTest {
                     .collect(Collectors.toCollection(TreeSet::new));
         }
 
-        String source = Files.readString(
-                Path.of("src/test/java/io/github/hectorvent/floci/services/cloudformation/"
-                        + "CfnProvisionerFixture.java"));
-        Set<String> wired = new TreeSet<>();
-        Matcher matcher = Pattern.compile("new (\\w+CfnProvisioner)\\(").matcher(source);
-        while (matcher.find()) {
-            wired.add(matcher.group(1));
+        CfnProvisionerFixture.Builder builder = CfnProvisionerFixture.builder();
+        for (Method setter : CfnProvisionerFixture.Builder.class.getDeclaredMethods()) {
+            boolean namesOneCollaborator = Modifier.isPublic(setter.getModifiers())
+                    && setter.getReturnType() == CfnProvisionerFixture.Builder.class
+                    && setter.getParameterCount() == 1
+                    && !setter.isVarArgs()
+                    && !REGISTRY_OVERRIDES.contains(setter.getName());
+            if (namesOneCollaborator) {
+                setter.invoke(builder, mock(setter.getParameterTypes()[0]));
+            }
         }
 
-        Set<String> unaccounted = new TreeSet<>(onDisk);
-        unaccounted.removeAll(wired);
-        unaccounted.removeAll(NOT_INFERABLE);
+        CloudFormationResourceRegistry registry = builder.buildRegistry();
+        Set<String> reachable = registry.registeredTypes().stream()
+                .map(registry::ownerOf)
+                .collect(Collectors.toCollection(TreeSet::new));
 
-        assertTrue(unaccounted.isEmpty(),
-                "These provisioners are neither wired from a service nor exempt, so a fixture test "
-                        + "naming their service would silently hit the stub arm. Wire them in "
-                        + "inferredProvisioners(), or add them to NOT_INFERABLE with a reason: "
-                        + unaccounted);
+        Set<String> unreachable = new TreeSet<>(onDisk);
+        unreachable.removeAll(reachable);
+        unreachable.removeAll(NOT_INFERABLE);
+
+        assertTrue(unreachable.isEmpty(),
+                "These provisioners cannot be reached through any public Builder setter, so a "
+                        + "fixture test naming their service would silently hit the stub arm. Give "
+                        + "them a service field AND a setter in CfnProvisionerFixture, or add them "
+                        + "to NOT_INFERABLE with a reason: " + unreachable);
 
         Set<String> staleExemptions = new TreeSet<>(NOT_INFERABLE);
         staleExemptions.removeAll(onDisk);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogGroupProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationLogGroupProvisionerTest.java
@@ -3,7 +3,6 @@ package io.github.hectorvent.floci.services.cloudformation;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
-import io.github.hectorvent.floci.services.cloudformation.provisioners.LogsCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,14 +39,12 @@ class CloudFormationLogGroupProvisionerTest {
     @BeforeEach
     void setUp() {
         logsService = mock(CloudWatchLogsService.class);
-        // Registering the provisioner is load-bearing, not decoration: AWS::Logs::LogGroup now lives
-        // in LogsCfnProvisioner, so with an empty registry these calls would fall through to the
-        // dispatcher's stub arm and assert against a synthetic id instead of the real logic. Going
-        // through the dispatcher rather than the provisioner directly also covers the plumbing this
-        // migration changed, that existingPhysicalId and existingAttributes reach ProvisionContext.
+        // Naming the service is enough: the fixture wires LogsCfnProvisioner from it, the way CDI
+        // does. Testing through the dispatcher rather than the provisioner directly also covers the
+        // plumbing that carries existingPhysicalId and existingAttributes into ProvisionContext.
         provisioner = CfnProvisionerFixture.builder()
                 .objectMapper(mapper)
-                .provisioners(new LogsCfnProvisioner(logsService))
+                .logs(logsService)
                 .build();
     }
 


### PR DESCRIPTION
## Summary

`CfnProvisionerFixture` defaulted to an **empty registry**, which made every fixture-based test
quietly fragile across a migration.

A test that named a service and provisioned one of its types kept passing when that type moved into
a provisioner: the empty registry sent it to the dispatcher's stub arm, which reports
`CREATE_COMPLETE` with a synthetic physical id, so the assertions ran against a resource nothing had
provisioned. #2756 hit exactly this and needed an explicit registration line to stay honest.

`build()` now infers the provisioners CDI would discover for the services the test named:

```java
CfnProvisionerFixture.builder()
        .logs(logsService)   // wires LogsCfnProvisioner
        .ec2(ec2Service)     // wires all six Ec2*CfnProvisioners
        .build();
```

Twenty-nine of the thirty-one provisioners take exactly one service, which is what makes the
inference unambiguous; one service can back several, as `Ec2Service` does. `provisioners(...)` still
takes an explicit set and now *replaces* the inferred one, for the two the fixture cannot build
itself (`CodeBuild` and `CodePipeline` take collaborators beyond a single service).

An earlier revision of this PR claimed twenty-eight of thirty. That was a count of constructor
arity, not of coverage, and @pgermosen was right to check it against the classes on disk.

**Stacked on #2759 → #2758 → #2756 → #2754 → #2744 → #2739.** Review those first.

### Why this matters now rather than later

Wave 1 migrated 14 types and hit the trap once. Waves 2-5 migrate the remaining 65, and the tests
most exposed are the largest ones still building the provisioner positionally: `RdsCfnProvisionerTest`
(1,200 lines), `CloudFormationIamAttachmentProvisionerTest` (746),
`SecretTargetAttachmentCfnProvisionerTest` (681), `ApiGatewayV2CfnProvisionerTest` (511), plus the
DynamoDB, Events and Lambda tests. Each would otherwise need the mistake spotted by hand, and each
would fail silently if it were not.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

Test-only; no production code changes.

## AWS Compatibility

N/A. Test infrastructure only.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

CloudFormation + Cloud Control: **889 tests, 0 failures, 0 errors**. `CfnProvisionerFixtureTest`
adds 6. Five pin the inference: a named service wires its provisioner, an unnamed one does not, one
service can wire several, the service-less `CdkMetadataCfnProvisioner` is always available, and an
explicit set replaces inference rather than adding to it.

The sixth, `everyProvisionerIsReachableThroughThePublicBuilderOrExplicitlyExempt`, is the gate that
stops this fixture from reproducing the very failure it exists to prevent. It drives every public
single-argument `Builder` setter, builds the registry, and reads back which provisioners actually
resolved, then fails on any class on disk that is neither reachable nor in a documented
`NOT_INFERABLE` set. It also fails on a stale exemption, so the list cannot rot.

Resolving reachability rather than reading it matters, and the first attempt got this wrong: it
matched `new (\w+CfnProvisioner)\(` against the fixture's source, which scores a construction arm
as wired even when its field has no setter and can never be non-null. Six provisioners were in
exactly that state. Verified the replacement bites by deleting one setter while leaving its field
and construction arm in place, which the textual version passed:

```
These provisioners cannot be reached through any public Builder setter ... : [WafV2CfnProvisioner]
```

**Verified load-bearing rather than incidental.** Neutering the inference puts #2756's log group
test back on the stub arm:

```
expected: <test-stack-LogGroup-abc123def456> but was: <LogGroup-bf9816a5>
```

That test reverts to naming its service, dropping the explicit registration it needed before.

