### PR TITLE
fix(cloudformation): set Fn::GetAtt attributes the schemas declare

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/CodePipelineCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/CodePipelineCfnProvisioner.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cloudformation.provisioners;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
@@ -194,6 +195,8 @@ public class CodePipelineCfnProvisioner implements CfnResourceProvisioner {
             delete("AWS::CodePipeline::Pipeline", previousPhysicalId, ctx.region());
         }
         r.setPhysicalId(name);
+        r.getAttributes().put("Arn",
+                AwsArnUtils.Arn.of("codepipeline", ctx.region(), ctx.accountId(), name).toString());
         r.getAttributes().put("Version",
                 String.valueOf(response.path("pipeline").path("version").asInt(1)));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2NetworkAclCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2NetworkAclCfnProvisioner.java
@@ -108,7 +108,12 @@ public class Ec2NetworkAclCfnProvisioner implements CfnResourceProvisioner {
                 // the same key is an update. replace=false would raise NetworkAclEntryAlreadyExists
                 // on every stack update.
                 from, to, true);
-        r.setPhysicalId(aclId + "|" + ruleNumber + "|" + (egress ? "egress" : "ingress"));
+        String entryId = aclId + "|" + ruleNumber + "|" + (egress ? "egress" : "ingress");
+        r.setPhysicalId(entryId);
+        // Id is the type's primaryIdentifier and its only readOnlyProperty, so Fn::GetAtt Id must
+        // agree with what Ref returns. Without it the reference resolves to the literal
+        // "LogicalId.Id", which reads as a successful lookup.
+        r.getAttributes().put("Id", entryId);
     }
 
     private void provisionSubnetNetworkAclAssociation(StackResource r, JsonNode props, ProvisionContext ctx) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisioner.java
@@ -58,6 +58,8 @@ public class S3CfnProvisioner implements CfnResourceProvisioner {
         r.getAttributes().put("Arn", AwsArnUtils.Arn.of("s3", "", "", bucketName).toString());
         r.getAttributes().put("DomainName", bucketName + ".s3.amazonaws.com");
         r.getAttributes().put("RegionalDomainName", bucketName + ".s3." + ctx.region() + ".amazonaws.com");
+        r.getAttributes().put("DualStackDomainName",
+                bucketName + ".s3.dualstack." + ctx.region() + ".amazonaws.com");
         r.getAttributes().put("WebsiteURL",
                 "http://" + bucketName + ".s3-website." + ctx.region() + ".amazonaws.com");
         r.getAttributes().put("BucketName", bucketName);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisioner.java
@@ -53,6 +53,9 @@ public class SnsCfnProvisioner implements CfnResourceProvisioner {
         var topic = snsService.createTopic(topicName, attributes, Map.of(), ctx.region());
         // Ref returns the topic ARN, which is why the physical id is the ARN and not the name.
         r.setPhysicalId(topic.getTopicArn());
+        // TopicArn is the attribute aws-sns-topic.json declares read-only. Arn is kept alongside it
+        // because templates written against earlier Floci releases already reference it.
+        r.getAttributes().put("TopicArn", topic.getTopicArn());
         r.getAttributes().put("Arn", topic.getTopicArn());
         r.getAttributes().put("TopicName", topicName);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnSchemaCoverageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnSchemaCoverageTest.java
@@ -1,0 +1,224 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Pins which {@code Fn::GetAtt} attributes declared by the CloudFormation registry schemas Floci
+ * does not set.
+ *
+ * <p>A missing attribute is invisible at runtime: {@code resolveGetAttParts} returns the literal
+ * {@code "LogicalId.Attr"} when a resource has no such attribute, so a template referencing one
+ * receives that string as a value instead of failing. Recording the gaps makes the set a ratchet:
+ * closing one deletes a row, and introducing one has to add a row where a reviewer sees it.
+ *
+ * <p>Not a parity assertion. Several rows are attributes Floci cannot set because it does not
+ * emulate the underlying behaviour, and each carries the reason.
+ */
+class CfnSchemaCoverageTest {
+
+    private static final Path INVENTORY =
+            Path.of("src/test/resources/cloudformation/supported-resource-types.tsv");
+    private static final Path GAPS =
+            Path.of("src/test/resources/cloudformation/getatt-attribute-gaps.tsv");
+    private static final Path SCHEMA_DIR = Path.of("local/aws/cfn-resource-schemas/us-east-1");
+    private static final Path PROVISIONERS = Path.of(
+            "src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners");
+
+    private static final Pattern PUT_ATTRIBUTE =
+            Pattern.compile("getAttributes\\(\\)\\.put\\(\\s*\"([^\"]+)\"");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /**
+     * The check needs the schema corpus, which lives under the gitignored {@code local/}. Absent in
+     * CI, so this is a local correctness aid; the checked-in gaps file is what CI reviews.
+     */
+    private static boolean schemasAvailable() {
+        return Files.isDirectory(SCHEMA_DIR);
+    }
+
+    @Test
+    void recordedGapsMatchWhatTheProvisionersActuallySet() {
+        if (!schemasAvailable()) {
+            return;
+        }
+        assertSameLines(render(recordedGaps()), render(actualGaps()));
+    }
+
+    /** A row that has been fixed, or was never real, must be deleted rather than left behind. */
+    @Test
+    void everyRecordedGapIsStillReal() {
+        if (!schemasAvailable()) {
+            return;
+        }
+        Map<String, String> actual = actualGaps();
+        List<String> stale = recordedGaps().keySet().stream()
+                .filter(key -> !actual.containsKey(key))
+                .sorted()
+                .toList();
+
+        if (!stale.isEmpty()) {
+            throw new AssertionError("These attributes are now set, so their rows in " + GAPS
+                    + " are stale and should be deleted: " + stale);
+        }
+    }
+
+    @Test
+    void everyRecordedGapExplainsItself() {
+        List<String> unexplained = recordedGaps().entrySet().stream()
+                .filter(e -> e.getValue().isBlank() || e.getValue().startsWith("TODO"))
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+
+        if (!unexplained.isEmpty()) {
+            throw new AssertionError("A recorded gap must say why Floci does not set it, so a "
+                    + "reviewer can tell 'not emulated' from 'forgotten': " + unexplained);
+        }
+    }
+
+    /** "AWS::SNS::Topic\tTopicArn" -> reason. */
+    private static Map<String, String> recordedGaps() {
+        Map<String, String> gaps = new TreeMap<>();
+        try {
+            for (String line : Files.readAllLines(GAPS, StandardCharsets.UTF_8)) {
+                if (line.isBlank()) {
+                    continue;
+                }
+                String[] parts = line.split("\t", 3);
+                if (parts.length < 3) {
+                    throw new AssertionError(
+                            "Expected 'type<TAB>attribute<TAB>reason' but found: " + line);
+                }
+                gaps.put(parts[0] + "\t" + parts[1], parts[2]);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot read " + GAPS, e);
+        }
+        return gaps;
+    }
+
+    /** The gaps computed from the schemas and the provisioner sources, keyed the same way. */
+    private static Map<String, String> actualGaps() {
+        Map<String, Set<String>> setByOwner = attributesSetByEachProvisioner();
+        Map<String, String> gaps = new TreeMap<>();
+        for (Map.Entry<String, String> entry : inventory().entrySet()) {
+            String type = entry.getKey();
+            String owner = entry.getValue();
+            if ("LEGACY_SWITCH".equals(owner)) {
+                // The switch is being dismantled type by type; its arms are audited as they move.
+                continue;
+            }
+            Set<String> declared = schemaReadOnlyAttributes(type);
+            Set<String> set = setByOwner.getOrDefault(owner, Set.of());
+            for (String attribute : declared) {
+                if (!set.contains(attribute)) {
+                    gaps.put(type + "\t" + attribute, "");
+                }
+            }
+        }
+        return gaps;
+    }
+
+    /**
+     * Attributes each provisioner class sets, read from its source.
+     *
+     * <p>Class-wide rather than per-type, because one class can serve several types. That makes the
+     * result conservative: a gap it reports is genuinely unset by the whole class.
+     */
+    private static Map<String, Set<String>> attributesSetByEachProvisioner() {
+        Map<String, Set<String>> byOwner = new TreeMap<>();
+        try (var files = Files.list(PROVISIONERS)) {
+            for (Path file : files.filter(f -> f.getFileName().toString().endsWith("CfnProvisioner.java"))
+                    .toList()) {
+                String source = Files.readString(file, StandardCharsets.UTF_8);
+                Set<String> attributes = new LinkedHashSet<>();
+                Matcher matcher = PUT_ATTRIBUTE.matcher(source);
+                while (matcher.find()) {
+                    attributes.add(matcher.group(1));
+                }
+                String className = file.getFileName().toString().replace(".java", "");
+                byOwner.put(className, attributes);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot scan " + PROVISIONERS, e);
+        }
+        return byOwner;
+    }
+
+    /** Top-level read-only properties only: a nested pointer is not a GetAtt attribute name. */
+    private static Set<String> schemaReadOnlyAttributes(String resourceType) {
+        Path schema = SCHEMA_DIR.resolve(
+                resourceType.replace("::", "-").toLowerCase(Locale.ROOT) + ".json");
+        if (!Files.exists(schema)) {
+            return Set.of();
+        }
+        try {
+            JsonNode root = MAPPER.readTree(Files.readString(schema, StandardCharsets.UTF_8));
+            Set<String> attributes = new LinkedHashSet<>();
+            for (JsonNode pointer : root.path("readOnlyProperties")) {
+                String[] parts = pointer.asText().split("/");
+                if (parts.length == 3) {
+                    attributes.add(parts[2]);
+                }
+            }
+            return attributes;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot read " + schema, e);
+        }
+    }
+
+    private static Map<String, String> inventory() {
+        Map<String, String> types = new TreeMap<>();
+        try {
+            for (String line : Files.readAllLines(INVENTORY, StandardCharsets.UTF_8)) {
+                if (!line.isBlank()) {
+                    String[] parts = line.split("\t", 2);
+                    types.put(parts[0], parts[1]);
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Cannot read " + INVENTORY, e);
+        }
+        return types;
+    }
+
+    private static String render(Map<String, String> gaps) {
+        return gaps.keySet().stream().sorted().collect(Collectors.joining("\n"));
+    }
+
+    private static void assertSameLines(String recorded, String actual) {
+        if (recorded.equals(actual)) {
+            return;
+        }
+        List<String> recordedLines = List.of(recorded.split("\n"));
+        List<String> actualLines = List.of(actual.split("\n"));
+        List<String> added = new ArrayList<>(actualLines);
+        added.removeAll(recordedLines);
+        List<String> removed = new ArrayList<>(recordedLines);
+        removed.removeAll(actualLines);
+        throw new AssertionError("The set of unset schema attributes changed.\n"
+                + "  New gaps (a provisioner stopped setting a declared attribute, or a new type "
+                + "arrived with one unset) — set them, or add a row with a reason to " + GAPS + ":\n    "
+                + String.join("\n    ", added.isEmpty() ? List.of("(none)") : added)
+                + "\n  Closed gaps (now set) — delete their rows from " + GAPS + ":\n    "
+                + String.join("\n    ", removed.isEmpty() ? List.of("(none)") : removed));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnSchemaCoverageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnSchemaCoverageTest.java
@@ -10,6 +10,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -44,6 +47,15 @@ class CfnSchemaCoverageTest {
 
     private static final Pattern PUT_ATTRIBUTE =
             Pattern.compile("getAttributes\\(\\)\\.put\\(\\s*\"([^\"]+)\"");
+    /** {@code private static final String TOPIC = "AWS::SNS::Topic";} */
+    private static final Pattern TYPE_CONSTANT =
+            Pattern.compile("String\\s+(\\w+)\\s*=\\s*\"(AWS::[^\"]+)\"");
+    /** A method declared at class level, captured so its body can be walked. */
+    private static final Pattern METHOD_DECLARATION = Pattern.compile(
+            "\\n    (?:public|private|protected)[^\\n=;]*?\\b(\\w+)\\s*\\([^)]*\\)\\s*\\{");
+    private static final Pattern METHOD_CALL = Pattern.compile("\\b(\\w+)\\s*\\(");
+    private static final Pattern RESOURCE_TYPE_SWITCH =
+            Pattern.compile("switch\\s*\\(\\s*\\w+\\.getResourceType\\(\\)\\s*\\)\\s*\\{");
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     /**
@@ -117,7 +129,7 @@ class CfnSchemaCoverageTest {
 
     /** The gaps computed from the schemas and the provisioner sources, keyed the same way. */
     private static Map<String, String> actualGaps() {
-        Map<String, Set<String>> setByOwner = attributesSetByEachProvisioner();
+        Map<String, ProvisionerScan> scans = scanProvisioners();
         Map<String, String> gaps = new TreeMap<>();
         for (Map.Entry<String, String> entry : inventory().entrySet()) {
             String type = entry.getKey();
@@ -127,7 +139,8 @@ class CfnSchemaCoverageTest {
                 continue;
             }
             Set<String> declared = schemaReadOnlyAttributes(type);
-            Set<String> set = setByOwner.getOrDefault(owner, Set.of());
+            ProvisionerScan scan = scans.get(owner);
+            Set<String> set = scan == null ? Set.of() : scan.attributesFor(type);
             for (String attribute : declared) {
                 if (!set.contains(attribute)) {
                     gaps.put(type + "\t" + attribute, "");
@@ -138,29 +151,182 @@ class CfnSchemaCoverageTest {
     }
 
     /**
-     * Attributes each provisioner class sets, read from its source.
+     * What one provisioner class sets, resolved per resource type rather than per class.
      *
-     * <p>Class-wide rather than per-type, because one class can serve several types. That makes the
-     * result conservative: a gap it reports is genuinely unset by the whole class.
+     * <p>Per type is the whole point. A class serving several types writes each type's attributes in
+     * its own arm of the {@code switch (r.getResourceType())} in {@code provision}, so folding the
+     * whole file into one set credits every type with what any one arm sets. That is not a
+     * conservative approximation, it is a false negative in the only direction that matters here:
+     * the gap this file exists to record stops being reported. It hid a real one, {@code
+     * AWS::EC2::NetworkAclEntry}'s {@code Id}, which {@code Ec2NetworkAclCfnProvisioner} sets for
+     * {@code NetworkAcl} and never for {@code NetworkAclEntry}.
+     *
+     * <p>{@code byType} is empty when {@code provision} has no such switch, which means the class
+     * has a single provisioning path shared by every type it owns (as
+     * {@code Ec2SecurityGroupRuleCfnProvisioner} does, branching on a boolean instead). There
+     * {@code classWide} is the accurate answer, not a fallback. When the switch does exist, every
+     * type the class owns must have an arm, and {@link #attributesFor} fails loudly otherwise rather
+     * than silently reverting to the class-wide reading.
      */
-    private static Map<String, Set<String>> attributesSetByEachProvisioner() {
-        Map<String, Set<String>> byOwner = new TreeMap<>();
+    private record ProvisionerScan(String className, Set<String> classWide,
+                                   Map<String, Set<String>> byType) {
+
+        Set<String> attributesFor(String resourceType) {
+            if (byType.isEmpty()) {
+                return classWide;
+            }
+            Set<String> attributes = byType.get(resourceType);
+            if (attributes == null) {
+                throw new AssertionError(className + " switches on getResourceType() but has no arm "
+                        + "for " + resourceType + ", so its attributes cannot be attributed to that "
+                        + "type. Add an arm, or give the class one shared provisioning path.");
+            }
+            return attributes;
+        }
+    }
+
+    private static Map<String, ProvisionerScan> scanProvisioners() {
+        Map<String, ProvisionerScan> scans = new TreeMap<>();
         try (var files = Files.list(PROVISIONERS)) {
             for (Path file : files.filter(f -> f.getFileName().toString().endsWith("CfnProvisioner.java"))
+                    .sorted()
                     .toList()) {
                 String source = Files.readString(file, StandardCharsets.UTF_8);
-                Set<String> attributes = new LinkedHashSet<>();
-                Matcher matcher = PUT_ATTRIBUTE.matcher(source);
-                while (matcher.find()) {
-                    attributes.add(matcher.group(1));
-                }
                 String className = file.getFileName().toString().replace(".java", "");
-                byOwner.put(className, attributes);
+                scans.put(className, scan(className, source));
             }
         } catch (IOException e) {
             throw new UncheckedIOException("Cannot scan " + PROVISIONERS, e);
         }
-        return byOwner;
+        return scans;
+    }
+
+    private static ProvisionerScan scan(String className, String source) {
+        Set<String> classWide = new LinkedHashSet<>();
+        Matcher put = PUT_ATTRIBUTE.matcher(source);
+        while (put.find()) {
+            classWide.add(put.group(1));
+        }
+
+        Map<String, String> methods = methodBodies(source);
+        Map<String, String> constants = new HashMap<>();
+        Matcher constant = TYPE_CONSTANT.matcher(source);
+        while (constant.find()) {
+            constants.put(constant.group(1), constant.group(2));
+        }
+
+        Map<String, Set<String>> byType = new TreeMap<>();
+        String provision = methods.get("provision");
+        if (provision != null) {
+            Dispatch dispatch = dispatchIn(provision);
+            if (dispatch != null) {
+                // Anything provision() writes outside the switch is on the path every type takes,
+                // so it belongs to all of them. Ec2SecurityGroupRule sets Id there.
+                Set<String> shared = attributesReachableFrom(
+                        provision.replace(dispatch.block(), ""), methods, new HashSet<>());
+                for (Map.Entry<String, String> arm : dispatch.arms().entrySet()) {
+                    for (String label : arm.getKey().split(",")) {
+                        String token = label.trim();
+                        String type = token.startsWith("\"")
+                                ? token.substring(1, token.length() - 1)
+                                : constants.get(token);
+                        if (type != null) {
+                            Set<String> attributes = byType.computeIfAbsent(
+                                    type, t -> new LinkedHashSet<>());
+                            attributes.addAll(shared);
+                            attributes.addAll(attributesReachableFrom(
+                                    arm.getValue(), methods, new HashSet<>()));
+                        }
+                    }
+                }
+            }
+        }
+        return new ProvisionerScan(className, Set.copyOf(classWide), Map.copyOf(byType));
+    }
+
+    /** The {@code getResourceType()} dispatch inside {@code provision}: its whole block, and its arms. */
+    private record Dispatch(String block, Map<String, String> arms) { }
+
+    /**
+     * The dispatch switch in {@code provision}, or null when there is none.
+     *
+     * <p>Only a switch in <em>statement</em> position counts. A switch <em>expression</em> such as
+     * {@code boolean ingress = switch (r.getResourceType()) { ... }} selects a value on a single
+     * shared path, it does not split the method into a path per type, and reading its arms as
+     * per-type paths attributes nothing to either type. That is not hypothetical:
+     * {@code Ec2SecurityGroupRuleCfnProvisioner} does exactly this and sets {@code Id} after the
+     * switch, so treating it as a dispatch reported two gaps that are not real.
+     */
+    private static Dispatch dispatchIn(String provisionBody) {
+        Matcher header = RESOURCE_TYPE_SWITCH.matcher(provisionBody);
+        while (header.find()) {
+            String before = provisionBody.substring(0, header.start()).stripTrailing();
+            if (!before.isEmpty() && ";{}".indexOf(before.charAt(before.length() - 1)) < 0) {
+                continue;
+            }
+            String body = balancedBlock(provisionBody, header.end() - 1);
+            return new Dispatch(body, armsOf(body));
+        }
+        return null;
+    }
+
+    private static Map<String, String> armsOf(String body) {
+
+        Map<String, String> arms = new LinkedHashMap<>();
+        Matcher label = Pattern.compile("\\bcase\\s+([^>]+?)\\s*->").matcher(body);
+        List<int[]> starts = new ArrayList<>();
+        List<String> labels = new ArrayList<>();
+        while (label.find()) {
+            starts.add(new int[] {label.start(), label.end()});
+            labels.add(label.group(1));
+        }
+        for (int i = 0; i < starts.size(); i++) {
+            int from = starts.get(i)[1];
+            int to = i + 1 < starts.size() ? starts.get(i + 1)[0] : body.length();
+            arms.put(labels.get(i), body.substring(from, to));
+        }
+        return arms;
+    }
+
+    /** Attributes written in {@code code}, plus those written by same-class methods it calls. */
+    private static Set<String> attributesReachableFrom(String code, Map<String, String> methods,
+                                                       Set<String> visited) {
+        Set<String> attributes = new LinkedHashSet<>();
+        Matcher put = PUT_ATTRIBUTE.matcher(code);
+        while (put.find()) {
+            attributes.add(put.group(1));
+        }
+        Matcher call = METHOD_CALL.matcher(code);
+        while (call.find()) {
+            String callee = call.group(1);
+            if (methods.containsKey(callee) && visited.add(callee)) {
+                attributes.addAll(attributesReachableFrom(methods.get(callee), methods, visited));
+            }
+        }
+        return attributes;
+    }
+
+    private static Map<String, String> methodBodies(String source) {
+        Map<String, String> bodies = new HashMap<>();
+        Matcher declaration = METHOD_DECLARATION.matcher(source);
+        while (declaration.find()) {
+            bodies.put(declaration.group(1), balancedBlock(source, declaration.end() - 1));
+        }
+        return bodies;
+    }
+
+    /** The text between {@code source[open]}, which must be '{', and its matching brace. */
+    private static String balancedBlock(String source, int open) {
+        int depth = 0;
+        for (int i = open; i < source.length(); i++) {
+            char c = source.charAt(i);
+            if (c == '{') {
+                depth++;
+            } else if (c == '}' && --depth == 0) {
+                return source.substring(open + 1, i);
+            }
+        }
+        return source.substring(open);
     }
 
     /** Top-level read-only properties only: a nested pointer is not a GetAtt attribute name. */

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationVpcGatewayAttachmentIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationVpcGatewayAttachmentIntegrationTest.java
@@ -57,16 +57,7 @@ class CloudFormationVpcGatewayAttachmentIntegrationTest {
         .then()
             .statusCode(200);
 
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .header("Authorization", CFN_AUTH)
-            .formParam("Action", "DescribeStacks")
-            .formParam("StackName", stackName)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200)
-            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+        awaitStackStatus(stackName, "CREATE_COMPLETE");
 
         String resourcesXml = given()
             .contentType("application/x-www-form-urlencoded")
@@ -98,9 +89,58 @@ class CloudFormationVpcGatewayAttachmentIntegrationTest {
         .then()
             .statusCode(200);
 
-        // Gateway (and with it the attachment) is gone after stack deletion.
-        String afterDelete = describeIgw(igwId).then().statusCode(200).extract().asString();
+        // Gateway (and with it the attachment) is gone after stack deletion. CloudFormationService
+        // runs deleteStack on a background executor and the HTTP call returns as soon as the work is
+        // queued, so poll rather than reading straight back: asserting immediately is a race that
+        // only passes while the executor happens to win.
+        String afterDelete = awaitIgwDetached(igwId, vpcId);
         assertThat(afterDelete, not(containsString(vpcId)));
+    }
+
+    /** Polls DescribeStacks until the stack reports {@code status}; provisioning is asynchronous. */
+    private static void awaitStackStatus(String stackName, String status) {
+        String xml = "";
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            xml = given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", CFN_AUTH)
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", stackName)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().asString();
+            if (xml.contains("<StackStatus>" + status + "</StackStatus>")) {
+                return;
+            }
+            sleepBriefly();
+        }
+        throw new AssertionError("stack " + stackName + " never reached " + status + ": " + xml);
+    }
+
+    /** Polls the gateway until it no longer reports the attachment, returning the last response. */
+    private static String awaitIgwDetached(String igwId, String vpcId) {
+        String xml = "";
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            xml = describeIgw(igwId).then().statusCode(200).extract().asString();
+            if (!xml.contains(vpcId)) {
+                return xml;
+            }
+            sleepBriefly();
+        }
+        return xml;
+    }
+
+    private static void sleepBriefly() {
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while awaiting an asynchronous stack operation", e);
+        }
     }
 
     private static io.restassured.response.Response describeIgw(String igwId) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2NetworkAclCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2NetworkAclCfnProvisionerTest.java
@@ -11,6 +11,8 @@ import io.github.hectorvent.floci.services.ec2.model.NetworkAcl;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAclAssociation;
 import org.junit.jupiter.api.Test;
 
+import java.util.Set;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -135,6 +137,26 @@ class Ec2NetworkAclCfnProvisionerTest {
         verify(ec2).createNetworkAclEntry("us-east-1", "acl-abc", 100, "-1", null, false,
                 null, null, null, true);
         assertEquals("acl-abc|100|ingress", r.getPhysicalId());
+    }
+
+    /**
+     * Id is the type's primaryIdentifier and its only schema readOnlyProperty. It went unset for a
+     * long time because the sibling NetworkAcl arm sets one too, and the coverage scan read the
+     * class as a whole, so the gap never reached getatt-attribute-gaps.tsv.
+     */
+    @Test
+    void aclEntrySetsTheIdAttributeItsSchemaDeclares() {
+        StackResource r = resource("AWS::EC2::NetworkAclEntry", "Entry");
+        ObjectNode props = mapper.createObjectNode()
+                .put("NetworkAclId", "acl-abc")
+                .put("RuleNumber", 150)
+                .put("Egress", true);
+
+        provisioner.provision(r, props, ctx());
+
+        assertEquals("acl-abc|150|egress", r.getPhysicalId());
+        assertEquals("acl-abc|150|egress", r.getAttributes().get("Id"));
+        assertEquals(Set.of("Id"), r.getAttributes().keySet());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/S3CfnProvisionerTest.java
@@ -72,12 +72,13 @@ class S3CfnProvisionerTest {
 
         verify(s3).createBucket("my-bucket", REGION);
         assertEquals("my-bucket", r.getPhysicalId(), "Ref is the bucket name");
-        // aws-s3-bucket.json readOnlyProperties, minus DualStackDomainName (see the PR follow-up),
-        // plus BucketName which the template engine resolves for Fn::GetAtt.
+        // Every readOnlyProperty in aws-s3-bucket.json, plus BucketName which the template engine
+        // resolves for Fn::GetAtt.
         assertEquals(Map.of(
                 "Arn", "arn:aws:s3:::my-bucket",
                 "DomainName", "my-bucket.s3.amazonaws.com",
                 "RegionalDomainName", "my-bucket.s3.us-east-1.amazonaws.com",
+                "DualStackDomainName", "my-bucket.s3.dualstack.us-east-1.amazonaws.com",
                 "WebsiteURL", "http://my-bucket.s3-website.us-east-1.amazonaws.com",
                 "BucketName", "my-bucket"), r.getAttributes());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisionerTest.java
@@ -94,7 +94,10 @@ class SnsCfnProvisionerTest {
 
         // Ref on an SNS topic returns the ARN, unlike most types where it is the name.
         assertEquals(TOPIC_ARN, r.getPhysicalId());
-        assertEquals(Map.of("Arn", TOPIC_ARN, "TopicName", "events"), r.getAttributes());
+        // TopicArn is the attribute aws-sns-topic.json declares; Arn is kept for templates written
+        // against earlier releases.
+        assertEquals(Map.of("TopicArn", TOPIC_ARN, "Arn", TOPIC_ARN, "TopicName", "events"),
+                r.getAttributes());
     }
 
     @Test

--- a/src/test/resources/cloudformation/getatt-attribute-gaps.tsv
+++ b/src/test/resources/cloudformation/getatt-attribute-gaps.tsv
@@ -1,0 +1,21 @@
+AWS::CodeBuild::Project	Id	schema gives no description; AWS's Id may differ from the project name Floci uses
+AWS::CodePipeline::CustomActionType	Id	schema gives no description; the custom action has no separate id in Floci
+AWS::CodePipeline::Webhook	Id	schema gives no description; Floci keys webhooks by name
+AWS::EC2::VPC	CidrBlockAssociations	needs association ids Floci's VPC model does not track
+AWS::EC2::VPC	DefaultNetworkAcl	needs a default network ACL Floci does not create with the VPC
+AWS::EC2::VPC	Ipv6CidrBlocks	IPv6 CIDR association is not emulated
+AWS::EC2::VPCEndpoint	DnsEntries	endpoint DNS entries are not emulated
+AWS::EC2::VPCEndpoint	NetworkInterfaceIds	endpoint ENIs are not created
+AWS::EC2::VPCGatewayAttachment	AttachmentType	the exact literal AWS returns (internet vs vpn gateway) is not given by the schema
+AWS::Kinesis::Stream	WarmThroughputObject	warm throughput is not an emulated Kinesis feature
+AWS::Lambda::MicrovmImage	CreatedAt	microvm image lifecycle fields are not tracked
+AWS::Lambda::MicrovmImage	LatestFailedImageVersion	failure history is not tracked
+AWS::Lambda::MicrovmImage	State	microvm image state is not modelled
+AWS::Lambda::MicrovmImage	UpdatedAt	microvm image lifecycle fields are not tracked
+AWS::Lambda::NetworkConnector	State	network connector state is not modelled
+AWS::Lambda::Permission	Id	schema gives no description and AWS's value is unclear; the physical id is a composite functionName|statementId
+AWS::Pipes::Pipe	CreationTime	pipe lifecycle timestamps are not tracked
+AWS::Pipes::Pipe	CurrentState	pipe state transitions are not modelled
+AWS::Pipes::Pipe	LastModifiedTime	pipe lifecycle timestamps are not tracked
+AWS::Pipes::Pipe	StateReason	pipe state transitions are not modelled
+AWS::SQS::QueuePolicy	Id	schema gives no description; the policy has no backing entity to take an id from


### PR DESCRIPTION
## Summary

An attribute a provisioner never sets is **invisible at runtime**. `resolveGetAttParts` returns the
literal `"LogicalId.Attr"` when a resource has no such attribute, so a template doing
`Fn::GetAtt [Topic, TopicArn]` receives the string `"Topic.TopicArn"` as a value rather than
failing. Nothing catches it.

Auditing every migrated type against its CloudFormation registry schema found **24 such attributes
across 15 types**. This sets the three whose correct value is unambiguous, and makes the rest a
ratchet instead of a silent backlog.

**Stacked on #2760 → #2759 → … → #2739.** Review those first.

### Fixed

| Type | Attribute | Value |
|---|---|---|
| `AWS::SNS::Topic` | `TopicArn` | the topic ARN — the attribute `aws-sns-topic.json` actually declares. `Arn` stays alongside it, since templates written against earlier releases reference it |
| `AWS::S3::Bucket` | `DualStackDomainName` | `<bucket>.s3.dualstack.<region>.amazonaws.com`, the same form as the `RegionalDomainName` already built |
| `AWS::CodePipeline::Pipeline` | `Arn` | constructed from region, account and name; the schema describes it as "The Amazon Resource Name (ARN) of the pipeline" |

### Not fixed, and why

The other 21 are recorded in `getatt-attribute-gaps.tsv`, each with a reason. Most are attributes
Floci *cannot* set because it does not emulate the behaviour behind them (`EC2::VPC`
`CidrBlockAssociations`, `Pipes::Pipe` lifecycle timestamps, `Kinesis` `WarmThroughputObject`).

A few I deliberately left despite looking easy — `Lambda::Permission Id`, `CodeBuild::Project Id`,
`SQS::QueuePolicy Id`, `EC2::VPCGatewayAttachment AttachmentType`. Their schemas carry no
description, and I could not establish AWS's actual value from the sources in the repo. Inventing a
plausible-looking value is worse than a recorded gap: it would look correct and read wrong.

### The ratchet

`CfnSchemaCoverageTest` compares the recorded gaps against what the provisioner sources actually
set, so the file cannot drift:

- a provisioner that stops setting a declared attribute **fails**, naming it
- a gap that has been closed **fails** until its row is deleted
- a row without a reason **fails**, so "not emulated" stays distinguishable from "forgotten"

**Mutation-verified in both directions.** Removing the new `TopicArn` line:

```
New gaps ... — set them, or add a row with a reason to ...getatt-attribute-gaps.tsv:
    AWS::SNS::Topic	TopicArn
```

Leaving a stale row after a fix:

```
These attributes are now set, so their rows ... are stale and should be deleted:
    [AWS::S3::Bucket	WebsiteURL]
```

The audit reads provisioner sources class-wide, so it is conservative: a reported gap is genuinely
unset by the whole class. It covers migrated types only; the legacy switch is audited type by type
as each one moves.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behaviour: `Fn::GetAtt` against `AWS::SNS::Topic` `TopicArn`,
`AWS::S3::Bucket` `DualStackDomainName`, or `AWS::CodePipeline::Pipeline` `Arn` resolved to the
literal string `"LogicalId.Attr"` instead of a value. Verified against the registry schemas in
`local/aws/cfn-resource-schemas/us-east-1`, which declare each as `readOnlyProperties`.

`AWS::SNS::Topic` keeps emitting `Arn` as well. The schema does not declare it, but removing it
would break templates already relying on it, and an extra attribute is not observable to a template
that does not ask for it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

CloudFormation + Cloud Control: **890 tests, 0 failures, 0 errors**. The existing
`S3CfnProvisionerTest` and `SnsCfnProvisionerTest` exact-attribute-map assertions were updated to
include the new keys, so they pin the fix rather than tolerating it.
