### PR TITLE
fix(sfn): include JSONata field in error cause

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -31,7 +31,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.regex.Pattern;
 
 import static io.github.hectorvent.floci.services.stepfunctions.AslExecutor.FailStateException;
 
@@ -50,7 +49,6 @@ import static com.dashjoin.jsonata.Jsonata.jsonata;
 public class JsonataEvaluator {
 
     private static final Set<String> HASH_ALGORITHMS = Set.of("MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512");
-    private static final Pattern JSONATA_ERROR_CODE_PREFIX = Pattern.compile("^[A-Z]\\d{4}:");
 
     /**
      * The largest magnitude a {@code double} can still hold as an exact integer count of longs.
@@ -274,12 +272,9 @@ public class JsonataEvaluator {
             if (!"States.QueryEvaluationError".equals(failure.error)) {
                 throw failure;
             }
-            String separator = failure.cause != null
-                    && JSONATA_ERROR_CODE_PREFIX.matcher(failure.cause).find()
-                    ? ". " : ": ";
             throw new FailStateException(failure.error,
                     "The JSONata expression '" + expr + "' specified for the field '" + field
-                            + "' threw an error during evaluation" + separator + failure.cause);
+                            + "' threw an error during evaluation. " + failure.cause);
         }
         if (value.isMissingNode()) {
             throw new FailStateException("States.QueryEvaluationError",

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -31,6 +31,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
 
 import static io.github.hectorvent.floci.services.stepfunctions.AslExecutor.FailStateException;
 
@@ -49,6 +50,7 @@ import static com.dashjoin.jsonata.Jsonata.jsonata;
 public class JsonataEvaluator {
 
     private static final Set<String> HASH_ALGORITHMS = Set.of("MD5", "SHA-1", "SHA-256", "SHA-384", "SHA-512");
+    private static final Pattern JSONATA_ERROR_CODE_PREFIX = Pattern.compile("^[A-Z]\\d{4}:");
 
     /**
      * The largest magnitude a {@code double} can still hold as an exact integer count of longs.
@@ -195,10 +197,10 @@ public class JsonataEvaluator {
     }
 
     /**
-     * The cause AWS reports for a failed JSONata expression: the error code, then the message
-     * jsonata-js renders for it, as in {@code T0412: Argument 1 of function "sum" must be an array
-     * of "numbers"}. AWS puts a sentence naming the expression and the field in front of that,
-     * which needs the field path {@link #resolveTemplate} does not thread today (#2665).
+     * The reusable tail of the cause AWS reports for a failed JSONata expression: the error code,
+     * then the message jsonata-js renders for it, as in {@code T0412: Argument 1 of function "sum"
+     * must be an array of "numbers"}. {@link #evaluateField} adds the sentence naming the
+     * expression and field because this lower-level method intentionally has no field context.
      *
      * <p>The dashjoin port renders the message itself, and three things go wrong on the way. Its
      * copy of the catalog has the word "function" replaced by "Object" throughout; its substituter
@@ -264,10 +266,24 @@ public class JsonataEvaluator {
      * {@code Choices[1]/Condition}, {@code Output/a/b}.
      */
     JsonNode evaluateField(String expression, String field, JsonNode statesVar, JsonNode variables) {
-        JsonNode value = evaluate(expression, statesVar, variables);
+        String expr = isExpression(expression) ? unwrap(expression) : expression;
+        JsonNode value;
+        try {
+            value = evaluate(expression, statesVar, variables);
+        } catch (FailStateException failure) {
+            if (!"States.QueryEvaluationError".equals(failure.error)) {
+                throw failure;
+            }
+            String separator = failure.cause != null
+                    && JSONATA_ERROR_CODE_PREFIX.matcher(failure.cause).find()
+                    ? ". " : ": ";
+            throw new FailStateException(failure.error,
+                    "The JSONata expression '" + expr + "' specified for the field '" + field
+                            + "' threw an error during evaluation" + separator + failure.cause);
+        }
         if (value.isMissingNode()) {
             throw new FailStateException("States.QueryEvaluationError",
-                    "The JSONata expression '" + (isExpression(expression) ? unwrap(expression) : expression)
+                    "The JSONata expression '" + expr
                             + "' specified for the field '" + field + "' returned nothing (undefined).");
         }
         return value;

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -921,6 +921,21 @@ class JsonataEvaluatorTest {
     }
 
     @Test
+    void failedExpressionNamesTheExpressionAndNestedFieldPath() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        JsonNode template = objectMapper.createObjectNode()
+                .set("v", objectMapper.getNodeFactory().textNode("{% $abs(\"x\") %}"));
+
+        AslExecutor.FailStateException failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.resolveTemplate(template, "Output", statesVar));
+
+        assertEquals("States.QueryEvaluationError", failure.error);
+        assertEquals("The JSONata expression '$abs(\"x\")' specified for the field 'Output/v' "
+                + "threw an error during evaluation. T0410: Argument 1 of function \"abs\" "
+                + "does not match function signature", failure.cause);
+    }
+
+    @Test
     void anExplicitNullIsAValueAndKeepsEveryPositionEvaluating() throws Exception {
         JsonNode statesVar = objectMapper.readTree("{\"input\": {\"bar\": null}}");
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -936,6 +936,19 @@ class JsonataEvaluatorTest {
     }
 
     @Test
+    void failedNonCodedExpressionUsesAwsSentenceSeparator() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        AslExecutor.FailStateException failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluateField("{% $replace('a','','b') %}", "Output/v", statesVar, null));
+
+        assertEquals("States.QueryEvaluationError", failure.error);
+        assertEquals("The JSONata expression '$replace('a','','b')' specified for the field 'Output/v' "
+                + "threw an error during evaluation. Second argument of replace function "
+                + "cannot be an empty string", failure.cause);
+    }
+
+    @Test
     void anExplicitNullIsAValueAndKeepsEveryPositionEvaluating() throws Exception {
         JsonNode statesVar = objectMapper.readTree("{\"input\": {\"bar\": null}}");
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataFunctionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataFunctionsIntegrationTest.java
@@ -247,7 +247,8 @@ class StepFunctionsJsonataFunctionsIntegrationTest {
         Response resp = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", resp.jsonPath().getString("error"));
-        assertEquals("T0412: Argument [\"a\"] must be an array of \"numbers\"",
+        assertEquals("The JSONata expression '$sum(['a'])' specified for the field 'Output/v' "
+                        + "threw an error during evaluation. T0412: Argument [\"a\"] must be an array of \"numbers\"",
                 resp.jsonPath().getString("cause"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1301,6 +1301,31 @@ class StepFunctionsJsonataIntegrationTest {
     }
 
     @Test
+    void failedOutputExpressionCauseNamesExpressionAndField() throws Exception {
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Transform",
+                    "States": {
+                        "Transform": {
+                            "Type": "Pass",
+                            "Output": {"v": "{% $abs(\\\"x\\\") %}"},
+                            "End": true
+                        }
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("jsonata-output-evaluation-error-cause", definition);
+        Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
+
+        assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
+        assertEquals("The JSONata expression '$abs(\"x\")' specified for the field 'Output/v' "
+                + "threw an error during evaluation. T0410: Argument 1 of function \"abs\" "
+                + "does not match function signature", failure.jsonPath().getString("cause"));
+    }
+
+    @Test
     void assignExpressionReturningNothingFailsTheState() throws Exception {
         // Real AWS names 'Assign/x' for this definition; before this guard the variable was never
         // bound and the next state read it as missing.


### PR DESCRIPTION
## Summary

- prefix JSONata evaluation failures with the expression and ASL field path that failed
- preserve coded and non-coded JSONata error tails after AWS's sentence separator and keep the catchable `States.QueryEvaluationError`
- cover both nested evaluator output and the real execution failure cause

## Testing

```text
JAVA_HOME=/opt/homebrew/opt/openjdk@25/libexec/openjdk.jdk/Contents/Home ./mvnw test -Dtest=StepFunctionsJsonataFunctionsIntegrationTest,JsonataEvaluatorTest,StepFunctionsJsonataIntegrationTest
```

157 tests passed.

Fixes #2736
