### PR TITLE
fix(stepfunctions): enforce both TimeoutSeconds clocks

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -111,6 +111,35 @@ uniformly between zero and the computed delay, as on AWS. One deviation. The del
 between attempts is capped at 30 seconds, the same cap Floci applies to `Wait` states,
 so emulated runs stay fast.
 
+## Timeouts
+
+ASL carries two `TimeoutSeconds` fields and Floci enforces both, in the two terminal shapes
+AWS uses.
+
+The state machine's own `TimeoutSeconds` is the whole execution's budget. It is checked before
+every state and inside a `Wait`, so a `Wait` longer than what is left is cut rather than slept
+out. The execution ends `TIMED_OUT` with `stopDate` set and no `error` and no `cause` at all;
+`States.Timeout` is named only in the single `ExecutionTimedOut` event, whose `previousEventId`
+is `0`. The state that was cut gets no `*StateExited` event. A `Parallel` or `Map` branch runs
+on its own thread and is not cut mid-state: the budget is enforced again as soon as the branch
+returns.
+
+A `Task` that waits for a task token — an activity, or a `.waitForTaskToken` integration — has
+two independent bounds. `TimeoutSeconds` is the whole wait; `HeartbeatSeconds` is the longest gap
+allowed between two `SendTaskHeartbeat` calls, and every heartbeat pushes that gap forward, so a
+worker that reports as often as the definition asks runs until `TimeoutSeconds` runs out. Either
+clock ends the state the same way: an `ActivityTimedOut` event — `TaskTimedOut` for a
+`.waitForTaskToken` integration — carrying `States.Timeout` and no cause, then an execution that
+reads `FAILED` with that same error. A `Catch` on a heartbeat expiry matches under
+`States.HeartbeatTimeout` and under `States.Timeout` alike. Neither timeout carries a cause:
+`DescribeExecution` and the `ExecutionFailed` event both leave the key out, where every other
+failure reports one. A `Task` that declares no `TimeoutSeconds` waits 300 seconds, where AWS
+waits a year.
+
+One deviation. AWS starts the `TimeoutSeconds` clock when a worker picks the task up, the instant
+it emits `ActivityStarted`. Floci emits `ActivityStarted` at schedule time, so both clocks start
+when the task is scheduled.
+
 ## JSONata nulls
 
 An expression that evaluates to JSON `null` produces a value, not a missing one. It keeps its key

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -108,6 +108,9 @@ public class AslExecutor {
 
     private static final Logger LOG = Logger.getLogger(AslExecutor.class);
     private static final int MAX_WAIT_SECONDS = 30;
+    // How long a Task waits for its token when the state declares no TimeoutSeconds. AWS lets it
+    // run for a year; the emulator would rather free the worker thread.
+    private static final int DEFAULT_TASK_TOKEN_TIMEOUT_SECONDS = 300;
     private static final int INLINE_MAP_MAX_CONCURRENCY = 40;
     private static final int DISTRIBUTED_MAP_MAX_CONCURRENCY = 10_000;
 
@@ -364,6 +367,12 @@ public class AslExecutor {
             String startAt = definition.path("StartAt").asText();
             String topLevelQueryLanguage = definition.path("QueryLanguage").asText("JSONPath");
             JsonNode currentInput = parseInput(exec.getInput());
+            // The state machine's total budget, computed once so every state measures against the
+            // same instant. Long.MAX_VALUE stands for a definition with no TimeoutSeconds.
+            int timeoutSeconds = definition.path("TimeoutSeconds").asInt(0);
+            long executionDeadlineNanos = timeoutSeconds > 0
+                    ? System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
+                    : Long.MAX_VALUE;
             JsonNode execContext = buildContext(exec, sm);
             // Execution-scoped JSONata variables (the Assign field). Mutated in place as states
             // assign, so later states observe earlier assignments.
@@ -371,6 +380,9 @@ public class AslExecutor {
 
             String currentStateName = startAt;
             while (currentStateName != null) {
+                if (System.nanoTime() >= executionDeadlineNanos) {
+                    throw new ExecutionTimedOutException();
+                }
                 JsonNode stateDef = states.path(currentStateName);
                 if (stateDef.isMissingNode()) {
                     throw new RuntimeException("State not found: " + currentStateName);
@@ -388,7 +400,8 @@ public class AslExecutor {
                 var jsonata = isJsonata(stateDef, topLevelQueryLanguage);
                 try {
                     var stateResult = executeStateWithRetry(currentStateName, type, stateDef, currentInput,
-                            history, eventId, sm, jsonata, topLevelQueryLanguage, execContext, variables);
+                            history, eventId, sm, jsonata, topLevelQueryLanguage, execContext, variables,
+                            executionDeadlineNanos);
                     addEvent(history, eventId, stateExitedEventType(type),
                             Map.of("name", currentStateName, "output", stateResult.output().toString(),
                                    "outputDetails", Map.of("truncated", false)));
@@ -435,6 +448,15 @@ public class AslExecutor {
                     Map.of("output", currentInput.toString(), "outputDetails", Map.of("truncated", false)));
             onUpdate.accept(exec, history);
 
+        } catch (ExecutionTimedOutException e) {
+            // A timed out execution carries neither error nor cause: DescribeExecution leaves both
+            // keys out, and States.Timeout is named only inside the ExecutionTimedOut event, which
+            // points at the start of the execution rather than at the state it cut.
+            exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("TIMED_OUT");
+            addEvent(history, eventId, "ExecutionTimedOut", 0L, Map.of("error", "States.Timeout"));
+            onUpdate.accept(exec, history);
+
         } catch (Exception e) {
             LOG.warnv("ASL execution failed for {0}: {1}", exec.getExecutionArn(), e.getMessage());
             // This path previously set only the status, leaving error and cause null forever on an
@@ -472,14 +494,14 @@ public class AslExecutor {
     private StateResult executeStateWithRetry(String name, String type, JsonNode stateDef, JsonNode input,
                                               List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
                                               boolean jsonata, String topLevelQueryLanguage, JsonNode context,
-                                              ObjectNode variables) throws Exception {
+                                              ObjectNode variables, long executionDeadlineNanos) throws Exception {
         var retriers = stateDef.path("Retry");
         var attemptsPerRetrier = new HashMap<Integer, Integer>();
         var attempt = 0;
         while (true) {
             try {
                 return executeState(name, type, stateDef, input, history, eventId, sm, jsonata,
-                        topLevelQueryLanguage, context, variables, attempt);
+                        topLevelQueryLanguage, context, variables, attempt, executionDeadlineNanos);
             } catch (FailStateException e) {
                 var retrierIndex = findMatchingRetrier(retriers, e);
                 if (retrierIndex < 0) {
@@ -490,7 +512,7 @@ public class AslExecutor {
                 if (attemptsUsed > retrier.path("MaxAttempts").asInt(3)) {
                     throw e;
                 }
-                sleepBeforeRetry(retrier, attemptsUsed);
+                sleepBeforeRetry(retrier, attemptsUsed, executionDeadlineNanos);
                 attempt++;
                 updateRetryCount(context, attempt);
             }
@@ -501,20 +523,25 @@ public class AslExecutor {
         if (!retriers.isArray()) {
             return -1;
         }
-        var error = failure.error != null ? failure.error : "States.Runtime";
         for (var i = 0; i < retriers.size(); i++) {
-            if (catchMatches(retriers.get(i), error)) {
+            if (catchMatches(retriers.get(i), failure)) {
                 return i;
             }
         }
         return -1;
     }
 
-    private void sleepBeforeRetry(JsonNode retrier, int attemptsUsed) throws InterruptedException {
+    /**
+     * Backs off before the next attempt. The backoff is a pause inside the state, so a retrier
+     * whose interval outlasts the state machine's {@code TimeoutSeconds} budget ends the execution
+     * where the budget runs out rather than attempting again past it, which is what AWS does. The
+     * deadline is read even when the delay is zero, so a state that already spent the budget stops
+     * instead of retrying instantly.
+     */
+    private void sleepBeforeRetry(JsonNode retrier, int attemptsUsed, long executionDeadlineNanos)
+            throws InterruptedException {
         var delaySeconds = retryDelaySeconds(retrier, attemptsUsed, ThreadLocalRandom.current().nextDouble());
-        if (delaySeconds > 0) {
-            Thread.sleep((long) (delaySeconds * 1000));
-        }
+        sleepOrTimeOutExecution((long) (delaySeconds * 1_000_000_000L), executionDeadlineNanos);
     }
 
     /**
@@ -544,13 +571,14 @@ public class AslExecutor {
     private StateResult executeState(String name, String type, JsonNode stateDef, JsonNode input,
                                      List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
                                      boolean jsonata, String topLevelQueryLanguage, JsonNode context,
-                                     ObjectNode variables, int attempt) throws Exception {
+                                     ObjectNode variables, int attempt,
+                                     long executionDeadlineNanos) throws Exception {
         return switch (type) {
             case "Pass" -> executePassState(stateDef, input, jsonata, context, variables);
             case "Task" -> executeTaskState(name, stateDef, input, history, eventId, sm, jsonata, context,
                     variables, attempt);
             case "Choice" -> executeChoiceState(stateDef, input, jsonata, context, variables);
-            case "Wait" -> executeWaitState(stateDef, input, jsonata, context, variables);
+            case "Wait" -> executeWaitState(stateDef, input, jsonata, context, variables, executionDeadlineNanos);
             case "Succeed" -> executeSucceedState(stateDef, input, jsonata, context, variables);
             case "Fail" -> executeFail(stateDef, input, jsonata, context, variables);
             case "Parallel" -> executeParallelState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context, variables);
@@ -632,8 +660,11 @@ public class AslExecutor {
                     ? mockedTaskResult(mockedSteps, stateName, attempt)
                     : invokeResource(effectiveResource, effectiveInput, sm, taskToken);
             if (tokenFuture != null) {
-                taskResult = awaitToken(tokenFuture, stateDef);
+                taskResult = awaitToken(tokenFuture, stateDef, taskToken);
             }
+        } catch (TaskTimedOutException e) {
+            addTaskTimedOutEvent(history, eventId, profile);
+            throw e;
         } catch (Exception e) {
             var failure = e instanceof FailStateException f ? f : null;
             addTaskFailedEvent(history, eventId, profile,
@@ -685,17 +716,45 @@ public class AslExecutor {
                 "No mocked response defined for attempt " + attempt + " of state '" + stateName + "'");
     }
 
-    private JsonNode awaitToken(CompletableFuture<JsonNode> future, JsonNode stateDef) throws Exception {
-        int timeout = stateDef.path("HeartbeatSeconds").asInt(0);
-        if (timeout <= 0) {
-            timeout = 300;
+    /**
+     * Waits for the worker to answer the task token under the two independent bounds AWS enforces:
+     * {@code TimeoutSeconds} is the whole wait, and {@code HeartbeatSeconds} is the longest gap
+     * allowed between two SendTaskHeartbeat calls, each of which pushes that gap forward. Either
+     * clock ends the state as a {@link TaskTimedOutException}: the error is {@code States.Timeout}
+     * and there is no cause.
+     *
+     * <p>Both clocks start when the task is scheduled. AWS starts TimeoutSeconds when a worker
+     * picks the task up, which is the instant it emits ActivityStarted; Floci emits that event at
+     * schedule time, so there is no later instant to anchor on here.
+     */
+    private JsonNode awaitToken(CompletableFuture<JsonNode> future, JsonNode stateDef, String taskToken)
+            throws Exception {
+        int timeoutSeconds = stateDef.path("TimeoutSeconds").asInt(0);
+        if (timeoutSeconds <= 0) {
+            timeoutSeconds = DEFAULT_TASK_TOKEN_TIMEOUT_SECONDS;
         }
+        int heartbeatSeconds = stateDef.path("HeartbeatSeconds").asInt(0);
+        long timeoutDeadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
         try {
-            return future.get(timeout, TimeUnit.SECONDS);
-        } catch (java.util.concurrent.TimeoutException e) {
-            future.cancel(true);
-            throw new FailStateException("States.HeartbeatTimeout",
-                    "Task timed out after " + timeout + " seconds");
+            while (true) {
+                long wakeAtNanos = Math.min(timeoutDeadlineNanos,
+                        heartbeatDeadlineNanos(taskToken, heartbeatSeconds));
+                try {
+                    return future.get(wakeAtNanos - System.nanoTime(), TimeUnit.NANOSECONDS);
+                } catch (java.util.concurrent.TimeoutException e) {
+                    if (System.nanoTime() >= timeoutDeadlineNanos) {
+                        future.cancel(true);
+                        throw new TaskTimedOutException("States.Timeout");
+                    }
+                    // Read the gap again rather than trusting the one this thread parked on: a
+                    // heartbeat that landed meanwhile has already moved it past now, and the task
+                    // goes back to waiting on the later deadline.
+                    if (System.nanoTime() >= heartbeatDeadlineNanos(taskToken, heartbeatSeconds)) {
+                        future.cancel(true);
+                        throw new TaskTimedOutException("States.HeartbeatTimeout");
+                    }
+                }
+            }
         } catch (ExecutionException e) {
             Throwable cause = e.getCause();
             if (cause instanceof FailStateException fse) {
@@ -703,7 +762,19 @@ public class AslExecutor {
             }
             throw new FailStateException("States.TaskFailed",
                     cause != null ? cause.getMessage() : "Task failed");
+        } finally {
+            sfnService.get().discardPendingToken(taskToken);
         }
+    }
+
+    /**
+     * When the worker's silence becomes too long: its last heartbeat plus the state's
+     * {@code HeartbeatSeconds}, or never for a state that declares none.
+     */
+    private long heartbeatDeadlineNanos(String taskToken, int heartbeatSeconds) {
+        return heartbeatSeconds > 0
+                ? sfnService.get().lastTaskHeartbeatNanos(taskToken) + TimeUnit.SECONDS.toNanos(heartbeatSeconds)
+                : Long.MAX_VALUE;
     }
 
     /**
@@ -1845,7 +1916,8 @@ public class AslExecutor {
     }
 
     private StateResult executeWaitState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
-                                         ObjectNode variables) throws InterruptedException {
+                                         ObjectNode variables, long executionDeadlineNanos)
+            throws InterruptedException {
         int seconds = 0;
         if (jsonata) {
             if (stateDef.has("Seconds")) {
@@ -1869,13 +1941,30 @@ public class AslExecutor {
         }
         // Timestamp and TimestampPath: wait until that time or now, whichever is sooner
         if (seconds > 0) {
-            TimeUnit.SECONDS.sleep(seconds);
+            sleepOrTimeOutExecution(TimeUnit.SECONDS.toNanos(seconds), executionDeadlineNanos);
         }
         if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, null, context, variables);
             return new StateResult(output, stateDef.path("Next").asText(null));
         }
         return new StateResult(input, stateDef.path("Next").asText(null));
+    }
+
+    /**
+     * Sleeps out a pause the definition asked for, ending the execution instead when the state
+     * machine's {@code TimeoutSeconds} budget runs out first. The two pauses long enough to
+     * outlast that budget are a Wait and a Retry's backoff, and both leave the state they cut
+     * without its Exited event, the same way AWS does.
+     */
+    private void sleepOrTimeOutExecution(long pauseNanos, long executionDeadlineNanos)
+            throws InterruptedException {
+        long remainingNanos = executionDeadlineNanos - System.nanoTime();
+        if (pauseNanos < remainingNanos) {
+            TimeUnit.NANOSECONDS.sleep(pauseNanos);
+            return;
+        }
+        TimeUnit.NANOSECONDS.sleep(Math.max(remainingNanos, 0));
+        throw new ExecutionTimedOutException();
     }
 
     private StateResult executeSucceedState(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
@@ -1890,7 +1979,9 @@ public class AslExecutor {
     private StateResult executeFail(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
                                     ObjectNode variables) {
         String error = stateDef.path("Error").asText(null);
-        String cause = stateDef.path("Cause").asText(null);
+        // A Fail state that declares no Cause reports an empty one, not a missing key. A task that
+        // ran out of one of its clocks is the only failure that omits the key.
+        String cause = stateDef.path("Cause").asText("");
         if (jsonata) {
             JsonNode statesVar = buildStatesVar(input, null, context);
             if (error != null && JsonataEvaluator.isExpression(error)) {
@@ -2519,8 +2610,11 @@ public class AslExecutor {
             updateStateContext(context, currentState);
             StateResult result;
             try {
+                // A Parallel or Map branch runs on its own thread and is not cut mid-state by the
+                // execution's TimeoutSeconds: the state loop that resumes once the branch returns
+                // is where the budget is enforced.
                 result = executeStateWithRetry(currentState, type, stateDef, currentInput, ignored, eventId, sm,
-                        stateJsonata, topLevelQueryLanguage, context, variables);
+                        stateJsonata, topLevelQueryLanguage, context, variables, Long.MAX_VALUE);
             } catch (FailStateException e) {
                 StateResult caught = handleCatch(stateDef, currentInput, e, stateJsonata, context, variables);
                 if (caught == null) {
@@ -3553,24 +3647,45 @@ public class AslExecutor {
         addEvent(history, eventId, profile.prefix() + "Failed", details);
     }
 
+    /**
+     * The event a Task leaves when one of its clocks runs out. It names {@code States.Timeout} for
+     * both {@code TimeoutSeconds} and {@code HeartbeatSeconds}, and carries no cause.
+     */
+    private void addTaskTimedOutEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile) {
+        var details = new LinkedHashMap<String, Object>();
+        if ("Task".equals(profile.prefix())) {
+            details.put("resourceType", profile.resourceType());
+            details.put("resource", profile.resource());
+        }
+        details.put("error", "States.Timeout");
+        addEvent(history, eventId, profile.prefix() + "TimedOut", details);
+    }
+
     private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId, FailStateException e) {
-        failExecution(exec, history, eventId, e.error != null ? e.error : "States.Runtime",
-                e.cause != null ? e.cause : "");
+        failExecution(exec, history, eventId, e.error != null ? e.error : "States.Runtime", e.cause);
     }
 
     /**
      * The single terminal-failure write: every way an execution can fail leaves the same
      * {@code error}, {@code cause} and {@code ExecutionFailed} event behind, so a client cannot
      * tell a Fail state from a state that threw from a runtime Error by what it reads back.
+     *
+     * <p>A null {@code cause} is the failure saying it has none, and both DescribeExecution and the
+     * ExecutionFailed event leave the key out rather than reporting it empty. Only a task that ran
+     * out of its TimeoutSeconds or HeartbeatSeconds budget arrives here without one.
      */
     private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId,
                                String error, String cause) {
+        var details = new LinkedHashMap<String, Object>();
+        details.put("error", error);
+        if (cause != null) {
+            details.put("cause", cause);
+        }
         exec.setError(error);
         exec.setCause(cause);
         exec.setStopDate(System.currentTimeMillis() / 1000.0);
         exec.setStatus("FAILED");
-        addEvent(history, eventId, "ExecutionFailed",
-                Map.of("error", error, "cause", cause));
+        addEvent(history, eventId, "ExecutionFailed", details);
     }
 
     private StateResult handleCatch(JsonNode stateDef, JsonNode input, FailStateException failure,
@@ -3583,7 +3698,7 @@ public class AslExecutor {
         String cause = failure.cause != null ? failure.cause : "";
         for (int i = 0; i < catchers.size(); i++) {
             JsonNode catcher = catchers.get(i);
-            if (!catchMatches(catcher, error)) {
+            if (!catchMatches(catcher, failure)) {
                 continue;
             }
             String next = catcher.path("Next").asText(null);
@@ -3607,11 +3722,12 @@ public class AslExecutor {
         return null;
     }
 
-    private boolean catchMatches(JsonNode catcher, String error) {
+    private boolean catchMatches(JsonNode catcher, FailStateException failure) {
         var errors = catcher.path("ErrorEquals");
         if (!errors.isArray()) {
             return false;
         }
+        var error = failure.error != null ? failure.error : "States.Runtime";
         // States.Runtime is never retried or caught, even when named explicitly in
         // ErrorEquals. Verified against real AWS: the execution fails immediately.
         if ("States.Runtime".equals(error)) {
@@ -3619,7 +3735,7 @@ public class AslExecutor {
         }
         for (JsonNode candidate : errors) {
             var expected = candidate.asText();
-            if (expected.equals(error)) {
+            if (failure.isNamedBy(expected)) {
                 return true;
             }
             if ("States.TaskFailed".equals(expected)
@@ -3663,6 +3779,17 @@ public class AslExecutor {
 
     record StateResult(JsonNode output, String nextState) {}
 
+    /**
+     * Thrown when the state machine's top-level {@code TimeoutSeconds} budget runs out. It is not a
+     * {@link FailStateException} on purpose: a Catch clause never sees it, no Retry re-runs the
+     * state it cut, and the execution ends TIMED_OUT rather than FAILED.
+     */
+    static class ExecutionTimedOutException extends RuntimeException {
+        ExecutionTimedOutException() {
+            super("States.Timeout");
+        }
+    }
+
     static class FailStateException extends RuntimeException {
         final String error;
         final String cause;
@@ -3671,6 +3798,35 @@ public class AslExecutor {
             super(error + ": " + cause);
             this.error = error;
             this.cause = cause;
+        }
+
+        /**
+         * Whether an {@code ErrorEquals} entry spelling {@code errorName} names this failure. A
+         * failure answers to the error it reports, and a task timeout answers to the name of the
+         * clock that ran out as well.
+         */
+        boolean isNamedBy(String errorName) {
+            return errorName.equals(error);
+        }
+    }
+
+    /**
+     * Thrown when a Task ran out of one of the two clocks bounding its wait for a task token. Both
+     * report {@code States.Timeout} with no cause and emit a {@code TimedOut} history event; a
+     * {@code HeartbeatSeconds} expiry is also caught by an {@code ErrorEquals} naming
+     * {@code States.HeartbeatTimeout}.
+     */
+    static class TaskTimedOutException extends FailStateException {
+        private final String expiredClockError;
+
+        TaskTimedOutException(String expiredClockError) {
+            super("States.Timeout", null);
+            this.expiredClockError = expiredClockError;
+        }
+
+        @Override
+        boolean isNamedBy(String errorName) {
+            return super.isNamedBy(errorName) || errorName.equals(expiredClockError);
         }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -410,7 +410,9 @@ public class StepFunctionsJsonHandler {
     private Response handleSendTaskFailure(JsonNode request) {
         service.sendTaskFailure(
                 request.path("taskToken").asText(),
-                request.path("cause").asText(null),
+                // A SendTaskFailure that names no cause fails the task with an empty one, not with
+                // a missing key.
+                request.path("cause").asText(""),
                 request.path("error").asText(null)
         );
         return Response.ok(objectMapper.createObjectNode()).build();

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -49,6 +49,9 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     private final Map<String, List<HistoryEvent>> historyCache = new ConcurrentHashMap<>();
     private final Map<String, BlockingQueue<ActivityTask>> activityQueues = new ConcurrentHashMap<>();
     private final Map<String, CompletableFuture<JsonNode>> pendingTaskTokens = new ConcurrentHashMap<>();
+    // When each pending token last showed progress, so a Task's HeartbeatSeconds can bound the gap
+    // between heartbeats instead of the whole wait.
+    private final Map<String, Long> taskHeartbeatNanos = new ConcurrentHashMap<>();
     private final RegionResolver regionResolver;
     private final AslExecutor aslExecutor;
     private final ObjectMapper objectMapper;
@@ -104,6 +107,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         activityQueues.clear();
         pendingTaskTokens.values().forEach(f -> f.completeExceptionally(new RuntimeException("StepFunctionsService cleared")));
         pendingTaskTokens.clear();
+        taskHeartbeatNanos.clear();
     }
 
     @Override
@@ -744,7 +748,30 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     public CompletableFuture<JsonNode> registerPendingToken(String token) {
         CompletableFuture<JsonNode> future = new CompletableFuture<>();
         pendingTaskTokens.put(token, future);
+        taskHeartbeatNanos.put(token, System.nanoTime());
         return future;
+    }
+
+    /**
+     * When the token last showed progress: the moment its task was scheduled, then every
+     * SendTaskHeartbeat that named it. A token that is no longer pending reads as having just
+     * reported, so a task whose result already arrived is never failed on a heartbeat gap.
+     */
+    public long lastTaskHeartbeatNanos(String taskToken) {
+        Long reportedAt = taskToken != null ? taskHeartbeatNanos.get(taskToken) : null;
+        return reportedAt != null ? reportedAt : System.nanoTime();
+    }
+
+    /**
+     * Forgets a token the waiting task has stopped listening for, so a later SendTaskSuccess,
+     * SendTaskFailure or SendTaskHeartbeat naming it reports no pending task.
+     */
+    public void discardPendingToken(String taskToken) {
+        if (taskToken == null) {
+            return;
+        }
+        pendingTaskTokens.remove(taskToken);
+        taskHeartbeatNanos.remove(taskToken);
     }
 
     // ──────────────────────────── Tasks ────────────────────────────
@@ -782,8 +809,16 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         return true;
     }
 
+    /**
+     * Resets the gap a Task's {@code HeartbeatSeconds} allows. A heartbeat for a token nobody is
+     * waiting for is logged and changes nothing, as in {@link #sendTaskSuccess(String, String)}.
+     */
     public void sendTaskHeartbeat(String taskToken) {
-        LOG.debugv("Task heartbeat for token {0}", taskToken);
+        if (taskToken == null || !pendingTaskTokens.containsKey(taskToken)) {
+            LOG.warnv("SendTaskHeartbeat: no pending task for token {0}", taskToken);
+            return;
+        }
+        taskHeartbeatNanos.put(taskToken, System.nanoTime());
     }
 
     // ──────────────────────────── Map runs ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsTimeoutSecondsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsTimeoutSecondsIntegrationTest.java
@@ -1,0 +1,406 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * The two {@code TimeoutSeconds} fields of ASL, each enforced on its own clock: the state
+ * machine's total budget and a {@code Task}'s wait for its task token, the second one bounded a
+ * second time by {@code HeartbeatSeconds}.
+ *
+ * <p>The bounds here are one to ten seconds where the report that measured them against us-east-1
+ * used three and five; the shape of the terminal execution is what the assertions pin, not the
+ * duration.
+ */
+@QuarkusTest
+class StepFunctionsTimeoutSecondsIntegrationTest {
+
+    private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void stateMachineTimeoutSecondsCutsAWaitLongerThanTheRemainingBudget() throws Exception {
+        String smArn = createStateMachine("top-level-timeout-wait", """
+                {
+                    "StartAt": "Linger",
+                    "TimeoutSeconds": 1,
+                    "States": {
+                        "Linger": {"Type": "Wait", "Seconds": 3, "End": true}
+                    }
+                }
+                """);
+
+        Response timedOut = waitForTerminalExecution(startExecution(smArn, "{}"));
+
+        assertEquals("TIMED_OUT", timedOut.jsonPath().getString("status"));
+        JsonNode body = mapper.readTree(timedOut.body().asString());
+        assertTrue(body.has("stopDate"), "stopDate must be set on a timed out execution");
+        assertFalse(body.has("error"), "TIMED_OUT carries no error key: " + body);
+        assertFalse(body.has("cause"), "TIMED_OUT carries no cause key: " + body);
+    }
+
+    @Test
+    void timedOutExecutionEmitsExecutionTimedOutAndNoStateExitedForTheCutState() throws Exception {
+        String smArn = createStateMachine("top-level-timeout-history", """
+                {
+                    "StartAt": "Linger",
+                    "TimeoutSeconds": 1,
+                    "States": {
+                        "Linger": {"Type": "Wait", "Seconds": 3, "End": true}
+                    }
+                }
+                """);
+
+        String execArn = startExecution(smArn, "{}");
+        waitForTerminalExecution(execArn);
+        JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
+
+        assertEquals(List.of("ExecutionStarted", "WaitStateEntered", "ExecutionTimedOut"),
+                eventTypes(events), "history was " + events);
+        JsonNode timedOut = events.get(events.size() - 1);
+        assertEquals(0, timedOut.path("previousEventId").asLong());
+        assertEquals("States.Timeout",
+                timedOut.path("executionTimedOutEventDetails").path("error").asText());
+        assertFalse(timedOut.path("executionTimedOutEventDetails").has("cause"),
+                "ExecutionTimedOut carries only the error: " + timedOut);
+    }
+
+    @Test
+    void stateMachineTimeoutSecondsStopsTheLoopBeforeEnteringTheNextState() throws Exception {
+        // A Parallel branch runs on its own thread and sleeps its Wait out in full, so the budget
+        // is already spent by the time the state loop reaches the state after it.
+        String smArn = createStateMachine("top-level-timeout-loop", """
+                {
+                    "StartAt": "Fork",
+                    "TimeoutSeconds": 1,
+                    "States": {
+                        "Fork": {
+                            "Type": "Parallel",
+                            "Branches": [{
+                                "StartAt": "Linger",
+                                "States": {"Linger": {"Type": "Wait", "Seconds": 3, "End": true}}
+                            }],
+                            "Next": "Unreached"
+                        },
+                        "Unreached": {"Type": "Pass", "End": true}
+                    }
+                }
+                """);
+
+        String execArn = startExecution(smArn, "{}");
+        Response timedOut = waitForTerminalExecution(execArn);
+
+        assertEquals("TIMED_OUT", timedOut.jsonPath().getString("status"));
+        JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateExited",
+                "ExecutionTimedOut"), eventTypes(events), "history was " + events);
+    }
+
+    @Test
+    void stateMachineTimeoutSecondsCutsARetryBackoffLongerThanTheRemainingBudget() throws Exception {
+        // The Lambda does not exist, so every attempt fails immediately and the only thing this
+        // state spends time on is the backoff between attempts. AWS ends the execution when the
+        // budget runs out, mid-backoff; before this the backoff ran in full and the state failed
+        // on its own error afterwards, so the execution ended FAILED past its budget.
+        String smArn = createStateMachine("top-level-timeout-retry", """
+                {
+                    "StartAt": "Flaky",
+                    "TimeoutSeconds": 1,
+                    "States": {
+                        "Flaky": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::lambda:invoke",
+                            "Parameters": {"FunctionName": "absent-function"},
+                            "Retry": [{"ErrorEquals": ["States.ALL"], "IntervalSeconds": 10, "MaxAttempts": 1}],
+                            "End": true
+                        }
+                    }
+                }
+                """);
+
+        String execArn = startExecution(smArn, "{}");
+        long startedAt = System.currentTimeMillis();
+        Response timedOut = waitForTerminalExecution(execArn);
+        long elapsedMillis = System.currentTimeMillis() - startedAt;
+
+        assertEquals("TIMED_OUT", timedOut.jsonPath().getString("status"), timedOut.body().asString());
+        assertTrue(elapsedMillis < 5_000,
+                "the 10-second backoff outlasted the 1-second budget: " + elapsedMillis + " ms");
+        JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
+        assertEquals("ExecutionTimedOut", events.get(events.size() - 1).path("type").asText(),
+                "history was " + events);
+    }
+
+    @Test
+    void taskTimeoutSecondsBoundsTheWholeWaitForTheTaskToken() throws Exception {
+        String activityArn = createActivity("timeout-seconds-total");
+        String smArn = createStateMachine("task-timeout-seconds", activityTask(activityArn, 1, 0));
+
+        Response failed = waitForTerminalExecution(startExecution(smArn, "{}"));
+
+        assertEquals("FAILED", failed.jsonPath().getString("status"));
+        assertEquals("States.Timeout", failed.jsonPath().getString("error"));
+        JsonNode body = mapper.readTree(failed.body().asString());
+        assertFalse(body.has("cause"),
+                "a task that ran out of time carries no cause key: " + body);
+    }
+
+    @Test
+    void taskHeartbeatSecondsBoundsTheGapBetweenHeartbeats() throws Exception {
+        String activityArn = createActivity("heartbeat-seconds-gap");
+        String smArn = createStateMachine("task-heartbeat-gap", activityTask(activityArn, 10, 1));
+        String execArn = startExecution(smArn, "{}");
+
+        // A worker picks the task up and then goes silent, so the gap HeartbeatSeconds allows runs
+        // out long before the state's TimeoutSeconds does.
+        getActivityTask(activityArn);
+        Response failed = waitForTerminalExecution(execArn);
+
+        assertEquals("FAILED", failed.jsonPath().getString("status"));
+        assertEquals("States.Timeout", failed.jsonPath().getString("error"));
+        JsonNode body = mapper.readTree(failed.body().asString());
+        assertFalse(body.has("cause"),
+                "a task that missed its heartbeats carries no cause key: " + body);
+
+        JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
+        assertEquals(List.of("ExecutionStarted", "TaskStateEntered", "ActivityScheduled",
+                "ActivityStarted", "ActivityTimedOut", "ExecutionFailed"),
+                eventTypes(events), "history was " + events);
+        JsonNode timedOut = events.get(events.size() - 2);
+        assertEquals("States.Timeout",
+                timedOut.path("activityTimedOutEventDetails").path("error").asText());
+        assertFalse(timedOut.path("activityTimedOutEventDetails").has("cause"),
+                "ActivityTimedOut carries only the error: " + timedOut);
+    }
+
+    @Test
+    void aCatchMatchesAHeartbeatExpiryUnderEitherErrorName() throws Exception {
+        for (String errorEquals : List.of("States.HeartbeatTimeout", "States.Timeout")) {
+            String activityArn = createActivity("heartbeat-seconds-catch");
+            String smArn = createStateMachine("task-heartbeat-catch",
+                    caughtActivityTask(activityArn, errorEquals));
+            String execArn = startExecution(smArn, "{}");
+
+            getActivityTask(activityArn);
+            Response caught = waitForTerminalExecution(execArn);
+
+            assertEquals("SUCCEEDED", caught.jsonPath().getString("status"),
+                    "Catch on " + errorEquals + " left the execution " + caught.body().asString());
+            assertEquals("States.Timeout",
+                    mapper.readTree(caught.jsonPath().getString("output")).path("Error").asText(),
+                    "Catch on " + errorEquals + " reported the wrong error");
+        }
+    }
+
+    @Test
+    void heartbeatsKeepATaskAliveUntilItsTimeoutSecondsRunOut() throws Exception {
+        String activityArn = createActivity("heartbeat-seconds-reset");
+        String smArn = createStateMachine("task-heartbeat-reset", activityTask(activityArn, 12, 3));
+        String execArn = startExecution(smArn, "{}");
+
+        String taskToken = getActivityTask(activityArn);
+        // Five seconds of work reported every 500 ms: nearly twice the heartbeat gap, so the task
+        // survives only if each heartbeat pushes that gap's deadline forward.
+        for (int beat = 0; beat < 10; beat++) {
+            Thread.sleep(500);
+            sendTaskHeartbeat(taskToken);
+        }
+        sendTaskSuccess(taskToken, "{\"answered\":true}");
+
+        Response succeeded = waitForTerminalExecution(execArn);
+        assertEquals("SUCCEEDED", succeeded.jsonPath().getString("status"),
+                "execution was " + succeeded.body().asString());
+        assertTrue(mapper.readTree(succeeded.jsonPath().getString("output")).path("answered").asBoolean());
+    }
+
+    private static String activityTask(String activityArn, int timeoutSeconds, int heartbeatSeconds) {
+        String heartbeat = heartbeatSeconds > 0 ? ",\"HeartbeatSeconds\": " + heartbeatSeconds : "";
+        return """
+                {
+                    "StartAt": "Await",
+                    "States": {
+                        "Await": {
+                            "Type": "Task",
+                            "Resource": "%s",
+                            "TimeoutSeconds": %d%s,
+                            "End": true
+                        }
+                    }
+                }
+                """.formatted(activityArn, timeoutSeconds, heartbeat);
+    }
+
+    private static String caughtActivityTask(String activityArn, String errorEquals) {
+        return """
+                {
+                    "StartAt": "Await",
+                    "States": {
+                        "Await": {
+                            "Type": "Task",
+                            "Resource": "%s",
+                            "TimeoutSeconds": 10,
+                            "HeartbeatSeconds": 1,
+                            "Catch": [{"ErrorEquals": ["%s"], "Next": "Recovered"}],
+                            "End": true
+                        },
+                        "Recovered": {"Type": "Pass", "End": true}
+                    }
+                }
+                """.formatted(activityArn, errorEquals);
+    }
+
+    private static List<String> eventTypes(JsonNode events) {
+        List<String> types = new ArrayList<>();
+        events.forEach(event -> types.add(event.path("type").asText()));
+        return types;
+    }
+
+    private static String createActivity(String name) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.CreateActivity")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"name": "%s-%d"}
+                        """.formatted(name, System.currentTimeMillis()))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("activityArn");
+    }
+
+    private static String getActivityTask(String activityArn) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.GetActivityTask")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"activityArn": "%s", "workerName": "timeout-seconds-worker"}
+                        """.formatted(activityArn))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        String taskToken = resp.jsonPath().getString("taskToken");
+        assertFalse(taskToken == null || taskToken.isBlank(), "no activity task was queued");
+        return taskToken;
+    }
+
+    private static void sendTaskHeartbeat(String taskToken) {
+        given()
+                .header("X-Amz-Target", "AWSStepFunctions.SendTaskHeartbeat")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"taskToken": %s}
+                        """.formatted(quote(taskToken)))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private static void sendTaskSuccess(String taskToken, String output) {
+        given()
+                .header("X-Amz-Target", "AWSStepFunctions.SendTaskSuccess")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"taskToken": %s, "output": %s}
+                        """.formatted(quote(taskToken), quote(output)))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private static String createStateMachine(String name, String definition) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.CreateStateMachine")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"name": "%s-%d", "definition": %s, "roleArn": "%s"}
+                        """.formatted(name, System.currentTimeMillis(), quote(definition), ROLE_ARN))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("stateMachineArn");
+    }
+
+    private static String startExecution(String smArn, String input) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.StartExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"stateMachineArn": "%s", "input": %s}
+                        """.formatted(smArn, quote(input)))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("executionArn");
+    }
+
+    private static Response describeExecution(String execArn) {
+        return given()
+                .header("X-Amz-Target", "AWSStepFunctions.DescribeExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(execArn))
+                .when()
+                .post("/");
+    }
+
+    private static Response getExecutionHistory(String execArn) {
+        return given()
+                .header("X-Amz-Target", "AWSStepFunctions.GetExecutionHistory")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(execArn))
+                .when()
+                .post("/");
+    }
+
+    /**
+     * Polls for 20 seconds: twice the longest bound any definition here declares, and far short of
+     * the 300-second default a task that ignores TimeoutSeconds falls back on.
+     */
+    private static Response waitForTerminalExecution(String execArn) throws InterruptedException {
+        for (int poll = 0; poll < 200; poll++) {
+            Response resp = describeExecution(execArn);
+            String status = resp.jsonPath().getString("status");
+            if (!"RUNNING".equals(status)) {
+                return resp;
+            }
+            Thread.sleep(100);
+        }
+        fail("Execution " + execArn + " was still RUNNING after 20 seconds");
+        return null;
+    }
+
+    private static String quote(String raw) {
+        return "\"" + raw
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                + "\"";
+    }
+}


### PR DESCRIPTION
Replaced by #2782, which carries this change together with the rest of the `AslExecutor` work.