### PR TITLE
fix(stepfunctions): bound an execution's history and make StopExecution stop it

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -108,6 +108,16 @@ public class AslExecutor {
 
     private static final Logger LOG = Logger.getLogger(AslExecutor.class);
     private static final int MAX_WAIT_SECONDS = 30;
+
+    /**
+     * AWS ends an execution once its history reaches this many events. The count is neither reset
+     * nor offset: the event that ends the execution is number 25,000 itself, so the last event the
+     * state machine produced is 24,999.
+     */
+    private static final int MAX_HISTORY_EVENTS = 25_000;
+    private static final String HISTORY_EVENT_LIMIT_CAUSE =
+            "The execution reached the maximum number of history events (" + MAX_HISTORY_EVENTS + ").";
+
     private static final int INLINE_MAP_MAX_CONCURRENCY = 40;
     private static final int DISTRIBUTED_MAP_MAX_CONCURRENCY = 10_000;
 
@@ -354,9 +364,10 @@ public class AslExecutor {
 
     private void doExecute(StateMachine sm, Execution exec, List<HistoryEvent> history,
                            BiConsumer<Execution, List<HistoryEvent>> onUpdate) {
-        // Declared outside the try so the terminal handlers below can keep numbering the history
-        // where the execution left it.
-        AtomicLong eventId = new AtomicLong(history.size());
+        // Shared with every Parallel branch and every inline Map iteration of this execution: the
+        // 25,000-event limit is the execution's, not the thread's. It starts where the history
+        // already is, because ExecutionStarted is an event of this execution too.
+        AtomicLong producedEventCount = new AtomicLong(history.size());
         var firstState = true;
         try {
             JsonNode definition = objectMapper.readTree(sm.getDefinition());
@@ -370,14 +381,15 @@ public class AslExecutor {
             ObjectNode variables = objectMapper.createObjectNode();
 
             String currentStateName = startAt;
-            while (currentStateName != null) {
+            while (currentStateName != null && !abortedByCaller(exec)) {
                 JsonNode stateDef = states.path(currentStateName);
                 if (stateDef.isMissingNode()) {
                     throw new RuntimeException("State not found: " + currentStateName);
                 }
 
                 String type = stateDef.path("Type").asText();
-                addEvent(history, eventId, stateEnteredEventType(type), firstState ? 0L : eventId.get(),
+                publishStateEnteredEvent(history, producedEventCount, stateEnteredEventType(type),
+                        firstState ? 0L : history.size(),
                         Map.of("name", currentStateName, "input", currentInput.toString(),
                                "inputDetails", Map.of("truncated", false)));
                 firstState = false;
@@ -388,8 +400,9 @@ public class AslExecutor {
                 var jsonata = isJsonata(stateDef, topLevelQueryLanguage);
                 try {
                     var stateResult = executeStateWithRetry(currentStateName, type, stateDef, currentInput,
-                            history, eventId, sm, jsonata, topLevelQueryLanguage, execContext, variables);
-                    addEvent(history, eventId, stateExitedEventType(type),
+                            history, producedEventCount, sm, jsonata, topLevelQueryLanguage, execContext,
+                            variables);
+                    publishEvent(history, producedEventCount, stateExitedEventType(type),
                             Map.of("name", currentStateName, "output", stateResult.output().toString(),
                                    "outputDetails", Map.of("truncated", false)));
 
@@ -411,35 +424,33 @@ public class AslExecutor {
                         failure = catchClauseFailure;
                     }
                     if (caught != null) {
-                        addEvent(history, eventId, stateExitedEventType(type),
+                        publishEvent(history, producedEventCount, stateExitedEventType(type),
                                 Map.of("name", currentStateName, "output", caught.output().toString(),
                                        "outputDetails", Map.of("truncated", false)));
                         currentInput = caught.output();
                         currentStateName = caught.nextState();
                         continue;
                     }
-                    failExecution(exec, history, eventId, failure);
+                    failExecution(exec, history, failure);
                     onUpdate.accept(exec, history);
                     return;
                 }
             }
 
-            // Status is the publication point, so it is set last. describeExecution hands out this
-            // same live Execution, so a client polling for SUCCEEDED between setStatus and setOutput
-            // would read a terminal execution with a null output, which real Step Functions never
-            // returns. The same ordering applies to every terminal path below.
-            exec.setOutput(currentInput.toString());
-            exec.setStopDate(System.currentTimeMillis() / 1000.0);
-            exec.setStatus("SUCCEEDED");
-            addEvent(history, eventId, "ExecutionSucceeded",
-                    Map.of("output", currentInput.toString(), "outputDetails", Map.of("truncated", false)));
+            succeedExecution(exec, history, currentInput);
             onUpdate.accept(exec, history);
 
+        } catch (FailStateException e) {
+            // A state's own failure is handled inside the loop, where its Catch clauses apply. What
+            // reaches here is a failure raised while recording a state's entered event, outside the
+            // per-state try: the execution hit the history-event limit.
+            failExecution(exec, history, e);
+            onUpdate.accept(exec, history);
         } catch (Exception e) {
             LOG.warnv("ASL execution failed for {0}: {1}", exec.getExecutionArn(), e.getMessage());
             // This path previously set only the status, leaving error and cause null forever on an
             // execution DescribeExecution reports as FAILED.
-            failExecution(exec, history, eventId, "States.Runtime",
+            failExecution(exec, history, "States.Runtime",
                     e.getMessage() != null ? e.getMessage() : "Unknown error");
             onUpdate.accept(exec, history);
         } catch (Error e) {
@@ -449,7 +460,7 @@ public class AslExecutor {
             // and the rethrow keeps the Error itself from being swallowed here. The cause carries
             // toString() rather than getMessage(), because an Error's message is often null and
             // the type name is the whole diagnostic.
-            failExecution(exec, history, eventId, "States.Runtime", e.toString());
+            failExecution(exec, history, "States.Runtime", e.toString());
             onUpdate.accept(exec, history);
             throw e;
         } finally {
@@ -470,15 +481,15 @@ public class AslExecutor {
      * caller's Catch handling, preserving Retry-before-Catch order.
      */
     private StateResult executeStateWithRetry(String name, String type, JsonNode stateDef, JsonNode input,
-                                              List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
-                                              boolean jsonata, String topLevelQueryLanguage, JsonNode context,
-                                              ObjectNode variables) throws Exception {
+                                              List<HistoryEvent> history, AtomicLong producedEventCount,
+                                              StateMachine sm, boolean jsonata, String topLevelQueryLanguage,
+                                              JsonNode context, ObjectNode variables) throws Exception {
         var retriers = stateDef.path("Retry");
         var attemptsPerRetrier = new HashMap<Integer, Integer>();
         var attempt = 0;
         while (true) {
             try {
-                return executeState(name, type, stateDef, input, history, eventId, sm, jsonata,
+                return executeState(name, type, stateDef, input, history, producedEventCount, sm, jsonata,
                         topLevelQueryLanguage, context, variables, attempt);
             } catch (FailStateException e) {
                 var retrierIndex = findMatchingRetrier(retriers, e);
@@ -542,19 +553,21 @@ public class AslExecutor {
     }
 
     private StateResult executeState(String name, String type, JsonNode stateDef, JsonNode input,
-                                     List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
-                                     boolean jsonata, String topLevelQueryLanguage, JsonNode context,
-                                     ObjectNode variables, int attempt) throws Exception {
+                                     List<HistoryEvent> history, AtomicLong producedEventCount,
+                                     StateMachine sm, boolean jsonata, String topLevelQueryLanguage,
+                                     JsonNode context, ObjectNode variables, int attempt) throws Exception {
         return switch (type) {
             case "Pass" -> executePassState(stateDef, input, jsonata, context, variables);
-            case "Task" -> executeTaskState(name, stateDef, input, history, eventId, sm, jsonata, context,
-                    variables, attempt);
+            case "Task" -> executeTaskState(name, stateDef, input, history, producedEventCount, sm,
+                    jsonata, context, variables, attempt);
             case "Choice" -> executeChoiceState(stateDef, input, jsonata, context, variables);
             case "Wait" -> executeWaitState(stateDef, input, jsonata, context, variables);
             case "Succeed" -> executeSucceedState(stateDef, input, jsonata, context, variables);
             case "Fail" -> executeFail(stateDef, input, jsonata, context, variables);
-            case "Parallel" -> executeParallelState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context, variables);
-            case "Map" -> executeMapState(name, stateDef, input, sm, jsonata, topLevelQueryLanguage, context, variables);
+            case "Parallel" -> executeParallelState(name, stateDef, input, producedEventCount, sm, jsonata,
+                    topLevelQueryLanguage, context, variables);
+            case "Map" -> executeMapState(name, stateDef, input, producedEventCount, sm, jsonata,
+                    topLevelQueryLanguage, context, variables);
             default -> new StateResult(input, stateDef.path("Next").asText(null));
         };
     }
@@ -585,9 +598,9 @@ public class AslExecutor {
     }
 
     private StateResult executeTaskState(String stateName, JsonNode stateDef, JsonNode input,
-                                         List<HistoryEvent> history, AtomicLong eventId, StateMachine sm,
-                                         boolean jsonata, JsonNode context, ObjectNode variables,
-                                         int attempt) throws Exception {
+                                         List<HistoryEvent> history, AtomicLong producedEventCount,
+                                         StateMachine sm, boolean jsonata, JsonNode context,
+                                         ObjectNode variables, int attempt) throws Exception {
         var resource = stateDef.path("Resource").asText();
         var isWaitForToken = resource.endsWith(".waitForTaskToken");
         var effectiveResource = isWaitForToken
@@ -623,8 +636,8 @@ public class AslExecutor {
         }
 
         var profile = taskEventProfile(resource, isActivity);
-        addTaskScheduledEvent(history, eventId, profile, stateDef, effectiveInput, sm);
-        addTaskStartedEvent(history, eventId, profile);
+        addTaskScheduledEvent(history, producedEventCount, profile, stateDef, effectiveInput, sm);
+        addTaskStartedEvent(history, producedEventCount, profile);
 
         JsonNode taskResult;
         try {
@@ -636,12 +649,12 @@ public class AslExecutor {
             }
         } catch (Exception e) {
             var failure = e instanceof FailStateException f ? f : null;
-            addTaskFailedEvent(history, eventId, profile,
+            addTaskFailedEvent(history, producedEventCount, profile,
                     failure != null && failure.error != null ? failure.error : "States.Runtime",
                     failure != null ? failure.cause : e.getMessage());
             throw e;
         }
-        addTaskSucceededEvent(history, eventId, profile, taskResult);
+        addTaskSucceededEvent(history, producedEventCount, profile, taskResult);
 
         if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, taskResult, context, variables);
@@ -1903,8 +1916,9 @@ public class AslExecutor {
         throw new FailStateException(error, cause);
     }
 
-    private StateResult executeParallelState(String name, JsonNode stateDef, JsonNode input, StateMachine sm,
-                                              boolean jsonata, String topLevelQueryLanguage, JsonNode context,
+    private StateResult executeParallelState(String name, JsonNode stateDef, JsonNode input,
+                                              AtomicLong producedEventCount, StateMachine sm, boolean jsonata,
+                                              String topLevelQueryLanguage, JsonNode context,
                                               ObjectNode variables) throws Exception {
         JsonNode branches = stateDef.path("Branches");
         List<Future<JsonNode>> futures = new ArrayList<>();
@@ -1924,8 +1938,8 @@ public class AslExecutor {
             // scope is thread-bound, so without this a branch's Task integrations would resolve to
             // the default account rather than the execution's.
             futures.add(executor.submit(() -> callUnderExecutionAccount(sm,
-                    () -> executeBranch(startAt, branchStates, capturedInput, sm, topLevelQueryLanguage,
-                            branchContext, branchVariables))));
+                    () -> executeBranch(startAt, branchStates, capturedInput, producedEventCount, sm,
+                            topLevelQueryLanguage, branchContext, branchVariables))));
         }
 
         int timeoutSeconds = stateDef.path("TimeoutSeconds").asInt(0);
@@ -1986,8 +2000,9 @@ public class AslExecutor {
         return new StateResult(output, stateDef.path("Next").asText(null));
     }
 
-    private StateResult executeMapState(String name, JsonNode stateDef, JsonNode input, StateMachine sm,
-                                         boolean jsonata, String topLevelQueryLanguage, JsonNode context,
+    private StateResult executeMapState(String name, JsonNode stateDef, JsonNode input,
+                                         AtomicLong producedEventCount, StateMachine sm, boolean jsonata,
+                                         String topLevelQueryLanguage, JsonNode context,
                                          ObjectNode variables) throws Exception {
         String processorMode = stateDef.path("ItemProcessor").path("ProcessorConfig")
                 .path("Mode").asText("INLINE");
@@ -2055,8 +2070,13 @@ public class AslExecutor {
             if (hasResultWriter) {
                 childInputsByIndex[i] = iterInput;
             }
-            JsonNode branchOutput = executeBranch(startAt, iteratorStates, iterInput, sm,
-                    topLevelQueryLanguage, iterContext, variables.deepCopy());
+            // A Distributed Map runs each item as a child execution, and a child execution has a
+            // history of its own: the item's events count against its own limit, not the parent's.
+            // An inline Map's iterations are part of this execution and count here.
+            AtomicLong childExecutionEventCount = distributed ? new AtomicLong() : producedEventCount;
+            JsonNode branchOutput = executeBranch(startAt, iteratorStates, iterInput,
+                    childExecutionEventCount, sm, topLevelQueryLanguage, iterContext,
+                    variables.deepCopy());
             if (hasResultWriter) {
                 childTimingsByIndex[i] = new long[]{startMs, System.currentTimeMillis()};
             }
@@ -2499,10 +2519,17 @@ public class AslExecutor {
         return limited;
     }
 
-    private JsonNode executeBranch(String startAt, JsonNode states, JsonNode input, StateMachine sm,
-                                    String topLevelQueryLanguage, JsonNode context, ObjectNode variables) throws Exception {
-        List<HistoryEvent> ignored = new ArrayList<>();
-        AtomicLong eventId = new AtomicLong(0);
+    /**
+     * Runs the states of one Parallel branch or one Map iteration. floci does not publish their
+     * events, but they are events of the execution all the same, so each one is counted against its
+     * history-event limit: a branch that never reaches a terminal state ends the whole execution at
+     * event 25,000, exactly as one in the top-level flow does. A null history is what tells the
+     * states below they are running inside a branch.
+     */
+    private JsonNode executeBranch(String startAt, JsonNode states, JsonNode input,
+                                    AtomicLong producedEventCount, StateMachine sm,
+                                    String topLevelQueryLanguage, JsonNode context,
+                                    ObjectNode variables) throws Exception {
         JsonNode currentInput = input;
         String currentState = startAt;
 
@@ -2517,10 +2544,12 @@ public class AslExecutor {
             String type = stateDef.path("Type").asText();
             boolean stateJsonata = isJsonata(stateDef, topLevelQueryLanguage);
             updateStateContext(context, currentState);
+            countTowardsHistoryEventLimit(producedEventCount);
             StateResult result;
             try {
-                result = executeStateWithRetry(currentState, type, stateDef, currentInput, ignored, eventId, sm,
-                        stateJsonata, topLevelQueryLanguage, context, variables);
+                result = executeStateWithRetry(currentState, type, stateDef, currentInput,
+                        null, producedEventCount, sm, stateJsonata, topLevelQueryLanguage, context,
+                        variables);
             } catch (FailStateException e) {
                 StateResult caught = handleCatch(stateDef, currentInput, e, stateJsonata, context, variables);
                 if (caught == null) {
@@ -2528,6 +2557,7 @@ public class AslExecutor {
                 }
                 result = caught;
             }
+            countTowardsHistoryEventLimit(producedEventCount);
             currentInput = result.output();
             currentState = result.nextState();
             if ("Succeed".equals(type) || stateDef.path("End").asBoolean(false)) {
@@ -3458,18 +3488,76 @@ public class AslExecutor {
 
     // ──────────────────────────── History helpers ────────────────────────────
 
-    private void addEvent(List<HistoryEvent> history, AtomicLong counter, String type, Map<String, Object> details) {
-        addEvent(history, counter, type, counter.get(), details);
+    /**
+     * Counts one event towards the limit AWS puts on an execution's history, leaving the last slot
+     * free: it belongs to the event that ends the execution. The count is taken before it is
+     * judged, so however many branches and Map iterations are producing events at once, exactly one
+     * of them takes event 24,999 and every other one finds the limit reached.
+     *
+     * <p>Reaching it raises {@code States.Runtime} at the state that produced the event, and that
+     * ends the whole execution: {@link #catchMatches} refuses {@code States.Runtime} before it
+     * reads {@code ErrorEquals}, so a Retry and a Catch the state declares for it both stand down.
+     */
+    static void countTowardsHistoryEventLimit(AtomicLong producedEventCount) {
+        if (producedEventCount.incrementAndGet() >= MAX_HISTORY_EVENTS) {
+            throw new FailStateException("States.Runtime", HISTORY_EVENT_LIMIT_CAUSE);
+        }
     }
 
-    private void addEvent(List<HistoryEvent> history, AtomicLong counter, String type, long previousEventId,
-                          Map<String, Object> details) {
-        var event = new HistoryEvent();
-        event.setId(counter.incrementAndGet());
-        event.setPreviousEventId(previousEventId);
-        event.setType(type);
-        event.setDetails(details);
-        history.add(event);
+    /**
+     * Records an event the state machine produced: counted against the history-event limit, then
+     * published.
+     *
+     * <p>{@code history} is null inside a Parallel branch or a Map iteration. Their states are
+     * states of this execution and their events count against its limit, but floci does not publish
+     * them, so there is nothing to build for them beyond the count.
+     */
+    private void publishEvent(List<HistoryEvent> history, AtomicLong producedEventCount, String type,
+                              Map<String, Object> details) {
+        countTowardsHistoryEventLimit(producedEventCount);
+        if (history == null) {
+            return;
+        }
+        appendEvent(history, type, history.size(), details);
+    }
+
+    /**
+     * Records a state's Entered event with the previousEventId the top-level flow works out: AWS
+     * leaves the Entered event of the state an execution starts in unchained, at previousEventId 0,
+     * rather than pointing it at the ExecutionStarted event before it. Only the top-level flow
+     * publishes these, so its history is never null.
+     */
+    private void publishStateEnteredEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
+                                          String type, long previousEventId,
+                                          Map<String, Object> details) {
+        countTowardsHistoryEventLimit(producedEventCount);
+        appendEvent(history, type, previousEventId, details);
+    }
+
+    /**
+     * Records the event that ends the execution. It does not count towards the history-event limit:
+     * an execution always gets to say how it ended, in the slot {@link #publishEvent} leaves free.
+     */
+    private void publishTerminalEvent(List<HistoryEvent> history, String type, Map<String, Object> details) {
+        appendEvent(history, type, history.size(), details);
+    }
+
+    /**
+     * Appends an event and numbers it from the end of the history: the published history is the one
+     * authority for an event's id, so an event's id is its position in the list. Held under the
+     * history's own monitor, because StopExecution appends the terminal event of an aborted
+     * execution from another thread and seals the history against anything after it.
+     */
+    private void appendEvent(List<HistoryEvent> history, String type, long previousEventId,
+                             Map<String, Object> details) {
+        synchronized (history) {
+            var event = new HistoryEvent();
+            event.setId(history.size() + 1L);
+            event.setPreviousEventId(previousEventId);
+            event.setType(type);
+            event.setDetails(details);
+            history.add(event);
+        }
     }
 
     private record TaskEventProfile(String prefix, String resourceType, String resource) {}
@@ -3492,8 +3580,9 @@ public class AslExecutor {
         return new TaskEventProfile("Task", resource, resource);
     }
 
-    private void addTaskScheduledEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile,
-                                       JsonNode stateDef, JsonNode effectiveInput, StateMachine sm) {
+    private void addTaskScheduledEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
+                                       TaskEventProfile profile, JsonNode stateDef, JsonNode effectiveInput,
+                                       StateMachine sm) {
         var details = new LinkedHashMap<String, Object>();
         if (profile.resourceType() != null) {
             details.put("resourceType", profile.resourceType());
@@ -3512,33 +3601,34 @@ public class AslExecutor {
         if (stateDef.path("HeartbeatSeconds").isNumber()) {
             details.put("heartbeatInSeconds", stateDef.path("HeartbeatSeconds").asLong());
         }
-        addEvent(history, eventId, profile.prefix() + "Scheduled", details);
+        publishEvent(history, producedEventCount, profile.prefix() + "Scheduled", details);
     }
 
-    private void addTaskStartedEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile) {
+    private void addTaskStartedEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
+                                     TaskEventProfile profile) {
         if ("Task".equals(profile.prefix())) {
-            addEvent(history, eventId, profile.prefix() + "Started",
+            publishEvent(history, producedEventCount, profile.prefix() + "Started",
                     Map.of("resourceType", profile.resourceType(), "resource", profile.resource()));
         } else {
-            addEvent(history, eventId, profile.prefix() + "Started", null);
+            publishEvent(history, producedEventCount, profile.prefix() + "Started", null);
         }
     }
 
-    private void addTaskSucceededEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile,
-                                       JsonNode taskResult) {
+    private void addTaskSucceededEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
+                                       TaskEventProfile profile, JsonNode taskResult) {
         var output = taskResult.toString();
         if ("Task".equals(profile.prefix())) {
-            addEvent(history, eventId, profile.prefix() + "Succeeded",
+            publishEvent(history, producedEventCount, profile.prefix() + "Succeeded",
                     Map.of("resourceType", profile.resourceType(), "resource", profile.resource(),
                            "output", output, "outputDetails", Map.of("truncated", false)));
         } else {
-            addEvent(history, eventId, profile.prefix() + "Succeeded",
+            publishEvent(history, producedEventCount, profile.prefix() + "Succeeded",
                     Map.of("output", output, "outputDetails", Map.of("truncated", false)));
         }
     }
 
-    private void addTaskFailedEvent(List<HistoryEvent> history, AtomicLong eventId, TaskEventProfile profile,
-                                    String error, String cause) {
+    private void addTaskFailedEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
+                                    TaskEventProfile profile, String error, String cause) {
         var details = new LinkedHashMap<String, Object>();
         if ("Task".equals(profile.prefix())) {
             details.put("resourceType", profile.resourceType());
@@ -3550,11 +3640,11 @@ public class AslExecutor {
         if (cause != null) {
             details.put("cause", cause);
         }
-        addEvent(history, eventId, profile.prefix() + "Failed", details);
+        publishEvent(history, producedEventCount, profile.prefix() + "Failed", details);
     }
 
-    private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId, FailStateException e) {
-        failExecution(exec, history, eventId, e.error != null ? e.error : "States.Runtime",
+    private void failExecution(Execution exec, List<HistoryEvent> history, FailStateException e) {
+        failExecution(exec, history, e.error != null ? e.error : "States.Runtime",
                 e.cause != null ? e.cause : "");
     }
 
@@ -3563,14 +3653,49 @@ public class AslExecutor {
      * {@code error}, {@code cause} and {@code ExecutionFailed} event behind, so a client cannot
      * tell a Fail state from a state that threw from a runtime Error by what it reads back.
      */
-    private void failExecution(Execution exec, List<HistoryEvent> history, AtomicLong eventId,
-                               String error, String cause) {
-        exec.setError(error);
-        exec.setCause(cause);
-        exec.setStopDate(System.currentTimeMillis() / 1000.0);
-        exec.setStatus("FAILED");
-        addEvent(history, eventId, "ExecutionFailed",
-                Map.of("error", error, "cause", cause));
+    private void failExecution(Execution exec, List<HistoryEvent> history, String error, String cause) {
+        synchronized (exec) {
+            if (abortedByCaller(exec)) {
+                return;
+            }
+            exec.setError(error);
+            exec.setCause(cause);
+            exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("FAILED");
+        }
+        publishTerminalEvent(history, "ExecutionFailed", Map.of("error", error, "cause", cause));
+    }
+
+    /**
+     * The single terminal-success write, the mirror of {@link #failExecution}.
+     *
+     * <p>Status is the publication point, so it is set last. describeExecution hands out this same
+     * live Execution, so a client polling for SUCCEEDED between setStatus and setOutput would read
+     * a terminal execution with a null output, which real Step Functions never returns.
+     */
+    private void succeedExecution(Execution exec, List<HistoryEvent> history, JsonNode output) {
+        synchronized (exec) {
+            if (abortedByCaller(exec)) {
+                return;
+            }
+            exec.setOutput(output.toString());
+            exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("SUCCEEDED");
+        }
+        publishTerminalEvent(history, "ExecutionSucceeded",
+                Map.of("output", output.toString(), "outputDetails", Map.of("truncated", false)));
+    }
+
+    /**
+     * True once StopExecution published ABORTED on this execution. The state loop reads it between
+     * states and every terminal write here reads it before publishing, so the worker's own status
+     * loses the race against a stop that arrived while it was still stepping: what a caller has
+     * already read back from DescribeExecution is what stands.
+     */
+    private static boolean abortedByCaller(Execution exec) {
+        synchronized (exec) {
+            return "ABORTED".equals(exec.getStatus());
+        }
     }
 
     private StateResult handleCatch(JsonNode stateDef, JsonNode input, FailStateException failure,

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -46,7 +46,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     private final StorageBackend<String, Execution> executionStore;
     private final StorageBackend<String, Activity> activityStore;
     private final StorageBackend<String, MapRun> mapRunStore;
-    private final Map<String, List<HistoryEvent>> historyCache = new ConcurrentHashMap<>();
+    private final Map<String, ExecutionHistory> historyCache = new ConcurrentHashMap<>();
     private final Map<String, BlockingQueue<ActivityTask>> activityQueues = new ConcurrentHashMap<>();
     private final Map<String, CompletableFuture<JsonNode>> pendingTaskTokens = new ConcurrentHashMap<>();
     private final RegionResolver regionResolver;
@@ -524,7 +524,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
 
         executionStore.put(arn, exec);
 
-        var history = new ArrayList<HistoryEvent>();
+        var history = new ExecutionHistory();
         var startEvent = new HistoryEvent();
         startEvent.setId(1L);
         startEvent.setPreviousEventId(0L);
@@ -537,9 +537,10 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
 
         LOG.infov("Started execution: {0}", arn);
 
+        // The executor appends to this same history, so the cache entry put above is already the
+        // finished history by the time this runs.
         aslExecutor.executeAsync(sm, exec, history, mockedTestCase, (updatedExec, updatedHistory) -> {
             executionStore.put(updatedExec.getExecutionArn(), updatedExec);
-            historyCache.put(updatedExec.getExecutionArn(), updatedHistory);
             LOG.infov("Execution {0} completed with status {1}", updatedExec.getExecutionArn(), updatedExec.getStatus());
         });
 
@@ -660,30 +661,80 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
                 .map(e -> e.getStateMachineArn().equals(stateMachineArn)).orElse(false));
     }
 
+    /**
+     * Aborts a running execution. The caller's {@code error} and {@code cause} land on the
+     * Execution itself, not only on the history event, so DescribeExecution reports them.
+     *
+     * <p>The worker thread may still be inside a state when this runs. It shares this Execution
+     * instance and reads the status it publishes here, so the writes are made under the same
+     * monitor the worker's terminal write takes: ABORTED is the status that stands.
+     *
+     * <p>ExecutionAborted seals the history for the same reason: the worker still has the state it
+     * is inside left to record, and those events belong to an execution the caller has already
+     * been told is finished.
+     */
     public void stopExecution(String arn, String cause, String error) {
         Execution exec = describeExecution(arn);
-        if (!"RUNNING".equals(exec.getStatus())) {
-            return;
+        synchronized (exec) {
+            if (!"RUNNING".equals(exec.getStatus())) {
+                return;
+            }
+            exec.setError(error);
+            exec.setCause(cause);
+            exec.setStopDate(System.currentTimeMillis() / 1000.0);
+            exec.setStatus("ABORTED");
         }
-        exec.setStopDate(System.currentTimeMillis() / 1000.0);
-        exec.setStatus("ABORTED");
         executionStore.put(arn, exec);
 
-        List<HistoryEvent> history = historyCache.getOrDefault(arn, new ArrayList<>());
-        HistoryEvent event = new HistoryEvent();
-        event.setId(history.size() + 1L);
-        event.setPreviousEventId((long) history.size());
-        event.setType("ExecutionAborted");
         Map<String, Object> details = new HashMap<>();
         if (error != null) details.put("error", error);
         if (cause != null) details.put("cause", cause);
-        event.setDetails(details);
-        history.add(event);
+        // An execution can outlive its history: the executions are stored, the histories are held in
+        // memory only, so a restart in persistent mode brings a RUNNING execution back with nothing
+        // behind it. The abort still gets recorded, against a history that starts here.
+        historyCache.computeIfAbsent(arn, key -> new ExecutionHistory())
+                .sealWith("ExecutionAborted", details);
     }
 
     public List<HistoryEvent> getExecutionHistory(String arn) {
         describeExecution(arn);
-        return historyCache.getOrDefault(arn, Collections.emptyList());
+        ExecutionHistory history = historyCache.get(arn);
+        return history != null ? history : Collections.emptyList();
+    }
+
+    /**
+     * The history of one execution, appended to by the worker thread running the state machine and
+     * by the thread serving StopExecution. Sealing it with the terminal event is what makes that
+     * event the last one: the worker is still inside a state when the abort lands, and the events
+     * it has left to record belong to an execution the caller has already been told is finished.
+     *
+     * <p>The seal is enforced in {@link #add}, the one way the worker appends. {@code addAll} does
+     * not route through it, so a bulk append would write past the seal; nothing does one today.
+     */
+    static final class ExecutionHistory extends ArrayList<HistoryEvent> {
+
+        private static final long serialVersionUID = 1L;
+
+        private boolean sealed;
+
+        @Override
+        public synchronized boolean add(HistoryEvent event) {
+            if (sealed) {
+                return false;
+            }
+            return super.add(event);
+        }
+
+        /** Appends the terminal event, numbered from the end of the history, and takes no more. */
+        synchronized void sealWith(String terminalEventType, Map<String, Object> details) {
+            HistoryEvent terminalEvent = new HistoryEvent();
+            terminalEvent.setId(size() + 1L);
+            terminalEvent.setPreviousEventId((long) size());
+            terminalEvent.setType(terminalEventType);
+            terminalEvent.setDetails(details);
+            add(terminalEvent);
+            sealed = true;
+        }
     }
 
     // ──────────────────────────── Activities ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
@@ -1,0 +1,377 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.Vertx;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Guards the bound AWS puts on a running execution: a state machine that never reaches a terminal
+ * state is ended at 25,000 history events with {@code States.Runtime}. The cut is an event count,
+ * not a wall clock, and the counter is neither reset nor offset: the {@code ExecutionFailed} event
+ * is event 25,000 itself, so the last event the machine produced is 24,999.
+ *
+ * <p>A {@code Choice} that loops back through a {@code Pass} reaches it in a few hundred
+ * milliseconds, which is why nothing here waits on the clock.
+ */
+@QuarkusTest
+class AslExecutorHistoryEventLimitTest {
+
+    private static final String REGION = "us-east-2";
+    private static final String ACCOUNT = "000000000000";
+
+    /** A Choice that spins forever, four history events per lap and no terminal state. */
+    private static final String RUNAWAY_LOOP = """
+            {
+              "StartAt": "Loop",
+              "States": {
+                "Loop": {
+                  "Type": "Choice",
+                  "Choices": [{"Variable": "$.spin", "BooleanEquals": true, "Next": "Tick"}],
+                  "Default": "Done"
+                },
+                "Tick": {"Type": "Pass", "Next": "Loop"},
+                "Done": {"Type": "Succeed"}
+              }
+            }
+            """;
+
+    /**
+     * A Parallel branch that laps 10,000 times, four history events per lap. The lap count is high
+     * enough that the branch alone produces far more than 25,000 events, and finite so the run ends
+     * either way: bounded, at event 25,000; unbounded, by finishing every lap.
+     */
+    private static final String RUNAWAY_PARALLEL_BRANCH = """
+            {
+              "QueryLanguage": "JSONata",
+              "StartAt": "Seed",
+              "States": {
+                "Seed": {"Type": "Pass", "Assign": {"laps": 0}, "Next": "Fan"},
+                "Fan": {
+                  "Type": "Parallel",
+                  "Branches": [{
+                    "StartAt": "Spin",
+                    "States": {
+                      "Spin": {
+                        "Type": "Choice",
+                        "Choices": [{"Condition": "{% $laps < 10000 %}", "Next": "Tick"}],
+                        "Default": "Stop"
+                      },
+                      "Tick": {"Type": "Pass", "Assign": {"laps": "{% $laps + 1 %}"}, "Next": "Spin"},
+                      "Stop": {"Type": "Succeed"}
+                    }
+                  }],
+                  "End": true
+                }
+              }
+            }
+            """;
+
+    /**
+     * The same runaway branch under a Parallel that declares a Retry and a Catch for States.ALL,
+     * the two clauses AWS allows on a Parallel. Reaching the limit is States.Runtime, which
+     * catchMatches refuses before it reads ErrorEquals, so neither clause runs.
+     */
+    private static final String RUNAWAY_PARALLEL_BRANCH_UNDER_RETRY_AND_CATCH = """
+            {
+              "QueryLanguage": "JSONata",
+              "StartAt": "Seed",
+              "States": {
+                "Seed": {"Type": "Pass", "Assign": {"laps": 0}, "Next": "Fan"},
+                "Fan": {
+                  "Type": "Parallel",
+                  "Retry": [{"ErrorEquals": ["States.ALL"], "IntervalSeconds": 30, "MaxAttempts": 3}],
+                  "Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Recovered"}],
+                  "Branches": [{
+                    "StartAt": "Spin",
+                    "States": {
+                      "Spin": {
+                        "Type": "Choice",
+                        "Choices": [{"Condition": "{% $laps < 10000 %}", "Next": "Tick"}],
+                        "Default": "Stop"
+                      },
+                      "Tick": {"Type": "Pass", "Assign": {"laps": "{% $laps + 1 %}"}, "Next": "Spin"},
+                      "Stop": {"Type": "Succeed"}
+                    }
+                  }],
+                  "Next": "Recovered"
+                },
+                "Recovered": {"Type": "Succeed"}
+              }
+            }
+            """;
+
+    /**
+     * More items than the 25,000-event limit has room for: each one enters and exits a single Pass,
+     * so 13,000 items are 26,000 events if the parent is charged for them.
+     */
+    private static final int DISTRIBUTED_MAP_ITEMS = 13_000;
+
+    /** One item per iteration, run one at a time so the run is the same on every machine. */
+    private static final String DISTRIBUTED_MAP_OVER_MANY_ITEMS = """
+            {
+              "StartAt": "Fan",
+              "States": {
+                "Fan": {
+                  "Type": "Map",
+                  "ItemsPath": "$.items",
+                  "MaxConcurrency": 1,
+                  "ItemProcessor": {
+                    "ProcessorConfig": {"Mode": "DISTRIBUTED", "ExecutionType": "STANDARD"},
+                    "StartAt": "Handle",
+                    "States": {"Handle": {"Type": "Pass", "End": true}}
+                  },
+                  "End": true
+                }
+              }
+            }
+            """;
+
+    /**
+     * The same items run inline, 40 at a time. An inline Map's iterations are part of this
+     * execution, so together they run it out of history events while 40 of them are in flight.
+     */
+    private static final String INLINE_MAP_OVER_MANY_ITEMS = """
+            {
+              "StartAt": "Fan",
+              "States": {
+                "Fan": {
+                  "Type": "Map",
+                  "ItemsPath": "$.items",
+                  "MaxConcurrency": 40,
+                  "ItemProcessor": {
+                    "StartAt": "Handle",
+                    "States": {"Handle": {"Type": "Pass", "End": true}}
+                  },
+                  "End": true
+                }
+              }
+            }
+            """;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final List<HistoryEvent> history = new ArrayList<>();
+    private AslExecutor executor;
+
+    @Inject
+    Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        executor = new AslExecutor(
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
+                mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
+                mock(S3Service.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerService.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
+                objectMapper,
+                new JsonataEvaluator(objectMapper),
+                mock(Instance.class), mock(EmulatorConfig.class), vertx, null);
+    }
+
+    @Test
+    void runawayLoopFailsWithTheHistoryEventLimitError() {
+        Execution execution = run(RUNAWAY_LOOP);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("States.Runtime", execution.getError());
+        assertEquals("The execution reached the maximum number of history events (25000).",
+                execution.getCause());
+        assertNotNull(execution.getStopDate());
+    }
+
+    @Test
+    void executionFailedIsTheTwentyFiveThousandthEvent() {
+        run(RUNAWAY_LOOP);
+
+        assertEquals(25000, history.size());
+        HistoryEvent last = history.get(history.size() - 1);
+        assertEquals("ExecutionFailed", last.getType());
+        assertEquals(25000L, last.getId());
+        // Not reset and not offset: 24,999 is the last event the machine itself produced.
+        HistoryEvent lastFromTheMachine = history.get(history.size() - 2);
+        assertEquals(24999L, lastFromTheMachine.getId());
+        assertNotEquals("ExecutionFailed", lastFromTheMachine.getType());
+    }
+
+    @Test
+    void eventsProducedInsideAParallelBranchCountTowardsTheLimit() {
+        Execution execution = run(RUNAWAY_PARALLEL_BRANCH);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("States.Runtime", execution.getError());
+        assertEquals("The execution reached the maximum number of history events (25000).",
+                execution.getCause());
+    }
+
+    /**
+     * The branch produced the events that ran the execution out of them, and floci publishes none
+     * of them. What the caller reads back is the four events the top-level flow did produce, ending
+     * in the failure: an unbroken chain, not four events numbered as if 25,000 had happened.
+     */
+    @Test
+    void aParallelBranchLeavesThePublishedHistoryUnbroken() {
+        run(RUNAWAY_PARALLEL_BRANCH);
+
+        assertEquals(List.of("PassStateEntered", "PassStateExited", "ParallelStateEntered",
+                             "ExecutionFailed"),
+                history.stream().map(HistoryEvent::getType).toList());
+        for (int index = 0; index < history.size(); index++) {
+            assertEquals(index + 1L, history.get(index).getId(), "unexpected id at index " + index);
+            assertEquals((long) index, history.get(index).getPreviousEventId(),
+                    "unexpected previousEventId at index " + index);
+        }
+    }
+
+    /**
+     * A Distributed Map runs each item as a child execution, and a child execution has a history of
+     * its own. The parent is charged for the Map run, not for what the items do inside it, so a
+     * Distributed Map over more items than the limit has room for still succeeds.
+     */
+    @Test
+    void aDistributedMapItemDoesNotSpendTheParentsHistoryEvents() {
+        Execution execution = run(DISTRIBUTED_MAP_OVER_MANY_ITEMS, manyItemsInput());
+
+        assertEquals("SUCCEEDED", execution.getStatus(),
+                "error=" + execution.getError() + " cause=" + execution.getCause());
+    }
+
+    /**
+     * The same items run inline are the execution's own, whatever the concurrency: 40 iterations
+     * counting against one limit run it out of history events, where a Distributed Map's items do
+     * not.
+     */
+    @Test
+    void concurrentInlineMapIterationsSpendTheExecutionsHistoryEvents() {
+        Execution execution = run(INLINE_MAP_OVER_MANY_ITEMS, manyItemsInput());
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("States.Runtime", execution.getError());
+        assertEquals("The execution reached the maximum number of history events (25000).",
+                execution.getCause());
+    }
+
+    /**
+     * The event that reaches the limit is what ends the execution, so exactly one of the iterations
+     * racing for the last countable event may take it. Reading the count and then taking it lets
+     * every racer through the check and spends more events than the execution has.
+     */
+    @Test
+    void onlyOneOfTheThreadsRacingForTheLastCountableEventTakesIt() throws Exception {
+        int racers = 40;
+        // 24,998 events produced: one is left before the limit, and event 25,000 is the failure.
+        AtomicLong producedEventCount = new AtomicLong(24_998);
+        CountDownLatch ready = new CountDownLatch(racers);
+        CountDownLatch go = new CountDownLatch(1);
+        AtomicInteger counted = new AtomicInteger();
+
+        List<Thread> racerThreads = new ArrayList<>();
+        for (int racer = 0; racer < racers; racer++) {
+            Thread thread = new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                    AslExecutor.countTowardsHistoryEventLimit(producedEventCount);
+                    counted.incrementAndGet();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (AslExecutor.FailStateException expected) {
+                    // The limit was already reached by another racer.
+                }
+            });
+            racerThreads.add(thread);
+            thread.start();
+        }
+        ready.await();
+        go.countDown();
+        for (Thread thread : racerThreads) {
+            thread.join();
+        }
+
+        assertEquals(1, counted.get(), "more than one racer took the last countable event");
+    }
+
+    /** {@code {"items": [0, 1, ... ]}}, one item per iteration of the Distributed Map. */
+    private static String manyItemsInput() {
+        StringBuilder input = new StringBuilder("{\"items\": [0");
+        for (int item = 1; item < DISTRIBUTED_MAP_ITEMS; item++) {
+            input.append(',').append(item);
+        }
+        return input.append("]}").toString();
+    }
+
+    @Test
+    void neitherRetryNorCatchInterceptsTheHistoryEventLimit() {
+        long startedAt = System.currentTimeMillis();
+
+        Execution execution = run(RUNAWAY_PARALLEL_BRANCH_UNDER_RETRY_AND_CATCH);
+
+        assertEquals("FAILED", execution.getStatus());
+        assertEquals("States.Runtime", execution.getError());
+        assertEquals("The execution reached the maximum number of history events (25000).",
+                execution.getCause());
+        assertEquals("ExecutionFailed", history.get(history.size() - 1).getType());
+        assertNotEquals("SucceedStateEntered", history.get(history.size() - 2).getType());
+        // Three attempts at IntervalSeconds 30 would put this past 90 seconds if the Retry ran.
+        assertTrue(System.currentTimeMillis() - startedAt < 30_000,
+                "the Retry's backoff ran");
+    }
+
+    private Execution run(String definition) {
+        return run(definition, "{\"spin\": true}");
+    }
+
+    private Execution run(String definition, String input) {
+        StateMachine stateMachine = new StateMachine();
+        stateMachine.setName("history-event-limit-test");
+        stateMachine.setStateMachineArn(
+                "arn:aws:states:%s:%s:stateMachine:history-event-limit-test".formatted(REGION, ACCOUNT));
+        stateMachine.setRoleArn("arn:aws:iam::%s:role/test-role".formatted(ACCOUNT));
+        stateMachine.setDefinition(definition);
+
+        Execution execution = new Execution();
+        execution.setName("history-event-limit-execution");
+        execution.setExecutionArn(
+                "arn:aws:states:%s:%s:execution:history-event-limit-test:history-event-limit-execution"
+                        .formatted(REGION, ACCOUNT));
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput(input);
+
+        executor.executeSync(stateMachine, execution, history, (updated, events) -> {
+        });
+        return execution;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -257,6 +257,48 @@ class AslExecutorTaskHistoryEventsTest {
         assertNull(started.getDetails());
     }
 
+    /**
+     * A Parallel branch and a Map iteration run states of their own whose events floci does not
+     * publish. The published history is still one unbroken chain: the ids of the events around them
+     * do not skip the numbers those states used.
+     */
+    @Test
+    void parallelAndMapPublishAnUnbrokenEventChain() throws Exception {
+        var history = new ArrayList<HistoryEvent>();
+        var execution = run("""
+                {
+                  "StartAt": "Fan",
+                  "States": {
+                    "Fan": {
+                      "Type": "Parallel",
+                      "Branches": [{
+                        "StartAt": "BranchStep",
+                        "States": {"BranchStep": {"Type": "Pass", "Next": "BranchTail"},
+                                   "BranchTail": {"Type": "Pass", "End": true}}
+                      }],
+                      "Next": "Iterate"
+                    },
+                    "Iterate": {
+                      "Type": "Map",
+                      "ItemsPath": "$[0].items",
+                      "ItemProcessor": {
+                        "StartAt": "ItemStep",
+                        "States": {"ItemStep": {"Type": "Pass", "End": true}}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """, "{\"items\": [1, 2]}", null, history);
+
+        assertEquals("SUCCEEDED", execution.getStatus(), "history: " + typesOf(history));
+        assertEquals(
+                List.of("ParallelStateEntered", "ParallelStateExited",
+                        "MapStateEntered", "MapStateExited", "ExecutionSucceeded"),
+                typesOf(history));
+        assertChain(history);
+    }
+
     private static List<String> typesOf(List<HistoryEvent> history) {
         return history.stream().map(HistoryEvent::getType).toList();
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsStopExecutionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsStopExecutionIntegrationTest.java
@@ -1,0 +1,194 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Guards that {@code StopExecution} stops the execution instead of relabelling it: the status,
+ * error and cause it writes are what {@code DescribeExecution} returns, and the worker thread that
+ * is still inside the {@code Wait} does not overwrite them when it gets there.
+ */
+@QuarkusTest
+class StepFunctionsStopExecutionIntegrationTest {
+
+    private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+
+    /** Long enough that the stop lands mid-flight, short enough that the re-read is cheap. */
+    private static final int WAIT_SECONDS = 3;
+
+    private static final String WAITING_MACHINE = """
+            {"StartAt": "W", "States": {"W": {"Type": "Wait", "Seconds": %d, "End": true}}}
+            """.formatted(WAIT_SECONDS);
+
+    @Inject
+    StepFunctionsService stepFunctionsService;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    /**
+     * The executions survive a restart in persistent storage mode; their histories do not, because
+     * the history lives in memory. An execution that reloads as RUNNING with no history behind it is
+     * still stoppable, and StopExecution reports the abort it performed rather than an error. The
+     * same pairing happens during a reset, between the moment the in-memory state is dropped and
+     * the moment the stored executions are.
+     */
+    @Test
+    void executionWithNoHistoryInMemoryIsStillStoppable() throws Exception {
+        String executionArn = startWaitingExecution("stop-without-history");
+        Thread.sleep(300);
+
+        stepFunctionsService.clear();
+
+        stopExecution(executionArn, "Manual", "probe");
+
+        Response described = describeExecution(executionArn);
+        assertEquals("ABORTED", described.jsonPath().getString("status"));
+        assertEquals("Manual", described.jsonPath().getString("error"));
+        assertEquals("probe", described.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void stoppedExecutionReportsTheCallersErrorAndCause() throws Exception {
+        String executionArn = startWaitingExecution("stop-reports-error");
+        Thread.sleep(300);
+
+        stopExecution(executionArn, "Manual", "probe");
+
+        Response described = describeExecution(executionArn);
+        assertEquals("ABORTED", described.jsonPath().getString("status"));
+        assertEquals("Manual", described.jsonPath().getString("error"));
+        assertEquals("probe", described.jsonPath().getString("cause"));
+    }
+
+    @Test
+    void stoppedExecutionStaysAbortedAfterTheWaitElapses() throws Exception {
+        String executionArn = startWaitingExecution("stop-survives-wait");
+        Thread.sleep(300);
+
+        stopExecution(executionArn, "Manual", "probe");
+        double stopDate = describeExecution(executionArn).jsonPath().getDouble("stopDate");
+
+        Thread.sleep((WAIT_SECONDS + 2) * 1000L);
+
+        Response described = describeExecution(executionArn);
+        assertEquals("ABORTED", described.jsonPath().getString("status"));
+        assertEquals("Manual", described.jsonPath().getString("error"));
+        assertEquals("probe", described.jsonPath().getString("cause"));
+        assertEquals(stopDate, described.jsonPath().getDouble("stopDate"));
+    }
+
+    @Test
+    void abortedExecutionEndsItsHistoryAtExecutionAborted() throws Exception {
+        String executionArn = startWaitingExecution("stop-ends-history");
+        Thread.sleep(300);
+
+        stopExecution(executionArn, "Manual", "probe");
+
+        // The worker is still inside the Wait. Let it come out and try to record the state it left.
+        Thread.sleep((WAIT_SECONDS + 2) * 1000L);
+
+        List<Map<String, Object>> events = getExecutionHistory(executionArn).jsonPath().getList("events");
+        List<String> types = events.stream().map(event -> (String) event.get("type")).toList();
+        List<Object> ids = events.stream().map(event -> event.get("id")).toList();
+
+        assertAll(
+                () -> assertEquals("ExecutionAborted", types.get(types.size() - 1),
+                        "history continued past the terminal event: " + types),
+                () -> assertEquals(ids.size(), new HashSet<>(ids).size(),
+                        "history repeats an event id: " + ids + " for " + types));
+    }
+
+    private String startWaitingExecution(String namePrefix) {
+        String name = namePrefix + "-" + UUID.randomUUID();
+        String stateMachineArn = createStateMachine(name, WAITING_MACHINE);
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.StartExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"stateMachineArn": "%s", "input": "{}"}
+                        """.formatted(stateMachineArn))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response.jsonPath().getString("executionArn");
+    }
+
+    private String createStateMachine(String name, String definition) {
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.CreateStateMachine")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"name": "%s", "definition": %s, "roleArn": "%s"}
+                        """.formatted(name, quote(definition), ROLE_ARN))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response.jsonPath().getString("stateMachineArn");
+    }
+
+    private void stopExecution(String executionArn, String error, String cause) {
+        given()
+                .header("X-Amz-Target", "AWSStepFunctions.StopExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s", "error": "%s", "cause": "%s"}
+                        """.formatted(executionArn, error, cause))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private Response describeExecution(String executionArn) {
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.DescribeExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(executionArn))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response;
+    }
+
+    private Response getExecutionHistory(String executionArn) {
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.GetExecutionHistory")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s", "includeExecutionData": true}
+                        """.formatted(executionArn))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response;
+    }
+
+    private static String quote(String raw) {
+        return "\"" + raw
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                + "\"";
+    }
+}


### PR DESCRIPTION
Replaced by #2782, which carries this change together with the rest of the `AslExecutor` work.