### PR TITLE
fix(stepfunctions): catch Error from JSONata evaluation as States.QueryEvaluationError

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -191,6 +191,16 @@ public class JsonataEvaluator {
             return toJsonNode(result);
         } catch (Exception e) {
             throw new AslExecutor.FailStateException("States.QueryEvaluationError", queryEvaluationCause(e));
+        } catch (StackOverflowError | OutOfMemoryError e) {
+            // These two are the resource an expression itself spends: nesting deep enough to
+            // exhaust the parser's stack, and asking for a value larger than the JVM can hold.
+            // AWS bounds both and fails the state with States.QueryEvaluationError, so the state's
+            // own Retry and Catch (and a Catch on States.ALL) still see it. Every other Error says
+            // the runtime is broken rather than this expression, and it keeps going to
+            // AslExecutor's terminal catch (Error e), which fails the execution as States.Runtime
+            // and rethrows. The message is often null here, so toString() carries the diagnosis,
+            // the same way that terminal catch already renders it.
+            throw new AslExecutor.FailStateException("States.QueryEvaluationError", e.toString());
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -908,6 +908,29 @@ class JsonataEvaluatorTest {
                 + expectedFieldPath + "' returned nothing (undefined).", failure.cause);
     }
 
+    /**
+     * #2738: {@code evaluate} caught {@code Exception}, not {@code Error}, so a
+     * {@code java.lang.Error} raised while parsing or evaluating an expression escaped straight
+     * past this method to {@code AslExecutor}'s last-resort {@code catch (Error e)}, failing the
+     * whole execution as {@code States.Runtime} before the state's own {@code Retry}/{@code Catch}
+     * ever ran. This pins the {@code StackOverflowError} arm of the catch, with an expression
+     * nested 200,000 parentheses deep that overflows the JVM call stack during parsing in a few
+     * milliseconds and never grows a string past a few hundred KB. The other arm,
+     * {@code OutOfMemoryError}, is the issue's own reproduction and is pinned end to end by
+     * {@code StepFunctionsJsonataIntegrationTest.parallelBranchErrorIsCatchableByStatesAll}.
+     */
+    @Test
+    void aStackOverflowErrorDuringParsingBecomesAQueryEvaluationError() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        String deeplyNested = "(".repeat(200_000) + "1" + ")".repeat(200_000);
+
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate("{% " + deeplyNested + " %}", statesVar));
+
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertTrue(ex.cause.contains("StackOverflowError"), ex.cause);
+    }
+
     @Test
     void evaluateFieldNamesTheFieldOfAPositionThatHoldsASingleExpression() throws Exception {
         JsonNode statesVar = objectMapper.readTree("{\"input\": {}}");

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1300,6 +1300,59 @@ class StepFunctionsJsonataIntegrationTest {
         assertTrue(caught.path("caught").asBoolean(), caught.toString());
     }
 
+    /**
+     * #2738: a {@code java.lang.Error} raised while evaluating a branch's expression used to
+     * escape {@code JsonataEvaluator}'s catch and reach {@code AslExecutor}'s own last-resort
+     * {@code catch (Error e)}, failing the whole execution as {@code States.Runtime} before the
+     * {@code Parallel}'s own {@code Catch} ever ran. On real AWS (measured in us-east-1) the same
+     * definition ends {@code SUCCEEDED} with output {@code {"caught":true}}.
+     *
+     * <p>The branch expression is the issue's own reproduction verbatim (quotes swapped to
+     * JSONata's single-quote string literal, which embeds in this JSON body without escaping):
+     * a tail-recursive function doubles a string 31 times, which dashjoin loops rather than
+     * recursing on (JSONata optimises the tail call), so it grows the string until doubling it
+     * once more would exceed the JVM's maximum array length and throws
+     * {@code OutOfMemoryError: Overflow: String length out of range} from that bound check, not
+     * from a filled heap. Measured in isolation against the {@code -Xmx6g} this suite's own
+     * surefire {@code argLine} sets, the expression peaks around 1.5 GB of transient garbage and
+     * completes in ~200 ms, comfortably inside the 6 GB budget: it does not exhaust the heap of
+     * the run. This is the only test that reaches the {@code OutOfMemoryError} arm of
+     * {@code JsonataEvaluator.evaluate}'s catch; the {@code StackOverflowError} arm is pinned by
+     * {@code JsonataEvaluatorTest.aStackOverflowErrorDuringParsingBecomesAQueryEvaluationError}.
+     */
+    @Test
+    void parallelBranchErrorIsCatchableByStatesAll() throws Exception {
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "P",
+                    "States": {
+                        "P": {
+                            "Type": "Parallel",
+                            "Branches": [{
+                                "StartAt": "E",
+                                "States": {
+                                    "E": {
+                                        "Type": "Pass",
+                                        "Output": {"r": "{% ($p := function($s, $n) { $n = 0 ? $s : $p($s & $s, $n - 1) }; $length($p('x', 31))) %}"},
+                                        "End": true
+                                    }
+                                }
+                            }],
+                            "Catch": [{"ErrorEquals": ["States.ALL"], "Next": "Caught"}],
+                            "End": true
+                        },
+                        "Caught": {"Type": "Pass", "Output": {"caught": true}, "End": true}
+                    }
+                }
+                """;
+
+        String smArn = createStateMachine("sfn-error-catchable-test", definition);
+        JsonNode output = objectMapper.readTree(waitForExecution(startExecution(smArn, "{}")));
+
+        assertTrue(output.path("caught").asBoolean(), output.toString());
+    }
+
     @Test
     void assignExpressionReturningNothingFailsTheState() throws Exception {
         // Real AWS names 'Assign/x' for this definition; before this guard the variable was never


### PR DESCRIPTION
Replaced by #2783, which carries this change together with the rest of the `JsonataEvaluator` work.