### PR TITLE
fix(stepfunctions): reject definitions with no terminal state, dangling targets or unsupported fields

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -1928,25 +1928,12 @@ public class AslExecutor {
                             branchContext, branchVariables))));
         }
 
-        int timeoutSeconds = stateDef.path("TimeoutSeconds").asInt(0);
-        long deadlineNanos = timeoutSeconds > 0
-                ? System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds)
-                : Long.MAX_VALUE;
-
+        // TimeoutSeconds is not a valid field on Parallel — the validator refuses it at
+        // CreateStateMachine, so no definition that reaches execution can carry one.
         ArrayNode results = objectMapper.createArrayNode();
         try {
             for (Future<JsonNode> future : futures) {
-                long remainingNanos = deadlineNanos - System.nanoTime();
-                if (remainingNanos <= 0) {
-                    throw new FailStateException("States.Timeout",
-                            "Parallel state timed out after " + timeoutSeconds + " seconds");
-                }
-                try {
-                    results.add(future.get(remainingNanos, TimeUnit.NANOSECONDS));
-                } catch (java.util.concurrent.TimeoutException e) {
-                    throw new FailStateException("States.Timeout",
-                            "Parallel state timed out after " + timeoutSeconds + " seconds");
-                }
+                results.add(future.get());
             }
         } catch (InterruptedException e) {
             futures.forEach(future -> future.cancel(true));

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -80,6 +80,13 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     private static final String RESULT_WRITER_RESOURCE = "arn:aws:states:::s3:putObject";
     private static final Set<String> RESULT_WRITER_TRANSFORMATIONS = Set.of("NONE", "COMPACT", "FLATTEN");
     private static final Set<String> RESULT_WRITER_OUTPUT_TYPES = Set.of("JSON", "JSONL");
+    // Measured against real AWS: TimeoutSeconds is accepted on Task only, Catch and Retry are
+    // accepted on Task, Parallel and Map only. Every other state type refuses these fields with
+    // "Field '<name>' is not supported".
+    private static final Map<String, Set<String>> FIELDS_ALLOWED_STATE_TYPES = Map.of(
+            "TimeoutSeconds", Set.of("Task"),
+            "Catch", Set.of("Task", "Parallel", "Map"),
+            "Retry", Set.of("Task", "Parallel", "Map"));
 
     @Inject
     public StepFunctionsService(StorageFactory storageFactory, RegionResolver regionResolver,
@@ -1054,6 +1061,12 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
             "Pass", "Task", "Choice", "Wait", "Succeed", "Fail", "Parallel", "Map");
     private static final String PARSE_ERROR_MARKER = "INVALID_JSON_DESCRIPTION:";
     private static final String UNSUPPORTED_JSONATA_MARKER = "UNSUPPORTED_JSONATA_EXPRESSION:";
+    private static final String UNSUPPORTED_FIELD_MARKER = "UNSUPPORTED_FIELD:";
+    private static final String MISSING_END_STATE_MARKER = "MISSING_END_STATE:";
+    private static final String UNREACHABLE_STATE_MARKER = "UNREACHABLE_STATE:";
+    // Payload is "<target state name><SOH><location>"; SOH cannot appear in a state name.
+    private static final String DANGLING_TARGET_MARKER = "DANGLING_TARGET:";
+    private static final char DANGLING_TARGET_SEPARATOR = '\u0001';
 
     // Parse the structured location out of validator flat error strings,
     // which currently encode it as "...field 'X' ... at /States/Y".
@@ -1129,6 +1142,25 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         if (error.startsWith(UNSUPPORTED_JSONATA_MARKER)) {
             return toJsonataDiagnostic(error.substring(UNSUPPORTED_JSONATA_MARKER.length()).trim());
         }
+        if (error.startsWith(UNSUPPORTED_FIELD_MARKER)) {
+            return toUnsupportedFieldDiagnostic(error.substring(UNSUPPORTED_FIELD_MARKER.length()));
+        }
+        if (error.equals(MISSING_END_STATE_MARKER)) {
+            return new Diagnostic("ERROR", "MISSING_END_STATE", "Workflow has no terminal state", null);
+        }
+        if (error.startsWith(UNREACHABLE_STATE_MARKER)) {
+            String location = error.substring(UNREACHABLE_STATE_MARKER.length());
+            String name = location.substring(location.lastIndexOf('/') + 1);
+            return new Diagnostic("ERROR", "MISSING_TRANSITION_TARGET",
+                    "State \"" + name + "\" is not reachable.", location);
+        }
+        if (error.startsWith(DANGLING_TARGET_MARKER)) {
+            String payload = error.substring(DANGLING_TARGET_MARKER.length());
+            int separator = payload.indexOf(DANGLING_TARGET_SEPARATOR);
+            return new Diagnostic("ERROR", "MISSING_TRANSITION_TARGET",
+                    "Missing 'Next' target: " + payload.substring(0, separator),
+                    payload.substring(separator + 1));
+        }
         String message = error;
         String location = null;
         Matcher locM = LOCATION_SUFFIX_PATTERN.matcher(message);
@@ -1153,6 +1185,16 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         }
         return new Diagnostic("ERROR", "UNSUPPORTED_JSONATA_EXPRESSION",
                 message.substring(0, locationMatcher.start()).trim(), locationMatcher.group(1));
+    }
+
+    // Payload is "<field name> <location>"; unlike the generic schema-error shape, AWS points this
+    // diagnostic at the state itself rather than appending the field name to the location.
+    private static Diagnostic toUnsupportedFieldDiagnostic(String payload) {
+        int separator = payload.indexOf(' ');
+        String field = payload.substring(0, separator);
+        String location = payload.substring(separator + 1);
+        return new Diagnostic("ERROR", "SCHEMA_VALIDATION_FAILED",
+                "Field '" + field + "' is not supported", location);
     }
 
     private static void validateStateMachineName(String name) {
@@ -1406,17 +1448,27 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
                     "Invalid State Machine Definition: '" + first.substring(PARSE_ERROR_MARKER.length()).trim() + "'", 400);
         }
         // A JSONata error already carries its own AWS code and location, so it is reported on its
-        // own rather than folded into the schema list.
-        List<String> schemaErrors = errors.stream()
+        // own rather than folded into the rest.
+        List<String> nonJsonataErrors = errors.stream()
                 .filter(error -> !error.startsWith(UNSUPPORTED_JSONATA_MARKER))
                 .toList();
-        if (schemaErrors.isEmpty()) {
+        if (nonJsonataErrors.isEmpty()) {
             throw new AwsException("InvalidDefinition",
-                    "Invalid State Machine Definition: '" + first + "'", 400);
+                    "Invalid State Machine Definition: '" + flatten(toDiagnostic(first)) + "'", 400);
         }
         throw new AwsException("InvalidDefinition",
-                "Invalid State Machine Definition: 'SCHEMA_VALIDATION_FAILED: "
-                        + String.join(", ", schemaErrors) + "'", 400);
+                "Invalid State Machine Definition: '"
+                        + String.join(", ", nonJsonataErrors.stream()
+                                .map(error -> flatten(toDiagnostic(error))).toList())
+                        + "'", 400);
+    }
+
+    // Renders one diagnostic back to a flat string for the CreateStateMachine wire message:
+    // "<code>: <message> at <location>". Unlike ValidateStateMachineDefinition, which omits
+    // location entirely when there is none, AWS's CreateStateMachine always renders the suffix,
+    // printing the literal "null" for a diagnostic with no location — measured against real AWS.
+    private static String flatten(Diagnostic diagnostic) {
+        return diagnostic.code() + ": " + diagnostic.message() + " at " + diagnostic.location();
     }
 
     private List<String> collectValidationErrors(String definition) {
@@ -1454,16 +1506,129 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         String topLevelQL = def.path("QueryLanguage").asText("JSONPath");
         boolean topLevelJsonata = "JSONata".equals(topLevelQL);
 
+        Set<String> topLevelStateNames = new HashSet<>();
+        states.fieldNames().forEachRemaining(topLevelStateNames::add);
+
         var fields = states.fields();
         while (fields.hasNext()) {
             var entry = fields.next();
-            validateState("/States/" + entry.getKey(), entry.getValue(), topLevelJsonata, errors);
+            validateState("/States/" + entry.getKey(), entry.getValue(), topLevelJsonata,
+                    topLevelStateNames, errors);
+        }
+
+        // MISSING_END_STATE is a top-level-only rule, and it suppresses the reachability walk at
+        // that same level: a workflow with no terminal state anywhere is refused outright, with no
+        // "not reachable" diagnostics piled on top of it.
+        if (hasTerminalState(states)) {
+            validateReachability("/States", states, startAt, errors);
+        } else {
+            errors.add(MISSING_END_STATE_MARKER);
         }
         return errors;
     }
 
-    private void validateState(String statePath, JsonNode stateDef,
-                               boolean topLevelJsonata, List<String> errors) {
+    private static boolean hasTerminalState(JsonNode states) {
+        for (JsonNode state : states) {
+            if (!state.isObject()) {
+                continue;
+            }
+            String type = state.path("Type").asText(null);
+            if ("Succeed".equals(type) || "Fail".equals(type) || state.path("End").asBoolean(false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Walks the transition graph of one container of states (the top-level {@code States}, a
+     * Map's {@code ItemProcessor}, or a Parallel branch) from its {@code StartAt} and flags every
+     * state nothing routes to. Skipped when {@code startAt} does not resolve to a state in the
+     * same container — that shape is reported elsewhere and there is no root to walk from.
+     */
+    private static void validateReachability(String containerPath, JsonNode states, String startAt,
+                                              List<String> errors) {
+        if (startAt == null || !states.has(startAt)) {
+            return;
+        }
+        Set<String> reachable = new HashSet<>();
+        Deque<String> pending = new ArrayDeque<>();
+        reachable.add(startAt);
+        pending.add(startAt);
+        while (!pending.isEmpty()) {
+            for (String target : transitionTargets(states.path(pending.poll()))) {
+                if (states.has(target) && reachable.add(target)) {
+                    pending.add(target);
+                }
+            }
+        }
+        states.fieldNames().forEachRemaining(name -> {
+            if (!reachable.contains(name)) {
+                errors.add(UNREACHABLE_STATE_MARKER + containerPath + "/" + name);
+            }
+        });
+    }
+
+    private static List<String> transitionTargets(JsonNode state) {
+        List<String> targets = new ArrayList<>();
+        addIfTextual(state, "Next", targets);
+        addIfTextual(state, "Default", targets);
+        for (JsonNode choice : state.path("Choices")) {
+            addIfTextual(choice, "Next", targets);
+        }
+        for (JsonNode catcher : state.path("Catch")) {
+            addIfTextual(catcher, "Next", targets);
+        }
+        return targets;
+    }
+
+    private static void addIfTextual(JsonNode node, String field, List<String> targets) {
+        if (node.path(field).isTextual()) {
+            targets.add(node.path(field).asText());
+        }
+    }
+
+    /**
+     * Flags every {@code Next}, {@code Default} and {@code Catch[].Next} in one state that names a
+     * state absent from its own container. Independent of {@link #validateReachability}: a
+     * dangling target is invalid on its own, whether or not MISSING_END_STATE suppressed the
+     * unreachable-state walk for this container.
+     */
+    private static void validateTransitionTargets(String statePath, JsonNode stateDef,
+                                                   Set<String> siblingStateNames, List<String> errors) {
+        validateTarget(stateDef, "Next", statePath + "/Next", siblingStateNames, errors);
+        validateTarget(stateDef, "Default", statePath + "/Default", siblingStateNames, errors);
+        JsonNode choices = stateDef.path("Choices");
+        for (int i = 0; i < choices.size(); i++) {
+            validateTarget(choices.path(i), "Next", statePath + "/Choices[" + i + "]/Next",
+                    siblingStateNames, errors);
+        }
+        JsonNode catches = stateDef.path("Catch");
+        for (int i = 0; i < catches.size(); i++) {
+            validateTarget(catches.path(i), "Next", statePath + "/Catch[" + i + "]/Next",
+                    siblingStateNames, errors);
+        }
+    }
+
+    private static void validateTarget(JsonNode node, String field, String location,
+                                       Set<String> siblingStateNames, List<String> errors) {
+        JsonNode value = node.path(field);
+        if (value.isTextual() && !siblingStateNames.contains(value.asText())) {
+            errors.add(DANGLING_TARGET_MARKER + value.asText() + DANGLING_TARGET_SEPARATOR + location);
+        }
+    }
+
+    private static void validateFieldsAllowedForType(String statePath, JsonNode stateDef,
+                                                      String stateType, List<String> errors) {
+        FIELDS_ALLOWED_STATE_TYPES.forEach((field, allowedTypes) -> {
+            if (stateDef.has(field) && !allowedTypes.contains(stateType)) {
+                errors.add(UNSUPPORTED_FIELD_MARKER + field + " " + statePath);
+            }
+        });
+    }
+
+    private void validateState(String statePath, JsonNode stateDef, boolean topLevelJsonata,
+                               Set<String> siblingStateNames, List<String> errors) {
         if (!stateDef.isObject()) {
             errors.add("State must be an object at " + statePath);
             return;
@@ -1485,9 +1650,11 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
                 || stateDef.path("Choices").isEmpty())) {
             errors.add("Choice state must declare a non-empty field 'Choices' at " + statePath);
         }
-
         String stateQL = stateDef.path("QueryLanguage").asText(null);
         boolean stateIsJsonata = stateQL != null ? "JSONata".equals(stateQL) : topLevelJsonata;
+
+        validateFieldsAllowedForType(statePath, stateDef, stateType, errors);
+        validateTransitionTargets(statePath, stateDef, siblingStateNames, errors);
 
         // JSONPath-only fields are not allowed when the state uses JSONata
         if (stateIsJsonata) {
@@ -1509,14 +1676,16 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
                 validateResultWriter(statePath, stateDef.get("ResultWriter"), stateIsJsonata, errors);
             }
             String processorField = stateDef.has("ItemProcessor") ? "ItemProcessor" : "Iterator";
-            validateNestedStates(stateDef.path(processorField).path("States"),
-                    statePath + "/" + processorField + "/States", topLevelJsonata, errors);
+            JsonNode processor = stateDef.path(processorField);
+            validateNestedStates(processor.path("States"), statePath + "/" + processorField + "/States",
+                    processor.path("StartAt").asText(null), topLevelJsonata, errors);
         } else if ("Parallel".equals(stateType)) {
             JsonNode branches = stateDef.path("Branches");
             if (branches.isArray()) {
                 for (int i = 0; i < branches.size(); i++) {
-                    validateNestedStates(branches.path(i).path("States"),
-                            statePath + "/Branches[" + i + "]/States", topLevelJsonata, errors);
+                    JsonNode branch = branches.path(i);
+                    validateNestedStates(branch.path("States"), statePath + "/Branches[" + i + "]/States",
+                            branch.path("StartAt").asText(null), topLevelJsonata, errors);
                 }
             }
         }
@@ -1567,13 +1736,18 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         }
     }
 
-    private void validateNestedStates(JsonNode states, String statesPath,
+    private void validateNestedStates(JsonNode states, String statesPath, String startAt,
                                       boolean inheritedJsonata, List<String> errors) {
         if (!states.isObject()) {
             return;
         }
+        Set<String> stateNames = new HashSet<>();
+        states.fieldNames().forEachRemaining(stateNames::add);
         states.fields().forEachRemaining(entry -> validateState(
-                statesPath + "/" + entry.getKey(), entry.getValue(), inheritedJsonata, errors));
+                statesPath + "/" + entry.getKey(), entry.getValue(), inheritedJsonata, stateNames, errors));
+        // Unlike the top level, MISSING_END_STATE does not apply here: ItemProcessor and Branches
+        // are always walked for reachability regardless of whether they have a terminal state.
+        validateReachability(statesPath, states, startAt, errors);
     }
 
     private void validateMapConcurrency(String statePath, JsonNode stateDef,

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -1266,13 +1266,24 @@ class StepFunctionsJsonataIntegrationTest {
         // executing the state 'Transform' (entered at the event id #2). The JSONata expression
         // '$states.input.missing' specified for the field 'Output/v' returned nothing (undefined)."
         // Floci does not yet render the "An error occurred while executing the state" prefix (#2668).
+        //
+        // Transform is a Task, not a Pass: measured against real AWS, Catch (used below) is refused
+        // on Pass regardless of query language — SCHEMA_VALIDATION_FAILED, "Field 'Catch' is not
+        // supported" — so only Task, Parallel and Map can carry the Catch this test exercises.
+        createBucket("jsonata-output-returned-nothing");
         String definition = """
                 {
                     "QueryLanguage": "JSONata",
                     "StartAt": "Transform",
                     "States": {
                         "Transform": {
-                            "Type": "Pass",
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::s3:putObject",
+                            "Arguments": {
+                                "Bucket": "jsonata-output-returned-nothing",
+                                "Key": "object.txt",
+                                "Body": "hello"
+                            },
                             "Output": {"v": "{% $states.input.missing %}"},
                             "End": true
                         }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsValidateStateMachineDefinitionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsValidateStateMachineDefinitionIntegrationTest.java
@@ -28,6 +28,8 @@ class StepFunctionsValidateStateMachineDefinitionIntegrationTest {
     private static final String CT = "application/x-amz-json-1.0";
     private static final String TARGET = "AWSStepFunctions.ValidateStateMachineDefinition";
     private static final String LIST_TARGET = "AWSStepFunctions.ListStateMachines";
+    private static final String CREATE_TARGET = "AWSStepFunctions.CreateStateMachine";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/service-role/sfn";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     // ASL with the inner double-quotes already JSON-escaped, so it embeds cleanly
@@ -95,6 +97,17 @@ class StepFunctionsValidateStateMachineDefinitionIntegrationTest {
     private static Response validateDefinition(String definition) {
         String body = OBJECT_MAPPER.createObjectNode().put("definition", definition).toString();
         return given().contentType(CT).header("X-Amz-Target", TARGET)
+                .body(body)
+                .when().post("/");
+    }
+
+    private static Response createStateMachine(String name, String definition) {
+        String body = OBJECT_MAPPER.createObjectNode()
+                .put("name", name)
+                .put("definition", definition)
+                .put("roleArn", ROLE_ARN)
+                .toString();
+        return given().contentType(CT).header("X-Amz-Target", CREATE_TARGET)
                 .body(body)
                 .when().post("/");
     }
@@ -616,6 +629,375 @@ class StepFunctionsValidateStateMachineDefinitionIntegrationTest {
                 .when().post("/")
                 .then().statusCode(400)
                 .body("__type", containsString("ValidationException"));
+    }
+
+    @Test
+    void loopWithNoTerminalState_returnsFailWithMissingEndState() {
+        String def = """
+                {"StartAt":"A","States":{
+                  "A":{"Type":"Pass","Next":"B"},
+                  "B":{"Type":"Pass","Next":"A"}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_END_STATE"))
+                .body("diagnostics[0].message", equalTo("Workflow has no terminal state"))
+                .body("diagnostics[0].location", nullValue());
+    }
+
+    @Test
+    void missingEndStateSuppressesUnreachableStateDiagnosticForOtherStates() {
+        // Same loop as above, plus a state nothing routes to. If MISSING_END_STATE did not
+        // suppress the reachability walk, "Unused" would also be reported as not reachable.
+        String def = """
+                {"StartAt":"A","States":{
+                  "A":{"Type":"Pass","Next":"B"},
+                  "B":{"Type":"Pass","Next":"A"},
+                  "Unused":{"Type":"Pass","Next":"A"}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_END_STATE"));
+    }
+
+    @Test
+    void missingEndStateCoexistsWithADanglingTargetInAWSOrder() {
+        // MISSING_END_STATE only suppresses the unreachable-state half of the reachability walk:
+        // a dangling Next target is a separate, independent check and still fires. Measured
+        // against real AWS: both diagnostics come back in the same response, dangling target
+        // first and MISSING_END_STATE second.
+        String def = """
+                {"StartAt":"A","States":{"A":{"Type":"Pass","Next":"NOPE"}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(2))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("Missing 'Next' target: NOPE"))
+                .body("diagnostics[0].location", equalTo("/States/A/Next"))
+                .body("diagnostics[1].code", equalTo("MISSING_END_STATE"))
+                .body("diagnostics[1].message", equalTo("Workflow has no terminal state"))
+                .body("diagnostics[1].location", nullValue());
+    }
+
+    @Test
+    void unreachableTerminalStateAddedToLoop_returnsFailWithMissingTransitionTarget() {
+        // Adding an unreachable terminal to the same loop gives a state a top-level state has:
+        // MISSING_END_STATE no longer applies, and the reachability walk now runs and catches C.
+        String def = """
+                {"StartAt":"A","States":{
+                  "A":{"Type":"Pass","Next":"B"},
+                  "B":{"Type":"Pass","Next":"A"},
+                  "C":{"Type":"Pass","End":true}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("State \"C\" is not reachable."))
+                .body("diagnostics[0].location", equalTo("/States/C"));
+    }
+
+    @Test
+    void nestedLoopWithNoTerminalState_isAcceptedBecauseMissingEndStateIsTopLevelOnly() {
+        String def = """
+                {"StartAt":"M","States":{"M":{"Type":"Map","ItemsPath":"$.items",
+                  "ItemProcessor":{"StartAt":"A","States":{
+                    "A":{"Type":"Pass","Next":"B"},
+                    "B":{"Type":"Pass","Next":"A"}
+                  }},
+                  "End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("OK"))
+                .body("diagnostics", hasSize(0));
+    }
+
+    @Test
+    void timeoutSecondsOnMap_returnsFailWithSchemaError() {
+        String def = """
+                {"StartAt":"M","States":{"M":{"Type":"Map","TimeoutSeconds":5,"ItemsPath":"$.items",
+                  "ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},
+                    "StartAt":"W","States":{"W":{"Type":"Wait","Seconds":25,"End":true}}},
+                  "End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("SCHEMA_VALIDATION_FAILED"))
+                .body("diagnostics[0].message", equalTo("Field 'TimeoutSeconds' is not supported"))
+                .body("diagnostics[0].location", equalTo("/States/M"));
+    }
+
+    @Test
+    void timeoutSecondsOnParallel_returnsFailWithSchemaError() {
+        String def = """
+                {"StartAt":"P","States":{"P":{"Type":"Parallel","TimeoutSeconds":5,
+                  "Branches":[{"StartAt":"W","States":{"W":{"Type":"Wait","Seconds":25,"End":true}}}],
+                  "End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("SCHEMA_VALIDATION_FAILED"))
+                .body("diagnostics[0].message", equalTo("Field 'TimeoutSeconds' is not supported"))
+                .body("diagnostics[0].location", equalTo("/States/P"));
+    }
+
+    @Test
+    void timeoutSecondsAcceptedOnTask() {
+        String def = """
+                {"StartAt":"T","States":{"T":{"Type":"Task",
+                  "Resource":"arn:aws:states:::lambda:invoke","TimeoutSeconds":5,"End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("OK"))
+                .body("diagnostics", hasSize(0));
+    }
+
+    @Test
+    void timeoutSecondsRejectedOnPass() {
+        // Same rule as Map and Parallel above, generalized to a state type that never carries it.
+        String def = """
+                {"StartAt":"X","States":{"X":{"Type":"Pass","TimeoutSeconds":5,"End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("SCHEMA_VALIDATION_FAILED"))
+                .body("diagnostics[0].message", equalTo("Field 'TimeoutSeconds' is not supported"))
+                .body("diagnostics[0].location", equalTo("/States/X"));
+    }
+
+    @Test
+    void catchRejectedOnPass() {
+        String def = """
+                {"StartAt":"X","States":{"X":{"Type":"Pass","End":true,
+                  "Catch":[{"ErrorEquals":["States.ALL"],"Next":"X"}]}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("SCHEMA_VALIDATION_FAILED"))
+                .body("diagnostics[0].message", equalTo("Field 'Catch' is not supported"))
+                .body("diagnostics[0].location", equalTo("/States/X"));
+    }
+
+    @Test
+    void retryRejectedOnWait() {
+        String def = """
+                {"StartAt":"X","States":{"X":{"Type":"Wait","Seconds":1,"End":true,
+                  "Retry":[{"ErrorEquals":["States.ALL"]}]}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("SCHEMA_VALIDATION_FAILED"))
+                .body("diagnostics[0].message", equalTo("Field 'Retry' is not supported"))
+                .body("diagnostics[0].location", equalTo("/States/X"));
+    }
+
+    @Test
+    void catchAndRetryAcceptedOnTaskParallelAndMap() {
+        String def = """
+                {"StartAt":"T","States":{
+                  "T":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke",
+                       "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Done"}],
+                       "Retry":[{"ErrorEquals":["States.ALL"]}],"Next":"Par"},
+                  "Par":{"Type":"Parallel",
+                       "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Done"}],
+                       "Retry":[{"ErrorEquals":["States.ALL"]}],
+                       "Branches":[{"StartAt":"B","States":{"B":{"Type":"Pass","End":true}}}],
+                       "Next":"M"},
+                  "M":{"Type":"Map","ItemsPath":"$.items",
+                       "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Done"}],
+                       "Retry":[{"ErrorEquals":["States.ALL"]}],
+                       "ItemProcessor":{"StartAt":"P","States":{"P":{"Type":"Pass","End":true}}},
+                       "Next":"Done"},
+                  "Done":{"Type":"Succeed"}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("OK"))
+                .body("diagnostics", hasSize(0));
+    }
+
+    @Test
+    void catchRejectedOnPassEvenWhenJsonata() {
+        // QueryLanguage does not change which state types accept Catch: measured against real
+        // AWS, a JSONata Pass state with a Catch still fails SCHEMA_VALIDATION_FAILED, the same
+        // as in JSONPath mode.
+        String def = """
+                {"QueryLanguage":"JSONata","StartAt":"X","States":{"X":{"Type":"Pass","End":true,
+                  "Catch":[{"ErrorEquals":["States.ALL"],"Next":"X"}]}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("SCHEMA_VALIDATION_FAILED"))
+                .body("diagnostics[0].message", equalTo("Field 'Catch' is not supported"))
+                .body("diagnostics[0].location", equalTo("/States/X"));
+    }
+
+    @Test
+    void danglingNextTarget_returnsFailAtNextLocation() {
+        String def = """
+                {"StartAt":"A","States":{
+                  "A":{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke","Next":"Ghost",
+                       "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Z"}]},
+                  "Z":{"Type":"Pass","End":true}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("Missing 'Next' target: Ghost"))
+                .body("diagnostics[0].location", equalTo("/States/A/Next"));
+    }
+
+    @Test
+    void danglingChoiceNextTarget_returnsFailAtChoicesLocation() {
+        String def = """
+                {"StartAt":"C","States":{
+                  "C":{"Type":"Choice",
+                       "Choices":[{"Variable":"$.x","IsPresent":true,"Next":"Ghost"}],
+                       "Default":"Z"},
+                  "Z":{"Type":"Pass","End":true}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("Missing 'Next' target: Ghost"))
+                .body("diagnostics[0].location", equalTo("/States/C/Choices[0]/Next"));
+    }
+
+    @Test
+    void danglingChoiceDefaultTarget_returnsFailAtDefaultLocation() {
+        String def = """
+                {"StartAt":"A","States":{
+                  "A":{"Type":"Choice",
+                       "Choices":[{"Variable":"$.x","IsPresent":true,"Next":"Z"}],
+                       "Default":"Ghost"},
+                  "Z":{"Type":"Pass","End":true}
+                }}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("Missing 'Next' target: Ghost"))
+                .body("diagnostics[0].location", equalTo("/States/A/Default"));
+    }
+
+    @Test
+    void danglingCatchNextTarget_returnsFailAtCatchLocation() {
+        String def = """
+                {"StartAt":"T","States":{"T":{"Type":"Task",
+                  "Resource":"arn:aws:states:::lambda:invoke",
+                  "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Ghost"}],
+                  "End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("Missing 'Next' target: Ghost"))
+                .body("diagnostics[0].location", equalTo("/States/T/Catch[0]/Next"));
+    }
+
+    @Test
+    void unreachableStateInsideItemProcessor_returnsFailAtStructuredPath() {
+        String def = """
+                {"StartAt":"M","States":{"M":{"Type":"Map","ItemsPath":"$.items",
+                  "ItemProcessor":{"StartAt":"W","States":{
+                    "W":{"Type":"Pass","End":true},
+                    "Ghost":{"Type":"Pass","End":true}
+                  }},
+                  "End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("State \"Ghost\" is not reachable."))
+                .body("diagnostics[0].location", equalTo("/States/M/ItemProcessor/States/Ghost"));
+    }
+
+    @Test
+    void unreachableStateInsideParallelBranch_returnsFailAtStructuredPath() {
+        String def = """
+                {"StartAt":"P","States":{"P":{"Type":"Parallel",
+                  "Branches":[{"StartAt":"W","States":{
+                    "W":{"Type":"Pass","End":true},
+                    "Ghost":{"Type":"Pass","End":true}
+                  }}],
+                  "End":true}}}
+                """;
+        validateDefinition(def)
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].code", equalTo("MISSING_TRANSITION_TARGET"))
+                .body("diagnostics[0].message", equalTo("State \"Ghost\" is not reachable."))
+                .body("diagnostics[0].location", equalTo("/States/P/Branches[0]/States/Ghost"));
+    }
+
+    @Test
+    void createStateMachineRefusesLoopWithNoTerminalState() {
+        String def = """
+                {"StartAt":"A","States":{
+                  "A":{"Type":"Pass","Next":"B"},
+                  "B":{"Type":"Pass","Next":"A"}
+                }}
+                """;
+        createStateMachine("no-terminal-" + System.nanoTime(), def)
+                .then().statusCode(400)
+                .body("__type", equalTo("InvalidDefinition"))
+                .body("message", equalTo("Invalid State Machine Definition: "
+                        + "'MISSING_END_STATE: Workflow has no terminal state at null'"));
+    }
+
+    @Test
+    void createStateMachineRefusesTimeoutSecondsOnParallel() {
+        // Once this is refused at CreateStateMachine, no definition that reaches execution can
+        // carry a Parallel TimeoutSeconds — the AslExecutor branch that read it is unreachable.
+        String def = """
+                {"StartAt":"P","States":{"P":{"Type":"Parallel","TimeoutSeconds":5,
+                  "Branches":[{"StartAt":"W","States":{"W":{"Type":"Wait","Seconds":25,"End":true}}}],
+                  "End":true}}}
+                """;
+        createStateMachine("parallel-timeout-" + System.nanoTime(), def)
+                .then().statusCode(400)
+                .body("__type", equalTo("InvalidDefinition"))
+                .body("message", equalTo("Invalid State Machine Definition: "
+                        + "'SCHEMA_VALIDATION_FAILED: Field 'TimeoutSeconds' is not supported "
+                        + "at /States/P'"));
     }
 
     private static String mapDefinition(String topLevelFields, String concurrencyFields) {


### PR DESCRIPTION
Replaced by #2784, which carries this change together with the rest of the `collectValidationErrors` work.