### PR TITLE
fix(stepfunctions): reject JSONata expressions that do not parse at definition time

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataTopLevelReferences.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataTopLevelReferences.java
@@ -2,7 +2,6 @@ package io.github.hectorvent.floci.services.stepfunctions;
 
 import com.dashjoin.jsonata.Parser;
 import io.quarkus.runtime.annotations.RegisterForReflection;
-import org.jboss.logging.Logger;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -14,7 +13,8 @@ import java.util.Objects;
 import java.util.Set;
 
 /**
- * Names every reference a Step Functions JSONata expression makes against the top-level context.
+ * Parses a Step Functions JSONata expression once and reports either the message the parser refused
+ * it with, or every reference it makes against the top-level context.
  *
  * <p>A Step Functions expression is evaluated with no context item: the input arrives as
  * {@code $states.input} and workflow variables as {@code $name}. A path that starts from neither
@@ -39,10 +39,19 @@ import java.util.Set;
 @RegisterForReflection(targets = Parser.Symbol.class, fields = true)
 final class JsonataTopLevelReferences {
 
-    private static final Logger LOG = Logger.getLogger(JsonataTopLevelReferences.class);
-
     /** The name AWS prints for {@code $}, the context item itself. */
     private static final String CONTEXT_ITEM = "$";
+
+    /** The pseudo-reference reported for {@code $$}, AWS's separate name rule. */
+    static final String ROOT_REFERENCE = "$$";
+
+    /**
+     * The pseudo-reference reported for a {@code $states.errorOutput} path, wherever it starts.
+     * Not a top-level context read like the others: {@code $states} is always in scope, but the
+     * {@code errorOutput} field only exists on it inside a {@code Catch} entry's own {@code Output}
+     * and {@code Assign}, and only the caller knows whether the walk is there.
+     */
+    static final String STATES_ERROR_OUTPUT = "$states.errorOutput";
 
     private static final Map<String, Field> TREE_FIELDS = resolveTreeFields(
             "type", "value", "steps", "lhs", "rhs", "expression", "expressions",
@@ -52,22 +61,32 @@ final class JsonataTopLevelReferences {
     }
 
     /**
-     * The distinct top-level references in {@code expression}, in the order they are written.
-     * An expression that does not parse names none: a syntax error is AWS's separate
-     * {@code INVALID_JSONATA_EXPRESSION} rule, and naming nothing leaves the definition accepted.
+     * What parsing {@code expression} once finds: either the parser's own message, unchanged
+     * (AWS's {@code INVALID_JSONATA_EXPRESSION} refuses it with the same sentence, its
+     * {@code S0xxx: } code prefix stripped, and {@link com.dashjoin.jsonata.JException#getMessage()}
+     * never carries that prefix), or the distinct top-level references the expression makes, in
+     * the order they are written.
      */
-    static List<String> in(String expression) {
+    record Analysis(List<String> topLevelReferences, String parseError) {
+        static Analysis parseError(String message) {
+            return new Analysis(List.of(), message);
+        }
+
+        static Analysis references(List<String> names) {
+            return new Analysis(names, null);
+        }
+    }
+
+    static Analysis analyze(String expression) {
         Parser.Symbol root;
         try {
             root = new Parser().parse(expression);
         } catch (Exception e) {
-            LOG.debugf(e, "JSONata expression not parsed, so no top-level reference is named: %s",
-                    expression);
-            return List.of();
+            return Analysis.parseError(e.getMessage());
         }
         Set<String> names = new LinkedHashSet<>();
         collect(root, names);
-        return new ArrayList<>(names);
+        return Analysis.references(new ArrayList<>(names));
     }
 
     private static void collect(Parser.Symbol node, Set<String> names) {
@@ -76,7 +95,12 @@ final class JsonataTopLevelReferences {
             return;
         }
         switch (type) {
-            case "path" -> collect(first(node, "steps"), names);
+            case "path" -> {
+                collect(first(node, "steps"), names);
+                if (isStatesErrorOutputPath(node)) {
+                    names.add(STATES_ERROR_OUTPUT);
+                }
+            }
             case "name" -> names.add(String.valueOf(read(node, "value")));
             case "variable" -> collectContextItem(node, names);
             case "unary" -> collectUnary(node, names);
@@ -105,13 +129,34 @@ final class JsonataTopLevelReferences {
 
     /**
      * {@code $} carries the empty name and is the context item AWS refuses. {@code $$} carries the
-     * name {@code "$"} and AWS refuses it under a different message, which is a separate rule.
-     * Every other variable is a workflow variable or a function, and AWS accepts an undefined one.
+     * name {@code "$"} and AWS refuses it too, under a different message. Every other variable is a
+     * workflow variable or a function, and AWS accepts an undefined one.
      */
     private static void collectContextItem(Parser.Symbol variable, Set<String> names) {
-        if ("".equals(read(variable, "value"))) {
+        String value = String.valueOf(read(variable, "value"));
+        if (value.isEmpty()) {
             names.add(CONTEXT_ITEM);
+        } else if (CONTEXT_ITEM.equals(value)) {
+            // "$$" parses as a variable named "$": the sigil is consumed twice, once as the
+            // variable marker and once as its name.
+            names.add(ROOT_REFERENCE);
         }
+    }
+
+    /**
+     * Whether {@code path}'s first step is {@code $states} and its second is {@code errorOutput}.
+     * Only those two steps matter: whatever follows ({@code $states.errorOutput.Cause}) still reads
+     * the same field on {@code $states} first.
+     */
+    private static boolean isStatesErrorOutputPath(Parser.Symbol path) {
+        List<Parser.Symbol> steps = children(path, "steps");
+        if (steps == null || steps.size() < 2) {
+            return false;
+        }
+        Parser.Symbol first = steps.get(0);
+        Parser.Symbol second = steps.get(1);
+        return "variable".equals(read(first, "type")) && "states".equals(read(first, "value"))
+                && "name".equals(read(second, "type")) && "errorOutput".equals(read(second, "value"));
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -1054,6 +1054,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
             "Pass", "Task", "Choice", "Wait", "Succeed", "Fail", "Parallel", "Map");
     private static final String PARSE_ERROR_MARKER = "INVALID_JSON_DESCRIPTION:";
     private static final String UNSUPPORTED_JSONATA_MARKER = "UNSUPPORTED_JSONATA_EXPRESSION:";
+    private static final String INVALID_JSONATA_MARKER = "INVALID_JSONATA_EXPRESSION:";
 
     // Parse the structured location out of validator flat error strings,
     // which currently encode it as "...field 'X' ... at /States/Y".
@@ -1127,7 +1128,12 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
                     error.substring(PARSE_ERROR_MARKER.length()).trim(), null);
         }
         if (error.startsWith(UNSUPPORTED_JSONATA_MARKER)) {
-            return toJsonataDiagnostic(error.substring(UNSUPPORTED_JSONATA_MARKER.length()).trim());
+            return toJsonataDiagnostic("UNSUPPORTED_JSONATA_EXPRESSION",
+                    error.substring(UNSUPPORTED_JSONATA_MARKER.length()).trim());
+        }
+        if (error.startsWith(INVALID_JSONATA_MARKER)) {
+            return toJsonataDiagnostic("INVALID_JSONATA_EXPRESSION",
+                    error.substring(INVALID_JSONATA_MARKER.length()).trim());
         }
         String message = error;
         String location = null;
@@ -1146,12 +1152,12 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         return new Diagnostic("ERROR", "SCHEMA_VALIDATION_FAILED", message, location);
     }
 
-    private static Diagnostic toJsonataDiagnostic(String message) {
+    private static Diagnostic toJsonataDiagnostic(String code, String message) {
         Matcher locationMatcher = JSONATA_LOCATION_SUFFIX_PATTERN.matcher(message);
         if (!locationMatcher.find()) {
-            return new Diagnostic("ERROR", "UNSUPPORTED_JSONATA_EXPRESSION", message, null);
+            return new Diagnostic("ERROR", code, message, null);
         }
-        return new Diagnostic("ERROR", "UNSUPPORTED_JSONATA_EXPRESSION",
+        return new Diagnostic("ERROR", code,
                 message.substring(0, locationMatcher.start()).trim(), locationMatcher.group(1));
     }
 
@@ -1408,7 +1414,8 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         // A JSONata error already carries its own AWS code and location, so it is reported on its
         // own rather than folded into the schema list.
         List<String> schemaErrors = errors.stream()
-                .filter(error -> !error.startsWith(UNSUPPORTED_JSONATA_MARKER))
+                .filter(error -> !error.startsWith(UNSUPPORTED_JSONATA_MARKER)
+                        && !error.startsWith(INVALID_JSONATA_MARKER))
                 .toList();
         if (schemaErrors.isEmpty()) {
             throw new AwsException("InvalidDefinition",
@@ -1523,12 +1530,14 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     }
 
     /**
-     * Reports every JSONata expression in the state that reads the top-level context, which real
-     * AWS refuses at CreateStateMachine time. Only the fields AWS parses as JSONata are walked:
-     * measured against {@code validate-state-machine-definition}, a {@code {% %}} string in
-     * Comment, Next, Default, Resource, ErrorEquals, Retry, Credentials or ReaderConfig.CSVHeaders
-     * is left alone, while Output, Assign, Arguments, Items, Seconds, Condition, ItemBatcher,
-     * ItemReader, ItemSelector, ResultWriter and the rest are parsed and reported.
+     * Reports every JSONata expression in the state that does not parse, or that reads the
+     * top-level context, or that reads {@code $states.errorOutput} outside the one place it
+     * exists: all three are refused by real AWS at CreateStateMachine time. Only the fields AWS
+     * parses as JSONata are walked: measured against {@code validate-state-machine-definition}, a
+     * {@code {% %}} string in Comment, Next, Default, Resource, ErrorEquals, Retry, Credentials or
+     * ReaderConfig.CSVHeaders is left alone, while Output, Assign, Arguments, Items, Seconds,
+     * Condition, ItemBatcher, ItemReader, ItemSelector, ResultWriter and the rest are parsed and
+     * reported.
      *
      * <p>Those names are ASL fields, not payload keys. AWS parses a payload whole, so
      * {@code Assign: {"Next": "{% phone %}"}} and {@code Arguments: {"Payload": {"Comment":
@@ -1536,35 +1545,84 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
      * walk enters one of {@link #JSONATA_PAYLOAD_FIELDS}.
      */
     private static void collectTopLevelReferences(String path, JsonNode node, List<String> errors) {
-        collectTopLevelReferences(path, node, false, errors);
+        collectTopLevelReferences(path, node, JsonataScope.STATE_ROOT, errors);
     }
 
-    private static void collectTopLevelReferences(String path, JsonNode node, boolean insidePayload,
+    private static void collectTopLevelReferences(String path, JsonNode node, JsonataScope scope,
                                                   List<String> errors) {
         if (node.isObject()) {
             node.fields().forEachRemaining(field -> {
-                String name = field.getKey();
-                if (insidePayload || !ASL_FIELDS_AWS_DOES_NOT_PARSE_AS_JSONATA.contains(name)) {
-                    collectTopLevelReferences(path + "/" + name, field.getValue(),
-                            insidePayload || JSONATA_PAYLOAD_FIELDS.contains(name), errors);
+                if (scope.parsesAsJsonata(field.getKey())) {
+                    collectTopLevelReferences(path + "/" + field.getKey(), field.getValue(),
+                            scope.enter(field.getKey()), errors);
                 }
             });
             return;
         }
         if (node.isArray()) {
             for (int index = 0; index < node.size(); index++) {
-                collectTopLevelReferences(path + "[" + index + "]", node.get(index), insidePayload,
-                        errors);
+                collectTopLevelReferences(path + "[" + index + "]", node.get(index), scope, errors);
             }
             return;
         }
         if (!node.isTextual() || !JsonataEvaluator.isExpression(node.asText())) {
             return;
         }
-        for (String reference : JsonataTopLevelReferences.in(JsonataEvaluator.unwrap(node.asText()))) {
-            errors.add(UNSUPPORTED_JSONATA_MARKER + " Reference to '" + reference
-                    + "' at the top level is not supported. at " + path);
+        JsonataTopLevelReferences.Analysis analysis =
+                JsonataTopLevelReferences.analyze(JsonataEvaluator.unwrap(node.asText()));
+        if (analysis.parseError() != null) {
+            errors.add(INVALID_JSONATA_MARKER + " " + analysis.parseError() + " at " + path);
+            return;
         }
+        for (String reference : analysis.topLevelReferences()) {
+            addUnsupportedReferenceError(path, reference, scope, errors);
+        }
+    }
+
+    /**
+     * The three things the walk carries down from the ASL fields it has already entered, each of
+     * which changes how a {@code {% %}} string below is read: inside a payload every key is a
+     * payload key, so {@link #ASL_FIELDS_AWS_DOES_NOT_PARSE_AS_JSONATA} no longer applies;
+     * {@code atCatchEntry} marks a catcher object, whose own {@code Output} and {@code Assign} are
+     * the one place {@code $states.errorOutput} resolves; and {@code insideCatchOutputOrAssign}
+     * says the walk is in one of those two, at any depth.
+     */
+    private record JsonataScope(boolean insidePayload, boolean atCatchEntry,
+                                boolean insideCatchOutputOrAssign) {
+
+        private static final JsonataScope STATE_ROOT = new JsonataScope(false, false, false);
+
+        private boolean parsesAsJsonata(String field) {
+            return insidePayload || !ASL_FIELDS_AWS_DOES_NOT_PARSE_AS_JSONATA.contains(field);
+        }
+
+        private JsonataScope enter(String field) {
+            if (insidePayload) {
+                return this;
+            }
+            return new JsonataScope(
+                    JSONATA_PAYLOAD_FIELDS.contains(field),
+                    "Catch".equals(field),
+                    insideCatchOutputOrAssign
+                            || (atCatchEntry && ("Output".equals(field) || "Assign".equals(field))));
+        }
+    }
+
+    private static void addUnsupportedReferenceError(String path, String reference,
+                                                     JsonataScope scope, List<String> errors) {
+        if (JsonataTopLevelReferences.STATES_ERROR_OUTPUT.equals(reference)) {
+            if (!scope.insideCatchOutputOrAssign()) {
+                errors.add(UNSUPPORTED_JSONATA_MARKER
+                        + " Field '$states.errorOutput' does not exist. at " + path);
+            }
+            return;
+        }
+        if (JsonataTopLevelReferences.ROOT_REFERENCE.equals(reference)) {
+            errors.add(UNSUPPORTED_JSONATA_MARKER + " Reference to '$$' is not supported. at " + path);
+            return;
+        }
+        errors.add(UNSUPPORTED_JSONATA_MARKER + " Reference to '" + reference
+                + "' at the top level is not supported. at " + path);
     }
 
     private void validateNestedStates(JsonNode states, String statesPath,

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataTopLevelReferencesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataTopLevelReferencesTest.java
@@ -8,15 +8,21 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Every expression here was run through
  * {@code aws stepfunctions validate-state-machine-definition --region us-east-1} as the Output of
  * a one-state Pass machine. The names asserted are the ones AWS puts in
- * {@code Reference to '<name>' at the top level is not supported.}, and the expressions asserted
- * empty are the ones AWS answers {@code result: OK}.
+ * {@code Reference to '<name>' at the top level is not supported.}, the expressions asserted
+ * empty are the ones AWS answers {@code result: OK}, and the parse errors asserted are the
+ * messages AWS puts in its {@code INVALID_JSONATA_EXPRESSION} diagnostic, word for word.
  */
 class JsonataTopLevelReferencesTest {
+
+    private static List<String> references(String expression) {
+        return JsonataTopLevelReferences.analyze(expression).topLevelReferences();
+    }
 
     @ParameterizedTest
     @ValueSource(strings = {
@@ -43,7 +49,7 @@ class JsonataTopLevelReferencesTest {
             "phone.**.deeper"})
     @DisplayName("AWS names the identifier read at the top level")
     void namesTheTopLevelIdentifier(String expression) {
-        assertEquals(List.of("phone"), JsonataTopLevelReferences.in(expression));
+        assertEquals(List.of("phone"), references(expression));
     }
 
     @ParameterizedTest
@@ -71,7 +77,7 @@ class JsonataTopLevelReferencesTest {
             "$now()"})
     @DisplayName("AWS accepts a name that is not read from the top-level context")
     void namesNothingWhenTheReferenceIsAnchored(String expression) {
-        assertEquals(List.of(), JsonataTopLevelReferences.in(expression));
+        assertEquals(List.of(), references(expression));
     }
 
     @ParameterizedTest
@@ -79,32 +85,62 @@ class JsonataTopLevelReferencesTest {
             "$map($states.input.a, function($x){ $ })"})
     @DisplayName("the context item itself is named '$', as AWS names it")
     void namesTheContextItem(String expression) {
-        assertEquals(List.of("$"), JsonataTopLevelReferences.in(expression));
+        assertEquals(List.of("$"), references(expression));
     }
 
-    @Test
-    @DisplayName("'$$' is AWS's separate rule and is left to it")
-    void leavesTheRootReferenceAlone() {
-        assertEquals(List.of(), JsonataTopLevelReferences.in("$$"));
-        assertEquals(List.of(), JsonataTopLevelReferences.in("$$.phone"));
+    @ParameterizedTest
+    @ValueSource(strings = {"$$", "$$.phone"})
+    @DisplayName("'$$' is named on its own, as AWS's separate rule needs")
+    void namesTheRootReference(String expression) {
+        assertEquals(List.of("$$"), references(expression));
     }
 
     @Test
     @DisplayName("every distinct name is reported once, in writing order")
     void reportsEveryDistinctNameOnce() {
-        assertEquals(List.of("aaa", "bbb"), JsonataTopLevelReferences.in("aaa + bbb"));
-        assertEquals(List.of("bbb", "aaa"), JsonataTopLevelReferences.in("[bbb, aaa]"));
-        assertEquals(List.of("aaa"), JsonataTopLevelReferences.in("aaa + aaa"));
-        assertEquals(List.of("aaa", "bbb"), JsonataTopLevelReferences.in("(aaa; bbb)"));
-        assertEquals(List.of("aaa", "bbb"),
-                JsonataTopLevelReferences.in("$number(aaa) + $number(bbb)"));
+        assertEquals(List.of("aaa", "bbb"), references("aaa + bbb"));
+        assertEquals(List.of("bbb", "aaa"), references("[bbb, aaa]"));
+        assertEquals(List.of("aaa"), references("aaa + aaa"));
+        assertEquals(List.of("aaa", "bbb"), references("(aaa; bbb)"));
+        assertEquals(List.of("aaa", "bbb"), references("$number(aaa) + $number(bbb)"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "$states.errorOutput",
+            "$states.errorOutput.Cause",
+            "$states.errorOutput.Error",
+            "[$states.errorOutput]",
+            "$states.errorOutput ? 1 : 2"})
+    @DisplayName("'$states.errorOutput' is named on its own; whether it is allowed is the caller's call")
+    void namesTheStatesErrorOutputPath(String expression) {
+        assertEquals(List.of("$states.errorOutput"), references(expression));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"$states.input.errorOutput", "$states.error", "$states"})
+    @DisplayName("only the exact '$states.errorOutput' path is named")
+    void namesNothingForALookalikeStatesPath(String expression) {
+        assertEquals(List.of(), references(expression));
     }
 
     @Test
-    @DisplayName("a syntax error names nothing, so the definition stays accepted")
-    void namesNothingWhenTheExpressionDoesNotParse() {
-        assertEquals(List.of(), JsonataTopLevelReferences.in("phone[1,2)"));
-        assertEquals(List.of(), JsonataTopLevelReferences.in("phone %.other"));
-        assertEquals(List.of(), JsonataTopLevelReferences.in(""));
+    @DisplayName("a syntax error names nothing but reports the message AWS prints for it")
+    void reportsTheParserMessageWhenTheExpressionDoesNotParse() {
+        assertParseError("phone[1,2)", "Expected \"]\", got \",\"");
+        assertParseError("phone %.other", "The symbol \".\" cannot be used as a unary operator");
+        assertParseError("", "Unexpected end of expression");
+    }
+
+    private static void assertParseError(String expression, String expectedMessage) {
+        JsonataTopLevelReferences.Analysis analysis = JsonataTopLevelReferences.analyze(expression);
+        assertEquals(List.of(), analysis.topLevelReferences());
+        assertEquals(expectedMessage, analysis.parseError());
+    }
+
+    @Test
+    @DisplayName("an expression that parses carries no parse error")
+    void carriesNoParseErrorWhenTheExpressionParses() {
+        assertNull(JsonataTopLevelReferences.analyze("phone").parseError());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsTopLevelReferenceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsTopLevelReferenceIntegrationTest.java
@@ -13,8 +13,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 /**
- * A JSONata expression that reads the top-level context is refused when the state machine is
- * created, as real AWS refuses it. Every message and location asserted here was measured with
+ * A JSONata expression that reads the top-level context, or that does not parse at all, is refused
+ * when the state machine is created, as real AWS refuses it. Every message and location asserted
+ * here was measured with
  * {@code aws stepfunctions validate-state-machine-definition --region us-east-1} on the same
  * definition, and the CreateStateMachine wire shape with
  * {@code aws stepfunctions create-state-machine}.
@@ -82,6 +83,18 @@ class StepFunctionsTopLevelReferenceIntegrationTest {
                 .body("message", equalTo("Invalid State Machine Definition: "
                         + "'UNSUPPORTED_JSONATA_EXPRESSION: Reference to 'phone' at the top level "
                         + "is not supported. at /States/E/Output/v'"));
+    }
+
+    @Test
+    @DisplayName("CreateStateMachine refuses a syntax error with AWS's InvalidDefinition message")
+    void createStateMachineRefusesASyntaxError() {
+        create("invalid-jsonata-expression-" + System.nanoTime(),
+                passWithOutput("{\"v\":\"{% phone[1,2) %}\"}"))
+                .then().statusCode(400)
+                .body("__type", equalTo("InvalidDefinition"))
+                .body("message", equalTo("Invalid State Machine Definition: "
+                        + "'INVALID_JSONATA_EXPRESSION: Expected \"]\", got \",\" "
+                        + "at /States/E/Output/v'"));
     }
 
     @Test
@@ -304,8 +317,14 @@ class StepFunctionsTopLevelReferenceIntegrationTest {
     }
 
     @Test
-    @DisplayName("a syntax error is left to the execution, as it is today")
-    void syntaxErrorsAreOutOfScope() {
-        expectAccepted(passWithOutput("{\"v\":\"{% phone[1,2) %}\"}"));
+    @DisplayName("a syntax error is refused at definition time")
+    void syntaxErrorsAreRefusedAtDefinitionTime() {
+        validate(passWithOutput("{\"v\":\"{% phone[1,2) %}\"}")).then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].severity", equalTo("ERROR"))
+                .body("diagnostics[0].code", equalTo("INVALID_JSONATA_EXPRESSION"))
+                .body("diagnostics[0].message", equalTo("Expected \"]\", got \",\""))
+                .body("diagnostics[0].location", equalTo("/States/E/Output/v"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsValidateStateMachineDefinitionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsValidateStateMachineDefinitionIntegrationTest.java
@@ -1,12 +1,18 @@
 package io.github.hectorvent.floci.services.stepfunctions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -92,6 +98,42 @@ class StepFunctionsValidateStateMachineDefinitionIntegrationTest {
         RestAssuredJsonUtils.configureAwsContentTypes();
     }
 
+    // A one-state Pass machine whose Output holds the given JSONata expression. The ObjectMapper
+    // escapes the quotes and braces the expressions carry into a valid JSON string.
+    private static String outputExpressionDefinition(String expression) {
+        ObjectNode root = OBJECT_MAPPER.createObjectNode();
+        root.put("QueryLanguage", "JSONata");
+        root.put("StartAt", "Main");
+        ObjectNode main = root.putObject("States").putObject("Main");
+        main.put("Type", "Pass");
+        main.put("Output", "{% " + expression + " %}");
+        main.put("End", true);
+        return root.toString();
+    }
+
+    // A Task whose Catch entry holds the given JSONata expression in its own Output or Assign,
+    // the one place AWS resolves $states.errorOutput.
+    private static String catchDefinition(String catcherField, String expression) {
+        ObjectNode root = OBJECT_MAPPER.createObjectNode();
+        root.put("QueryLanguage", "JSONata");
+        root.put("StartAt", "Main");
+        ObjectNode states = root.putObject("States");
+        ObjectNode main = states.putObject("Main");
+        main.put("Type", "Task");
+        main.put("Resource", "arn:aws:states:::lambda:invoke");
+        main.put("Next", "Handled");
+        ObjectNode catcher = main.putArray("Catch").addObject();
+        catcher.putArray("ErrorEquals").add("States.ALL");
+        catcher.put("Next", "Handled");
+        if ("Assign".equals(catcherField)) {
+            catcher.putObject("Assign").put("lastError", "{% " + expression + " %}");
+        } else {
+            catcher.put(catcherField, "{% " + expression + " %}");
+        }
+        states.putObject("Handled").put("Type", "Pass").put("End", true);
+        return root.toString();
+    }
+
     private static Response validateDefinition(String definition) {
         String body = OBJECT_MAPPER.createObjectNode().put("definition", definition).toString();
         return given().contentType(CT).header("X-Amz-Target", TARGET)
@@ -140,6 +182,76 @@ class StepFunctionsValidateStateMachineDefinitionIntegrationTest {
                   }
                 }
                 """.replace("__RESULT_WRITER__", resultWriter);
+    }
+
+    // Every (expression, message) pair here was run through
+    // `aws stepfunctions validate-state-machine-definition --region us-east-1`: the message is
+    // AWS's INVALID_JSONATA_EXPRESSION text, which is floci's own parser message with its
+    // "S0xxx: " code prefix stripped.
+    private static Stream<Arguments> invalidJsonataExpressions() {
+        return Stream.of(
+                Arguments.of("a[1,2)", "Expected \"]\", got \",\""),
+                Arguments.of("\"unterminated", "String literal must be terminated by a matching quote"),
+                Arguments.of("1 +", "Unexpected end of expression"),
+                Arguments.of("{\"a\":}", "The symbol \"}\" cannot be used as a unary operator"),
+                Arguments.of("$x :=", "Unexpected end of expression"),
+                Arguments.of("$match(\"a\", /abc", "No terminating / in regular expression"),
+                Arguments.of("phone %.other", "The symbol \".\" cannot be used as a unary operator"),
+                Arguments.of("", "Unexpected end of expression"));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidJsonataExpressions")
+    void unparsableJsonataExpression_returnsFailWithInvalidJsonataExpression(
+            String expression, String expectedMessage) {
+        validateDefinition(outputExpressionDefinition(expression))
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].severity", equalTo("ERROR"))
+                .body("diagnostics[0].code", equalTo("INVALID_JSONATA_EXPRESSION"))
+                .body("diagnostics[0].message", equalTo(expectedMessage))
+                .body("diagnostics[0].location", equalTo("/States/Main/Output"));
+    }
+
+    @Test
+    void doubleDollarReference_returnsFailWithUnsupportedJsonataExpression() {
+        validateDefinition(outputExpressionDefinition("$$"))
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].severity", equalTo("ERROR"))
+                .body("diagnostics[0].code", equalTo("UNSUPPORTED_JSONATA_EXPRESSION"))
+                .body("diagnostics[0].message", equalTo("Reference to '$$' is not supported."))
+                .body("diagnostics[0].location", equalTo("/States/Main/Output"));
+    }
+
+    @Test
+    void statesErrorOutputOutsideCatch_returnsFailWithUnsupportedJsonataExpression() {
+        validateDefinition(outputExpressionDefinition("$states.errorOutput"))
+                .then().statusCode(200)
+                .body("result", equalTo("FAIL"))
+                .body("diagnostics", hasSize(1))
+                .body("diagnostics[0].severity", equalTo("ERROR"))
+                .body("diagnostics[0].code", equalTo("UNSUPPORTED_JSONATA_EXPRESSION"))
+                .body("diagnostics[0].message", equalTo("Field '$states.errorOutput' does not exist."))
+                .body("diagnostics[0].location", equalTo("/States/Main/Output"));
+    }
+
+    @Test
+    void statesErrorOutputInsideCatchOutput_isAccepted() {
+        validateDefinition(catchDefinition("Output", "$states.errorOutput"))
+                .then().statusCode(200)
+                .body("result", equalTo("OK"))
+                .body("diagnostics", hasSize(0));
+    }
+
+    @Test
+    void statesErrorOutputInsideCatchAssign_isAccepted() {
+        validateDefinition(catchDefinition("Assign", "$states.errorOutput"))
+                .then().statusCode(200)
+                .body("result", equalTo("OK"))
+                .body("diagnostics", hasSize(0));
     }
 
     @Test


### PR DESCRIPTION
Replaced by #2784, which carries this change together with the rest of the `collectValidationErrors` work.