### PR TITLE
fix(stepfunctions): match AWS on the JSONata expressions it refuses

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -158,7 +158,7 @@ top of the JSONata language, alongside every function JSONata itself provides.
 
 | Function | Returns |
 | --- | --- |
-| `$parse(jsonString)` | the deserialized value; the replacement for `$eval`, which AWS disables |
+| `$parse(jsonString)` | the deserialized value; the replacement for `$eval`, which AWS disables and so does Floci, answering `T1006` to a call |
 | `$partition(array, chunkSize)` | `array` split into chunks of `chunkSize`, the last one holding the remainder |
 | `$range(start, end, step)` | the values from `start` to `end`, inclusive when `step` lands on `end` |
 | `$hash(str, algorithm)` | the hex digest of `str`; `algorithm` is `MD5`, `SHA-1`, `SHA-256`, `SHA-384` or `SHA-512`, case-sensitive |
@@ -179,16 +179,41 @@ JSONata's own `$string` follows AWS's number notation: a whole number is written
 `1e21` and in exponent notation from there, on both signs, so `$string(1e20)` is
 `100000000000000000000` and `$string(1e21)` is `1e+21`.
 
-Evaluation is bounded, as it is on AWS: one expression may run for five seconds and nest 500
-levels deep, and past either the state fails with `States.QueryEvaluationError`. Both bounds sit
-well above what AWS itself accepts, so an expression that evaluates there evaluates here. AWS
-refuses a non-tail-recursive function past a nesting depth near 100, and the largest sequence it
-accepts evaluates here in about a tenth of a second.
+JSONata's own `$formatNumber` checks its picture string against the fourteen rules of XPath F&O
+4.7.3, as AWS does, so `$formatNumber(1, "x")` fails with `D3086` rather than answering `x1`: a
+picture with no digit in it describes no number.
 
-One deviation. AWS also bounds the *memory* an expression may use, refusing
-`[1..900000] ~> $count()` with `Expression evaluation memory limit exceeded` while accepting the
-same expression at 800,000 elements. Floci bounds time and depth but not memory, and its ranges
-are lazy, so that expression answers immediately at any size.
+Evaluation is bounded on three axes, as it is on AWS, and past any of them the state fails with
+`States.QueryEvaluationError`.
+
+- **Depth**: one expression may nest 100 levels, which is AWS's own ceiling: AWS accepts `1+1+…+1`
+  at 100 terms, 99 parentheses, 99 brackets, 99 `~>` stages, and a non-tail-recursive `$f(31)`,
+  which nests `3n+5`, and refuses one level more of each. The refusal names the depth reached, as
+  in `Stack overflow error: … Depth=101 max=100`.
+- **Memory**: one value an expression builds may hold 6,990,256 bytes, counting a number as eight
+  bytes and a character as one. That is AWS's own bound: AWS accepts `[1..873782]` and refuses one
+  element more, and it accepts a string doubled 22 times, 2^22 characters, refusing the 23rd. The
+  refusal is AWS's own
+  `Expression evaluation memory limit exceeded`, which is what `[1..900000] ~> $count()` and
+  `$sum([1..900000])` now answer.
+- **Time**: five seconds, which is the library's own default and roughly fifty times the slowest
+  evaluation of a payload AWS itself accepts. A recursive expression with no base case is a tail
+  call, so it loops rather than nesting and only the clock ends it.
+
+JSON has no literal for a non-finite number, so AWS writes each one as the string JavaScript names
+it by, wherever it lands: `1/0` is `"Infinity"`, `1e308 * 10` is `"Infinity"`, `0/0` is `"NaN"` and
+`$parseInteger("abc", "0")` is `"NaN"`, and nested, `[1/0]` is `["Infinity"]` and `{"k": 1/0}` is
+`{"k": "Infinity"}`.
+
+One deviation, on the arithmetic half of that. A non-finite number a **function** answers is a value
+like any other here, so `$parseInteger("abc", "0")` is `"NaN"` on its own, inside an array and
+inside an object, as on AWS. One the **arithmetic** produces is not: the JSONata library refuses to
+carry it and raises instead, so Floci sees the value only in that refusal, after it has unwound
+whatever was being built around it. `1/0`, `-1/0` and `1e308 * 10` are answered because the
+expression's own result is what was refused; `[1/0]`, `{"k": 1/0}` and `$string(1/0)` fail the state
+with `States.QueryEvaluationError` where AWS answers a string, and `0/0` fails the field that holds
+it, because NaN is dropped as not-a-number without even a refusal to read it from. A state that
+fails is one a `Catch` fires on, which is the half of the divergence worth keeping.
 
 ## Nested workflows
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/FormatNumberPicture.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/FormatNumberPicture.java
@@ -1,0 +1,238 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.dashjoin.jsonata.JException;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * The picture string of {@code $formatNumber}, checked against the rules XPath F&amp;O 4.7.3 gives
+ * it, which is what AWS applies and the bundled JSONata library does not: it formats through
+ * {@link java.text.DecimalFormat} and answers {@code "x1"} for {@code $formatNumber(1, "x")} where
+ * AWS fails the state with D3086.
+ *
+ * <p>A picture may break more than one of the fourteen rules, and the code reported is the last
+ * one, which is the one AWS reports: a picture with no digit at all breaks two at once, the
+ * mantissa holding no digit (D3085) and the active part holding a passive character (D3086), and
+ * D3086 is the answer.
+ *
+ * <p>The symbols the rules are written in terms of are the built-in ones, each replaceable through
+ * the third argument of {@code $formatNumber}.
+ */
+final class FormatNumberPicture {
+
+    private final char decimalSeparator;
+    private final char exponentSeparator;
+    private final char groupingSeparator;
+    private final char digit;
+    private final char patternSeparator;
+    private final char percent;
+    private final char perMille;
+    private final char zeroDigit;
+
+    private FormatNumberPicture(Map<?, ?> options) {
+        decimalSeparator = symbol(options, "decimal-separator", '.');
+        exponentSeparator = symbol(options, "exponent-separator", 'e');
+        groupingSeparator = symbol(options, "grouping-separator", ',');
+        digit = symbol(options, "digit", '#');
+        patternSeparator = symbol(options, "pattern-separator", ';');
+        percent = symbol(options, "percent", '%');
+        perMille = symbol(options, "per-mille", '‰');
+        zeroDigit = symbol(options, "zero-digit", '0');
+    }
+
+    private static char symbol(Map<?, ?> options, String name, char builtIn) {
+        Object override = options == null ? null : options.get(name);
+        return override instanceof String text && text.length() == 1 ? text.charAt(0) : builtIn;
+    }
+
+    /**
+     * Fails with the code of the rule the picture breaks, or returns when it breaks none. The
+     * picture is split into sub-pictures first, one for positive numbers and an optional second
+     * one for negative numbers.
+     */
+    static void validate(String picture, Map<?, ?> options) {
+        FormatNumberPicture symbols = new FormatNumberPicture(options);
+        String[] subPictures =
+                picture.split(Pattern.quote(String.valueOf(symbols.patternSeparator)), -1);
+        if (subPictures.length > 2) {
+            throw new JException("D3080", -1);
+        }
+        for (String subPicture : subPictures) {
+            String error = symbols.errorIn(symbols.split(subPicture));
+            if (error != null) {
+                throw new JException(error, -1);
+            }
+        }
+    }
+
+    /**
+     * The parts a sub-picture is read in. The prefix and the suffix are the passive characters at
+     * either edge, so the active part is what sits between them; the mantissa is the active part
+     * up to the exponent separator, and the integer and fractional parts are the mantissa either
+     * side of the decimal separator.
+     */
+    private record Parts(String subPicture, String activePart, String mantissaPart,
+                         String integerPart, String fractionalPart, String exponentPart) { }
+
+    private Parts split(String subPicture) {
+        int activeStart = 0;
+        while (activeStart < subPicture.length() && !isActiveOutsideExponent(subPicture.charAt(activeStart))) {
+            activeStart++;
+        }
+        int activeEnd = subPicture.length();
+        while (activeEnd > 0 && !isActiveOutsideExponent(subPicture.charAt(activeEnd - 1))) {
+            activeEnd--;
+        }
+        // A sub-picture with no active character at all is all active part and has no edges.
+        if (activeEnd == 0) {
+            activeStart = 0;
+            activeEnd = subPicture.length();
+        }
+        String activePart = subPicture.substring(activeStart, activeEnd);
+        int exponentAt = subPicture.indexOf(exponentSeparator, activeStart);
+        boolean hasExponent = exponentAt >= 0 && exponentAt <= activeEnd;
+        String mantissaPart = hasExponent ? upTo(activePart, exponentAt) : activePart;
+        String exponentPart = hasExponent ? from(activePart, exponentAt + 1) : null;
+        int decimalAt = mantissaPart.indexOf(decimalSeparator);
+        String integerPart = decimalAt < 0 ? mantissaPart : mantissaPart.substring(0, decimalAt);
+        String fractionalPart =
+                decimalAt < 0 ? subPicture.substring(activeEnd) : mantissaPart.substring(decimalAt + 1);
+        return new Parts(subPicture, activePart, mantissaPart, integerPart, fractionalPart, exponentPart);
+    }
+
+    /** The exponent separator is located in the sub-picture, so it can point past the active part. */
+    private static String upTo(String text, int end) {
+        return text.substring(0, Math.min(end, text.length()));
+    }
+
+    private static String from(String text, int start) {
+        return text.substring(Math.min(start, text.length()));
+    }
+
+    /**
+     * The code of the last rule the sub-picture breaks, or null when it breaks none. The rules are
+     * read in the order the codes number them, and a later one replaces what an earlier one found.
+     */
+    private String errorIn(Parts parts) {
+        String error = separatorCountError(parts.subPicture());
+        error = later(error, digitError(parts));
+        error = later(error, groupingSeparatorError(parts));
+        error = later(error, optionalDigitError(parts));
+        error = later(error, exponentError(parts));
+        return error;
+    }
+
+    private static String later(String error, String found) {
+        return found != null ? found : error;
+    }
+
+    /** D3081 to D3084: a symbol that may appear once appears twice, or two that exclude each other. */
+    private String separatorCountError(String subPicture) {
+        String error = null;
+        if (subPicture.indexOf(decimalSeparator) != subPicture.lastIndexOf(decimalSeparator)) {
+            error = "D3081";
+        }
+        if (subPicture.indexOf(percent) != subPicture.lastIndexOf(percent)) {
+            error = "D3082";
+        }
+        if (subPicture.indexOf(perMille) != subPicture.lastIndexOf(perMille)) {
+            error = "D3083";
+        }
+        if (subPicture.indexOf(percent) >= 0 && subPicture.indexOf(perMille) >= 0) {
+            error = "D3084";
+        }
+        return error;
+    }
+
+    /** D3085 and D3086: the mantissa holds no digit, and the active part holds a passive character. */
+    private String digitError(Parts parts) {
+        String error = null;
+        if (!holdsDigit(parts.mantissaPart())) {
+            error = "D3085";
+        }
+        if (!parts.activePart().chars().allMatch(character -> isActive((char) character))) {
+            error = "D3086";
+        }
+        return error;
+    }
+
+    /** D3087 to D3089: a grouping separator next to the decimal separator, at the end, or doubled. */
+    private String groupingSeparatorError(Parts parts) {
+        String subPicture = parts.subPicture();
+        int decimalAt = subPicture.indexOf(decimalSeparator);
+        String error = null;
+        if (decimalAt >= 0 && (characterAt(subPicture, decimalAt - 1) == groupingSeparator
+                || characterAt(subPicture, decimalAt + 1) == groupingSeparator)) {
+            error = "D3087";
+        } else if (decimalAt < 0 && !parts.integerPart().isEmpty()
+                && parts.integerPart().charAt(parts.integerPart().length() - 1) == groupingSeparator) {
+            error = "D3088";
+        }
+        if (subPicture.indexOf("" + groupingSeparator + groupingSeparator) >= 0) {
+            error = "D3089";
+        }
+        return error;
+    }
+
+    /**
+     * D3090 and D3091: an optional digit with a mandatory one on the side the number grows from,
+     * which is to its left in the integer part and to its right in the fractional part.
+     */
+    private String optionalDigitError(Parts parts) {
+        String error = null;
+        int firstOptional = parts.integerPart().indexOf(digit);
+        if (firstOptional >= 0 && holdsDecimalDigit(parts.integerPart().substring(0, firstOptional))) {
+            error = "D3090";
+        }
+        int lastOptional = parts.fractionalPart().lastIndexOf(digit);
+        if (lastOptional >= 0 && holdsDecimalDigit(parts.fractionalPart().substring(lastOptional))) {
+            error = "D3091";
+        }
+        return error;
+    }
+
+    /** D3092 and D3093: an exponent alongside a percent, and an exponent that is not all digits. */
+    private String exponentError(Parts parts) {
+        if (parts.exponentPart() == null) {
+            return null;
+        }
+        boolean scaled = parts.subPicture().indexOf(percent) >= 0
+                || parts.subPicture().indexOf(perMille) >= 0;
+        String error = null;
+        if (!parts.exponentPart().isEmpty() && scaled) {
+            error = "D3092";
+        }
+        if (parts.exponentPart().isEmpty()
+                || !parts.exponentPart().chars().allMatch(character -> isDecimalDigit((char) character))) {
+            error = "D3093";
+        }
+        return error;
+    }
+
+    private static char characterAt(String text, int index) {
+        return index >= 0 && index < text.length() ? text.charAt(index) : '\0';
+    }
+
+    private boolean holdsDigit(String text) {
+        return text.chars().anyMatch(character -> isDecimalDigit((char) character) || character == digit);
+    }
+
+    private boolean holdsDecimalDigit(String text) {
+        return text.chars().anyMatch(character -> isDecimalDigit((char) character));
+    }
+
+    private boolean isDecimalDigit(char character) {
+        return character >= zeroDigit && character < zeroDigit + 10;
+    }
+
+    private boolean isActive(char character) {
+        return isDecimalDigit(character) || character == decimalSeparator
+                || character == exponentSeparator || character == groupingSeparator
+                || character == digit || character == patternSeparator;
+    }
+
+    private boolean isActiveOutsideExponent(char character) {
+        return isActive(character) && character != exponentSeparator;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.stepfunctions;
 import com.dashjoin.jsonata.Functions;
 import com.dashjoin.jsonata.JException;
 import com.dashjoin.jsonata.Jsonata;
+import com.dashjoin.jsonata.Utils;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -21,6 +23,7 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HexFormat;
 import java.util.Iterator;
@@ -91,14 +94,33 @@ public class JsonataEvaluator {
     static final long EVALUATION_TIMEOUT_MILLIS = 5_000;
 
     /**
-     * How deep evaluation may nest before the state fails. A non-tail-recursive function nests at
-     * roughly {@code 3n+5} for {@code $f(n)}; measured against AWS with {@code test-state}, AWS
-     * accepts {@code n=30} (depth 95) and refuses {@code n=40} (depth 125), so its own ceiling
-     * sits near 100. Five times that leaves no expression AWS accepts able to reach this bound,
-     * and it still trips before the JVM stack does: on a 1 MB thread stack the bound raises a
-     * JSONata error while 1000 or more overflows the stack instead.
+     * How deep evaluation may nest before the state fails, which is the ceiling AWS itself holds:
+     * AWS accepts an evaluation at depth 100 and refuses one at 101, whatever the nesting is made
+     * of. An addition chain nests one level per term, parentheses, brackets and the chain operator
+     * nest one level more than their count, and a non-tail-recursive {@code $f(n)} nests
+     * {@code 3n+5}.
+     *
+     * <p>The bound trips before the JVM stack does: on a 1 MB thread stack it raises a JSONata
+     * error, which the state fails on, where 1000 or more overflows the stack instead.
      */
-    static final int MAX_EVALUATION_DEPTH = 500;
+    static final int MAX_EVALUATION_DEPTH = 100;
+
+    /** What one number, boolean or null of a value counts as against {@link #MAX_EXPRESSION_BYTES}. */
+    private static final int BYTES_PER_SCALAR = 8;
+
+    /**
+     * How much memory one value an expression builds may hold before the state fails, 6,990,256
+     * bytes, which is the bound AWS itself holds: AWS accepts {@code [1..873782]} and refuses one
+     * element more, and it accepts a string of 2^22 characters and refuses one of 2^23. Both of
+     * those refusals land just past this bound when a number counts as {@link #BYTES_PER_SCALAR}
+     * bytes and a character as one.
+     *
+     * <p>What is bounded is the largest single value an evaluation step produces, not the sum of
+     * everything alive at once. Checking it walks that value and stops as soon as the walk passes
+     * the bound, so one check costs at most 873,783 steps, and a lazy range is counted from its
+     * length without being materialised.
+     */
+    static final long MAX_EXPRESSION_BYTES = 873_782L * BYTES_PER_SCALAR;
 
     private final ObjectMapper objectMapper;
     private final ObjectReader strictJsonReader;
@@ -161,6 +183,7 @@ public class JsonataEvaluator {
 
     JsonNode evaluate(String expression, JsonNode statesVar, JsonNode variables) {
         String expr = isExpression(expression) ? unwrap(expression) : expression;
+        ExpressionNesting nesting = new ExpressionNesting();
         try {
             Jsonata jsonataExpr = jsonata(expr);
             // Off, the library keeps JSONata's null marker in the result instead of flattening it
@@ -173,7 +196,12 @@ public class JsonataEvaluator {
             // case loops for ever and the execution never leaves RUNNING. The bounds raise a
             // JSONata error, which the catch below turns into States.QueryEvaluationError.
             frame.setRuntimeBounds(evaluationTimeoutMillis, maxEvaluationDepth);
+            nesting.trackOn(frame);
+            boundHeldMemory(frame);
             stepFunctionsExtensions.forEach(frame::bind);
+            // AWS disables $eval, and the library ships it. An unbound name called as a function is
+            // the library's own T1006, which is the code AWS answers. $parse is the replacement.
+            frame.bind("eval", (Object) null);
             // Workflow variables (the Assign field) are referenced as top-level $name in AWS's
             // JSONata dialect, e.g. $CheckpointCount. They are bound alongside $states, never
             // inside it: AWS reserves $states for input/result/errorOutput/context only. $states is
@@ -190,8 +218,120 @@ public class JsonataEvaluator {
             Object result = jsonataExpr.evaluate(null, frame);
             return toJsonNode(result);
         } catch (Exception e) {
+            JsonNode nonFinite = nesting.isTheWholeExpression() ? nonFiniteRefusal(e) : null;
+            if (nonFinite != null) {
+                return nonFinite;
+            }
             throw new AslExecutor.FailStateException("States.QueryEvaluationError", queryEvaluationCause(e));
         }
+    }
+
+    /**
+     * How deeply nested the evaluation step running is, the expression's own root node being 1.
+     * A step that fails never leaves, so once an exception has unwound the count is the depth of
+     * the step that raised it.
+     */
+    private static final class ExpressionNesting {
+
+        private int depth;
+
+        /**
+         * Counts on the same pair of callbacks the library installs its bounds through, keeping
+         * the library's own and running after it.
+         */
+        void trackOn(Jsonata.Frame frame) {
+            Jsonata.EntryCallback boundsOnEntry = (Jsonata.EntryCallback) frame.lookup("__evaluate_entry");
+            frame.setEvaluateEntryCallback((expression, input, environment) -> {
+                boundsOnEntry.callback(expression, input, environment);
+                depth++;
+            });
+            afterEachEvaluationStep(frame, (expression, input, environment, result) -> depth--);
+        }
+
+        /** Whether the step that failed is the expression itself rather than a step inside it. */
+        boolean isTheWholeExpression() {
+            return depth == 1;
+        }
+    }
+
+    /**
+     * The value behind a D1001, which the library raises rather than carrying a non-finite number:
+     * {@code 1/0} and {@code 1e308*10} both fail there where AWS answers {@code "Infinity"}. The
+     * exception is the only place the library leaves the value, and it carries no way back to where
+     * the arithmetic ran, so this recovers the value only when the step that raised it is the whole
+     * expression. {@code [1/0]} fails the state instead of answering AWS's {@code ["Infinity"]},
+     * which is the conservative half of the divergence: a state that fails is one a Catch fires on.
+     */
+    private JsonNode nonFiniteRefusal(Exception e) {
+        if (e instanceof JException jsonataError && "D1001".equals(jsonataError.getError())
+                && jsonataError.getCurrent() instanceof Number value) {
+            return fromJsonataValue(value.doubleValue());
+        }
+        return null;
+    }
+
+    /**
+     * Adds the memory bound to the time and depth bounds the library installs. The exit callback
+     * carries the value every evaluation step produces, which is what the bound is on.
+     */
+    private static void boundHeldMemory(Jsonata.Frame frame) {
+        afterEachEvaluationStep(frame, (expression, input, environment, result) -> {
+            if (heldBytes(result, 0) > MAX_EXPRESSION_BYTES) {
+                throw new JException("Expression evaluation memory limit exceeded", -1);
+            }
+        });
+    }
+
+    /**
+     * Runs {@code addition} after every evaluation step, keeping whatever the frame already runs
+     * there. The library installs its time and depth bounds through that same callback, so an
+     * addition extends them rather than replacing them.
+     */
+    private static void afterEachEvaluationStep(Jsonata.Frame frame, Jsonata.ExitCallback addition) {
+        Jsonata.ExitCallback installed = (Jsonata.ExitCallback) frame.lookup("__evaluate_exit");
+        frame.setEvaluateExitCallback((expression, input, environment, result) -> {
+            installed.callback(expression, input, environment, result);
+            addition.callback(expression, input, environment, result);
+        });
+    }
+
+    /**
+     * What {@code value} adds to the {@code held} bytes already counted, stopping as soon as the
+     * total passes {@link #MAX_EXPRESSION_BYTES} so a value far over the bound costs no more to
+     * refuse than one just over it. A range is counted from its length: the library materialises it
+     * lazily, and AWS refuses it on the elements it stands for rather than on what it has built.
+     */
+    private static long heldBytes(Object value, long held) {
+        if (held > MAX_EXPRESSION_BYTES) {
+            return held;
+        }
+        if (value instanceof String text) {
+            return held + text.length();
+        }
+        if (value instanceof Utils.RangeList range) {
+            return held + (long) range.size() * BYTES_PER_SCALAR;
+        }
+        if (value instanceof List<?> list) {
+            return elementsHeldBytes(list, held);
+        }
+        if (value instanceof Map<?, ?> map) {
+            return elementsHeldBytes(map.entrySet(), held);
+        }
+        if (value instanceof Map.Entry<?, ?> entry) {
+            return heldBytes(entry.getValue(), heldBytes(entry.getKey(), held));
+        }
+        return held + BYTES_PER_SCALAR;
+    }
+
+    private static long elementsHeldBytes(Iterable<?> elements, long held) {
+        long total = held;
+        for (Object element : elements) {
+            total = heldBytes(element, total);
+            if (total > MAX_EXPRESSION_BYTES) {
+                return total;
+            }
+        }
+        return total;
     }
 
     /**
@@ -356,7 +496,20 @@ public class JsonataEvaluator {
             list.forEach(element -> array.add(fromJsonataValue(element)));
             return array;
         }
+        // JSON has no literal for a non-finite number, so AWS writes each one as the string
+        // JavaScript names it by: 1/0 comes back as "Infinity" and $parseInteger("abc","0") as
+        // "NaN".
+        if (value instanceof Double number && !Double.isFinite(number)) {
+            return TextNode.valueOf(nonFiniteName(number));
+        }
         return objectMapper.valueToTree(value);
+    }
+
+    private static String nonFiniteName(double value) {
+        if (Double.isNaN(value)) {
+            return "NaN";
+        }
+        return value > 0 ? "Infinity" : "-Infinity";
     }
 
     /**
@@ -364,8 +517,10 @@ public class JsonataEvaluator {
      * Functions dialect adds on top of the JSONata language, per
      * https://docs.aws.amazon.com/step-functions/latest/dg/transforming-data.html: five the
      * dashjoin library does not have at all, and $random it has with the wrong arity, so the
-     * binding shadows it to accept AWS's optional seed. The seventh, $string, is a JSONata
-     * function the library has but writes with a different number notation than AWS.
+     * binding shadows it to accept AWS's optional seed. The other three are JSONata functions the
+     * library has and answers differently from AWS: $string writes a number in another notation,
+     * $parseInteger answers nothing where AWS answers NaN, and $formatNumber accepts picture
+     * strings AWS refuses.
      *
      * <p>Each of the six declares one optional slot more than the arity AWS documents. The library
      * pads a short call with Java nulls up to the declared arity and refuses a call longer than
@@ -385,7 +540,42 @@ public class JsonataEvaluator {
                 "hash", new Jsonata.JFunction((input, arguments) -> hash(arguments), "<x?x?x?:x>"),
                 "random", new Jsonata.JFunction((input, arguments) -> random(arguments), "<x?x?:x>"),
                 "uuid", new Jsonata.JFunction((input, arguments) -> uuid(arguments), "<x?:x>"),
-                "string", new Jsonata.JFunction((input, arguments) -> string(arguments), "<x-b?:s>"));
+                "string", new Jsonata.JFunction((input, arguments) -> string(arguments), "<x-b?:s>"),
+                "parseInteger", new Jsonata.JFunction((input, arguments) -> parseInteger(arguments), "<s-s:n>"),
+                "formatNumber", new Jsonata.JFunction((input, arguments) -> formatNumber(arguments), "<n-so?:s>"));
+    }
+
+    /**
+     * $parseInteger(value, picture): the JSONata function, answering NaN where the picture cannot
+     * read the value, which is what AWS answers. The library answers nothing there, and an ASL
+     * field that evaluates to nothing fails the state.
+     */
+    private static Object parseInteger(List<Object> arguments) {
+        Object value = argument(arguments, 0);
+        if (value == null) {
+            return null;
+        }
+        try {
+            Number parsed = Functions.parseInteger((String) value, (String) argument(arguments, 1));
+            return parsed == null ? Double.NaN : parsed;
+        } catch (ParseException e) {
+            throw new JException(e.getMessage(), -1);
+        }
+    }
+
+    /**
+     * $formatNumber(value, picture, options): the JSONata function, with the picture string checked
+     * against the rules AWS applies to it first. See {@link FormatNumberPicture}.
+     */
+    private static Object formatNumber(List<Object> arguments) {
+        Object value = argument(arguments, 0);
+        if (value == null) {
+            return null;
+        }
+        Map<?, ?> options = (Map<?, ?>) argument(arguments, 2);
+        String picture = (String) argument(arguments, 1);
+        FormatNumberPicture.validate(picture, options);
+        return Functions.formatNumber((Number) value, picture, options);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluatorTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -597,18 +598,13 @@ class JsonataEvaluatorTest {
 
         assertEquals("States.QueryEvaluationError", ex.error);
         assertEquals("Stack overflow error: Check for non-terminating recursive"
-                + " function.  Consider rewriting as tail-recursive. Depth=501 max=500", ex.cause);
+                + " function.  Consider rewriting as tail-recursive. Depth=101 max=100", ex.cause);
     }
 
     /**
      * The boundary from below: the risk of a bound is that it fails a working state machine, so
-     * these must all still evaluate. Measured with {@code aws stepfunctions test-state}, AWS
-     * returns 30 for the first and 800000 for the second, which makes them the ceiling of what
-     * AWS itself accepts on each axis: it refuses the recursion at n=40 (nesting depth 125) and
-     * the sequence at 900,000 elements.
-     *
-     * <p>The last two AWS refuses on its memory limit and Floci evaluates, which is where the
-     * bounds are deliberately looser than AWS rather than tighter.
+     * these must all still evaluate. AWS accepts every one of them and refuses the next value on
+     * each axis: the recursion at n=32, the sequence at 873,783 elements.
      */
     @Test
     @Timeout(60)
@@ -617,11 +613,242 @@ class JsonataEvaluatorTest {
         String recursionHead = "{% ($f := function($x){ $x <= 0 ? 0 : 1 + $f($x-1) }; $f(";
 
         assertEquals(30, evaluator.evaluate(recursionHead + "30)) %}", statesVar).asInt());
+        assertEquals(31, evaluator.evaluate(recursionHead + "31)) %}", statesVar).asInt());
         assertEquals(800000, evaluator.evaluate("{% [1..800000] ~> $count() %}", statesVar).asInt());
-
-        assertEquals(160, evaluator.evaluate(recursionHead + "160)) %}", statesVar).asInt());
         assertEquals(40000200000L,
                 evaluator.evaluate("{% $sum($map([1..200000], function($v){$v * 2})) %}", statesVar).asLong());
+    }
+
+    /**
+     * The four nesting shapes of issue #2737, at the last {@code n} AWS accepts and at the first
+     * it refuses. An addition chain nests one level per term, so AWS accepts 100 terms;
+     * parentheses, brackets and the chain operator nest one level more than their count, so AWS
+     * accepts 99 of each. Both put AWS's ceiling at
+     * nesting depth 100, which is what {@link JsonataEvaluator#MAX_EVALUATION_DEPTH} holds.
+     */
+    @Test
+    @Timeout(30)
+    void everyNestingShapeFailsAtTheDepthAwsFailsAt() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals(100, evaluator.evaluate("{% 1" + "+1".repeat(99) + " %}", statesVar).asInt());
+        assertEquals(1, evaluator.evaluate("{% " + "(".repeat(99) + "1" + ")".repeat(99) + " %}", statesVar).asInt());
+        assertTrue(evaluator.evaluate("{% " + "[".repeat(99) + "1" + "]".repeat(99) + " %}",
+                statesVar).isArray());
+        assertEquals("1", evaluator.evaluate("{% 1" + "~>$string".repeat(99) + " %}", statesVar).asText());
+
+        for (String tooDeep : new String[]{
+                "1" + "+1".repeat(100),
+                "(".repeat(100) + "1" + ")".repeat(100),
+                "[".repeat(100) + "1" + "]".repeat(100),
+                "1" + "~>$string".repeat(100)}) {
+            AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                    () -> evaluator.evaluate("{% " + tooDeep + " %}", statesVar),
+                    "expected the depth bound to refuse " + tooDeep.substring(0, 20) + "...");
+            assertEquals("States.QueryEvaluationError", ex.error);
+            assertTrue(ex.cause.endsWith("Depth=101 max=100"), ex.cause);
+        }
+    }
+
+    /**
+     * The non-tail-recursive shape of issue #2737, which nests three levels per call: AWS accepts
+     * {@code $f(31)} and refuses {@code $f(32)}, and the depth bound reproduces both.
+     */
+    @Test
+    @Timeout(30)
+    void nonTailRecursionFailsAtTheCallDepthAwsFailsAt() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        String recursionHead = "{% ($f := function($x){ $x <= 0 ? 0 : 1 + $f($x-1) }; $f(";
+
+        assertEquals(31, evaluator.evaluate(recursionHead + "31)) %}", statesVar).asInt());
+
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate(recursionHead + "32)) %}", statesVar));
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertTrue(ex.cause.endsWith("Depth=101 max=100"), ex.cause);
+    }
+
+    /**
+     * The memory bound of issue #2737 on the sequence AWS draws it on: AWS accepts
+     * {@code [1..873782]} and refuses one element more, and counting a number as eight bytes puts
+     * those two on either side of {@link JsonataEvaluator#MAX_EXPRESSION_BYTES} here as well.
+     */
+    @Test
+    @Timeout(60)
+    void theLargestSequenceAwsAcceptsEvaluatesAndTheNextOneFailsOnTheMemoryBound() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals(873782, evaluator.evaluate("{% [1..873782] ~> $count() %}", statesVar).asInt());
+
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate("{% [1..873783] ~> $count() %}", statesVar));
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertEquals("Expression evaluation memory limit exceeded", ex.cause);
+    }
+
+    /**
+     * The same memory bound on a string: a string that doubles 22 times evaluates on AWS and one
+     * that doubles 23 times does not. A character counts as one byte, which leaves 2^22 characters
+     * inside the bound and 2^23 outside it, as on AWS.
+     */
+    @Test
+    @Timeout(60)
+    void aStringDoublingStopsAtTheSameBoundAwsStopsAt() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        String doublingHead = "{% ($f := function($s, $n){ $n = 0 ? $s : $f($s & $s, $n - 1) };"
+                + " $length($f('x', ";
+
+        assertEquals(4194304, evaluator.evaluate(doublingHead + "22))) %}", statesVar).asInt());
+
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate(doublingHead + "23))) %}", statesVar));
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertEquals("Expression evaluation memory limit exceeded", ex.cause);
+    }
+
+    /**
+     * The two expressions of issue #2737 that AWS refuses on its memory limit. They fail the state
+     * here too, so a Catch fires on them rather than the state succeeding with a value.
+     */
+    @Test
+    @Timeout(60)
+    void theSequencesAwsRefusesOnItsMemoryLimitFailTheStateHere() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        for (String expression : new String[]{"[1..900000] ~> $count()", "$sum([1..900000])"}) {
+            AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                    () -> evaluator.evaluate("{% " + expression + " %}", statesVar),
+                    "expected the memory bound to refuse " + expression);
+            assertEquals("States.QueryEvaluationError", ex.error);
+            assertEquals("Expression evaluation memory limit exceeded", ex.cause);
+        }
+    }
+
+    /**
+     * AWS disables $eval and answers T1006 for a call to it. The library ships $eval, so the name
+     * is left unbound here and a call to it answers the same code; $parse is the replacement AWS
+     * documents.
+     */
+    @Test
+    void evalIsNotBoundBecauseAwsDisablesIt() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate("{% $eval('1+1') %}", statesVar));
+
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertEquals("T1006: Attempted to invoke a non-function", ex.cause);
+    }
+
+    /**
+     * JSON has no literal for a non-finite number, so AWS writes each one as the string JavaScript
+     * names it by. The library refuses to carry the value at all and raises D1001 instead, and the
+     * value that refusal carries is what these answer.
+     */
+    @Test
+    void aNonFiniteNumberIsTheStringAwsWritesForIt() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals("Infinity", evaluator.evaluate("{% 1/0 %}", statesVar).asText());
+        assertEquals("Infinity", evaluator.evaluate("{% 1e308 * 10 %}", statesVar).asText());
+        assertEquals("-Infinity", evaluator.evaluate("{% -1/0 %}", statesVar).asText());
+    }
+
+    /**
+     * The shapes AWS answers a string for and Floci does not. A non-finite number the library's own
+     * arithmetic produces reaches Floci only as the exception the library raises instead of carrying
+     * the value, and by then the exception has unwound whatever value was being built around it, so
+     * only an expression whose own result is non-finite can be answered. AWS answers
+     * {@code ["Infinity"]} for the first, {@code {"k":"Infinity"}} for the second and
+     * {@code "NaN"} for {@code 0/0}.
+     *
+     * <p>Failing the state is the half of the divergence a Catch fires on, which is why the value is
+     * not answered at the top of an expression that was building something else with it.
+     */
+    @Test
+    void aNonFiniteNumberTheArithmeticBuildsInsideAValueFailsTheStateInstead() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        for (String expression : new String[]{"[1/0]", "{'k': 1/0}", "[1/0, 2]", "$string(1/0)"}) {
+            AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                    () -> evaluator.evaluate("{% " + expression + " %}", statesVar),
+                    "expected " + expression + " to fail the state");
+            assertEquals("States.QueryEvaluationError", ex.error);
+            assertEquals("D1001: Number out of range: \"Infinity\"", ex.cause);
+        }
+
+        // NaN raises nothing at all: the library reads it as not a number and drops it, so the
+        // expression returns nothing and the field it was written in is what fails.
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluateField("{% 0/0 %}", "Output/r", statesVar, null));
+        assertEquals("The JSONata expression '0/0' specified for the field 'Output/r' "
+                + "returned nothing (undefined).", ex.cause);
+    }
+
+    /**
+     * $parseInteger answers NaN for a value its picture cannot read, where the library answers
+     * nothing and an ASL field that evaluates to nothing fails the state.
+     */
+    @Test
+    void parseIntegerAnswersNaNForAValueThePictureCannotRead() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals("NaN", evaluator.evaluateField("{% $parseInteger('abc', '0') %}",
+                "Output/r", statesVar, null).asText());
+        // A non-finite number a function answers is carried like any other value, so it reaches the
+        // output as AWS writes it wherever it lands, which is what arithmetic cannot do.
+        assertEquals("[\"NaN\"]",
+                evaluator.evaluate("{% [$parseInteger('abc', '0')] %}", statesVar).toString());
+        assertEquals("{\"k\":\"NaN\"}",
+                evaluator.evaluate("{% {'k': $parseInteger('abc', '0')} %}", statesVar).toString());
+        // A value the picture does read stays the integer it was, not a double.
+        assertEquals("123", evaluator.evaluate("{% $parseInteger('123', '0') %}", statesVar).toString());
+    }
+
+    /**
+     * A picture string with no digit in it describes no number, and AWS fails the state on it
+     * where the library formats through DecimalFormat and answers "x1".
+     */
+    @Test
+    void formatNumberRefusesAPictureThatDescribesNoNumber() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                () -> evaluator.evaluate("{% $formatNumber(1, 'x') %}", statesVar));
+
+        assertEquals("States.QueryEvaluationError", ex.error);
+        assertEquals("D3086: The sub-picture must not contain a passive character that is preceded"
+                + " by an active character and that is followed by another active character", ex.cause);
+    }
+
+    @Test
+    void formatNumberNamesTheRuleThePictureBreaks() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+        Map<String, String> expectedCodes = Map.ofEntries(
+                Map.entry("0.0;0.0;0.0", "D3080"), Map.entry("0.0.0", "D3081"),
+                Map.entry("0%%", "D3082"), Map.entry("0‰‰", "D3083"),
+                Map.entry("0%‰", "D3084"), Map.entry("0,.0", "D3087"),
+                Map.entry("0,", "D3088"), Map.entry("0,,0", "D3089"),
+                Map.entry("0#", "D3090"), Map.entry("##0.0#0", "D3091"),
+                Map.entry("0e0%", "D3092"), Map.entry("#0e", "D3093"));
+
+        expectedCodes.forEach((picture, code) -> {
+            AslExecutor.FailStateException ex = assertThrows(AslExecutor.FailStateException.class,
+                    () -> evaluator.evaluate("{% $formatNumber(1, '" + picture + "') %}", statesVar),
+                    "expected " + picture + " to fail");
+            assertTrue(ex.cause.startsWith(code + ":"), picture + " gave " + ex.cause);
+        });
+    }
+
+    @Test
+    void formatNumberStillFormatsThePicturesTheRulesAllow() {
+        JsonNode statesVar = objectMapper.createObjectNode();
+
+        assertEquals("1,234.57", evaluator.evaluate("{% $formatNumber(1234.5678, '#,##0.00') %}",
+                statesVar).asText());
+        assertEquals("12.3%", evaluator.evaluate("{% $formatNumber(0.123, '#0.0%') %}", statesVar).asText());
+        assertEquals("$1,234.57", evaluator.evaluate("{% $formatNumber(1234.5678, '$#,##0.00') %}",
+                statesVar).asText());
     }
 
     @Test


### PR DESCRIPTION
Replaced by #2783, which carries this change together with the rest of the `JsonataEvaluator` work.