### PR TITLE
fix(cloudformation): skip re-invoking custom resource handlers when properties are unchanged

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -6364,6 +6364,16 @@ public class CloudFormationResourceProvisioner {
         // The prior values were stashed at the last create/update; read them before we overwrite below.
         ObjectNode oldResourceProperties = isUpdate ? readStashedProperties(r) : null;
 
+        // CloudFormation invokes a custom resource's Update handler only when its resolved
+        // properties changed (UserGuide/template-custom-resources-sns.md: "During a stack update,
+        // if no changes are made to a custom resource, CloudFormation will not send any requests
+        // to it."). Replaying every custom resource during an unrelated stack update can repeat
+        // non-idempotent side effects. The prior resolved properties are already stashed on the
+        // resource, so an exact match is a safe no-op that preserves physical ID and attributes.
+        if (oldResourceProperties != null && oldResourceProperties.equals(resourceProperties)) {
+            return;
+        }
+
         JsonNode response = invokeCustomResourceHandler(serviceToken, requestType, r.getLogicalId(),
                 r.getResourceType(), priorPhysicalId, resourceProperties, oldResourceProperties,
                 region, accountId, stackName);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CustomResourceProvisionerTest.java
@@ -164,6 +164,47 @@ class CustomResourceProvisionerTest {
     }
 
     @Test
+    void updateWithUnchangedResolvedPropertiesSkipsHandlerInvocation() {
+        stubHandler("phys-123", Map.of("Greeting", "hello"));
+
+        // Initial Create — stashes the resolved ResourceProperties on the resource.
+        StackResource created = provisioner.provision("MyCr", "Custom::Test", props(),
+                engine(), "us-east-1", "000000000000", "my-stack");
+        assertEquals("phys-123", created.getPhysicalId());
+
+        // "Update" with byte-identical resolved properties: real CloudFormation would not send
+        // any request to the custom resource at all (UserGuide/template-custom-resources-sns.md:
+        // "During a stack update, if no changes are made to a custom resource, CloudFormation
+        // will not send any requests to it.").
+        StackResource updated = provisioner.provision("MyCr", "Custom::Test", props(),
+                engine(), "us-east-1", "000000000000", "my-stack",
+                created.getPhysicalId(), created.getAttributes());
+
+        verify(lambdaService, times(1)).invoke(any(), eq(SERVICE_TOKEN), any(),
+                eq(InvocationType.RequestResponse));
+        assertEquals("CREATE_COMPLETE", updated.getStatus());
+        assertEquals("phys-123", updated.getPhysicalId());
+        assertEquals("hello", updated.getAttributes().get("Greeting"));
+    }
+
+    @Test
+    void updateWithChangedResolvedPropertiesStillInvokesHandler() {
+        stubHandler("phys-123", Map.of("Greeting", "hello"));
+
+        StackResource created = provisioner.provision("MyCr", "Custom::Test", props(),
+                engine(), "us-east-1", "000000000000", "my-stack");
+
+        ObjectNode changedProps = props();
+        changedProps.put("Message", "bye");
+        provisioner.provision("MyCr", "Custom::Test", changedProps,
+                engine(), "us-east-1", "000000000000", "my-stack",
+                created.getPhysicalId(), created.getAttributes());
+
+        verify(lambdaService, times(2)).invoke(any(), eq(SERVICE_TOKEN), any(),
+                eq(InvocationType.RequestResponse));
+    }
+
+    @Test
     void deleteReinvokesHandlerWithDeleteRequestType() {
         stubHandler("phys-123", Map.of("Greeting", "hello"));
         StackResource r = provisioner.provision("MyCr", "Custom::Test", props(),


### PR DESCRIPTION
## Summary

Real AWS does not re-invoke a custom resource's handler during a stack update unless that resource's own resolved properties changed. Per AWS docs (`UserGuide/template-custom-resources-sns.md`, confirmed via context7): "During a stack update, if no changes are made to a custom resource, CloudFormation will not send any requests to it."

floci's `provisionCustomResource()` already stashes each custom resource's prior resolved `ResourceProperties` on the resource (`CR_PROPERTIES_ATTR`) and reads them back into `oldResourceProperties` on Update — but never compared old vs new before invoking the handler. Every stack update therefore replayed **every** custom resource in the template, regardless of whether that specific resource's properties changed, repeating non-idempotent side effects (e.g. handlers that create IAM service-linked roles, mutate external state, etc.) on completely unrelated stack updates.

## Provenance

This gap was originally spotted as one part of a now-dead internal branch (`feature/lza-cloudformation-idempotency`) whose other four changes were superseded by floci's per-stage snapshot/resume mechanism. That branch's own skip-guard code (commit `13687feea`) is not ported/cherry-picked here — the codebase moved through a 370-line CFN provisioner-migration refactor (`bdfaa01c4`) since then, and the guard was re-derived fresh against the current `provisionCustomResource()` in `CloudFormationResourceProvisioner.java`. The re-derived fix happens to land in the same spot the original branch found, using the stash/read infrastructure (`CR_PROPERTIES_ATTR` / `readStashedProperties`) that already exists in current code — that infrastructure was apparently carried through the refactor, but the actual comparison-and-skip line was dropped.

## Scope (deliberate)

- **Custom resources only** (`Custom::*` / `AWS::CloudFormation::CustomResource`), not standard AWS-native resource types. The AWS doc citation above is specific to custom resources; native resource providers have their own (different) update/no-op semantics that floci's other provisioners already handle case-by-case, and this PR does not touch them.
- **Comparison is on resolved `ResourceProperties`** — post-intrinsic-function-resolution, post-parameter-substitution, post-scalar-stringification (the same `ObjectNode` that gets sent to the handler and stashed for the *next* update), using Jackson's structural `ObjectNode.equals`. This matches what real AWS diffs (`ResourceProperties` vs `OldResourceProperties` in the Update event), not template text.
- Does not special-case `DependsOn`/`Conditions`/`Metadata` changes — those aren't part of the resolved `ResourceProperties` payload sent to the handler, and no evidence surfaced that AWS treats a metadata-only change as forcing a custom-resource Update.

## Wire-fidelity extractor

N/A — this is a behavioral/orchestration fix (whether the handler is invoked at all), not a wire-shape/Botocore-modeled constraint on any operation's parameters.

## RED test proof

Added to `CustomResourceProvisionerTest`:
- `updateWithUnchangedResolvedPropertiesSkipsHandlerInvocation` — provisions Create then Update with byte-identical resolved properties; before the fix, `lambdaService.invoke` was called twice (`TooManyActualInvocations`); after the fix, called once, with the resource's prior physicalId/attributes preserved.
- `updateWithChangedResolvedPropertiesStillInvokesHandler` — companion test proving a real property change still invokes the handler on both Create and Update (guards against over-scoping the skip).

## Test results

- `rtk mvn --ultra-compact test -Dtest=CustomResourceProvisionerTest`: 6/6 passing (was 5/6 before the fix, RED confirmed on `updateWithUnchangedResolvedPropertiesSkipsHandlerInvocation`).
- `rtk mvn --ultra-compact clean test-compile`: BUILD SUCCESS.
- Full CloudFormation suite (`-Dtest='io.github.hectorvent.floci.services.cloudformation.**'`): 810/810 passing.

## Local code review

Ran `review-local.ts` against the changed file (`CloudFormationResourceProvisioner.java`, isolated-file review). All 13 findings are pre-existing gaps in unrelated methods elsewhere in this legacy monolith file (IAM inline-policy rollback, EKS/APIGWv2 delete swallowing, DynamoDB adoption, Kinesis retention/tags, KMS alias, SSM/Cognito secret persistence, etc.) — none touch the 10 changed lines. Logged to `issues/cfn-monolith-provisioner-review-findings.md` (append to the existing ledger from a prior pass on the same file) rather than fixed inline, to keep this PR's diff scoped to the skip-guard fix.

## docs-check

`make docs-check`: passes (no docs touched — this is a behavioral fix with no new operation, member, or service).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AWS Compatibility

Botocore-derived / AWS-documentation-derived: the fix implements documented AWS CloudFormation custom-resource update behavior (cited above), not something LZA-exercised in a live pipeline run.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes