### PR TITLE
fix(cloudformation): update AWS::IAM::ManagedPolicy in place on retry

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -76,6 +76,7 @@ import io.github.hectorvent.floci.services.elbv2.model.Rule;
 import io.github.hectorvent.floci.services.elbv2.model.RuleCondition;
 import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
 import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.iam.model.IamPolicy;
 import io.github.hectorvent.floci.services.iam.model.IamRole;
 import io.github.hectorvent.floci.services.kms.KmsService;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
@@ -3049,12 +3050,37 @@ public class CloudFormationResourceProvisioner {
                 : "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
         List<String> roleNames = resolveStringList(props, "Roles", engine);
 
-        var policy = iamService.createPolicy(policyName, "/", null, document, Map.of());
-        r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
+        String existingArn = r.getPhysicalId();
+        IamPolicy policy;
+        boolean createdPolicy = false;
+        try {
+            policy = iamService.createPolicy(policyName, "/", null, document, Map.of());
+            createdPolicy = true;
+            r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
+        } catch (AwsException e) {
+            if (!"EntityAlreadyExists".equals(e.getErrorCode()) || existingArn == null) {
+                throw e;
+            }
+            // Same-stack update/retry: apply this template's current PolicyDocument as a new
+            // default version on the policy this resource already owns, or a changed document is
+            // silently dropped while the stack still reports UPDATE_COMPLETE - the same class of
+            // gap #1965/#2152 fixed for LogGroup and #2084/#2143 fixed for IAM role trust
+            // policies, one resource type over.
+            policy = iamService.getPolicy(existingArn);
+            String existingPolicyId = r.getAttributes().get("PolicyId");
+            if (existingPolicyId == null || existingPolicyId.isBlank()
+                    || !existingPolicyId.equals(policy.getPolicyId())) {
+                // Not this stack's policy: a different resource collided on name+path, or
+                // ManagedPolicyName changed to a name already used elsewhere. Not ours to adopt.
+                throw e;
+            }
+            iamService.createPolicyVersion(existingArn, document, true);
+        }
         r.setPhysicalId(policy.getArn());
+        r.getAttributes().put("PolicyId", policy.getPolicyId());
         // PolicyArn is the attribute CloudFormation documents for this type, and what a template
         // written against AWS asks for. Without it Fn::GetAtt does not resolve and the unresolved
-        // literal reaches whatever consumed it — a role's ManagedPolicyArns, typically, which then
+        // literal reaches whatever consumed it, a role's ManagedPolicyArns typically, which then
         // fails with "policy does not exist" and rolls the stack back. "Arn" stays for callers
         // already using it.
         r.getAttributes().put("Arn", policy.getArn());
@@ -3062,9 +3088,10 @@ public class CloudFormationResourceProvisioner {
         r.getAttributes().put("ManagedPolicyRoleTargets", String.join("\n", roleNames));
 
         LinkedHashSet<String> attachedRoleNames = new LinkedHashSet<>();
+        String policyArn = policy.getArn();
         try {
             for (String roleName : roleNames) {
-                iamService.attachRolePolicy(roleName, policy.getArn());
+                iamService.attachRolePolicy(roleName, policyArn);
                 attachedRoleNames.add(roleName);
             }
         } catch (RuntimeException failure) {
@@ -3072,18 +3099,23 @@ public class CloudFormationResourceProvisioner {
             Collections.reverse(rollbackRoles);
             boolean cleanupSucceeded = true;
             for (String roleName : rollbackRoles) {
-                String cleanupDescription = "detach policy " + policy.getArn() + " from role " + roleName;
+                String cleanupDescription = "detach policy " + policyArn + " from role " + roleName;
                 if (!CfnRollback.attemptIamCleanup(failure, cleanupDescription,
-                        () -> iamService.detachRolePolicy(roleName, policy.getArn()))) {
+                        () -> iamService.detachRolePolicy(roleName, policyArn))) {
                     cleanupSucceeded = false;
                 }
             }
-            if (!CfnRollback.attemptIamCleanup(failure, "delete policy " + policy.getArn(),
-                    () -> iamService.deletePolicy(policy.getArn()))) {
-                cleanupSucceeded = false;
-            }
-            if (cleanupSucceeded) {
-                r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
+            // Only a policy this attempt created is ours to delete on failure - one this attempt
+            // merely adopted (updated with a new version) pre-existed this attempt and rolling back
+            // means leaving it alone, not destroying it.
+            if (createdPolicy) {
+                if (!CfnRollback.attemptIamCleanup(failure, "delete policy " + policyArn,
+                        () -> iamService.deletePolicy(policyArn))) {
+                    cleanupSucceeded = false;
+                }
+                if (cleanupSucceeded) {
+                    r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
+                }
             }
             throw failure;
         }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -871,18 +871,28 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
         Map<String, PolicyVersion> versions = policy.getVersions();
         PolicyVersion version;
         synchronized (versions) {
-            int nextVersionNum = versions.size() + 1;
-            if (nextVersionNum > 5) {
+            if (versions.size() >= 5) {
                 throw new AwsException("LimitExceeded",
                         "A managed policy can have up to 5 versions.", 409);
             }
-            String versionId = "v" + nextVersionNum;
+            // Derive the id from the policy's own monotonic counter, not versions.size() + 1: size()
+            // drops when a version is deleted, so a policy with v1/v2/v4/v5 (v3 deleted) would
+            // otherwise compute "v5" again from size()+1=5 and silently overwrite the surviving v5.
+            // The containsKey advance is a self-heal for policies persisted before this counter
+            // existed, whose deserialized default undercounts - it costs nothing for the normal case,
+            // since the counter is already correct there and the loop body never runs.
+            int versionNum = policy.getNextVersionNumber();
+            while (versions.containsKey("v" + versionNum)) {
+                versionNum++;
+            }
+            String versionId = "v" + versionNum;
             version = new PolicyVersion(versionId, document, setAsDefault);
             if (setAsDefault) {
                 versions.values().forEach(v -> v.setDefaultVersion(false));
                 policy.setDefaultVersionId(versionId);
             }
             versions.put(versionId, version);
+            policy.setNextVersionNumber(versionNum + 1);
         }
         policy.setUpdateDate(Instant.now());
         policies.put(policyArn, policy);

--- a/src/main/java/io/github/hectorvent/floci/services/iam/model/IamPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/model/IamPolicy.java
@@ -19,6 +19,13 @@ public class IamPolicy {
     private String arn;
     private String description;
     private String defaultVersionId = "v1";
+    // Monotonic counter for the next version number to assign, independent of how many versions
+    // currently exist. versions.size() drops when a version is deleted, so deriving the next id
+    // from it can reissue an id still in use by a surviving version once one gets pruned out of
+    // order (e.g. v3 deleted while v1/v2/v4/v5 remain: versions.size() becomes 4, size()+1 = 5,
+    // "v5" already exists and would be silently overwritten). AWS version ids are monotonic and
+    // never reused, so this only ever increments.
+    private int nextVersionNumber = 2;
     private int attachmentCount = 0;
     private Instant createDate;
     private Instant updateDate;
@@ -63,6 +70,9 @@ public class IamPolicy {
 
     public String getDefaultVersionId() { return defaultVersionId; }
     public void setDefaultVersionId(String defaultVersionId) { this.defaultVersionId = defaultVersionId; }
+
+    public int getNextVersionNumber() { return nextVersionNumber; }
+    public void setNextVersionNumber(int nextVersionNumber) { this.nextVersionNumber = nextVersionNumber; }
 
     public int getAttachmentCount() { return attachmentCount; }
     public void setAttachmentCount(int attachmentCount) { this.attachmentCount = attachmentCount; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamAttachmentProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamAttachmentProvisionerTest.java
@@ -286,6 +286,85 @@ class CloudFormationIamAttachmentProvisionerTest {
     }
 
     @Test
+    void sameStackManagedPolicyRetryUpdatesDocumentInPlace() {
+        // github.com/floci-io/floci/issues/2237 - adopting an existing managed policy on update must
+        // still apply this template's current PolicyDocument as a new default version, or a changed
+        // document is silently dropped while the stack still reports UPDATE_COMPLETE. Same class of
+        // gap sameStackRoleUpdateAppliesChangedTrustPolicy covers for AWS::IAM::Role, one resource
+        // type over.
+        String policyArn = "arn:aws:iam::" + ACCOUNT_ID + ":policy/existing-policy";
+        IamPolicy policy = new IamPolicy(
+                "ANPAEXISTING", "existing-policy", "/", policyArn, null, "{}");
+        when(iamService.createPolicy("existing-policy", "/", null, policyDocument(), Map.of()))
+                .thenThrow(new AwsException("EntityAlreadyExists", "already exists", 409));
+        when(iamService.getPolicy(policyArn)).thenReturn(policy);
+
+        StackResource result = provision("ManagedPolicy", "AWS::IAM::ManagedPolicy", """
+                {
+                  "ManagedPolicyName": "existing-policy",
+                  "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                }
+                """, policyArn, Map.of("PolicyId", policy.getPolicyId()));
+
+        assertEquals("CREATE_COMPLETE", result.getStatus());
+        verify(iamService).createPolicyVersion(policyArn, policyDocument(), true);
+        verify(iamService, never()).deletePolicy(anyString());
+        assertEquals(policyArn, result.getPhysicalId());
+        assertEquals(policy.getPolicyId(), result.getAttributes().get("PolicyId"));
+    }
+
+    @Test
+    void sameStackManagedPolicyRetryFailureDoesNotDeleteAdoptedPolicy() {
+        // Companion to sameStackManagedPolicyRetryUpdatesDocumentInPlace: an adopted policy pre-dates
+        // this attempt, so a later failure (e.g. a bad Roles entry) must never delete it. Only a
+        // policy this attempt actually created is this attempt's to clean up.
+        String policyArn = "arn:aws:iam::" + ACCOUNT_ID + ":policy/existing-policy";
+        IamPolicy policy = new IamPolicy(
+                "ANPAEXISTING", "existing-policy", "/", policyArn, null, "{}");
+        when(iamService.createPolicy("existing-policy", "/", null, policyDocument(), Map.of()))
+                .thenThrow(new AwsException("EntityAlreadyExists", "already exists", 409));
+        when(iamService.getPolicy(policyArn)).thenReturn(policy);
+        doThrow(new AwsException("NoSuchEntity", "missing role", 404))
+                .when(iamService).attachRolePolicy("missing-role", policyArn);
+
+        StackResource result = provision("ManagedPolicy", "AWS::IAM::ManagedPolicy", """
+                {
+                  "ManagedPolicyName": "existing-policy",
+                  "PolicyDocument": {"Version": "2012-10-17", "Statement": []},
+                  "Roles": ["missing-role"]
+                }
+                """, policyArn, Map.of("PolicyId", policy.getPolicyId()));
+
+        assertEquals("CREATE_FAILED", result.getStatus());
+        verify(iamService, never()).deletePolicy(anyString());
+    }
+
+    @Test
+    void managedPolicyRetryForADifferentPolicyIsNotAdopted() {
+        // If the tracked PolicyId does not match what EntityAlreadyExists actually collided with,
+        // this attempt does not own that policy (a different resource claimed the same name+path,
+        // or ManagedPolicyName changed to a name already used elsewhere). Must not silently version
+        // someone else's policy.
+        String policyArn = "arn:aws:iam::" + ACCOUNT_ID + ":policy/existing-policy";
+        IamPolicy otherPolicy = new IamPolicy(
+                "ANPAOTHER", "existing-policy", "/", policyArn, null, "{}");
+        when(iamService.createPolicy("existing-policy", "/", null, policyDocument(), Map.of()))
+                .thenThrow(new AwsException("EntityAlreadyExists", "already exists", 409));
+        when(iamService.getPolicy(policyArn)).thenReturn(otherPolicy);
+
+        StackResource result = provision("ManagedPolicy", "AWS::IAM::ManagedPolicy", """
+                {
+                  "ManagedPolicyName": "existing-policy",
+                  "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                }
+                """, policyArn, Map.of("PolicyId", "ANPANOTMINE"));
+
+        assertEquals("CREATE_FAILED", result.getStatus());
+        assertEquals("already exists", result.getStatusReason());
+        verify(iamService, never()).createPolicyVersion(anyString(), anyString(), eq(true));
+    }
+
+    @Test
     void cleanupFailureDoesNotMaskPrimaryFailureOrSkipDeletion() {
         IamRole role = role("cleanup-role");
         when(iamService.createRole("cleanup-role", "/", emptyTrustPolicy(), null, 3600, Map.of()))

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -322,6 +322,32 @@ class IamServiceTest {
     }
 
     @Test
+    void createPolicyVersionAfterOutOfOrderDeletionDoesNotReuseId() {
+        // github.com/floci-io/floci/issues/2237 (Related) - deriving the next version id from
+        // versions.size() + 1 reissues an id still held by a surviving version once an earlier one
+        // is deleted out of order: v1/v2/v3 with v1 deleted leaves size() == 2, so size() + 1 == 3
+        // collides with the existing v3 and silently overwrites its document.
+        String doc1 = "{\"v\":1}";
+        String doc2 = "{\"v\":2}";
+        String doc3 = "{\"v\":3}";
+        String doc4 = "{\"v\":4}";
+        IamPolicy policy = iamService.createPolicy("P", "/", null, doc1, null);
+        String arn = policy.getArn();
+
+        iamService.createPolicyVersion(arn, doc2, false);
+        iamService.createPolicyVersion(arn, doc3, false);
+        iamService.setDefaultPolicyVersion(arn, "v3");
+        iamService.deletePolicyVersion(arn, "v1");
+
+        PolicyVersion v4 = iamService.createPolicyVersion(arn, doc4, false);
+
+        assertEquals("v4", v4.getVersionId());
+        IamPolicy afterCreate = iamService.getPolicy(arn);
+        assertEquals(doc3, afterCreate.getVersions().get("v3").getDocument(),
+                "the surviving v3 must not be overwritten by the newly created version");
+    }
+
+    @Test
     void deletePolicyVersionDefaultFails() {
         IamPolicy policy = iamService.createPolicy("P", "/", null, "{}", null);
         assertThrows(AwsException.class,


### PR DESCRIPTION
Same-stack create-retry on a ManagedPolicy resource failed outright with EntityAlreadyExists instead of applying the template's current PolicyDocument, unlike the adopt-on-update path already used for AWS::IAM::Role. Now the retry is verified against a tracked PolicyId attribute and, once confirmed to be this resource's own policy, the document is applied as a new default version via createPolicyVersion.

Also fixes createPolicyVersion deriving the next version id from versions.size() + 1, which can reissue an id still held by a surviving version once an earlier one is deleted out of order. Replaced with a monotonic counter on IamPolicy, self-healing for policies persisted before the counter existed.

Fixes floci-io/floci#2237

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

