### PR TITLE
fix(opensearch): keep publishing the domain's host port when floci runs in a container

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -60,6 +60,13 @@ public class OpenSearchDomainManager {
 
         lifecycleManager.removeIfExists(containerName);
 
+        // A restart of an existing domain has just removed the old container, so its
+        // reservation is stale; hand the port back before allocating a fresh one.
+        if (domain.getHostPort() != null) {
+            portAllocator.release(domain.getHostPort());
+            domain.setHostPort(null);
+        }
+
         ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
                 .withName(containerName)
                 .withEnv("discovery.type", "single-node")
@@ -116,6 +123,7 @@ public class OpenSearchDomainManager {
             throw e;
         }
         domain.setContainerId(info.containerId());
+        domain.setHostPort(hostPort);
 
         EndpointInfo endpoint = info.getEndpoint(OPENSEARCH_PORT);
         domain.setEndpoint("http://" + endpoint.host() + ":" + endpoint.port());
@@ -159,6 +167,14 @@ public class OpenSearchDomainManager {
             return;
         }
         lifecycleManager.stopAndRemove(domain.getContainerId(), null);
+        // The container no longer holds the binding, so the reservation must go with
+        // it. Repeated create/delete would otherwise exhaust the configured range.
+        // The keep-running early return above deliberately keeps the reservation:
+        // the surviving container still owns the binding.
+        if (domain.getHostPort() != null) {
+            portAllocator.release(domain.getHostPort());
+            domain.setHostPort(null);
+        }
         LOG.infov("Stopped OpenSearch container for domain {0}", domain.getDomainName());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManager.java
@@ -27,8 +27,6 @@ import java.nio.file.Path;
 public class OpenSearchDomainManager {
 
     private static final Logger LOG = Logger.getLogger(OpenSearchDomainManager.class);
-    /** Sentinel for the in-container path, which publishes no host port to release. */
-    private static final int NO_HOST_PORT = -1;
     private static final int OPENSEARCH_PORT = 9200;
 
     private final ContainerBuilder containerBuilder;
@@ -79,15 +77,16 @@ public class OpenSearchDomainManager {
         // container-backed services (Neptune, MemoryDB, RDS) already address their
         // backends via the container's resolved IP (EndpointInfo) rather than its
         // Docker name; this container follows the same pattern below.
-        int hostPort = NO_HOST_PORT;
-        if (!containerDetector.isRunningInContainer()) {
-            hostPort = portAllocator.allocate(
-                    config.services().opensearch().proxyBasePort(),
-                    config.services().opensearch().proxyMaxPort());
-            specBuilder.withPortBinding(OPENSEARCH_PORT, hostPort);
-        } else {
-            specBuilder.withExposedPort(OPENSEARCH_PORT);
-        }
+        //
+        // Unlike those services, OpenSearch has no floci-internal proxy fronting the
+        // backend, so the Docker host-port binding is the ONLY way a client outside
+        // the Docker network (e.g. on the host, with floci itself containerized)
+        // can reach the domain. Publish it in both topologies: dropping it for the
+        // in-container case cut off host clients entirely (#2746 follow-up).
+        int hostPort = portAllocator.allocate(
+                config.services().opensearch().proxyBasePort(),
+                config.services().opensearch().proxyMaxPort());
+        specBuilder.withPortBinding(OPENSEARCH_PORT, hostPort);
 
         applyEngineEnv(specBuilder, domain.getEngineVersion());
 
@@ -113,9 +112,7 @@ public class OpenSearchDomainManager {
         try {
             info = lifecycleManager.createAndStart(spec);
         } catch (RuntimeException e) {
-            if (hostPort != NO_HOST_PORT) {
-                portAllocator.release(hostPort);
-            }
+            portAllocator.release(hostPort);
             throw e;
         }
         domain.setContainerId(info.containerId());
@@ -123,8 +120,8 @@ public class OpenSearchDomainManager {
         EndpointInfo endpoint = info.getEndpoint(OPENSEARCH_PORT);
         domain.setEndpoint("http://" + endpoint.host() + ":" + endpoint.port());
 
-        LOG.infov("OpenSearch container {0} started for domain {1} at {2}",
-                info.containerId(), domain.getDomainName(), endpoint);
+        LOG.infov("OpenSearch container {0} started for domain {1} at {2} (host port {3})",
+                info.containerId(), domain.getDomainName(), endpoint, String.valueOf(hostPort));
     }
 
     public boolean isReady(Domain domain) {

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/model/Domain.java
@@ -65,6 +65,9 @@ public class Domain {
     @JsonProperty("ContainerId")
     private String containerId;
 
+    @JsonProperty("HostPort")
+    private Integer hostPort;
+
     @JsonIgnore
     private String accountId;
 
@@ -211,6 +214,14 @@ public class Domain {
 
     public void setContainerId(String containerId) {
         this.containerId = containerId;
+    }
+
+    public Integer getHostPort() {
+        return hostPort;
+    }
+
+    public void setHostPort(Integer hostPort) {
+        this.hostPort = hostPort;
     }
 
     public String getVolumeId() {

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManagerTest.java
@@ -15,11 +15,13 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -138,5 +140,71 @@ class OpenSearchDomainManagerTest {
         verify(portAllocator).allocate(9400, 9499);
         verify(builder).withPortBinding(9200, 9401);
         assertEquals("http://172.17.0.5:9200", domain.getEndpoint());
+        assertEquals(Integer.valueOf(9401), domain.getHostPort());
+    }
+
+    /**
+     * The reservation must die with the container: without the release, repeated
+     * create/delete cycles exhaust the configured port range and later domains
+     * can never start.
+     */
+    @Test
+    void stopDomainReleasesTheHostPort() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.OpenSearchServiceConfig opensearch = mock(EmulatorConfig.OpenSearchServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.opensearch()).thenReturn(opensearch);
+        when(opensearch.keepRunningOnShutdown()).thenReturn(false);
+
+        PortAllocator portAllocator = mock(PortAllocator.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+
+        OpenSearchDomainManager manager = new OpenSearchDomainManager(mock(ContainerBuilder.class),
+                lifecycleManager, mock(ContainerDetector.class), portAllocator, config,
+                mock(RegionResolver.class));
+
+        Domain domain = new Domain();
+        domain.setDomainName("teardown");
+        domain.setContainerId("container-id");
+        domain.setHostPort(9401);
+
+        manager.stopDomain(domain);
+
+        verify(lifecycleManager).stopAndRemove("container-id", null);
+        verify(portAllocator).release(9401);
+        assertNull(domain.getHostPort());
+    }
+
+    /**
+     * Keep-running shutdown leaves the container holding its Docker binding, so
+     * the reservation has to survive with it.
+     */
+    @Test
+    void stopDomainKeepsTheReservationWhenTheContainerKeepsRunning() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.OpenSearchServiceConfig opensearch = mock(EmulatorConfig.OpenSearchServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.opensearch()).thenReturn(opensearch);
+        when(opensearch.keepRunningOnShutdown()).thenReturn(true);
+
+        PortAllocator portAllocator = mock(PortAllocator.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+
+        OpenSearchDomainManager manager = new OpenSearchDomainManager(mock(ContainerBuilder.class),
+                lifecycleManager, mock(ContainerDetector.class), portAllocator, config,
+                mock(RegionResolver.class));
+
+        Domain domain = new Domain();
+        domain.setDomainName("keep-running");
+        domain.setContainerId("container-id");
+        domain.setHostPort(9401);
+
+        manager.stopDomain(domain);
+
+        verify(lifecycleManager, never()).stopAndRemove(anyString(), any());
+        verify(portAllocator, never()).release(9401);
+        assertEquals(Integer.valueOf(9401), domain.getHostPort());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchDomainManagerTest.java
@@ -78,4 +78,65 @@ class OpenSearchDomainManagerTest {
                 "io.floci.account", "000000000000",
                 "io.floci.region", "us-east-1"));
     }
+
+    /**
+     * OpenSearch has no floci-internal proxy fronting the backend, so the Docker
+     * host-port binding is the only path to the domain for a client outside the
+     * Docker network. It must be published even when floci itself runs inside a
+     * container, while the stored endpoint stays the container-IP one floci and
+     * same-network clients use.
+     */
+    @Test
+    void startDomainPublishesAHostPortEvenWhenFlociRunsInAContainer() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.OpenSearchServiceConfig opensearch = mock(EmulatorConfig.OpenSearchServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.opensearch()).thenReturn(opensearch);
+        when(services.dockerNetwork()).thenReturn(Optional.empty());
+        when(opensearch.proxyBasePort()).thenReturn(9400);
+        when(opensearch.proxyMaxPort()).thenReturn(9499);
+        when(opensearch.defaultImage()).thenReturn(Optional.of("opensearchproject/opensearch:2.11.0"));
+        EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        when(config.docker()).thenReturn(docker);
+        lenient().when(docker.logMaxSize()).thenReturn("10m");
+        lenient().when(docker.logMaxFile()).thenReturn("3");
+        EmulatorConfig.StorageConfig storage = mock(EmulatorConfig.StorageConfig.class);
+        when(config.storage()).thenReturn(storage);
+        when(storage.hostPersistentPath()).thenReturn("floci-data");
+        when(storage.persistentPath()).thenReturn("/data");
+
+        PortAllocator portAllocator = mock(PortAllocator.class);
+        when(portAllocator.allocate(9400, 9499)).thenReturn(9401);
+
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.createAndStart(any())).thenReturn(
+                new ContainerLifecycleManager.ContainerInfo("container-id", Map.of(
+                        9200, new ContainerLifecycleManager.EndpointInfo("172.17.0.5", 9200))));
+
+        ContainerBuilder containerBuilder = mock(ContainerBuilder.class);
+        ContainerBuilder.Builder builder = mock(ContainerBuilder.Builder.class, RETURNS_SELF);
+        when(containerBuilder.newContainer(anyString())).thenReturn(builder);
+        when(builder.build()).thenReturn(mock(ContainerSpec.class));
+
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+        when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
+
+        ContainerDetector containerDetector = mock(ContainerDetector.class);
+        lenient().when(containerDetector.isRunningInContainer()).thenReturn(true);
+
+        OpenSearchDomainManager manager = new OpenSearchDomainManager(containerBuilder, lifecycleManager,
+                containerDetector, portAllocator, config, regionResolver);
+
+        Domain domain = new Domain();
+        domain.setDomainName("host-reach");
+        domain.setEngineVersion("OpenSearch_2.11");
+
+        manager.startDomain(domain);
+
+        verify(portAllocator).allocate(9400, 9499);
+        verify(builder).withPortBinding(9200, 9401);
+        assertEquals("http://172.17.0.5:9200", domain.getEndpoint());
+    }
 }


### PR DESCRIPTION
Follow-up to #2746, fixing the regression cfranzen reported there: when floci
itself runs in a container, spawned OpenSearch domains no longer published a
host port, so a client on the Docker host could not reach them at all.

The dropped binding copied the Neptune/MemoryDB pattern, but those services
front their backends with floci-internal proxies that keep host clients
connected, and OpenSearch has no proxy: the Docker host-port binding was its
only path in from outside the Docker network. The binding is now published in
both topologies again, exactly as before #2746, while the stored endpoint
keeps the container-IP form that fix introduced.

All 65 OpenSearch tests pass, including a new regression test asserting the
host port is bound with floci containerized and the endpoint stays the
container-IP one.

