### PR TITLE
fix(docker): PortAllocator also checks ports other containers already publish on the host

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/PortAllocator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/PortAllocator.java
@@ -1,10 +1,15 @@
 package io.github.hectorvent.floci.core.common.docker;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
@@ -22,6 +27,22 @@ public class PortAllocator {
     // Prevents TOCTOU races when multiple containers are launched concurrently.
     private final Set<Integer> reserved = new ConcurrentSkipListSet<>();
 
+    // Nullable: the no-arg constructor below (used throughout this class's own
+    // test suite, and by any caller that predates this field) leaves it null,
+    // which keeps isPortBoundByAnyContainer a no-op and this class's behavior
+    // toward every existing caller byte-identical. Only the CDI-managed
+    // instance - built via the @Inject constructor - ever has one.
+    private final DockerClient dockerClient;
+
+    public PortAllocator() {
+        this(null);
+    }
+
+    @Inject
+    public PortAllocator(DockerClient dockerClient) {
+        this.dockerClient = dockerClient;
+    }
+
     /**
      * Atomically finds and reserves a free TCP port within the specified range.
      * The port is held in-memory until {@link #release(int)} is called, preventing
@@ -34,7 +55,7 @@ public class PortAllocator {
      */
     public synchronized int allocate(int basePort, int maxPort) {
         for (int port = basePort; port <= maxPort; port++) {
-            if (!reserved.contains(port) && isPortFree(port)) {
+            if (!reserved.contains(port) && isPortFree(port) && !isPortBoundByAnyContainer(port)) {
                 reserved.add(port);
                 LOG.debugv("Allocated port {0} from range {1}-{2}", String.valueOf(port), String.valueOf(basePort), String.valueOf(maxPort));
                 return port;
@@ -83,6 +104,17 @@ public class PortAllocator {
     /**
      * Checks if a specific port is currently free.
      *
+     * <p>This binds a {@link ServerSocket} in floci's OWN network namespace. That
+     * namespace is meaningful when floci itself runs as a bare process, but floci
+     * normally runs inside its own Docker container, where every other network
+     * namespace on the host - in particular a SIBLING container's own {@code -p
+     * hostPort:containerPort} publication (an EKS cluster's k3s container, an
+     * MSK broker, an ECR registry mirror) - is completely invisible to this
+     * check: "is port free" here can only ever mean "free inside my own
+     * container," which is not the question a caller allocating a HOST port for
+     * a sibling container is actually asking. See {@link #isPortBoundByAnyContainer}
+     * for the other half {@link #allocate} needs to answer that question for real.
+     *
      * @param port the port to check
      * @return true if the port is available, false otherwise
      */
@@ -93,5 +125,49 @@ public class PortAllocator {
         } catch (IOException e) {
             return false;
         }
+    }
+
+    /**
+     * Reports whether port is already published as a host port by ANY Docker
+     * container (running or not - a container mid-{@code docker run} that has
+     * not started yet, the shape a losing race between two sibling k3s
+     * containers takes, still holds its port binding). This is what
+     * {@link #isPortFree} cannot see from inside floci's own container network
+     * namespace, and why {@link #allocate} checks both: a host running two
+     * floci instances that each manage their own sibling containers on the
+     * SAME Docker host - lex00/floci issue naming this class of bug: two
+     * independently-started EKS real-mode clusters both allocating host port
+     * 6500 for their own k3s API server container, because each floci
+     * instance's own in-process/in-namespace check saw its OWN container as
+     * having nothing bound - is exactly the case this closes.
+     *
+     * <p>Returns false (never blocks allocation) when this instance was built
+     * without a {@link DockerClient} - the no-arg constructor's own contract,
+     * unchanged for every caller that predates this method - or when the
+     * Docker API call itself fails, matching {@link #isPortFree}'s own
+     * fail-permissive posture for a probe that could not be completed.
+     */
+    boolean isPortBoundByAnyContainer(int port) {
+        if (dockerClient == null) {
+            return false;
+        }
+        try {
+            List<Container> containers = dockerClient.listContainersCmd().withShowAll(true).exec();
+            for (Container c : containers) {
+                ContainerPort[] ports = c.getPorts();
+                if (ports == null) {
+                    continue;
+                }
+                for (ContainerPort p : ports) {
+                    Integer publicPort = p.getPublicPort();
+                    if (publicPort != null && publicPort == port) {
+                        return true;
+                    }
+                }
+            }
+        } catch (Exception e) {
+            LOG.debugv("Error checking Docker port bindings for {0}: {1}", port, e.getMessage());
+        }
+        return false;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/PortAllocator.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/PortAllocator.java
@@ -9,6 +9,7 @@ import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.net.ServerSocket;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -54,8 +55,13 @@ public class PortAllocator {
      * @throws RuntimeException if no free port is available in the range
      */
     public synchronized int allocate(int basePort, int maxPort) {
+        // One Docker API round-trip per allocation, not one per candidate: the
+        // snapshot is only as fresh as the moment allocate() started either way,
+        // and this loop runs inside a lock every consumer of the shared
+        // allocator blocks on.
+        Set<Integer> published = publishedHostPorts();
         for (int port = basePort; port <= maxPort; port++) {
-            if (!reserved.contains(port) && isPortFree(port) && !isPortBoundByAnyContainer(port)) {
+            if (!reserved.contains(port) && !published.contains(port) && isPortFree(port)) {
                 reserved.add(port);
                 LOG.debugv("Allocated port {0} from range {1}-{2}", String.valueOf(port), String.valueOf(basePort), String.valueOf(maxPort));
                 return port;
@@ -112,7 +118,7 @@ public class PortAllocator {
      * MSK broker, an ECR registry mirror) - is completely invisible to this
      * check: "is port free" here can only ever mean "free inside my own
      * container," which is not the question a caller allocating a HOST port for
-     * a sibling container is actually asking. See {@link #isPortBoundByAnyContainer}
+     * a sibling container is actually asking. See {@link #publishedHostPorts}
      * for the other half {@link #allocate} needs to answer that question for real.
      *
      * @param port the port to check
@@ -128,31 +134,33 @@ public class PortAllocator {
     }
 
     /**
-     * Reports whether port is already published as a host port by ANY Docker
-     * container (running or not - a container mid-{@code docker run} that has
-     * not started yet, the shape a losing race between two sibling k3s
-     * containers takes, still holds its port binding). This is what
-     * {@link #isPortFree} cannot see from inside floci's own container network
-     * namespace, and why {@link #allocate} checks both: a host running two
-     * floci instances that each manage their own sibling containers on the
-     * SAME Docker host - lex00/floci issue naming this class of bug: two
+     * Snapshots every host port ANY Docker container currently publishes
+     * (running or not - a container mid-{@code docker run} that has not
+     * started yet, the shape a losing race between two sibling k3s containers
+     * takes, still holds its port binding). This is what {@link #isPortFree}
+     * cannot see from inside floci's own container network namespace, and why
+     * {@link #allocate} checks both: a host running two floci instances that
+     * each manage their own sibling containers on the SAME Docker host - two
      * independently-started EKS real-mode clusters both allocating host port
      * 6500 for their own k3s API server container, because each floci
      * instance's own in-process/in-namespace check saw its OWN container as
-     * having nothing bound - is exactly the case this closes.
+     * having nothing bound - is exactly the case this closes. One Docker API
+     * call per invocation; {@link #allocate} calls it once per allocation and
+     * checks every candidate against the returned snapshot.
      *
-     * <p>Returns false (never blocks allocation) when this instance was built
-     * without a {@link DockerClient} - the no-arg constructor's own contract,
-     * unchanged for every caller that predates this method - or when the
-     * Docker API call itself fails, matching {@link #isPortFree}'s own
+     * <p>Returns an empty set (never blocks allocation) when this instance was
+     * built without a {@link DockerClient} - the no-arg constructor's own
+     * contract, unchanged for every caller that predates this method - or when
+     * the Docker API call itself fails, matching {@link #isPortFree}'s own
      * fail-permissive posture for a probe that could not be completed.
      */
-    boolean isPortBoundByAnyContainer(int port) {
+    Set<Integer> publishedHostPorts() {
         if (dockerClient == null) {
-            return false;
+            return Set.of();
         }
         try {
             List<Container> containers = dockerClient.listContainersCmd().withShowAll(true).exec();
+            Set<Integer> published = new HashSet<>();
             for (Container c : containers) {
                 ContainerPort[] ports = c.getPorts();
                 if (ports == null) {
@@ -160,14 +168,15 @@ public class PortAllocator {
                 }
                 for (ContainerPort p : ports) {
                     Integer publicPort = p.getPublicPort();
-                    if (publicPort != null && publicPort == port) {
-                        return true;
+                    if (publicPort != null) {
+                        published.add(publicPort);
                     }
                 }
             }
+            return published;
         } catch (Exception e) {
-            LOG.debugv("Error checking Docker port bindings for {0}: {1}", port, e.getMessage());
+            LOG.debugv("Error checking Docker port bindings: {0}", e.getMessage());
+            return Set.of();
         }
-        return false;
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/PortAllocatorDockerAwareTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/PortAllocatorDockerAwareTest.java
@@ -1,0 +1,92 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.ContainerPort;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Proves lex00/floci#139's fix: two independently-started floci instances,
+ * each in its own Docker container and so each with its own network
+ * namespace, that both try to allocate a host port for a sibling container
+ * (an EKS real-mode cluster's k3s API server is the shape that found this -
+ * EksClusterManager always requests the same base range) must not both
+ * settle on the SAME port just because each one's own in-namespace
+ * ServerSocket probe sees nothing bound.
+ *
+ * A single-process allocator cannot reproduce a second floci INSTANCE
+ * choosing the same port; what it CAN reproduce, and what actually causes
+ * the bug, is the one thing {@link PortAllocator#isPortFree} structurally
+ * cannot see: a port already published by SOME OTHER container on the same
+ * Docker host, discoverable only through the Docker API - not through this
+ * process's own socket namespace. That is exactly what
+ * {@link PortAllocator#isPortBoundByAnyContainer} adds, and what this test
+ * exercises directly, with a mocked {@link DockerClient} standing in for a
+ * sibling container's own port binding.
+ */
+class PortAllocatorDockerAwareTest {
+
+    @Test
+    void allocateSkipsAPortAlreadyPublishedByAnotherContainer() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ListContainersCmd listCmd = mock(ListContainersCmd.class);
+        when(dockerClient.listContainersCmd()).thenReturn(listCmd);
+        when(listCmd.withShowAll(anyBoolean())).thenReturn(listCmd);
+
+        ContainerPort boundPort = new ContainerPort().withPublicPort(19900);
+        Container sibling = mock(Container.class);
+        when(sibling.getPorts()).thenReturn(new ContainerPort[]{boundPort});
+        when(listCmd.exec()).thenReturn(List.of(sibling));
+
+        PortAllocator allocator = new PortAllocator(dockerClient);
+
+        // 19900 is free from this process's own ServerSocket point of view -
+        // nothing here is bound to it - but the mocked DockerClient reports it
+        // as already published by a sibling container, exactly the shape two
+        // independently-started k3s API server containers both requesting the
+        // EKS manager's base port produce on a real host. BREAK: comment out
+        // the isPortBoundByAnyContainer call in allocate() and this assertion
+        // fails, allocating 19900 - the pre-fix bug, reproduced without
+        // starting a second Docker container at all.
+        int allocated = allocator.allocate(19900, 19999);
+
+        assertNotEquals(19900, allocated, "must not allocate a port a container already publishes, even though this process's own socket check sees it as free");
+        allocator.release(allocated);
+    }
+
+    @Test
+    void allocateStillWorksWithNoDockerClient() {
+        // The no-arg constructor's own contract, unchanged: every pre-existing
+        // caller (this class's sibling PortAllocatorTest, every other service
+        // that built a PortAllocator directly before this fix existed) keeps
+        // behaving exactly as it did, because isPortBoundByAnyContainer is a
+        // no-op with no DockerClient to ask.
+        PortAllocator allocator = new PortAllocator();
+        int port = allocator.allocate(19900, 19999);
+        assertEquals(19900, port, "with no DockerClient, the first free port in range is still chosen");
+        allocator.release(port);
+    }
+
+    @Test
+    void dockerApiFailureDoesNotBlockAllocation() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        when(dockerClient.listContainersCmd()).thenThrow(new RuntimeException("docker daemon unreachable"));
+
+        PortAllocator allocator = new PortAllocator(dockerClient);
+        // Fail-permissive, matching isPortFree's own posture for a probe that
+        // could not be completed: a Docker API error must not make every
+        // allocation in the estate throw.
+        int port = allocator.allocate(19900, 19999);
+        assertEquals(19900, port);
+        allocator.release(port);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/PortAllocatorDockerAwareTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/PortAllocatorDockerAwareTest.java
@@ -12,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -29,7 +31,7 @@ import static org.mockito.Mockito.when;
  * cannot see: a port already published by SOME OTHER container on the same
  * Docker host, discoverable only through the Docker API - not through this
  * process's own socket namespace. That is exactly what
- * {@link PortAllocator#isPortBoundByAnyContainer} adds, and what this test
+ * {@link PortAllocator#publishedHostPorts} adds, and what this test
  * exercises directly, with a mocked {@link DockerClient} standing in for a
  * sibling container's own port binding.
  */
@@ -54,7 +56,7 @@ class PortAllocatorDockerAwareTest {
         // as already published by a sibling container, exactly the shape two
         // independently-started k3s API server containers both requesting the
         // EKS manager's base port produce on a real host. BREAK: comment out
-        // the isPortBoundByAnyContainer call in allocate() and this assertion
+        // the published.contains(port) check in allocate() and this assertion
         // fails, allocating 19900 - the pre-fix bug, reproduced without
         // starting a second Docker container at all.
         int allocated = allocator.allocate(19900, 19999);
@@ -68,12 +70,42 @@ class PortAllocatorDockerAwareTest {
         // The no-arg constructor's own contract, unchanged: every pre-existing
         // caller (this class's sibling PortAllocatorTest, every other service
         // that built a PortAllocator directly before this fix existed) keeps
-        // behaving exactly as it did, because isPortBoundByAnyContainer is a
+        // behaving exactly as it did, because publishedHostPorts is a
         // no-op with no DockerClient to ask.
         PortAllocator allocator = new PortAllocator();
         int port = allocator.allocate(19900, 19999);
         assertEquals(19900, port, "with no DockerClient, the first free port in range is still chosen");
         allocator.release(port);
+    }
+
+    @Test
+    void allocateFetchesTheContainerListOncePerInvocation() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ListContainersCmd listCmd = mock(ListContainersCmd.class);
+        when(dockerClient.listContainersCmd()).thenReturn(listCmd);
+        when(listCmd.withShowAll(anyBoolean())).thenReturn(listCmd);
+
+        // Several leading candidates already published - the exact scenario the
+        // Docker check exists for, and the one where a per-candidate round-trip
+        // would multiply API calls inside the allocator's lock.
+        Container sibling = mock(Container.class);
+        when(sibling.getPorts()).thenReturn(new ContainerPort[]{
+                new ContainerPort().withPublicPort(19900),
+                new ContainerPort().withPublicPort(19901),
+                new ContainerPort().withPublicPort(19902),
+        });
+        when(listCmd.exec()).thenReturn(List.of(sibling));
+
+        PortAllocator allocator = new PortAllocator(dockerClient);
+        int allocated = allocator.allocate(19900, 19999);
+
+        assertNotEquals(19900, allocated);
+        assertNotEquals(19901, allocated);
+        assertNotEquals(19902, allocated);
+        // The snapshot is only as fresh as the start of allocate() either way,
+        // so one listContainersCmd round-trip must serve every candidate.
+        verify(dockerClient, times(1)).listContainersCmd();
+        allocator.release(allocated);
     }
 
     @Test


### PR DESCRIPTION
Follow-up promised on #2798. PortAllocator.isPortFree binds a ServerSocket
in floci's own process, the container's network namespace when floci runs
containerized, so a port another container already publishes via -p looks
free, and the container that trusted the allocation fails with "port is
already allocated".

allocate() now also consults the Docker API's view of published host ports,
covering every consumer of the shared allocator (EC2, ECR, EKS, MSK, MWAA,
OpenSearch). The DockerClient is optional and a Docker API failure never
blocks allocation, so existing callers' behavior is unchanged.

The new PortAllocatorDockerAwareTest fails if the Docker-API check is
removed; 101 tests pass across the allocator and its EKS, MSK and
OpenSearch consumers.

