### PR TITLE
fix(build): resolve the JSON schema library from Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <quarkus.platform.version>3.37.4</quarkus.platform.version>
         <jackson.version>2.22.1</jackson.version>
         <apicurio.version>2.6.13.Final</apicurio.version>
+        <everit.json.schema.version>1.14.6</everit.json.schema.version>
         <wire.version>6.4.5</wire.version>
     </properties>
 
@@ -257,7 +258,24 @@
                     <groupId>io.apicurio</groupId>
                     <artifactId>apicurio-common-app-components-logging</artifactId>
                 </exclusion>
+                <!-- Apicurio asks for the JSON schema library under its JitPack coordinate
+                     (com.github.everit-org.json-schema), which has never been published to Maven
+                     Central. Resolving it needs a JitPack repository, so a clone with a cold
+                     ~/.m2 fails to build. Replaced below with the same library under the
+                     coordinate its author publishes to Central. -->
+                <exclusion>
+                    <groupId>com.github.everit-org.json-schema</groupId>
+                    <artifactId>org.everit.json.schema</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <!-- The same project as com.github.everit-org.json-schema, rehomed by its author to a
+             Central-published coordinate: identical org.everit.json.schema packages, so apicurio's
+             JsonSchemaCompatibilityChecker and JsonSchemaContentValidator load unchanged. -->
+        <dependency>
+            <groupId>com.github.erosb</groupId>
+            <artifactId>everit-json-schema</artifactId>
+            <version>${everit.json.schema.version}</version>
         </dependency>
         <dependency>
             <groupId>io.apicurio</groupId>

--- a/src/test/java/io/github/hectorvent/floci/services/glue/schemaregistry/SchemaCompatibilityCheckerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/schemaregistry/SchemaCompatibilityCheckerTest.java
@@ -59,6 +59,20 @@ class SchemaCompatibilityCheckerTest {
                     + "  required string phone = 3;\n"
                     + "}\n";
 
+    private static final String JSON_V1 =
+            "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\","
+                    + "\"properties\":{\"id\":{\"type\":\"integer\"}},\"required\":[\"id\"]}";
+
+    private static final String JSON_ADD_OPTIONAL =
+            "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\","
+                    + "\"properties\":{\"id\":{\"type\":\"integer\"},"
+                    + "\"email\":{\"type\":\"string\"}},\"required\":[\"id\"]}";
+
+    private static final String JSON_ADD_REQUIRED =
+            "{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\","
+                    + "\"properties\":{\"id\":{\"type\":\"integer\"},"
+                    + "\"email\":{\"type\":\"string\"}},\"required\":[\"id\",\"email\"]}";
+
     @Test
     void noneAlwaysCompatible() {
         var r = SchemaCompatibilityChecker.check("NONE", List.of(AVRO_V1), AVRO_ADD_REQUIRED, "AVRO");
@@ -157,5 +171,41 @@ class SchemaCompatibilityCheckerTest {
     void validateDefinitionRejectsInvalidAvro() {
         String error = SchemaCompatibilityChecker.validateDefinition("{garbage", "AVRO");
         assertNotNull(error);
+    }
+
+    // JSON goes through apicurio's JsonSchemaCompatibilityChecker and JsonSchemaContentValidator,
+    // which are backed by the org.everit.json.schema library. These cases are what prove that
+    // library actually loads: the AVRO and PROTOBUF paths never touch it, so before this the JSON
+    // branch of checkerFor/validatorFor was entirely uncovered.
+
+    @Test
+    void jsonBackwardAcceptsAnUnchangedSchema() {
+        var r = SchemaCompatibilityChecker.check("BACKWARD", List.of(JSON_V1), JSON_V1, "JSON");
+        assertTrue(r.compatible(), () -> "expected compatible, got: " + r.reason());
+    }
+
+    /**
+     * Apicurio treats adding even an optional property as narrowing, because data that carried that
+     * key with another type validated before and no longer does. Asserted as observed rather than
+     * assumed: it is the opposite of the AVRO case above.
+     */
+    @Test
+    void jsonBackwardTreatsANewOptionalPropertyAsNarrowing() {
+        var r = SchemaCompatibilityChecker.check("BACKWARD", List.of(JSON_V1), JSON_ADD_OPTIONAL, "JSON");
+        assertFalse(r.compatible());
+        assertNotNull(r.reason());
+    }
+
+    @Test
+    void jsonBackwardRejectsAddingARequiredProperty() {
+        var r = SchemaCompatibilityChecker.check("BACKWARD", List.of(JSON_V1), JSON_ADD_REQUIRED, "JSON");
+        assertFalse(r.compatible());
+        assertNotNull(r.reason());
+    }
+
+    @Test
+    void jsonFirstVersionIsCompatible() {
+        var r = SchemaCompatibilityChecker.check("BACKWARD", List.of(), JSON_V1, "JSON");
+        assertTrue(r.compatible(), () -> "expected compatible, got: " + r.reason());
     }
 }


### PR DESCRIPTION
## Summary

Reported on Slack: a local build fails to resolve
`com.github.everit-org.json-schema:org.everit.json.schema`, a transitive dependency of apicurio.

Reproduced, with one correction to the diagnosis: **the artifact was never on Maven Central**, so it
has not "become" unavailable. `com.github.everit-org.json-schema` is a JitPack coordinate
(`com.github.<user>.<repo>`).

Evidence:

```
$ curl -sI https://repo1.maven.org/maven2/com/github/everit-org/json-schema/\
org.everit.json.schema/1.14.4/org.everit.json.schema-1.14.4.jar
HTTP 404                       # the parent directory is 404 too
$ mvn dependency:get -Dartifact=com.github.everit-org.json-schema:org.everit.json.schema:1.14.4 \
      -Dmaven.repo.local=/tmp/coldrepo
[ERROR] Could not find artifact ... in central (https://repo.maven.apache.org/maven2)
```

`pom.xml` declares no `<repositories>` and there is no `~/.m2/settings.xml`, so Maven only ever
consults Central. Every build that currently works is resolving the jar from a **warm `~/.m2`**,
CI included via its restored Maven cache. That is why this stayed invisible: it breaks only on a
cold clone, which is exactly what a new contributor has.

Apicurio declares the JitPack coordinate in its own POM, so this is upstream's choice rather than
something introduced here.

## The fix

`com.github.erosb:everit-json-schema` is the same project, rehomed by its author to a
Central-published coordinate:

| | JitPack coordinate | Central coordinate |
|---|---|---|
| groupId:artifactId | `com.github.everit-org.json-schema:org.everit.json.schema` | `com.github.erosb:everit-json-schema` |
| classes under `org/everit/json/schema` | 174 | 174 |
| on Maven Central | 404 | 200 |
| latest | 1.14.4 | **1.14.6** |

Same packages, so apicurio's `JsonSchemaCompatibilityChecker` and `JsonSchemaContentValidator` load
unchanged. Excluded from apicurio, declared directly, and `dependency:tree` shows exactly one everit.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A for the wire protocol. Same library, same classes, newer patch version. It backs Glue schema
registry compatibility checks for the `JSON` data format, whose behaviour is unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`mvn dependency:resolve` against an **empty local repository** now succeeds, which is the check that
matters here.

**The test coverage was the real gap.** `SchemaCompatibilityCheckerTest` had **zero JSON cases** —
only AVRO and PROTOBUF, neither of which touches this library. So the entire JSON branch of
`checkerFor` / `validatorFor` was untested, and a green suite proved nothing about whether the
dependency resolves. Three JSON cases now cover it, and dropping the replacement fails exactly those
three:

```
java.lang.NoClassDefFoundError: org/everit/json/schema/loader/SchemaLoader
```

One assertion is written to observed behaviour rather than assumption: apicurio reports adding an
*optional* JSON property as `OBJECT_TYPE_PROPERTY_SCHEMAS_NARROWED`, i.e. incompatible — the
opposite of the AVRO case — because data carrying that key with a different type validated before
and no longer does. I had asserted the intuitive answer first and it was wrong.
