### PR TITLE
fix(lambda): implement GetLayerVersionByArn

### DIFF
--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -166,8 +166,8 @@ services:
 
 Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL controller, which routes the request into the normal `Invoke` path.
 
-**Layers:** `PublishLayerVersion`, `GetLayerVersion`, `ListLayerVersions`, `ListLayers`, and
-`DeleteLayerVersion` are implemented, with real local storage under
+**Layers:** `PublishLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `ListLayerVersions`,
+`ListLayers`, and `DeleteLayerVersion` are implemented, with real local storage under
 `{lambda.codePath}/layers/{name}/{version}`. `CreateFunction`/`UpdateFunctionConfiguration`
 validate each `Layers` ARN eagerly against that storage, matching real AWS - an unresolvable ARN
 is rejected with `InvalidParameterValueException`, not silently accepted. Only resolves layers
@@ -180,7 +180,7 @@ a name you control and reference that ARN instead.
 
 These AWS Lambda operations have no handler in Floci. Calls will return `404` or an error:
 
-- Layer permissions and cross-account ARN lookup (`GetLayerVersionByArn`, `AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
+- Layer permissions (`AddLayerVersionPermission`, `RemoveLayerVersionPermission`, `GetLayerVersionPolicy`)
 - Provisioned concurrency (`PutProvisionedConcurrencyConfig`, `GetProvisionedConcurrencyConfig`, `ListProvisionedConcurrencyConfigs`, `DeleteProvisionedConcurrencyConfig`)
 - Dead-letter, async invoke config, and event invoke config operations
 - `InvokeWithResponseStream`

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerController.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -31,11 +32,14 @@ import java.util.Map;
  * GetLayerVersion:      GET    /2018-10-31/layers/{LayerName}/versions/{VersionNumber}
  * DeleteLayerVersion:   DELETE /2018-10-31/layers/{LayerName}/versions/{VersionNumber}
  * ListLayers:           GET    /2018-10-31/layers
+ * GetLayerVersionByArn: GET    /2018-10-31/layers?find=LayerVersion&Arn={arn}
  */
 @Path("/2018-10-31")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class LambdaLayerController {
+
+    private static final String FIND_LAYER_VERSION = "LayerVersion";
 
     private final ObjectMapper objectMapper;
     private final LambdaLayerService layerService;
@@ -96,9 +100,23 @@ public class LambdaLayerController {
         return Response.noContent().build();
     }
 
+    /**
+     * ListLayers, and GetLayerVersionByArn when {@code find=LayerVersion}. AWS gives the two
+     * actions the same method and path, and JAX-RS cannot route on a query parameter. The match
+     * is case-sensitive; any other value is a ListLayers call.
+     */
     @GET
     @Path("/layers")
-    public Response listLayers(@Context HttpHeaders headers) {
+    public Response listLayers(@QueryParam("find") String find,
+                               @QueryParam("Arn") String arn,
+                               @Context HttpHeaders headers,
+                               @Context UriInfo uriInfo) {
+        if (FIND_LAYER_VERSION.equals(find)) {
+            LambdaLayerVersion lv = layerService.getLayerVersionByArn(arn);
+            // The layer's own region, not the caller's: tasksLocation resolves the bucket from it.
+            String layerRegion = AwsArnUtils.parse(lv.getLayerVersionArn()).region();
+            return Response.ok(buildLayerVersionResponse(lv, layerRegion, uriInfo)).build();
+        }
         String region = regionResolver.resolveRegion(headers);
         List<LambdaLayerVersion> layers = layerService.listLayers(region);
         ObjectNode root = objectMapper.createObjectNode();

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
@@ -228,6 +228,15 @@ public class LambdaLayerService {
                             + " constraint: Member must satisfy regular expression pattern: "
                             + LAYER_VERSION_ARN_PATTERN, 400);
         }
+        // resolveLayerByArn keys on region/name/version within the caller's own partition, so an
+        // ARN naming another account would otherwise resolve to the caller's same-named layer.
+        // No layer here can be shared cross-account (layer permissions are unimplemented), so a
+        // foreign account is always a miss; this is where sharing would hook in if that changes.
+        String requestedAccount = AwsArnUtils.accountOrDefault(layerVersionArn, null);
+        if (requestedAccount != null && !requestedAccount.equals(regionResolver.getAccountId())) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The resource you requested does not exist.", 404);
+        }
         LambdaLayerVersion lv = resolveLayerByArn(layerVersionArn);
         if (lv == null) {
             throw new AwsException("ResourceNotFoundException",

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
@@ -232,6 +232,15 @@ public class LambdaLayerService {
         // ARN naming another account would otherwise resolve to the caller's same-named layer.
         // No layer here can be shared cross-account (layer permissions are unimplemented), so a
         // foreign account is always a miss; this is where sharing would hook in if that changes.
+        // resolveLayerByArn also drops the partition, so an ARN naming another one would
+        // otherwise resolve to the local layer under a foreign-partition ARN. Floci emulates
+        // the aws partition; the live service rejects the others outright.
+        AwsArnUtils.Arn parsed = AwsArnUtils.parse(layerVersionArn);
+        if (parsed.partition() != null && !parsed.partition().isEmpty()
+                && !"aws".equals(parsed.partition())) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Invalid layer version " + layerVersionArn, 400);
+        }
         String requestedAccount = AwsArnUtils.accountOrDefault(layerVersionArn, null);
         if (requestedAccount != null && !requestedAccount.equals(regionResolver.getAccountId())) {
             throw new AwsException("ResourceNotFoundException",

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
@@ -25,6 +25,7 @@ import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Business logic for Lambda Layer management.
@@ -33,6 +34,18 @@ import java.util.Map;
 public class LambdaLayerService {
 
     private static final Logger LOG = Logger.getLogger(LambdaLayerService.class);
+
+    /**
+     * Arn constraint GetLayerVersionByArn enforces. Taken from the live service's own
+     * ValidationException rather than the API reference, which publishes a laxer pattern and
+     * omits the AWS-managed {@code awslayer} form entirely.
+     */
+    private static final String LAYER_VERSION_ARN_PATTERN =
+            "((arn:(aws[a-zA-Z-]*)?:lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\\d{1}"
+                    + ":\\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)"
+                    + "|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+))";
+    private static final Pattern LAYER_VERSION_ARN = Pattern.compile(LAYER_VERSION_ARN_PATTERN);
+    private static final int MAX_LAYER_VERSION_ARN_LENGTH = 140;
 
     private final LambdaLayerStore layerStore;
     private final ZipExtractor zipExtractor;
@@ -195,6 +208,32 @@ public class LambdaLayerService {
             LOG.debugv("Could not delete stored layer archive for {0} v{1}: {2}",
                     lv.getLayerName(), lv.getVersion(), e.getMessage());
         }
+    }
+
+    /**
+     * GetLayerVersionByArn. Arn is validated before lookup, so a malformed value is a 400
+     * ValidationException and a well-formed but absent one a 404 — both as the live service
+     * answers them.
+     */
+    public LambdaLayerVersion getLayerVersionByArn(String layerVersionArn) {
+        if (layerVersionArn == null || layerVersionArn.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'arn' failed to satisfy constraint: "
+                            + "Member must not be null", 400);
+        }
+        if (layerVersionArn.length() > MAX_LAYER_VERSION_ARN_LENGTH
+                || !LAYER_VERSION_ARN.matcher(layerVersionArn).matches()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + layerVersionArn + "' at 'arn' failed to satisfy"
+                            + " constraint: Member must satisfy regular expression pattern: "
+                            + LAYER_VERSION_ARN_PATTERN, 400);
+        }
+        LambdaLayerVersion lv = resolveLayerByArn(layerVersionArn);
+        if (lv == null) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The resource you requested does not exist.", 404);
+        }
+        return lv;
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaGetLayerVersionByArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaGetLayerVersionByArnIntegrationTest.java
@@ -178,6 +178,35 @@ class LambdaGetLayerVersionByArnIntegrationTest {
     }
 
     @Test
+    @Order(7)
+    void arnNamingAnotherAccountDoesNotResolveTheCallersOwnLayer() throws Exception {
+        String arn = publishLayer();
+        // Same region, name and version — only the account differs. The lookup is keyed within
+        // the caller's own partition, so without an account check this would return the layer
+        // above under someone else's ARN.
+        String foreign = arn.replaceFirst(":\\d{12}:", ":111111111111:");
+
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", foreign)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("ResourceNotFoundException"));
+
+        // control: the identical ARN under the caller's own account still resolves
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", arn)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("LayerVersionArn", equalTo(arn));
+    }
+
+    @Test
     @Order(8)
     void listLayersStillWorksWithoutFind() throws Exception {
         publishLayer();

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaGetLayerVersionByArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaGetLayerVersionByArnIntegrationTest.java
@@ -1,0 +1,247 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * GetLayerVersionByArn: GET /2018-10-31/layers?find=LayerVersion&amp;Arn={arn}. Shares
+ * ListLayers' path, so these also pin that ListLayers itself is unchanged.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaGetLayerVersionByArnIntegrationTest {
+
+    private static final String LAYER_NAME = "by-arn-layer";
+
+    private static String layerZipBase64() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("python/shared.py"));
+            zos.write("VALUE = 1".getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static String publishLayer() throws Exception {
+        return given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Content": { "ZipFile": "%s" },
+                    "CompatibleRuntimes": ["python3.12"],
+                    "CompatibleArchitectures": ["x86_64"],
+                    "Description": "resolved by arn",
+                    "LicenseInfo": "Apache-2.0"
+                }
+                """.formatted(layerZipBase64()))
+        .when()
+            .post("/2018-10-31/layers/" + LAYER_NAME + "/versions")
+        .then()
+            .statusCode(201)
+            .extract().path("LayerVersionArn");
+    }
+
+    @Test
+    @Order(1)
+    void returnsTheLayerVersion_notAListLayersBody() throws Exception {
+        String arn = publishLayer();
+
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", arn)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            // A LayerVersion object, never the ListLayers envelope.
+            .body("Layers", nullValue())
+            .body("LayerVersionArn", equalTo(arn))
+            .body("LayerArn", containsString(":layer:" + LAYER_NAME))
+            .body("Version", equalTo(1))
+            .body("Description", equalTo("resolved by arn"))
+            .body("LicenseInfo", equalTo("Apache-2.0"))
+            .body("CompatibleRuntimes", hasItem("python3.12"))
+            .body("CompatibleArchitectures", hasItem("x86_64"))
+            .body("Content.CodeSha256", notNullValue())
+            .body("Content.CodeSize", notNullValue())
+            .body("Content.Location", containsString("/layers/"));
+    }
+
+    @Test
+    @Order(2)
+    void matchesGetLayerVersionForTheSameVersion() throws Exception {
+        String arn = publishLayer();
+        long version = Long.parseLong(arn.substring(arn.lastIndexOf(':') + 1));
+
+        String byName = given()
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_NAME + "/versions/" + version)
+        .then()
+            .statusCode(200)
+            .extract().path("Content.CodeSha256");
+
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", arn)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Content.CodeSha256", equalTo(byName));
+    }
+
+    @Test
+    @Order(3)
+    void wellFormedButAbsentArnIsResourceNotFound() {
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", "arn:aws:lambda:us-east-1:000000000000:layer:no-such-layer:9")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("ResourceNotFoundException"))
+            .body("message", equalTo("The resource you requested does not exist."));
+    }
+
+    @Test
+    @Order(4)
+    void malformedArnIsValidationException() {
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", "not-an-arn")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("failed to satisfy constraint"));
+    }
+
+    @Test
+    @Order(5)
+    void arnWithoutAVersionIsValidationException() {
+        // A layer ARN, not a layer *version* ARN: the pattern requires the trailing version.
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", "arn:aws:lambda:us-east-1:000000000000:layer:" + LAYER_NAME)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    @Order(6)
+    void findWithoutArnIsValidationException() {
+        given()
+            .queryParam("find", "LayerVersion")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("Member must not be null"));
+    }
+
+    @Test
+    @Order(7)
+    void awsManagedLayerArnFormPassesValidation() {
+        // arn:<partition>:lambda:::awslayer:<name> is the second alternative in the pattern the
+        // live service enforces. No such layer can exist here, so it resolves to 404, not 400.
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", "arn:aws:lambda:::awslayer:AmazonLinux1803")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    @Order(8)
+    void listLayersStillWorksWithoutFind() throws Exception {
+        publishLayer();
+
+        given()
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers", notNullValue())
+            .body("Layers.LayerName", hasItem(LAYER_NAME));
+    }
+
+    @Test
+    @Order(9)
+    void unknownFindValueFallsThroughToListLayers() throws Exception {
+        publishLayer();
+
+        // Measured against the live service: an unrecognised `find` is ignored and the request
+        // is answered as ListLayers, rather than rejected.
+        given()
+            .queryParam("find", "SomethingElse")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers", notNullValue());
+    }
+
+    @Test
+    @Order(10)
+    void findMatchIsCaseSensitive() {
+        // Also measured: only the exact string dispatches; other casings are ListLayers calls,
+        // which is why an Arn alongside them is simply ignored rather than resolved.
+        for (String find : new String[] {"layerversion", "LAYERVERSION", "LayerversioN"}) {
+            given()
+                .queryParam("find", find)
+                .queryParam("Arn", "arn:aws:lambda:us-east-1:000000000000:layer:" + LAYER_NAME + ":1")
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(200)
+                .body("Layers", notNullValue());
+        }
+    }
+
+    // ── cleanup ───────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(11)
+    void cleanup_deletePublishedVersions() {
+        List<Integer> versions = given()
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_NAME + "/versions")
+        .then()
+            .statusCode(200)
+            .extract().path("LayerVersions.Version");
+
+        for (Integer version : versions) {
+            given()
+            .when()
+                .delete("/2018-10-31/layers/" + LAYER_NAME + "/versions/" + version)
+            .then()
+                .statusCode(204);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaGetLayerVersionByArnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaGetLayerVersionByArnIntegrationTest.java
@@ -207,6 +207,35 @@ class LambdaGetLayerVersionByArnIntegrationTest {
     }
 
     @Test
+    @Order(7)
+    void arnInAnotherPartitionIsRejected() throws Exception {
+        String arn = publishLayer();
+        // Same account, region, name and version - only the partition differs. Measured against
+        // the live service, which answers InvalidParameterValueException rather than resolving.
+        for (String partition : new String[] {"aws-cn", "aws-us-gov", "aws-iso"}) {
+            given()
+                .queryParam("find", "LayerVersion")
+                .queryParam("Arn", arn.replaceFirst("^arn:aws:", "arn:" + partition + ":"))
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidParameterValueException"))
+                .body("message", containsString("Invalid layer version arn:" + partition + ":"));
+        }
+
+        // control: the same ARN in the aws partition still resolves
+        given()
+            .queryParam("find", "LayerVersion")
+            .queryParam("Arn", arn)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("LayerVersionArn", equalTo(arn));
+    }
+
+    @Test
     @Order(8)
     void listLayersStillWorksWithoutFind() throws Exception {
         publishLayer();


### PR DESCRIPTION
## Summary

`GET /2018-10-31/layers?find=LayerVersion&Arn={arn}` is **GetLayerVersionByArn**, but only `ListLayers` was bound to that path and it took no query parameters at all. A GetLayerVersionByArn call was therefore answered with a `ListLayers` body and HTTP 200 — an SDK deserialises that against the GetLayerVersionByArn output shape, finds none of its members, and hands the caller an empty result instead of the layer version or a `ResourceNotFoundException`. `aws lambda get-layer-version-by-arn --arn …` prints nothing at all.

AWS gives the two actions the same method and path, discriminated only by `find`, and JAX-RS cannot route on a query parameter, so the branch lives in the handler. The response reuses the builder `GetLayerVersion` already returns, and resolves `Content.Location` against the layer's own region rather than the caller's, matching the lookup `resolveLayerByArn` already keys on.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Wire details from the [GetLayerVersionByArn reference](https://docs.aws.amazon.com/lambda/latest/api/API_GetLayerVersionByArn.html): `GET /2018-10-31/layers?find=LayerVersion&Arn=Arn`, returning the `LayerVersion` object with `InvalidParameterValueException` and `ResourceNotFoundException` as documented errors.

Rather than infer the edges, I measured them against the live service (signed read-only GETs, `lambda.ap-southeast-1.amazonaws.com`):

| Request | Live AWS | This PR |
| --- | --- | --- |
| `find=LayerVersion&Arn=<present>` | 200 + LayerVersion object | same |
| `find=LayerVersion&Arn=<absent>` | 404 `ResourceNotFoundException`, *"The resource you requested does not exist."* | same |
| `find=LayerVersion`, no `Arn` | 400 `ValidationException`, *"Value null at 'arn' … Member must not be null"* | same |
| `find=LayerVersion&Arn=not-an-arn` | 400 `ValidationException` + the pattern | same |
| `find=Nonsense` | 200 + ListLayers body | same |
| `find=layerversion` / `LAYERVERSION` | 200 + ListLayers body — the match is case-sensitive | same |

Two things that measurement changed, and that I would have got wrong from the reference alone:

**The error code is `ValidationException`, not `InvalidParameterValueException`.** The reference lists the latter; the live service returns the former, with the `1 validation error detected: …` message format. This also matches how `LambdaService` already reports validation failures elsewhere.

**The enforced `Arn` pattern is not the published one.** The reference gives `arn:[a-zA-Z0-9-]+:lambda:[a-zA-Z0-9-]+:\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+`. The live service reports this in its own `ValidationException`:

```
((arn:(aws[a-zA-Z-]*)?:lambda:(eusc-)?[a-z]{2}((-gov)|(-iso([a-z]?)))?-[a-z]+-\d{1}:\d{12}:layer:[a-zA-Z0-9-_]+:[0-9]+)
|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+))
```

It constrains the region segment more tightly and additionally accepts the AWS-managed `arn:<partition>:lambda:::awslayer:<name>` form the reference omits entirely. This PR enforces the measured pattern, so an `awslayer` ARN passes validation and resolves to a 404 rather than being rejected as malformed.

Where the reference and the service disagree I followed the service, on the grounds that an emulator's job is to match what clients actually talk to.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Full suite: **14492 tests, 0 failures, 0 errors, 12 skipped**. `make docs-check` clean; `docs/services/lambda.md` moves the action out of "Not Implemented".

13 cases in `LambdaGetLayerVersionByArnIntegrationTest`: the LayerVersion shape (asserting the `Layers` envelope is absent), parity with `GetLayerVersion` for the same version, the four error cases above pinned by `__type`, the `awslayer` form, case-sensitivity of `find`, cross-account rejection, and two pinning that `ListLayers` itself is unchanged. The class deletes the versions it publishes — without that, `LambdaPermissionTagLayerIntegrationTest.listLayers_returnsEmptyList` fails on shared state.

## Scope

Deliberately limited to GetLayerVersionByArn. While measuring I found that `ListLayers`, which shares this path, ignores its own documented `CompatibleRuntime`, `CompatibleArchitecture`, `Marker` and `MaxItems` parameters and never emits `NextMarker` — filed separately as #2808 rather than folded in here, since it is a different action with its own pagination and enum-validation semantics.

No existing issue covered this one; I searched `layer`, `GetLayerVersionByArn` and `PublishLayerVersion` before opening.


## Review follow-up (`fc3d061`)

`resolveLayerByArn` keys on region, name and version and drops the ARN's account segment. Storage is already partitioned per account, so the lookup runs inside the caller's own partition — a foreign-account ARN never reaches that account's layers (measured: account B gets 404 from `GetLayerVersion` and an empty `ListLayers` for account A's layer). The real effect is a wrong-resource answer: where the caller owns a same-named layer, its own layer came back under someone else's ARN.

`GetLayerVersionByArn` is the only layer action that takes an account explicitly, so it now honours it — an ARN outside the caller's account is a 404, the same answer `GetLayerVersion` already gives for a layer the caller cannot see. Pinned by `arnNamingAnotherAccountDoesNotResolveTheCallersOwnLayer`, which I confirmed fails without the guard.

`validateLayersResolvable` (CreateFunction / UpdateFunctionConfiguration) and the container launcher share the resolver and have the same blind spot on `main` today, independent of this PR. Fixing them would start failing `CreateFunction` calls that currently succeed, so that is filed as #2813 for a maintainer's view rather than folded in here.