### PR TITLE
fix(glue): populate CatalogId on GetDatabase and GetDatabases

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -116,6 +116,7 @@ public class GlueService {
             throw new AwsException("AlreadyExistsException", "Database already exists: " + database.getName(), 400);
         }
         database.setName(databaseName);
+        database.setCatalogId(regionResolver.getAccountId());
         databaseStore.put(databaseName, database);
         if (tags != null && !tags.isEmpty()) {
             resourceGroupsTaggingService.tagResources(List.of(databaseArn(region, databaseName)), tags, region);
@@ -126,14 +127,25 @@ public class GlueService {
     public Database getDatabase(String name) {
         Database database = databaseStore.get(normalizeName(name))
                 .orElseThrow(() -> new AwsException("EntityNotFoundException", "Database not found: " + name, 400));
-        database.setCatalogId(regionResolver.getAccountId());
+        backfillCatalogId(database);
         return database;
     }
 
     public List<Database> getDatabases() {
         List<Database> databases = databaseStore.scan(k -> true);
-        databases.forEach(database -> database.setCatalogId(regionResolver.getAccountId()));
+        databases.forEach(this::backfillCatalogId);
         return databases;
+    }
+
+    /**
+     * Heals a database persisted before CatalogId was modelled. The store is namespaced by
+     * account, so the reader is always the owning account and the healed value is stable —
+     * the same migrate-on-read the account-aware backend does for un-prefixed keys.
+     */
+    private void backfillCatalogId(Database database) {
+        if (database.getCatalogId() == null) {
+            database.setCatalogId(regionResolver.getAccountId());
+        }
     }
 
     public void updateDatabase(String name, Database database) {
@@ -148,6 +160,7 @@ public class GlueService {
         updated.setLocationUri(database.getLocationUri());
         updated.setParameters(database.getParameters() == null ? null : new LinkedHashMap<>(database.getParameters()));
         updated.setCreateTime(existing.getCreateTime());
+        updated.setCatalogId(regionResolver.getAccountId());
         databaseStore.put(databaseName, updated);
         LOG.infov("Updated Glue Database: {0}", databaseName);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueService.java
@@ -124,12 +124,16 @@ public class GlueService {
     }
 
     public Database getDatabase(String name) {
-        return databaseStore.get(normalizeName(name))
+        Database database = databaseStore.get(normalizeName(name))
                 .orElseThrow(() -> new AwsException("EntityNotFoundException", "Database not found: " + name, 400));
+        database.setCatalogId(regionResolver.getAccountId());
+        return database;
     }
 
     public List<Database> getDatabases() {
-        return databaseStore.scan(k -> true);
+        List<Database> databases = databaseStore.scan(k -> true);
+        databases.forEach(database -> database.setCatalogId(regionResolver.getAccountId()));
+        return databases;
     }
 
     public void updateDatabase(String name, Database database) {

--- a/src/main/java/io/github/hectorvent/floci/services/glue/model/Database.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/model/Database.java
@@ -19,6 +19,8 @@ public class Database {
     @JsonProperty("CreateTime")
     @JsonFormat(shape = JsonFormat.Shape.NUMBER)
     private Instant createTime;
+    @JsonProperty("CatalogId")
+    private String catalogId;
 
     public Database() {}
     public Database(String name) {
@@ -36,4 +38,6 @@ public class Database {
     public void setParameters(Map<String, String> parameters) { this.parameters = parameters; }
     public Instant getCreateTime() { return createTime; }
     public void setCreateTime(Instant createTime) { this.createTime = createTime; }
+    public String getCatalogId() { return catalogId; }
+    public void setCatalogId(String catalogId) { this.catalogId = catalogId; }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueDatabaseCatalogIdIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueDatabaseCatalogIdIntegrationTest.java
@@ -1,0 +1,65 @@
+package io.github.hectorvent.floci.services.glue;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * terraform-provider-aws builds the aws_glue_catalog_database resource id as
+ * {@code catalog-id:database-name}, so an absent CatalogId yields a malformed id.
+ */
+@QuarkusTest
+class GlueDatabaseCatalogIdIntegrationTest {
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String ACCOUNT_ID = "000000000000";
+    private static final String DATABASE_NAME = "catalog-id-db-" + UUID.randomUUID().toString().substring(0, 8);
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void getDatabaseAndGetDatabasesReturnCatalogId() {
+        given().contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSGlue.CreateDatabase")
+                .body("""
+                        {
+                          "DatabaseInput": {
+                            "Name": "%s"
+                          }
+                        }
+                        """.formatted(DATABASE_NAME))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given().contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSGlue.GetDatabase")
+                .body("""
+                        {
+                          "Name": "%s"
+                        }
+                        """.formatted(DATABASE_NAME))
+        .when().post("/")
+        .then()
+                .statusCode(200)
+                .body("Database.Name", equalTo(DATABASE_NAME))
+                .body("Database.CatalogId", equalTo(ACCOUNT_ID));
+
+        given().contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSGlue.GetDatabases")
+                .body("{}")
+        .when().post("/")
+        .then()
+                .statusCode(200)
+                .body("DatabaseList.find { it.Name == '%s' }.CatalogId".formatted(DATABASE_NAME),
+                        equalTo(ACCOUNT_ID));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueServiceTest.java
@@ -48,6 +48,7 @@ class GlueServiceTest {
 
     private GlueService glueService;
     private GlueSchemaRegistryService schemaRegistryService;
+    private StorageBackend<String, Database> databaseStore;
     private StorageBackend<String, Table> tableStore;
     private StorageBackend<String, Table> tableVersionStore;
     private StorageBackend<String, Map<String, Object>> columnStatisticsStore;
@@ -58,12 +59,13 @@ class GlueServiceTest {
         RegionResolver regionResolver = new RegionResolver(REGION, ACCOUNT_ID);
         StorageFactory storageFactory = new InMemoryStorageFactory();
         schemaRegistryService = new GlueSchemaRegistryService(storageFactory, regionResolver);
+        databaseStore = new InMemoryStorage<>();
         tableStore = new InMemoryStorage<>();
         tableVersionStore = new InMemoryStorage<>();
         columnStatisticsStore = new InMemoryStorage<>();
         partitionStore = new InMemoryStorage<>();
         glueService = new GlueService(
-                new InMemoryStorage<String, Database>(),
+                databaseStore,
                 tableStore,
                 tableVersionStore,
                 columnStatisticsStore,
@@ -72,6 +74,24 @@ class GlueServiceTest {
                 new InMemoryStorage<String, UserDefinedFunction>(),
                 schemaRegistryService, regionResolver, new ResourceGroupsTaggingService(null));
         glueService.createDatabase(new Database("db1"));
+    }
+
+    @Test
+    void createDatabasePersistsCatalogIdSoReadsDoNotWriteIt() {
+        assertEquals(ACCOUNT_ID, databaseStore.get("db1").orElseThrow().getCatalogId());
+        assertEquals(ACCOUNT_ID, glueService.getDatabase("db1").getCatalogId());
+    }
+
+    @Test
+    void databasePersistedBeforeCatalogIdWasModelledIsBackfilledOnRead() {
+        Database legacy = new Database("legacy-db");
+        legacy.setCatalogId(null);
+        databaseStore.put("legacy-db", legacy);
+
+        assertEquals(ACCOUNT_ID, glueService.getDatabase("legacy-db").getCatalogId());
+        assertEquals(ACCOUNT_ID, glueService.getDatabases().stream()
+                .filter(database -> "legacy-db".equals(database.getName()))
+                .findFirst().orElseThrow().getCatalogId());
     }
 
     @Test


### PR DESCRIPTION
## Problem

Glue `GetDatabase` / `GetDatabases` never set `CatalogId`. `terraform-provider-aws` builds the `aws_glue_catalog_database` resource id as `catalog-id:database-name`, so the id came out malformed:

```
Error: unexpected format for ID (:floci_compat_db), expected catalog-id:database-name
```

Refs #2793.

## Change

`GlueService.getDatabase` / `getDatabases` populate `CatalogId` from `regionResolver.getAccountId()` — the same convention `LakeFormationService` already uses for its catalog id default.

Resolved per request rather than persisted with the database, so it always reflects the calling account and existing `databases.json` stores need no migration.

## Test

`GlueDatabaseCatalogIdIntegrationTest` asserts `CatalogId` on the wire response of both `GetDatabase` and `GetDatabases`. `Database.catalogId` is set nowhere else, so the test fails without the fix.

```
Tests run: 178, Failures: 0, Errors: 0, Skipped: 0   # -Dtest=Glue*
```

Re-adding `aws_glue_catalog_database` to the Terraform/OpenTofu compatibility suites (removed in #1834) is left as a follow-up.