### PR TITLE
fix(apigateway): report RestApi as available

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayController.java
@@ -1908,6 +1908,7 @@ public class ApiGatewayController {
         node.put("name", api.getName());
         if (api.getDescription() != null) node.put("description", api.getDescription());
         node.put("createdDate", api.getCreatedDate());
+        node.put("apiStatus", "AVAILABLE");
         if (api.getTags() != null && !api.getTags().isEmpty()) {
             ObjectNode tagsNode = objectMapper.createObjectNode();
             api.getTags().forEach(tagsNode::put);

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -35,6 +35,7 @@ class ApiGatewayIntegrationTest {
                 .body("id", notNullValue())
                 .body("name", equalTo("test-api"))
                 .body("description", equalTo("Integration test API"))
+                .body("apiStatus", equalTo("AVAILABLE"))
                 .extract().path("id");
     }
 
@@ -45,7 +46,8 @@ class ApiGatewayIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("id", equalTo(apiId))
-                .body("name", equalTo("test-api"));
+                .body("name", equalTo("test-api"))
+                .body("apiStatus", equalTo("AVAILABLE"));
     }
 
     @Test @Order(3)


### PR DESCRIPTION
## Summary

- return AWS `apiStatus: "AVAILABLE"` from the shared API Gateway v1 RestApi serializer
- cover both CreateRestApi and GetRestApi response shapes

## Root cause

Floci's synchronous RestApi responses omitted the current AWS field Terraform's waiter reads, so the state stayed empty until timeout. The shared serializer is used by create, read, list, import, put, and update paths, so one derived field fixes every response path without persisting artificial state.

## Tests

- `./mvnw -B -Dtest=ApiGatewayIntegrationTest test`
- `./mvnw -B -DskipTests compile`
- CI-equivalent four-shard full suite: 1,085 test classes, 14,645 tests, 0 failures, 0 errors
- `./mvnw -B -DskipTests package`
- `git diff --check`

Closes #2804
