### PR TITLE
fix(lambda): honour ListLayers and ListLayerVersions query parameters

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/lambda-layers.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/lambda-layers.test.ts
@@ -249,3 +249,125 @@ describe('Lambda Layer Attachment', () => {
     expect(response.Layers![0].Arn).toBe(layerVersionArn);
   });
 });
+
+describe('Lambda Layers listing parameters', () => {
+  let lambda: LambdaClient;
+  let layerName: string;
+
+  const zip = (marker: string) =>
+    buildMinimalZip('nodejs/node_modules/shared/index.js', Buffer.from(marker));
+
+  beforeAll(async () => {
+    lambda = makeClient(LambdaClient);
+    layerName = `compat-layer-params-${uniqueName()}`;
+
+    // v1 nodejs20.x/x86_64, v2 python3.13/arm64, v3 nodejs20.x/arm64: every filter
+    // combination below then selects a different subset of the same layer.
+    await lambda.send(
+      new PublishLayerVersionCommand({
+        LayerName: layerName,
+        Content: { ZipFile: zip('v1') },
+        CompatibleRuntimes: ['nodejs20.x'],
+        CompatibleArchitectures: ['x86_64'],
+      })
+    );
+    await lambda.send(
+      new PublishLayerVersionCommand({
+        LayerName: layerName,
+        Content: { ZipFile: zip('v2') },
+        CompatibleRuntimes: ['python3.13'],
+        CompatibleArchitectures: ['arm64'],
+      })
+    );
+    await lambda.send(
+      new PublishLayerVersionCommand({
+        LayerName: layerName,
+        Content: { ZipFile: zip('v3') },
+        CompatibleRuntimes: ['nodejs20.x'],
+        CompatibleArchitectures: ['arm64'],
+      })
+    );
+  });
+
+  afterAll(async () => {
+    for (const VersionNumber of [1, 2, 3]) {
+      try {
+        await lambda.send(new DeleteLayerVersionCommand({ LayerName: layerName, VersionNumber }));
+      } catch { /* ignore */ }
+    }
+  });
+
+  it('filters listLayerVersions by CompatibleRuntime', async () => {
+    const response = await lambda.send(
+      new ListLayerVersionsCommand({ LayerName: layerName, CompatibleRuntime: 'python3.13' })
+    );
+
+    expect(response.LayerVersions?.map((v) => v.Version)).toEqual([2]);
+  });
+
+  it('filters listLayerVersions by CompatibleArchitecture', async () => {
+    const response = await lambda.send(
+      new ListLayerVersionsCommand({ LayerName: layerName, CompatibleArchitecture: 'arm64' })
+    );
+
+    expect(response.LayerVersions?.map((v) => v.Version).sort()).toEqual([2, 3]);
+  });
+
+  it('applies both filters together', async () => {
+    const response = await lambda.send(
+      new ListLayerVersionsCommand({
+        LayerName: layerName,
+        CompatibleRuntime: 'nodejs20.x',
+        CompatibleArchitecture: 'arm64',
+      })
+    );
+
+    expect(response.LayerVersions?.map((v) => v.Version)).toEqual([3]);
+  });
+
+  it('pages listLayerVersions with MaxItems and resumes from NextMarker', async () => {
+    const seen: number[] = [];
+    let marker: string | undefined;
+    let pages = 0;
+
+    do {
+      const page = await lambda.send(
+        new ListLayerVersionsCommand({ LayerName: layerName, MaxItems: 1, Marker: marker })
+      );
+      expect(page.LayerVersions).toHaveLength(1);
+      seen.push(page.LayerVersions![0].Version!);
+      marker = page.NextMarker;
+      pages += 1;
+    } while (marker && pages < 5);
+
+    // The marker walks every version exactly once and clears on the last page.
+    expect(marker).toBeFalsy();
+    expect(seen.sort()).toEqual([1, 2, 3]);
+  });
+
+  it('reports the newest matching version as LatestMatchingVersion, not the newest overall', async () => {
+    const python = await lambda.send(
+      new ListLayersCommand({ CompatibleRuntime: 'python3.13' })
+    );
+    const node = await lambda.send(new ListLayersCommand({ CompatibleRuntime: 'nodejs20.x' }));
+
+    expect(
+      python.Layers?.find((l) => l.LayerName === layerName)?.LatestMatchingVersion?.Version
+    ).toBe(2);
+    expect(
+      node.Layers?.find((l) => l.LayerName === layerName)?.LatestMatchingVersion?.Version
+    ).toBe(3);
+  });
+
+  it('drops a layer with no matching version out of listLayers', async () => {
+    const response = await lambda.send(new ListLayersCommand({ CompatibleRuntime: 'java21' }));
+
+    expect(response.Layers?.some((l) => l.LayerName === layerName)).toBe(false);
+  });
+
+  it('rejects an unknown CompatibleRuntime with ValidationException', async () => {
+    await expect(
+      lambda.send(new ListLayersCommand({ CompatibleRuntime: 'bogus9.x' }))
+    ).rejects.toMatchObject({ name: 'ValidationException' });
+  });
+});

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -168,7 +168,16 @@ Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL 
 
 **Layers:** `PublishLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `ListLayerVersions`,
 `ListLayers`, and `DeleteLayerVersion` are implemented, with real local storage under
-`{lambda.codePath}/layers/{name}/{version}`. `CreateFunction`/`UpdateFunctionConfiguration`
+`{lambda.codePath}/layers/{name}/{version}`. `ListLayers` and `ListLayerVersions` honour
+`CompatibleRuntime`, `CompatibleArchitecture`, `MaxItems` (1-50, defaulting to 50) and `Marker`,
+and always emit `NextMarker`, null on the last page. Under a filter, `LatestMatchingVersion` is
+the newest version that matches rather than the newest overall, and a layer with no matching
+version is omitted; a version published without `CompatibleArchitectures` matches neither
+architecture. `Marker` is opaque and signed with a key generated at startup, so a fabricated,
+edited or previous-run token is rejected with `InvalidParameterValueException` rather than
+applied as a cursor. One divergence: a parameter sent with an empty value
+(`?CompatibleRuntime=`) is treated as absent rather than rejected, because RESTEasy binds an
+empty query value as null. `CreateFunction`/`UpdateFunctionConfiguration`
 validate each `Layers` ARN eagerly against that storage, matching real AWS - an unresolvable ARN
 is rejected with `InvalidParameterValueException`, not silently accepted. Only resolves layers
 published into this same local Floci instance; a real AWS-owned layer ARN (e.g. the AWS AppConfig

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.lambda.model.LambdaLayerVersion;
 import jakarta.inject.Inject;
@@ -21,7 +22,6 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -68,14 +68,20 @@ public class LambdaLayerController {
     @GET
     @Path("/layers/{layerName}/versions")
     public Response listLayerVersions(@PathParam("layerName") String layerName,
+                                      @QueryParam("CompatibleRuntime") String compatibleRuntime,
+                                      @QueryParam("CompatibleArchitecture") String compatibleArchitecture,
+                                      @QueryParam("MaxItems") String maxItems,
+                                      @QueryParam("Marker") String marker,
                                       @Context HttpHeaders headers) {
         String region = regionResolver.resolveRegion(headers);
-        List<LambdaLayerVersion> versions = layerService.listLayerVersions(region, layerName);
+        PaginatedResult<LambdaLayerVersion> result = layerService.listLayerVersions(
+                region, layerName, compatibleRuntime, compatibleArchitecture, maxItems, marker);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode arr = root.putArray("LayerVersions");
-        for (LambdaLayerVersion lv : versions) {
+        for (LambdaLayerVersion lv : result.items()) {
             arr.add(buildLayerVersionSummary(lv));
         }
+        putNextMarker(root, result.nextToken());
         return Response.ok(root).build();
     }
 
@@ -109,6 +115,10 @@ public class LambdaLayerController {
     @Path("/layers")
     public Response listLayers(@QueryParam("find") String find,
                                @QueryParam("Arn") String arn,
+                               @QueryParam("CompatibleRuntime") String compatibleRuntime,
+                               @QueryParam("CompatibleArchitecture") String compatibleArchitecture,
+                               @QueryParam("MaxItems") String maxItems,
+                               @QueryParam("Marker") String marker,
                                @Context HttpHeaders headers,
                                @Context UriInfo uriInfo) {
         if (FIND_LAYER_VERSION.equals(find)) {
@@ -118,10 +128,11 @@ public class LambdaLayerController {
             return Response.ok(buildLayerVersionResponse(lv, layerRegion, uriInfo)).build();
         }
         String region = regionResolver.resolveRegion(headers);
-        List<LambdaLayerVersion> layers = layerService.listLayers(region);
+        PaginatedResult<LambdaLayerVersion> result = layerService.listLayers(
+                region, compatibleRuntime, compatibleArchitecture, maxItems, marker);
         ObjectNode root = objectMapper.createObjectNode();
         ArrayNode arr = root.putArray("Layers");
-        for (LambdaLayerVersion lv : layers) {
+        for (LambdaLayerVersion lv : result.items()) {
             ObjectNode layerNode = objectMapper.createObjectNode();
             layerNode.put("LayerName", lv.getLayerName());
             layerNode.put("LayerArn", lv.getLayerArn());
@@ -141,7 +152,17 @@ public class LambdaLayerController {
             }
             arr.add(layerNode);
         }
+        putNextMarker(root, result.nextToken());
         return Response.ok(root).build();
+    }
+
+    /** AWS always emits NextMarker, null on the last page rather than omitting the field. */
+    private static void putNextMarker(ObjectNode root, String nextMarker) {
+        if (nextMarker == null) {
+            root.putNull("NextMarker");
+        } else {
+            root.put("NextMarker", nextMarker);
+        }
     }
 
     private ObjectNode buildLayerVersionResponse(LambdaLayerVersion lv, String region, UriInfo uriInfo) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.lambda;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.lambda.model.LambdaLayerVersion;
 import io.github.hectorvent.floci.services.lambda.zip.ZipExtractor;
@@ -13,6 +14,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -25,7 +27,9 @@ import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Business logic for Lambda Layer management.
@@ -46,6 +50,37 @@ public class LambdaLayerService {
                     + "|(arn:[a-zA-Z0-9-]+:lambda:::awslayer:[a-zA-Z0-9-_]+))";
     private static final Pattern LAYER_VERSION_ARN = Pattern.compile(LAYER_VERSION_ARN_PATTERN);
     private static final int MAX_LAYER_VERSION_ARN_LENGTH = 140;
+    private static final int MAX_ITEMS_LIMIT = 50;
+
+    /** Tag identifying a Marker as one Floci issued; see {@link #encodeMarker}. */
+    private static final String MARKER_PREFIX = "floci:layer-page:";
+
+    private static final List<String> COMPATIBLE_ARCHITECTURES = List.of("x86_64", "arm64");
+
+    /**
+     * Runtime identifiers accepted for CompatibleRuntime, taken from the live service's own
+     * ValidationException rather than the API reference: it accepts values the reference omits
+     * (java8.al2023, java17.al2023, python3.15, nodejs26.x, the greengrass runtime ARNs) and
+     * rejects everything else, case-sensitively. Rendered into the error message as-is, so the
+     * order is fixed here; the live service's own ordering varies between responses.
+     */
+    private static final List<String> COMPATIBLE_RUNTIMES = List.of(
+            "nodejs", "nodejs4.3", "nodejs4.3-edge", "nodejs6.10", "nodejs8.9", "nodejs8.10",
+            "nodejs8.x", "nodejs10.x", "nodejs12.x", "nodejs14.x", "nodejs16.x", "nodejs18.x",
+            "nodejs20.x", "nodejs22.x", "nodejs24.x", "nodejs26.x",
+            "java8", "java8.al2", "java8.al2023", "java11", "java11.al2023", "java17",
+            "java17.al2023", "java21", "java25",
+            "python2.7", "python2.7-greengrass", "python3.4", "python3.6", "python3.7",
+            "python3.8", "python3.9", "python3.10", "python3.11", "python3.12", "python3.13",
+            "python3.14", "python3.15",
+            "dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "dotnetcore3.1", "dotnet6",
+            "dotnet8", "dotnet10",
+            "ruby2.5", "ruby2.6", "ruby2.7", "ruby3.2", "ruby3.3", "ruby3.4", "ruby4.0",
+            "go1.x", "go1.9", "provided", "provided.al2", "provided.al2023",
+            "byol", "custom", "nasa",
+            "arn:aws:greengrass:::runtime/function/executable",
+            "arn:aws-cn:greengrass:::runtime/function/executable",
+            "arn:aws-us-gov:greengrass:::runtime/function/executable");
 
     private final LambdaLayerStore layerStore;
     private final ZipExtractor zipExtractor;
@@ -162,17 +197,162 @@ public class LambdaLayerService {
     }
 
     /**
-     * Lists all versions of a layer.
+     * Lists the versions of a layer, honouring the documented CompatibleRuntime,
+     * CompatibleArchitecture, MaxItems and Marker parameters. An unknown layer name is an
+     * empty page, not a 404 — the live service answers 200 for a layer that never existed.
      */
-    public List<LambdaLayerVersion> listLayerVersions(String region, String layerName) {
-        return layerStore.listVersions(region, layerName);
+    public PaginatedResult<LambdaLayerVersion> listLayerVersions(String region, String layerName,
+                                                                 String compatibleRuntime,
+                                                                 String compatibleArchitecture,
+                                                                 String maxItems, String marker) {
+        Integer limit = validateListParameters(maxItems, compatibleRuntime, compatibleArchitecture);
+        List<LambdaLayerVersion> versions = layerStore.listVersions(region, layerName).stream()
+                .filter(lv -> matchesFilters(lv, compatibleRuntime, compatibleArchitecture))
+                .toList();
+        // Zero-padded so the cursor's string ordering matches the numeric version ordering.
+        return page(versions, lv -> String.format("%019d", lv.getVersion()), limit, marker);
     }
 
     /**
-     * Lists all layers in a region (returns the latest version of each).
+     * Lists the layers in a region, honouring the same four parameters. Under a filter,
+     * LatestMatchingVersion is the newest version that matches rather than the newest overall,
+     * and a layer with no matching version drops out of the list entirely.
      */
-    public List<LambdaLayerVersion> listLayers(String region) {
-        return layerStore.listLayers(region);
+    public PaginatedResult<LambdaLayerVersion> listLayers(String region, String compatibleRuntime,
+                                                          String compatibleArchitecture,
+                                                          String maxItems, String marker) {
+        Integer limit = validateListParameters(maxItems, compatibleRuntime, compatibleArchitecture);
+        List<LambdaLayerVersion> latestMatching = layerStore.listAllVersions(region).stream()
+                .filter(lv -> matchesFilters(lv, compatibleRuntime, compatibleArchitecture))
+                .collect(Collectors.groupingBy(LambdaLayerVersion::getLayerName))
+                .values().stream()
+                .map(versions -> versions.stream()
+                        .max(Comparator.comparingLong(LambdaLayerVersion::getVersion))
+                        .orElseThrow())
+                .sorted(Comparator.comparing(LambdaLayerVersion::getLayerName))
+                .toList();
+        return page(latestMatching, LambdaLayerVersion::getLayerName, limit, marker);
+    }
+
+    /**
+     * A layer version matches a filter only by listing the value explicitly: one published
+     * without CompatibleArchitectures is absent from both x86_64 and arm64 results rather than
+     * defaulting to x86_64 the way a function's Architectures does.
+     */
+    private static boolean matchesFilters(LambdaLayerVersion lv, String compatibleRuntime,
+                                          String compatibleArchitecture) {
+        if (compatibleRuntime != null) {
+            List<String> runtimes = lv.getCompatibleRuntimes();
+            if (runtimes == null || !runtimes.contains(compatibleRuntime)) {
+                return false;
+            }
+        }
+        if (compatibleArchitecture != null) {
+            List<String> architectures = lv.getCompatibleArchitectures();
+            if (architectures == null || !architectures.contains(compatibleArchitecture)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static <T> PaginatedResult<T> page(List<T> items, Function<T, String> cursorOf,
+                                               Integer maxItems, String marker) {
+        String after = decodeMarker(marker);
+        List<T> remaining = after == null ? items
+                : items.stream().filter(i -> cursorOf.apply(i).compareTo(after) > 0).toList();
+        List<T> pageItems = remaining.stream()
+                .limit(maxItems != null ? maxItems : MAX_ITEMS_LIMIT)
+                .toList();
+        String nextMarker = pageItems.size() < remaining.size()
+                ? encodeMarker(cursorOf.apply(pageItems.get(pageItems.size() - 1)))
+                : null;
+        return new PaginatedResult<>(pageItems, nextMarker);
+    }
+
+    /**
+     * Validates the three parseable list parameters and returns the effective MaxItems.
+     *
+     * <p>Mirrors the live service's ordering, measured rather than documented: a MaxItems that
+     * is not an integer is a SerializationException that short-circuits everything else, while
+     * range and enum failures accumulate into one ValidationException in a fixed member order
+     * (maxItems, compatibleRuntime, compatibleArchitecture) regardless of query-string order.
+     * An empty MaxItems is treated as omitted; a blank one is not.
+     */
+    private static Integer validateListParameters(String maxItems, String compatibleRuntime,
+                                                  String compatibleArchitecture) {
+        Integer parsed = parseMaxItems(maxItems);
+        List<String> errors = new ArrayList<>();
+        if (parsed != null && parsed < 1) {
+            errors.add(constraintFailure(maxItems, "maxItems",
+                    "Member must have value greater than or equal to 1"));
+        } else if (parsed != null && parsed > MAX_ITEMS_LIMIT) {
+            errors.add(constraintFailure(maxItems, "maxItems",
+                    "Member must have value less than or equal to " + MAX_ITEMS_LIMIT));
+        }
+        if (compatibleRuntime != null && !COMPATIBLE_RUNTIMES.contains(compatibleRuntime)) {
+            errors.add(constraintFailure(compatibleRuntime, "compatibleRuntime",
+                    "Member must satisfy enum value set: " + COMPATIBLE_RUNTIMES));
+        }
+        if (compatibleArchitecture != null
+                && !COMPATIBLE_ARCHITECTURES.contains(compatibleArchitecture)) {
+            errors.add(constraintFailure(compatibleArchitecture, "compatibleArchitecture",
+                    "Member must satisfy enum value set: " + COMPATIBLE_ARCHITECTURES));
+        }
+        if (!errors.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    errors.size() + (errors.size() == 1 ? " validation error" : " validation errors")
+                            + " detected: " + String.join("; ", errors), 400);
+        }
+        return parsed;
+    }
+
+    private static Integer parseMaxItems(String maxItems) {
+        if (maxItems == null || maxItems.isEmpty()) {
+            return null;
+        }
+        try {
+            return Integer.valueOf(maxItems);
+        } catch (NumberFormatException e) {
+            throw new AwsException("SerializationException",
+                    "'" + maxItems + "' can not be converted to Integer", 400);
+        }
+    }
+
+    private static String constraintFailure(String value, String member, String requirement) {
+        return "Value '" + value + "' at '" + member + "' failed to satisfy constraint: "
+                + requirement;
+    }
+
+    /**
+     * The live service's Marker is an encrypted token it rejects when it did not issue it.
+     * Floci cannot reproduce the token itself, so it tags its own and rejects anything that
+     * does not carry the tag, which is what makes an arbitrary string a 400 rather than a
+     * silently empty page.
+     */
+    private static String encodeMarker(String cursor) {
+        return Base64.getUrlEncoder().withoutPadding()
+                .encodeToString((MARKER_PREFIX + cursor).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String decodeMarker(String marker) {
+        if (marker == null) {
+            return null;
+        }
+        String decoded;
+        try {
+            decoded = new String(Base64.getUrlDecoder().decode(marker), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw invalidPaginationKey();
+        }
+        if (!decoded.startsWith(MARKER_PREFIX)) {
+            throw invalidPaginationKey();
+        }
+        return decoded.substring(MARKER_PREFIX.length());
+    }
+
+    private static AwsException invalidPaginationKey() {
+        return new AwsException("InvalidParameterValueException", "Invalid pagination key.", 400);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
@@ -11,14 +11,18 @@ import io.github.hectorvent.floci.services.s3.S3Service;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -52,8 +56,10 @@ public class LambdaLayerService {
     private static final int MAX_LAYER_VERSION_ARN_LENGTH = 140;
     private static final int MAX_ITEMS_LIMIT = 50;
 
-    /** Tag identifying a Marker as one Floci issued; see {@link #encodeMarker}. */
-    private static final String MARKER_PREFIX = "floci:layer-page:";
+    private static final char MARKER_SEPARATOR = '.';
+
+    /** Signing key for pagination markers, per process; see {@link #encodeMarker}. */
+    private static final byte[] MARKER_KEY = newMarkerKey();
 
     private static final List<String> COMPATIBLE_ARCHITECTURES = List.of("x86_64", "arm64");
 
@@ -326,13 +332,15 @@ public class LambdaLayerService {
 
     /**
      * The live service's Marker is an encrypted token it rejects when it did not issue it.
-     * Floci cannot reproduce the token itself, so it tags its own and rejects anything that
-     * does not carry the tag, which is what makes an arbitrary string a 400 rather than a
-     * silently empty page.
+     * Floci signs the cursor instead, with a key generated at startup: a fabricated or edited
+     * marker fails the check, which is what makes an arbitrary string a 400 rather than a
+     * silently skipped or empty page. A marker from an earlier run is stale for the same
+     * reason, matching a client that replays an expired token against AWS.
      */
     private static String encodeMarker(String cursor) {
+        String signed = cursor + MARKER_SEPARATOR + sign(cursor);
         return Base64.getUrlEncoder().withoutPadding()
-                .encodeToString((MARKER_PREFIX + cursor).getBytes(StandardCharsets.UTF_8));
+                .encodeToString(signed.getBytes(StandardCharsets.UTF_8));
     }
 
     private static String decodeMarker(String marker) {
@@ -345,10 +353,33 @@ public class LambdaLayerService {
         } catch (IllegalArgumentException e) {
             throw invalidPaginationKey();
         }
-        if (!decoded.startsWith(MARKER_PREFIX)) {
+        int separator = decoded.lastIndexOf(MARKER_SEPARATOR);
+        if (separator < 0) {
             throw invalidPaginationKey();
         }
-        return decoded.substring(MARKER_PREFIX.length());
+        String cursor = decoded.substring(0, separator);
+        byte[] presented = decoded.substring(separator + 1).getBytes(StandardCharsets.UTF_8);
+        if (!MessageDigest.isEqual(presented, sign(cursor).getBytes(StandardCharsets.UTF_8))) {
+            throw invalidPaginationKey();
+        }
+        return cursor;
+    }
+
+    private static String sign(String cursor) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(MARKER_KEY, "HmacSHA256"));
+            return Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(mac.doFinal(cursor.getBytes(StandardCharsets.UTF_8)));
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("HmacSHA256 is required to paginate layers", e);
+        }
+    }
+
+    private static byte[] newMarkerKey() {
+        byte[] key = new byte[32];
+        new SecureRandom().nextBytes(key);
+        return key;
     }
 
     private static AwsException invalidPaginationKey() {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerStore.java
@@ -59,6 +59,20 @@ public class LambdaLayerStore {
     }
 
     /**
+     * Returns every version of every layer in a region, ordered by layer name then version
+     * ascending. ListLayers needs all versions, not just the latest of each: under a
+     * CompatibleRuntime or CompatibleArchitecture filter, LatestMatchingVersion is the newest
+     * version that matches, which may not be the newest version overall.
+     */
+    public List<LambdaLayerVersion> listAllVersions(String region) {
+        String prefix = "layer::" + region + "::";
+        return backend.scan(k -> k.startsWith(prefix)).stream()
+                .sorted(java.util.Comparator.comparing(LambdaLayerVersion::getLayerName)
+                        .thenComparingLong(LambdaLayerVersion::getVersion))
+                .toList();
+    }
+
+    /**
      * Returns all distinct layers in a region (latest version of each).
      */
     public List<LambdaLayerVersion> listLayers(String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaListLayersParametersIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaListLayersParametersIntegrationTest.java
@@ -1,0 +1,443 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+/**
+ * CompatibleRuntime, CompatibleArchitecture, MaxItems and Marker on ListLayers and
+ * ListLayerVersions.
+ *
+ * <p>The list-wide assertions filter on {@code ruby3.4}, a runtime no other test publishes:
+ * integration tests share one emulator, so an unfiltered ListLayers would also see whatever
+ * layers a concurrently ordered class has published.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaListLayersParametersIntegrationTest {
+
+    private static final String PAGE_RUNTIME = "ruby3.4";
+    private static final String LAYER_A = "lp-alpha";
+    private static final String LAYER_B = "lp-beta";
+    private static final String LAYER_NO_ARCH = "lp-no-arch";
+    private static final String LAYER_VERSIONS = "lp-versions";
+
+    private static String layerZipBase64() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("ruby/shared.rb"));
+            zos.write("VALUE = 1".getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    /** Publishes a version; {@code architectures} may be null to omit CompatibleArchitectures. */
+    private static int publish(String layerName, String runtime, String architectures) throws Exception {
+        String archField = architectures == null ? "" : "\"CompatibleArchitectures\": " + architectures + ",";
+        return given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "Content": { "ZipFile": "%s" },
+                    "CompatibleRuntimes": ["%s"],
+                    %s
+                    "Description": "list parameter probe"
+                }
+                """.formatted(layerZipBase64(), runtime, archField))
+        .when()
+            .post("/2018-10-31/layers/" + layerName + "/versions")
+        .then()
+            .statusCode(201)
+            .extract().path("Version");
+    }
+
+    @Test
+    @Order(1)
+    void seedLayers() throws Exception {
+        publish(LAYER_A, PAGE_RUNTIME, "[\"x86_64\"]");
+        publish(LAYER_B, PAGE_RUNTIME, "[\"arm64\"]");
+        publish(LAYER_NO_ARCH, PAGE_RUNTIME, null);
+        // Two versions whose runtimes differ, so a filter can select the older one.
+        publish(LAYER_VERSIONS, "ruby3.3", "[\"x86_64\"]");
+        publish(LAYER_VERSIONS, "ruby4.0", "[\"arm64\"]");
+    }
+
+    // ── filters ──────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(2)
+    void listLayersFiltersByCompatibleRuntime() {
+        given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers.LayerName", contains(LAYER_A, LAYER_B, LAYER_NO_ARCH));
+    }
+
+    @Test
+    @Order(3)
+    void listLayersFiltersByCompatibleArchitecture() {
+        given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+            .queryParam("CompatibleArchitecture", "arm64")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers.LayerName", contains(LAYER_B));
+    }
+
+    @Test
+    @Order(4)
+    void layerWithoutCompatibleArchitecturesMatchesNoArchitectureFilter() {
+        // Measured on the live service: unlike a function's Architectures, an absent
+        // CompatibleArchitectures does not default to x86_64 for filtering purposes.
+        for (String architecture : new String[] {"x86_64", "arm64"}) {
+            given()
+                .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+                .queryParam("CompatibleArchitecture", architecture)
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(200)
+                .body("Layers.findAll { it.LayerName == '" + LAYER_NO_ARCH + "' }", empty());
+        }
+    }
+
+    @Test
+    @Order(5)
+    void latestMatchingVersionIsTheNewestVersionSatisfyingTheFilter() {
+        // v2 is ruby4.0, v1 is ruby3.3: filtering on ruby3.3 must report v1, not the newest.
+        given()
+            .queryParam("CompatibleRuntime", "ruby3.3")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers.find { it.LayerName == '" + LAYER_VERSIONS + "' }.LatestMatchingVersion.Version",
+                    equalTo(1));
+    }
+
+    @Test
+    @Order(6)
+    void layerWithNoMatchingVersionDropsOutOfTheList() {
+        given()
+            .queryParam("CompatibleRuntime", "ruby2.5")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers.findAll { it.LayerName == '" + LAYER_VERSIONS + "' }", empty());
+    }
+
+    // ── pagination ───────────────────────────────────────────────────────────
+
+    @Test
+    @Order(7)
+    void maxItemsLimitsThePageAndMarkerResumesIt() {
+        String marker = given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+            .queryParam("MaxItems", 2)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers.LayerName", contains(LAYER_A, LAYER_B))
+            .body("NextMarker", notNullValue())
+            .extract().path("NextMarker");
+
+        given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+            .queryParam("MaxItems", 2)
+            .queryParam("Marker", marker)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            // Resumes after the last item of page one, with no overlap and nothing skipped.
+            .body("Layers.LayerName", contains(LAYER_NO_ARCH))
+            .body("NextMarker", nullValue());
+    }
+
+    @Test
+    @Order(8)
+    void nextMarkerIsPresentAndNullOnTheLastPage() {
+        given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            // AWS emits the field on every response rather than omitting it when there is no
+            // next page, so a client that reads it unconditionally does not see a missing key.
+            .body("$", hasKey("NextMarker"))
+            .body("NextMarker", nullValue());
+    }
+
+    @Test
+    @Order(9)
+    void emptyMaxItemsIsTreatedAsOmitted() {
+        // Matches the live service, which also answers 200 for MaxItems= rather than rejecting
+        // it. Note the empty value never reaches the parameter: RESTEasy Reactive binds an
+        // empty query value as null, which is why CompatibleRuntime= and Marker= are accepted
+        // here but rejected by AWS - see the PR's "known divergence".
+        given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+            .queryParam("MaxItems", "")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .body("Layers", hasSize(3));
+    }
+
+    @Test
+    @Order(10)
+    void unknownMarkerIsInvalidPaginationKey() {
+        for (String marker : new String[] {"garbage", "AAAAAAAA", "!!not-base64!!"}) {
+            given()
+                .queryParam("Marker", marker)
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidParameterValueException"))
+                .body("message", equalTo("Invalid pagination key."));
+        }
+    }
+
+    // ── parameter validation ─────────────────────────────────────────────────
+
+    @Test
+    @Order(11)
+    void maxItemsBelowRangeIsValidationException() {
+        given()
+            .queryParam("MaxItems", 0)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("1 validation error detected: Value '0' at 'maxItems' "
+                    + "failed to satisfy constraint: Member must have value greater than or equal to 1"));
+    }
+
+    @Test
+    @Order(12)
+    void maxItemsAboveRangeIsValidationException() {
+        given()
+            .queryParam("MaxItems", 51)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("Member must have value less than or equal to 50"));
+    }
+
+    @Test
+    @Order(13)
+    void nonIntegerMaxItemsIsSerializationException() {
+        for (String value : new String[] {"abc", "2.5", " 2 "}) {
+            given()
+                .queryParam("MaxItems", value)
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"))
+                .body("message", equalTo("'" + value + "' can not be converted to Integer"));
+        }
+    }
+
+    @Test
+    @Order(14)
+    void unknownOrMiscasedRuntimeIsValidationException() {
+        for (String runtime : new String[] {"bogus9.x", "RUBY3.4"}) {
+            given()
+                .queryParam("CompatibleRuntime", runtime)
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", containsString("Value '" + runtime + "' at 'compatibleRuntime' "
+                        + "failed to satisfy constraint: Member must satisfy enum value set: ["));
+        }
+    }
+
+    @Test
+    @Order(15)
+    void unknownOrMiscasedArchitectureIsValidationException() {
+        for (String architecture : new String[] {"sparc", "ARM64"}) {
+            given()
+                .queryParam("CompatibleArchitecture", architecture)
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", containsString("Value '" + architecture + "' at "
+                        + "'compatibleArchitecture' failed to satisfy constraint: "
+                        + "Member must satisfy enum value set: [x86_64, arm64]"));
+        }
+    }
+
+    @Test
+    @Order(16)
+    void validationFailuresAccumulateInMemberOrder() {
+        // Measured: the live service reports every failing member in one response, ordered
+        // maxItems, compatibleRuntime, compatibleArchitecture whatever the query-string order.
+        given()
+            .queryParam("CompatibleArchitecture", "sparc")
+            .queryParam("CompatibleRuntime", "bogus9.x")
+            .queryParam("MaxItems", 0)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("3 validation errors detected: Value '0' at 'maxItems'"))
+            .body("message", containsString("; Value 'bogus9.x' at 'compatibleRuntime'"))
+            .body("message", containsString("; Value 'sparc' at 'compatibleArchitecture'"));
+    }
+
+    @Test
+    @Order(17)
+    void serializationFailureShortCircuitsValidation() {
+        // A MaxItems that will not parse is reported alone, without the runtime error.
+        given()
+            .queryParam("MaxItems", "abc")
+            .queryParam("CompatibleRuntime", "bogus9.x")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(18)
+    void markerIsValidatedAfterTheEnums() {
+        given()
+            .queryParam("Marker", "garbage")
+            .queryParam("CompatibleRuntime", "bogus9.x")
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    // ── ListLayerVersions takes the same four parameters ──────────────────────
+
+    @Test
+    @Order(19)
+    void listLayerVersionsFiltersAndPaginates() {
+        given()
+            .queryParam("CompatibleRuntime", "ruby3.3")
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_VERSIONS + "/versions")
+        .then()
+            .statusCode(200)
+            .body("LayerVersions.Version", contains(1))
+            .body("NextMarker", nullValue());
+
+        String marker = given()
+            .queryParam("MaxItems", 1)
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_VERSIONS + "/versions")
+        .then()
+            .statusCode(200)
+            .body("LayerVersions.Version", contains(1))
+            .body("NextMarker", notNullValue())
+            .extract().path("NextMarker");
+
+        given()
+            .queryParam("MaxItems", 1)
+            .queryParam("Marker", marker)
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_VERSIONS + "/versions")
+        .then()
+            .statusCode(200)
+            .body("LayerVersions.Version", contains(2))
+            .body("NextMarker", nullValue());
+    }
+
+    @Test
+    @Order(20)
+    void listLayerVersionsRejectsTheSameBadParameters() {
+        given()
+            .queryParam("MaxItems", 0)
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_VERSIONS + "/versions")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        given()
+            .queryParam("Marker", "garbage")
+        .when()
+            .get("/2018-10-31/layers/" + LAYER_VERSIONS + "/versions")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValueException"));
+    }
+
+    @Test
+    @Order(21)
+    void listLayerVersionsOfAnUnknownLayerIsAnEmptyPage() {
+        // Measured on the live service: a layer that never existed is 200 with an empty list.
+        given()
+        .when()
+            .get("/2018-10-31/layers/lp-no-such-layer/versions")
+        .then()
+            .statusCode(200)
+            .body("LayerVersions", empty())
+            .body("NextMarker", nullValue());
+    }
+
+    // ── cleanup ───────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(22)
+    void cleanup_deletePublishedVersions() {
+        for (String layerName : List.of(LAYER_A, LAYER_B, LAYER_NO_ARCH, LAYER_VERSIONS)) {
+            List<Integer> versions = given()
+            .when()
+                .get("/2018-10-31/layers/" + layerName + "/versions")
+            .then()
+                .statusCode(200)
+                .extract().path("LayerVersions.Version");
+
+            for (Integer version : versions) {
+                given()
+                .when()
+                    .delete("/2018-10-31/layers/" + layerName + "/versions/" + version)
+                .then()
+                    .statusCode(204);
+            }
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaListLayersParametersIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaListLayersParametersIntegrationTest.java
@@ -227,6 +227,56 @@ class LambdaListLayersParametersIntegrationTest {
         }
     }
 
+    @Test
+    @Order(10)
+    void forgedMarkerIsRejectedEvenWhenWellFormed() {
+        // A caller who knows the cursor format cannot mint a marker: the signature is over a
+        // key this process generated, so a hand-built token is rejected rather than applied
+        // as a cursor, which would silently skip or empty the page.
+        for (String forged : new String[] {"lp-alpha.AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+                                           "lp-alpha.", ".signature", "lp-alpha"}) {
+            String encoded = Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(forged.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            given()
+                .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+                .queryParam("Marker", encoded)
+            .when()
+                .get("/2018-10-31/layers")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("InvalidParameterValueException"))
+                .body("message", equalTo("Invalid pagination key."));
+        }
+    }
+
+    @Test
+    @Order(10)
+    void markerFromOneListingIsNotAcceptedWithADifferentCursorSpliced() {
+        // Take a real marker, decode it, swap the cursor, re-encode: the signature no longer
+        // matches, so the edited token is refused.
+        String marker = given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+            .queryParam("MaxItems", 1)
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(200)
+            .extract().path("NextMarker");
+
+        String decoded = new String(Base64.getUrlDecoder().decode(marker),
+                java.nio.charset.StandardCharsets.UTF_8);
+        String spliced = LAYER_B + decoded.substring(decoded.lastIndexOf('.'));
+        given()
+            .queryParam("CompatibleRuntime", PAGE_RUNTIME)
+            .queryParam("Marker", Base64.getUrlEncoder().withoutPadding()
+                    .encodeToString(spliced.getBytes(java.nio.charset.StandardCharsets.UTF_8)))
+        .when()
+            .get("/2018-10-31/layers")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValueException"));
+    }
+
     // ── parameter validation ─────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

`ListLayers` and `ListLayerVersions` accepted `CompatibleRuntime`, `CompatibleArchitecture`, `MaxItems` and `Marker` and ignored all four, and never emitted `NextMarker`. A client paginating with `MaxItems` saw no `NextMarker`, concluded there was one page, and silently got the whole list; a client filtering by runtime or architecture got layers that do not match the filter.

Both actions now filter, paginate and emit `NextMarker`.

Closes #2808

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Scope

`ListLayerVersions` is included alongside `ListLayers`: it takes the same four parameters, was ignoring them the same way, and shares the filter and pagination code. #2808 flagged it as unverified — it is confirmed here (see the before/after table).

Nothing else in the layer surface is touched. `ListLayers`'s ordering did have to change: it grouped versions through a `HashMap`, so the order was nondeterministic and no cursor could be stable over it. It is now layer-name ascending, which is also what the live service returns.

## AWS Compatibility

API reference: [ListLayers](https://docs.aws.amazon.com/lambda/latest/api/API_ListLayers.html), [ListLayerVersions](https://docs.aws.amazon.com/lambda/latest/api/API_ListLayerVersions.html).

Where the reference and the live service disagree, this follows the live service. The reference documents only `InvalidParameterValueException` for these actions; the live service actually returns three different errors.

### Measured against `lambda.ap-southeast-1.amazonaws.com`

Read-only calls (`ListLayers`/`ListLayerVersions`) against an account holding two layers, one `python3.13`/`arm64` and one `nodejs22.x` with no `CompatibleArchitectures`.

| Request | Live AWS | Floci before | Floci after |
| --- | --- | --- | --- |
| *(no parameters)* | 200, 2 items, `"NextMarker":null` | 200, all items, no `NextMarker` | 200, page of ≤50, `NextMarker` |
| `MaxItems=1` | 200, 1 item, `NextMarker` set | 200, all items | 200, 1 item, `NextMarker` set |
| `Marker=<token from page 1>` | 200, remaining items | ignored | 200, remaining items |
| `CompatibleRuntime=python3.13` | 200, 1 item | 200, all items | 200, matching only |
| `CompatibleArchitecture=x86_64` | 200, **0 items** | 200, all items | 200, 0 items |
| `MaxItems=0` | 400 `ValidationException` | 200 | 400 `ValidationException` |
| `MaxItems=51` | 400 `ValidationException` | 200 | 400 `ValidationException` |
| `MaxItems=abc` / `2.5` / `' 2 '` | 400 `SerializationException` | 200 | 400 `SerializationException` |
| `MaxItems=` *(empty)* | 200, treated as omitted | 200 | 200, treated as omitted |
| `CompatibleRuntime=bogus9.x` | 400 `ValidationException` | 200 | 400 `ValidationException` |
| `CompatibleRuntime=PYTHON3.13` | 400 `ValidationException` | 200 | 400 `ValidationException` |
| `CompatibleArchitecture=sparc` / `ARM64` | 400 `ValidationException` | 200 | 400 `ValidationException` |
| `Marker=garbage` / `AAAAAAAA` | 400 `InvalidParameterValueException` `Invalid pagination key.` | 200 | same |
| `ListLayerVersions` on an unknown layer | 200, empty list | 200, empty list | unchanged |

Exact messages are reproduced, e.g.

```
1 validation error detected: Value '0' at 'maxItems' failed to satisfy constraint: Member must have value greater than or equal to 1
```

### Details measured rather than assumed

- **Validation failures accumulate.** Two bad parameters produce `2 validation errors detected: …; …`, three produce `3`. The member order is fixed — `maxItems`, `compatibleRuntime`, `compatibleArchitecture` — and does **not** follow query-string order (verified by sending them reversed).
- **`SerializationException` short-circuits.** `MaxItems=abc&CompatibleRuntime=bogus9.x` returns `SerializationException` alone, never a combined message.
- **`Marker` is validated after the enums.** A bad marker plus a bad runtime returns the runtime `ValidationException`.
- **`NextMarker` is always present**, as JSON `null` on the last page rather than omitted: `{"NextMarker":null,"Layers":[]}`.
- **The runtime enum is wider than the reference.** The live service prints its accepted set in the `ValidationException`; it includes values the reference omits (`java8.al2023`, `java17.al2023`, `python3.15`, `nodejs26.x`, `nasa`, `byol`, the three greengrass runtime ARNs). The constant is taken from the live set, so a runtime that can be published can also be filtered on. The live service's own ordering of that set varies between responses, so a fixed order is used here.
- **An absent `CompatibleArchitectures` matches no architecture filter.** The layer without one was returned by neither `x86_64` nor `arm64` — unlike a function's `Architectures`, it does not default to `x86_64`.

## Deliberate choices, and what could not be measured

- **`Marker` is opaque and signed.** The live token is a ~448-character encrypted blob that the service rejects when it did not issue it. Floci signs the cursor with an HMAC keyed from a value generated at startup, which gives the same property: a fabricated or edited marker fails the check rather than being applied as a cursor, and a marker from a previous run is stale, as an expired token is against AWS.
- **Not built on `core/common/Pagination`.** That helper models AWS's `maxResults`/`nextToken` idiom and throws its own message wording (`maxResults must be between 1 and N`, `Invalid nextToken.`). Lambda's `MaxItems`/`Marker` pair has different error types and different text, and unknown-token rejection is deliberate here rather than absent. Happy to fold this into the shared helper instead if you would rather grow it to cover both idioms.
- **Default page size is 50, inferred not measured.** The test account has only two layers, so an unparameterised response never paginated. 50 is the documented `MaxItems` maximum, so it is the natural default; say the word if Floci should return everything instead.
- **`ListLayerVersions` ordering is unchanged (version ascending).** The reference does not specify an order and every layer in the account available to me has a single version, so I could not measure the live one. Existing behaviour is preserved and paginated over rather than guessed at.
- **`LatestMatchingVersion` under a filter is the newest *matching* version**, and a layer whose versions all fail the filter drops out. Same reason — no multi-version layer to measure against — but the field's name and the reference's "list only layers that indicate that they're compatible" both point this way. This is the one behaviour here I would most like a second opinion on.

## Known divergence

A parameter sent with an **empty** value — `?CompatibleRuntime=`, `?CompatibleArchitecture=`, `?Marker=` — is treated as absent, where AWS returns 400. RESTEasy Reactive binds an empty query value as `null` for a `String` `@QueryParam`, so the resource method cannot tell it from an omitted parameter. (`UriInfo.getQueryParameters()` does keep the key, with an empty value list, so it is recoverable — but that applies to every query parameter in Floci, not just these, so it seemed like the wrong thing to special-case here.) `?MaxItems=` is unaffected: AWS also treats that one as omitted. Noted in `docs/services/lambda.md`; happy to open a separate issue if you would like it tracked.

## Testing

- `LambdaListLayersParametersIntegrationTest` — 24 tests covering filters, `LatestMatchingVersion` under a filter, cursor round-tripping with no overlap or gap, every validation edge above, the same parameters on `ListLayerVersions`, and marker forgery (a hand-built token, and a real token with its cursor spliced). It filters on `ruby3.4`, a runtime no other test publishes, so its assertions stay deterministic on the shared emulator, and it deletes every version it publishes.
- Lambda package: **693 tests, 0 failures**.
- Full suite, on the rebased tip: **14704 tests, 0 failures, 0 errors, 12 skipped** — 8 shards, split with CI's own `.github/ci/partition.sh`, all 8 green in a single pass.
- `make docs-check`: clean.
- SDK coverage added in `compatibility-tests/sdk-test-node/tests/lambda-layers.test.ts` (`385b4a9`) — 7 cases covering both filters, the two together, `MaxItems`/`NextMarker` walking every version exactly once, `LatestMatchingVersion` under a filter, a layer dropping out of `ListLayers`, and the enum rejection surfacing as `ValidationException`. AGENTS.md prefers SDK clients over raw HTTP on the management plane and the integration test drives the wire protocol directly, so this closes that gap.
- Compatibility suite (`sdk-test-node`, run CI-style inside the container network with `--dns` pointed at Floci), on the rebased tip: **465/467**, with `lambda-layers.test.ts` **20/20**. The two failures are the WebSocket chat-broadcast suites (`apigatewayv2-websocket-dataplane`, `apigatewayv2-websocket-tls`); a control run of those two files against the released `floci/floci:1.7.0` image reproduces them identically, so they are pre-existing and unrelated.
- Negative control for the new SDK tests: running this same compatibility image against a probe built from a branch *without* the parameter support fails exactly the 7 new cases and nothing else, so they pin the change rather than passing regardless.

## Review follow-up (`5e9246c`)

Greptile was right that the original marker tag was a shape check rather than proof of provenance — the prefix was a fixed string in the source, so a caller could mint one, and the forged cursor was then applied to the page. Markers are now HMAC-signed; see the bullet above and the two new tests.

A follow-up review asked for the listing context (endpoint, layer, region, filters) to be signed into the marker as well. I measured that against the live service rather than implementing it, and it argues the other way: replaying a real `ListLayers` marker with a *different* filter returns 200 with 0 items — AWS applies the cursor to the newly filtered set rather than rejecting the token, which is what this PR already does — and replaying one on `ListLayerVersions` returns `500 InternalFailure`, which is not behaviour worth reproducing. Binding the context would make Floci reject requests the real service answers. Details in the review thread; happy to add it if a maintainer would rather Floci be stricter than AWS here.

## Rebased on `main` after #2812

#2812 has merged. This branch is rebased onto it and the conflict is resolved by keeping
both sides: #2812's `find=LayerVersion` dispatch in `listLayers` stays, and the four query
parameters are added alongside it. No behaviour from either change is dropped. The partition
guard that started here went in with #2812, so it is no longer part of this diff.

`LambdaListLayersParametersIntegrationTest` re-run on the rebased tip: **24 tests, 0 failures**.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
