### PR TITLE
fix(stepfunctions): let a mocked response with no attempts start execution

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -398,6 +398,11 @@ entry, `Return` and `Throw` together, `Throw` without `Error`) as a structured 4
 at `StartExecution`. Step Functions Local instead returns a plain HTTP 500 for most of
 these and starts the execution only to fail it with `States.Runtime` for the last two.
 
+A mocked response with no attempt entries (`{}`) is not rejected. As in Step Functions
+Local, the execution starts and fails with `States.Runtime` only if the state that names
+it is entered. This keeps a generated mock file usable when the collection it was built
+from is empty and the state is never reached.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/SfnMockLoader.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/SfnMockLoader.java
@@ -121,14 +121,15 @@ public class SfnMockLoader {
         return root;
     }
 
+    /**
+     * An entry with no attempts stays empty instead of being rejected. Step Functions Local
+     * treats it as a lookup that finds nothing, so the execution starts and fails with
+     * {@code States.Runtime} only if the state that names it is entered.
+     */
     private List<MockedResponseStep> parseSteps(String responseKey, JsonNode responseNode) {
         var steps = new ArrayList<MockedResponseStep>();
         responseNode.fields().forEachRemaining(
                 entry -> steps.add(parseStep(responseKey, entry.getKey(), entry.getValue())));
-        if (steps.isEmpty()) {
-            throw new AwsException("ValidationException",
-                    "Mocked response '" + responseKey + "' must define at least one attempt entry", 400);
-        }
         steps.sort(Comparator.comparingInt(MockedResponseStep::fromAttempt));
         return List.copyOf(steps);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/SfnMockLoaderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/SfnMockLoaderTest.java
@@ -146,6 +146,24 @@ class SfnMockLoaderTest {
     }
 
     @Test
+    void acceptsMockedResponseWithNoAttemptEntries() throws IOException {
+        var testCase = loader("""
+                {
+                  "StateMachines": {
+                    "Test": { "TestCases": { "Case": { "Skipped": "Empty", "Call API": "Ok" } } }
+                  },
+                  "MockedResponses": {
+                    "Empty": {},
+                    "Ok": { "0": { "Return": { "StatusCode": 200 } } }
+                  }
+                }
+                """).requireTestCase("Test", "Case");
+
+        assertTrue(testCase.stateResponses().get("Skipped").isEmpty());
+        assertEquals(1, testCase.stateResponses().get("Call API").size());
+    }
+
+    @Test
     void reportsMissingFile() {
         var loader = new SfnMockLoader(
                 Optional.of(tempDir.resolve("absent.json").toString()), new ObjectMapper());

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsMockedServiceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsMockedServiceIntegrationTest.java
@@ -35,6 +35,7 @@ class StepFunctionsMockedServiceIntegrationTest {
     private static String mockSmArn;
     private static String ddbSmArn;
     private static String expressSmArn;
+    private static String skipSmArn;
 
     @BeforeAll
     static void configureRestAssured() {
@@ -110,6 +111,29 @@ class StepFunctionsMockedServiceIntegrationTest {
                   }
                 }
                 """.formatted(UNSUPPORTED_RESOURCE));
+
+        skipSmArn = createStateMachine("sfn-mock-skip-test", null, """
+                {
+                  "StartAt": "Decide",
+                  "States": {
+                    "Decide": {
+                      "Type": "Choice",
+                      "Choices": [{"Variable": "$.go", "StringEquals": "skip", "Next": "Skip"}],
+                      "Default": "Run"
+                    },
+                    "Skip": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    },
+                    "Run": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(UNSUPPORTED_RESOURCE, UNSUPPORTED_RESOURCE));
 
         given()
                 .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
@@ -259,6 +283,32 @@ class StepFunctionsMockedServiceIntegrationTest {
         assertEquals("FAILED", describe.jsonPath().getString("status"));
         assertEquals("States.TaskFailed", describe.jsonPath().getString("error"));
         assertTrue(describe.jsonPath().getString("cause").contains("Unsupported resource"));
+    }
+
+    @Test
+    @Order(10)
+    void emptyMockedResponseIsIgnoredWhenItsStateIsNotEntered() throws Exception {
+        // Verified against Step Functions Local 2.0.0. A mocked response with no attempt entries
+        // does not stop the execution from starting when its state is never entered.
+        var execArn = startExecution(skipSmArn + "#EmptyUnusedResponse", "{\"go\": \"run\"}");
+
+        var describe = waitForTerminalState(execArn);
+        assertEquals("SUCCEEDED", describe.jsonPath().getString("status"));
+
+        var output = mapper.readTree(describe.jsonPath().getString("output"));
+        assertEquals(200, output.path("StatusCode").asInt());
+    }
+
+    @Test
+    @Order(11)
+    void emptyMockedResponseFailsTheExecutionWhenItsStateIsEntered() {
+        // Verified against Step Functions Local 2.0.0. Entering the state fails the execution
+        // with States.Runtime rather than rejecting StartExecution.
+        var execArn = startExecution(skipSmArn + "#EmptyUnusedResponse", "{\"go\": \"skip\"}");
+
+        var describe = waitForTerminalState(execArn);
+        assertEquals("FAILED", describe.jsonPath().getString("status"));
+        assertEquals("States.Runtime", describe.jsonPath().getString("error"));
     }
 
     private static String createStateMachine(String name, String type, String definition) {

--- a/src/test/resources/fixtures/sfn-mock-config.json
+++ b/src/test/resources/fixtures/sfn-mock-config.json
@@ -11,6 +11,11 @@
       "TestCases": {
         "MockedApiRealDdb": { "Call API": "Ok200" }
       }
+    },
+    "sfn-mock-skip-test": {
+      "TestCases": {
+        "EmptyUnusedResponse": { "Skip": "Empty", "Run": "Ok200" }
+      }
     }
   },
   "MockedResponses": {
@@ -23,6 +28,7 @@
     "ThrowThenOk": {
       "0": { "Throw": { "Error": "ApiGateway.429", "Cause": "Too many requests" } },
       "1-2": { "Return": { "StatusCode": 200, "ResponseBody": { "retried": true } } }
-    }
+    },
+    "Empty": {}
   }
 }


### PR DESCRIPTION
## Summary

Closes #2523

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against amazon/aws-stepfunctions-local:2.0.0.

A MockedResponses entry with no attempt keys was rejected at StartExecution, so a generated mock file failed the whole execution when the collection it was built from was empty. Step Functions Local starts the execution and fails it with States.Runtime only when the state that names the entry is entered.

An empty entry is a lookup that finds nothing, not a malformed entry. Floci already accepts a mock that defines attempt 1 but not attempt 0 and fails the same way at run time. Every other malformed entry keeps its 400 at StartExecution, which stays stricter than Step Functions Local.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

