### PR TITLE
fix(lambda): delete only the named version when DeleteFunction has a Qualifier

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/lambda.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/lambda.test.ts
@@ -241,3 +241,72 @@ describe('Lambda Publish flag', () => {
     expect((listed.Versions ?? []).map((v) => v.Version).sort()).toEqual(['$LATEST', '1', '2']);
   });
 });
+
+describe('Lambda version deletion', () => {
+  let lambda: LambdaClient;
+  let fnName: string;
+
+  const versions = async () => {
+    const r = await lambda.send(new ListVersionsByFunctionCommand({ FunctionName: fnName }));
+    return (r.Versions ?? []).map((v) => v.Version).sort();
+  };
+
+  beforeAll(async () => {
+    lambda = makeClient(LambdaClient);
+    fnName = `test-delver-${uniqueName()}`;
+
+    await lambda.send(new CreateFunctionCommand({
+      FunctionName: fnName,
+      Runtime: 'nodejs20.x',
+      Role: `arn:aws:iam::${ACCOUNT}:role/lambda-role`,
+      Handler: 'index.handler',
+      Code: { ZipFile: buildMinimalZip('index.js', Buffer.from('exports.handler = async () => 1;')) },
+    }));
+    await lambda.send(new PublishVersionCommand({ FunctionName: fnName }));
+    await lambda.send(new UpdateFunctionCodeCommand({
+      FunctionName: fnName,
+      ZipFile: buildMinimalZip('index.js', Buffer.from('exports.handler = async () => 2;')),
+    }));
+    await lambda.send(new PublishVersionCommand({ FunctionName: fnName }));
+  });
+
+  afterAll(async () => {
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName })).catch(() => {});
+  });
+
+  it('should delete only the qualified version, leaving the function intact', async () => {
+    expect(await versions()).toEqual(['$LATEST', '1', '2']);
+
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName, Qualifier: '2' }));
+
+    // The function survives — before this was fixed, the whole function was deleted.
+    const fn = await lambda.send(new GetFunctionCommand({ FunctionName: fnName }));
+    expect(fn.Configuration?.FunctionName).toBe(fnName);
+    expect(await versions()).toEqual(['$LATEST', '1']);
+  });
+
+  it('should refuse to delete $LATEST by qualifier', async () => {
+    await expect(
+      lambda.send(new DeleteFunctionCommand({ FunctionName: fnName, Qualifier: '$LATEST' }))
+    ).rejects.toThrow(/cannot be deleted without deleting the function/);
+    expect(await versions()).toEqual(['$LATEST', '1']);
+  });
+
+  it('should refuse to delete a version an alias references', async () => {
+    await lambda.send(new CreateAliasCommand({
+      FunctionName: fnName,
+      Name: 'pinned',
+      FunctionVersion: '1',
+    }));
+
+    await expect(
+      lambda.send(new DeleteFunctionCommand({ FunctionName: fnName, Qualifier: '1' }))
+    ).rejects.toThrow(/aliases reference it/);
+    expect(await versions()).toEqual(['$LATEST', '1']);
+  });
+
+  it('should treat a version that does not exist as a no-op', async () => {
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName, Qualifier: '99' }));
+    expect(await versions()).toEqual(['$LATEST', '1']);
+  });
+});

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -173,6 +173,13 @@ returns the qualified one (`...:function:name:2`), as `PublishVersion` does. Wit
 both answer for `$LATEST` and create nothing. `UpdateFunctionConfiguration` has no `Publish`
 parameter in the AWS API and none here.
 
+`DeleteFunction` honours `Qualifier` — it removes that published version only, leaving `$LATEST`,
+the other versions and the function's aliases in place; without a qualifier the whole function
+goes. Matching the live service, deleting `$LATEST` by qualifier and naming an alias are both
+rejected with `InvalidParameterValueException`, a version an alias points at is a
+`ResourceConflictException`, and a version that does not exist is a silent success rather than
+a 404.
+
 **Layers:** `PublishLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `ListLayerVersions`,
 `ListLayers`, and `DeleteLayerVersion` are implemented, with real local storage under
 `{lambda.codePath}/layers/{name}/{version}`. `ListLayers` and `ListLayerVersions` honour

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -196,9 +196,10 @@ public class LambdaController {
     @DELETE
     @Path("/functions/{functionName}")
     public Response deleteFunction(@Context HttpHeaders headers,
-                                   @PathParam("functionName") String functionName) {
+                                   @PathParam("functionName") String functionName,
+                                   @QueryParam("Qualifier") String qualifier) {
         String region = regionResolver.resolveRegion(headers);
-        lambdaService.deleteFunction(region, functionName);
+        lambdaService.deleteFunction(region, functionName, qualifier);
         return Response.noContent().build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -706,7 +706,68 @@ public class LambdaService implements ResourceProvider {
         return fn;
     }
 
+    /**
+     * DeleteFunction without a Qualifier: removes the function and every version of it.
+     */
     public void deleteFunction(String region, String functionName) {
+        deleteFunction(region, functionName, null);
+    }
+
+    /**
+     * DeleteFunction. A Qualifier names a single published version to remove, leaving the
+     * function and its other versions in place; without one the whole function goes.
+     */
+    public void deleteFunction(String region, String functionName, String qualifier) {
+        if (qualifier != null && !qualifier.isEmpty()) {
+            deleteFunctionVersion(region, functionName, qualifier);
+            return;
+        }
+        deleteWholeFunction(region, functionName);
+    }
+
+    /**
+     * Removes one published version. Error behaviour follows the live service: deleting
+     * {@code $LATEST} or naming an alias is rejected, a version an alias points at is a
+     * conflict, and a version that does not exist is a silent success rather than a 404.
+     */
+    private void deleteFunctionVersion(String region, String functionName, String qualifier) {
+        LambdaFunction fn = getFunction(region, functionName);
+        if ("$LATEST".equals(qualifier)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "$LATEST version cannot be deleted without deleting the function.", 400);
+        }
+        if (!qualifier.chars().allMatch(Character::isDigit)) {
+            // A non-numeric qualifier names an alias, which the live service refuses to
+            // resolve here rather than deleting the version behind it.
+            throw new AwsException("InvalidParameterValueException",
+                    "Deletion of aliases is not currently supported.", 400);
+        }
+        String name = fn.getFunctionName();
+        List<String> referencing = aliasStore == null ? List.of()
+                : aliasStore.list(region, name).stream()
+                        .filter(alias -> qualifier.equals(alias.getFunctionVersion()))
+                        .map(LambdaAlias::getName)
+                        .toList();
+        if (!referencing.isEmpty()) {
+            throw new AwsException("ResourceConflictException",
+                    "Unable to delete version because the following aliases reference it: "
+                            + referencing, 409);
+        }
+        Optional<LambdaFunction> version = functionStore.get(region, name, qualifier);
+        if (version.isEmpty()) {
+            return;
+        }
+        synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
+            warmPool.drainEnvironment(version.get());
+            functionStore.deleteVersion(region, name, qualifier);
+            // The snapshot shares $LATEST's code directory, so this only reclaims once no
+            // remaining version references it.
+            reclaimLegacyCodeDirectoryIfUnused(name);
+        }
+        LOG.infov("Deleted version {0} of Lambda function: {1}", qualifier, name);
+    }
+
+    private void deleteWholeFunction(String region, String functionName) {
         LambdaFunction fn = getFunction(region, functionName); // throws 404 if not found
         functionName = fn.getFunctionName();
         String arn = fn.getFunctionArn();

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -57,6 +57,14 @@ import java.util.regex.Pattern;
 public class LambdaService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(LambdaService.class);
+
+    /**
+     * Qualifier constraint the live service enforces, taken from its own ValidationException
+     * rather than the API reference, which publishes a laxer pattern. Notably it is ASCII-only,
+     * so a non-ASCII digit is rejected here rather than being read as a version number.
+     */
+    private static final String QUALIFIER_PATTERN = "\\$(LATEST(\\.PUBLISHED)?)|[a-zA-Z0-9-_$]+";
+    private static final Pattern QUALIFIER = Pattern.compile(QUALIFIER_PATTERN);
     private static final Pattern EFS_ACCESS_POINT_ARN = Pattern.compile(
             "^arn:aws[a-zA-Z-]*:elasticfilesystem:(?:eusc-)?[a-z]{2}"
                     + "(?:(?:-gov)|(?:-iso(?:b)?))?-[a-z]+-\\d:"
@@ -731,12 +739,18 @@ public class LambdaService implements ResourceProvider {
      * conflict, and a version that does not exist is a silent success rather than a 404.
      */
     private void deleteFunctionVersion(String region, String functionName, String qualifier) {
+        if (!QUALIFIER.matcher(qualifier).matches()) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + qualifier + "' at 'qualifier' failed"
+                            + " to satisfy constraint: Member must satisfy regular expression"
+                            + " pattern: " + QUALIFIER_PATTERN, 400);
+        }
         LambdaFunction fn = getFunction(region, functionName);
         if ("$LATEST".equals(qualifier)) {
             throw new AwsException("InvalidParameterValueException",
                     "$LATEST version cannot be deleted without deleting the function.", 400);
         }
-        if (!qualifier.chars().allMatch(Character::isDigit)) {
+        if (!qualifier.chars().allMatch(c -> c >= '0' && c <= '9')) {
             // A non-numeric qualifier names an alias, which the live service refuses to
             // resolve here rather than deleting the version behind it.
             throw new AwsException("InvalidParameterValueException",

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaDeleteFunctionQualifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaDeleteFunctionQualifierIntegrationTest.java
@@ -13,6 +13,7 @@ import java.util.zip.ZipOutputStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 /**
@@ -117,6 +118,31 @@ class LambdaDeleteFunctionQualifierIntegrationTest {
             .statusCode(400)
             .body("__type", equalTo("InvalidParameterValueException"))
             .body("message", equalTo("Deletion of aliases is not currently supported."));
+    }
+
+    @Test
+    @Order(3)
+    void nonAsciiQualifierIsRejectedByThePattern() {
+        // Character.isDigit accepts non-ASCII decimal digits, so a full-width or Arabic-Indic
+        // digit would otherwise be read as a version number and answered with a silent 204.
+        // The live service pattern-validates the qualifier first; measured on GetFunction,
+        // which enforces the same constraint.
+        for (String qualifier : new String[] {"\uFF13", "\u0663"}) {
+            given()
+                .queryParam("Qualifier", qualifier)
+            .when()
+                .delete("/2015-03-31/functions/" + FN)
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", containsString("at 'qualifier' failed to satisfy constraint"));
+        }
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2", "3"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaDeleteFunctionQualifierIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaDeleteFunctionQualifierIntegrationTest.java
@@ -1,0 +1,260 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * DeleteFunction with a Qualifier removes one published version, not the function.
+ *
+ * <p>Behaviour here mirrors the live service, which was measured for each case: deleting
+ * {@code $LATEST} or an alias name is rejected, a version an alias references is a conflict,
+ * a version that does not exist is a silent success, and the function, its other versions
+ * and its aliases all survive.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaDeleteFunctionQualifierIntegrationTest {
+
+    private static final String FN = "del-qualifier-fn";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    private static String zipBase64(String marker) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("handler.py"));
+            zos.write(("def handler(e, c):\n    return '" + marker + "'\n").getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static void updateCode(String marker) throws Exception {
+        given()
+            .contentType("application/json")
+            .body("{\"ZipFile\": \"" + zipBase64(marker) + "\"}")
+        .when()
+            .put("/2015-03-31/functions/" + FN + "/code")
+        .then()
+            .statusCode(200);
+    }
+
+    private static void publish() {
+        given()
+            .contentType("application/json")
+            .body("{}")
+        .when()
+            .post("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .statusCode(201);
+    }
+
+    @Test
+    @Order(1)
+    void seedFunctionWithThreeVersions() throws Exception {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "python3.12",
+                    "Role": "%s",
+                    "Handler": "handler.handler",
+                    "Code": { "ZipFile": "%s" }
+                }
+                """.formatted(FN, ROLE, zipBase64("v1")))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201);
+
+        publish();                 // version 1
+        updateCode("v2");
+        publish();                 // version 2
+        updateCode("v3");
+        publish();                 // version 3
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .statusCode(200)
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2", "3"));
+    }
+
+    @Test
+    @Order(2)
+    void deletingLatestByQualifierIsRejected() {
+        given()
+            .queryParam("Qualifier", "$LATEST")
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValueException"))
+            .body("message", equalTo("$LATEST version cannot be deleted without deleting the function."));
+    }
+
+    @Test
+    @Order(3)
+    void deletingByAliasNameIsRejected() {
+        given()
+            .queryParam("Qualifier", "notaversion")
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidParameterValueException"))
+            .body("message", equalTo("Deletion of aliases is not currently supported."));
+    }
+
+    @Test
+    @Order(4)
+    void deletingAVersionThatDoesNotExistSucceedsSilently() {
+        // Measured: the live service returns success and changes nothing, rather than 404.
+        given()
+            .queryParam("Qualifier", "99")
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2", "3"));
+    }
+
+    @Test
+    @Order(5)
+    void versionReferencedByAnAliasCannotBeDeleted() {
+        given()
+            .contentType("application/json")
+            .body("{\"Name\": \"live\", \"FunctionVersion\": \"1\"}")
+        .when()
+            .post("/2015-03-31/functions/" + FN + "/aliases")
+        .then()
+            .statusCode(201);
+
+        given()
+            .queryParam("Qualifier", "1")
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("ResourceConflictException"))
+            .body("message", equalTo(
+                    "Unable to delete version because the following aliases reference it: [live]"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2", "3"));
+    }
+
+    @Test
+    @Order(6)
+    void deletingAnUnreferencedVersionRemovesOnlyThatVersion() {
+        given()
+            .queryParam("Qualifier", "2")
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(204);
+
+        // The regression this test exists for: before the qualifier was honoured, this call
+        // deleted the whole function.
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(200)
+            .body("Configuration.FunctionName", equalTo(FN));
+
+        // Checked through ListVersionsByFunction rather than a qualified GetFunction:
+        // GetFunction ignores Qualifier today and would answer for $LATEST either way.
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "3"));
+
+        // The alias, pointing at a different version, is untouched.
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/aliases/live")
+        .then()
+            .statusCode(200)
+            .body("FunctionVersion", equalTo("1"));
+    }
+
+    @Test
+    @Order(8)
+    void deleteWithoutAQualifierStillRemovesTheWholeFunction() {
+        given()
+        .when()
+            .delete("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(404);
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(9)
+    void emptyQualifierIsTreatedAsAbsent() throws Exception {
+        // RESTEasy binds an empty query value as null, so ?Qualifier= is a whole-function
+        // delete; pinned so the distinction is not lost if that binding ever changes.
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s-empty",
+                    "Runtime": "python3.12",
+                    "Role": "%s",
+                    "Handler": "handler.handler",
+                    "Code": { "ZipFile": "%s" }
+                }
+                """.formatted(FN, ROLE, zipBase64("v1")))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201);
+
+        given()
+            .queryParam("Qualifier", "")
+        .when()
+            .delete("/2015-03-31/functions/" + FN + "-empty")
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "-empty")
+        .then()
+            .statusCode(404);
+    }
+}


### PR DESCRIPTION
## Summary

`DeleteFunction` accepted a `Qualifier` and dropped it. The controller never bound the query parameter, so every call took the unqualified path and deleted the function together with `$LATEST` and every other version. A caller pruning one old version silently lost the whole function — with a `204` and no warning.

The qualified path now removes that version alone, leaving the function, its other versions and its aliases in place.

Closes #2819

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## AWS Compatibility

API reference: [DeleteFunction](https://docs.aws.amazon.com/lambda/latest/api/API_DeleteFunction.html) — "Specify a version to delete. You can't delete a version that an alias references."

The reference documents none of the error behaviour, so every case below was measured against the live service (`lambda.ap-southeast-1.amazonaws.com`) on a throwaway function with `$LATEST`, `1`, `2`, `3` and an alias `live` pointing at version 1.

| Request | Live AWS | Floci before | Floci after |
| --- | --- | --- | --- |
| `--qualifier 2` (unreferenced) | 204, versions become `$LATEST 1 3` | **whole function deleted** | 204, only version 2 removed |
| *(no qualifier)* | function and all versions removed | same | unchanged |
| `--qualifier 99` (absent) | **204, nothing changes** | whole function deleted | 204, nothing changes |
| `--qualifier notaversion` | 400 `InvalidParameterValueException` — `Deletion of aliases is not currently supported.` | whole function deleted | same as AWS |
| `--qualifier $LATEST` | 400 `InvalidParameterValueException` — `$LATEST version cannot be deleted without deleting the function.` | whole function deleted | same as AWS |
| version an alias references | 409 `ResourceConflictException` — `Unable to delete version because the following aliases reference it: [live]` | whole function deleted | same as AWS |

After deleting an unreferenced version the live service leaves the function present and the alias intact, both of which are asserted here.

Two results worth calling out because the plausible guess is wrong:

- **A version that does not exist is a silent success, not a 404.** I would have returned `ResourceNotFoundException`.
- **A non-numeric qualifier is not resolved to the aliased version** — the service refuses outright with `Deletion of aliases is not currently supported.`

## Implementation

`LambdaFunctionStore.deleteVersion` already existed, documented as "Deletes one published version, leaving `$LATEST` and the other versions in place"; nothing reached it. The change binds `Qualifier` in the controller and adds the qualified branch in the service, leaving the unqualified teardown (code store, version counters, aliases, S3 package) exactly as it was.

The qualified branch takes the same per-function lock the unqualified one does, drains the version's warm containers, and calls `reclaimLegacyCodeDirectoryIfUnused` — which only reclaims once no remaining version references the shared code directory.

## Not in scope

A deleted version is verified gone through `ListVersionsByFunction` rather than a qualified `GetFunction`, because `GetFunction` ignores `Qualifier` today and answers for `$LATEST` either way. That is #2821 and is left alone here. Also from the same measurement pass: #2820 (`Publish` ignored by `CreateFunction`/`UpdateFunctionCode`) and #2822 (`PublishVersion` neither de-duplicates an unchanged publish nor honours `CodeSha256`).

## Testing

- `LambdaDeleteFunctionQualifierIntegrationTest` — 9 tests, one per measured case, plus the empty-qualifier binding and the unqualified teardown. Reverting the controller's one-line change fails 6 of them, so they pin the destructive behaviour rather than merely passing.
- Full suite, on the pre-rebase tip: **14489 tests, 0 failures, 0 errors, 12 skipped** (sharded with CI's own `.github/ci/partition.sh`).  The rebase onto `main` added only upstream commits (#2812, #2815) plus a one-paragraph resolution in `docs/services/lambda.md`; this branch's Java is byte-identical across it, and the targeted test, `docs-check` and the compatibility suite were all re-run on the rebased tip.
- `make docs-check`: clean.
- Compatibility suite (`sdk-test-node`, run CI-style inside the container network with `--dns` pointed at Floci), re-run on the rebased tip: **462/464**, with `lambda.test.ts` **18/18** and `lambda-layers.test.ts` **13/13**. The two failures are the WebSocket chat-broadcast suites (`apigatewayv2-websocket-dataplane`, `apigatewayv2-websocket-tls`); a control run of those two files against the released `floci/floci:1.7.0` image reproduces them identically, so they are pre-existing and unrelated. (The cognito sign-up failure noted in the earlier revision no longer occurs.)
- SDK coverage added (`13e8956`): the integration test drives the endpoint over raw HTTP, so per AGENTS.md ("prefer AWS SDK clients over raw HTTP for management-plane validation") the four qualified-delete cases are now also exercised through `@aws-sdk/client-lambda` in the compatibility suite.

## Review follow-up (`ccb381b`)

The qualifier is now pattern-validated before the version/alias logic. `Character.isDigit` accepts non-ASCII decimal digits, so a full-width or Arabic-Indic digit was read as a version number and answered with a silent 204. Measuring showed the live service rejects those at the pattern with `ValidationException` — and enforces a stricter pattern than the reference publishes: `\$(LATEST(\.PUBLISHED)?)|[a-zA-Z0-9-_$]+`. An ASCII non-numeric qualifier still reaches the alias branch, as measured.

A second review point, that the alias-reference check races with alias mutation, is answered in the thread: the alias mutation paths do not take `lockForConcurrencyOp`, so moving the check inside that block would not close the window it appears to close. Left for a separate change rather than folded in.

## Rebased on `main`

#2812 has merged and this branch is rebased onto it. The only conflict was the coverage
paragraph in `docs/services/lambda.md`; both sides are kept. The Java change is untouched,
and `LambdaDeleteFunctionQualifierIntegrationTest` is **9 tests, 0 failures** on the rebased tip.

It still shares `docs/services/lambda.md` and `lambda.test.ts` with #2825, so whichever of the
two merges second will want the same one-paragraph resolution.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
