### PR TITLE
fix(lambda): honour Publish on CreateFunction and UpdateFunctionCode

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/lambda.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/lambda.test.ts
@@ -17,6 +17,8 @@ import {
   UpdateAliasCommand,
   DeleteAliasCommand,
   PublishVersionCommand,
+  ListVersionsByFunctionCommand,
+  UpdateFunctionCodeCommand,
 } from '@aws-sdk/client-lambda';
 import { makeClient, uniqueName, ACCOUNT, buildMinimalZip } from './setup';
 
@@ -183,5 +185,59 @@ describe('Lambda ImageConfig.WorkingDirectory', () => {
     } finally {
       await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName })).catch(() => {});
     }
+  });
+});
+
+describe('Lambda Publish flag', () => {
+  let lambda: LambdaClient;
+  let fnName: string;
+
+  beforeAll(() => {
+    lambda = makeClient(LambdaClient);
+    fnName = `test-publish-${uniqueName()}`;
+  });
+
+  afterAll(async () => {
+    await lambda.send(new DeleteFunctionCommand({ FunctionName: fnName })).catch(() => {});
+  });
+
+  it('should publish version 1 on create and keep the ARN unqualified', async () => {
+    const response = await lambda.send(new CreateFunctionCommand({
+      FunctionName: fnName,
+      Runtime: 'nodejs20.x',
+      Role: `arn:aws:iam::${ACCOUNT}:role/lambda-role`,
+      Handler: 'index.handler',
+      Code: { ZipFile: buildMinimalZip('index.js', Buffer.from('exports.handler = async () => 1;')) },
+      Publish: true,
+    }));
+
+    expect(response.Version).toBe('1');
+    expect(response.FunctionArn).toMatch(new RegExp(`:function:${fnName}$`));
+
+    const listed = await lambda.send(new ListVersionsByFunctionCommand({ FunctionName: fnName }));
+    expect((listed.Versions ?? []).map((v) => v.Version).sort()).toEqual(['$LATEST', '1']);
+  });
+
+  it('should publish the next version on code update and return a qualified ARN', async () => {
+    const response = await lambda.send(new UpdateFunctionCodeCommand({
+      FunctionName: fnName,
+      ZipFile: buildMinimalZip('index.js', Buffer.from('exports.handler = async () => 2;')),
+      Publish: true,
+    }));
+
+    expect(response.Version).toBe('2');
+    expect(response.FunctionArn).toMatch(new RegExp(`:function:${fnName}:2$`));
+  });
+
+  it('should create no version when Publish is not set', async () => {
+    const response = await lambda.send(new UpdateFunctionCodeCommand({
+      FunctionName: fnName,
+      ZipFile: buildMinimalZip('index.js', Buffer.from('exports.handler = async () => 3;')),
+    }));
+
+    expect(response.Version).toBe('$LATEST');
+
+    const listed = await lambda.send(new ListVersionsByFunctionCommand({ FunctionName: fnName }));
+    expect((listed.Versions ?? []).map((v) => v.Version).sort()).toEqual(['$LATEST', '1', '2']);
   });
 });

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -166,6 +166,13 @@ services:
 
 Function URLs are also reachable directly on `/{proxy:.*}` under the Lambda URL controller, which routes the request into the normal `Invoke` path.
 
+**Versions:** `CreateFunction` and `UpdateFunctionCode` honour `Publish`, publishing a version
+and reporting it in the response's `Version`. The two differ in the ARN they return, matching the
+live service: `CreateFunction` keeps the unqualified `FunctionArn` while `UpdateFunctionCode`
+returns the qualified one (`...:function:name:2`), as `PublishVersion` does. Without `Publish`
+both answer for `$LATEST` and create nothing. `UpdateFunctionConfiguration` has no `Publish`
+parameter in the AWS API and none here.
+
 **Layers:** `PublishLayerVersion`, `GetLayerVersion`, `GetLayerVersionByArn`, `ListLayerVersions`,
 `ListLayers`, and `DeleteLayerVersion` are implemented, with real local storage under
 `{lambda.codePath}/layers/{name}/{version}`. `CreateFunction`/`UpdateFunctionConfiguration`

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -70,8 +70,10 @@ public class LambdaController {
             @SuppressWarnings("unchecked")
             Map<String, Object> request = objectMapper.readValue(body, Map.class);
             LambdaFunction fn = lambdaService.createFunction(region, request);
+            Map<String, Object> configuration = buildFunctionConfiguration(fn);
+            unqualifyArn(configuration);
             return Response.status(201)
-                    .entity(buildFunctionConfiguration(fn))
+                    .entity(configuration)
                     .build();
         } catch (AwsException e) {
             throw e;
@@ -583,6 +585,18 @@ public class LambdaController {
         java.util.Map<String, Double> result = new java.util.HashMap<>();
         raw.forEach((k, v) -> result.put(k, ((Number) v).doubleValue()));
         return result;
+    }
+
+    /**
+     * CreateFunction reports the version it published but keeps the unqualified ARN, unlike
+     * UpdateFunctionCode and PublishVersion which both answer with the qualified form. Measured
+     * against the live service; the reference does not distinguish them.
+     */
+    private static void unqualifyArn(Map<String, Object> configuration) {
+        if (configuration.get("FunctionArn") instanceof String arn
+                && !"$LATEST".equals(configuration.get("Version"))) {
+            configuration.put("FunctionArn", arn.substring(0, arn.lastIndexOf(':')));
+        }
     }
 
     private Map<String, Object> buildFunctionConfiguration(LambdaFunction fn) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -454,6 +454,9 @@ public class LambdaService implements ResourceProvider {
 
         functionStore.save(region, fn);
         LOG.infov("Created Lambda function: {0} in region {1}", functionName, region);
+        if (Boolean.TRUE.equals(request.get("Publish"))) {
+            return publishVersion(region, functionName, null);
+        }
         return fn;
     }
 
@@ -530,6 +533,9 @@ public class LambdaService implements ResourceProvider {
 
         functionStore.save(region, fn);
         LOG.infov("Updated code for function: {0}", functionName);
+        if (Boolean.TRUE.equals(request.get("Publish"))) {
+            return publishVersion(region, functionName, null);
+        }
         return fn;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishFlagIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishFlagIntegrationTest.java
@@ -1,0 +1,220 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * The Publish flag on CreateFunction and UpdateFunctionCode.
+ *
+ * <p>Response shapes here were measured against the live service, which is not consistent
+ * between the two: CreateFunction reports the published version but answers with the
+ * unqualified ARN, while UpdateFunctionCode returns the qualified one.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class LambdaPublishFlagIntegrationTest {
+
+    private static final String FN = "publish-flag-fn";
+    private static final String FN_NO_PUBLISH = "publish-flag-nopub-fn";
+    private static final String ROLE = "arn:aws:iam::000000000000:role/lambda-role";
+
+    private static String zipBase64(String marker) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("handler.py"));
+            zos.write(("def handler(e, c):\n    return '" + marker + "'\n").getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static String createBody(String name, String marker, boolean publish) throws Exception {
+        return """
+            {
+                "FunctionName": "%s",
+                "Runtime": "python3.12",
+                "Role": "%s",
+                "Handler": "handler.handler",
+                "Code": { "ZipFile": "%s" },
+                "Publish": %s
+            }
+            """.formatted(name, ROLE, zipBase64(marker), publish);
+    }
+
+    @Test
+    @Order(1)
+    void createWithPublishReturnsVersionOneAndAnUnqualifiedArn() throws Exception {
+        given()
+            .contentType("application/json")
+            .body(createBody(FN, "v1", true))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201)
+            .body("Version", equalTo("1"))
+            // Measured: CreateFunction keeps the plain ARN even when it publishes.
+            .body("FunctionArn", endsWith(":function:" + FN))
+            .body("FunctionArn", not(endsWith(":1")));
+    }
+
+    @Test
+    @Order(2)
+    void createWithPublishActuallyCreatesTheVersion() {
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .statusCode(200)
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1"));
+    }
+
+    @Test
+    @Order(3)
+    void unqualifiedGetStillDescribesLatest() {
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(200)
+            .body("Configuration.Version", equalTo("$LATEST"));
+    }
+
+    @Test
+    @Order(4)
+    void updateCodeWithPublishReturnsTheNextVersionAndAQualifiedArn() throws Exception {
+        given()
+            .contentType("application/json")
+            .body("{\"ZipFile\": \"" + zipBase64("v2") + "\", \"Publish\": true}")
+        .when()
+            .put("/2015-03-31/functions/" + FN + "/code")
+        .then()
+            .statusCode(200)
+            .body("Version", equalTo("2"))
+            // Measured: unlike CreateFunction, this one is qualified.
+            .body("FunctionArn", endsWith(":function:" + FN + ":2"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2"));
+    }
+
+    @Test
+    @Order(5)
+    void updateCodeWithoutPublishReturnsLatestAndCreatesNoVersion() throws Exception {
+        given()
+            .contentType("application/json")
+            .body("{\"ZipFile\": \"" + zipBase64("v3") + "\"}")
+        .when()
+            .put("/2015-03-31/functions/" + FN + "/code")
+        .then()
+            .statusCode(200)
+            .body("Version", equalTo("$LATEST"))
+            .body("FunctionArn", endsWith(":function:" + FN));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST", "1", "2"));
+    }
+
+    @Test
+    @Order(6)
+    void publishedVersionKeepsTheCodeItWasPublishedFrom() {
+        // Version 1 was published from v1's code while $LATEST has since moved to v3, so their
+        // CodeSha256 must differ — the point of publishing being an immutable snapshot.
+        String latestSha = given()
+        .when()
+            .get("/2015-03-31/functions/" + FN)
+        .then()
+            .statusCode(200)
+            .extract().path("Configuration.CodeSha256");
+
+        String versionOneSha = given()
+        .when()
+            .get("/2015-03-31/functions/" + FN + "/versions")
+        .then()
+            .statusCode(200)
+            .extract().path("Versions.find { it.Version == '1' }.CodeSha256");
+
+        org.junit.jupiter.api.Assertions.assertNotEquals(latestSha, versionOneSha);
+    }
+
+    @Test
+    @Order(7)
+    void createWithoutPublishReturnsLatestAndCreatesNoVersion() throws Exception {
+        given()
+            .contentType("application/json")
+            .body(createBody(FN_NO_PUBLISH, "v1", false))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201)
+            .body("Version", equalTo("$LATEST"))
+            .body("FunctionArn", endsWith(":function:" + FN_NO_PUBLISH));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/" + FN_NO_PUBLISH + "/versions")
+        .then()
+            .body("Versions.Version", containsInAnyOrder("$LATEST"));
+    }
+
+    @Test
+    @Order(8)
+    void omittingPublishEntirelyBehavesAsFalse() throws Exception {
+        String name = FN_NO_PUBLISH + "-omitted";
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "Runtime": "python3.12",
+                    "Role": "%s",
+                    "Handler": "handler.handler",
+                    "Code": { "ZipFile": "%s" }
+                }
+                """.formatted(name, ROLE, zipBase64("v1")))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(201)
+            .body("Version", equalTo("$LATEST"));
+
+        given()
+        .when()
+            .delete("/2015-03-31/functions/" + name)
+        .then()
+            .statusCode(204);
+    }
+
+    // ── cleanup ───────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(9)
+    void cleanup_deleteFunctions() {
+        for (String name : new String[] {FN, FN_NO_PUBLISH}) {
+            given()
+            .when()
+                .delete("/2015-03-31/functions/" + name)
+            .then()
+                .statusCode(204);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`CreateFunction` and `UpdateFunctionCode` never read `Publish`. No version was created unless the caller made a separate `PublishVersion` call, and both actions reported `Version` as `$LATEST`.

Both now publish and report the new version.

Closes #2820

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Why it matters beyond the flag

The Terraform provider reads `Version` and `qualified_arn` straight from these responses, so every `aws_lambda_function` with `publish = true` recorded `$LATEST`. Lambda@Edge associations require a numeric version and cannot use `$LATEST`, so that shape of stack could not be modelled against Floci at all.

## AWS Compatibility

API reference: [CreateFunction](https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html), [UpdateFunctionCode](https://docs.aws.amazon.com/lambda/latest/api/API_UpdateFunctionCode.html).

Measured against the live service (`lambda.ap-southeast-1.amazonaws.com`) on a throwaway function, created and deleted for the probe:

| Call | Live AWS `Version` | Live AWS `FunctionArn` | Floci before | Floci after |
| --- | --- | --- | --- | --- |
| `create-function --publish` | `1` | **unqualified** — `...:function:fn` | `$LATEST`, no version created | matches AWS |
| `update-function-code --publish` | `2` | **qualified** — `...:function:fn:2` | `$LATEST`, no version created | matches AWS |
| `publish-version` (explicit) | `3` | qualified — `...:function:fn:3` | already correct | unchanged |
| `create-function` (no `--publish`) | `$LATEST` | unqualified | already correct | unchanged |
| `update-function-code` (no `--publish`) | `$LATEST` | unqualified, version list unchanged | already correct | unchanged |

**The two publishing calls disagree about the ARN**, and that is the reason this PR is shaped the way it is. `CreateFunction` reports the version it just published but answers with the *unqualified* ARN, while `UpdateFunctionCode` returns the *qualified* one, as `PublishVersion` does. The reference gives no hint of the distinction — making them consistent is the obvious implementation, and it is wrong. Getting it backwards would store the wrong `arn` in Terraform state for every function that publishes.

`UpdateFunctionConfiguration` has no `Publish` parameter in the AWS API — the CLI rejects `--publish` with `Unknown options: --publish` — so it is deliberately untouched.

## Implementation

The service delegates to the existing `publishVersion`, which already snapshots code and configuration correctly; nothing was reaching it from these paths. The `CreateFunction` ARN is un-qualified in the controller, where response shaping belongs — the published snapshot is stored by reference, so mutating its ARN to suit one response would corrupt the stored version record.

## Interaction with #2822

Once `Publish` is honoured, `PublishVersion`'s missing de-duplication starts to matter more: the live service does not publish when code and configuration are unchanged, while Floci mints a fresh version every call. A no-op Terraform apply would therefore create a new version each run. That is #2822, fixed separately.

## Testing

- `LambdaPublishFlagIntegrationTest` — 9 tests: both publishing calls' version *and* ARN shape, the no-publish paths creating nothing, `Publish` omitted entirely behaving as false, and a published version keeping the `CodeSha256` it was published from after `$LATEST` moves on. Reverting the service change fails 4 of the 9.
- SDK coverage in `compatibility-tests/sdk-test-node/tests/lambda.test.ts` — the same behaviour through `@aws-sdk/client-lambda`, per AGENTS.md's preference for SDK clients over raw HTTP on the management plane.
- Full suite, on the pre-rebase tip: **14489 tests, 0 failures, 0 errors, 12 skipped** (sharded with CI's own `.github/ci/partition.sh`).  The rebase onto `main` added only upstream commits (#2812, #2815) plus a one-paragraph resolution in `docs/services/lambda.md`; this branch's Java is byte-identical across it, and the targeted test, `docs-check` and the compatibility suite were all re-run on the rebased tip.
- `make docs-check`: clean.
- Compatibility suite (`sdk-test-node`, run CI-style inside the container network with `--dns` pointed at Floci), re-run on the rebased tip: **461/463**, with `lambda.test.ts` **17/17**. The two failures are the WebSocket chat-broadcast suites (`apigatewayv2-websocket-dataplane`, `apigatewayv2-websocket-tls`); a control run of those two files against the released `floci/floci:1.7.0` image reproduces them identically, so they are pre-existing and unrelated.

## Rebased on `main`

#2812 has merged and this branch is rebased onto it. The only conflict was the coverage
paragraph in `docs/services/lambda.md`; both sides are kept. The Java change is untouched
by the rebase, and `LambdaPublishFlagIntegrationTest` is **9 tests, 0 failures** on the
rebased tip.

It still shares `docs/services/lambda.md` and `lambda.test.ts` with #2824, so whichever of
the two merges second will want the same one-paragraph resolution.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
