### PR TITLE
fix(sqs): honor queue-level ReceiveMessageWaitTimeSeconds on long poll

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -243,7 +243,7 @@ public class SqsJsonHandler {
         String queueUrl = request.path("QueueUrl").asText(null);
         int maxMessages = request.path("MaxNumberOfMessages").asInt(1);
         int visibilityTimeout = request.path("VisibilityTimeout").asInt(-1);
-        int waitTimeSeconds = request.path("WaitTimeSeconds").asInt(0);
+        Integer waitTimeSeconds = parseOptionalInteger(request.path("WaitTimeSeconds"), "WaitTimeSeconds");
 
         java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
         requestedAttrs.addAll(jsonNodeToList(request.path("AttributeNames")));

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -262,7 +262,7 @@ public class SqsQueryHandler {
         String queueUrl = getParam(params, "QueueUrl");
         int maxMessages = getIntParam(params, "MaxNumberOfMessages", 1);
         int visibilityTimeout = getIntParam(params, "VisibilityTimeout", -1);
-        int waitTimeSeconds = getIntParam(params, "WaitTimeSeconds", 0);
+        Integer waitTimeSeconds = getIntegerParam(params, "WaitTimeSeconds");
 
         java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
         requestedAttrs.addAll(collectIndexed(params, "AttributeName."));

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -294,6 +294,7 @@ public class SqsService implements Resettable, ResourceProvider {
         queue.getAttributes().putIfAbsent("VisibilityTimeout", String.valueOf(defaultVisibilityTimeout));
         queue.getAttributes().putIfAbsent("MaximumMessageSize", String.valueOf(maxMessageSize));
         queue.getAttributes().putIfAbsent("DelaySeconds", "0");
+        queue.getAttributes().putIfAbsent("ReceiveMessageWaitTimeSeconds", "0");
         queue.getAttributes().putIfAbsent("MessageRetentionPeriod", "345600");
         if (queue.isFifo()) {
             if (attributes != null && attributes.containsKey("ContentBasedDeduplication") && "true".equals(attributes.get("ContentBasedDeduplication"))) {
@@ -609,6 +610,18 @@ public class SqsService implements Resettable, ResourceProvider {
         }
     }
 
+    private int parseReceiveMessageWaitTimeSecondsAttribute(String value) {
+        if (value == null || value.isEmpty()) {
+            return 0;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            return parsed > 0 ? parsed : 0;
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
     private void notifyReceivers(String storageKey) {
         Object lock = queueLocks.get(storageKey);
         if (lock != null) {
@@ -637,9 +650,9 @@ public class SqsService implements Resettable, ResourceProvider {
     }
 
     public List<Message> receiveMessage(String queueUrl, int maxMessages, int visibilityTimeout,
-                                        int waitTimeSeconds, String region) {
+                                        Integer waitTimeSeconds, String region) {
         String storageKey = regionKey(region, queueUrl);
-        getQueueByUrl(storageKey, queueUrl)
+        Queue queueForWait = getQueueByUrl(storageKey, queueUrl)
                 .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
                         "The specified queue does not exist.", 400));
 
@@ -647,8 +660,11 @@ public class SqsService implements Resettable, ResourceProvider {
             maxMessages = 1;
         }
 
+        int effectiveWait = waitTimeSeconds != null ? waitTimeSeconds
+                : parseReceiveMessageWaitTimeSecondsAttribute(
+                        queueForWait.getAttributes().get("ReceiveMessageWaitTimeSeconds"));
         long start = System.currentTimeMillis();
-        long maxWait = waitTimeSeconds * 1000L;
+        long maxWait = effectiveWait * 1000L;
         Object lock = queueLocks.computeIfAbsent(storageKey, k -> new Object());
         // The queue incarnation this call polls against. DeleteQueue removes it
         // from messagesByQueue (and CreateQueue registers a fresh instance), so


### PR DESCRIPTION
## Summary
Fixes #2826

Queue-level `ReceiveMessageWaitTimeSeconds` was stored but never applied — an empty `ReceiveMessage` without `WaitTimeSeconds` returned immediately instead of long-polling for the queue default. Same defect class as #1567 (queue-level `DelaySeconds`).

## Root cause
- `SqsJsonHandler` and `SqsQueryHandler` parsed `WaitTimeSeconds` as primitive `int` defaulting to `0`, so omission collapsed to `0`.
- `SqsService.receiveMessage` computed `maxWait = waitTimeSeconds * 1000L` and returned immediately on `maxWait <= 0`, never reading the queue attribute.

## Fix
- Parse `WaitTimeSeconds` as nullable `Integer` in both handlers (`parseOptionalInteger` / `getIntegerParam` — mirrors the `DelaySeconds` fix).
- Change `SqsService.receiveMessage` signature from `int` to `Integer`; when `null`, fall back to `parseReceiveMessageWaitTimeSecondsAttribute(queue.getAttributes().get("ReceiveMessageWaitTimeSeconds"))` (default 0).
- Default the attribute to `"0"` on queue creation.

## Test plan
- [x] `./mvnw test -Dtest=SqsServiceTest` — 74 tests pass
- [x] `./mvnw test -Dtest=SqsJsonProtocolTest,SqsIntegrationTest,SqsFifoIntegrationTest` — 51 tests pass
- Manual: queue with `ReceiveMessageWaitTimeSeconds=5`, empty `ReceiveMessage` without `WaitTimeSeconds` blocks ~5s; request-level `WaitTimeSeconds=0` overrides to short poll.