### PR TITLE
fix(lambda): make the code-volume populate concurrency configurable

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -197,6 +197,7 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 | `FLOCI_SERVICES_LAMBDA_CONTAINER_IDLE_TIMEOUT_SECONDS` | `300` | Seconds of inactivity before an idle Lambda container is removed |
 | `FLOCI_SERVICES_LAMBDA_REGION_CONCURRENCY_LIMIT` | `1000` | Maximum concurrent Lambda invocations across all functions in a region |
 | `FLOCI_SERVICES_LAMBDA_UNRESERVED_CONCURRENCY_MIN` | `100` | Minimum unreserved concurrency pool |
+| `FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY` | `max(2, cpus/2)` | Maximum concurrent first-time code-volume populates (functions whose unpacked code is at least 32 MB). The default is derived from the CPU count the JVM sees, so a CPU-constrained Floci container collapses it to 2 and concurrent cold starts of distinct functions serialise into pairs; set this to decouple the cap from the CPU allocation |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED` | `false` | Watch Lambda code directories for changes and reload without redeployment |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ALLOWED_PATHS` | _(none)_ | Comma-separated host paths that hot-reload is allowed to watch |
 | `FLOCI_SERVICES_LAMBDA_DOCKER_NETWORK` | _(none)_ | Docker network for Lambda containers (overrides `FLOCI_SERVICES_DOCKER_NETWORK`) |

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -207,6 +207,7 @@ These AWS Lambda operations have no handler in Floci. Calls will return `404` or
 | `FLOCI_SERVICES_LAMBDA_EXTRA_HOSTS` | *(unset)* | Comma-separated `hostname:ip` entries added to each Lambda container's `/etc/hosts`; `ip` may be `host-gateway`, mirroring `docker run --add-host` |
 | `FLOCI_SERVICES_LAMBDA_DOCKER_HOST_OVERRIDE` | *(unset)* | Explicit host/IP that spawned Lambda containers use to reach Floci's Runtime API, bypassing auto-detection |
 | `FLOCI_SERVICES_LAMBDA_CONTAINER_NAME_PREFIX` | `floci` | Base name prefix for spawned Lambda containers and code volumes (e.g. `acme` → `acme-<function>-<id>` containers, `acme-code-<function>-<hash>` volumes). Must be a valid Docker name segment (`[A-Za-z0-9][A-Za-z0-9_.-]*`); invalid values are ignored with a warning |
+| `FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY` | `max(2, cpus/2)` | Maximum concurrent first-time code-volume populates. See the note below |
 | `FLOCI_SERVICES_LAMBDA_EXECUTOR` | `docker` | Execution backend: `docker` (containers) or `kubernetes` (pods) |
 | `FLOCI_SERVICES_LAMBDA_KUBERNETES_NAMESPACE` | `default` | Namespace Lambda pods are created in |
 | `FLOCI_SERVICES_LAMBDA_KUBERNETES_LABELS` | *(unset)* | Extra pod labels as comma-separated `key=value` entries |
@@ -225,6 +226,25 @@ These AWS Lambda operations have no handler in Floci. Calls will return `404` or
     ```bash
     docker volume prune --filter label=floci=true
     ```
+
+!!! note "Concurrent cold starts of large functions"
+    A function whose unpacked code is at least 32 MB has that code streamed once into a
+    read-only Docker volume, so later cold starts mount it instead of copying. Those
+    first-time *populates* are capped — a burst of them overwhelms the Docker daemon — and
+    the default cap is `max(2, cpus/2)`, derived from the CPU count the JVM sees.
+
+    Because the JVM honours the container's cgroup CPU quota, running Floci with a small CPU
+    allocation collapses the cap to 2, and a burst of cold starts across *distinct* large
+    functions completes in waves of two rather than in parallel. Six such functions invoked
+    at once take roughly three times the wall-clock of one. Raise the cap to decouple it from
+    the CPU allocation:
+
+    ```bash
+    FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY=8
+    ```
+
+    Only first-time populates are gated. Warm containers, already-populated volumes, and
+    functions under 32 MB are never serialised by this.
 
 ### Runtime API host override
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1830,6 +1830,21 @@ public interface EmulatorConfig {
         Optional<String> containerNamePrefix();
 
         /**
+         * Maximum concurrent first-time code-volume populates. Populating streams a large
+         * function's unpacked code into a helper container, so a burst of them can overwhelm
+         * the Docker daemon; this caps how many run at once.
+         *
+         * <p>Unset derives {@code max(2, availableProcessors() / 2)}. That derivation reads the
+         * JVM's view of the cgroup CPU quota, so a CPU-constrained Floci container collapses the
+         * cap to 2 and concurrent cold starts of distinct functions serialize into pairs. Set
+         * this to decouple the cap from the CPU allocation. Values below 1 are ignored with a
+         * warning rather than deadlocking every populate.
+         *
+         * Env var: FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY
+         */
+        Optional<Integer> codeVolumePopulateConcurrency();
+
+        /**
          * Extra /etc/hosts entries added to every Lambda container, as "hostname:ip" pairs.
          * The ip may be the literal "host-gateway" to map to the Docker host, mirroring
          * {@code docker run --add-host hostname:host-gateway}.

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -146,6 +146,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         this.layerService = layerService;
         this.awsEnv = awsEnv;
         this.executionRoleCredentials = executionRoleCredentials;
+        this.populateSemaphore = new java.util.concurrent.Semaphore(resolvePopulateConcurrency(config));
     }
 
     @PostConstruct
@@ -603,12 +604,40 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
     // overwhelmed the Docker daemon, so copies hung/failed and left half-built "Created" containers.
     // This gates ONLY the heavy populate — not every launch — so ordinary cold starts (volume mounts
     // for already-populated large code, or the small-code direct copy) are never serialized.
-    private static final java.util.concurrent.Semaphore POPULATE_SEMAPHORE =
-            new java.util.concurrent.Semaphore(Math.max(2, Runtime.getRuntime().availableProcessors() / 2));
+    //
+    // Per-instance rather than static so the permit count can come from configuration; Floci runs a
+    // single @ApplicationScoped launcher, so this is still one gate for the whole emulator.
+    private final java.util.concurrent.Semaphore populateSemaphore;
 
-    private static void acquirePopulatePermit(String functionName) {
+    /**
+     * Permits for {@link #populateSemaphore}: the configured value when set and positive,
+     * otherwise {@code max(2, availableProcessors() / 2)}.
+     *
+     * <p>The derived default reads the JVM's view of the cgroup CPU quota, so a CPU-constrained
+     * Floci container collapses it to 2 and concurrent cold starts of distinct functions
+     * serialize into pairs. The populate itself is IO-bound (streaming a tar into a helper
+     * container), so CPU count is a weak proxy for how many the daemon can take — hence the
+     * override. The default is unchanged, since the daemon overload the cap exists to prevent is
+     * real and its safe ceiling is host-specific.
+     */
+    static int resolvePopulateConcurrency(EmulatorConfig config) {
+        int derived = Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+        Optional<Integer> configured = config.services().lambda().codeVolumePopulateConcurrency();
+        if (configured.isEmpty()) {
+            return derived;
+        }
+        int permits = configured.get();
+        if (permits < 1) {
+            LOG.warnv("Ignoring floci.services.lambda.code-volume-populate-concurrency {0}: must be "
+                    + "at least 1; using {1}", permits, derived);
+            return derived;
+        }
+        return permits;
+    }
+
+    private void acquirePopulatePermit(String functionName) {
         try {
-            POPULATE_SEMAPHORE.acquire();
+            populateSemaphore.acquire();
         } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
             throw new RuntimeException("Interrupted while waiting to populate code volume for " + functionName, ie);
@@ -871,7 +900,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
                     LOG.warnv("Could not remove code-volume helper {0}: {1}", helperId, e.getMessage());
                 }
             }
-            POPULATE_SEMAPHORE.release();
+            populateSemaphore.release();
         }
     }
 
@@ -1097,7 +1126,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
                                            Path sourceDir, String remotePath, String functionName,
                                            DirectoryTarWriter tarWriter, boolean failOnTarFailure) {
         // No per-copy gating here: the heavy /var/task populate for large code already holds a
-        // POPULATE_SEMAPHORE permit; small-code direct copies and layer copies are light enough
+        // populateSemaphore permit; small-code direct copies and layer copies are light enough
         // to run unthrottled.
         try (java.io.PipedOutputStream pos = new java.io.PipedOutputStream();
              java.io.PipedInputStream pis = new java.io.PipedInputStream(pos, TAR_PIPE_BUFFER_BYTES)) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -265,6 +265,7 @@ floci:
       # aws-config-path:                      # Host path to bind-mount (read-only) at /opt/aws-config for real credential discovery
       # extra-hosts:                          # Extra /etc/hosts entries for Lambda containers, "hostname:ip" ("host-gateway" allowed as ip)
       # container-name-prefix: floci          # FLOCI_SERVICES_LAMBDA_CONTAINER_NAME_PREFIX — base name prefix for spawned containers and code volumes ([A-Za-z0-9][A-Za-z0-9_.-]*; invalid values fall back to "floci")
+      # code-volume-populate-concurrency:     # FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY — max concurrent first-time code-volume populates (default max(2, cpus/2), which a CPU-constrained container collapses to 2)
       executor: docker                        # docker | kubernetes (run Lambda environments as pods)
       # kubernetes:
       #   namespace: default                  # Namespace Lambda pods are created in

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherPopulateConcurrencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherPopulateConcurrencyTest.java
@@ -1,0 +1,62 @@
+package io.github.hectorvent.floci.services.lambda.launcher;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for the configurable code-volume populate concurrency
+ * ({@code floci.services.lambda.code-volume-populate-concurrency}). Plain {@code mock()} rather
+ * than the Mockito extension, for the same strict-stubbing reason as
+ * {@link ContainerLauncherNamePrefixTest}.
+ */
+class ContainerLauncherPopulateConcurrencyTest {
+
+    private static int derivedDefault() {
+        return Math.max(2, Runtime.getRuntime().availableProcessors() / 2);
+    }
+
+    @Test
+    void derivesFromCpuCountWhenUnset() {
+        assertEquals(derivedDefault(), ContainerLauncher.resolvePopulateConcurrency(config(null)));
+    }
+
+    @Test
+    void usesConfiguredValueWhenSet() {
+        assertEquals(1, ContainerLauncher.resolvePopulateConcurrency(config(1)));
+        assertEquals(16, ContainerLauncher.resolvePopulateConcurrency(config(16)));
+    }
+
+    @Test
+    void configuredValueDecouplesTheCapFromTheCpuCount() {
+        // The point of the option: a CPU-constrained container derives 2, which serializes
+        // concurrent cold starts of distinct large functions into pairs. An explicit value must
+        // win over the derivation whether it is above or below it.
+        int derived = derivedDefault();
+        assertEquals(derived + 4, ContainerLauncher.resolvePopulateConcurrency(config(derived + 4)));
+        assertEquals(1, ContainerLauncher.resolvePopulateConcurrency(config(1)));
+    }
+
+    @Test
+    void ignoresNonPositiveValues() {
+        // Zero permits would deadlock every populate, and a negative Semaphore count would make
+        // acquire() block until as many releases arrived. Fall back instead of hanging.
+        assertEquals(derivedDefault(), ContainerLauncher.resolvePopulateConcurrency(config(0)));
+        assertEquals(derivedDefault(), ContainerLauncher.resolvePopulateConcurrency(config(-1)));
+    }
+
+    private static EmulatorConfig config(Integer permits) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.LambdaServiceConfig lambda = mock(EmulatorConfig.LambdaServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.lambda()).thenReturn(lambda);
+        when(lambda.codeVolumePopulateConcurrency()).thenReturn(Optional.ofNullable(permits));
+        return config;
+    }
+}


### PR DESCRIPTION
## Summary

Concurrent first-time code-volume populates are capped by a semaphore sized
`Math.max(2, Runtime.getRuntime().availableProcessors() / 2)`, a `private static final` with no
configuration override. The JVM honours the container's cgroup CPU quota, so a CPU-constrained
Floci container derives **2** permits, and concurrent cold starts of *distinct* large functions
complete in waves of two instead of in parallel.

This adds `floci.services.lambda.code-volume-populate-concurrency`
(`FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY`) and **leaves the derived default
unchanged**.

Refs #2050 (see "Relationship to #2050" below).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire-protocol surface is touched — this is local execution behaviour, not an AWS API shape, so
there is no AWS reference to cite or live API to diff against. Real Lambda has no equivalent knob
(AWS provisions execution environments per function without a shared local Docker daemon to
protect), so the honest framing is fidelity of *behaviour under concurrency*: cold-starting N
distinct functions should cost roughly `max(individual cold start)`, not `N/permits x` that.

### Measurements

Six distinct functions, 41 MB packages each (over the 32 MB `CODE_VOLUME_MIN_BYTES` threshold, so
each takes the populate path), all cold, fired concurrently. Each function gets its own volume —
`codeVolumeName` keys on function name as well as code SHA, verified with `docker volume ls` — so
these are six genuinely independent populates, not one populate plus five cache hits.

Varying **only** the CPU quota on Floci's own container, against `main` (`f7f16cd`):

| Floci container CPU quota | permits from `max(2, cpus/2)` | observed waves | wall-clock |
|---|---|---|---|
| unlimited (16 cpu) | 8 | one wave of 6 | **8.3 s** |
| `--cpus=8` | 4 | 4, then 2 | **13.2 s** |
| `--cpus=4` | 2 | 2, 2, 2 | **19.2 s** |

The wave sizes track the formula exactly. That is what rules out generic CPU starvation as the
explanation — starvation would slow all six roughly uniformly toward a single max, not produce
discrete equal-size waves whose size is a function of the permit count. The `--cpus=8` row was run
as a falsifiable prediction (predicted 4-then-2 before running it) precisely to separate the two.

With this patch, same `--cpus=4` container:

| Configuration | wall-clock |
|---|---|
| default (env var unset) | **18.9 s** — unchanged, still waves of 2 |
| `FLOCI_SERVICES_LAMBDA_CODE_VOLUME_POPULATE_CONCURRENCY=8` | **8.5 s** — one wave of 6 |

So the default is preserved (18.9 s vs 19.2 s unpatched, same wave shape) and the override does
what it says.

## Why keep the default

The cap is worth having — the daemon overload it was added to prevent is real, and its safe
ceiling is host-specific, so I did not want to guess a new default in this PR. What was missing is
a way to decouple it from the CPU allocation. Worth noting for whoever revisits the default: the
populate is IO-bound (create a helper container, stream a tar into it), so CPU count is a weak
proxy for how many the daemon can absorb — but changing the default is a separate judgement call
with a real failure mode behind it, and is deliberately out of scope here.

Values below 1 fall back to the derived default with a warning: zero permits would deadlock every
populate, and a negative `Semaphore` count would make `acquire()` block until that many releases
arrived.

The semaphore becomes an instance field so the permit count can come from config. Floci runs a
single `@ApplicationScoped` launcher, so it is still one gate for the whole emulator.

## Relationship to #2050

#2050 bundles two bugs. I reproduced both before touching anything, building from `main` rather
than a release tag.

**Bug 1 (API Gateway 404 on any `Authorization` header) is already fixed on `main`** — by #2149,
merged 2026-08-14 and released in 1.7.0. The reporter was on 1.5.34 (released 2026-07-29), which
predates it. Nothing in this PR touches it.

Worth recording that the reported *mechanism* was not the actual one. The report hypothesised that
Floci unconditionally interprets any `Authorization` header as a SigV4 signature. It does not —
the cause was region resolution: `dispatch()` only ran its cross-region API-id scan when the header
was absent or blank, so any non-SigV4 header (non-blank) skipped the scan and lookup fell back to
the *default* region, where an API deployed elsewhere does not exist. Measured on 1.5.34, REST API
deployed to `us-west-2`, default region `us-east-1`:

| `Authorization` header | result |
|---|---|
| *(none)* | API found (scan ran) |
| `Bearer <token>` | 404 `Invalid API id specified` |
| SigV4, credential scope `us-west-2` | API found |
| SigV4, credential scope `us-east-1` | 404 `Invalid API id specified` |

A `Bearer` header behaves *identically to a well-formed SigV4 header naming the wrong region* —
which is what refutes the interception theory. All four rows return 200 on `main`.

**Bug 2 (concurrent cold starts serialise) is what this PR addresses**, and `main` had already
improved it substantially: the same 6-function test takes 18.8 s on 1.5.34 (stepped in pairs) and
8.3 s on unconstrained `main`. What survives is the CPU-derived cap above, which is exactly the
configuration a laptop Docker Desktop VM lands in — so the reporter's symptom is still reachable
on current `main`, just via a mechanism their "global lock / concurrency=1" guess only half
described.

Between #2149 and this change I believe #2050 is fully addressed, but since it is a two-bug issue
where the other half was fixed elsewhere, I have used `Refs` rather than `Closes` and left the call
to a maintainer.

## Checklist

- [x] Full suite passes locally — run as CI does, sharded 4 ways via `.github/ci/partition.sh`:
      **14,614 tests, 0 failures, 0 errors** (shards of 3407 / 3132 / 3609 / 4466)
- [x] New or updated test added — `ContainerLauncherPopulateConcurrencyTest`, mirroring
      `ContainerLauncherNamePrefixTest`'s plain-`mock()` pattern for config resolution
- [x] `make docs-check` clean
- [x] End-to-end verified against a running emulator, both default and overridden (table above)
- [x] Node compatibility suite run against a live emulator on the patched image:
      **458 passed, 2 failed** (`apigatewayv2-websocket-dataplane`, `apigatewayv2-websocket-tls`,
      both "Chat-style broadcast" → `Timeout waiting for message`). **Attributed as pre-existing:**
      the released `floci/floci:1.7.0` image, unpatched, fails the identical two tests under the
      same harness — `2 failed | 32 passed (34)` on both. Neither touches Lambda code-volume
      populate concurrency.
- [x] Commit messages follow Conventional Commits