### PR TITLE
feat(cognito): implement SetUserPoolMfaConfig

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/cognito.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/cognito.test.ts
@@ -260,7 +260,9 @@ describe('Cognito MFA configuration', () => {
 
   afterAll(async () => {
     if (poolId) {
-      await cognito.send(new DeleteUserPoolCommand({ UserPoolId: poolId })).catch(() => {});
+      await cognito
+        .send(new DeleteUserPoolCommand({ UserPoolId: poolId }))
+        .catch((error) => console.warn(`failed to delete MFA test pool ${poolId}`, error));
     }
   });
 

--- a/compatibility-tests/sdk-test-node/tests/cognito.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/cognito.test.ts
@@ -22,6 +22,8 @@ import {
   AdminAddUserToGroupCommand,
   AdminRemoveUserFromGroupCommand,
   AdminListGroupsForUserCommand,
+  SetUserPoolMfaConfigCommand,
+  GetUserPoolMfaConfigCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
 import { makeClient, uniqueName, ENDPOINT, fetchLatestSesVerificationCode } from './setup';
 
@@ -241,5 +243,60 @@ describe('Cognito', () => {
   it('should delete user pool', async () => {
     await cognito.send(new DeleteUserPoolCommand({ UserPoolId: poolId }));
     poolId = '';
+  });
+});
+
+describe('Cognito MFA configuration', () => {
+  let cognito: CognitoIdentityProviderClient;
+  let poolId: string;
+
+  beforeAll(async () => {
+    cognito = makeClient(CognitoIdentityProviderClient);
+    const pool = await cognito.send(
+      new CreateUserPoolCommand({ PoolName: `mfa-${uniqueName()}` })
+    );
+    poolId = pool.UserPool!.Id!;
+  });
+
+  afterAll(async () => {
+    if (poolId) {
+      await cognito.send(new DeleteUserPoolCommand({ UserPoolId: poolId })).catch(() => {});
+    }
+  });
+
+  it('should report OFF and omit software-token config before it is set', async () => {
+    const config = await cognito.send(new GetUserPoolMfaConfigCommand({ UserPoolId: poolId }));
+    expect(config.MfaConfiguration).toBe('OFF');
+    // The live service returns only the factors that have been configured.
+    expect(config.SoftwareTokenMfaConfiguration).toBeUndefined();
+  });
+
+  it('should set and round-trip MFA configuration', async () => {
+    const set = await cognito.send(
+      new SetUserPoolMfaConfigCommand({
+        UserPoolId: poolId,
+        MfaConfiguration: 'OPTIONAL',
+        SoftwareTokenMfaConfiguration: { Enabled: true },
+      })
+    );
+    expect(set.MfaConfiguration).toBe('OPTIONAL');
+    expect(set.SoftwareTokenMfaConfiguration?.Enabled).toBe(true);
+
+    // What the Terraform provider reads back to decide whether
+    // mfa_configuration / software_token_mfa_configuration have drifted.
+    const got = await cognito.send(new GetUserPoolMfaConfigCommand({ UserPoolId: poolId }));
+    expect(got.MfaConfiguration).toBe('OPTIONAL');
+    expect(got.SoftwareTokenMfaConfiguration?.Enabled).toBe(true);
+  });
+
+  it('should reject an invalid MfaConfiguration', async () => {
+    await expect(
+      cognito.send(
+        new SetUserPoolMfaConfigCommand({
+          UserPoolId: poolId,
+          MfaConfiguration: 'SOMETIMES' as never,
+        })
+      )
+    ).rejects.toThrow();
   });
 });

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -29,7 +29,7 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 | UpdateUserPool | Updates mutable user pool settings and persisted user-pool tags. |
 | DeleteUserPool | Deletes a local user pool and its related state. |
 | GetUserPoolMfaConfig | Returns the pool's MFA mode and, once configured, its software-token setting. |
-| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. An absent `MfaConfiguration` means `OFF`, and turning MFA off drops the factor configuration with it. Validation follows the live service: `OFF` alongside a software-token, email or SMS factor is rejected, and `ON`/`OPTIONAL` with none of those three is rejected — in both cases on the member being present, not on its `Enabled` value. `WebAuthnConfiguration` sits outside both rules, as it does in AWS. SMS, email and WebAuthn configurations are validated and not stored — Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
+| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. An absent `MfaConfiguration` means `OFF`, and turning MFA off drops the factor configuration with it. Validation follows the live service: `OFF` alongside a software-token, email or SMS factor is rejected, and `ON`/`OPTIONAL` with none of those three is rejected, in both cases on the member being present, not on its `Enabled` value. `WebAuthnConfiguration` sits outside both rules, as it does in AWS. SMS, email and WebAuthn configurations are validated and not stored: Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
 
 ### User Pool Tags
 

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -28,6 +28,8 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 | ListUserPools | Lists local user pools visible in the request region. |
 | UpdateUserPool | Updates mutable user pool settings and persisted user-pool tags. |
 | DeleteUserPool | Deletes a local user pool and its related state. |
+| GetUserPoolMfaConfig | Returns the pool's MFA mode and, once configured, its software-token setting. |
+| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. SMS, email and WebAuthn MFA are accepted and not stored — Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
 
 ### User Pool Tags
 

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -29,7 +29,7 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 | UpdateUserPool | Updates mutable user pool settings and persisted user-pool tags. |
 | DeleteUserPool | Deletes a local user pool and its related state. |
 | GetUserPoolMfaConfig | Returns the pool's MFA mode and, once configured, its software-token setting. |
-| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. SMS, email and WebAuthn MFA are accepted and not stored — Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
+| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. An absent `MfaConfiguration` means `OFF`, and turning MFA off drops the factor configuration with it. Validation follows the live service: `OFF` alongside a software-token, email or SMS factor is rejected, and `ON`/`OPTIONAL` with none of those three is rejected — in both cases on the member being present, not on its `Enabled` value. `WebAuthnConfiguration` sits outside both rules, as it does in AWS. SMS, email and WebAuthn configurations are validated and not stored — Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
 
 ### User Pool Tags
 

--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -29,7 +29,7 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 | UpdateUserPool | Updates mutable user pool settings and persisted user-pool tags. |
 | DeleteUserPool | Deletes a local user pool and its related state. |
 | GetUserPoolMfaConfig | Returns the pool's MFA mode and, once configured, its software-token setting. |
-| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. An absent `MfaConfiguration` means `OFF`, and turning MFA off drops the factor configuration with it. Validation follows the live service: `OFF` alongside a software-token, email or SMS factor is rejected, and `ON`/`OPTIONAL` with none of those three is rejected, in both cases on the member being present, not on its `Enabled` value. `WebAuthnConfiguration` sits outside both rules, as it does in AWS. SMS, email and WebAuthn configurations are validated and not stored: Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
+| SetUserPoolMfaConfig | Sets `MfaConfiguration` (`OFF`/`ON`/`OPTIONAL`) and `SoftwareTokenMfaConfiguration`. An absent `MfaConfiguration` means `OFF`, and turning MFA off drops the factor configuration with it. Validation follows the live service: `OFF` alongside a software-token, email or SMS factor is rejected, and `ON`/`OPTIONAL` with none of those three is rejected — in both cases on the member being present, not on its `Enabled` value. `WebAuthnConfiguration` sits outside both rules, as it does in AWS. SMS, email and WebAuthn configurations are validated and not stored — Floci cannot deliver those factors, so keeping the config would imply a capability it does not have. |
 
 ### User Pool Tags
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -197,7 +197,7 @@ public class CognitoJsonHandler {
 
     /**
      * Shared by Get and Set, which answer with the same members. SoftwareTokenMfaConfiguration
-     * is omitted while unset, matching the live service, which returns only the factors that
+     * is omitted while unset, matching the live service — it returns only the factors that
      * have been configured.
      */
     private ObjectNode buildMfaConfigResponse(UserPool pool) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -185,10 +185,13 @@ public class CognitoJsonHandler {
 
     private Response handleSetUserPoolMfaConfig(JsonNode request) {
         JsonNode softwareToken = request.path("SoftwareTokenMfaConfiguration");
+        boolean otherFactorConfigured = request.hasNonNull("EmailMfaConfiguration")
+                || request.hasNonNull("SmsMfaConfiguration");
         UserPool pool = service.setUserPoolMfaConfig(
                 request.path("UserPoolId").asText(),
                 request.hasNonNull("MfaConfiguration") ? request.path("MfaConfiguration").asText() : null,
-                softwareToken.hasNonNull("Enabled") ? softwareToken.path("Enabled").asBoolean() : null);
+                softwareToken.hasNonNull("Enabled") ? softwareToken.path("Enabled").asBoolean() : null,
+                otherFactorConfigured);
         return Response.ok(buildMfaConfigResponse(pool)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -197,7 +197,7 @@ public class CognitoJsonHandler {
 
     /**
      * Shared by Get and Set, which answer with the same members. SoftwareTokenMfaConfiguration
-     * is omitted while unset, matching the live service — it returns only the factors that
+     * is omitted while unset, matching the live service, which returns only the factors that
      * have been configured.
      */
     private ObjectNode buildMfaConfigResponse(UserPool pool) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -47,6 +47,7 @@ public class CognitoJsonHandler {
             case "UntagResource" -> handleUntagResource(request);
             case "ListTagsForResource" -> handleListTagsForResource(request);
             case "GetUserPoolMfaConfig" -> handleGetUserPoolMfaConfig(request);
+            case "SetUserPoolMfaConfig" -> handleSetUserPoolMfaConfig(request);
             case "DeleteUserPool" -> handleDeleteUserPool(request);
             case "CreateUserPoolClient" -> handleCreateUserPoolClient(request);
             case "DescribeUserPoolClient" -> handleDescribeUserPoolClient(request);
@@ -179,9 +180,31 @@ public class CognitoJsonHandler {
 
     private Response handleGetUserPoolMfaConfig(JsonNode request) {
         UserPool pool = service.describeUserPool(request.path("UserPoolId").asText());
+        return Response.ok(buildMfaConfigResponse(pool)).build();
+    }
+
+    private Response handleSetUserPoolMfaConfig(JsonNode request) {
+        JsonNode softwareToken = request.path("SoftwareTokenMfaConfiguration");
+        UserPool pool = service.setUserPoolMfaConfig(
+                request.path("UserPoolId").asText(),
+                request.hasNonNull("MfaConfiguration") ? request.path("MfaConfiguration").asText() : null,
+                softwareToken.hasNonNull("Enabled") ? softwareToken.path("Enabled").asBoolean() : null);
+        return Response.ok(buildMfaConfigResponse(pool)).build();
+    }
+
+    /**
+     * Shared by Get and Set, which answer with the same members. SoftwareTokenMfaConfiguration
+     * is omitted while unset, matching the live service — it returns only the factors that
+     * have been configured.
+     */
+    private ObjectNode buildMfaConfigResponse(UserPool pool) {
         ObjectNode response = objectMapper.createObjectNode();
+        if (pool.getSoftwareTokenMfaEnabled() != null) {
+            response.putObject("SoftwareTokenMfaConfiguration")
+                    .put("Enabled", pool.getSoftwareTokenMfaEnabled());
+        }
         response.put("MfaConfiguration", pool.getMfaConfiguration());
-        return Response.ok(response).build();
+        return response;
     }
 
     private Response handleDeleteUserPool(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -353,7 +353,7 @@ public class CognitoService implements ResourceProvider {
         }
         // Presence, not value: the live service rejects OFF alongside
         // SoftwareTokenMfaConfiguration{Enabled:false} just as it does Enabled:true, and
-        // conversely accepts ON alongside Enabled:false, so the member being there is what
+        // conversely accepts ON alongside Enabled:false — so the member being there is what
         // counts, despite the "must be enabled" wording of the second message.
         boolean anyFactorConfigured = softwareTokenMfaEnabled != null || otherFactorConfigured;
         if ("OFF".equals(mode) && anyFactorConfigured) {
@@ -368,7 +368,7 @@ public class CognitoService implements ResourceProvider {
         }
         pool.setMfaConfiguration(mode);
         if ("OFF".equals(mode)) {
-            // Turning MFA off drops the factor configuration with it: the live service
+            // Turning MFA off drops the factor configuration with it — the live service
             // answers OFF alone afterwards, with no SoftwareTokenMfaConfiguration member.
             pool.setSoftwareTokenMfaEnabled(null);
         } else if (softwareTokenMfaEnabled != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -333,16 +333,27 @@ public class CognitoService implements ResourceProvider {
     public UserPool setUserPoolMfaConfig(String id, String mfaConfiguration,
                                          Boolean softwareTokenMfaEnabled) {
         UserPool pool = describeUserPool(id);
-        if (mfaConfiguration != null) {
-            if (!List.of("OFF", "ON", "OPTIONAL").contains(mfaConfiguration)) {
-                throw new AwsException("InvalidParameterException",
-                        "1 validation error detected: Value '" + mfaConfiguration
-                                + "' at 'mfaConfiguration' failed to satisfy constraint: "
-                                + "Member must satisfy enum value set: [ON, OFF, OPTIONAL]", 400);
-            }
-            pool.setMfaConfiguration(mfaConfiguration);
+        // An absent MfaConfiguration means OFF, not "leave the current mode alone":
+        // measured against the live service, which resets a pool that was OPTIONAL back
+        // to OFF when the member is omitted.
+        String mode = mfaConfiguration != null ? mfaConfiguration : "OFF";
+        if (!List.of("OPTIONAL", "OFF", "ON").contains(mode)) {
+            throw new AwsException("InvalidParameterException",
+                    "1 validation error detected: Value '" + mode
+                            + "' at 'mfaConfiguration' failed to satisfy constraint: "
+                            + "Member must satisfy enum value set: [OPTIONAL, OFF, ON]", 400);
         }
-        if (softwareTokenMfaEnabled != null) {
+        if ("OFF".equals(mode) && softwareTokenMfaEnabled != null) {
+            throw new AwsException("InvalidParameterException",
+                    "Invalid MFA configuration given, can't turn off MFA and configure an "
+                            + "MFA together.", 400);
+        }
+        pool.setMfaConfiguration(mode);
+        if ("OFF".equals(mode)) {
+            // Turning MFA off drops the factor configuration with it — the live service
+            // answers OFF alone afterwards, with no SoftwareTokenMfaConfiguration member.
+            pool.setSoftwareTokenMfaEnabled(null);
+        } else if (softwareTokenMfaEnabled != null) {
             pool.setSoftwareTokenMfaEnabled(softwareTokenMfaEnabled);
         }
         poolStore.put(id, pool);

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -330,8 +330,16 @@ public class CognitoService implements ResourceProvider {
      * deliver an SMS or email factor, so retaining the config would claim a capability
      * that does not exist.
      */
+    /**
+     * @param otherFactorConfigured whether EmailMfaConfiguration or SmsMfaConfiguration was
+     *     present in the request. Both count towards the factor rules below even though
+     *     Floci does not deliver either challenge; WebAuthnConfiguration does not, measured
+     *     against the live service, which accepts it alongside OFF and does not accept it
+     *     as the sole factor for ON or OPTIONAL.
+     */
     public UserPool setUserPoolMfaConfig(String id, String mfaConfiguration,
-                                         Boolean softwareTokenMfaEnabled) {
+                                         Boolean softwareTokenMfaEnabled,
+                                         boolean otherFactorConfigured) {
         UserPool pool = describeUserPool(id);
         // An absent MfaConfiguration means OFF, not "leave the current mode alone":
         // measured against the live service, which resets a pool that was OPTIONAL back
@@ -343,10 +351,20 @@ public class CognitoService implements ResourceProvider {
                             + "' at 'mfaConfiguration' failed to satisfy constraint: "
                             + "Member must satisfy enum value set: [OPTIONAL, OFF, ON]", 400);
         }
-        if ("OFF".equals(mode) && softwareTokenMfaEnabled != null) {
+        // Presence, not value: the live service rejects OFF alongside
+        // SoftwareTokenMfaConfiguration{Enabled:false} just as it does Enabled:true, and
+        // conversely accepts ON alongside Enabled:false — so the member being there is what
+        // counts, despite the "must be enabled" wording of the second message.
+        boolean anyFactorConfigured = softwareTokenMfaEnabled != null || otherFactorConfigured;
+        if ("OFF".equals(mode) && anyFactorConfigured) {
             throw new AwsException("InvalidParameterException",
                     "Invalid MFA configuration given, can't turn off MFA and configure an "
                             + "MFA together.", 400);
+        }
+        if (!"OFF".equals(mode) && !anyFactorConfigured) {
+            throw new AwsException("InvalidParameterException",
+                    "Invalid MFA Configuration given. SMS MFA, Email MFA, or Software Token "
+                            + "MFA must be enabled.", 400);
         }
         pool.setMfaConfiguration(mode);
         if ("OFF".equals(mode)) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -353,7 +353,7 @@ public class CognitoService implements ResourceProvider {
         }
         // Presence, not value: the live service rejects OFF alongside
         // SoftwareTokenMfaConfiguration{Enabled:false} just as it does Enabled:true, and
-        // conversely accepts ON alongside Enabled:false — so the member being there is what
+        // conversely accepts ON alongside Enabled:false, so the member being there is what
         // counts, despite the "must be enabled" wording of the second message.
         boolean anyFactorConfigured = softwareTokenMfaEnabled != null || otherFactorConfigured;
         if ("OFF".equals(mode) && anyFactorConfigured) {
@@ -368,7 +368,7 @@ public class CognitoService implements ResourceProvider {
         }
         pool.setMfaConfiguration(mode);
         if ("OFF".equals(mode)) {
-            // Turning MFA off drops the factor configuration with it — the live service
+            // Turning MFA off drops the factor configuration with it: the live service
             // answers OFF alone afterwards, with no SoftwareTokenMfaConfiguration member.
             pool.setSoftwareTokenMfaEnabled(null);
         } else if (softwareTokenMfaEnabled != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -321,6 +321,34 @@ public class CognitoService implements ResourceProvider {
         return pool;
     }
 
+    /**
+     * SetUserPoolMfaConfig. Stores the MFA mode and the software-token setting, which is
+     * what GetUserPoolMfaConfig reports back and what the Terraform provider reads to
+     * detect drift on mfa_configuration / software_token_mfa_configuration.
+     *
+     * <p>SMS, email and WebAuthn MFA are accepted and not stored: Floci has no path to
+     * deliver an SMS or email factor, so retaining the config would claim a capability
+     * that does not exist.
+     */
+    public UserPool setUserPoolMfaConfig(String id, String mfaConfiguration,
+                                         Boolean softwareTokenMfaEnabled) {
+        UserPool pool = describeUserPool(id);
+        if (mfaConfiguration != null) {
+            if (!List.of("OFF", "ON", "OPTIONAL").contains(mfaConfiguration)) {
+                throw new AwsException("InvalidParameterException",
+                        "1 validation error detected: Value '" + mfaConfiguration
+                                + "' at 'mfaConfiguration' failed to satisfy constraint: "
+                                + "Member must satisfy enum value set: [ON, OFF, OPTIONAL]", 400);
+            }
+            pool.setMfaConfiguration(mfaConfiguration);
+        }
+        if (softwareTokenMfaEnabled != null) {
+            pool.setSoftwareTokenMfaEnabled(softwareTokenMfaEnabled);
+        }
+        poolStore.put(id, pool);
+        return pool;
+    }
+
     public List<UserPool> listUserPools() {
         return poolStore.scan(k -> true);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPool.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/UserPool.java
@@ -35,6 +35,8 @@ public class UserPool {
     private Map<String, Object> verificationMessageTemplate = new HashMap<>();
     private String smsAuthenticationMessage;
     private String mfaConfiguration = "OFF";
+    /** Null until SetUserPoolMfaConfig sets it; absent from responses while null, as AWS omits it. */
+    private Boolean softwareTokenMfaEnabled;
     private Map<String, Object> deviceConfiguration = new HashMap<>();
     private int estimatedNumberOfUsers = 0;
     private Map<String, Object> emailConfiguration = new HashMap<>();
@@ -122,6 +124,10 @@ public class UserPool {
     public void setSmsAuthenticationMessage(String smsAuthenticationMessage) { this.smsAuthenticationMessage = smsAuthenticationMessage; }
 
     public String getMfaConfiguration() { return mfaConfiguration; }
+    public Boolean getSoftwareTokenMfaEnabled() { return softwareTokenMfaEnabled; }
+    public void setSoftwareTokenMfaEnabled(Boolean softwareTokenMfaEnabled) {
+        this.softwareTokenMfaEnabled = softwareTokenMfaEnabled;
+    }
     public void setMfaConfiguration(String mfaConfiguration) { this.mfaConfiguration = mfaConfiguration; }
 
     public Map<String, Object> getDeviceConfiguration() { return deviceConfiguration; }

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
@@ -107,6 +107,38 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
+    @Order(6)
+    void turningMfaOffAlongsideEmailOrSmsIsRejected() {
+        // Measured: the rule covers EmailMfaConfiguration and SmsMfaConfiguration too, not
+        // just the software token, and it fires on the member being present rather than on
+        // its value.
+        for (String factor : new String[] {
+                "\"EmailMfaConfiguration\":{\"Message\":\"code {####}\",\"Subject\":\"code\"}",
+                "\"SmsMfaConfiguration\":{\"SmsAuthenticationMessage\":\"code {####}\"}"}) {
+            String body = cognitoAction("SetUserPoolMfaConfig", """
+                    {"UserPoolId":"%s","MfaConfiguration":"OFF",%s}
+                    """.formatted(poolId, factor))
+                    .then().statusCode(400).extract().asString();
+            assertTrue(body.contains("InvalidParameterException"), body);
+            assertTrue(body.contains("can't turn off MFA and configure an MFA together"), body);
+        }
+    }
+
+    @Test
+    @Order(7)
+    void enablingMfaWithNoFactorAtAllIsRejected() {
+        for (String mode : new String[] {"ON", "OPTIONAL"}) {
+            String body = cognitoAction("SetUserPoolMfaConfig", """
+                    {"UserPoolId":"%s","MfaConfiguration":"%s"}
+                    """.formatted(poolId, mode))
+                    .then().statusCode(400).extract().asString();
+            assertTrue(body.contains("InvalidParameterException"), body);
+            assertTrue(body.contains("SMS MFA, Email MFA, or Software Token MFA must be enabled"),
+                    body);
+        }
+    }
+
+    @Test
     @Order(8)
     void omittingMfaConfigurationEntirelyResetsThePoolToOff() throws Exception {
         // The pool is ON with a software-token factor at this point. Sending only the
@@ -126,21 +158,16 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
-    @Order(6)
-    void turningMfaOffAlongsideEmailOrSmsIsRejected() {
-        // Measured: the rule covers EmailMfaConfiguration and SmsMfaConfiguration too, not
-        // just the software token, and it fires on the member being present rather than on
-        // its value.
-        for (String factor : new String[] {
-                "\"EmailMfaConfiguration\":{\"Message\":\"code {####}\",\"Subject\":\"code\"}",
-                "\"SmsMfaConfiguration\":{\"SmsAuthenticationMessage\":\"code {####}\"}"}) {
-            String body = cognitoAction("SetUserPoolMfaConfig", """
-                    {"UserPoolId":"%s","MfaConfiguration":"OFF",%s}
-                    """.formatted(poolId, factor))
-                    .then().statusCode(400).extract().asString();
-            assertTrue(body.contains("InvalidParameterException"), body);
-            assertTrue(body.contains("can't turn off MFA and configure an MFA together"), body);
-        }
+    @Order(9)
+    void aDisabledFactorStillCountsAsConfigured() throws Exception {
+        // The message says "must be enabled", but the live service accepts ON alongside
+        // SoftwareTokenMfaConfiguration{Enabled:false}: presence is what it checks.
+        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","MfaConfiguration":"ON",
+                 "SoftwareTokenMfaConfiguration":{"Enabled":false}}
+                """.formatted(poolId));
+        assertEquals("ON", set.path("MfaConfiguration").asText());
+        assertEquals(false, set.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
     }
 
     @Test
@@ -163,33 +190,6 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
                 """.formatted(poolId))
                 .then().statusCode(400).extract().asString();
         assertTrue(body.contains("SMS MFA, Email MFA, or Software Token MFA must be enabled"), body);
-    }
-
-    @Test
-    @Order(7)
-    void enablingMfaWithNoFactorAtAllIsRejected() {
-        for (String mode : new String[] {"ON", "OPTIONAL"}) {
-            String body = cognitoAction("SetUserPoolMfaConfig", """
-                    {"UserPoolId":"%s","MfaConfiguration":"%s"}
-                    """.formatted(poolId, mode))
-                    .then().statusCode(400).extract().asString();
-            assertTrue(body.contains("InvalidParameterException"), body);
-            assertTrue(body.contains("SMS MFA, Email MFA, or Software Token MFA must be enabled"),
-                    body);
-        }
-    }
-
-    @Test
-    @Order(9)
-    void aDisabledFactorStillCountsAsConfigured() throws Exception {
-        // The message says "must be enabled", but the live service accepts ON alongside
-        // SoftwareTokenMfaConfiguration{Enabled:false}: presence is what it checks.
-        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
-                {"UserPoolId":"%s","MfaConfiguration":"ON",
-                 "SoftwareTokenMfaConfiguration":{"Enabled":false}}
-                """.formatted(poolId));
-        assertEquals("ON", set.path("MfaConfiguration").asText());
-        assertEquals(false, set.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
@@ -1,0 +1,134 @@
+package io.github.hectorvent.floci.services.cognito;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoAction;
+import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoJson;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * SetUserPoolMfaConfig, and the round trip through GetUserPoolMfaConfig.
+ *
+ * <p>The response shape was measured against the live service, which returns only the
+ * factors that have been configured — a pool with software-token MFA answers
+ * {@code {"SoftwareTokenMfaConfiguration":{"Enabled":true},"MfaConfiguration":"OPTIONAL"}}
+ * and omits the SMS, email and WebAuthn members entirely.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CognitoSetUserPoolMfaConfigIntegrationTest {
+
+    private static String poolId;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createPool() throws Exception {
+        JsonNode pool = cognitoJson("CreateUserPool", """
+                {"PoolName":"MfaConfigTestPool"}
+                """);
+        poolId = pool.path("UserPool").path("Id").asText();
+        assertTrue(!poolId.isEmpty(), "pool id");
+    }
+
+    @Test
+    @Order(2)
+    void softwareTokenConfigurationIsOmittedUntilItIsSet() throws Exception {
+        // Measured: the live service returns only configured factors, so an untouched
+        // pool carries no SoftwareTokenMfaConfiguration member at all.
+        JsonNode config = cognitoJson("GetUserPoolMfaConfig",
+                """
+                {"UserPoolId":"%s"}
+                """.formatted(poolId));
+        assertEquals("OFF", config.path("MfaConfiguration").asText());
+        assertTrue(config.path("SoftwareTokenMfaConfiguration").isMissingNode(),
+                "SoftwareTokenMfaConfiguration should be absent before it is configured");
+    }
+
+    @Test
+    @Order(3)
+    void setsMfaConfigurationAndSoftwareTokenAndReturnsThem() throws Exception {
+        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
+                {
+                    "UserPoolId":"%s",
+                    "MfaConfiguration":"OPTIONAL",
+                    "SoftwareTokenMfaConfiguration":{"Enabled":true}
+                }
+                """.formatted(poolId));
+        assertEquals("OPTIONAL", set.path("MfaConfiguration").asText());
+        assertTrue(set.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
+
+        // The round trip is what the Terraform provider reads to decide whether
+        // mfa_configuration / software_token_mfa_configuration have drifted.
+        JsonNode got = cognitoJson("GetUserPoolMfaConfig", """
+                {"UserPoolId":"%s"}
+                """.formatted(poolId));
+        assertEquals("OPTIONAL", got.path("MfaConfiguration").asText());
+        assertTrue(got.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
+    }
+
+    @Test
+    @Order(4)
+    void describeUserPoolReflectsTheNewMfaMode() throws Exception {
+        cognitoJson("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","MfaConfiguration":"ON"}
+                """.formatted(poolId));
+
+        JsonNode pool = cognitoJson("DescribeUserPool", """
+                {"UserPoolId":"%s"}
+                """.formatted(poolId));
+        assertEquals("ON", pool.path("UserPool").path("MfaConfiguration").asText());
+    }
+
+    @Test
+    @Order(5)
+    void omittingMfaConfigurationLeavesTheExistingModeAlone() throws Exception {
+        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","SoftwareTokenMfaConfiguration":{"Enabled":false}}
+                """.formatted(poolId));
+        assertEquals("ON", set.path("MfaConfiguration").asText());
+        assertEquals(false, set.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
+    }
+
+    @Test
+    @Order(6)
+    void invalidMfaConfigurationIsRejected() {
+        String body = cognitoAction("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","MfaConfiguration":"SOMETIMES"}
+                """.formatted(poolId))
+                .then().statusCode(400).extract().asString();
+        assertTrue(body.contains("InvalidParameterException"), body);
+        assertTrue(body.contains("Member must satisfy enum value set"), body);
+    }
+
+    @Test
+    @Order(7)
+    void unknownPoolIsResourceNotFound() {
+        String body = cognitoAction("SetUserPoolMfaConfig", """
+                {"UserPoolId":"ap-southeast-1_nosuchpool","MfaConfiguration":"OFF"}
+                """)
+                .then().statusCode(400).extract().asString();
+        assertTrue(body.contains("ResourceNotFoundException"), body);
+    }
+
+    @Test
+    @Order(8)
+    void cleanup_deletePool() {
+        cognitoAction("DeleteUserPool", """
+                {"UserPoolId":"%s"}
+                """.formatted(poolId))
+                .then().statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * SetUserPoolMfaConfig, and the round trip through GetUserPoolMfaConfig.
  *
  * <p>The response shape was measured against the live service, which returns only the
- * factors that have been configured: a pool with software-token MFA answers
+ * factors that have been configured — a pool with software-token MFA answers
  * {@code {"SoftwareTokenMfaConfiguration":{"Enabled":true},"MfaConfiguration":"OPTIONAL"}}
  * and omits the SMS, email and WebAuthn members entirely.
  */
@@ -174,7 +174,7 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     @Order(10)
     void webAuthnIsOutsideTheFactorRulesInBothDirections() throws Exception {
         // Measured: WebAuthnConfiguration is accepted alongside OFF, where every other
-        // factor is rejected, and it does not satisfy the "must be enabled" rule either:
+        // factor is rejected, and it does not satisfy the "must be enabled" rule either —
         // OPTIONAL with WebAuthn alone is refused.
         JsonNode off = cognitoJson("SetUserPoolMfaConfig", """
                 {"UserPoolId":"%s","MfaConfiguration":"OFF",

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
@@ -94,27 +94,49 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
 
     @Test
     @Order(5)
-    void omittingMfaConfigurationLeavesTheExistingModeAlone() throws Exception {
-        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
+    void omittingMfaConfigurationWithAFactorIsRejected() {
+        // Measured: an absent MfaConfiguration means OFF, not "leave the mode alone", so
+        // sending a factor alongside it is turning MFA off and configuring it at once.
+        String body = cognitoAction("SetUserPoolMfaConfig", """
                 {"UserPoolId":"%s","SoftwareTokenMfaConfiguration":{"Enabled":false}}
-                """.formatted(poolId));
-        assertEquals("ON", set.path("MfaConfiguration").asText());
-        assertEquals(false, set.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
+                """.formatted(poolId))
+                .then().statusCode(400).extract().asString();
+        assertTrue(body.contains("InvalidParameterException"), body);
+        assertTrue(body.contains("can't turn off MFA and configure an MFA together"), body);
     }
 
     @Test
     @Order(6)
+    void omittingMfaConfigurationEntirelyResetsThePoolToOff() throws Exception {
+        // The pool is ON with a software-token factor at this point. Sending only the
+        // pool id resets it: the live service answers OFF and drops the factor member.
+        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s"}
+                """.formatted(poolId));
+        assertEquals("OFF", set.path("MfaConfiguration").asText());
+        assertTrue(set.path("SoftwareTokenMfaConfiguration").isMissingNode(),
+                "turning MFA off drops the factor configuration with it");
+
+        JsonNode got = cognitoJson("GetUserPoolMfaConfig", """
+                {"UserPoolId":"%s"}
+                """.formatted(poolId));
+        assertEquals("OFF", got.path("MfaConfiguration").asText());
+        assertTrue(got.path("SoftwareTokenMfaConfiguration").isMissingNode());
+    }
+
+    @Test
+    @Order(7)
     void invalidMfaConfigurationIsRejected() {
         String body = cognitoAction("SetUserPoolMfaConfig", """
                 {"UserPoolId":"%s","MfaConfiguration":"SOMETIMES"}
                 """.formatted(poolId))
                 .then().statusCode(400).extract().asString();
         assertTrue(body.contains("InvalidParameterException"), body);
-        assertTrue(body.contains("Member must satisfy enum value set"), body);
+        assertTrue(body.contains("Member must satisfy enum value set: [OPTIONAL, OFF, ON]"), body);
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void unknownPoolIsResourceNotFound() {
         String body = cognitoAction("SetUserPoolMfaConfig", """
                 {"UserPoolId":"ap-southeast-1_nosuchpool","MfaConfiguration":"OFF"}
@@ -124,7 +146,7 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void cleanup_deletePool() {
         cognitoAction("DeleteUserPool", """
                 {"UserPoolId":"%s"}

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
@@ -83,7 +83,8 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     @Order(4)
     void describeUserPoolReflectsTheNewMfaMode() throws Exception {
         cognitoJson("SetUserPoolMfaConfig", """
-                {"UserPoolId":"%s","MfaConfiguration":"ON"}
+                {"UserPoolId":"%s","MfaConfiguration":"ON",
+                 "SoftwareTokenMfaConfiguration":{"Enabled":true}}
                 """.formatted(poolId));
 
         JsonNode pool = cognitoJson("DescribeUserPool", """
@@ -106,7 +107,7 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(8)
     void omittingMfaConfigurationEntirelyResetsThePoolToOff() throws Exception {
         // The pool is ON with a software-token factor at this point. Sending only the
         // pool id resets it: the live service answers OFF and drops the factor member.
@@ -125,7 +126,74 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
+    @Order(6)
+    void turningMfaOffAlongsideEmailOrSmsIsRejected() {
+        // Measured: the rule covers EmailMfaConfiguration and SmsMfaConfiguration too, not
+        // just the software token, and it fires on the member being present rather than on
+        // its value.
+        for (String factor : new String[] {
+                "\"EmailMfaConfiguration\":{\"Message\":\"code {####}\",\"Subject\":\"code\"}",
+                "\"SmsMfaConfiguration\":{\"SmsAuthenticationMessage\":\"code {####}\"}"}) {
+            String body = cognitoAction("SetUserPoolMfaConfig", """
+                    {"UserPoolId":"%s","MfaConfiguration":"OFF",%s}
+                    """.formatted(poolId, factor))
+                    .then().statusCode(400).extract().asString();
+            assertTrue(body.contains("InvalidParameterException"), body);
+            assertTrue(body.contains("can't turn off MFA and configure an MFA together"), body);
+        }
+    }
+
+    @Test
+    @Order(10)
+    void webAuthnIsOutsideTheFactorRulesInBothDirections() throws Exception {
+        // Measured: WebAuthnConfiguration is accepted alongside OFF, where every other
+        // factor is rejected, and it does not satisfy the "must be enabled" rule either —
+        // OPTIONAL with WebAuthn alone is refused.
+        JsonNode off = cognitoJson("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","MfaConfiguration":"OFF",
+                 "WebAuthnConfiguration":{"RelyingPartyId":"example.com",
+                                          "UserVerification":"preferred"}}
+                """.formatted(poolId));
+        assertEquals("OFF", off.path("MfaConfiguration").asText());
+
+        String body = cognitoAction("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","MfaConfiguration":"OPTIONAL",
+                 "WebAuthnConfiguration":{"RelyingPartyId":"example.com",
+                                          "UserVerification":"preferred"}}
+                """.formatted(poolId))
+                .then().statusCode(400).extract().asString();
+        assertTrue(body.contains("SMS MFA, Email MFA, or Software Token MFA must be enabled"), body);
+    }
+
+    @Test
     @Order(7)
+    void enablingMfaWithNoFactorAtAllIsRejected() {
+        for (String mode : new String[] {"ON", "OPTIONAL"}) {
+            String body = cognitoAction("SetUserPoolMfaConfig", """
+                    {"UserPoolId":"%s","MfaConfiguration":"%s"}
+                    """.formatted(poolId, mode))
+                    .then().statusCode(400).extract().asString();
+            assertTrue(body.contains("InvalidParameterException"), body);
+            assertTrue(body.contains("SMS MFA, Email MFA, or Software Token MFA must be enabled"),
+                    body);
+        }
+    }
+
+    @Test
+    @Order(9)
+    void aDisabledFactorStillCountsAsConfigured() throws Exception {
+        // The message says "must be enabled", but the live service accepts ON alongside
+        // SoftwareTokenMfaConfiguration{Enabled:false}: presence is what it checks.
+        JsonNode set = cognitoJson("SetUserPoolMfaConfig", """
+                {"UserPoolId":"%s","MfaConfiguration":"ON",
+                 "SoftwareTokenMfaConfiguration":{"Enabled":false}}
+                """.formatted(poolId));
+        assertEquals("ON", set.path("MfaConfiguration").asText());
+        assertEquals(false, set.path("SoftwareTokenMfaConfiguration").path("Enabled").asBoolean());
+    }
+
+    @Test
+    @Order(11)
     void invalidMfaConfigurationIsRejected() {
         String body = cognitoAction("SetUserPoolMfaConfig", """
                 {"UserPoolId":"%s","MfaConfiguration":"SOMETIMES"}
@@ -136,7 +204,7 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(12)
     void unknownPoolIsResourceNotFound() {
         String body = cognitoAction("SetUserPoolMfaConfig", """
                 {"UserPoolId":"ap-southeast-1_nosuchpool","MfaConfiguration":"OFF"}
@@ -146,7 +214,7 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(13)
     void cleanup_deletePool() {
         cognitoAction("DeleteUserPool", """
                 {"UserPoolId":"%s"}

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoSetUserPoolMfaConfigIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * SetUserPoolMfaConfig, and the round trip through GetUserPoolMfaConfig.
  *
  * <p>The response shape was measured against the live service, which returns only the
- * factors that have been configured — a pool with software-token MFA answers
+ * factors that have been configured: a pool with software-token MFA answers
  * {@code {"SoftwareTokenMfaConfiguration":{"Enabled":true},"MfaConfiguration":"OPTIONAL"}}
  * and omits the SMS, email and WebAuthn members entirely.
  */
@@ -174,7 +174,7 @@ class CognitoSetUserPoolMfaConfigIntegrationTest {
     @Order(10)
     void webAuthnIsOutsideTheFactorRulesInBothDirections() throws Exception {
         // Measured: WebAuthnConfiguration is accepted alongside OFF, where every other
-        // factor is rejected, and it does not satisfy the "must be enabled" rule either —
+        // factor is rejected, and it does not satisfy the "must be enabled" rule either:
         // OPTIONAL with WebAuthn alone is refused.
         JsonNode off = cognitoJson("SetUserPoolMfaConfig", """
                 {"UserPoolId":"%s","MfaConfiguration":"OFF",


### PR DESCRIPTION
## Summary

`SetUserPoolMfaConfig` was unrouted, so `CognitoJsonHandler` answered `UnsupportedOperation` and any caller configuring pool MFA failed. `GetUserPoolMfaConfig` already existed but reported only `MfaConfiguration`, so a software-token setting could not round-trip even once it could be set.

Both now share one response builder and answer with the shape the live service returns.

Part 1 of #2433.

Ownership is settled. @AbarnaaSree asked for #2433 on 21 Aug, so I checked the thread before opening this rather than stepping on it. They [confirmed the split on 31 Aug](https://github.com/floci-io/floci/issues/2433#issuecomment-5481652116): part 1 here, parts 2 and 3 with them. Their PR for the per-user preferences is #2896. This does not close #2433, which stays open for those parts.

## Type of change

- [x] New feature (`feat:`)

## Scope

Deliberately the **pool-level configuration only**, which is the split #2433 itself suggests. Parts 2 and 3 of that issue: `AdminSetUserMFAPreference` / `SetUserMFAPreference`, `UserMFASettingList` / `PreferredMfaSetting` on `AdminGetUser`, and the cross-validation rules, are untouched here.

`GetUserPoolMfaConfig` is widened alongside `Set` rather than in a separate change, because the two are one round trip: implementing `Set` without it lets a configuration be written and read back missing, which is worse than not implementing either.

## Why it matters

`aws_cognito_user_pool` exposes `mfa_configuration` and `software_token_mfa_configuration`, which the Terraform provider applies through `SetUserPoolMfaConfig` after `CreateUserPool`. Because the call raises rather than being a no-op, the provider marks the pool tainted and destroys/recreates it on the next apply, so a pool with MFA enabled does not merely lose its MFA setting, it never converges, and each run leaves an orphaned pool behind. Any config that then looks a pool up by name (a `data.aws_cognito_user_pools` filter) starts matching several.

## AWS Compatibility

API reference: [SetUserPoolMfaConfig](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_SetUserPoolMfaConfig.html), [GetUserPoolMfaConfig](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetUserPoolMfaConfig.html).

Measured against the live service (`cognito-idp.ap-southeast-1.amazonaws.com`), read-only, on a pool with software-token MFA enabled:

```
aws cognito-idp get-user-pool-mfa-config --user-pool-id <pool>
{
    "SoftwareTokenMfaConfiguration": { "Enabled": true },
    "MfaConfiguration": "OPTIONAL"
}
```

**Only the configured factors appear.** There is no `SmsMfaConfiguration`, `EmailMfaConfiguration` or `WebAuthnConfiguration` member at all, so an unset factor is omitted rather than returned empty, and that is what this implements.

| Call | Live AWS | Floci before | Floci after |
| --- | --- | --- | --- |
| `SetUserPoolMfaConfig` | 200, echoes the configuration | 400 `UnsupportedOperation` | matches AWS |
| `GetUserPoolMfaConfig`, unconfigured pool | `MfaConfiguration: OFF`, no factor members | `OFF` only | same as AWS |
| `GetUserPoolMfaConfig`, after set | mode **and** `SoftwareTokenMfaConfiguration` | `MfaConfiguration` only | same as AWS |
| `DescribeUserPool` after a set | reflects the new mode | n/a | reflects it |

`MfaConfiguration` is validated against the enum, and the constraint message lists it in the order the service emits: `[OPTIONAL, OFF, ON]`, not the reference's.

## Measured, including the mutations

The first version of this PR said two behaviours could not be verified without mutating a
real pool. I have since been able to run them against a UAT account of my own, and it has
twice changed the implementation.

**Round one**, three behaviours taken from the API reference were wrong (`4b2e91d`):

| Behaviour | What I had assumed | What the service does |
| --- | --- | --- |
| `MfaConfiguration` omitted | leave the current mode alone | treated as `OFF`, a pool at `OPTIONAL` is reset |
| Turning MFA `OFF` | keep the factor configuration | the factor goes with it; `Get` answers `OFF` alone afterwards |
| A factor sent while the effective mode is `OFF` | accepted | `InvalidParameterException`: `Invalid MFA configuration given, can't turn off MFA and configure an MFA together.` |

The validation enum is also ordered `[OPTIONAL, OFF, ON]`, which is the order the service
emits, not the reference's.

**Round two** (`a086094`), prompted by a review finding that only the software-token factor
was being checked. That was right for email and SMS and wrong for WebAuthn, and measuring it
surfaced a rule I had missed entirely:

| Request | Live AWS |
| --- | --- |
| `OFF` + `SoftwareTokenMfaConfiguration{Enabled:true}` | rejected, can't turn off MFA and configure an MFA together |
| `OFF` + `EmailMfaConfiguration` | rejected, same message |
| `OFF` + `SoftwareTokenMfaConfiguration{Enabled:false}` | rejected, it is **presence**, not the value |
| `OFF` + `WebAuthnConfiguration` | **200**, echoed back |
| `ON` or `OPTIONAL` with no factor | rejected: `SMS MFA, Email MFA, or Software Token MFA must be enabled` |
| `OPTIONAL` + `WebAuthnConfiguration` alone | rejected: WebAuthn does not satisfy it |
| `ON` + `SoftwareTokenMfaConfiguration{Enabled:false}` | **200**, presence again, despite "must be enabled" |

So WebAuthn sits outside both rules in both directions, and both rules key off the member
being present rather than its `Enabled` value.

**Not fully measured.** `OFF` + `SmsMfaConfiguration` returns a *different* error: `Invalid
SMS MFA configuration given, external id and a valid caller arn are required`, and the same
message comes back at `OPTIONAL`, so that validation is mode-independent and runs first (my
caller ARN was deliberately invalid). I have grouped SMS with email on the strength of the
shared "configure an MFA together" wording rather than a direct observation. Also unmeasured:
whether AWS rejects or ignores an unknown member. Floci accepts and ignores it.

Both rounds cost a test that had asserted the wrong thing and passed, the second was one
setting `MfaConfiguration: "ON"` with no factor at all, which the live service refuses.

## Deliberate choice

`SmsMfaConfiguration`, `EmailMfaConfiguration` and `WebAuthnConfiguration` are **validated
and not stored**. Floci has no path to deliver an SMS or email factor, and #2433 scopes the
sign-in challenge out explicitly, but they still take part in the validation rules above,
because AWS applies those rules whether or not the factor could ever be delivered, and a
caller that gets a 200 where AWS returns a 400 is the divergence that actually costs people
time.

I had originally reasoned that ignoring them outright was correct. Re-reading the issue,
that is wrong for `EmailMfaConfiguration` at least: the configuration plane is useful
precisely *because* it is independent of the challenge, it is what lets an application drop
its "am I talking to the emulator?" branch. Persisting the remaining blocks belongs in this
issue's arc; I have left it out of this PR only to keep it to one concern, and it is a small
addition on top if a maintainer would rather it landed here.

## Testing

- `CognitoSetUserPoolMfaConfigIntegrationTest` ,  **13 tests**: the round trip, `DescribeUserPool` reflecting the mode, the factor omitted until set, an omitted `MfaConfiguration` resetting the pool to `OFF`, a factor sent with the mode omitted being rejected, the email/SMS rejection, the WebAuthn exemption in both directions, `ON`/`OPTIONAL` with no factor being rejected, `Enabled:false` still counting as configured, enum rejection, and an unknown pool. Removing the dispatch case fails 5 of them with the exact `UnsupportedOperation` this fixes; reverting the factor rules fails 3 more. The class is `@Order`-ed because it drives one pool through a sequence of states.
- SDK coverage in `compatibility-tests/sdk-test-node/tests/cognito.test.ts`, per AGENTS.md's preference for SDK clients over raw HTTP on the management plane.
- Full suite, on the current tip `a086094`: **14693 tests, 0 failures, 0 errors, 12 skipped**: 8 shards, split with CI's own `.github/ci/partition.sh`, all 8 green in a single pass. (Re-run from scratch after the review fix; the earlier figure in this description was for `4b2e91d`.)
- `make docs-check`: clean.
- Compatibility suite (`sdk-test-node`, run CI-style inside the container network with `--dns` pointed at Floci), on `a086094`: **461/463**, with `cognito.test.ts` **24/24**. The two failures are the WebSocket chat-broadcast suites (`apigatewayv2-websocket-dataplane`, `apigatewayv2-websocket-tls`); a control run of those two files against the released `floci/floci:1.7.0` image reproduces them identically, so they are pre-existing and unrelated.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes