### PR TITLE
fix(lambda): isolate legacy code storage by account

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -279,7 +279,9 @@ public class LambdaService {
             throw new AwsException("InvalidParameterValueException", "Runtime is required for Zip package type", 400);
         }
 
-        if (functionStore.get(region, functionName).isPresent()) {
+        String accountId = regionResolver.getAccountId();
+
+        if (functionStore.getForAccount(accountId, region, functionName).isPresent()) {
             throw new AwsException("ResourceConflictException",
                     "Function already exist: " + functionName, 409);
         }
@@ -644,7 +646,7 @@ public class LambdaService {
             if (concurrencyLimiter != null) {
                 concurrencyLimiter.reset(arn);
             }
-            codeStore.delete(functionName);
+            codeStore.delete(accountIdOf(fn), functionName);
             functionStore.delete(region, functionName);
             versionCounters.remove(region + "::" + functionName);
             if (aliasStore != null) {
@@ -982,7 +984,13 @@ public class LambdaService {
         }
         return new ScalingConfig((int) longValue);
     }
+    private static String accountIdOf(LambdaFunction fn) {
+        if (fn.getAccountId() != null && !fn.getAccountId().isBlank()) {
+            return fn.getAccountId();
+        }
 
+        return AwsArnUtils.accountOrDefault(fn.getFunctionArn(), "");
+    }
     private void startPollingHelper(EventSourceMapping esm) {
         if (esm.getEventSourceArn().contains(":sqs:")) {
             poller.startPolling(esm);
@@ -1549,7 +1557,8 @@ public class LambdaService {
     }
 
     private void extractZipCodeBytes(LambdaFunction fn, byte[] zipBytes, String region) {
-        Path codePath = codeStore.getCodePath(fn.getFunctionName());
+        String accountId = accountIdOf(fn);
+        Path codePath = codeStore.getCodePath(accountId, fn.getFunctionName());
         try {
             zipExtractor.extractTo(zipBytes, codePath);
             fn.setCodeLocalPath(codePath.toAbsolutePath().normalize().toString());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
@@ -30,15 +30,18 @@ public class CodeStore {
         this.baseDir = baseDir;
     }
 
-    public Path getCodePath(String functionName) {
-        return baseDir.resolve(sanitizeName(functionName));
+    public Path getCodePath(String accountId, String functionName) {
+        return baseDir
+                .resolve(sanitizeName(accountId))
+                .resolve(sanitizeName(functionName));
     }
 
-    public void delete(String functionName) {
-        Path codePath = getCodePath(functionName);
+    public void delete(String accountId, String functionName) {
+        Path codePath = getCodePath(accountId, functionName);
         if (!Files.exists(codePath)) {
             return;
         }
+
         try {
             Files.walk(codePath)
                     .sorted(Comparator.reverseOrder())
@@ -51,12 +54,13 @@ public class CodeStore {
                     });
             LOG.debugv("Deleted code for function: {0}", functionName);
         } catch (IOException e) {
-            LOG.warnv("Failed to delete code directory for {0}: {1}", functionName, e.getMessage());
+            LOG.warnv("Failed to delete code directory for {0}: {1}",
+                    functionName, e.getMessage());
         }
     }
 
-    public boolean exists(String functionName) {
-        Path codePath = getCodePath(functionName);
+    public boolean exists(String accountId, String functionName) {
+        Path codePath = getCodePath(accountId, functionName);
         try {
             return Files.exists(codePath) && Files.list(codePath).findAny().isPresent();
         } catch (IOException e) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -1,5 +1,5 @@
 package io.github.hectorvent.floci.services.lambda;
-
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -37,7 +37,10 @@ class LambdaServiceTest {
 
     @BeforeEach
     void setUp() {
-        LambdaFunctionStore store = new LambdaFunctionStore(new InMemoryStorage<String, LambdaFunction>());
+        LambdaFunctionStore store =
+            new LambdaFunctionStore(
+                    AccountAwareStorageBackend.inMemory("000000000000")
+            );
         WarmPool warmPool = new WarmPool();
         CodeStore codeStore = new CodeStore(Path.of("target/test-data/lambda-code"));
         ZipExtractor zipExtractor = new ZipExtractor();
@@ -54,6 +57,21 @@ class LambdaServiceTest {
                 "Timeout", 10,
                 "MemorySize", 256
         ));
+    }
+    private static String zipCode(String content) {
+        try {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+            try (ZipOutputStream zip = new ZipOutputStream(output)) {
+                zip.putNextEntry(new ZipEntry("index.js"));
+                zip.write(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
+
+            return Base64.getEncoder().encodeToString(output.toByteArray());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static Map<String, Object> vpcConfig() {
@@ -884,5 +902,71 @@ class LambdaServiceTest {
                 .collect(java.util.stream.Collectors.toSet());
 
         assertEquals(expectedStatementIds, actualStatementIds);
+    }
+   @Test
+    void sameFunctionNameCanExistInDifferentAccounts() {
+        InMemoryStorage<String, LambdaFunction> storage = new InMemoryStorage<>();
+
+        LambdaFunctionStore accountOneStore =
+                new LambdaFunctionStore(
+                        new AccountAwareStorageBackend<>(
+                                storage,
+                                null,
+                                "111111111111"));
+
+        LambdaFunctionStore accountTwoStore =
+                new LambdaFunctionStore(
+                        new AccountAwareStorageBackend<>(
+                                storage,
+                                null,
+                                "222222222222"));
+
+        WarmPool warmPool = new WarmPool();
+        CodeStore codeStore =
+                new CodeStore(Path.of("target/test-data/lambda-code-cross-account"));
+        ZipExtractor zipExtractor = new ZipExtractor();
+
+        LambdaService accountOneService = new LambdaService(
+                accountOneStore,
+                warmPool,
+                codeStore,
+                zipExtractor,
+                new RegionResolver("us-east-1", "111111111111"));
+
+        LambdaService accountTwoService = new LambdaService(
+                accountTwoStore,
+                warmPool,
+                codeStore,
+                zipExtractor,
+                new RegionResolver("us-east-1", "222222222222"));
+
+        String functionName = "same-function";
+
+        Map<String, Object> firstRequest = baseRequest(functionName);
+        firstRequest.put("Code", Map.of("ZipFile", zipCode("account-one")));
+
+        Map<String, Object> secondRequest = baseRequest(functionName);
+        secondRequest.put("Code", Map.of("ZipFile", zipCode("account-two")));
+
+        LambdaFunction first =
+                accountOneService.createFunction(REGION, firstRequest);
+
+        LambdaFunction second =
+                accountTwoService.createFunction(REGION, secondRequest);
+
+        assertEquals(functionName, first.getFunctionName());
+        assertEquals(functionName, second.getFunctionName());
+
+        assertEquals("111111111111", first.getAccountId());
+        assertEquals("222222222222", second.getAccountId());
+
+        assertNotEquals(first.getFunctionArn(), second.getFunctionArn());
+        assertNotEquals(first.getCodeLocalPath(), second.getCodeLocalPath());
+
+        assertTrue(first.getCodeLocalPath().contains("111111111111"));
+        assertTrue(second.getCodeLocalPath().contains("222222222222"));
+        assertNotNull(first.getCodeLocalPath());
+        assertNotNull(second.getCodeLocalPath());
+
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.lambda.zip;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CodeStoreTest {
+
+    @Test
+    void sameFunctionNameUsesDifferentPathPerAccount() throws Exception {
+        Path baseDir = Files.createTempDirectory("code-store-test");
+        CodeStore codeStore = new CodeStore(baseDir);
+
+        Path accountOnePath =
+                codeStore.getCodePath("111111111111", "my-function");
+
+        Path accountTwoPath =
+                codeStore.getCodePath("222222222222", "my-function");
+
+        assertNotEquals(accountOnePath, accountTwoPath);
+
+        assertEquals(
+                baseDir.resolve("111111111111").resolve("my-function"),
+                accountOnePath);
+
+        assertEquals(
+                baseDir.resolve("222222222222").resolve("my-function"),
+                accountTwoPath);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes legacy Lambda code storage so functions with the same name in different AWS accounts use separate code directories.

## Changes

* Make `CodeStore` account-aware by storing code under:

  * `<accountId>/<functionName>`
* Update Lambda code extraction to use the function's account ID.
* Update Lambda deletion to delete code from the correct account-specific directory.
* Update function creation to check for existing functions within the current account.
* Add tests covering:

  * Same function name across different accounts
  * Account-specific code storage paths

## Testing

* `mvn test "-Dtest=CodeStoreTest,LambdaServiceTest"`
* **53 tests passed**
* **0 failures**
* **0 errors**
