### PR TITLE
fix(lambda): omit Environment when no variables are set

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/LambdaFunctionConfigTest.java
@@ -102,10 +102,13 @@ class LambdaFunctionConfigTest {
                 .as("default TracingConfig.Mode must be PassThrough")
                 .isEqualTo("PassThrough");
 
-        // Environment block must always be present (even when empty)
+        // AWS omits Environment entirely for a function with no variables — verified
+        // against the live service — so the SDK deserialises it as null here, the same
+        // as layers() and vpcConfig(). Returning an empty block instead gives Terraform
+        // a permanent `- environment {}` diff.
         assertThat(resp.environment())
-                .as("Environment must always be present in the response")
-                .isNotNull();
+                .as("Environment must be omitted when no variables are set")
+                .isNull();
     }
 
     // ─── UpdateFunctionConfiguration ─────────────────────────────────────────
@@ -207,16 +210,23 @@ class LambdaFunctionConfigTest {
                 .containsEntry("KEY_A", "value-a")
                 .containsEntry("KEY_B", "value-b");
 
-        // Clear environment — response must still include the Environment block
-        UpdateFunctionConfigurationResponse cleared = lambda.updateFunctionConfiguration(
+        // An Environment with no Variables member is "leave unchanged", not "clear" — the
+        // existing variables survive. Verified against the live service: sending
+        // Environment={} keeps {"KEY_A": "value-a"} on both the update response and the
+        // following read. (Clearing takes an empty Variables map, which AWS answers by
+        // omitting the member entirely.)
+        UpdateFunctionConfigurationResponse unchanged = lambda.updateFunctionConfiguration(
                 UpdateFunctionConfigurationRequest.builder()
                         .functionName(FN)
                         .environment(Environment.builder().build())
                         .build());
 
-        assertThat(cleared.environment())
-                .as("Environment block must be present even after clearing variables")
+        assertThat(unchanged.environment())
+                .as("an Environment with no Variables member must leave the variables alone")
                 .isNotNull();
+        assertThat(unchanged.environment().variables())
+                .containsEntry("KEY_A", "value-a")
+                .containsEntry("KEY_B", "value-b");
     }
 
     @Test

--- a/compatibility-tests/sdk-test-python/tests/test_lambda_function_config.py
+++ b/compatibility-tests/sdk-test-python/tests/test_lambda_function_config.py
@@ -114,9 +114,16 @@ class TestFunctionConfigurationDefaults:
         finally:
             lambda_client.delete_function(FunctionName=fn)
 
-    def test_get_function_configuration_environment_always_present(
+    def test_get_function_configuration_omits_environment_when_unset(
         self, lambda_client, minimal_lambda_zip, unique_name
     ):
+        """AWS omits Environment entirely for a function with no variables.
+
+        Verified against lambda.us-east-1.amazonaws.com and
+        lambda.ap-southeast-1.amazonaws.com: a function created without
+        --environment comes back with no Environment key at all, the same way
+        Layers and VpcConfig are omitted rather than returned empty.
+        """
         fn = f"pytest-cfg-{unique_name}"
         try:
             lambda_client.create_function(
@@ -127,8 +134,9 @@ class TestFunctionConfigurationDefaults:
                 Code={"ZipFile": minimal_lambda_zip},
             )
             resp = lambda_client.get_function_configuration(FunctionName=fn)
-            assert "Environment" in resp, (
-                "Environment block must always be present in GetFunctionConfiguration response"
+            assert "Environment" not in resp, (
+                "Environment must be omitted when no variables are set; an empty "
+                "block gives Terraform a permanent `- environment {}` diff"
             )
         finally:
             lambda_client.delete_function(FunctionName=fn)
@@ -246,13 +254,17 @@ class TestUpdateFunctionConfiguration:
             assert variables.get("KEY_A") == "value-a"
             assert variables.get("KEY_B") == "value-b"
 
-            # Clear environment — block must still be present
+            # Clear environment — AWS drops the block again. Measured live:
+            # update_function_configuration(Environment={"Variables": {}}) returns
+            # no Environment key, and the following get_function_configuration
+            # agrees, so a cleared function is indistinguishable from one that
+            # never had variables.
             cleared = lambda_client.update_function_configuration(
                 FunctionName=fn,
                 Environment={"Variables": {}},
             )
-            assert "Environment" in cleared, (
-                "Environment block must be present even after clearing variables"
+            assert "Environment" not in cleared, (
+                "Environment must be omitted once variables are cleared"
             )
         finally:
             lambda_client.delete_function(FunctionName=fn)

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -657,10 +657,12 @@ public class LambdaController {
                     .put("LocalMountPath", fileSystem.getLocalMountPath()));
         }
 
-        // Environment — always present (SDK expects it even when empty)
-        ObjectNode envNode = node.putObject("Environment");
+        // Environment — omitted entirely when no variables are set, as AWS does. An empty
+        // object is not the same answer as absence: the Terraform provider reads one back as
+        // an `environment {}` block in state, so a function declared without variables plans a
+        // removal on every run. Same rule as Layers, KMSKeyArn and VpcConfig above.
         if (fn.getEnvironment() != null && !fn.getEnvironment().isEmpty()) {
-            ObjectNode vars = envNode.putObject("Variables");
+            ObjectNode vars = node.putObject("Environment").putObject("Variables");
             fn.getEnvironment().forEach(vars::put);
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaIntegrationTest.java
@@ -551,4 +551,72 @@ class LambdaIntegrationTest {
         .then()
             .statusCode(404);
     }
+
+    // ── Environment is omitted, not empty, when no variables are set ──
+
+    @Test
+    @Order(41)
+    void environmentMemberIsAbsentUntilVariablesAreSet() {
+        String fn = "env-absent-fn";
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "env-absent-fn",
+                    "Runtime": "nodejs20.x",
+                    "Role": "arn:aws:iam::000000000000:role/lambda-role",
+                    "Handler": "index.handler"
+                }
+                """)
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201)
+            .body("$", not(hasKey("Environment")));
+
+        given()
+            .when()
+            .get(BASE_PATH + "/functions/" + fn + "/configuration")
+        .then()
+            .statusCode(200)
+            .body("$", not(hasKey("Environment")));
+
+        given()
+            .when()
+            .get(BASE_PATH + "/functions/" + fn)
+        .then()
+            .statusCode(200)
+            .body("Configuration", not(hasKey("Environment")));
+
+        // Setting a variable brings the member back...
+        given()
+            .contentType("application/json")
+            .body("""
+                { "Environment": { "Variables": { "FOO": "bar" } } }
+                """)
+        .when()
+            .put(BASE_PATH + "/functions/" + fn + "/configuration")
+        .then()
+            .statusCode(200)
+            .body("Environment.Variables.FOO", equalTo("bar"));
+
+        // ...and clearing it to an empty map removes it again, which is what AWS
+        // answers for a cleared function, not "Environment": {} or an empty Variables map.
+        given()
+            .contentType("application/json")
+            .body("""
+                { "Environment": { "Variables": {} } }
+                """)
+        .when()
+            .put(BASE_PATH + "/functions/" + fn + "/configuration")
+        .then()
+            .statusCode(200)
+            .body("$", not(hasKey("Environment")));
+
+        given()
+            .when()
+            .delete(BASE_PATH + "/functions/" + fn)
+        .then()
+            .statusCode(anyOf(is(200), is(204)));
+    }
 }


### PR DESCRIPTION
## Summary

When a function has no environment variables, Floci answered `"Environment": {}`. Real AWS omits the member entirely. The value is a permanent Terraform diff on every function declared without variables.

Closes #2834.

## Type of change

- [x] Bug fix (`fix:`)

## Why it matters

The Terraform AWS provider maps a present-but-empty `Environment` to an `environment {}` block in state. The configuration has no such block, so every plan wants to remove one:

```
~ resource "aws_lambda_function" "edge_auth" {
    - environment {}
      ~ version = "14" -> (known after apply)
  }
```

`apply` converges nothing and the next plan is identical. It bites hardest on Lambda@Edge, where environment variables are **not permitted at all**, so the block can never legitimately exist, and because the update forces a republish, each no-op apply also mints a new function version.

## AWS Compatibility

API reference: [GetFunctionConfiguration](https://docs.aws.amazon.com/lambda/latest/api/API_GetFunctionConfiguration.html), [CreateFunction](https://docs.aws.amazon.com/lambda/latest/api/API_CreateFunction.html). The reference lists `Environment` as an optional response member; it does not say what an unset one looks like, so this was measured rather than inferred.

Measured against `lambda.ap-southeast-1.amazonaws.com` and `lambda.us-east-1.amazonaws.com` in an account I own.

**Read-only, on an existing Lambda@Edge function with no variables**, the member is absent, alongside `Layers` and `VpcConfig`:

```
$ aws lambda get-function-configuration --region us-east-1 --function-name <edge-fn>
Environment member present: False
keys sample: ['FunctionName', 'Runtime', 'Architectures']
```

`aws lambda list-functions --query 'Functions[?Environment==`null`]'` matches that function, so `ListFunctions` omits it too.

**Mutations, on a throwaway function created and deleted for this purpose:**

| Step | Live AWS |
| --- | --- |
| `CreateFunction`, no `--environment` | `Environment` absent |
| `UpdateFunctionConfiguration --environment 'Variables={FOO=bar}'` | `{"Variables": {"FOO": "bar"}}` |
| `UpdateFunctionConfiguration --environment 'Variables={}'` | `Environment` **absent again** |
| `GetFunctionConfiguration` after that clear | `Environment` absent |

The last two rows are the reason the fix keys off `isEmpty()` rather than `!= null`: AWS treats a cleared function exactly like one that never had variables, and Floci's update path already stores an empty map for that input, so no change was needed there.

| Case | Live AWS | Floci before | Floci after |
| --- | --- | --- | --- |
| No variables ever set | member absent | `"Environment":{}` | member absent |
| Variables set | `{"Variables":{...}}` | same | unchanged |
| Variables cleared to `{}` | member absent | `"Environment":{}` | member absent |

## Scope

One line of behaviour in `buildFunctionConfiguration`, which is the single builder behind `CreateFunction`, `GetFunction`, `GetFunctionConfiguration`, `ListFunctions`, `UpdateFunctionConfiguration`, `UpdateFunctionCode`, `PublishVersion` and `ListVersionsByFunction`, so all of them are corrected together.

`Layers`, `KMSKeyArn`, `FileSystemConfigs` and `VpcConfig` in that same method already omit-when-empty, and `putVpcConfig`'s javadoc spells out the same rule ("AWS omits the block entirely once the last subnet and security group are removed"). `Environment` was the outlier; the removed comment claimed the SDK requires it even when empty, which the measurements above disprove.

Nothing else changes. The stored model, the request parsing and the execution path are untouched, the container still receives the same variables it did before.

## Testing

- `LambdaIntegrationTest#environmentMemberIsAbsentUntilVariablesAreSet`, new, self-contained (creates and deletes its own function so it leaves no state for sibling classes). Covers `CreateFunction`, `GetFunctionConfiguration` and `GetFunction` with no variables, then sets one and confirms the member returns, then clears it and confirms it goes away again.
- Negative control: with the `LambdaController` change reverted, that test fails at the first assertion (`LambdaIntegrationTest.java:575`, `1 expectation failed`) and passes with it applied.
- `LambdaIntegrationTest`: 25 tests, 0 failures.
- Full suite: **14,688 tests, 0 failures**, 8 of 8 shards green in one pass (sharded the way `ci.yml` partitions it, at 8 rather than 4).
- `make docs-check`: clean. No `docs/services/lambda.md` change, this corrects the shape of an already-documented action rather than adding coverage.
- Compatibility suite (`sdk-test-node`, run the way CI does, inside the container network with `--dns` pointed at Floci, image built from this branch): **458 of 460 passing**. The two failures are the WebSocket chat-broadcast cases in `apigatewayv2-websocket-dataplane` and `apigatewayv2-websocket-tls`; they are the same pair that fails on released `floci/floci:1.7.0`, so they are pre-existing and unrelated. No compatibility test asserts the `Environment` member's presence.
- No test in the *unit* suite asserted the member was always present, the only prior `Environment` assertions there are on a function that has variables, and they still pass.

### Compatibility tests this changes, and why

Three assertions in the SDK compatibility suites required the empty block. They are updated here, and I want to be explicit that I changed existing tests rather than quietly making them pass:

| Test | Asserted | Live AWS |
| --- | --- | --- |
| `test_lambda_function_config.py:test_get_function_configuration_environment_always_present` | `"Environment" in resp` | member absent |
| `test_lambda_function_config.py:test_update_environment_variables_round_trip` (cleared case) | `"Environment" in cleared` | member absent |
| `LambdaFunctionConfigTest.getFunctionConfigurationHasDefaults` | `environment()` not null | null |

Each encoded Floci's previous behaviour rather than the API's, which is exactly why they were green before. The measurements above are in the test comments so the next reader does not have to re-derive them.

One further correction in the same Java class, which was **not** failing. `updateFunctionConfigurationEnvironmentRoundTrips` sends `Environment.builder().build()`, an `Environment` with no `Variables` member, under a comment reading "Clear environment". That is not a clear: measured live, `Environment={}` leaves the existing variables in place, and both the update response and the following read still carry `KEY_A`. Floci already behaved that way, so the assertion was right and its description was wrong. I corrected the wording and added the assertion that actually pins the semantics, rather than changing what it tests.

I also swept the Go, AWS-CLI, Terraform, CDK and OpenTofu suites: their `Environment` matches are all tags that happen to share the name.

Locally, against a probe built from this branch: `sdk-test-python` **320 passed, 0 failed**; `sdk-test-java` **1663 run, 1 failure, 1 error**, the failure is the same WebSocket chat-broadcast case as node, and the error is `LambdaHotReloadTest` aborting because my probe did not set `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED`, which CI does. `LambdaFunctionConfigTest` passes.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

