### PR TITLE
fix(efs): implement UpdateFileSystemProtection and report protection on describe

### DIFF
--- a/docs/services/efs.md
+++ b/docs/services/efs.md
@@ -13,6 +13,7 @@ The EFS emulator provides a metadata control plane for file systems, mount targe
 | `CreateFileSystem` | - |
 | `DescribeFileSystems` | - |
 | `UpdateFileSystem` | - |
+| `UpdateFileSystemProtection` | - |
 | `DeleteFileSystem` | - |
 | `CreateTags` | - |
 | `DescribeTags` | - |

--- a/src/main/java/io/github/hectorvent/floci/services/efs/EfsController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/efs/EfsController.java
@@ -56,6 +56,14 @@ public class EfsController {
         return Response.status(202).entity(fs).build();
     }
 
+    @PUT
+    @Path("/file-systems/{FileSystemId}/protection")
+    public Response updateFileSystemProtection(@Context HttpHeaders headers, @PathParam("FileSystemId") String fileSystemId, UpdateFileSystemProtectionRequest request) {
+        String region = regionResolver.resolveRegion(headers);
+        FileSystemProtectionDescription protection = efsService.updateFileSystemProtection(region, fileSystemId, request);
+        return Response.ok(protection).build();
+    }
+
     @DELETE
     @Path("/file-systems/{FileSystemId}")
     public Response deleteFileSystem(@Context HttpHeaders headers, @PathParam("FileSystemId") String fileSystemId) {

--- a/src/main/java/io/github/hectorvent/floci/services/efs/EfsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/efs/EfsService.java
@@ -112,6 +112,10 @@ public class EfsService implements Resettable {
         size.setValueInStandard(0L);
         fs.setSizeInBytes(size);
 
+        // "Replication overwrite protection is ENABLED by default" -- the file system is
+        // writeable and cannot be a replication destination until something disables it.
+        fs.setFileSystemProtection(protection(ReplicationOverwriteProtection.ENABLED));
+
         fileSystemStore.put(regionKey, fs);
         
         BackupPolicy bp = new BackupPolicy();
@@ -134,7 +138,7 @@ public class EfsService implements Resettable {
                         fs.setName(tag.getValue());
                     });
                 }
-                return fs;
+                return withDefaultProtection(fs);
             })
             .sorted(Comparator.comparing(FileSystem::getFileSystemId))
             .collect(Collectors.toList());
@@ -181,7 +185,38 @@ public class EfsService implements Resettable {
         if (fs == null) {
             throw EfsException.fileSystemNotFound(fileSystemId);
         }
+        return withDefaultProtection(fs);
+    }
+
+    private static FileSystemProtectionDescription protection(ReplicationOverwriteProtection value) {
+        FileSystemProtectionDescription description = new FileSystemProtectionDescription();
+        description.setReplicationOverwriteProtection(value);
+        return description;
+    }
+
+    /**
+     * AWS always reports a protection status; there is no such thing as a file system
+     * without one. Applied on read as well as on create so that file systems already in
+     * a persisted store -- written before protection was modelled -- describe the same
+     * as one created today, rather than omitting the field.
+     */
+    private static FileSystem withDefaultProtection(FileSystem fs) {
+        if (fs.getFileSystemProtection() == null) {
+            fs.setFileSystemProtection(protection(ReplicationOverwriteProtection.ENABLED));
+        }
         return fs;
+    }
+
+    public FileSystemProtectionDescription updateFileSystemProtection(
+            String region, String fileSystemId, UpdateFileSystemProtectionRequest request) {
+        synchronized (lockFor(regionKey(region, fileSystemId))) {
+            FileSystem fs = getFileSystem(region, fileSystemId);
+            if (request != null && request.getReplicationOverwriteProtection() != null) {
+                fs.setFileSystemProtection(protection(request.getReplicationOverwriteProtection()));
+                fileSystemStore.put(regionKey(region, fileSystemId), fs);
+            }
+            return fs.getFileSystemProtection();
+        }
     }
 
     public FileSystem updateFileSystem(String region, String fileSystemId, UpdateFileSystemRequest request) {

--- a/src/main/java/io/github/hectorvent/floci/services/efs/model/FileSystem.java
+++ b/src/main/java/io/github/hectorvent/floci/services/efs/model/FileSystem.java
@@ -88,11 +88,16 @@ public class FileSystem {
         this.fileSystemId = fileSystemId;
     }
 
-    public FileSystemProtectionDescription getFileSystemProtectionDescription() {
+    // The wire name is FileSystemProtection, not FileSystemProtectionDescription --
+    // FileSystemProtectionDescription is the *shape* name, and the member on
+    // FileSystemDescription that carries it is called FileSystemProtection. Because
+    // UpperCamelCaseStrategy derives the JSON key from the accessor, the old
+    // getFileSystemProtectionDescription() name put the shape name on the wire.
+    public FileSystemProtectionDescription getFileSystemProtection() {
         return fileSystemProtection;
     }
 
-    public void setFileSystemProtectionDescription(FileSystemProtectionDescription fileSystemProtection) {
+    public void setFileSystemProtection(FileSystemProtectionDescription fileSystemProtection) {
         this.fileSystemProtection = fileSystemProtection;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/efs/model/UpdateFileSystemProtectionRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/efs/model/UpdateFileSystemProtectionRequest.java
@@ -1,0 +1,22 @@
+package io.github.hectorvent.floci.services.efs.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy.class)
+@RegisterForReflection
+public class UpdateFileSystemProtectionRequest {
+
+    private ReplicationOverwriteProtection replicationOverwriteProtection;
+
+    public ReplicationOverwriteProtection getReplicationOverwriteProtection() {
+        return replicationOverwriteProtection;
+    }
+
+    public void setReplicationOverwriteProtection(
+            ReplicationOverwriteProtection replicationOverwriteProtection) {
+        this.replicationOverwriteProtection = replicationOverwriteProtection;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/efs/EfsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/efs/EfsIntegrationTest.java
@@ -46,6 +46,7 @@ class EfsIntegrationTest {
             .body("FileSystemId", startsWith("fs-"))
             .body("Encrypted", equalTo(true))
             .body("NumberOfMountTargets", equalTo(0))
+            .body("FileSystemProtection.ReplicationOverwriteProtection", equalTo("ENABLED"))
             .body("Tags[0].Value", equalTo("MyFS"))
             .extract().jsonPath().getString("FileSystemId");
     }
@@ -200,6 +201,63 @@ class EfsIntegrationTest {
 
     @Test
     @Order(10)
+    void describeReportsProtectionEnabledByDefault() {
+        given()
+            .queryParam("FileSystemId", fileSystemId)
+        .when()
+            .get("/2015-02-01/file-systems")
+        .then()
+            .statusCode(200)
+            .body("FileSystems[0].FileSystemProtection.ReplicationOverwriteProtection",
+                    equalTo("ENABLED"));
+    }
+
+    @Test
+    @Order(11)
+    void updateFileSystemProtection() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ReplicationOverwriteProtection": "DISABLED"
+                }
+                """)
+        .when()
+            .put("/2015-02-01/file-systems/" + fileSystemId + "/protection")
+        .then()
+            .statusCode(200)
+            .body("ReplicationOverwriteProtection", equalTo("DISABLED"));
+
+        // The change has to survive the round trip, not just echo back: the terraform
+        // provider reads protection back through DescribeFileSystems.
+        given()
+            .queryParam("FileSystemId", fileSystemId)
+        .when()
+            .get("/2015-02-01/file-systems")
+        .then()
+            .statusCode(200)
+            .body("FileSystems[0].FileSystemProtection.ReplicationOverwriteProtection",
+                    equalTo("DISABLED"));
+    }
+
+    @Test
+    @Order(12)
+    void updateFileSystemProtectionOnMissingFileSystemIs404() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ReplicationOverwriteProtection": "DISABLED"
+                }
+                """)
+        .when()
+            .put("/2015-02-01/file-systems/fs-does-not-exist/protection")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(13)
     void deleteResources() {
         given()
             .contentType("application/json")


### PR DESCRIPTION
## Summary

A file system's replication overwrite protection was missing in two compounding ways: the operation that sets it did not exist, and the field that reports it never reached the wire.

`UpdateFileSystemProtection` had no route, so the Terraform AWS provider's `PUT /2015-02-01/file-systems/{id}/protection` fell through to the S3 handler and came back as an XML error body — which the SDK surfaces as `deserialization failed, failed to decode response body, invalid character '<' looking for beginning of value`, giving no hint that the operation is simply absent.

Separately, protection was never reported at all. `createFileSystem` left the field null, and `FileSystem`'s accessor was named `getFileSystemProtectionDescription()` — the *shape* name rather than the member name. Under `UpperCamelCaseStrategy` the accessor name becomes the JSON key, so even once the value was set it would have serialized under the wrong key and `DescribeFileSystems` would never have shown it.

Every consumer of gruntwork's `terraform-aws-data-storage` EFS module hits this, not only those who opt in, because the module emits the `aws_efs_file_system` `protection` block unconditionally.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire shape taken from the EFS API reference: `UpdateFileSystemProtection` is `PUT /2015-02-01/file-systems/{FileSystemId}/protection` with a `ReplicationOverwriteProtection` body member, and it returns the `FileSystemProtectionDescription` shape rather than the whole file system. `DescribeFileSystems` reports the same value under `FileSystemProtection`. `ENABLED` is the AWS default for a newly created file system, which is what `createFileSystem` now sets.

Verified three ways:

1. `EfsIntegrationTest` — 13/13, including new coverage that reads the value back from a *subsequent* `DescribeFileSystems`, not from the update's own response, since the JSON-key bug was invisible to any assertion that only read the mutation's reply.
2. A real AWS SDK round trip: create → describe reports `ENABLED` → update to `DISABLED` → describe reports `DISABLED`. This only passes if the wire names match the model, which is the half a handwritten assertion can miss.
3. `terraform-aws-data-storage/examples/efs`, previously failing at apply with the deserialization error above, now runs clean through destroy.

## Checklist

- [x] `./mvnw test -Dtest='Efs*'` passes locally (13/13); full suite left to CI
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make docs-check` clean

Found by a compatibility survey that runs the Gruntwork Terraform corpus against Floci; this is the tracked issue `floci-8rj` in that survey.
