### PR TITLE
fix(elasticache): report transit encryption, not the auth-token flag

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -370,8 +370,8 @@ public class ElastiCacheQueryHandler {
                   .elem("ReplicationGroupId", g.getReplicationGroupId())
                   .elem("AutoMinorVersionUpgrade", true)
                   .elem("AuthTokenEnabled", authTokenEnabled)
-                  .elem("TransitEncryptionEnabled", authTokenEnabled)
-                  .elem("AtRestEncryptionEnabled", false);
+                  .elem("TransitEncryptionEnabled", transitEncryptionEnabled(g))
+                  .elem("AtRestEncryptionEnabled", g.isAtRestEncryptionEnabled());
         if (g.getEngine() != null) {
             xml.elem("Engine", g.getEngine());
         }
@@ -745,6 +745,18 @@ private Response handleCreateCacheParameterGroup(MultivaluedMap<String, String> 
         return xml.end("CacheCluster").build();
     }
 
+    /**
+     * TransitEncryptionEnabled is not AuthTokenEnabled. An auth token forces encryption in transit,
+     * so a PASSWORD group is always encrypted — but the reverse does not hold: a group created with
+     * {@code TransitEncryptionEnabled=true} and no token is encrypted in transit too, and this
+     * handler records exactly that request as {@link AuthMode#IAM}. Reporting the auth-token flag
+     * for both answers false for such a group, which is permanent drift for Terraform's
+     * aws_elasticache_replication_group: it reads transit_encryption_enabled back on every plan.
+     */
+    private static boolean transitEncryptionEnabled(ReplicationGroup g) {
+        return g.getAuthMode() != AuthMode.NO_AUTH;
+    }
+
     private String replicationGroupXml(ReplicationGroup g) {
         Endpoint ep = g.getConfigurationEndpoint();
         boolean authTokenEnabled = g.getAuthMode() == AuthMode.PASSWORD;
@@ -755,7 +767,7 @@ private Response handleCreateCacheParameterGroup(MultivaluedMap<String, String> 
                   .elem("Description", g.getDescription())
                   .elem("Status", g.getStatus().wireName())
                   .elem("AuthTokenEnabled", authTokenEnabled)
-                  .elem("TransitEncryptionEnabled", authTokenEnabled)
+                  .elem("TransitEncryptionEnabled", transitEncryptionEnabled(g))
                   .elem("AtRestEncryptionEnabled", g.isAtRestEncryptionEnabled())
                   .elem("ClusterEnabled", g.isClusterEnabled())
                   .elem("ClusterMode", g.isClusterEnabled() ? "enabled" : "disabled")

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandlerTest.java
@@ -287,6 +287,57 @@ class ElastiCacheQueryHandlerTest {
         assertTrue(body.contains("<ARN>arn:aws:elasticache:us-east-1:000000000000:replicationgroup:g1</ARN>"), body);
     }
 
+    /**
+     * A group created with TransitEncryptionEnabled=true and no auth token is recorded as
+     * AuthMode.IAM. Reporting the auth-token flag as TransitEncryptionEnabled answered false for
+     * it, which Terraform reads back on every plan as drift on transit_encryption_enabled.
+     */
+    @Test
+    void describeReplicationGroups_reportsTransitEncryptionWithoutAnAuthToken() {
+        ReplicationGroup g = new ReplicationGroup("g1", "d", ReplicationGroupStatus.AVAILABLE,
+                AuthMode.IAM, new Endpoint("localhost", 6379), Instant.now(), 6379);
+        when(service.listReplicationGroups("g1")).thenReturn(List.of(g));
+        MultivaluedMap<String, String> p = params();
+        p.add("ReplicationGroupId", "g1");
+
+        String body = (String) handler.handle("DescribeReplicationGroups", p, "us-east-1").getEntity();
+
+        assertTrue(body.contains("<TransitEncryptionEnabled>true</TransitEncryptionEnabled>"), body);
+        // ... and it is still distinct from AuthTokenEnabled, which only a token sets.
+        assertTrue(body.contains("<AuthTokenEnabled>false</AuthTokenEnabled>"), body);
+    }
+
+    @Test
+    void describeReplicationGroups_reportsNoTransitEncryptionForAPlainGroup() {
+        when(service.listReplicationGroups("g1")).thenReturn(List.of(group("g1")));
+        MultivaluedMap<String, String> p = params();
+        p.add("ReplicationGroupId", "g1");
+
+        String body = (String) handler.handle("DescribeReplicationGroups", p, "us-east-1").getEntity();
+
+        assertTrue(body.contains("<TransitEncryptionEnabled>false</TransitEncryptionEnabled>"), body);
+    }
+
+    /**
+     * The member-cluster view of the same group reported AtRestEncryptionEnabled as a hardcoded
+     * false, so DescribeCacheClusters contradicted DescribeReplicationGroups about one group.
+     */
+    @Test
+    void describeCacheClusters_reportTheGroupsRealEncryptionFlags() {
+        ReplicationGroup group = new ReplicationGroup("grp", "d", ReplicationGroupStatus.AVAILABLE,
+                AuthMode.IAM, new Endpoint("localhost", 6379), Instant.now(), 6379);
+        group.setAtRestEncryptionEnabled(true);
+        when(service.listMemberCacheClusters("grp-0001-001")).thenReturn(List.of(
+                new ElastiCacheService.MemberCacheCluster(group, "grp-0001-001", 6379, true)));
+
+        MultivaluedMap<String, String> params = params();
+        params.putSingle("CacheClusterId", "grp-0001-001");
+        String body = (String) handler.handle("DescribeCacheClusters", params, "us-east-1").getEntity();
+
+        assertTrue(body.contains("<TransitEncryptionEnabled>true</TransitEncryptionEnabled>"), body);
+        assertTrue(body.contains("<AtRestEncryptionEnabled>true</AtRestEncryptionEnabled>"), body);
+    }
+
     @Test
     void listTagsForResource_readsAReplicationGroupByItsArn() {
         ReplicationGroup g = group("g1");


### PR DESCRIPTION
## Summary

`TransitEncryptionEnabled` was serialized as `authMode == PASSWORD` in both the replication-group view and the member-cache-cluster view. An auth token does force encryption in transit, but the reverse does not hold — and this handler already knows it does not: `CreateReplicationGroup` accepts `TransitEncryptionEnabled=true` with no token and records exactly that request as `AuthMode.IAM`. Every read then reported such a group as unencrypted in transit.

That is not cosmetic for Terraform. `aws_elasticache_replication_group` reads `transit_encryption_enabled` back on every plan rather than trusting what it sent, so a group created with TLS and no auth token showed permanent drift.

`DescribeCacheClusters` had a second, narrower version of the same problem: `AtRestEncryptionEnabled` was a hardcoded `false` on the member view, so the two describes contradicted each other about one group's storage encryption. It now reports what the group stores — the value `CreateReplicationGroup` already parsed and kept.

`AuthTokenEnabled` is unchanged and still means what it says: only a token sets it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

In the ElastiCache API, `AuthTokenEnabled` and `TransitEncryptionEnabled` are separate members of `ReplicationGroup` and of `CacheCluster`, and AWS reports them independently: a group with `TransitEncryptionEnabled=true` and no `AuthToken` comes back with transit true and auth-token false. AWS's constraint runs one way only — supplying an auth token *requires* transit encryption — which is why deriving one flag from the other is right in that direction and wrong in the other.

Three tests added to `ElastiCacheQueryHandlerTest`: transit reported for a token-less encrypted group (with `AuthTokenEnabled` still false alongside it), transit still false for a plain group, and the member-cluster view agreeing with the group view on both flags.

## Checklist

- [x] `./mvnw test -Dtest='ElastiCache*'` — every unit and non-container suite passes (`ElastiCacheQueryHandlerTest` 16/16, `ElastiCacheServiceTest` 23/23)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make docs-check` clean

One note on local verification: `ElastiCacheIntegrationTest` and `ElastiCacheClusterIntegrationTest` fail on my machine with `java.net.BindException: Can't assign requested address` when starting their Redis containers. I confirmed the identical failures on unmodified `main` at the same commit before touching anything — same tests, same counts — so this is my Docker networking, not the change. CI covers them.

Found by a compatibility survey that runs the Gruntwork Terraform corpus against Floci.
