### PR TITLE
fix(ecs): apply cluster settings given on CreateCluster

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsJsonHandler.java
@@ -143,7 +143,8 @@ public class EcsJsonHandler {
     private Response handleCreateCluster(JsonNode req, String region) {
         String name = req.path("clusterName").asText(null);
         Map<String, String> tags = parseTagMap(req.path("tags"));
-        EcsCluster cluster = service.createCluster(name, tags, region);
+        List<ClusterSetting> settings = parseClusterSettings(req.path("settings"));
+        EcsCluster cluster = service.createCluster(name, tags, settings, region);
         ObjectNode resp = objectMapper.createObjectNode();
         resp.set("cluster", clusterNode(cluster));
         return Response.ok(resp).build();

--- a/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ecs/EcsService.java
@@ -221,6 +221,20 @@ public class EcsService implements ContainerTeardown, ResourceProvider {
     }
 
     public EcsCluster createCluster(String clusterName, Map<String, String> tags, String region) {
+        return createCluster(clusterName, tags, null, region);
+    }
+
+    /**
+     * Creates a cluster, applying any {@code settings} the request carried.
+     *
+     * <p>Real AWS accepts {@code settings} (containerInsights and friends) on CreateCluster itself,
+     * not only through UpdateClusterSettings. Dropping them here meant a client that configured the
+     * cluster at creation, such as terraform-provider-aws's {@code setting} block, saw
+     * DescribeClusters come back without them and proposed the same change on every subsequent
+     * plan, forever (issue #2806).
+     */
+    public EcsCluster createCluster(String clusterName, Map<String, String> tags,
+                                    List<ClusterSetting> settings, String region) {
         String name = (clusterName == null || clusterName.isBlank()) ? DEFAULT_CLUSTER : clusterName;
         String key = clusterKey(region, name);
         if (clusters.containsKey(key)) {
@@ -232,6 +246,9 @@ public class EcsService implements ContainerTeardown, ResourceProvider {
         cluster.setStatus("ACTIVE");
         if (tags != null && !tags.isEmpty()) {
             cluster.setTags(new LinkedHashMap<>(tags));
+        }
+        if (settings != null && !settings.isEmpty()) {
+            cluster.setSettings(new ArrayList<>(settings));
         }
         clusters.put(key, cluster);
         LOG.infov("Created ECS cluster: {0} in {1}", name, region);

--- a/src/test/java/io/github/hectorvent/floci/services/ecs/EcsCreateClusterSettingsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ecs/EcsCreateClusterSettingsIntegrationTest.java
@@ -1,0 +1,87 @@
+package io.github.hectorvent.floci.services.ecs;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Issue #2806: CreateCluster dropped the request's {@code settings}, so a cluster configured at
+ * creation came back from DescribeClusters without them. Clients that set settings on create, such
+ * as terraform-provider-aws's {@code setting} block, then proposed the same change on every plan
+ * after apply, because the state they read never matched the configuration they sent.
+ *
+ * <p>Real AWS accepts settings on CreateCluster itself, not only through UpdateClusterSettings.
+ */
+@QuarkusTest
+class EcsCreateClusterSettingsIntegrationTest {
+
+    private static final String TARGET_PREFIX = "AmazonEC2ContainerServiceV20141113.";
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static io.restassured.specification.RequestSpecification ecs(String action) {
+        return given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", TARGET_PREFIX + action);
+    }
+
+    @Test
+    void settingsGivenOnCreateAreReturnedByCreateAndSurviveToDescribe() {
+        String cluster = "create-settings-" + Long.toString(System.nanoTime(), 36);
+
+        ecs("CreateCluster")
+            .body("""
+                {"clusterName": "%s",
+                 "settings": [{"name": "containerInsights", "value": "enabled"}]}
+                """.formatted(cluster))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("cluster.clusterName", equalTo(cluster))
+            .body("cluster.settings", hasSize(1))
+            .body("cluster.settings[0].name", equalTo("containerInsights"))
+            .body("cluster.settings[0].value", equalTo("enabled"));
+
+        // The drift the issue describes is not in the CreateCluster response but in what a later
+        // read reports, which is what a client compares its configuration against.
+        ecs("DescribeClusters")
+            .body("""
+                {"clusters": ["%s"]}
+                """.formatted(cluster))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("clusters[0].settings", hasSize(1))
+            .body("clusters[0].settings[0].name", equalTo("containerInsights"))
+            .body("clusters[0].settings[0].value", equalTo("enabled"));
+    }
+
+    @Test
+    void aClusterCreatedWithoutSettingsReportsNone() {
+        // The absent case must stay absent rather than gaining an empty array, since a client
+        // diffing its configuration would see that as a change too.
+        String cluster = "create-nosettings-" + Long.toString(System.nanoTime(), 36);
+
+        ecs("CreateCluster")
+            .body("""
+                {"clusterName": "%s"}
+                """.formatted(cluster))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("cluster.clusterName", equalTo(cluster))
+            .body("cluster.settings", org.hamcrest.Matchers.nullValue());
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2806.

`EcsJsonHandler.handleCreateCluster` read `clusterName` and `tags` and nothing else, and
`EcsService.createCluster` had no `settings` parameter at all, so settings sent at creation were
dropped. Real AWS accepts them on `CreateCluster` itself, not only through `UpdateClusterSettings`.

The effect is permanent drift for any client that configures a cluster at creation.
`terraform-provider-aws` sends its `setting` block on create, reads `DescribeClusters` back without
it, and proposes the same change on every `plan` after `apply`, forever.

## Root cause

The create path never parsed the field, while the update path two methods away already did:

```java
// handleCreateCluster
String name = req.path("clusterName").asText(null);
Map<String, String> tags = parseTagMap(req.path("tags"));
EcsCluster cluster = service.createCluster(name, tags, region);   // settings never read

// handleUpdateClusterSettings, in the same file
List<ClusterSetting> settings = parseClusterSettings(req.path("settings"));
```

Everything downstream was already in place: `clusterNode` serialises `settings`, and the
`EcsCluster` model carries them. Create was the only missing link.

## What changed

The handler parses `settings` with the existing `parseClusterSettings` helper and passes them to a
new `createCluster` overload. The previous overloads delegate to it, so the CloudFormation caller at
`CloudFormationResourceProvisioner` is untouched and no other call site changes.

Nineteen lines across two files.

## AWS Compatibility

`CreateCluster` accepts `settings` in the real API, and `DescribeClusters` reflects them afterwards.
Floci now matches on both. A cluster created without settings still reports none rather than an
empty array, which matters because a client diffing its configuration would treat an added empty
array as a change too.

## How it was tested

New `EcsCreateClusterSettingsIntegrationTest`:

| Test | Covers |
|---|---|
| `settingsGivenOnCreateAreReturnedByCreateAndSurviveToDescribe` | The create response carries the settings, and so does a later `DescribeClusters`, which is what a client actually compares its configuration against |
| `aClusterCreatedWithoutSettingsReportsNone` | The absent case stays absent rather than gaining an empty array |

Reverting only the handler change makes the first fail, so it is a real regression test rather than
a passing assertion.

Full suite: `Tests run: 14737, Failures: 0, Errors: 1, Skipped: 9`.

## One note on that error, since the suite is not green

The single error is `RdsDataServiceTest.batchExecuteStatementRunsEveryParameterSet` failing with
`java.sql.SQLException: No suitable driver found for jdbc:h2:mem:...`. **It is not from this
change**, and I checked rather than assumed:

| Run | RdsDataServiceTest |
|---|---|
| Clean `main` at `3aaf7452`, my change stashed | FAIL |
| This branch, run 1 | FAIL |
| This branch, run 2 | FAIL |

It fails identically on unmodified `main`, and passes when the class is run on its own, so it looks
like a driver registration race under the full parallel suite. Happy to file that separately if it
is not already known.

For completeness: `CodePipelineIntegrationTest.putApprovalResultValidatesErrors` also failed once on
this branch, with `Expected status code <400> but was <500>` on a repeat approval. It did not
reproduce on a second full run and passes in isolation, so it appears order dependent rather than
related to this change. Flagging it rather than leaving it unmentioned.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
