### PR TITLE
feat(batch): add UpdateComputeEnvironment and DeleteComputeEnvironment

### DIFF
--- a/docs/services/batch.md
+++ b/docs/services/batch.md
@@ -11,6 +11,8 @@ Floci Batch implements the AWS Batch control plane for local integration tests. 
 |---|---|---|
 | `CreateComputeEnvironment` | `POST /v1/createcomputeenvironment` | Store a local compute environment and return its ARN |
 | `DescribeComputeEnvironments` | `POST /v1/describecomputeenvironments` | Describe all or selected compute environments |
+| `UpdateComputeEnvironment` | `POST /v1/updatecomputeenvironment` | Update a compute environment's state, service role, and compute resources |
+| `DeleteComputeEnvironment` | `POST /v1/deletecomputeenvironment` | Delete a `DISABLED` compute environment not referenced by any job queue; deleting a missing one is a no-op |
 | `CreateJobQueue` | `POST /v1/createjobqueue` | Store a local job queue attached to compute environments |
 | `UpdateJobQueue` | `POST /v1/updatejobqueue` | Update a job queue's state, priority, and compute environment order |
 | `DeleteJobQueue` | `POST /v1/deletejobqueue` | Delete a `DISABLED` job queue; deleting a missing queue is a no-op |

--- a/src/main/java/io/github/hectorvent/floci/services/batch/BatchController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/batch/BatchController.java
@@ -50,6 +50,20 @@ public class BatchController {
     }
 
     @POST
+    @Path("/v1/updatecomputeenvironment")
+    public Response updateComputeEnvironment(@Context HttpHeaders headers, String body) {
+        return handle(headers, body, (request, region) ->
+                Response.ok(service.updateComputeEnvironment(request)).build());
+    }
+
+    @POST
+    @Path("/v1/deletecomputeenvironment")
+    public Response deleteComputeEnvironment(@Context HttpHeaders headers, String body) {
+        return handle(headers, body, (request, region) ->
+                Response.ok(service.deleteComputeEnvironment(request)).build());
+    }
+
+    @POST
     @Path("/v1/createjobqueue")
     public Response createJobQueue(@Context HttpHeaders headers, String body) {
         return handle(headers, body, (request, region) ->

--- a/src/main/java/io/github/hectorvent/floci/services/batch/BatchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/batch/BatchService.java
@@ -53,6 +53,7 @@ public class BatchService {
     private static final Pattern JOB_NAME_PATTERN = Pattern.compile("[A-Za-z0-9][A-Za-z0-9_-]{0,127}");
     private static final Set<String> SUPPORTED_JOB_DEFINITION_TYPES = Set.of("container");
     private static final Set<String> SUPPORTED_COMPUTE_ENVIRONMENT_TYPES = Set.of("MANAGED", "UNMANAGED");
+    private static final Set<String> SUPPORTED_COMPUTE_ENVIRONMENT_STATES = Set.of("ENABLED", "DISABLED");
     private static final Set<String> SUPPORTED_LIST_FILTERS = Set.of(
             "JOB_NAME", "JOB_DEFINITION", "BEFORE_CREATED_AT", "AFTER_CREATED_AT", "SHARE_IDENTIFIER");
 
@@ -109,6 +110,8 @@ public class BatchService {
         String name = requiredText(request, "computeEnvironmentName");
         String type = requiredText(request, "type");
         validateComputeEnvironmentType(type);
+        String state = text(request, "state", "ENABLED");
+        validateComputeEnvironmentState(state);
         if (resolveComputeEnvironmentOptional(name).isPresent()) {
             throw client("Compute environment already exists: " + name);
         }
@@ -116,7 +119,7 @@ public class BatchService {
         env.setComputeEnvironmentName(name);
         env.setComputeEnvironmentArn(arn(region, "compute-environment/" + name));
         env.setType(type);
-        env.setState(text(request, "state", "ENABLED"));
+        env.setState(state);
         env.setStatus("VALID");
         env.setStatusReason("Compute environment is available");
         env.setComputeResources(map(request.path("computeResources")));
@@ -163,6 +166,54 @@ public class BatchService {
             out.put("nextToken", String.valueOf(end));
         }
         return out;
+    }
+
+    public synchronized ObjectNode updateComputeEnvironment(JsonNode request) {
+        BatchComputeEnvironment env = resolveComputeEnvironment(requiredText(request, "computeEnvironment"));
+        if (request.hasNonNull("state")) {
+            String state = request.path("state").asText();
+            validateComputeEnvironmentState(state);
+            env.setState(state);
+        }
+        if (request.hasNonNull("serviceRole")) {
+            env.setServiceRole(request.path("serviceRole").asText());
+        }
+        if (request.hasNonNull("computeResources")) {
+            // Partial update: AWS only overwrites the compute-resource fields the caller sends
+            // (e.g. minvCpus/maxvCpus/desiredvCpus), not the whole sub-object.
+            env.getComputeResources().putAll(map(request.path("computeResources")));
+        }
+        computeEnvironmentStore.put(env.getComputeEnvironmentArn(), env);
+
+        ObjectNode out = objectMapper.createObjectNode();
+        out.put("computeEnvironmentName", env.getComputeEnvironmentName());
+        out.put("computeEnvironmentArn", env.getComputeEnvironmentArn());
+        return out;
+    }
+
+    public synchronized ObjectNode deleteComputeEnvironment(JsonNode request) {
+        String ref = requiredText(request, "computeEnvironment");
+        Optional<BatchComputeEnvironment> env = resolveComputeEnvironmentOptional(ref);
+        if (env.isEmpty()) {
+            return objectMapper.createObjectNode();
+        }
+        BatchComputeEnvironment target = env.get();
+        if (!"DISABLED".equals(target.getState())) {
+            throw client("Cannot delete compute environment in " + target.getState() + " state: "
+                    + target.getComputeEnvironmentName());
+        }
+        boolean stillAttached = jobQueueStore.scan(k -> true).stream()
+                .flatMap(q -> q.getComputeEnvironmentOrder().stream())
+                .anyMatch(order -> resolveComputeEnvironmentOptional(order.getComputeEnvironment())
+                        .map(BatchComputeEnvironment::getComputeEnvironmentArn)
+                        .map(arn -> arn.equals(target.getComputeEnvironmentArn()))
+                        .orElse(false));
+        if (stillAttached) {
+            throw client("Cannot delete compute environment still associated with a job queue: "
+                    + target.getComputeEnvironmentName());
+        }
+        computeEnvironmentStore.delete(target.getComputeEnvironmentArn());
+        return objectMapper.createObjectNode();
     }
 
     public synchronized ObjectNode createJobQueue(JsonNode request, String region) {
@@ -788,6 +839,12 @@ public class BatchService {
     private void validateComputeEnvironmentType(String type) {
         if (!SUPPORTED_COMPUTE_ENVIRONMENT_TYPES.contains(type)) {
             throw client("type must be MANAGED or UNMANAGED");
+        }
+    }
+
+    private void validateComputeEnvironmentState(String state) {
+        if (!SUPPORTED_COMPUTE_ENVIRONMENT_STATES.contains(state)) {
+            throw client("state must be ENABLED or DISABLED");
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/batch/BatchIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/batch/BatchIntegrationTest.java
@@ -499,6 +499,87 @@ class BatchIntegrationTest {
     }
 
     @Test
+    void updateAndDeleteComputeEnvironmentSupportsTeardownFlow() {
+        String suffix = uniqueSuffix();
+        String ceName = "teardown-ce-" + suffix;
+        String ceArn = createComputeEnvironment(ceName);
+        String queueName = "teardown-ce-queue-" + suffix;
+        createQueue(queueName, ceArn);
+
+        // AWS Batch requires DISABLED before delete: rejected while ENABLED.
+        givenJson("{\"computeEnvironment\":\"%s\"}".formatted(ceName))
+        .when()
+            .post("/v1/deletecomputeenvironment")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ClientException"));
+
+        givenJson("""
+                {
+                  "computeEnvironment": "%s",
+                  "state": "DISABLED",
+                  "serviceRole": "arn:aws:iam::000000000000:role/BatchServiceRole",
+                  "computeResources": {"desiredvCpus": 0}
+                }
+                """.formatted(ceName))
+        .when()
+            .post("/v1/updatecomputeenvironment")
+        .then()
+            .statusCode(200)
+            .body("computeEnvironmentName", equalTo(ceName))
+            .body("computeEnvironmentArn", equalTo(ceArn));
+
+        givenJson("{\"computeEnvironments\":[\"%s\"]}".formatted(ceArn))
+        .when()
+            .post("/v1/describecomputeenvironments")
+        .then()
+            .statusCode(200)
+            .body("computeEnvironments", hasSize(1))
+            .body("computeEnvironments[0].state", equalTo("DISABLED"))
+            .body("computeEnvironments[0].serviceRole",
+                    equalTo("arn:aws:iam::000000000000:role/BatchServiceRole"));
+
+        // DISABLED but still referenced by a job queue's computeEnvironmentOrder: still rejected.
+        givenJson("{\"computeEnvironment\":\"%s\"}".formatted(ceName))
+        .when()
+            .post("/v1/deletecomputeenvironment")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ClientException"));
+
+        givenJson("{\"jobQueue\":\"%s\",\"state\":\"DISABLED\"}".formatted(queueName))
+        .when()
+            .post("/v1/updatejobqueue")
+        .then()
+            .statusCode(200);
+        givenJson("{\"jobQueue\":\"%s\"}".formatted(queueName))
+        .when()
+            .post("/v1/deletejobqueue")
+        .then()
+            .statusCode(200);
+
+        givenJson("{\"computeEnvironment\":\"%s\"}".formatted(ceName))
+        .when()
+            .post("/v1/deletecomputeenvironment")
+        .then()
+            .statusCode(200)
+            .body("isEmpty()", equalTo(true));
+
+        givenJson("{\"computeEnvironments\":[\"%s\"]}".formatted(ceArn))
+        .when()
+            .post("/v1/describecomputeenvironments")
+        .then()
+            .statusCode(200)
+            .body("computeEnvironments", hasSize(0));
+
+        givenJson("{\"computeEnvironment\":\"%s\"}".formatted(ceName))
+        .when()
+            .post("/v1/deletecomputeenvironment")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
     void describeUnknownJobsReturnsEmptyList() {
         givenJson("{\"jobs\":[\"does-not-exist\"]}")
         .when()

--- a/src/test/java/io/github/hectorvent/floci/services/batch/BatchServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/batch/BatchServiceTest.java
@@ -311,6 +311,143 @@ class BatchServiceTest {
         assertEquals(0, repeated.size());
     }
 
+    @Test
+    void updateComputeEnvironmentChangesStateServiceRoleAndComputeResources() throws Exception {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+
+        String computeArn = service.createComputeEnvironment(json("""
+                {
+                  "computeEnvironmentName":"update-ce",
+                  "type":"MANAGED",
+                  "computeResources":{"type":"EC2","minvCpus":0,"maxvCpus":4,"instanceTypes":["optimal"]}
+                }
+                """), REGION).path("computeEnvironmentArn").asText();
+
+        JsonNode updated = service.updateComputeEnvironment(json("""
+                {
+                  "computeEnvironment":"update-ce",
+                  "state":"DISABLED",
+                  "serviceRole":"arn:aws:iam::000000000000:role/BatchServiceRole",
+                  "computeResources":{"maxvCpus":8,"desiredvCpus":2}
+                }
+                """));
+        assertEquals("update-ce", updated.path("computeEnvironmentName").asText());
+        assertEquals(computeArn, updated.path("computeEnvironmentArn").asText());
+
+        JsonNode detail = service.describeComputeEnvironments(json("""
+                {"computeEnvironments":["%s"]}
+                """.formatted(computeArn))).path("computeEnvironments").get(0);
+        assertEquals("DISABLED", detail.path("state").asText());
+        assertEquals("arn:aws:iam::000000000000:role/BatchServiceRole", detail.path("serviceRole").asText());
+        // Partial update: only the sent fields change, minvCpus/instanceTypes survive untouched.
+        assertEquals(0, detail.path("computeResources").path("minvCpus").asInt());
+        assertEquals(8, detail.path("computeResources").path("maxvCpus").asInt());
+        assertEquals(2, detail.path("computeResources").path("desiredvCpus").asInt());
+        assertEquals("optimal", detail.path("computeResources").path("instanceTypes").get(0).asText());
+    }
+
+    @Test
+    void updateComputeEnvironmentRejectsUnknownEnvironment() {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+        AwsException e = assertThrows(AwsException.class, () -> service.updateComputeEnvironment(json("""
+                {"computeEnvironment":"missing-ce","state":"DISABLED"}
+                """)));
+        assertEquals("ClientException", e.getErrorCode());
+    }
+
+    @Test
+    void updateComputeEnvironmentRejectsInvalidState() throws Exception {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+        service.createComputeEnvironment(json("""
+                {"computeEnvironmentName":"invalid-state-ce","type":"MANAGED"}
+                """), REGION);
+
+        AwsException e = assertThrows(AwsException.class, () -> service.updateComputeEnvironment(json("""
+                {"computeEnvironment":"invalid-state-ce","state":"SUSPENDED"}
+                """)));
+        assertEquals("ClientException", e.getErrorCode());
+
+        // Rejected before being written: the environment is still ENABLED, not stuck holding
+        // an invalid value DeleteComputeEnvironment could never match against.
+        JsonNode detail = service.describeComputeEnvironments(json("""
+                {"computeEnvironments":["invalid-state-ce"]}
+                """)).path("computeEnvironments").get(0);
+        assertEquals("ENABLED", detail.path("state").asText());
+    }
+
+    @Test
+    void createComputeEnvironmentRejectsInvalidState() {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+        AwsException e = assertThrows(AwsException.class, () -> service.createComputeEnvironment(json("""
+                {"computeEnvironmentName":"bad-create-ce","type":"MANAGED","state":"SUSPENDED"}
+                """), REGION));
+        assertEquals("ClientException", e.getErrorCode());
+    }
+
+    @Test
+    void deleteComputeEnvironmentRejectsEnabledEnvironment() throws Exception {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+        service.createComputeEnvironment(json("""
+                {"computeEnvironmentName":"delete-enabled-ce","type":"MANAGED"}
+                """), REGION);
+
+        AwsException e = assertThrows(AwsException.class, () -> service.deleteComputeEnvironment(json("""
+                {"computeEnvironment":"delete-enabled-ce"}
+                """)));
+        assertEquals("ClientException", e.getErrorCode());
+    }
+
+    @Test
+    void deleteComputeEnvironmentRejectsEnvironmentStillAttachedToJobQueue() throws Exception {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+
+        String computeArn = service.createComputeEnvironment(json("""
+                {"computeEnvironmentName":"attached-ce","type":"MANAGED"}
+                """), REGION).path("computeEnvironmentArn").asText();
+        service.createJobQueue(json("""
+                {
+                  "jobQueueName":"attached-queue",
+                  "priority":1,
+                  "computeEnvironmentOrder":[{"order":1,"computeEnvironment":"%s"}]
+                }
+                """.formatted(computeArn)), REGION);
+        service.updateComputeEnvironment(json("""
+                {"computeEnvironment":"attached-ce","state":"DISABLED"}
+                """));
+
+        AwsException e = assertThrows(AwsException.class, () -> service.deleteComputeEnvironment(json("""
+                {"computeEnvironment":"attached-ce"}
+                """)));
+        assertEquals("ClientException", e.getErrorCode());
+    }
+
+    @Test
+    void deleteComputeEnvironmentRemovesDisabledEnvironmentAndToleratesRepeatDeletes() throws Exception {
+        BatchService service = immediateService(new InMemoryStorage<String, BatchJob>());
+
+        String computeArn = service.createComputeEnvironment(json("""
+                {"computeEnvironmentName":"delete-ce","type":"MANAGED"}
+                """), REGION).path("computeEnvironmentArn").asText();
+
+        service.updateComputeEnvironment(json("""
+                {"computeEnvironment":"delete-ce","state":"DISABLED"}
+                """));
+        JsonNode deleted = service.deleteComputeEnvironment(json("""
+                {"computeEnvironment":"delete-ce"}
+                """));
+        assertEquals(0, deleted.size());
+
+        JsonNode envs = service.describeComputeEnvironments(json("""
+                {"computeEnvironments":["%s"]}
+                """.formatted(computeArn))).path("computeEnvironments");
+        assertEquals(0, envs.size());
+
+        JsonNode repeated = service.deleteComputeEnvironment(json("""
+                {"computeEnvironment":"delete-ce"}
+                """));
+        assertEquals(0, repeated.size());
+    }
+
     private BatchService dockerService(BatchDockerRunner runner) {
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);


### PR DESCRIPTION
## Summary

Adds `UpdateComputeEnvironment` and `DeleteComputeEnvironment` to `BatchController`/`BatchService`, mirroring the existing `UpdateJobQueue`/`DeleteJobQueue` pair. Closes #2293, closes #2803.

- `DeleteComputeEnvironment` requires `DISABLED` state and rejects deletion while the environment is still referenced by any job queue's `computeEnvironmentOrder`, matching AWS.
- `UpdateComputeEnvironment`'s `computeResources` is a partial merge — only the fields the caller sends change (e.g. `maxvCpus`), the rest survive untouched — matching AWS's actual semantics, not a full replace.
- Both `UpdateComputeEnvironment` and `CreateComputeEnvironment` now validate `state` is `ENABLED` or `DISABLED`, so an invalid value can never be persisted and later block deletion.
- Both actions return an empty body on success except `UpdateComputeEnvironment`, which returns `computeEnvironmentName`/`computeEnvironmentArn`. Deleting an already-gone environment is tolerated (idempotent).

**Deliberately out of scope for this PR**: CloudFormation's stack-delete dispatcher has no case for `AWS::Batch::ComputeEnvironment`, `AWS::Batch::JobQueue`, or `AWS::Batch::JobDefinition` — all three silently no-op on stack teardown today. Fixing that properly means migrating all of Batch's CFN handling (create and delete, all three types) out of the legacy `CloudFormationResourceProvisioner` switch into a per-service provisioner, per `AGENTS.md`'s stated convention. That's a bigger, separate change than this PR's two endpoints, and will follow as its own PR.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS Batch API reference (`API_UpdateComputeEnvironment.html`, `API_DeleteComputeEnvironment.html`) and the `batch-2016-08-10` service model: request/response field names (`computeEnvironment`, `computeResources.{minvCpus,maxvCpus,desiredvCpus}`, `serviceRole`, `state`), response shape, the DISABLED-before-delete precondition, and the `state` enum (`ENABLED`/`DISABLED`) — all stated explicitly in AWS's own docs.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
