### PR TITLE
fix(opensearch): include CognitoOptions in domain status

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchController.java
@@ -498,6 +498,7 @@ public class OpenSearchController {
         }
         node.set("ClusterConfig", toClusterConfigNode(domain.getClusterConfig()));
         node.set("EBSOptions", toEbsOptionsNode(domain.getEbsOptions()));
+        node.putObject("CognitoOptions").put("Enabled", false);
         if (domain.getVpcOptions() != null) {
             node.set("VPCOptions", toVpcOptionsNode(domain.getVpcOptions()));
         }

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchIntegrationTest.java
@@ -76,7 +76,8 @@ class OpenSearchIntegrationTest {
             .body("DomainStatus.EngineVersion", equalTo("OpenSearch_2.11"))
             .body("DomainStatus.ClusterConfig.InstanceType", equalTo("m5.large.search"))
             .body("DomainStatus.ClusterConfig.InstanceCount", equalTo(1))
-            .body("DomainStatus.EBSOptions.EBSEnabled", equalTo(true));
+            .body("DomainStatus.EBSOptions.EBSEnabled", equalTo(true))
+            .body("DomainStatus.CognitoOptions.Enabled", equalTo(false));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Return `DomainStatus.CognitoOptions.Enabled = false` when Cognito authentication is not configured.
- Keep every response using the shared `DomainStatus` serializer compatible with clients that expect this AWS response object.

Fixes #2801

## Root cause

The shared `DomainStatus` serializer omitted `CognitoOptions` entirely for domains without Cognito authentication. Terraform AWS Provider reads that object unconditionally, so the missing field caused a nil-pointer panic during refresh.

## Change

Add the disabled default object once in `toDomainStatusNode` and cover the public `DescribeDomain` response with a regression assertion.

## Verification

- TDD red: the new assertion failed with `Expected: false, Actual: null` before the fix.
- `./mvnw -Dtest='OpenSearch*Test' test`: 64 tests passed.
- Full suite in the repository's four CI-style shards: 14,822 tests passed, 0 failures, 0 errors, 9 skipped.
- `./mvnw -q -DskipTests test-compile`: passed with Java 25.
- `./mvnw clean package -DskipTests -B`: passed.
- `make docs-check`: passed.
- `git diff --check`: passed.
