### PR TITLE
docs: use x.y.z in the pinned image example

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,7 +763,7 @@ image: floci/floci:latest
 image: floci/floci:latest-compat
 
 # Pinned release
-image: floci/floci:1.5.11
+image: floci/floci:x.y.z
 
 # Track main
 image: floci/floci:nightly

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -17,7 +17,7 @@ The compat image is built on top of the standard image, so startup time and memo
 
 | Channel | Source | Published |
 |---|---|---|
-| **Release** | Tagged version (e.g. `1.7.0`) | 1st and 3rd Tuesday of each month |
+| **Release** | Tagged version (e.g. `x.y.z`) | 1st and 3rd Tuesday of each month |
 | **Nightly** | Tip of `main` | Every night at 23:00 CT |
 
 Release images are stable and recommended for most use cases. Between trains, `nightly` carries every merged fix from the following morning. Nightly images track active development and may include unreleased changes.
@@ -48,7 +48,7 @@ image: floci/floci:latest
 image: floci/floci:latest-compat
 
 # Pinned release : reproducible builds
-image: floci/floci:1.7.0
+image: floci/floci:x.y.z
 
 # Nightly : track main
 image: floci/floci:nightly


### PR DESCRIPTION
## Summary

The README's compose example pinned `1.5.11`. Current is `1.7.0`, so the example was stale, and every emulator README had the same problem for the same reason: a concrete version in a doc nobody re-edits at release time.

It now reads `x.y.z`, which is already how the channel table directly above the example writes the pinned channel. The snippet finally agrees with its own table and cannot go stale again.

Also covers the two places in `docs/configuration/docker-images.md` that named a concrete version, so the page cannot drift out of step with the README.

**The tradeoff, stated plainly:** `image: floci/[image]:x.y.z` is not copy-pasteable. The line above it, `image: floci/[image]:latest`, is, and it is the recommended one, so the pinned line reads as the pattern rather than a runnable default. That is the deliberate choice here.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Not applicable. Documentation only.

## Checklist

- [x] Tests pass locally (not run: no source changed, docs only)
- [ ] New or updated integration test added (not applicable, documentation only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
