### PR TITLE
feat(dynamodb): opt-in container-backed data plane using amazon/dynamodb-local

### DIFF
--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -239,6 +239,9 @@ Both are currently pinned as *passing* by
 rather than "fixed": tightening the native engine to match real AWS would change behaviour those
 tests assert, and is a separate decision from adding a backend.
 
+The table is marked from the moment the drop is issued, not only when it fails, so a read arriving
+while the container delete is still in flight cannot be answered from the generation being removed.
+
 If the container refuses to drop a table Floci has already deleted, the backend fails closed: that
 table is recorded, the drop is retried on the next request that names it, and until it succeeds any
 forwarded read or write for that name is answered with `ResourceNotFoundException` rather than data

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -239,6 +239,11 @@ Both are currently pinned as *passing* by
 rather than "fixed": tightening the native engine to match real AWS would change behaviour those
 tests assert, and is a separate decision from adding a backend.
 
+If the container refuses to drop a table Floci has already deleted, the backend fails closed: that
+table is recorded, the drop is retried on the next request that names it, and until it succeeds any
+forwarded read or write for that name is answered with `ResourceNotFoundException` rather than data
+from the deleted generation.
+
 ### Not yet mirrored
 
 Tables created through CloudFormation (`AWS::DynamoDB::Table`) go through

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -171,6 +171,11 @@ FLOCI_SERVICES_DYNAMODB_BACKEND=container
 The container is started on first use and stopped with the emulator. It needs the Docker socket,
 the same as Lambda, RDS and the other Docker-backed services.
 
+Its port is published on loopback only. DynamoDB local does not validate signatures and selects its
+store from the credential scope, so anything able to reach that port could read or write any
+account's tables without passing through Floci. Only Floci is meant to dial it, and when Floci
+itself runs in a container the port is not published at all: the two talk over the Docker network.
+
 **What stays in Floci.** The control plane is unchanged, so every parameter Floci already accepts
 keeps round-tripping: table metadata and ARNs, `DescribeTable`, tags, PITR/continuous backups,
 `ExportTableToPointInTime`, Kinesis streaming destinations, and stream fan-out to Lambda event
@@ -182,7 +187,7 @@ the caller's resolved account id as the access key, so the container's partition
 Floci's own account and region scoping without renaming tables.
 
 **How streams keep working.** Writes no longer pass through Floci, so before/after images cannot be
-captured inline — and they cannot be rebuilt from the forwarded calls either, because
+captured inline, and they cannot be rebuilt from the forwarded calls either, because
 `ReturnValues=ALL_OLD` does not exist on `BatchWriteItem` or `TransactWriteItems`. The mirrored
 table therefore always carries `NEW_AND_OLD_IMAGES`, and Floci replays the container's stream into
 its own, applying the caller's configured `StreamViewType` on the way out. Consumers see no
@@ -201,8 +206,8 @@ These come from downloadable DynamoDB itself and apply only when `backend=contai
 | Item collection metrics | Populated | Container returns nulls, so `ReturnItemCollectionMetrics=SIZE` yields none |
 | `TransactionConflictException` | Raised | Never raised by DynamoDB local |
 
-Enum members that AWS validates ahead of the table lookup — `ReturnValues`,
-`ReturnConsumedCapacity`, `ReturnItemCollectionMetrics` — are checked by Floci before the request
+Enum members that AWS validates ahead of the table lookup, namely `ReturnValues`,
+`ReturnConsumedCapacity` and `ReturnItemCollectionMetrics`, are checked by Floci before the request
 is forwarded, because DynamoDB local resolves the table first. Measured against live AWS: an
 invalid `ReturnConsumedCapacity` on a table that does not exist returns `ValidationException`,
 while the same call with a valid enum returns `ResourceNotFoundException`.
@@ -211,7 +216,7 @@ while the same call with a valid enum returns `ResourceNotFoundException`.
 
 Two conformance cases fail in container mode because DynamoDB local rejects something the
 in-process engine allows. Both were checked against the live DynamoDB API, which returns the
-container's error **verbatim** — so the container is right and the native backend is lenient:
+container's error **verbatim**, so the container is right and the native backend is lenient:
 
 - **Unused `ExpressionAttributeNames`.** Supplying `#st` without referencing it in any
   expression is rejected. Live AWS:
@@ -225,7 +230,7 @@ container's error **verbatim** — so the container is right and the native back
 
 Both are currently pinned as *passing* by
 `compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts`, so they are recorded here
-rather than "fixed" — tightening the native engine to match real AWS would change behaviour those
+rather than "fixed": tightening the native engine to match real AWS would change behaviour those
 tests assert, and is a separate decision from adding a backend.
 
 ### Not yet mirrored

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -202,27 +202,31 @@ These come from downloadable DynamoDB itself and apply only when `backend=contai
 | `TransactionConflictException` | Raised | Never raised by DynamoDB local |
 
 Enum members that AWS validates ahead of the table lookup — `ReturnValues`,
-`ReturnConsumedCapacity`, `ReturnItemCollectionMetrics` — are checked by Floci before the
-request is forwarded, because DynamoDB local resolves the table first and would answer
-`ResourceNotFoundException` where AWS answers `ValidationException`.
+`ReturnConsumedCapacity`, `ReturnItemCollectionMetrics` — are checked by Floci before the request
+is forwarded, because DynamoDB local resolves the table first. Measured against live AWS: an
+invalid `ReturnConsumedCapacity` on a table that does not exist returns `ValidationException`,
+while the same call with a valid enum returns `ResourceNotFoundException`.
 
 ### Where the container is stricter than the native backend
 
 Two conformance cases fail in container mode because DynamoDB local rejects something the
-in-process engine allows, and on the documentation the container looks right:
+in-process engine allows. Both were checked against the live DynamoDB API, which returns the
+container's error **verbatim** — so the container is right and the native backend is lenient:
 
 - **Unused `ExpressionAttributeNames`.** Supplying `#st` without referencing it in any
-  expression is rejected with `Value provided in ExpressionAttributeNames unused in
-  expressions`. The native backend accepts it.
-- **Mixing legacy and expression parameters.** `QueryFilter` alongside
-  `KeyConditionExpression` is rejected with `Can not use both expression and non-expression
-  parameters in the same request`. The native backend runs the query. The DynamoDB developer
-  guide is explicit that this combination is an error: "DynamoDB does not allow mixing legacy
-  conditional parameters and expression parameters in a single call."
+  expression is rejected. Live AWS:
+  `ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#st}`
+- **Mixing legacy and expression parameters.** `QueryFilter` alongside `KeyConditionExpression`
+  is rejected. Live AWS:
+  `ValidationException: Can not use both expression and non-expression parameters in the same
+  request: Non-expression parameters: {QueryFilter} Expression parameters: {KeyConditionExpression}`
+  The developer guide agrees: "DynamoDB does not allow mixing legacy conditional parameters and
+  expression parameters in a single call."
 
-Both are pinned as passing by `compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts`,
-so they are recorded here rather than "fixed" — tightening the native engine to match would
-change behaviour those tests currently assert, and is a separate decision from adding a backend.
+Both are currently pinned as *passing* by
+`compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts`, so they are recorded here
+rather than "fixed" — tightening the native engine to match real AWS would change behaviour those
+tests assert, and is a separate decision from adding a backend.
 
 ### Not yet mirrored
 

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -158,3 +158,53 @@ aws dynamodb list-exports \
 
 The export writes to `s3://<bucket>/<prefix>/AWSDynamoDB/<exportId>/data/` as one or more `.json.gz` files, along with `manifest-summary.json` and `manifest-files.json` — the same layout as real AWS DynamoDB exports.
 ```
+## Container-backed data plane (opt-in)
+
+By default Floci serves DynamoDB entirely in-process. Setting the backend to `container` delegates
+item storage, expression evaluation, PartiQL and transactions to an `amazon/dynamodb-local`
+container, so those semantics come from AWS's own downloadable engine:
+
+```bash
+FLOCI_SERVICES_DYNAMODB_BACKEND=container
+```
+
+The container is started on first use and stopped with the emulator. It needs the Docker socket,
+the same as Lambda, RDS and the other Docker-backed services.
+
+**What stays in Floci.** The control plane is unchanged, so every parameter Floci already accepts
+keeps round-tripping: table metadata and ARNs, `DescribeTable`, tags, PITR/continuous backups,
+`ExportTableToPointInTime`, Kinesis streaming destinations, and stream fan-out to Lambda event
+source mappings and EventBridge Pipes. DynamoDB local models none of those.
+
+**How accounts and regions stay separated.** DynamoDB local keeps a separate store per
+(access key id, region) unless `-sharedDb` is passed, which Floci deliberately omits. Floci sends
+the caller's resolved account id as the access key, so the container's partitioning matches
+Floci's own account and region scoping without renaming tables.
+
+**How streams keep working.** Writes no longer pass through Floci, so before/after images cannot be
+captured inline — and they cannot be rebuilt from the forwarded calls either, because
+`ReturnValues=ALL_OLD` does not exist on `BatchWriteItem` or `TransactWriteItems`. The mirrored
+table therefore always carries `NEW_AND_OLD_IMAGES`, and Floci replays the container's stream into
+its own, applying the caller's configured `StreamViewType` on the way out. Consumers see no
+difference.
+
+### Known divergences in this mode
+
+These come from downloadable DynamoDB itself and apply only when `backend=container`:
+
+| Behaviour | Native backend | Container backend |
+|---|---|---|
+| Table-name case sensitivity | `Authors` and `authors` are distinct, as in AWS | Names are case-insensitive; the second create fails |
+| `TagResource` / `ListTagsOfResource` | Supported | Served by Floci; never reaches the container |
+| Point-in-time recovery | Supported | Served by Floci; DynamoDB local has no PITR |
+| `billingModeSummary` | Populated | Served by Floci |
+| Item collection metrics | Populated | Container returns nulls |
+| `TransactionConflictException` | Raised | Never raised by DynamoDB local |
+
+### Not yet mirrored
+
+Tables created through CloudFormation (`AWS::DynamoDB::Table`) go through
+`DynamoDbService.createTable` rather than the JSON handler, so they are not mirrored into the
+container and their data plane will not work in this mode. The same applies to the legacy
+`states:::dynamodb:*` Step Functions task path and IoT rule actions, which call the service
+directly. Use the native backend for those.

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -176,6 +176,12 @@ store from the credential scope, so anything able to reach that port could read 
 account's tables without passing through Floci. Only Floci is meant to dial it, and when Floci
 itself runs in a container the port is not published at all: the two talk over the Docker network.
 
+That last point carries a caveat worth stating. Any other container sharing that Docker network can
+reach the backing store directly, the same way it can reach the Postgres behind RDS or the Valkey
+behind ElastiCache. Give the backing container a network of its own
+(`FLOCI_SERVICES_DYNAMODB_CONTAINER_DOCKER_NETWORK`) if the network Floci runs on also hosts
+containers that should not have unmediated access.
+
 **What stays in Floci.** The control plane is unchanged, so every parameter Floci already accepts
 keeps round-tripping: table metadata and ARNs, `DescribeTable`, tags, PITR/continuous backups,
 `ExportTableToPointInTime`, Kinesis streaming destinations, and stream fan-out to Lambda event

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -242,7 +242,10 @@ tests assert, and is a separate decision from adding a backend.
 If the container refuses to drop a table Floci has already deleted, the backend fails closed: that
 table is recorded, the drop is retried on the next request that names it, and until it succeeds any
 forwarded read or write for that name is answered with `ResourceNotFoundException` rather than data
-from the deleted generation.
+from the deleted generation. PartiQL names its table inside the statement text, so while a drop is
+outstanding in a region every `ExecuteStatement`, `ExecuteTransaction` and `BatchExecuteStatement`
+in that region is refused rather than parsed: a statement form Floci's own parser does not accept
+but the container does would otherwise slip through.
 
 ### Not yet mirrored
 

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -198,8 +198,31 @@ These come from downloadable DynamoDB itself and apply only when `backend=contai
 | `TagResource` / `ListTagsOfResource` | Supported | Served by Floci; never reaches the container |
 | Point-in-time recovery | Supported | Served by Floci; DynamoDB local has no PITR |
 | `billingModeSummary` | Populated | Served by Floci |
-| Item collection metrics | Populated | Container returns nulls |
+| Item collection metrics | Populated | Container returns nulls, so `ReturnItemCollectionMetrics=SIZE` yields none |
 | `TransactionConflictException` | Raised | Never raised by DynamoDB local |
+
+Enum members that AWS validates ahead of the table lookup — `ReturnValues`,
+`ReturnConsumedCapacity`, `ReturnItemCollectionMetrics` — are checked by Floci before the
+request is forwarded, because DynamoDB local resolves the table first and would answer
+`ResourceNotFoundException` where AWS answers `ValidationException`.
+
+### Where the container is stricter than the native backend
+
+Two conformance cases fail in container mode because DynamoDB local rejects something the
+in-process engine allows, and on the documentation the container looks right:
+
+- **Unused `ExpressionAttributeNames`.** Supplying `#st` without referencing it in any
+  expression is rejected with `Value provided in ExpressionAttributeNames unused in
+  expressions`. The native backend accepts it.
+- **Mixing legacy and expression parameters.** `QueryFilter` alongside
+  `KeyConditionExpression` is rejected with `Can not use both expression and non-expression
+  parameters in the same request`. The native backend runs the query. The DynamoDB developer
+  guide is explicit that this combination is an error: "DynamoDB does not allow mixing legacy
+  conditional parameters and expression parameters in a single call."
+
+Both are pinned as passing by `compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts`,
+so they are recorded here rather than "fixed" — tightening the native engine to match would
+change behaviour those tests currently assert, and is a separate decision from adding a backend.
 
 ### Not yet mirrored
 

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -208,3 +208,8 @@ Tables created through CloudFormation (`AWS::DynamoDB::Table`) go through
 container and their data plane will not work in this mode. The same applies to the legacy
 `states:::dynamodb:*` Step Functions task path and IoT rule actions, which call the service
 directly. Use the native backend for those.
+
+The container runs with `-inMemory`, so it starts empty. With a persistent or hybrid storage mode
+Floci reloads its table definitions across a restart while the container does not, leaving the
+data plane returning `ResourceNotFoundException` for tables Floci still lists. Recreate the tables,
+or run this mode with `FLOCI_STORAGE_SERVICES_DYNAMODB_MODE=memory` so both sides forget together.

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -239,18 +239,17 @@ Both are currently pinned as *passing* by
 rather than "fixed": tightening the native engine to match real AWS would change behaviour those
 tests assert, and is a separate decision from adding a backend.
 
-The table is marked before Floci deletes its own copy, not when the container drop is issued and not
-only when that drop fails, so no read between the two can be answered from the generation being
-removed. The mark is withdrawn if Floci then rejects the delete, for instance because deletion
-protection is on.
+Forwarded requests are gated on Floci's own metadata: if Floci does not have the table, the request
+is refused with `ResourceNotFoundException` rather than answered from a copy the container may still
+hold. The control plane is the authority and its delete is atomic, so there is no window in which a
+deleted table can still be read, and no separate tracking of in-flight deletions to get wrong.
 
-If the container refuses to drop a table Floci has already deleted, the backend fails closed: that
-table is recorded, the drop is retried on the next request that names it, and until it succeeds any
-forwarded read or write for that name is answered with `ResourceNotFoundException` rather than data
-from the deleted generation. PartiQL names its table inside the statement text, so while a drop is
-outstanding in a region every `ExecuteStatement`, `ExecuteTransaction` and `BatchExecuteStatement`
-in that region is refused rather than parsed: a statement form Floci's own parser does not accept
-but the container does would otherwise slip through.
+PartiQL names its table inside the statement text, where that check cannot see it. If a container
+drop fails, every `ExecuteStatement`, `ExecuteTransaction` and `BatchExecuteStatement` in the
+affected account and region is refused until the drop goes through, which is retried on each
+attempt. Pointing Floci's own PartiQL parser at the statement would be the alternative, but that
+parser is part of the engine this backend exists to bypass: a form it does not accept but the
+container does would let the statement past.
 
 ### Not yet mirrored
 

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -244,6 +244,11 @@ is refused with `ResourceNotFoundException` rather than answered from a copy the
 hold. The control plane is the authority and its delete is atomic, so there is no window in which a
 deleted table can still be read, and no separate tracking of in-flight deletions to get wrong.
 
+That check is only as good as the agreement between the two sides, so a CreateTable whose container
+mirror cannot be established withdraws the table Floci had already committed. The control plane
+never advertises a table whose data plane is not usable, and a request cannot land on whatever the
+container happens to still hold under that name.
+
 PartiQL names its table inside the statement text, where that check cannot see it. If a container
 drop fails, every `ExecuteStatement`, `ExecuteTransaction` and `BatchExecuteStatement` in the
 affected account and region is refused until the drop goes through, which is retried on each

--- a/docs/services/dynamodb.md
+++ b/docs/services/dynamodb.md
@@ -239,8 +239,10 @@ Both are currently pinned as *passing* by
 rather than "fixed": tightening the native engine to match real AWS would change behaviour those
 tests assert, and is a separate decision from adding a backend.
 
-The table is marked from the moment the drop is issued, not only when it fails, so a read arriving
-while the container delete is still in flight cannot be answered from the generation being removed.
+The table is marked before Floci deletes its own copy, not when the container drop is issued and not
+only when that drop fails, so no read between the two can be answered from the generation being
+removed. The mark is withdrawn if Floci then rejects the delete, for instance because deletion
+protection is on.
 
 If the container refuses to drop a table Floci has already deleted, the backend fails closed: that
 table is recorded, the drop is retried on the next request that names it, and until it succeeds any

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1023,10 +1023,6 @@ public interface EmulatorConfig {
         @WithDefault("amazon/dynamodb-local:3.3.1")
         String containerImage();
 
-        /** Host port published for the backing container. 0 allocates dynamically. */
-        @WithDefault("0")
-        int containerHostPort();
-
         /** Docker network to attach the backing container to. Empty = default bridge. */
         Optional<String> containerDockerNetwork();
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -999,8 +999,40 @@ public interface EmulatorConfig {
     }
 
     interface DynamoDbServiceConfig {
+        /** Backend that owns item storage and expression evaluation. */
+        String BACKEND_NATIVE = "native";
+        String BACKEND_CONTAINER = "container";
+
         @WithDefault("true")
         boolean enabled();
+
+        /**
+         * Which engine serves the DynamoDB data plane.
+         *
+         * <p>{@code native} (the default) keeps Floci's in-process engine and is unchanged.
+         * {@code container} delegates item storage, expression evaluation and PartiQL to an
+         * {@code amazon/dynamodb-local} container, while the control plane (table metadata,
+         * ARNs, tags, PITR, exports, Kinesis streaming destinations) stays in Floci. The
+         * container is not a drop-in replacement: it inherits the documented divergences of
+         * downloadable DynamoDB, most notably case-insensitive table names.
+         */
+        @WithDefault(BACKEND_NATIVE)
+        String backend();
+
+        /** Image backing {@code backend=container}. Pinned; {@code latest} moves under you. */
+        @WithDefault("amazon/dynamodb-local:3.3.1")
+        String containerImage();
+
+        /** Host port published for the backing container. 0 allocates dynamically. */
+        @WithDefault("0")
+        int containerHostPort();
+
+        /** Docker network to attach the backing container to. Empty = default bridge. */
+        Optional<String> containerDockerNetwork();
+
+        /** How long to wait for the backing container to accept requests. */
+        @WithDefault("60")
+        int containerStartupTimeoutSeconds();
     }
 
     interface SnsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -36,7 +36,7 @@ import java.util.Optional;
 public class ContainerBuilder {
 
     /** Host interface a backing service binds to when only Floci should reach it. */
-    static final String LOOPBACK_HOST_IP = "127.0.0.1";
+    public static final String LOOPBACK_HOST_IP = "127.0.0.1";
 
     private final EmulatorConfig config;
     private final DockerHostResolver dockerHostResolver;

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -35,6 +35,9 @@ import java.util.Optional;
 @ApplicationScoped
 public class ContainerBuilder {
 
+    /** Host interface a backing service binds to when only Floci should reach it. */
+    static final String LOOPBACK_HOST_IP = "127.0.0.1";
+
     private final EmulatorConfig config;
     private final DockerHostResolver dockerHostResolver;
     private final EmbeddedDnsServer embeddedDnsServer;
@@ -125,6 +128,7 @@ public class ContainerBuilder {
         private boolean privileged;
         private String cgroupnsMode;
         private String user;
+        private String hostIp;
         private final List<String> groupAdd = new ArrayList<>();
         private final List<String> dnsServers = new ArrayList<>();
 
@@ -224,6 +228,18 @@ public class ContainerBuilder {
          * Use this when you don't care which host port is used.
          */
         public Builder withDynamicPort(int containerPort) {
+            return withPortBinding(containerPort, 0);
+        }
+
+        /**
+         * Publishes a port on an ephemeral host port bound to loopback only.
+         *
+         * <p>For a backing service that only Floci itself should reach. A plain
+         * {@link #withDynamicPort(int)} lets Docker bind every interface, which puts the container
+         * on the network for any peer that can route to the host.
+         */
+        public Builder withLoopbackDynamicPort(int containerPort) {
+            this.hostIp = LOOPBACK_HOST_IP;
             return withPortBinding(containerPort, 0);
         }
 
@@ -452,7 +468,8 @@ public class ContainerBuilder {
                     List.copyOf(dnsServers),
                     workingDir,
                     user,
-                    List.copyOf(groupAdd)
+                    List.copyOf(groupAdd),
+                    hostIp
             );
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -775,8 +775,14 @@ public class ContainerLifecycleManager {
                     hostPort = portAllocator.allocateAny();
                 }
 
-                ports.bind(ExposedPort.tcp(containerPort), Ports.Binding.bindPort(hostPort));
-                LOG.debugv("Port binding: {0} -> {1}", String.valueOf(containerPort), String.valueOf(hostPort));
+                // A spec with no hostIp keeps Docker's default of publishing on every interface.
+                Ports.Binding binding = spec.hostIp() == null || spec.hostIp().isBlank()
+                        ? Ports.Binding.bindPort(hostPort)
+                        : Ports.Binding.bindIpAndPort(spec.hostIp(), hostPort);
+                ports.bind(ExposedPort.tcp(containerPort), binding);
+                LOG.debugv("Port binding: {0} -> {1}{2}", String.valueOf(containerPort),
+                        String.valueOf(hostPort),
+                        spec.hostIp() == null ? "" : " on " + spec.hostIp());
             }
             hostConfig.withPortBindings(ports);
         }

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
@@ -31,6 +31,8 @@ import java.util.Map;
  * @param workingDir Working directory inside the container (overrides image WORKDIR)
  * @param user User the container process runs as, formatted "uid[:gid]" (null = image USER)
  * @param groupAdd Supplementary group IDs added to the container process
+ * @param hostIp Host interface published ports bind to (null = Docker's default, all interfaces).
+ *               Use 127.0.0.1 for a backing service only Floci itself should reach.
  */
 public record ContainerSpec(
         String image,
@@ -52,14 +54,15 @@ public record ContainerSpec(
         List<String> dnsServers,
         String workingDir,
         String user,
-        List<String> groupAdd
+        List<String> groupAdd,
+        String hostIp
 ) {
     /**
      * Creates a minimal spec with just the image name.
      * All other fields will be null or empty lists.
      */
     public ContainerSpec(String image) {
-        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(), null, null, List.of());
+        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(), null, null, List.of(), null);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -18,6 +18,8 @@ import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheCont
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheMemcachedContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
 import io.github.hectorvent.floci.services.docdb.container.DocDbContainerManager;
+import io.github.hectorvent.floci.services.dynamodb.container.DynamoDbLocalContainerManager;
+import io.github.hectorvent.floci.services.dynamodb.container.DynamoDbStreamPump;
 import io.github.hectorvent.floci.services.lambda.DynamoDbStreamsEventSourcePoller;
 import io.github.hectorvent.floci.services.lambda.KinesisEventSourcePoller;
 import io.github.hectorvent.floci.services.lambda.SqsEventSourcePoller;
@@ -77,6 +79,8 @@ public class EmulatorLifecycle {
     private final MemoryDbContainerManager memoryDbContainerManager;
     private final MemoryDbProxyManager memoryDbProxyManager;
     private final DocDbContainerManager docDbContainerManager;
+    private final DynamoDbLocalContainerManager dynamoDbLocalContainerManager;
+    private final DynamoDbStreamPump dynamoDbStreamPump;
     private final NeptuneContainerManager neptuneContainerManager;
     private final NeptuneProxyManager neptuneProxyManager;
     private final RabbitMqManager rabbitMqManager;
@@ -110,6 +114,8 @@ public class EmulatorLifecycle {
                              MemoryDbContainerManager memoryDbContainerManager,
                              MemoryDbProxyManager memoryDbProxyManager,
                              DocDbContainerManager docDbContainerManager,
+                             DynamoDbLocalContainerManager dynamoDbLocalContainerManager,
+                             DynamoDbStreamPump dynamoDbStreamPump,
                              NeptuneContainerManager neptuneContainerManager,
                              NeptuneProxyManager neptuneProxyManager,
                              RabbitMqManager rabbitMqManager,
@@ -142,6 +148,8 @@ public class EmulatorLifecycle {
         this.memoryDbContainerManager = memoryDbContainerManager;
         this.memoryDbProxyManager = memoryDbProxyManager;
         this.docDbContainerManager = docDbContainerManager;
+        this.dynamoDbLocalContainerManager = dynamoDbLocalContainerManager;
+        this.dynamoDbStreamPump = dynamoDbStreamPump;
         this.neptuneContainerManager = neptuneContainerManager;
         this.neptuneProxyManager = neptuneProxyManager;
         this.rabbitMqManager = rabbitMqManager;
@@ -310,6 +318,8 @@ public class EmulatorLifecycle {
         rdsContainerManager.stopAll();
         memoryDbContainerManager.stopAll();
         docDbContainerManager.stopAll();
+        dynamoDbStreamPump.stopAll();
+        dynamoDbLocalContainerManager.stopAll();
         neptuneContainerManager.stopAll();
         rabbitMqManager.stopAll();
         flinkContainerManager.stopAll();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -61,16 +61,15 @@ public class DynamoDbJsonHandler {
 
         // Marked before the dispatch that removes Floci's metadata, so a read cannot slip in
         // between the two and be served from the generation about to be dropped.
-        boolean markedForDelete = "DeleteTable".equals(action)
-                && containerBackend.beginDelete(request, region);
+        String deleteMarker = "DeleteTable".equals(action)
+                ? containerBackend.beginDelete(request, region)
+                : null;
 
         Response response;
         try {
             response = dispatch(action, request, region);
         } catch (Exception e) {
-            if (markedForDelete) {
-                containerBackend.abandonDelete(request, region);
-            }
+            containerBackend.abandonDelete(request, region, deleteMarker);
             throw e;
         }
 
@@ -78,8 +77,8 @@ public class DynamoDbJsonHandler {
         // container, or the two views of the table diverge.
         if (response.getStatus() >= 200 && response.getStatus() < 300) {
             mirrorControlPlane(action, request, region);
-        } else if (markedForDelete) {
-            containerBackend.abandonDelete(request, region);
+        } else {
+            containerBackend.abandonDelete(request, region, deleteMarker);
         }
         return response;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsErrorResponse;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsJsonController;
+import io.github.hectorvent.floci.services.dynamodb.container.DynamoDbContainerBackend;
 import io.github.hectorvent.floci.services.dynamodb.model.*;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -31,18 +32,53 @@ public class DynamoDbJsonHandler {
     private final KinesisService kinesisService;
     private final ObjectMapper objectMapper;
     private final DynamoDbPartiQLHandler partiQLHandler;
+    private final DynamoDbContainerBackend containerBackend;
 
     @Inject
     public DynamoDbJsonHandler(DynamoDbService dynamoDbService, DynamoDbStreamService dynamoDbStreamService,
-                               KinesisService kinesisService, ObjectMapper objectMapper) {
+                               KinesisService kinesisService, ObjectMapper objectMapper,
+                               DynamoDbContainerBackend containerBackend) {
         this.dynamoDbService = dynamoDbService;
         this.dynamoDbStreamService = dynamoDbStreamService;
         this.kinesisService = kinesisService;
         this.objectMapper = objectMapper;
         this.partiQLHandler = new DynamoDbPartiQLHandler(dynamoDbService, objectMapper);
+        this.containerBackend = containerBackend;
     }
 
     public Response handle(String action, JsonNode request, String region) throws Exception {
+        // Null in unit tests, which construct this handler directly — same as the stream and
+        // Kinesis collaborators above.
+        if (containerBackend == null || !containerBackend.isEnabled()) {
+            return dispatch(action, request, region);
+        }
+
+        Response forwarded = containerBackend.forwardIfDataPlane(action, request, region);
+        if (forwarded != null) {
+            return forwarded;
+        }
+
+        Response response = dispatch(action, request, region);
+        // Mirror only what Floci accepted: a rejected control-plane call must not reach the
+        // container, or the two views of the table diverge.
+        if (response.getStatus() >= 200 && response.getStatus() < 300) {
+            mirrorControlPlane(action, request, region);
+        }
+        return response;
+    }
+
+    private void mirrorControlPlane(String action, JsonNode request, String region) {
+        // DeleteTable is the one case with nothing left to describe; the backend only needs the
+        // name, which it reads from the request.
+        TableDefinition table = null;
+        String tableName = request.path("TableName").asText(null);
+        if (tableName != null && !"DeleteTable".equals(action)) {
+            table = dynamoDbService.describeTable(DynamoDbTableNames.resolve(tableName), region);
+        }
+        containerBackend.mirrorControlPlane(action, request, region, table);
+    }
+
+    private Response dispatch(String action, JsonNode request, String region) throws Exception {
         return switch (action) {
             case "CreateTable" -> handleCreateTable(request, region);
             case "DeleteTable" -> handleDeleteTable(request, region);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -59,11 +59,27 @@ public class DynamoDbJsonHandler {
             return forwarded;
         }
 
-        Response response = dispatch(action, request, region);
+        // Marked before the dispatch that removes Floci's metadata, so a read cannot slip in
+        // between the two and be served from the generation about to be dropped.
+        boolean markedForDelete = "DeleteTable".equals(action)
+                && containerBackend.beginDelete(request, region);
+
+        Response response;
+        try {
+            response = dispatch(action, request, region);
+        } catch (Exception e) {
+            if (markedForDelete) {
+                containerBackend.abandonDelete(request, region);
+            }
+            throw e;
+        }
+
         // Mirror only what Floci accepted: a rejected control-plane call must not reach the
         // container, or the two views of the table diverge.
         if (response.getStatus() >= 200 && response.getStatus() < 300) {
             mirrorControlPlane(action, request, region);
+        } else if (markedForDelete) {
+            containerBackend.abandonDelete(request, region);
         }
         return response;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -47,7 +47,7 @@ public class DynamoDbJsonHandler {
     }
 
     public Response handle(String action, JsonNode request, String region) throws Exception {
-        // Null in unit tests, which construct this handler directly — same as the stream and
+        // Null in unit tests, which construct this handler directly, same as the stream and
         // Kinesis collaborators above.
         if (containerBackend == null || !containerBackend.isEnabled()) {
             return dispatch(action, request, region);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -59,26 +59,11 @@ public class DynamoDbJsonHandler {
             return forwarded;
         }
 
-        // Marked before the dispatch that removes Floci's metadata, so a read cannot slip in
-        // between the two and be served from the generation about to be dropped.
-        String deleteMarker = "DeleteTable".equals(action)
-                ? containerBackend.beginDelete(request, region)
-                : null;
-
-        Response response;
-        try {
-            response = dispatch(action, request, region);
-        } catch (Exception e) {
-            containerBackend.abandonDelete(request, region, deleteMarker);
-            throw e;
-        }
-
+        Response response = dispatch(action, request, region);
         // Mirror only what Floci accepted: a rejected control-plane call must not reach the
         // container, or the two views of the table diverge.
         if (response.getStatus() >= 200 && response.getStatus() < 300) {
             mirrorControlPlane(action, request, region);
-        } else {
-            containerBackend.abandonDelete(request, region, deleteMarker);
         }
         return response;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -53,6 +53,7 @@ public class DynamoDbJsonHandler {
             return dispatch(action, request, region);
         }
 
+        validateEnumsBeforeForward(action, request);
         Response forwarded = containerBackend.forwardIfDataPlane(action, request, region);
         if (forwarded != null) {
             return forwarded;
@@ -65,6 +66,52 @@ public class DynamoDbJsonHandler {
             mirrorControlPlane(action, request, region);
         }
         return response;
+    }
+
+    /**
+     * Rejects bad enum members before the request reaches the container.
+     *
+     * <p>AWS validates these ahead of the table lookup, so an invalid {@code ReturnValues} on a
+     * table that does not exist is a ValidationException, not a ResourceNotFoundException.
+     * DynamoDB local resolves the table first and answers ResourceNotFoundException, so Floci
+     * keeps this check in front of the forward rather than inheriting the weaker ordering.
+     */
+    private void validateEnumsBeforeForward(String action, JsonNode request) {
+        List<String> validationErrors = new ArrayList<>();
+        collectEnumError(request, "ReturnConsumedCapacity", VALID_RETURN_CONSUMED_CAPACITY,
+                "returnConsumedCapacity", "[INDEXES, TOTAL, NONE]", validationErrors);
+        collectEnumError(request, "ReturnItemCollectionMetrics", VALID_RETURN_ITEM_COLLECTION_METRICS,
+                "returnItemCollectionMetrics", "[SIZE, NONE]", validationErrors);
+
+        switch (action) {
+            case "PutItem" -> collectEnumError(request, "ReturnValues", VALID_RETURN_VALUES_PUT,
+                    "returnValues", "[NONE, ALL_OLD]", validationErrors);
+            case "DeleteItem" -> collectEnumError(request, "ReturnValues", VALID_RETURN_VALUES_DELETE,
+                    "returnValues", "[NONE, ALL_OLD]", validationErrors);
+            case "UpdateItem" -> collectEnumError(request, "ReturnValues", VALID_RETURN_VALUES_UPDATE,
+                    "returnValues", "[NONE, ALL_OLD, ALL_NEW, UPDATED_OLD, UPDATED_NEW]",
+                    validationErrors);
+            default -> { }
+        }
+
+        if (!validationErrors.isEmpty()) {
+            int n = validationErrors.size();
+            throw new AwsException("ValidationException",
+                    n + " validation error" + (n > 1 ? "s" : "") + " detected: "
+                    + String.join("; ", validationErrors), 400);
+        }
+    }
+
+    private static void collectEnumError(JsonNode request, String member, Set<String> allowed,
+                                         String path, String rendered, List<String> errors) {
+        if (!request.has(member)) {
+            return;
+        }
+        String value = request.get(member).asText();
+        if (!allowed.contains(value)) {
+            errors.add("Value '" + value + "' at '" + path + "' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: " + rendered);
+        }
     }
 
     private void mirrorControlPlane(String action, JsonNode request, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -16,6 +16,7 @@ import org.jboss.logging.Logger;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -84,8 +85,15 @@ public class DynamoDbContainerBackend {
      */
     private final Map<String, OrphanedTable> orphanedTables = new ConcurrentHashMap<>();
 
-    /** A table left in the container after Floci deleted its own copy. */
-    private record OrphanedTable(String accountId, String region, String tableName) { }
+    /**
+     * A table left in the container after Floci deleted its own copy.
+     *
+     * <p>{@code markerId} identifies who installed it. Overlapping DeleteTable requests share a
+     * key, so an unwind must only withdraw the marker it put there itself and never one a
+     * concurrent request has since confirmed.
+     */
+    private record OrphanedTable(String accountId, String region, String tableName,
+                                 String markerId) { }
 
     @Inject
     public DynamoDbContainerBackend(EmulatorConfig config,
@@ -222,14 +230,17 @@ public class DynamoDbContainerBackend {
      *
      * @return true when this call installed the marker, so only that caller may remove it
      */
-    public boolean beginDelete(JsonNode request, String region) {
+    public String beginDelete(JsonNode request, String region) {
         String tableName = request.path("TableName").asText(null);
         if (tableName == null) {
-            return false;
+            return null;
         }
         String accountId = regionResolver.getAccountId();
-        return orphanedTables.putIfAbsent(key(accountId, region, tableName),
-                new OrphanedTable(accountId, region, tableName)) == null;
+        String markerId = UUID.randomUUID().toString();
+        OrphanedTable marker = new OrphanedTable(accountId, region, tableName, markerId);
+        return orphanedTables.putIfAbsent(key(accountId, region, tableName), marker) == null
+                ? markerId
+                : null;
     }
 
     /**
@@ -238,11 +249,15 @@ public class DynamoDbContainerBackend {
      * <p>Only ever called with the result of that method, so a marker left by an earlier genuine
      * drop failure is never cleared by a DeleteTable that Floci itself rejected.
      */
-    public void abandonDelete(JsonNode request, String region) {
+    public void abandonDelete(JsonNode request, String region, String markerId) {
         String tableName = request.path("TableName").asText(null);
-        if (tableName != null) {
-            orphanedTables.remove(key(regionResolver.getAccountId(), region, tableName));
+        if (tableName == null || markerId == null) {
+            return;
         }
+        // Withdraw only this request's own marker. A concurrent DeleteTable may have succeeded and
+        // had its container drop fail in the meantime, and that orphan must survive this unwind.
+        orphanedTables.computeIfPresent(key(regionResolver.getAccountId(), region, tableName),
+                (key, existing) -> markerId.equals(existing.markerId()) ? null : existing);
     }
 
     /**
@@ -326,7 +341,8 @@ public class DynamoDbContainerBackend {
      * forwarded reads, and would collide with the next table of the same name.
      */
     private void dropFromContainer(String tableName, String region) {
-        dropAs(new OrphanedTable(regionResolver.getAccountId(), region, tableName));
+        dropAs(new OrphanedTable(regionResolver.getAccountId(), region, tableName,
+                UUID.randomUUID().toString()));
     }
 
     /** Drops a table under the account that owns it, not the account making the current request. */
@@ -345,7 +361,7 @@ public class DynamoDbContainerBackend {
         DynamoDbLocalClient.Result result =
                 client.call(orphan.accountId(), "DeleteTable", mirror, region);
         if (result.isSuccess() || "ResourceNotFoundException".equals(result.errorCode())) {
-            orphanedTables.remove(orphanKey);
+            orphanedTables.remove(orphanKey, orphan);
             return;
         }
         throw new IllegalStateException("DynamoDB container backend could not drop " + tableName

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -1,0 +1,223 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Routes the DynamoDB data plane to the backing {@code amazon/dynamodb-local} container when
+ * {@code floci.services.dynamodb.backend=container}.
+ *
+ * <p>The split is deliberate and narrow:
+ *
+ * <ul>
+ *   <li><b>Container</b> — item storage, expression evaluation, PartiQL, transactions. These are
+ *       forwarded verbatim so their semantics, error codes and messages come from AWS's own
+ *       downloadable engine rather than a reimplementation.</li>
+ *   <li><b>Floci</b> — everything else: table metadata, ARNs, tags, PITR, exports, Kinesis
+ *       streaming destinations and stream fan-out to Lambda event source mappings and Pipes.
+ *       The container never becomes the source of truth for the control plane, so every
+ *       CreateTable parameter Floci already accepts keeps round-tripping unchanged.</li>
+ * </ul>
+ *
+ * <p>Table shape is mirrored into the container on CreateTable; the mirror carries only what the
+ * container models. Anything it would reject — tags, SSE, table class, deletion protection — is
+ * stripped, because Floci is still the thing that answers DescribeTable.
+ */
+@ApplicationScoped
+public class DynamoDbContainerBackend {
+
+    private static final Logger LOG = Logger.getLogger(DynamoDbContainerBackend.class);
+
+    /**
+     * Actions whose semantics the container owns. Everything absent from this set stays in Floci.
+     */
+    private static final Set<String> DATA_PLANE_ACTIONS = Set.of(
+            "PutItem", "GetItem", "UpdateItem", "DeleteItem",
+            "Query", "Scan",
+            "BatchWriteItem", "BatchGetItem",
+            "TransactWriteItems", "TransactGetItems",
+            "ExecuteStatement", "ExecuteTransaction", "BatchExecuteStatement");
+
+    /**
+     * CreateTable members DynamoDB local does not model. Floci keeps serving all of them.
+     */
+    private static final List<String> UNSUPPORTED_CREATE_MEMBERS = List.of(
+            "Tags", "SSESpecification", "TableClass", "DeletionProtectionEnabled",
+            "ResourcePolicy", "WarmThroughput", "OnDemandThroughput");
+
+    private final EmulatorConfig config;
+    private final DynamoDbLocalClient client;
+    private final DynamoDbStreamPump streamPump;
+    private final ObjectMapper objectMapper;
+
+    /** region + "/" + tableName of tables already mirrored, so UpdateTable can tell new from known. */
+    private final Map<String, String> mirroredStreamArns = new ConcurrentHashMap<>();
+
+    @Inject
+    public DynamoDbContainerBackend(EmulatorConfig config,
+                                    DynamoDbLocalClient client,
+                                    DynamoDbStreamPump streamPump,
+                                    ObjectMapper objectMapper) {
+        this.config = config;
+        this.client = client;
+        this.streamPump = streamPump;
+        this.objectMapper = objectMapper;
+    }
+
+    public boolean isEnabled() {
+        return EmulatorConfig.DynamoDbServiceConfig.BACKEND_CONTAINER
+                .equalsIgnoreCase(config.services().dynamodb().backend());
+    }
+
+    /**
+     * Forwards {@code action} to the container when it owns that action's semantics.
+     *
+     * @return the container's response, or null when Floci should handle the action itself
+     */
+    public Response forwardIfDataPlane(String action, JsonNode request, String region) {
+        if (!DATA_PLANE_ACTIONS.contains(action)) {
+            return null;
+        }
+        DynamoDbLocalClient.Result result = client.call(action, request, region);
+        // Errors are passed through verbatim: the container's codes and messages are the
+        // reason for routing here in the first place.
+        return Response.status(result.statusCode()).entity(result.body()).build();
+    }
+
+    /**
+     * Mirrors a control-plane change into the container after Floci has applied it.
+     *
+     * @param table Floci's authoritative definition, already updated
+     */
+    public void mirrorControlPlane(String action, JsonNode request, String region, TableDefinition table) {
+        try {
+            switch (action) {
+                case "CreateTable" -> mirrorCreateTable(request, region, table);
+                case "DeleteTable" -> mirrorDeleteTable(request, region);
+                case "UpdateTable" -> mirrorUpdateTable(request, region, table);
+                case "UpdateTimeToLive" -> mirrorUpdateTimeToLive(request, region);
+                default -> { }
+            }
+        } catch (RuntimeException e) {
+            // A mirror failure must not corrupt Floci's own view of the table, which is already
+            // committed. Surface it loudly instead: the data plane for this table is now broken.
+            LOG.errorv(e, "Failed to mirror {0} into the DynamoDB container backend", action);
+            throw e;
+        }
+    }
+
+    private void mirrorCreateTable(JsonNode request, String region, TableDefinition table) {
+        ObjectNode mirror = request.deepCopy();
+        for (String member : UNSUPPORTED_CREATE_MEMBERS) {
+            mirror.remove(member);
+        }
+        // The container's stream is the source of the events Floci fans out, so it must carry
+        // both images regardless of the view type the caller asked for. Floci applies the
+        // caller's StreamViewType when it re-emits, in DynamoDbStreamService.captureEvent.
+        boolean streamed = request.path("StreamSpecification").path("StreamEnabled").asBoolean(false);
+        if (streamed) {
+            ObjectNode spec = objectMapper.createObjectNode();
+            spec.put("StreamEnabled", true);
+            spec.put("StreamViewType", "NEW_AND_OLD_IMAGES");
+            mirror.set("StreamSpecification", spec);
+        }
+
+        DynamoDbLocalClient.Result result = client.call("CreateTable", mirror, region);
+        if (!result.isSuccess()) {
+            throw new IllegalStateException("DynamoDB container backend rejected CreateTable for "
+                    + table.getTableName() + ": " + result.errorCode() + " " + result.errorMessage());
+        }
+
+        if (streamed) {
+            String streamArn = result.body().path("TableDescription").path("LatestStreamArn").asText(null);
+            if (streamArn != null) {
+                mirroredStreamArns.put(key(region, table.getTableName()), streamArn);
+                streamPump.register(table, region, streamArn);
+            }
+        }
+    }
+
+    private void mirrorDeleteTable(JsonNode request, String region) {
+        String tableName = request.path("TableName").asText(null);
+        if (tableName == null) {
+            return;
+        }
+        streamPump.deregister(region, tableName);
+        mirroredStreamArns.remove(key(region, tableName));
+
+        ObjectNode mirror = objectMapper.createObjectNode();
+        mirror.put("TableName", tableName);
+        DynamoDbLocalClient.Result result = client.call("DeleteTable", mirror, region);
+        if (!result.isSuccess() && !"ResourceNotFoundException".equals(result.errorCode())) {
+            LOG.warnv("DynamoDB container backend could not drop {0}: {1} {2}",
+                    tableName, result.errorCode(), result.errorMessage());
+        }
+    }
+
+    private void mirrorUpdateTable(JsonNode request, String region, TableDefinition table) {
+        ObjectNode mirror = request.deepCopy();
+        for (String member : UNSUPPORTED_CREATE_MEMBERS) {
+            mirror.remove(member);
+        }
+        boolean enablingStream = request.path("StreamSpecification").path("StreamEnabled").asBoolean(false);
+        if (enablingStream) {
+            ObjectNode spec = objectMapper.createObjectNode();
+            spec.put("StreamEnabled", true);
+            spec.put("StreamViewType", "NEW_AND_OLD_IMAGES");
+            mirror.set("StreamSpecification", spec);
+        }
+        if (mirror.size() <= 1) {
+            // TableName only: nothing the container models changed.
+            return;
+        }
+
+        DynamoDbLocalClient.Result result = client.call("UpdateTable", mirror, region);
+        if (!result.isSuccess()) {
+            LOG.warnv("DynamoDB container backend could not apply UpdateTable to {0}: {1} {2}",
+                    table.getTableName(), result.errorCode(), result.errorMessage());
+            return;
+        }
+        if (enablingStream) {
+            String streamArn = result.body().path("TableDescription").path("LatestStreamArn").asText(null);
+            if (streamArn != null) {
+                mirroredStreamArns.put(key(region, table.getTableName()), streamArn);
+                streamPump.register(table, region, streamArn);
+            }
+        } else if (request.path("StreamSpecification").has("StreamEnabled")) {
+            streamPump.deregister(region, table.getTableName());
+        }
+    }
+
+    private void mirrorUpdateTimeToLive(JsonNode request, String region) {
+        DynamoDbLocalClient.Result result = client.call("UpdateTimeToLive", request, region);
+        if (!result.isSuccess()) {
+            LOG.warnv("DynamoDB container backend could not apply UpdateTimeToLive: {0} {1}",
+                    result.errorCode(), result.errorMessage());
+        }
+    }
+
+    private static String key(String region, String tableName) {
+        return region + "/" + tableName;
+    }
+
+    /**
+     * Exposed so {@link DynamoDbStreamService} consumers see events for tables that already
+     * existed when a stream was enabled.
+     */
+    public boolean isMirrored(String region, String tableName) {
+        return mirroredStreamArns.containsKey(key(region, tableName));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -23,17 +23,17 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>The split is deliberate and narrow:
  *
  * <ul>
- *   <li><b>Container</b> — item storage, expression evaluation, PartiQL, transactions. These are
+ *   <li><b>Container</b>: item storage, expression evaluation, PartiQL, transactions. These are
  *       forwarded verbatim so their semantics, error codes and messages come from AWS's own
  *       downloadable engine rather than a reimplementation.</li>
- *   <li><b>Floci</b> — everything else: table metadata, ARNs, tags, PITR, exports, Kinesis
+ *   <li><b>Floci</b>: everything else, namely table metadata, ARNs, tags, PITR, exports, Kinesis
  *       streaming destinations and stream fan-out to Lambda event source mappings and Pipes.
  *       The container never becomes the source of truth for the control plane, so every
  *       CreateTable parameter Floci already accepts keeps round-tripping unchanged.</li>
  * </ul>
  *
  * <p>Table shape is mirrored into the container on CreateTable; the mirror carries only what the
- * container models. Anything it would reject — tags, SSE, table class, deletion protection — is
+ * container models. Anything it would reject (tags, SSE, table class, deletion protection) is
  * stripped, because Floci is still the thing that answers DescribeTable.
  */
 @ApplicationScoped
@@ -136,6 +136,15 @@ public class DynamoDbContainerBackend {
         }
 
         DynamoDbLocalClient.Result result = client.call("CreateTable", mirror, region);
+        if ("ResourceInUseException".equals(result.errorCode()) && !result.isSuccess()) {
+            // A table of this name survived in the container, which means an earlier DeleteTable
+            // mirror did not land. Floci has already committed the new table, so the stale one and
+            // its items must go, otherwise reads would serve data from the previous generation.
+            LOG.warnv("Dropping a stale container table for {0} left by a failed delete",
+                    table.getTableName());
+            dropFromContainer(table.getTableName(), region);
+            result = client.call("CreateTable", mirror, region);
+        }
         if (!result.isSuccess()) {
             throw new IllegalStateException("DynamoDB container backend rejected CreateTable for "
                     + table.getTableName() + ": " + result.errorCode() + " " + result.errorMessage());
@@ -157,14 +166,26 @@ public class DynamoDbContainerBackend {
         }
         streamPump.deregister(region, tableName);
         mirroredStreamArns.remove(key(region, tableName));
+        dropFromContainer(tableName, region);
+    }
 
+    /**
+     * Removes a table from the container, tolerating one that is already gone.
+     *
+     * <p>Anything else is fatal rather than logged. Floci has already dropped its own copy by this
+     * point, so a surviving container table would keep the deleted items reachable through
+     * forwarded reads, and would collide with the next table of the same name.
+     */
+    private void dropFromContainer(String tableName, String region) {
         ObjectNode mirror = objectMapper.createObjectNode();
         mirror.put("TableName", tableName);
         DynamoDbLocalClient.Result result = client.call("DeleteTable", mirror, region);
-        if (!result.isSuccess() && !"ResourceNotFoundException".equals(result.errorCode())) {
-            LOG.warnv("DynamoDB container backend could not drop {0}: {1} {2}",
-                    tableName, result.errorCode(), result.errorMessage());
+        if (result.isSuccess() || "ResourceNotFoundException".equals(result.errorCode())) {
+            return;
         }
+        throw new IllegalStateException("DynamoDB container backend could not drop " + tableName
+                + ", its items would stay readable: " + result.errorCode() + " "
+                + result.errorMessage());
     }
 
     private void mirrorUpdateTable(JsonNode request, String region, TableDefinition table) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -300,14 +300,21 @@ public class DynamoDbContainerBackend {
     private void dropAs(OrphanedTable orphan) {
         String tableName = orphan.tableName();
         String region = orphan.region();
+        String orphanKey = key(orphan.accountId(), region, tableName);
+
+        // Marked before the request, not after it fails. Floci has already dropped its own copy,
+        // and the container delete is a round trip: a read arriving inside that window would
+        // otherwise be forwarded and answered from the generation being removed.
+        orphanedTables.put(orphanKey, orphan);
+
         ObjectNode mirror = objectMapper.createObjectNode();
         mirror.put("TableName", tableName);
         DynamoDbLocalClient.Result result =
                 client.call(orphan.accountId(), "DeleteTable", mirror, region);
         if (result.isSuccess() || "ResourceNotFoundException".equals(result.errorCode())) {
+            orphanedTables.remove(orphanKey);
             return;
         }
-        orphanedTables.put(key(orphan.accountId(), region, tableName), orphan);
         throw new IllegalStateException("DynamoDB container backend could not drop " + tableName
                 + ", its items would stay readable: " + result.errorCode() + " "
                 + result.errorMessage());

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -70,22 +71,33 @@ public class DynamoDbContainerBackend {
     private final DynamoDbLocalClient client;
     private final DynamoDbStreamPump streamPump;
     private final ObjectMapper objectMapper;
+    private final RegionResolver regionResolver;
 
-    /** region + "/" + tableName of tables already mirrored, so UpdateTable can tell new from known. */
+    /** Tables already mirrored, so UpdateTable can tell new from known. Keyed by account. */
     private final Map<String, String> mirroredStreamArns = new ConcurrentHashMap<>();
 
-    /** Tables Floci has deleted that the container would not drop. Forwards for these are refused. */
-    private final Set<String> orphanedTables = ConcurrentHashMap.newKeySet();
+    /**
+     * Tables Floci has deleted that the container would not drop. Forwards naming them are refused.
+     *
+     * <p>Keyed and retried by the account that owns them. The account selects the store inside the
+     * container, so retrying under a later caller's account would drop that caller's live table.
+     */
+    private final Map<String, OrphanedTable> orphanedTables = new ConcurrentHashMap<>();
+
+    /** A table left in the container after Floci deleted its own copy. */
+    private record OrphanedTable(String accountId, String region, String tableName) { }
 
     @Inject
     public DynamoDbContainerBackend(EmulatorConfig config,
                                     DynamoDbLocalClient client,
                                     DynamoDbStreamPump streamPump,
-                                    ObjectMapper objectMapper) {
+                                    ObjectMapper objectMapper,
+                                    RegionResolver regionResolver) {
         this.config = config;
         this.client = client;
         this.streamPump = streamPump;
         this.objectMapper = objectMapper;
+        this.regionResolver = regionResolver;
     }
 
     public boolean isEnabled() {
@@ -127,11 +139,12 @@ public class DynamoDbContainerBackend {
         }
         for (String tableName : referencedTables(request)) {
             String orphanKey = key(region, tableName);
-            if (!orphanedTables.contains(orphanKey)) {
+            OrphanedTable orphan = orphanedTables.get(orphanKey);
+            if (orphan == null) {
                 continue;
             }
             try {
-                dropFromContainer(tableName, region);
+                dropAs(orphan);
                 orphanedTables.remove(orphanKey);
             } catch (RuntimeException e) {
                 throw new AwsException("ResourceNotFoundException",
@@ -150,19 +163,21 @@ public class DynamoDbContainerBackend {
      * soon as the retry succeeds.
      */
     private void refuseAllWhileAnyTableIsOrphaned(String region) {
-        for (String orphanKey : Set.copyOf(orphanedTables)) {
-            if (!orphanKey.startsWith(region + "/")) {
+        String accountId = regionResolver.getAccountId();
+        for (Map.Entry<String, OrphanedTable> entry : Map.copyOf(orphanedTables).entrySet()) {
+            OrphanedTable orphan = entry.getValue();
+            if (!orphan.accountId().equals(accountId) || !orphan.region().equals(region)) {
                 continue;
             }
             try {
-                dropFromContainer(orphanKey.substring(region.length() + 1), region);
-                orphanedTables.remove(orphanKey);
+                dropAs(orphan);
+                orphanedTables.remove(entry.getKey());
             } catch (RuntimeException e) {
-                LOG.debugv("Still cannot drop {0}, refusing PartiQL", orphanKey);
+                LOG.debugv("Still cannot drop {0}, refusing PartiQL", entry.getKey());
             }
         }
-        boolean stillOrphaned = orphanedTables.stream()
-                .anyMatch(orphanKey -> orphanKey.startsWith(region + "/"));
+        boolean stillOrphaned = orphanedTables.values().stream()
+                .anyMatch(o -> o.accountId().equals(accountId) && o.region().equals(region));
         if (stillOrphaned) {
             throw new AwsException("ResourceNotFoundException",
                     "Requested resource not found", 400);
@@ -255,7 +270,7 @@ public class DynamoDbContainerBackend {
             String streamArn = result.body().path("TableDescription").path("LatestStreamArn").asText(null);
             if (streamArn != null) {
                 mirroredStreamArns.put(key(region, table.getTableName()), streamArn);
-                streamPump.register(table, region, streamArn);
+                streamPump.register(regionResolver.getAccountId(), table, region, streamArn);
             }
         }
     }
@@ -265,7 +280,7 @@ public class DynamoDbContainerBackend {
         if (tableName == null) {
             return;
         }
-        streamPump.deregister(region, tableName);
+        streamPump.deregister(regionResolver.getAccountId(), region, tableName);
         mirroredStreamArns.remove(key(region, tableName));
         dropFromContainer(tableName, region);
     }
@@ -278,13 +293,21 @@ public class DynamoDbContainerBackend {
      * forwarded reads, and would collide with the next table of the same name.
      */
     private void dropFromContainer(String tableName, String region) {
+        dropAs(new OrphanedTable(regionResolver.getAccountId(), region, tableName));
+    }
+
+    /** Drops a table under the account that owns it, not the account making the current request. */
+    private void dropAs(OrphanedTable orphan) {
+        String tableName = orphan.tableName();
+        String region = orphan.region();
         ObjectNode mirror = objectMapper.createObjectNode();
         mirror.put("TableName", tableName);
-        DynamoDbLocalClient.Result result = client.call("DeleteTable", mirror, region);
+        DynamoDbLocalClient.Result result =
+                client.call(orphan.accountId(), "DeleteTable", mirror, region);
         if (result.isSuccess() || "ResourceNotFoundException".equals(result.errorCode())) {
             return;
         }
-        orphanedTables.add(key(region, tableName));
+        orphanedTables.put(key(orphan.accountId(), region, tableName), orphan);
         throw new IllegalStateException("DynamoDB container backend could not drop " + tableName
                 + ", its items would stay readable: " + result.errorCode() + " "
                 + result.errorMessage());
@@ -317,10 +340,10 @@ public class DynamoDbContainerBackend {
             String streamArn = result.body().path("TableDescription").path("LatestStreamArn").asText(null);
             if (streamArn != null) {
                 mirroredStreamArns.put(key(region, table.getTableName()), streamArn);
-                streamPump.register(table, region, streamArn);
+                streamPump.register(regionResolver.getAccountId(), table, region, streamArn);
             }
         } else if (request.path("StreamSpecification").has("StreamEnabled")) {
-            streamPump.deregister(region, table.getTableName());
+            streamPump.deregister(regionResolver.getAccountId(), region, table.getTableName());
         }
     }
 
@@ -332,8 +355,12 @@ public class DynamoDbContainerBackend {
         }
     }
 
-    private static String key(String region, String tableName) {
-        return region + "/" + tableName;
+    private static String key(String accountId, String region, String tableName) {
+        return accountId + "/" + region + "/" + tableName;
+    }
+
+    private String key(String region, String tableName) {
+        return key(regionResolver.getAccountId(), region, tableName);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,6 +12,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -66,6 +68,9 @@ public class DynamoDbContainerBackend {
     /** region + "/" + tableName of tables already mirrored, so UpdateTable can tell new from known. */
     private final Map<String, String> mirroredStreamArns = new ConcurrentHashMap<>();
 
+    /** Tables Floci has deleted that the container would not drop. Forwards for these are refused. */
+    private final Set<String> orphanedTables = ConcurrentHashMap.newKeySet();
+
     @Inject
     public DynamoDbContainerBackend(EmulatorConfig config,
                                     DynamoDbLocalClient client,
@@ -91,10 +96,66 @@ public class DynamoDbContainerBackend {
         if (!DATA_PLANE_ACTIONS.contains(action)) {
             return null;
         }
+        refuseOrphanedTables(request, region);
         DynamoDbLocalClient.Result result = client.call(action, request, region);
         // Errors are passed through verbatim: the container's codes and messages are the
         // reason for routing here in the first place.
         return Response.status(result.statusCode()).entity(result.body()).build();
+    }
+
+    /**
+     * Blocks a forward that names a table Floci deleted but the container would not drop.
+     *
+     * <p>Forwarded reads never consult Floci's metadata, so a table left behind by a failed drop
+     * would keep answering with items from the deleted generation. The drop is retried first, since
+     * the original failure may have been transient. If it still will not go, the request is refused
+     * with what Floci's own metadata implies rather than served from the container.
+     */
+    private void refuseOrphanedTables(JsonNode request, String region) {
+        if (orphanedTables.isEmpty()) {
+            return;
+        }
+        for (String tableName : referencedTables(request)) {
+            String orphanKey = key(region, tableName);
+            if (!orphanedTables.contains(orphanKey)) {
+                continue;
+            }
+            try {
+                dropFromContainer(tableName, region);
+                orphanedTables.remove(orphanKey);
+            } catch (RuntimeException e) {
+                throw new AwsException("ResourceNotFoundException",
+                        "Requested resource not found", 400);
+            }
+        }
+    }
+
+    /**
+     * Table names a data-plane request names, across the single-table, batch and transact shapes.
+     */
+    private static Set<String> referencedTables(JsonNode request) {
+        Set<String> tables = new LinkedHashSet<>();
+        JsonNode single = request.get("TableName");
+        if (single != null && single.isTextual()) {
+            tables.add(single.asText());
+        }
+        JsonNode requestItems = request.get("RequestItems");
+        if (requestItems != null && requestItems.isObject()) {
+            requestItems.fieldNames().forEachRemaining(tables::add);
+        }
+        JsonNode transactItems = request.get("TransactItems");
+        if (transactItems != null && transactItems.isArray()) {
+            for (JsonNode item : transactItems) {
+                // Each entry wraps exactly one of Put, Update, Delete, Get or ConditionCheck.
+                item.forEach(operation -> {
+                    JsonNode name = operation.get("TableName");
+                    if (name != null && name.isTextual()) {
+                        tables.add(name.asText());
+                    }
+                });
+            }
+        }
+        return tables;
     }
 
     /**
@@ -150,6 +211,7 @@ public class DynamoDbContainerBackend {
                     + table.getTableName() + ": " + result.errorCode() + " " + result.errorMessage());
         }
 
+        orphanedTables.remove(key(region, table.getTableName()));
         if (streamed) {
             String streamArn = result.body().path("TableDescription").path("LatestStreamArn").asText(null);
             if (streamArn != null) {
@@ -183,6 +245,7 @@ public class DynamoDbContainerBackend {
         if (result.isSuccess() || "ResourceNotFoundException".equals(result.errorCode())) {
             return;
         }
+        orphanedTables.add(key(region, tableName));
         throw new IllegalStateException("DynamoDB container backend could not drop " + tableName
                 + ", its items would stay readable: " + result.errorCode() + " "
                 + result.errorMessage());

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -213,6 +213,39 @@ public class DynamoDbContainerBackend {
     }
 
     /**
+     * Marks a table for refusal before Floci deletes its own copy.
+     *
+     * <p>Mirroring runs after the dispatch that removes Floci's metadata, so a request arriving
+     * between the two would otherwise find no marker and be forwarded to a table that still holds
+     * the old generation. Marking first closes that, at the cost of having to unwind when the
+     * delete Floci was asked for does not actually happen.
+     *
+     * @return true when this call installed the marker, so only that caller may remove it
+     */
+    public boolean beginDelete(JsonNode request, String region) {
+        String tableName = request.path("TableName").asText(null);
+        if (tableName == null) {
+            return false;
+        }
+        String accountId = regionResolver.getAccountId();
+        return orphanedTables.putIfAbsent(key(accountId, region, tableName),
+                new OrphanedTable(accountId, region, tableName)) == null;
+    }
+
+    /**
+     * Removes a marker installed by {@link #beginDelete} when the delete did not go ahead.
+     *
+     * <p>Only ever called with the result of that method, so a marker left by an earlier genuine
+     * drop failure is never cleared by a DeleteTable that Floci itself rejected.
+     */
+    public void abandonDelete(JsonNode request, String region) {
+        String tableName = request.path("TableName").asText(null);
+        if (tableName != null) {
+            orphanedTables.remove(key(regionResolver.getAccountId(), region, tableName));
+        }
+    }
+
+    /**
      * Mirrors a control-plane change into the container after Floci has applied it.
      *
      * @param table Floci's authoritative definition, already updated

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -54,6 +54,12 @@ public class DynamoDbContainerBackend {
             "ExecuteStatement", "ExecuteTransaction", "BatchExecuteStatement");
 
     /**
+     * Actions that name their tables inside PartiQL statement text rather than a TableName member.
+     */
+    private static final Set<String> PARTIQL_ACTIONS = Set.of(
+            "ExecuteStatement", "ExecuteTransaction", "BatchExecuteStatement");
+
+    /**
      * CreateTable members DynamoDB local does not model. Floci keeps serving all of them.
      */
     private static final List<String> UNSUPPORTED_CREATE_MEMBERS = List.of(
@@ -96,7 +102,7 @@ public class DynamoDbContainerBackend {
         if (!DATA_PLANE_ACTIONS.contains(action)) {
             return null;
         }
-        refuseOrphanedTables(request, region);
+        refuseOrphanedTables(action, request, region);
         DynamoDbLocalClient.Result result = client.call(action, request, region);
         // Errors are passed through verbatim: the container's codes and messages are the
         // reason for routing here in the first place.
@@ -111,8 +117,12 @@ public class DynamoDbContainerBackend {
      * the original failure may have been transient. If it still will not go, the request is refused
      * with what Floci's own metadata implies rather than served from the container.
      */
-    private void refuseOrphanedTables(JsonNode request, String region) {
+    private void refuseOrphanedTables(String action, JsonNode request, String region) {
         if (orphanedTables.isEmpty()) {
+            return;
+        }
+        if (PARTIQL_ACTIONS.contains(action)) {
+            refuseAllWhileAnyTableIsOrphaned(region);
             return;
         }
         for (String tableName : referencedTables(request)) {
@@ -127,6 +137,35 @@ public class DynamoDbContainerBackend {
                 throw new AwsException("ResourceNotFoundException",
                         "Requested resource not found", 400);
             }
+        }
+    }
+
+    /**
+     * Refuses PartiQL while any table is orphaned, after retrying every outstanding drop.
+     *
+     * <p>PartiQL names its table inside the statement text. Floci's own PartiQL parser could be
+     * pointed at it, but that parser is part of the engine this backend exists to bypass: a form it
+     * does not accept but the container does would silently reopen the hole. Refusing every
+     * statement while a drop is outstanding cannot be defeated that way, and the block clears as
+     * soon as the retry succeeds.
+     */
+    private void refuseAllWhileAnyTableIsOrphaned(String region) {
+        for (String orphanKey : Set.copyOf(orphanedTables)) {
+            if (!orphanKey.startsWith(region + "/")) {
+                continue;
+            }
+            try {
+                dropFromContainer(orphanKey.substring(region.length() + 1), region);
+                orphanedTables.remove(orphanKey);
+            } catch (RuntimeException e) {
+                LOG.debugv("Still cannot drop {0}, refusing PartiQL", orphanKey);
+            }
+        }
+        boolean stillOrphaned = orphanedTables.stream()
+                .anyMatch(orphanKey -> orphanKey.startsWith(region + "/"));
+        if (stillOrphaned) {
+            throw new AwsException("ResourceNotFoundException",
+                    "Requested resource not found", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -246,19 +246,31 @@ public class DynamoDbContainerBackend {
             mirror.set("StreamSpecification", spec);
         }
 
-        DynamoDbLocalClient.Result result = client.call("CreateTable", mirror, region);
-        if ("ResourceInUseException".equals(result.errorCode()) && !result.isSuccess()) {
-            // A table of this name survived in the container, which means an earlier DeleteTable
-            // mirror did not land. Floci has already committed the new table, so the stale one and
-            // its items must go, otherwise reads would serve data from the previous generation.
-            LOG.warnv("Dropping a stale container table for {0} left by a failed delete",
-                    table.getTableName());
-            dropFromContainer(table.getTableName(), region);
+        DynamoDbLocalClient.Result result;
+        try {
             result = client.call("CreateTable", mirror, region);
-        }
-        if (!result.isSuccess()) {
-            throw new IllegalStateException("DynamoDB container backend rejected CreateTable for "
-                    + table.getTableName() + ": " + result.errorCode() + " " + result.errorMessage());
+            if ("ResourceInUseException".equals(result.errorCode()) && !result.isSuccess()) {
+                // A table of this name survived in the container, which means an earlier
+                // DeleteTable mirror did not land. Floci has already committed the new table, so
+                // the stale one and its items must go, otherwise reads would serve data from the
+                // previous generation.
+                LOG.warnv("Dropping a stale container table for {0} left by a failed delete",
+                        table.getTableName());
+                dropFromContainer(table.getTableName(), region);
+                result = client.call("CreateTable", mirror, region);
+            }
+            if (!result.isSuccess()) {
+                throw new IllegalStateException("DynamoDB container backend rejected CreateTable "
+                        + "for " + table.getTableName() + ": " + result.errorCode() + " "
+                        + result.errorMessage());
+            }
+        } catch (RuntimeException e) {
+            // Floci committed this table before the mirror ran, and forwards are gated on Floci
+            // knowing it. Leaving the metadata in place would point every request at whatever the
+            // container still holds under that name, which is the previous generation. Withdraw it
+            // so the control plane keeps telling the truth about what is usable.
+            withdrawFlociTable(table.getTableName(), region);
+            throw e;
         }
 
         failedDrops.remove(key(region, table.getTableName()));
@@ -268,6 +280,20 @@ public class DynamoDbContainerBackend {
                 mirroredStreamArns.put(key(region, table.getTableName()), streamArn);
                 streamPump.register(regionResolver.getAccountId(), table, region, streamArn);
             }
+        }
+    }
+
+    /**
+     * Removes a table Floci committed whose container mirror could not be established.
+     *
+     * <p>Best effort: the mirror failure is already being reported, and masking it with a
+     * secondary failure from the withdrawal would lose the actionable error.
+     */
+    private void withdrawFlociTable(String tableName, String region) {
+        try {
+            dynamoDbService.deleteTable(tableName, region);
+        } catch (RuntimeException e) {
+            LOG.warnv(e, "Could not withdraw {0} after its container mirror failed", tableName);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackend.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -16,7 +17,6 @@ import org.jboss.logging.Logger;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -73,39 +73,37 @@ public class DynamoDbContainerBackend {
     private final DynamoDbStreamPump streamPump;
     private final ObjectMapper objectMapper;
     private final RegionResolver regionResolver;
+    private final DynamoDbService dynamoDbService;
 
     /** Tables already mirrored, so UpdateTable can tell new from known. Keyed by account. */
     private final Map<String, String> mirroredStreamArns = new ConcurrentHashMap<>();
 
     /**
-     * Tables Floci has deleted that the container would not drop. Forwards naming them are refused.
+     * Drops the container refused, recorded so PartiQL can be held off until they go through.
      *
      * <p>Keyed and retried by the account that owns them. The account selects the store inside the
      * container, so retrying under a later caller's account would drop that caller's live table.
+     * Everything other than PartiQL is gated on Floci's own metadata instead, which needs no
+     * bookkeeping to be correct.
      */
-    private final Map<String, OrphanedTable> orphanedTables = new ConcurrentHashMap<>();
+    private final Map<String, OrphanedTable> failedDrops = new ConcurrentHashMap<>();
 
-    /**
-     * A table left in the container after Floci deleted its own copy.
-     *
-     * <p>{@code markerId} identifies who installed it. Overlapping DeleteTable requests share a
-     * key, so an unwind must only withdraw the marker it put there itself and never one a
-     * concurrent request has since confirmed.
-     */
-    private record OrphanedTable(String accountId, String region, String tableName,
-                                 String markerId) { }
+    /** A table left in the container after Floci deleted its own copy. */
+    private record OrphanedTable(String accountId, String region, String tableName) { }
 
     @Inject
     public DynamoDbContainerBackend(EmulatorConfig config,
                                     DynamoDbLocalClient client,
                                     DynamoDbStreamPump streamPump,
                                     ObjectMapper objectMapper,
-                                    RegionResolver regionResolver) {
+                                    RegionResolver regionResolver,
+                                    DynamoDbService dynamoDbService) {
         this.config = config;
         this.client = client;
         this.streamPump = streamPump;
         this.objectMapper = objectMapper;
         this.regionResolver = regionResolver;
+        this.dynamoDbService = dynamoDbService;
     }
 
     public boolean isEnabled() {
@@ -122,7 +120,11 @@ public class DynamoDbContainerBackend {
         if (!DATA_PLANE_ACTIONS.contains(action)) {
             return null;
         }
-        refuseOrphanedTables(action, request, region);
+        if (PARTIQL_ACTIONS.contains(action)) {
+            refuseWhileAnyDropIsOutstanding(region);
+        } else {
+            requireTablesKnownToFloci(request, region);
+        }
         DynamoDbLocalClient.Result result = client.call(action, request, region);
         // Errors are passed through verbatim: the container's codes and messages are the
         // reason for routing here in the first place.
@@ -130,63 +132,49 @@ public class DynamoDbContainerBackend {
     }
 
     /**
-     * Blocks a forward that names a table Floci deleted but the container would not drop.
+     * Refuses a forward Floci's own metadata says should not succeed.
      *
-     * <p>Forwarded reads never consult Floci's metadata, so a table left behind by a failed drop
-     * would keep answering with items from the deleted generation. The drop is retried first, since
-     * the original failure may have been transient. If it still will not go, the request is refused
-     * with what Floci's own metadata implies rather than served from the container.
+     * <p>Forwarded calls would otherwise never consult the control plane, so a table the container
+     * still holds after a failed drop would keep answering reads. Floci's table store is the
+     * authority and its delete is atomic, so asking it is both correct and free of the races that
+     * tracking in-flight deletions separately invites.
      */
-    private void refuseOrphanedTables(String action, JsonNode request, String region) {
-        if (orphanedTables.isEmpty()) {
-            return;
-        }
-        if (PARTIQL_ACTIONS.contains(action)) {
-            refuseAllWhileAnyTableIsOrphaned(region);
-            return;
-        }
+    private void requireTablesKnownToFloci(JsonNode request, String region) {
         for (String tableName : referencedTables(request)) {
-            String orphanKey = key(region, tableName);
-            OrphanedTable orphan = orphanedTables.get(orphanKey);
-            if (orphan == null) {
-                continue;
-            }
-            try {
-                dropAs(orphan);
-                orphanedTables.remove(orphanKey);
-            } catch (RuntimeException e) {
-                throw new AwsException("ResourceNotFoundException",
-                        "Requested resource not found", 400);
-            }
+            // Throws ResourceNotFoundException when Floci does not have the table.
+            dynamoDbService.describeTable(tableName, region);
         }
     }
 
     /**
-     * Refuses PartiQL while any table is orphaned, after retrying every outstanding drop.
+     * Refuses PartiQL while a drop is outstanding, after retrying the outstanding drops.
      *
-     * <p>PartiQL names its table inside the statement text. Floci's own PartiQL parser could be
-     * pointed at it, but that parser is part of the engine this backend exists to bypass: a form it
-     * does not accept but the container does would silently reopen the hole. Refusing every
-     * statement while a drop is outstanding cannot be defeated that way, and the block clears as
-     * soon as the retry succeeds.
+     * <p>PartiQL names its table inside the statement text, so the metadata check above cannot see
+     * it. Floci's own parser could be pointed at the statement, but that parser is part of the
+     * engine this backend exists to bypass: a form it does not accept but the container does would
+     * silently let the statement through. Refusing every statement in the affected account and
+     * region while a drop is outstanding cannot be defeated that way, and clears as soon as a
+     * retry succeeds.
      */
-    private void refuseAllWhileAnyTableIsOrphaned(String region) {
+    private void refuseWhileAnyDropIsOutstanding(String region) {
+        if (failedDrops.isEmpty()) {
+            return;
+        }
         String accountId = regionResolver.getAccountId();
-        for (Map.Entry<String, OrphanedTable> entry : Map.copyOf(orphanedTables).entrySet()) {
-            OrphanedTable orphan = entry.getValue();
-            if (!orphan.accountId().equals(accountId) || !orphan.region().equals(region)) {
+        for (Map.Entry<String, OrphanedTable> entry : Map.copyOf(failedDrops).entrySet()) {
+            OrphanedTable outstanding = entry.getValue();
+            if (!outstanding.accountId().equals(accountId) || !outstanding.region().equals(region)) {
                 continue;
             }
             try {
-                dropAs(orphan);
-                orphanedTables.remove(entry.getKey());
+                dropAs(outstanding);
             } catch (RuntimeException e) {
                 LOG.debugv("Still cannot drop {0}, refusing PartiQL", entry.getKey());
             }
         }
-        boolean stillOrphaned = orphanedTables.values().stream()
+        boolean stillOutstanding = failedDrops.values().stream()
                 .anyMatch(o -> o.accountId().equals(accountId) && o.region().equals(region));
-        if (stillOrphaned) {
+        if (stillOutstanding) {
             throw new AwsException("ResourceNotFoundException",
                     "Requested resource not found", 400);
         }
@@ -218,46 +206,6 @@ public class DynamoDbContainerBackend {
             }
         }
         return tables;
-    }
-
-    /**
-     * Marks a table for refusal before Floci deletes its own copy.
-     *
-     * <p>Mirroring runs after the dispatch that removes Floci's metadata, so a request arriving
-     * between the two would otherwise find no marker and be forwarded to a table that still holds
-     * the old generation. Marking first closes that, at the cost of having to unwind when the
-     * delete Floci was asked for does not actually happen.
-     *
-     * @return true when this call installed the marker, so only that caller may remove it
-     */
-    public String beginDelete(JsonNode request, String region) {
-        String tableName = request.path("TableName").asText(null);
-        if (tableName == null) {
-            return null;
-        }
-        String accountId = regionResolver.getAccountId();
-        String markerId = UUID.randomUUID().toString();
-        OrphanedTable marker = new OrphanedTable(accountId, region, tableName, markerId);
-        return orphanedTables.putIfAbsent(key(accountId, region, tableName), marker) == null
-                ? markerId
-                : null;
-    }
-
-    /**
-     * Removes a marker installed by {@link #beginDelete} when the delete did not go ahead.
-     *
-     * <p>Only ever called with the result of that method, so a marker left by an earlier genuine
-     * drop failure is never cleared by a DeleteTable that Floci itself rejected.
-     */
-    public void abandonDelete(JsonNode request, String region, String markerId) {
-        String tableName = request.path("TableName").asText(null);
-        if (tableName == null || markerId == null) {
-            return;
-        }
-        // Withdraw only this request's own marker. A concurrent DeleteTable may have succeeded and
-        // had its container drop fail in the meantime, and that orphan must survive this unwind.
-        orphanedTables.computeIfPresent(key(regionResolver.getAccountId(), region, tableName),
-                (key, existing) -> markerId.equals(existing.markerId()) ? null : existing);
     }
 
     /**
@@ -313,7 +261,7 @@ public class DynamoDbContainerBackend {
                     + table.getTableName() + ": " + result.errorCode() + " " + result.errorMessage());
         }
 
-        orphanedTables.remove(key(region, table.getTableName()));
+        failedDrops.remove(key(region, table.getTableName()));
         if (streamed) {
             String streamArn = result.body().path("TableDescription").path("LatestStreamArn").asText(null);
             if (streamArn != null) {
@@ -341,8 +289,7 @@ public class DynamoDbContainerBackend {
      * forwarded reads, and would collide with the next table of the same name.
      */
     private void dropFromContainer(String tableName, String region) {
-        dropAs(new OrphanedTable(regionResolver.getAccountId(), region, tableName,
-                UUID.randomUUID().toString()));
+        dropAs(new OrphanedTable(regionResolver.getAccountId(), region, tableName));
     }
 
     /** Drops a table under the account that owns it, not the account making the current request. */
@@ -350,20 +297,15 @@ public class DynamoDbContainerBackend {
         String tableName = orphan.tableName();
         String region = orphan.region();
         String orphanKey = key(orphan.accountId(), region, tableName);
-
-        // Marked before the request, not after it fails. Floci has already dropped its own copy,
-        // and the container delete is a round trip: a read arriving inside that window would
-        // otherwise be forwarded and answered from the generation being removed.
-        orphanedTables.put(orphanKey, orphan);
-
         ObjectNode mirror = objectMapper.createObjectNode();
         mirror.put("TableName", tableName);
         DynamoDbLocalClient.Result result =
                 client.call(orphan.accountId(), "DeleteTable", mirror, region);
         if (result.isSuccess() || "ResourceNotFoundException".equals(result.errorCode())) {
-            orphanedTables.remove(orphanKey, orphan);
+            failedDrops.remove(orphanKey);
             return;
         }
+        failedDrops.put(orphanKey, orphan);
         throw new IllegalStateException("DynamoDB container backend could not drop " + tableName
                 + ", its items would stay readable: " + result.errorCode() + " "
                 + result.errorMessage());

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalClient.java
@@ -61,17 +61,33 @@ public class DynamoDbLocalClient {
      * Sends a DynamoDB action to the container and returns the raw result.
      */
     public Result call(String action, JsonNode body, String region) {
-        return send(TARGET_PREFIX + action, body, region);
+        return call(regionResolver.getAccountId(), action, body, region);
+    }
+
+    /**
+     * Sends a DynamoDB action on behalf of a specific account rather than the calling one.
+     *
+     * <p>The account picks the store inside the container, so anything retrying work queued by an
+     * earlier caller must name that caller's account explicitly. Using the current request's
+     * account would operate on a different account's tables.
+     */
+    public Result call(String accountId, String action, JsonNode body, String region) {
+        return send(accountId, TARGET_PREFIX + action, body, region);
     }
 
     /**
      * Sends a DynamoDB Streams action to the container and returns the raw result.
      */
     public Result callStreams(String action, JsonNode body, String region) {
-        return send(STREAMS_TARGET_PREFIX + action, body, region);
+        return callStreams(regionResolver.getAccountId(), action, body, region);
     }
 
-    private Result send(String target, JsonNode body, String region) {
+    /** Streams counterpart of {@link #call(String, String, JsonNode, String)}. */
+    public Result callStreams(String accountId, String action, JsonNode body, String region) {
+        return send(accountId, STREAMS_TARGET_PREFIX + action, body, region);
+    }
+
+    private Result send(String accountId, String target, JsonNode body, String region) {
         String effectiveRegion = region != null ? region : regionResolver.getDefaultRegion();
         String payload;
         try {
@@ -85,7 +101,7 @@ public class DynamoDbLocalClient {
                 .timeout(Duration.ofSeconds(30))
                 .header("Content-Type", CONTENT_TYPE)
                 .header("X-Amz-Target", target)
-                .header("Authorization", authorizationHeader(effectiveRegion))
+                .header("Authorization", authorizationHeader(accountId, effectiveRegion))
                 .POST(HttpRequest.BodyPublishers.ofString(payload))
                 .build();
 
@@ -115,9 +131,9 @@ public class DynamoDbLocalClient {
         return new Result(response.statusCode(), parsed);
     }
 
-    private String authorizationHeader(String region) {
+    private String authorizationHeader(String accountId, String region) {
         String scopeDate = SCOPE_DATE.format(LocalDate.now(ZoneOffset.UTC));
-        return "AWS4-HMAC-SHA256 Credential=" + regionResolver.getAccountId() + "/" + scopeDate
+        return "AWS4-HMAC-SHA256 Credential=" + accountId + "/" + scopeDate
                 + "/" + region + "/dynamodb/aws4_request, "
                 + "SignedHeaders=content-type;host;x-amz-target, "
                 + "Signature=" + PLACEHOLDER_SIGNATURE;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalClient.java
@@ -1,0 +1,162 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Forwards DynamoDB JSON 1.0 requests to the backing {@code amazon/dynamodb-local} container.
+ *
+ * <p>DynamoDB local does not verify request signatures, but it does read the access key id and
+ * region out of the SigV4 credential scope to select which store to serve. Sending Floci's
+ * resolved account id as the access key therefore reproduces Floci's own account plus region
+ * partitioning inside the container, with no {@code -sharedDb} and no name mangling. The
+ * signature itself is a fixed placeholder because nothing validates it.
+ *
+ * <p>The access key id must be alphanumeric — DynamoDB local rejects anything else with
+ * {@code UnrecognizedClientException} — which a 12-digit AWS account id already satisfies.
+ */
+@ApplicationScoped
+public class DynamoDbLocalClient {
+
+    private static final Logger LOG = Logger.getLogger(DynamoDbLocalClient.class);
+
+    private static final String TARGET_PREFIX = "DynamoDB_20120810.";
+    private static final String STREAMS_TARGET_PREFIX = "DynamoDBStreams_20120810.";
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String PLACEHOLDER_SIGNATURE = "0".repeat(64);
+    private static final DateTimeFormatter SCOPE_DATE = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final DynamoDbLocalContainerManager containerManager;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient;
+
+    @Inject
+    public DynamoDbLocalClient(DynamoDbLocalContainerManager containerManager,
+                               RegionResolver regionResolver,
+                               ObjectMapper objectMapper) {
+        this.containerManager = containerManager;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+    }
+
+    /**
+     * Sends a DynamoDB action to the container and returns the raw result.
+     */
+    public Result call(String action, JsonNode body, String region) {
+        return send(TARGET_PREFIX + action, body, region);
+    }
+
+    /**
+     * Sends a DynamoDB Streams action to the container and returns the raw result.
+     */
+    public Result callStreams(String action, JsonNode body, String region) {
+        return send(STREAMS_TARGET_PREFIX + action, body, region);
+    }
+
+    private Result send(String target, JsonNode body, String region) {
+        String effectiveRegion = region != null ? region : regionResolver.getDefaultRegion();
+        String payload;
+        try {
+            payload = objectMapper.writeValueAsString(body);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not serialize DynamoDB request for " + target, e);
+        }
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(containerManager.baseUrl() + "/"))
+                .timeout(Duration.ofSeconds(30))
+                .header("Content-Type", CONTENT_TYPE)
+                .header("X-Amz-Target", target)
+                .header("Authorization", authorizationHeader(effectiveRegion))
+                .POST(HttpRequest.BodyPublishers.ofString(payload))
+                .build();
+
+        HttpResponse<String> response;
+        try {
+            response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+        } catch (IOException e) {
+            throw new IllegalStateException("DynamoDB local request failed for " + target, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted during DynamoDB local request " + target, e);
+        }
+
+        JsonNode parsed;
+        try {
+            parsed = response.body() == null || response.body().isBlank()
+                    ? objectMapper.createObjectNode()
+                    : objectMapper.readTree(response.body());
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "DynamoDB local returned an unparseable body for " + target + ": " + response.body(), e);
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debugv("{0} -> HTTP {1}", target, response.statusCode());
+        }
+        return new Result(response.statusCode(), parsed);
+    }
+
+    private String authorizationHeader(String region) {
+        String scopeDate = SCOPE_DATE.format(LocalDate.now(ZoneOffset.UTC));
+        return "AWS4-HMAC-SHA256 Credential=" + regionResolver.getAccountId() + "/" + scopeDate
+                + "/" + region + "/dynamodb/aws4_request, "
+                + "SignedHeaders=content-type;host;x-amz-target, "
+                + "Signature=" + PLACEHOLDER_SIGNATURE;
+    }
+
+    /**
+     * A raw response from the container.
+     *
+     * @param statusCode HTTP status; anything outside 2xx carries an AWS JSON error body
+     * @param body parsed response body, never null
+     */
+    public record Result(int statusCode, JsonNode body) {
+
+        public boolean isSuccess() {
+            return statusCode >= 200 && statusCode < 300;
+        }
+
+        /**
+         * Returns the AWS error code from a failure body, for example {@code ValidationException}.
+         * DynamoDB reports it in {@code __type} as {@code <namespace>#<Code>}.
+         */
+        public String errorCode() {
+            JsonNode type = body.get("__type");
+            if (type == null || !type.isTextual()) {
+                return "InternalFailure";
+            }
+            String raw = type.asText();
+            int hash = raw.lastIndexOf('#');
+            return hash >= 0 ? raw.substring(hash + 1) : raw;
+        }
+
+        public String errorMessage() {
+            for (String field : new String[]{"message", "Message"}) {
+                JsonNode node = body.get(field);
+                if (node != null && node.isTextual()) {
+                    return node.asText();
+                }
+            }
+            return "DynamoDB local request failed";
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalClient.java
@@ -26,8 +26,8 @@ import java.time.format.DateTimeFormatter;
  * partitioning inside the container, with no {@code -sharedDb} and no name mangling. The
  * signature itself is a fixed placeholder because nothing validates it.
  *
- * <p>The access key id must be alphanumeric — DynamoDB local rejects anything else with
- * {@code UnrecognizedClientException} — which a 12-digit AWS account id already satisfies.
+ * <p>The access key id must be alphanumeric. DynamoDB local rejects anything else with
+ * {@code UnrecognizedClientException}, and a 12-digit AWS account id already satisfies it.
  */
 @ApplicationScoped
 public class DynamoDbLocalClient {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
@@ -1,0 +1,169 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import io.github.hectorvent.floci.core.common.docker.ContainerSpec;
+import io.github.hectorvent.floci.core.common.docker.ContainerStorageHelper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+
+/**
+ * Owns the single {@code amazon/dynamodb-local} container that backs the DynamoDB data plane
+ * when {@code floci.services.dynamodb.backend=container}.
+ *
+ * <p>One container serves every account and region. DynamoDB local keeps a separate store per
+ * (access key id, region) pair unless {@code -sharedDb} is given, so {@code -sharedDb} is
+ * deliberately omitted: {@link DynamoDbLocalClient} sends the caller's account id as the access
+ * key, which reproduces Floci's own account plus region scoping inside the container.
+ */
+@ApplicationScoped
+public class DynamoDbLocalContainerManager {
+
+    private static final Logger LOG = Logger.getLogger(DynamoDbLocalContainerManager.class);
+
+    static final int DYNAMODB_LOCAL_PORT = 8000;
+
+    private static final long PROBE_CONNECT_MS = 1000;
+    private static final long PROBE_RETRY_MS = 250;
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final ContainerLogStreamer logStreamer;
+    private final ContainerDetector containerDetector;
+    private final EmulatorConfig config;
+    private final RegionResolver regionResolver;
+
+    private final Object startLock = new Object();
+    private volatile String containerId;
+    private volatile EndpointInfo endpoint;
+    private Closeable logStream;
+
+    @Inject
+    public DynamoDbLocalContainerManager(ContainerBuilder containerBuilder,
+                                         ContainerLifecycleManager lifecycleManager,
+                                         ContainerLogStreamer logStreamer,
+                                         ContainerDetector containerDetector,
+                                         EmulatorConfig config,
+                                         RegionResolver regionResolver) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.logStreamer = logStreamer;
+        this.containerDetector = containerDetector;
+        this.config = config;
+        this.regionResolver = regionResolver;
+    }
+
+    /**
+     * Returns the base URL of the backing container, starting it on first use.
+     */
+    public String baseUrl() {
+        EndpointInfo current = endpoint;
+        if (current == null) {
+            synchronized (startLock) {
+                current = endpoint;
+                if (current == null) {
+                    current = start();
+                    endpoint = current;
+                }
+            }
+        }
+        return "http://" + current.host() + ":" + current.port();
+    }
+
+    private EndpointInfo start() {
+        EmulatorConfig.DynamoDbServiceConfig ddb = config.services().dynamodb();
+        String image = ddb.containerImage();
+        String containerName = ContainerStorageHelper.dockerName(config, "floci-dynamodb-local");
+
+        LOG.infov("Starting DynamoDB local container {0} from image {1}", containerName, image);
+        lifecycleManager.removeIfExists(containerName);
+
+        ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
+                .withName(containerName)
+                .withDockerNetwork(ddb.containerDockerNetwork())
+                .withLogRotation()
+                // -sharedDb is deliberately omitted; see the class javadoc.
+                .withCmd(List.of("-jar", "DynamoDBLocal.jar", "-inMemory"))
+                .withLabels(ContainerStorageHelper.resourceIdentityLabels(
+                        "dynamodb", "local", regionResolver.getAccountId(),
+                        regionResolver.getDefaultRegion()));
+
+        int configuredPort = ddb.containerHostPort();
+        if (containerDetector.isRunningInContainer()) {
+            specBuilder.withExposedPort(DYNAMODB_LOCAL_PORT);
+        } else if (configuredPort > 0) {
+            specBuilder.withPortBinding(DYNAMODB_LOCAL_PORT, configuredPort);
+        } else {
+            specBuilder.withDynamicPort(DYNAMODB_LOCAL_PORT);
+        }
+
+        ContainerSpec spec = specBuilder.build();
+        ContainerInfo info = lifecycleManager.createAndStart(spec);
+        EndpointInfo resolved = info.getEndpoint(DYNAMODB_LOCAL_PORT);
+        containerId = info.containerId();
+
+        String shortId = info.containerId().length() >= 8
+                ? info.containerId().substring(0, 8)
+                : info.containerId();
+        logStream = logStreamer.attach(
+                info.containerId(), "/aws/dynamodb/local", logStreamer.generateLogStreamName(shortId),
+                regionResolver.getDefaultRegion(), "dynamodb-local");
+
+        waitForReady(resolved, ddb.containerStartupTimeoutSeconds());
+        LOG.infov("DynamoDB local container ready on {0}", resolved);
+        return resolved;
+    }
+
+    private static void waitForReady(EndpointInfo target, int timeoutSeconds) {
+        long deadline = System.currentTimeMillis() + timeoutSeconds * 1000L;
+        int attempt = 0;
+        while (System.currentTimeMillis() < deadline) {
+            attempt++;
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(target.host(), target.port()), (int) PROBE_CONNECT_MS);
+                return;
+            } catch (IOException e) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debugv("DynamoDB local probe attempt {0}: {1}", attempt, e.getMessage());
+                }
+            }
+            try {
+                Thread.sleep(PROBE_RETRY_MS);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while waiting for DynamoDB local", ie);
+            }
+        }
+        throw new IllegalStateException("DynamoDB local did not become ready on " + target
+                + " within " + timeoutSeconds + "s");
+    }
+
+    /**
+     * Stops the backing container. Safe to call when it was never started.
+     */
+    public void stopAll() {
+        synchronized (startLock) {
+            if (containerId == null) {
+                return;
+            }
+            LOG.info("Stopping DynamoDB local container");
+            lifecycleManager.stopAndRemove(containerId, logStream);
+            containerId = null;
+            endpoint = null;
+            logStream = null;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
@@ -131,19 +131,22 @@ public class DynamoDbLocalContainerManager {
     /**
      * Resolves the address Floci dials the backing container on.
      *
-     * <p>In native mode the published port is bound to {@code 127.0.0.1}, so the literal address is
-     * used rather than the shared resolver's {@code localhost}. A host that resolves
-     * {@code localhost} to {@code ::1} first would otherwise dial an address the container never
-     * bound, and startup would time out with the data plane unavailable.
+     * <p>In native mode the published port is bound to {@code 127.0.0.1}, so the literal address
+     * replaces the shared resolver's {@code localhost}. A host that resolves {@code localhost} to
+     * {@code ::1} first would otherwise dial an address the container never bound, and startup
+     * would time out with the data plane unavailable. Only the host is swapped: the port comes
+     * from the resolver, which reads the binding Docker actually made.
      */
     private EndpointInfo resolveEndpoint(ContainerInfo info) {
-        if (containerDetector.isRunningInContainer()) {
-            return info.getEndpoint(DYNAMODB_LOCAL_PORT);
+        EndpointInfo resolved = info.getEndpoint(DYNAMODB_LOCAL_PORT);
+        if (resolved == null) {
+            throw new IllegalStateException(
+                    "DynamoDB local exposed no endpoint on port " + DYNAMODB_LOCAL_PORT);
         }
-        int hostPort = info.publishedHostPort(DYNAMODB_LOCAL_PORT).orElseThrow(
-                () -> new IllegalStateException(
-                        "DynamoDB local was started without a published port on " + DYNAMODB_LOCAL_PORT));
-        return new EndpointInfo(ContainerBuilder.LOOPBACK_HOST_IP, hostPort);
+        if (containerDetector.isRunningInContainer()) {
+            return resolved;
+        }
+        return new EndpointInfo(ContainerBuilder.LOOPBACK_HOST_IP, resolved.port());
     }
 
     private static void waitForReady(EndpointInfo target, int timeoutSeconds) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
@@ -101,13 +101,14 @@ public class DynamoDbLocalContainerManager {
                         "dynamodb", "local", regionResolver.getAccountId(),
                         regionResolver.getDefaultRegion()));
 
-        int configuredPort = ddb.containerHostPort();
         if (containerDetector.isRunningInContainer()) {
             specBuilder.withExposedPort(DYNAMODB_LOCAL_PORT);
-        } else if (configuredPort > 0) {
-            specBuilder.withPortBinding(DYNAMODB_LOCAL_PORT, configuredPort);
         } else {
-            specBuilder.withDynamicPort(DYNAMODB_LOCAL_PORT);
+            // Loopback only. The backing container performs no signature validation and picks its
+            // store straight from the credential scope, so anything that can reach the published
+            // port can read or write any account's tables without going through Floci at all.
+            // Nothing but Floci is meant to dial it.
+            specBuilder.withLoopbackDynamicPort(DYNAMODB_LOCAL_PORT);
         }
 
         ContainerSpec spec = specBuilder.build();

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManager.java
@@ -113,7 +113,7 @@ public class DynamoDbLocalContainerManager {
 
         ContainerSpec spec = specBuilder.build();
         ContainerInfo info = lifecycleManager.createAndStart(spec);
-        EndpointInfo resolved = info.getEndpoint(DYNAMODB_LOCAL_PORT);
+        EndpointInfo resolved = resolveEndpoint(info);
         containerId = info.containerId();
 
         String shortId = info.containerId().length() >= 8
@@ -126,6 +126,24 @@ public class DynamoDbLocalContainerManager {
         waitForReady(resolved, ddb.containerStartupTimeoutSeconds());
         LOG.infov("DynamoDB local container ready on {0}", resolved);
         return resolved;
+    }
+
+    /**
+     * Resolves the address Floci dials the backing container on.
+     *
+     * <p>In native mode the published port is bound to {@code 127.0.0.1}, so the literal address is
+     * used rather than the shared resolver's {@code localhost}. A host that resolves
+     * {@code localhost} to {@code ::1} first would otherwise dial an address the container never
+     * bound, and startup would time out with the data plane unavailable.
+     */
+    private EndpointInfo resolveEndpoint(ContainerInfo info) {
+        if (containerDetector.isRunningInContainer()) {
+            return info.getEndpoint(DYNAMODB_LOCAL_PORT);
+        }
+        int hostPort = info.publishedHostPort(DYNAMODB_LOCAL_PORT).orElseThrow(
+                () -> new IllegalStateException(
+                        "DynamoDB local was started without a published port on " + DYNAMODB_LOCAL_PORT));
+        return new EndpointInfo(ContainerBuilder.LOOPBACK_HOST_IP, hostPort);
     }
 
     private static void waitForReady(EndpointInfo target, int timeoutSeconds) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
@@ -54,15 +54,16 @@ public class DynamoDbStreamPump {
     /**
      * Starts replaying the container stream backing {@code table}.
      */
-    public void register(TableDefinition table, String region, String containerStreamArn) {
-        String key = key(region, table.getTableName());
-        cursors.put(key, new StreamCursor(table, region, containerStreamArn));
+    public void register(String accountId, TableDefinition table, String region,
+                         String containerStreamArn) {
+        String key = key(accountId, region, table.getTableName());
+        cursors.put(key, new StreamCursor(accountId, table, region, containerStreamArn));
         ensurePollerRunning();
         LOG.infov("Pumping DynamoDB container stream for {0} ({1})", table.getTableName(), containerStreamArn);
     }
 
-    public void deregister(String region, String tableName) {
-        cursors.remove(key(region, tableName));
+    public void deregister(String accountId, String region, String tableName) {
+        cursors.remove(key(accountId, region, tableName));
     }
 
     private void ensurePollerRunning() {
@@ -108,7 +109,7 @@ public class DynamoDbStreamPump {
         request.put("ShardIterator", iterator);
         request.put("Limit", BATCH_LIMIT);
 
-        DynamoDbLocalClient.Result result = client.callStreams("GetRecords", request, cursor.region);
+        DynamoDbLocalClient.Result result = client.callStreams(cursor.accountId, "GetRecords", request, cursor.region);
         if (!result.isSuccess()) {
             // A trimmed or expired iterator is recoverable: reopen on the next tick.
             LOG.debugv("GetRecords on the container stream for {0} failed: {1}",
@@ -132,7 +133,7 @@ public class DynamoDbStreamPump {
     private String openIterator(StreamCursor cursor) {
         ObjectNode describe = objectMapper.createObjectNode();
         describe.put("StreamArn", cursor.containerStreamArn);
-        DynamoDbLocalClient.Result described = client.callStreams("DescribeStream", describe, cursor.region);
+        DynamoDbLocalClient.Result described = client.callStreams(cursor.accountId, "DescribeStream", describe, cursor.region);
         if (!described.isSuccess()) {
             return null;
         }
@@ -159,7 +160,7 @@ public class DynamoDbStreamPump {
             iteratorRequest.put("ShardIteratorType", "AFTER_SEQUENCE_NUMBER");
             iteratorRequest.put("SequenceNumber", cursor.lastSequenceNumber);
         }
-        DynamoDbLocalClient.Result opened = client.callStreams("GetShardIterator", iteratorRequest, cursor.region);
+        DynamoDbLocalClient.Result opened = client.callStreams(cursor.accountId, "GetShardIterator", iteratorRequest, cursor.region);
         if (!opened.isSuccess()) {
             return null;
         }
@@ -193,11 +194,14 @@ public class DynamoDbStreamPump {
         }
     }
 
-    private static String key(String region, String tableName) {
-        return region + "/" + tableName;
+    private static String key(String accountId, String region, String tableName) {
+        // Two accounts may hold the same table name in the same region, and the container keeps
+        // their stores apart, so the cursor for one must not displace the other's.
+        return accountId + "/" + region + "/" + tableName;
     }
 
     static final class StreamCursor {
+        private final String accountId;
         private final TableDefinition table;
         private final String region;
         private final String containerStreamArn;
@@ -205,7 +209,9 @@ public class DynamoDbStreamPump {
         /** Last record handed to Floci, so a reopened iterator resumes instead of replaying. */
         private volatile String lastSequenceNumber;
 
-        StreamCursor(TableDefinition table, String region, String containerStreamArn) {
+        StreamCursor(String accountId, TableDefinition table, String region,
+                     String containerStreamArn) {
+            this.accountId = accountId;
             this.table = table;
             this.region = region;
             this.containerStreamArn = containerStreamArn;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
@@ -1,0 +1,200 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Re-emits the backing container's DynamoDB stream into Floci's own {@link DynamoDbStreamService}.
+ *
+ * <p>When the container owns the data plane, Floci no longer sees writes as they happen, so the
+ * before and after images its stream fan-out depends on cannot be captured inline. They cannot be
+ * reconstructed from the forwarded calls either: {@code ReturnValues=ALL_OLD} does not exist on
+ * BatchWriteItem or TransactWriteItems. The container implements the Streams API natively, so this
+ * pump reads it and replays each record through {@code captureEvent}. Everything downstream —
+ * Lambda event source mappings, EventBridge Pipes, {@code GetRecords} against Floci — keeps working
+ * unchanged and still honours the caller's own StreamViewType.
+ */
+@ApplicationScoped
+public class DynamoDbStreamPump {
+
+    private static final Logger LOG = Logger.getLogger(DynamoDbStreamPump.class);
+
+    private static final long POLL_INTERVAL_MS = 500;
+    private static final int BATCH_LIMIT = 100;
+
+    private final DynamoDbLocalClient client;
+    private final DynamoDbStreamService streamService;
+    private final ObjectMapper objectMapper;
+
+    private final Map<String, StreamCursor> cursors = new ConcurrentHashMap<>();
+    private final Object lifecycleLock = new Object();
+    private volatile ScheduledExecutorService poller;
+
+    @Inject
+    public DynamoDbStreamPump(DynamoDbLocalClient client,
+                              DynamoDbStreamService streamService,
+                              ObjectMapper objectMapper) {
+        this.client = client;
+        this.streamService = streamService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Starts replaying the container stream backing {@code table}.
+     */
+    public void register(TableDefinition table, String region, String containerStreamArn) {
+        String key = key(region, table.getTableName());
+        cursors.put(key, new StreamCursor(table, region, containerStreamArn));
+        ensurePollerRunning();
+        LOG.infov("Pumping DynamoDB container stream for {0} ({1})", table.getTableName(), containerStreamArn);
+    }
+
+    public void deregister(String region, String tableName) {
+        cursors.remove(key(region, tableName));
+    }
+
+    private void ensurePollerRunning() {
+        if (poller != null) {
+            return;
+        }
+        synchronized (lifecycleLock) {
+            if (poller != null) {
+                return;
+            }
+            ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+                Thread thread = new Thread(runnable, "ddb-container-stream-pump");
+                thread.setDaemon(true);
+                return thread;
+            });
+            executor.scheduleWithFixedDelay(
+                    this::drainAll, POLL_INTERVAL_MS, POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+            poller = executor;
+        }
+    }
+
+    private void drainAll() {
+        for (StreamCursor cursor : cursors.values()) {
+            try {
+                drain(cursor);
+            } catch (RuntimeException e) {
+                // One bad table must not stop the others; the next tick retries.
+                LOG.debugv(e, "DynamoDB container stream pump failed for {0}", cursor.table.getTableName());
+            }
+        }
+    }
+
+    private void drain(StreamCursor cursor) {
+        String iterator = cursor.shardIterator;
+        if (iterator == null) {
+            iterator = openIterator(cursor);
+            if (iterator == null) {
+                return;
+            }
+        }
+
+        ObjectNode request = objectMapper.createObjectNode();
+        request.put("ShardIterator", iterator);
+        request.put("Limit", BATCH_LIMIT);
+
+        DynamoDbLocalClient.Result result = client.callStreams("GetRecords", request, cursor.region);
+        if (!result.isSuccess()) {
+            // A trimmed or expired iterator is recoverable: reopen on the next tick.
+            LOG.debugv("GetRecords on the container stream for {0} failed: {1}",
+                    cursor.table.getTableName(), result.errorCode());
+            cursor.shardIterator = null;
+            return;
+        }
+
+        for (JsonNode record : result.body().path("Records")) {
+            replay(cursor, record);
+        }
+
+        JsonNode next = result.body().get("NextShardIterator");
+        cursor.shardIterator = next != null && next.isTextual() ? next.asText() : null;
+    }
+
+    private String openIterator(StreamCursor cursor) {
+        ObjectNode describe = objectMapper.createObjectNode();
+        describe.put("StreamArn", cursor.containerStreamArn);
+        DynamoDbLocalClient.Result described = client.callStreams("DescribeStream", describe, cursor.region);
+        if (!described.isSuccess()) {
+            return null;
+        }
+        JsonNode shards = described.body().path("StreamDescription").path("Shards");
+        if (!shards.isArray() || shards.isEmpty()) {
+            return null;
+        }
+        String shardId = shards.get(shards.size() - 1).path("ShardId").asText(null);
+        if (shardId == null) {
+            return null;
+        }
+
+        ObjectNode iteratorRequest = objectMapper.createObjectNode();
+        iteratorRequest.put("StreamArn", cursor.containerStreamArn);
+        iteratorRequest.put("ShardId", shardId);
+        // TRIM_HORIZON, not LATEST: the table is registered at CreateTable, so starting at the
+        // oldest record cannot replay writes that predate Floci knowing about the table.
+        iteratorRequest.put("ShardIteratorType", "TRIM_HORIZON");
+        DynamoDbLocalClient.Result opened = client.callStreams("GetShardIterator", iteratorRequest, cursor.region);
+        if (!opened.isSuccess()) {
+            return null;
+        }
+        String iterator = opened.body().path("ShardIterator").asText(null);
+        cursor.shardIterator = iterator;
+        return iterator;
+    }
+
+    private void replay(StreamCursor cursor, JsonNode record) {
+        String eventName = record.path("eventName").asText(null);
+        if (eventName == null) {
+            return;
+        }
+        JsonNode payload = record.path("dynamodb");
+        JsonNode oldImage = payload.hasNonNull("OldImage") ? payload.get("OldImage") : null;
+        JsonNode newImage = payload.hasNonNull("NewImage") ? payload.get("NewImage") : null;
+        streamService.captureEvent(
+                cursor.table.getTableName(), eventName, oldImage, newImage, cursor.table, cursor.region);
+    }
+
+    /**
+     * Stops polling. Safe to call when nothing was ever registered.
+     */
+    public void stopAll() {
+        synchronized (lifecycleLock) {
+            cursors.clear();
+            if (poller != null) {
+                poller.shutdownNow();
+                poller = null;
+            }
+        }
+    }
+
+    private static String key(String region, String tableName) {
+        return region + "/" + tableName;
+    }
+
+    private static final class StreamCursor {
+        private final TableDefinition table;
+        private final String region;
+        private final String containerStreamArn;
+        private volatile String shardIterator;
+
+        private StreamCursor(TableDefinition table, String region, String containerStreamArn) {
+            this.table = table;
+            this.region = region;
+            this.containerStreamArn = containerStreamArn;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
@@ -95,7 +95,7 @@ public class DynamoDbStreamPump {
         }
     }
 
-    private void drain(StreamCursor cursor) {
+    void drain(StreamCursor cursor) {
         String iterator = cursor.shardIterator;
         if (iterator == null) {
             iterator = openIterator(cursor);
@@ -119,6 +119,10 @@ public class DynamoDbStreamPump {
 
         for (JsonNode record : result.body().path("Records")) {
             replay(cursor, record);
+            String sequenceNumber = record.path("dynamodb").path("SequenceNumber").asText(null);
+            if (sequenceNumber != null) {
+                cursor.lastSequenceNumber = sequenceNumber;
+            }
         }
 
         JsonNode next = result.body().get("NextShardIterator");
@@ -144,9 +148,17 @@ public class DynamoDbStreamPump {
         ObjectNode iteratorRequest = objectMapper.createObjectNode();
         iteratorRequest.put("StreamArn", cursor.containerStreamArn);
         iteratorRequest.put("ShardId", shardId);
-        // TRIM_HORIZON, not LATEST: the table is registered at CreateTable, so starting at the
-        // oldest record cannot replay writes that predate Floci knowing about the table.
-        iteratorRequest.put("ShardIteratorType", "TRIM_HORIZON");
+        if (cursor.lastSequenceNumber == null) {
+            // TRIM_HORIZON, not LATEST: the table is registered at CreateTable, so starting at the
+            // oldest record cannot replay writes that predate Floci knowing about the table.
+            iteratorRequest.put("ShardIteratorType", "TRIM_HORIZON");
+        } else {
+            // Reopening after an expired or trimmed iterator. Resuming from the horizon would
+            // replay everything already emitted, and each replayed record is another event source
+            // mapping invocation.
+            iteratorRequest.put("ShardIteratorType", "AFTER_SEQUENCE_NUMBER");
+            iteratorRequest.put("SequenceNumber", cursor.lastSequenceNumber);
+        }
         DynamoDbLocalClient.Result opened = client.callStreams("GetShardIterator", iteratorRequest, cursor.region);
         if (!opened.isSuccess()) {
             return null;
@@ -185,13 +197,15 @@ public class DynamoDbStreamPump {
         return region + "/" + tableName;
     }
 
-    private static final class StreamCursor {
+    static final class StreamCursor {
         private final TableDefinition table;
         private final String region;
         private final String containerStreamArn;
         private volatile String shardIterator;
+        /** Last record handed to Floci, so a reopened iterator resumes instead of replaying. */
+        private volatile String lastSequenceNumber;
 
-        private StreamCursor(TableDefinition table, String region, String containerStreamArn) {
+        StreamCursor(TableDefinition table, String region, String containerStreamArn) {
             this.table = table;
             this.region = region;
             this.containerStreamArn = containerStreamArn;

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPump.java
@@ -22,8 +22,8 @@ import java.util.concurrent.TimeUnit;
  * before and after images its stream fan-out depends on cannot be captured inline. They cannot be
  * reconstructed from the forwarded calls either: {@code ReturnValues=ALL_OLD} does not exist on
  * BatchWriteItem or TransactWriteItems. The container implements the Streams API natively, so this
- * pump reads it and replays each record through {@code captureEvent}. Everything downstream —
- * Lambda event source mappings, EventBridge Pipes, {@code GetRecords} against Floci — keeps working
+ * pump reads it and replays each record through {@code captureEvent}. Everything downstream,
+ * Lambda event source mappings, EventBridge Pipes and {@code GetRecords} against Floci, keeps working
  * unchanged and still honours the caller's own StreamViewType.
  */
 @ApplicationScoped

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -244,14 +244,13 @@ floci:
       global-bucket-namespace: false
     dynamodb:
       enabled: true
-      # FLOCI_SERVICES_DYNAMODB_BACKEND — native (default) keeps Floci's in-process engine.
+      # FLOCI_SERVICES_DYNAMODB_BACKEND: native (default) keeps Floci's in-process engine.
       # container delegates item storage, expressions and PartiQL to an amazon/dynamodb-local
       # container while the control plane (metadata, ARNs, tags, PITR, exports, Kinesis
       # destinations, stream fan-out) stays in Floci. Not a drop-in: the container inherits
       # downloadable DynamoDB's documented divergences, notably case-insensitive table names.
       backend: native
       container-image: "amazon/dynamodb-local:3.3.1"
-      container-host-port: 0                      # 0 = allocate dynamically
       container-startup-timeout-seconds: 60
       # container-docker-network: floci-net       # Empty = default bridge
     sns:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -244,6 +244,16 @@ floci:
       global-bucket-namespace: false
     dynamodb:
       enabled: true
+      # FLOCI_SERVICES_DYNAMODB_BACKEND — native (default) keeps Floci's in-process engine.
+      # container delegates item storage, expressions and PartiQL to an amazon/dynamodb-local
+      # container while the control plane (metadata, ARNs, tags, PITR, exports, Kinesis
+      # destinations, stream fan-out) stays in Floci. Not a drop-in: the container inherits
+      # downloadable DynamoDB's documented divergences, notably case-insensitive table names.
+      backend: native
+      container-image: "amazon/dynamodb-local:3.3.1"
+      container-host-port: 0                      # 0 = allocate dynamically
+      container-startup-timeout-seconds: 60
+      # container-docker-network: floci-net       # Empty = default bridge
     sns:
       enabled: true
     lambda:

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderLoopbackPortTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderLoopbackPortTest.java
@@ -1,0 +1,37 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.dns.EmbeddedDnsServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ContainerBuilderLoopbackPortTest {
+
+    private final ContainerBuilder builder = new ContainerBuilder(
+            org.mockito.Mockito.mock(EmulatorConfig.class),
+            org.mockito.Mockito.mock(DockerHostResolver.class),
+            org.mockito.Mockito.mock(EmbeddedDnsServer.class));
+
+    @Test
+    void aLoopbackPortBindingPinsTheHostInterface() {
+        ContainerSpec spec = builder.newContainer("amazon/dynamodb-local:3.3.1")
+                .withLoopbackDynamicPort(8000)
+                .build();
+
+        assertEquals(ContainerBuilder.LOOPBACK_HOST_IP, spec.hostIp());
+        assertTrue(spec.hasPortBindings());
+        assertEquals(0, spec.portBindings().get(8000), "0 asks Docker for an ephemeral host port");
+    }
+
+    @Test
+    void anOrdinaryDynamicPortKeepsDockersDefaultOfEveryInterface() {
+        ContainerSpec spec = builder.newContainer("busybox:stable")
+                .withDynamicPort(8000)
+                .build();
+
+        assertNull(spec.hostIp());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -165,7 +165,7 @@ class ContainerLifecycleManagerLabelsTest {
         return new ContainerSpec(
                 "busybox:stable", null, List.of(), null, null, null, Map.of(), List.of(), null,
                 List.of(), List.of(), List.of(), labels, null, false, null, List.of(), null,
-                null, List.of());
+                null, List.of(), null);
     }
 
     private CreateContainerCmd stubCreateContainer() {

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -12,6 +12,8 @@ import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheCont
 import io.github.hectorvent.floci.services.elasticache.container.ElastiCacheMemcachedContainerManager;
 import io.github.hectorvent.floci.services.elasticache.proxy.ElastiCacheProxyManager;
 import io.github.hectorvent.floci.services.docdb.container.DocDbContainerManager;
+import io.github.hectorvent.floci.services.dynamodb.container.DynamoDbLocalContainerManager;
+import io.github.hectorvent.floci.services.dynamodb.container.DynamoDbStreamPump;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import io.github.hectorvent.floci.services.lambda.DynamoDbStreamsEventSourcePoller;
@@ -72,6 +74,8 @@ class EmulatorLifecycleTest {
     @Mock private io.github.hectorvent.floci.services.memorydb.container.MemoryDbContainerManager memoryDbContainerManager;
     @Mock private io.github.hectorvent.floci.services.memorydb.proxy.MemoryDbProxyManager memoryDbProxyManager;
     @Mock private DocDbContainerManager docDbContainerManager;
+    @Mock private DynamoDbLocalContainerManager dynamoDbLocalContainerManager;
+    @Mock private DynamoDbStreamPump dynamoDbStreamPump;
     @Mock private NeptuneContainerManager neptuneContainerManager;
     @Mock private NeptuneProxyManager neptuneProxyManager;
     @Mock private io.github.hectorvent.floci.services.amazonmq.container.RabbitMqManager rabbitMqManager;
@@ -116,7 +120,8 @@ class EmulatorLifecycleTest {
                 elastiCacheContainerManager, elastiCacheMemcachedContainerManager,
                 elastiCacheProxyManager, rdsContainerManager, rdsProxyManager,
                 memoryDbContainerManager, memoryDbProxyManager,
-                docDbContainerManager, neptuneContainerManager, neptuneProxyManager,
+                docDbContainerManager, dynamoDbLocalContainerManager, dynamoDbStreamPump,
+                neptuneContainerManager, neptuneProxyManager,
                 rabbitMqManager, flinkContainerManager, rdsService, elbV2Service, elbClassicService,
                 initializationHooksRunner, sqsPoller, kinesisPoller, dynamodbStreamsPoller,
                 pipesService, ec2MetadataServer, ecrRegistryManager, flociUiManager, initLifecycleState,

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbGsiSortKeyRestartTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbGsiSortKeyRestartTest.java
@@ -45,7 +45,7 @@ class DynamoDbGsiSortKeyRestartTest {
     private DynamoDbJsonHandler handlerFor(StorageBackend<String, TableDefinition> store) {
         DynamoDbService service = new DynamoDbService(
                 store, null, new RegionResolver(REGION, "000000000000"), null, null);
-        return new DynamoDbJsonHandler(service, null, null, mapper);
+        return new DynamoDbJsonHandler(service, null, null, mapper, null);
     }
 
     private ObjectNode createTableWithGsiSortKeyRequest() {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -26,7 +26,7 @@ class DynamoDbJsonHandlerTest {
     void setUp() {
         service = new DynamoDbService(new InMemoryStorage<>());
         mapper = new ObjectMapper();
-        handler = new DynamoDbJsonHandler(service, null, null, mapper);
+        handler = new DynamoDbJsonHandler(service, null, null, mapper, null);
     }
 
     private TableDefinition createUsersTable(String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.dynamodb.container.DynamoDbContainerBackend;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
@@ -333,4 +335,32 @@ class DynamoDbJsonHandlerTest {
         assertEquals("None", reasons.get(0).get("Code").asText());
         assertNull(reasons.get(0).get("Message"), "non failed item must not have a Message field");
     }
+
+    /**
+     * Enum members AWS checks before the table lookup must not degrade to the container's
+     * ordering, which resolves the table first and answers ResourceNotFoundException.
+     */
+    @Test
+    void invalidEnumIsRejectedBeforeForwardingEvenWhenTheTableDoesNotExist() {
+        DynamoDbContainerBackend backend = org.mockito.Mockito.mock(DynamoDbContainerBackend.class);
+        org.mockito.Mockito.when(backend.isEnabled()).thenReturn(true);
+        DynamoDbJsonHandler containerHandler =
+                new DynamoDbJsonHandler(service, null, null, mapper, backend);
+
+        ObjectNode request = mapper.createObjectNode();
+        request.put("TableName", "NoSuchTable");
+        request.set("Item", item("userId", "u1"));
+        request.put("ReturnValues", "NOT_A_VALID_VALUE");
+
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> containerHandler.handle("PutItem", request, "us-east-1"));
+        assertEquals("ValidationException", thrown.getErrorCode());
+        assertTrue(thrown.getMessage().contains("returnValues"), thrown.getMessage());
+
+        // The request must never have reached the container.
+        org.mockito.Mockito.verify(backend, org.mockito.Mockito.never())
+                .forwardIfDataPlane(org.mockito.ArgumentMatchers.any(),
+                        org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamViewTypeDurabilityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbStreamViewTypeDurabilityTest.java
@@ -46,7 +46,7 @@ class DynamoDbStreamViewTypeDurabilityTest {
                                            DynamoDbStreamService streams) {
         DynamoDbService service = new DynamoDbService(
                 store, null, new RegionResolver(REGION, "000000000000"), streams, null);
-        return new DynamoDbJsonHandler(service, streams, null, mapper);
+        return new DynamoDbJsonHandler(service, streams, null, mapper, null);
     }
 
     private ObjectNode createTableRequest(String viewType) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -1,0 +1,172 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DynamoDbContainerBackendTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final DynamoDbLocalClient client = mock(DynamoDbLocalClient.class);
+    private final DynamoDbStreamPump streamPump = mock(DynamoDbStreamPump.class);
+
+    private DynamoDbContainerBackend backendWith(String configured) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.DynamoDbServiceConfig ddb = mock(EmulatorConfig.DynamoDbServiceConfig.class);
+        lenient().when(config.services()).thenReturn(services);
+        lenient().when(services.dynamodb()).thenReturn(ddb);
+        lenient().when(ddb.backend()).thenReturn(configured);
+        return new DynamoDbContainerBackend(config, client, streamPump, MAPPER);
+    }
+
+    private static TableDefinition table(String name) {
+        TableDefinition definition = new TableDefinition();
+        definition.setTableName(name);
+        return definition;
+    }
+
+    @Test
+    void isEnabledOnlyForTheContainerBackend() {
+        assertTrue(backendWith("container").isEnabled());
+        assertTrue(backendWith("CONTAINER").isEnabled(), "the backend name is case-insensitive");
+        assertFalse(backendWith("native").isEnabled());
+    }
+
+    @Test
+    void controlPlaneActionsAreNotForwarded() {
+        DynamoDbContainerBackend backend = backendWith("container");
+
+        // These are exactly the actions DynamoDB local cannot serve, so Floci must keep them.
+        for (String action : new String[]{
+                "CreateTable", "DescribeTable", "ListTables", "TagResource", "ListTagsOfResource",
+                "UpdateContinuousBackups", "ExportTableToPointInTime",
+                "EnableKinesisStreamingDestination"}) {
+            assertNull(backend.forwardIfDataPlane(action, MAPPER.createObjectNode(), "us-east-1"),
+                    action + " must stay in Floci");
+        }
+        verify(client, never()).call(any(), any(), any());
+    }
+
+    @Test
+    void dataPlaneActionsAreForwardedVerbatimIncludingErrors() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.validate#ValidationException");
+        error.put("message", "The provided expression refers to an attribute that does not exist");
+        when(client.call(eq("UpdateItem"), any(), eq("us-east-1")))
+                .thenReturn(new DynamoDbLocalClient.Result(400, error));
+
+        Response response = backend.forwardIfDataPlane("UpdateItem", MAPPER.createObjectNode(), "us-east-1");
+
+        // The container's status and body are the point of routing here: they must not be rewritten.
+        assertEquals(400, response.getStatus());
+        assertEquals(error, response.getEntity());
+    }
+
+    @Test
+    void createTableMirrorDropsMembersDynamoDbLocalRejects() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        when(client.call(eq("CreateTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+        request.putArray("Tags").addObject().put("Key", "env").put("Value", "dev");
+        request.putObject("SSESpecification").put("Enabled", true);
+        request.put("TableClass", "STANDARD_INFREQUENT_ACCESS");
+        request.put("DeletionProtectionEnabled", true);
+
+        backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users"));
+
+        ArgumentCaptor<JsonNode> mirrored = ArgumentCaptor.forClass(JsonNode.class);
+        verify(client).call(eq("CreateTable"), mirrored.capture(), eq("us-east-1"));
+        JsonNode sent = mirrored.getValue();
+        assertEquals("Users", sent.path("TableName").asText());
+        assertFalse(sent.has("Tags"), "Floci serves tags; DynamoDB local rejects them");
+        assertFalse(sent.has("SSESpecification"));
+        assertFalse(sent.has("TableClass"));
+        assertFalse(sent.has("DeletionProtectionEnabled"));
+        // The caller's request must not be mutated — Floci still answers DescribeTable from it.
+        assertTrue(request.has("Tags"));
+    }
+
+    @Test
+    void mirroredStreamAlwaysCarriesBothImagesAndRegistersThePump() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode created = MAPPER.createObjectNode();
+        created.putObject("TableDescription").put("LatestStreamArn", "arn:stream/1");
+        when(client.call(eq("CreateTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, created));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+        request.putObject("StreamSpecification")
+                .put("StreamEnabled", true)
+                .put("StreamViewType", "KEYS_ONLY");
+
+        TableDefinition definition = table("Users");
+        backend.mirrorControlPlane("CreateTable", request, "us-east-1", definition);
+
+        ArgumentCaptor<JsonNode> mirrored = ArgumentCaptor.forClass(JsonNode.class);
+        verify(client).call(eq("CreateTable"), mirrored.capture(), eq("us-east-1"));
+        // KEYS_ONLY would starve the pump of the images Floci needs to re-emit; it widens the
+        // mirror and narrows again in DynamoDbStreamService.captureEvent.
+        assertEquals("NEW_AND_OLD_IMAGES",
+                mirrored.getValue().path("StreamSpecification").path("StreamViewType").asText());
+        verify(streamPump).register(definition, "us-east-1", "arn:stream/1");
+        assertTrue(backend.isMirrored("us-east-1", "Users"));
+    }
+
+    @Test
+    void deleteTableDeregistersThePumpEvenWhenTheContainerHasNoSuchTable() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode notFound = MAPPER.createObjectNode();
+        notFound.put("__type", "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(400, notFound));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        backend.mirrorControlPlane("DeleteTable", request, "us-east-1", null);
+
+        verify(streamPump).deregister("us-east-1", "Users");
+    }
+
+    @Test
+    void aRejectedCreateTableMirrorSurfacesRatherThanLeavingASilentlyBrokenTable() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.validate#ValidationException");
+        error.put("message", "Invalid table/index name.");
+        when(client.call(eq("CreateTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(400, error));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        IllegalStateException thrown = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users")));
+        assertTrue(thrown.getMessage().contains("ValidationException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ class DynamoDbContainerBackendTest {
     private static final String ACCOUNT = "000000000000";
 
     private final RegionResolver regionResolver = mock(RegionResolver.class);
+    private final DynamoDbService dynamoDbService = mock(DynamoDbService.class);
 
     private DynamoDbContainerBackend backendWith(String configured) {
         return backendWith(configured, ACCOUNT);
@@ -49,7 +51,8 @@ class DynamoDbContainerBackendTest {
         lenient().when(services.dynamodb()).thenReturn(ddb);
         lenient().when(ddb.backend()).thenReturn(configured);
         lenient().when(regionResolver.getAccountId()).thenReturn(accountId);
-        return new DynamoDbContainerBackend(config, client, streamPump, MAPPER, regionResolver);
+        return new DynamoDbContainerBackend(
+                config, client, streamPump, MAPPER, regionResolver, dynamoDbService);
     }
 
     private static TableDefinition table(String name) {
@@ -227,76 +230,6 @@ class DynamoDbContainerBackendTest {
 
 
     @Test
-    void afterAFailedDropForwardedReadsAreRefusedRatherThanServingTheOldGeneration() {
-        DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode error = MAPPER.createObjectNode();
-        error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(500, error));
-
-        ObjectNode deleteRequest = MAPPER.createObjectNode();
-        deleteRequest.put("TableName", "Users");
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
-
-        // Floci's metadata says the table is gone. A forwarded read must agree, not answer from
-        // the container copy the drop failed to remove.
-        ObjectNode read = MAPPER.createObjectNode();
-        read.put("TableName", "Users");
-        AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
-                () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
-        assertEquals("ResourceNotFoundException", thrown.getErrorCode());
-        verify(client, never()).call(eq("GetItem"), any(), any());
-    }
-
-    @Test
-    void anOrphanedTableIsForwardedAgainOnceTheDropFinallySucceeds() {
-        DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode error = MAPPER.createObjectNode();
-        error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(500, error))
-                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
-        when(client.call(eq("GetItem"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
-
-        ObjectNode deleteRequest = MAPPER.createObjectNode();
-        deleteRequest.put("TableName", "Users");
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
-
-        // The retry succeeds, so the table is genuinely gone and the container can answer.
-        ObjectNode read = MAPPER.createObjectNode();
-        read.put("TableName", "Users");
-        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
-    }
-
-    @Test
-    void orphanCheckSeesTablesNamedByBatchAndTransactRequests() {
-        DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode error = MAPPER.createObjectNode();
-        error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(500, error));
-
-        ObjectNode deleteRequest = MAPPER.createObjectNode();
-        deleteRequest.put("TableName", "Users");
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
-
-        ObjectNode batch = MAPPER.createObjectNode();
-        batch.putObject("RequestItems").putObject("Users");
-        org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
-                () -> backend.forwardIfDataPlane("BatchGetItem", batch, "us-east-1"));
-
-        ObjectNode transact = MAPPER.createObjectNode();
-        transact.putArray("TransactItems").addObject().putObject("Put").put("TableName", "Users");
-        org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
-                () -> backend.forwardIfDataPlane("TransactWriteItems", transact, "us-east-1"));
-    }
-
-
-    @Test
     void partiqlIsRefusedWhileAnyTableIsOrphaned() {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
@@ -381,14 +314,14 @@ class DynamoDbContainerBackendTest {
     }
 
     @Test
-    void theOrphanRetryIsIssuedUnderTheAccountThatOwnsTheTable() {
+    void theOutstandingDropRetryIsIssuedUnderTheAccountThatOwnsTheTable() {
         DynamoDbContainerBackend backend = backendWith("container", "111111111111");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
         when(client.call(eq("111111111111"), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
-        when(client.call(eq("GetItem"), any(), any()))
+        when(client.call(eq("ExecuteStatement"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
 
         ObjectNode deleteRequest = MAPPER.createObjectNode();
@@ -396,78 +329,28 @@ class DynamoDbContainerBackendTest {
         org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
                 () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
 
-        ObjectNode read = MAPPER.createObjectNode();
-        read.put("TableName", "Users");
-        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
+        // PartiQL is the path that retries the outstanding drop, and the retry must carry the
+        // account that owns the table rather than whoever happens to be calling.
+        ObjectNode statement = MAPPER.createObjectNode();
+        statement.put("Statement", "SELECT * FROM \"Users\"");
+        assertEquals(200,
+                backend.forwardIfDataPlane("ExecuteStatement", statement, "us-east-1").getStatus());
 
-        // Both the original drop and the retry carried the owning account.
         verify(client, times(2)).call(eq("111111111111"), eq("DeleteTable"), any(), eq("us-east-1"));
     }
 
-
     @Test
-    void aReadArrivingWhileTheDropIsInFlightIsRefusedNotForwarded() {
+    void aForwardForATableFlociDoesNotKnowIsRefusedAndNeverReachesTheContainer() {
         DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode error = MAPPER.createObjectNode();
-        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        // Floci deleted the table. Whether the container still holds it is irrelevant: the control
+        // plane is the authority, so the read must not be served from it.
+        when(dynamoDbService.describeTable(eq("Users"), eq("us-east-1")))
+                .thenThrow(new AwsException("ResourceNotFoundException",
+                        "Requested resource not found", 400));
+
         ObjectNode read = MAPPER.createObjectNode();
         read.put("TableName", "Users");
 
-        // The stub answers the container's DeleteTable by re-entering the backend, standing in for
-        // a read that arrives after Floci dropped its metadata but before the drop comes back.
-        // Marking only on failure would leave orphanedTables empty at this point and forward it.
-        AwsException[] seen = new AwsException[1];
-        boolean[] reentered = {false};
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any())).thenAnswer(invocation -> {
-            // Guard set before the nested call: the read retries the drop, which re-enters here.
-            if (!reentered[0]) {
-                reentered[0] = true;
-                seen[0] = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
-                        () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
-            }
-            return new DynamoDbLocalClient.Result(500, error);
-        });
-
-        ObjectNode deleteRequest = MAPPER.createObjectNode();
-        deleteRequest.put("TableName", "Users");
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
-
-        assertEquals("ResourceNotFoundException", seen[0].getErrorCode());
-        verify(client, never()).call(eq("GetItem"), any(), any());
-    }
-
-    @Test
-    void theMarkerIsClearedOnceTheDropSucceeds() {
-        DynamoDbContainerBackend backend = backendWith("container");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
-        when(client.call(eq("GetItem"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
-
-        ObjectNode deleteRequest = MAPPER.createObjectNode();
-        deleteRequest.put("TableName", "Users");
-        backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null);
-
-        // The table is genuinely gone, so the container may answer for itself again.
-        ObjectNode read = MAPPER.createObjectNode();
-        read.put("TableName", "Users");
-        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
-    }
-
-
-    @Test
-    void beginDeleteRefusesForwardsBeforeFlociHasDroppedItsOwnCopy() {
-        DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode request = MAPPER.createObjectNode();
-        request.put("TableName", "Users");
-
-        assertNotNull(backend.beginDelete(request, "us-east-1"));
-
-        ObjectNode read = MAPPER.createObjectNode();
-        read.put("TableName", "Users");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(500, MAPPER.createObjectNode()));
         AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
                 () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
         assertEquals("ResourceNotFoundException", thrown.getErrorCode());
@@ -475,69 +358,38 @@ class DynamoDbContainerBackendTest {
     }
 
     @Test
-    void abandonDeleteRestoresForwardingWhenFlociRejectsTheDelete() {
+    void aForwardForATableFlociKnowsProceeds() {
         DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode request = MAPPER.createObjectNode();
-        request.put("TableName", "Users");
         when(client.call(eq("GetItem"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
 
-        String marker = backend.beginDelete(request, "us-east-1");
-        assertNotNull(marker);
-        // Floci refused the delete, for instance deletion protection, so the table still exists.
-        backend.abandonDelete(request, "us-east-1", marker);
-
         ObjectNode read = MAPPER.createObjectNode();
         read.put("TableName", "Users");
+
         assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
     }
 
     @Test
-    void beginDeleteDoesNotClaimAMarkerLeftByAnEarlierFailedDrop() {
+    void theMetadataCheckCoversEveryTableABatchOrTransactNames() {
         DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode error = MAPPER.createObjectNode();
-        error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+        when(dynamoDbService.describeTable(eq("Gone"), eq("us-east-1")))
+                .thenThrow(new AwsException("ResourceNotFoundException",
+                        "Requested resource not found", 400));
 
-        ObjectNode deleteRequest = MAPPER.createObjectNode();
-        deleteRequest.put("TableName", "Users");
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+        ObjectNode batch = MAPPER.createObjectNode();
+        ObjectNode items = batch.putObject("RequestItems");
+        items.putObject("Users");
+        items.putObject("Gone");
+        org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("BatchGetItem", batch, "us-east-1"));
 
-        // A second DeleteTable that Floci rejects must not clear the genuine orphan, so its
-        // abandon is never invoked: beginDelete reports it did not install the marker.
-        assertNull(backend.beginDelete(deleteRequest, "us-east-1"));
-    }
+        ObjectNode transact = MAPPER.createObjectNode();
+        transact.putArray("TransactItems").addObject().putObject("Put").put("TableName", "Gone");
+        org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("TransactWriteItems", transact, "us-east-1"));
 
-
-    @Test
-    void anUnwindDoesNotWithdrawAnOrphanConfirmedByAConcurrentDelete() {
-        DynamoDbContainerBackend backend = backendWith("container");
-        ObjectNode request = MAPPER.createObjectNode();
-        request.put("TableName", "Users");
-
-        // Request A marks first, then loses the race to delete Floci's copy.
-        String markerA = backend.beginDelete(request, "us-east-1");
-        assertNotNull(markerA);
-
-        // Request B wins, deletes Floci's copy, and its container drop fails: a genuine orphan.
-        ObjectNode error = MAPPER.createObjectNode();
-        error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
-                .thenReturn(new DynamoDbLocalClient.Result(500, error));
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
-                () -> backend.mirrorControlPlane("DeleteTable", request, "us-east-1", null));
-
-        // A now unwinds. It must not take B's orphan with it.
-        backend.abandonDelete(request, "us-east-1", markerA);
-
-        ObjectNode read = MAPPER.createObjectNode();
-        read.put("TableName", "Users");
-        AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
-                () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
-        assertEquals("ResourceNotFoundException", thrown.getErrorCode());
-        verify(client, never()).call(eq("GetItem"), any(), any());
+        verify(client, never()).call(eq("BatchGetItem"), any(), any());
+        verify(client, never()).call(eq("TransactWriteItems"), any(), any());
     }
 
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -30,14 +31,23 @@ class DynamoDbContainerBackendTest {
     private final DynamoDbLocalClient client = mock(DynamoDbLocalClient.class);
     private final DynamoDbStreamPump streamPump = mock(DynamoDbStreamPump.class);
 
+    private static final String ACCOUNT = "000000000000";
+
+    private final RegionResolver regionResolver = mock(RegionResolver.class);
+
     private DynamoDbContainerBackend backendWith(String configured) {
+        return backendWith(configured, ACCOUNT);
+    }
+
+    private DynamoDbContainerBackend backendWith(String configured, String accountId) {
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
         EmulatorConfig.DynamoDbServiceConfig ddb = mock(EmulatorConfig.DynamoDbServiceConfig.class);
         lenient().when(config.services()).thenReturn(services);
         lenient().when(services.dynamodb()).thenReturn(ddb);
         lenient().when(ddb.backend()).thenReturn(configured);
-        return new DynamoDbContainerBackend(config, client, streamPump, MAPPER);
+        lenient().when(regionResolver.getAccountId()).thenReturn(accountId);
+        return new DynamoDbContainerBackend(config, client, streamPump, MAPPER, regionResolver);
     }
 
     private static TableDefinition table(String name) {
@@ -134,7 +144,7 @@ class DynamoDbContainerBackendTest {
         // mirror and narrows again in DynamoDbStreamService.captureEvent.
         assertEquals("NEW_AND_OLD_IMAGES",
                 mirrored.getValue().path("StreamSpecification").path("StreamViewType").asText());
-        verify(streamPump).register(definition, "us-east-1", "arn:stream/1");
+        verify(streamPump).register(ACCOUNT, definition, "us-east-1", "arn:stream/1");
         assertTrue(backend.isMirrored("us-east-1", "Users"));
     }
 
@@ -143,7 +153,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode notFound = MAPPER.createObjectNode();
         notFound.put("__type", "com.amazonaws.dynamodb.v20120810#ResourceNotFoundException");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(400, notFound));
 
         ObjectNode request = MAPPER.createObjectNode();
@@ -151,7 +161,7 @@ class DynamoDbContainerBackendTest {
 
         backend.mirrorControlPlane("DeleteTable", request, "us-east-1", null);
 
-        verify(streamPump).deregister("us-east-1", "Users");
+        verify(streamPump).deregister(ACCOUNT, "us-east-1", "Users");
     }
 
     @Test
@@ -178,7 +188,7 @@ class DynamoDbContainerBackendTest {
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
         error.put("message", "boom");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error));
 
         ObjectNode request = MAPPER.createObjectNode();
@@ -200,7 +210,7 @@ class DynamoDbContainerBackendTest {
         when(client.call(eq("CreateTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(400, inUse))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
 
         ObjectNode request = MAPPER.createObjectNode();
@@ -209,7 +219,7 @@ class DynamoDbContainerBackendTest {
         backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users"));
 
         // Dropped the previous generation, then created the new one, so no items survive across it.
-        verify(client).call(eq("DeleteTable"), any(), eq("us-east-1"));
+        verify(client).call(eq(ACCOUNT), eq("DeleteTable"), any(), eq("us-east-1"));
         verify(client, times(2)).call(eq("CreateTable"), any(), eq("us-east-1"));
     }
 
@@ -219,7 +229,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error));
 
         ObjectNode deleteRequest = MAPPER.createObjectNode();
@@ -242,7 +252,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
         when(client.call(eq("GetItem"), any(), any()))
@@ -264,7 +274,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error));
 
         ObjectNode deleteRequest = MAPPER.createObjectNode();
@@ -289,7 +299,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error));
 
         ObjectNode deleteRequest = MAPPER.createObjectNode();
@@ -311,7 +321,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
         when(client.call(eq("ExecuteStatement"), any(), any()))
@@ -333,7 +343,7 @@ class DynamoDbContainerBackendTest {
         DynamoDbContainerBackend backend = backendWith("container");
         ObjectNode error = MAPPER.createObjectNode();
         error.put("__type", "com.amazon.coral.service#InternalFailure");
-        when(client.call(eq("DeleteTable"), any(), any()))
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(500, error));
         when(client.call(eq("ExecuteStatement"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
@@ -347,6 +357,49 @@ class DynamoDbContainerBackendTest {
         statement.put("Statement", "SELECT * FROM \"Users\"");
         assertEquals(200,
                 backend.forwardIfDataPlane("ExecuteStatement", statement, "eu-west-1").getStatus());
+    }
+
+
+    @Test
+    void anOrphanFromOneAccountNeitherBlocksNorDropsAnotherAccountsTable() {
+        // Account A's drop fails, leaving an orphan.
+        DynamoDbContainerBackend accountA = backendWith("container", "111111111111");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("111111111111"), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> accountA.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        // The retry must never be issued under another account: that would drop a live table.
+        verify(client, never()).call(eq("222222222222"), eq("DeleteTable"), any(), any());
+    }
+
+    @Test
+    void theOrphanRetryIsIssuedUnderTheAccountThatOwnsTheTable() {
+        DynamoDbContainerBackend backend = backendWith("container", "111111111111");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("111111111111"), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+        when(client.call(eq("GetItem"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
+
+        // Both the original drop and the retry carried the owning account.
+        verify(client, times(2)).call(eq("111111111111"), eq("DeleteTable"), any(), eq("us-east-1"));
     }
 
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -283,4 +283,70 @@ class DynamoDbContainerBackendTest {
                 () -> backend.forwardIfDataPlane("TransactWriteItems", transact, "us-east-1"));
     }
 
+
+    @Test
+    void partiqlIsRefusedWhileAnyTableIsOrphaned() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        // The table name lives in the statement text, so per-table matching cannot see it.
+        ObjectNode statement = MAPPER.createObjectNode();
+        statement.put("Statement", "SELECT * FROM \"Users\" WHERE pk = 'a'");
+        AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("ExecuteStatement", statement, "us-east-1"));
+        assertEquals("ResourceNotFoundException", thrown.getErrorCode());
+        verify(client, never()).call(eq("ExecuteStatement"), any(), any());
+    }
+
+    @Test
+    void partiqlFlowsAgainOnceTheOutstandingDropSucceeds() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+        when(client.call(eq("ExecuteStatement"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        ObjectNode statement = MAPPER.createObjectNode();
+        statement.put("Statement", "SELECT * FROM \"Other\"");
+        assertEquals(200,
+                backend.forwardIfDataPlane("ExecuteStatement", statement, "us-east-1").getStatus());
+    }
+
+    @Test
+    void anOrphanInAnotherRegionDoesNotBlockPartiql() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+        when(client.call(eq("ExecuteStatement"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        ObjectNode statement = MAPPER.createObjectNode();
+        statement.put("Statement", "SELECT * FROM \"Users\"");
+        assertEquals(200,
+                backend.forwardIfDataPlane("ExecuteStatement", statement, "eu-west-1").getStatus());
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -453,4 +453,58 @@ class DynamoDbContainerBackendTest {
         assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
     }
 
+
+    @Test
+    void beginDeleteRefusesForwardsBeforeFlociHasDroppedItsOwnCopy() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        assertTrue(backend.beginDelete(request, "us-east-1"));
+
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, MAPPER.createObjectNode()));
+        AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
+        assertEquals("ResourceNotFoundException", thrown.getErrorCode());
+        verify(client, never()).call(eq("GetItem"), any(), any());
+    }
+
+    @Test
+    void abandonDeleteRestoresForwardingWhenFlociRejectsTheDelete() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+        when(client.call(eq("GetItem"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        assertTrue(backend.beginDelete(request, "us-east-1"));
+        // Floci refused the delete, for instance deletion protection, so the table still exists.
+        backend.abandonDelete(request, "us-east-1");
+
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
+    }
+
+    @Test
+    void beginDeleteDoesNotClaimAMarkerLeftByAnEarlierFailedDrop() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        // A second DeleteTable that Floci rejects must not clear the genuine orphan, so its
+        // abandon is never invoked: beginDelete reports it did not install the marker.
+        assertFalse(backend.beginDelete(deleteRequest, "us-east-1"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -13,6 +13,8 @@ import org.mockito.ArgumentCaptor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -460,7 +462,7 @@ class DynamoDbContainerBackendTest {
         ObjectNode request = MAPPER.createObjectNode();
         request.put("TableName", "Users");
 
-        assertTrue(backend.beginDelete(request, "us-east-1"));
+        assertNotNull(backend.beginDelete(request, "us-east-1"));
 
         ObjectNode read = MAPPER.createObjectNode();
         read.put("TableName", "Users");
@@ -480,9 +482,10 @@ class DynamoDbContainerBackendTest {
         when(client.call(eq("GetItem"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
 
-        assertTrue(backend.beginDelete(request, "us-east-1"));
+        String marker = backend.beginDelete(request, "us-east-1");
+        assertNotNull(marker);
         // Floci refused the delete, for instance deletion protection, so the table still exists.
-        backend.abandonDelete(request, "us-east-1");
+        backend.abandonDelete(request, "us-east-1", marker);
 
         ObjectNode read = MAPPER.createObjectNode();
         read.put("TableName", "Users");
@@ -504,7 +507,37 @@ class DynamoDbContainerBackendTest {
 
         // A second DeleteTable that Floci rejects must not clear the genuine orphan, so its
         // abandon is never invoked: beginDelete reports it did not install the marker.
-        assertFalse(backend.beginDelete(deleteRequest, "us-east-1"));
+        assertNull(backend.beginDelete(deleteRequest, "us-east-1"));
+    }
+
+
+    @Test
+    void anUnwindDoesNotWithdrawAnOrphanConfirmedByAConcurrentDelete() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        // Request A marks first, then loses the race to delete Floci's copy.
+        String markerA = backend.beginDelete(request, "us-east-1");
+        assertNotNull(markerA);
+
+        // Request B wins, deletes Floci's copy, and its container drop fails: a genuine orphan.
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", request, "us-east-1", null));
+
+        // A now unwinds. It must not take B's orphan with it.
+        backend.abandonDelete(request, "us-east-1", markerA);
+
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
+        assertEquals("ResourceNotFoundException", thrown.getErrorCode());
+        verify(client, never()).call(eq("GetItem"), any(), any());
     }
 
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
@@ -210,6 +211,76 @@ class DynamoDbContainerBackendTest {
         // Dropped the previous generation, then created the new one, so no items survive across it.
         verify(client).call(eq("DeleteTable"), any(), eq("us-east-1"));
         verify(client, times(2)).call(eq("CreateTable"), any(), eq("us-east-1"));
+    }
+
+
+    @Test
+    void afterAFailedDropForwardedReadsAreRefusedRatherThanServingTheOldGeneration() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        // Floci's metadata says the table is gone. A forwarded read must agree, not answer from
+        // the container copy the drop failed to remove.
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        AwsException thrown = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
+        assertEquals("ResourceNotFoundException", thrown.getErrorCode());
+        verify(client, never()).call(eq("GetItem"), any(), any());
+    }
+
+    @Test
+    void anOrphanedTableIsForwardedAgainOnceTheDropFinallySucceeds() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+        when(client.call(eq("GetItem"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        // The retry succeeds, so the table is genuinely gone and the container can answer.
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
+    }
+
+    @Test
+    void orphanCheckSeesTablesNamedByBatchAndTransactRequests() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        ObjectNode batch = MAPPER.createObjectNode();
+        batch.putObject("RequestItems").putObject("Users");
+        org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("BatchGetItem", batch, "us-east-1"));
+
+        ObjectNode transact = MAPPER.createObjectNode();
+        transact.putArray("TransactItems").addObject().putObject("Put").put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                () -> backend.forwardIfDataPlane("TransactWriteItems", transact, "us-east-1"));
     }
 
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -392,4 +392,46 @@ class DynamoDbContainerBackendTest {
         verify(client, never()).call(eq("TransactWriteItems"), any(), any());
     }
 
+
+    @Test
+    void aFailedCreateMirrorWithdrawsTheTableFlociAlreadyCommitted() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.validate#ValidationException");
+        error.put("message", "nope");
+        when(client.call(eq("CreateTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(400, error));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users")));
+
+        // Forwards are gated on Floci knowing the table, so the metadata must not survive a mirror
+        // it could not establish: otherwise reads land on whatever the container still holds.
+        verify(dynamoDbService).deleteTable("Users", "us-east-1");
+    }
+
+    @Test
+    void aFailedStaleDropDuringRecreateAlsoWithdrawsTheTable() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode inUse = MAPPER.createObjectNode();
+        inUse.put("__type", "com.amazonaws.dynamodb.v20120810#ResourceInUseException");
+        ObjectNode dropError = MAPPER.createObjectNode();
+        dropError.put("__type", "com.amazon.coral.service#InternalFailure");
+        when(client.call(eq("CreateTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(400, inUse));
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, dropError));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users")));
+
+        verify(dynamoDbService).deleteTable("Users", "us-east-1");
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -402,4 +402,55 @@ class DynamoDbContainerBackendTest {
         verify(client, times(2)).call(eq("111111111111"), eq("DeleteTable"), any(), eq("us-east-1"));
     }
 
+
+    @Test
+    void aReadArrivingWhileTheDropIsInFlightIsRefusedNotForwarded() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+
+        // The stub answers the container's DeleteTable by re-entering the backend, standing in for
+        // a read that arrives after Floci dropped its metadata but before the drop comes back.
+        // Marking only on failure would leave orphanedTables empty at this point and forward it.
+        AwsException[] seen = new AwsException[1];
+        boolean[] reentered = {false};
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any())).thenAnswer(invocation -> {
+            // Guard set before the nested call: the read retries the drop, which re-enters here.
+            if (!reentered[0]) {
+                reentered[0] = true;
+                seen[0] = org.junit.jupiter.api.Assertions.assertThrows(AwsException.class,
+                        () -> backend.forwardIfDataPlane("GetItem", read, "us-east-1"));
+            }
+            return new DynamoDbLocalClient.Result(500, error);
+        });
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null));
+
+        assertEquals("ResourceNotFoundException", seen[0].getErrorCode());
+        verify(client, never()).call(eq("GetItem"), any(), any());
+    }
+
+    @Test
+    void theMarkerIsClearedOnceTheDropSucceeds() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        when(client.call(eq(ACCOUNT), eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+        when(client.call(eq("GetItem"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode deleteRequest = MAPPER.createObjectNode();
+        deleteRequest.put("TableName", "Users");
+        backend.mirrorControlPlane("DeleteTable", deleteRequest, "us-east-1", null);
+
+        // The table is genuinely gone, so the container may answer for itself again.
+        ObjectNode read = MAPPER.createObjectNode();
+        read.put("TableName", "Users");
+        assertEquals(200, backend.forwardIfDataPlane("GetItem", read, "us-east-1").getStatus());
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbContainerBackendTest.java
@@ -18,6 +18,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -105,7 +106,7 @@ class DynamoDbContainerBackendTest {
         assertFalse(sent.has("SSESpecification"));
         assertFalse(sent.has("TableClass"));
         assertFalse(sent.has("DeletionProtectionEnabled"));
-        // The caller's request must not be mutated — Floci still answers DescribeTable from it.
+        // The caller's request must not be mutated. Floci still answers DescribeTable from it.
         assertTrue(request.has("Tags"));
     }
 
@@ -169,4 +170,46 @@ class DynamoDbContainerBackendTest {
                 () -> backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users")));
         assertTrue(thrown.getMessage().contains("ValidationException"));
     }
+
+    @Test
+    void aFailedDeleteIsFatalSoDeletedItemsCannotStayReadable() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode error = MAPPER.createObjectNode();
+        error.put("__type", "com.amazon.coral.service#InternalFailure");
+        error.put("message", "boom");
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(500, error));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        // Floci has already dropped its own copy, so a surviving container table would keep the
+        // deleted items reachable through forwarded reads. Failing loudly beats that.
+        IllegalStateException thrown = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> backend.mirrorControlPlane("DeleteTable", request, "us-east-1", null));
+        assertTrue(thrown.getMessage().contains("would stay readable"), thrown.getMessage());
+    }
+
+    @Test
+    void createDropsAStaleContainerTableLeftByAFailedDelete() {
+        DynamoDbContainerBackend backend = backendWith("container");
+        ObjectNode inUse = MAPPER.createObjectNode();
+        inUse.put("__type", "com.amazonaws.dynamodb.v20120810#ResourceInUseException");
+        when(client.call(eq("CreateTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(400, inUse))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+        when(client.call(eq("DeleteTable"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, MAPPER.createObjectNode()));
+
+        ObjectNode request = MAPPER.createObjectNode();
+        request.put("TableName", "Users");
+
+        backend.mirrorControlPlane("CreateTable", request, "us-east-1", table("Users"));
+
+        // Dropped the previous generation, then created the new one, so no items survive across it.
+        verify(client).call(eq("DeleteTable"), any(), eq("us-east-1"));
+        verify(client, times(2)).call(eq("CreateTable"), any(), eq("us-east-1"));
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManagerEndpointTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManagerEndpointTest.java
@@ -1,0 +1,70 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
+import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.ContainerInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager.EndpointInfo;
+import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class DynamoDbLocalContainerManagerEndpointTest {
+
+    private DynamoDbLocalContainerManager managerWith(boolean inContainer) {
+        ContainerDetector detector = mock(ContainerDetector.class);
+        when(detector.isRunningInContainer()).thenReturn(inContainer);
+        return new DynamoDbLocalContainerManager(
+                mock(ContainerBuilder.class),
+                mock(ContainerLifecycleManager.class),
+                mock(ContainerLogStreamer.class),
+                detector,
+                mock(EmulatorConfig.class),
+                mock(RegionResolver.class));
+    }
+
+    private EndpointInfo resolve(DynamoDbLocalContainerManager manager, ContainerInfo info)
+            throws Exception {
+        Method m = DynamoDbLocalContainerManager.class
+                .getDeclaredMethod("resolveEndpoint", ContainerInfo.class);
+        m.setAccessible(true);
+        return (EndpointInfo) m.invoke(manager, info);
+    }
+
+    @Test
+    void nativeModeDialsTheLiteralLoopbackAddressNotLocalhost() throws Exception {
+        // The published port binds 127.0.0.1. A host resolving localhost to ::1 first would
+        // otherwise dial an address the container never bound.
+        ContainerInfo info = new ContainerInfo(
+                "cid",
+                Map.of(8000, new EndpointInfo("localhost", 49153)),
+                Map.of(8000, 49153));
+
+        EndpointInfo resolved = resolve(managerWith(false), info);
+
+        assertEquals(ContainerBuilder.LOOPBACK_HOST_IP, resolved.host());
+        assertEquals(49153, resolved.port());
+    }
+
+    @Test
+    void containerModeKeepsTheDockerNetworkAddress() throws Exception {
+        ContainerInfo info = new ContainerInfo(
+                "cid",
+                Map.of(8000, new EndpointInfo("172.20.0.3", 8000)),
+                Map.of());
+
+        EndpointInfo resolved = resolve(managerWith(true), info);
+
+        assertEquals("172.20.0.3", resolved.host());
+        assertEquals(8000, resolved.port());
+    }
+
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManagerEndpointTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbLocalContainerManagerEndpointTest.java
@@ -43,10 +43,12 @@ class DynamoDbLocalContainerManagerEndpointTest {
     void nativeModeDialsTheLiteralLoopbackAddressNotLocalhost() throws Exception {
         // The published port binds 127.0.0.1. A host resolving localhost to ::1 first would
         // otherwise dial an address the container never bound.
+        // Two arguments, exactly as ContainerLifecycleManager.startCreated builds it: the
+        // publishedHostPorts map is empty for anything createAndStart returns, so the port has to
+        // come from the endpoint rather than that map.
         ContainerInfo info = new ContainerInfo(
                 "cid",
-                Map.of(8000, new EndpointInfo("localhost", 49153)),
-                Map.of(8000, 49153));
+                Map.of(8000, new EndpointInfo("localhost", 49153)));
 
         EndpointInfo resolved = resolve(managerWith(false), info);
 
@@ -58,8 +60,7 @@ class DynamoDbLocalContainerManagerEndpointTest {
     void containerModeKeepsTheDockerNetworkAddress() throws Exception {
         ContainerInfo info = new ContainerInfo(
                 "cid",
-                Map.of(8000, new EndpointInfo("172.20.0.3", 8000)),
-                Map.of());
+                Map.of(8000, new EndpointInfo("172.20.0.3", 8000)));
 
         EndpointInfo resolved = resolve(managerWith(true), info);
 

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPumpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPumpTest.java
@@ -1,0 +1,116 @@
+package io.github.hectorvent.floci.services.dynamodb.container;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DynamoDbStreamPumpTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final DynamoDbLocalClient client = mock(DynamoDbLocalClient.class);
+    private final DynamoDbStreamService streamService = mock(DynamoDbStreamService.class);
+    private final DynamoDbStreamPump pump = new DynamoDbStreamPump(client, streamService, MAPPER);
+
+    private static TableDefinition table() {
+        TableDefinition definition = new TableDefinition();
+        definition.setTableName("Users");
+        return definition;
+    }
+
+    private void stubShardDiscovery() {
+        ObjectNode described = MAPPER.createObjectNode();
+        described.putObject("StreamDescription").putArray("Shards")
+                .addObject().put("ShardId", "shard-1");
+        when(client.callStreams(eq("DescribeStream"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, described));
+
+        ObjectNode opened = MAPPER.createObjectNode();
+        opened.put("ShardIterator", "iterator-1");
+        when(client.callStreams(eq("GetShardIterator"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, opened));
+    }
+
+    private static ObjectNode recordsResponse(String sequenceNumber, String nextIterator) {
+        ObjectNode body = MAPPER.createObjectNode();
+        ObjectNode record = body.putArray("Records").addObject();
+        record.put("eventName", "INSERT");
+        ObjectNode payload = record.putObject("dynamodb");
+        payload.put("SequenceNumber", sequenceNumber);
+        payload.putObject("NewImage").putObject("pk").put("S", "a");
+        if (nextIterator != null) {
+            body.put("NextShardIterator", nextIterator);
+        }
+        return body;
+    }
+
+    @Test
+    void recordsAreReplayedIntoFlociStreamServiceWithBothImages() {
+        stubShardDiscovery();
+        when(client.callStreams(eq("GetRecords"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, recordsResponse("001", "iterator-2")));
+
+        TableDefinition definition = table();
+        pump.drain(new DynamoDbStreamPump.StreamCursor(definition, "us-east-1", "arn:stream/1"));
+
+        ArgumentCaptor<JsonNode> newImage = ArgumentCaptor.forClass(JsonNode.class);
+        verify(streamService).captureEvent(
+                eq("Users"), eq("INSERT"), eq(null), newImage.capture(), eq(definition), eq("us-east-1"));
+        assertEquals("a", newImage.getValue().path("pk").path("S").asText());
+    }
+
+    @Test
+    void aLostIteratorResumesAfterTheLastRecordInsteadOfReplayingTheStream() {
+        stubShardDiscovery();
+        DynamoDbStreamPump.StreamCursor cursor =
+                new DynamoDbStreamPump.StreamCursor(table(), "us-east-1", "arn:stream/1");
+
+        // First drain consumes one record, then the iterator is lost.
+        when(client.callStreams(eq("GetRecords"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(200, recordsResponse("042", null)));
+        pump.drain(cursor);
+
+        // Second drain has to reopen. Resuming at TRIM_HORIZON would re-deliver record 042 and
+        // fire every event source mapping again.
+        pump.drain(cursor);
+
+        ArgumentCaptor<JsonNode> iteratorRequest = ArgumentCaptor.forClass(JsonNode.class);
+        verify(client, times(2)).callStreams(eq("GetShardIterator"), iteratorRequest.capture(), any());
+        JsonNode reopen = iteratorRequest.getAllValues().get(1);
+        assertEquals("AFTER_SEQUENCE_NUMBER", reopen.path("ShardIteratorType").asText());
+        assertEquals("042", reopen.path("SequenceNumber").asText());
+
+        JsonNode first = iteratorRequest.getAllValues().get(0);
+        assertEquals("TRIM_HORIZON", first.path("ShardIteratorType").asText(),
+                "the very first open must not skip writes made before the first poll");
+    }
+
+    @Test
+    void aFailedGetRecordsDropsTheIteratorRatherThanKillingThePump() {
+        stubShardDiscovery();
+        ObjectNode expired = MAPPER.createObjectNode();
+        expired.put("__type", "com.amazonaws.dynamodb.v20120810#ExpiredIteratorException");
+        when(client.callStreams(eq("GetRecords"), any(), any()))
+                .thenReturn(new DynamoDbLocalClient.Result(400, expired));
+
+        DynamoDbStreamPump.StreamCursor cursor =
+                new DynamoDbStreamPump.StreamCursor(table(), "us-east-1", "arn:stream/1");
+        pump.drain(cursor);
+        pump.drain(cursor);
+
+        // Two drains, two reopen attempts: the failure is recoverable, not terminal.
+        verify(client, times(2)).callStreams(eq("GetShardIterator"), any(), any());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPumpTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/container/DynamoDbStreamPumpTest.java
@@ -34,12 +34,12 @@ class DynamoDbStreamPumpTest {
         ObjectNode described = MAPPER.createObjectNode();
         described.putObject("StreamDescription").putArray("Shards")
                 .addObject().put("ShardId", "shard-1");
-        when(client.callStreams(eq("DescribeStream"), any(), any()))
+        when(client.callStreams(eq("000000000000"), eq("DescribeStream"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, described));
 
         ObjectNode opened = MAPPER.createObjectNode();
         opened.put("ShardIterator", "iterator-1");
-        when(client.callStreams(eq("GetShardIterator"), any(), any()))
+        when(client.callStreams(eq("000000000000"), eq("GetShardIterator"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, opened));
     }
 
@@ -59,11 +59,11 @@ class DynamoDbStreamPumpTest {
     @Test
     void recordsAreReplayedIntoFlociStreamServiceWithBothImages() {
         stubShardDiscovery();
-        when(client.callStreams(eq("GetRecords"), any(), any()))
+        when(client.callStreams(eq("000000000000"), eq("GetRecords"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, recordsResponse("001", "iterator-2")));
 
         TableDefinition definition = table();
-        pump.drain(new DynamoDbStreamPump.StreamCursor(definition, "us-east-1", "arn:stream/1"));
+        pump.drain(new DynamoDbStreamPump.StreamCursor("000000000000", definition, "us-east-1", "arn:stream/1"));
 
         ArgumentCaptor<JsonNode> newImage = ArgumentCaptor.forClass(JsonNode.class);
         verify(streamService).captureEvent(
@@ -75,10 +75,10 @@ class DynamoDbStreamPumpTest {
     void aLostIteratorResumesAfterTheLastRecordInsteadOfReplayingTheStream() {
         stubShardDiscovery();
         DynamoDbStreamPump.StreamCursor cursor =
-                new DynamoDbStreamPump.StreamCursor(table(), "us-east-1", "arn:stream/1");
+                new DynamoDbStreamPump.StreamCursor("000000000000", table(), "us-east-1", "arn:stream/1");
 
         // First drain consumes one record, then the iterator is lost.
-        when(client.callStreams(eq("GetRecords"), any(), any()))
+        when(client.callStreams(eq("000000000000"), eq("GetRecords"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(200, recordsResponse("042", null)));
         pump.drain(cursor);
 
@@ -87,7 +87,7 @@ class DynamoDbStreamPumpTest {
         pump.drain(cursor);
 
         ArgumentCaptor<JsonNode> iteratorRequest = ArgumentCaptor.forClass(JsonNode.class);
-        verify(client, times(2)).callStreams(eq("GetShardIterator"), iteratorRequest.capture(), any());
+        verify(client, times(2)).callStreams(eq("000000000000"), eq("GetShardIterator"), iteratorRequest.capture(), any());
         JsonNode reopen = iteratorRequest.getAllValues().get(1);
         assertEquals("AFTER_SEQUENCE_NUMBER", reopen.path("ShardIteratorType").asText());
         assertEquals("042", reopen.path("SequenceNumber").asText());
@@ -102,15 +102,15 @@ class DynamoDbStreamPumpTest {
         stubShardDiscovery();
         ObjectNode expired = MAPPER.createObjectNode();
         expired.put("__type", "com.amazonaws.dynamodb.v20120810#ExpiredIteratorException");
-        when(client.callStreams(eq("GetRecords"), any(), any()))
+        when(client.callStreams(eq("000000000000"), eq("GetRecords"), any(), any()))
                 .thenReturn(new DynamoDbLocalClient.Result(400, expired));
 
         DynamoDbStreamPump.StreamCursor cursor =
-                new DynamoDbStreamPump.StreamCursor(table(), "us-east-1", "arn:stream/1");
+                new DynamoDbStreamPump.StreamCursor("000000000000", table(), "us-east-1", "arn:stream/1");
         pump.drain(cursor);
         pump.drain(cursor);
 
         // Two drains, two reopen attempts: the failure is recoverable, not terminal.
-        verify(client, times(2)).callStreams(eq("GetShardIterator"), any(), any());
+        verify(client, times(2)).callStreams(eq("000000000000"), eq("GetShardIterator"), any(), any());
     }
 }


### PR DESCRIPTION
## Summary

Adds `floci.services.dynamodb.backend=container`, which delegates the DynamoDB **data plane** —
item storage, expression evaluation, PartiQL, transactions — to an `amazon/dynamodb-local`
container Floci spawns and owns. The control plane stays in Floci.

Default is unchanged (`backend=native`); nothing about the in-process engine moves.

Closes #2865.

### Why the split is where it is

DynamoDB local models none of the control plane: no tags, no PITR, no exports, no Kinesis
streaming destinations, no ARNs of the shape Floci hands out. So Floci keeps all of it, and
every `CreateTable` parameter it already accepts keeps round-tripping. Only the 13 actions
whose *semantics* are the reason to reach for the real engine are forwarded.

### Account and region scoping

DynamoDB local keeps a separate store per (access key id, region) unless `-sharedDb` is given,
which is deliberately omitted. The forwarding client sends Floci's resolved **account id** as the
access key, so the container's partitioning reproduces Floci's own account + region scoping with
no table renaming and no shared namespace. The documented alphanumeric constraint on the access
key holds — a key containing `-` is rejected with `UnrecognizedClientException` — and a 12-digit
account id satisfies it.

### Streams

Writes no longer pass through Floci, and the before/after images its fan-out depends on cannot be
rebuilt from the forwarded calls: `ReturnValues=ALL_OLD` does not exist on `BatchWriteItem` or
`TransactWriteItems`. The mirrored table therefore always carries `NEW_AND_OLD_IMAGES`, and a pump
replays the container's stream through `DynamoDbStreamService`, which re-applies the caller's own
`StreamViewType`. Lambda event source mappings, EventBridge Pipes and `GetRecords` against Floci
are all unaffected.

**This is the part I would most like a maintainer's eye on** — see "Open questions" below.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [x] Documentation update

## AWS Compatibility

Reference:
- DynamoDB local usage notes, incl. AWS's own list of divergences —
  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html
- Legacy conditional parameters —
  https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/LegacyConditionalParameters.html

### Measured against `amazon/dynamodb-local:3.3.1`

Served by the container: Streams (correct `OldImage`/`NewImage`, monotonic sequence numbers),
PartiQL, TTL config, transactions, and parallel `Scan` `Segment`/`TotalSegments` (honoured — the
usage-notes page saying these are ignored is **stale** for 3.3.1).

Not served, so they stay in Floci — all `UnknownOperationException`:
`ExportTableToPointInTime`, `ListExports`, `EnableKinesisStreamingDestination`,
`Update`/`DescribeContinuousBackups`. Tagging fails with an explicit
`Tagging is not currently supported in DynamoDB Local`.

Scoping, measured directly:

```
create AcctTbl as key=000000000000 region=us-east-1
  list-tables  000000000000 / us-east-1  ->  AcctTbl
  list-tables  111111111111 / us-east-1  ->  (empty)
  list-tables  000000000000 / eu-west-1  ->  (empty)
```

### Terraform

Applied a real `aws_dynamodb_table` module (composite key, two GSIs — one `INCLUDE` projection
with `non_key_attributes`, one `ALL` — TTL, PITR, `NEW_IMAGE` stream, tags, SSE, deletion
protection) against `backend=container`:

- `terraform apply` → clean
- `terraform plan -detailed-exitcode` → **exit 0, no drift**
- `terraform destroy` correctly refused while `deletion_protection_enabled = true`
- `PROVISIONED` billing with per-GSI throughput, and an LSI, also mirror correctly

A DynamoDB-stream event source mapping fired a real Lambda container end to end on a seeded write.

## Testing

- Full suite, sharded 8 ways as CI does: **14,798 tests, 0 failures, 0 errors**. Run on the
  pre-rebase tip; the rebase onto 2.0.0 added only `CHANGELOG.md` and a `pom.xml` version bump
  (no code), and `make docs-check` plus the full `services.dynamodb` package (510 tests) were
  re-run green on the rebased tip.
- `make docs-check`: clean
- Compatibility suite (`sdk-test-node`), run inside the network with Floci's embedded DNS:
  - **native backend: 472 passed / 2 failed**
  - **control (`upstream/main`, unmodified): 472 passed / 2 failed — identical failures**
    (`apigatewayv2-websocket-dataplane` and `-tls` chat broadcast). Pre-existing, not from this
    change.
  - **container backend: 469 passed / 5 failed** — the same 2 WebSocket, plus 3 DynamoDB
    conformance cases discussed below.

The compatibility suite caught a real bug in the first cut of this change: three Phase 11
conformance cases (`invalid ReturnValues`/`ReturnConsumedCapacity` on a non-existent table) passed
natively and failed in container mode, because AWS validates those enums *ahead of* the table
lookup while DynamoDB local resolves the table first. Floci now runs that check in front of the
forward, reusing the same constants and message wording the per-action handlers use, so both
backends emit byte-identical errors. Pinned by a unit test.

### The 3 remaining container-mode conformance failures

| Case | Assessment |
| --- | --- |
| `ReturnItemCollectionMetrics=SIZE` returns metrics on an LSI table | Container returns nulls. AWS documents this ("Item collection metrics ... nulls are returned"). Inherent to the backend. |
| unused `ExpressionAttributeNames` passes | Container **rejects** it; the native engine accepts. **Confirmed against live AWS** — see below. |
| `QueryFilter` (legacy) alongside `KeyConditionExpression` | Container **rejects** it; the native engine runs the query. **Confirmed against live AWS** — see below. |

### Live AWS measurements

Read-only `Query` calls against a real DynamoDB table (`ap-southeast-1`). The live service returns
the container's errors **verbatim**:

```
unused ExpressionAttributeNames:
  ValidationException: Value provided in ExpressionAttributeNames unused in expressions: keys: {#st}

QueryFilter + KeyConditionExpression:
  ValidationException: Can not use both expression and non-expression parameters in the same
  request: Non-expression parameters: {QueryFilter} Expression parameters: {KeyConditionExpression}
```

And the enum-ordering fix in this PR, checked with a SigV4-signed `Query` against a table that
does not exist:

```
ReturnConsumedCapacity=NOT_A_VALID_VALUE  -> ValidationException
  1 validation error detected: Value 'NOT_A_VALID_VALUE' at 'returnConsumedCapacity' failed to
  satisfy constraint: Member must satisfy enum value set: [INDEXES, TOTAL, NONE]

ReturnConsumedCapacity=NONE (control)     -> ResourceNotFoundException
```

That is byte-identical to what this PR now emits, and the control proves the table really is
absent — so AWS genuinely validates the enum ahead of the table lookup.

So the last two rows are places where **the native backend is lenient and real AWS is not**. I have
**not** changed the native engine to match: those behaviours are currently asserted as passing by
`dynamodb-conformance.test.ts`, and tightening them is a separate decision from adding a backend.
Happy to open issues for both.

## Open questions / what I could not measure

- **Live AWS coverage is partial.** The three divergences above were measured against the real
  service (read-only `Query` calls, plus one signed request to a non-existent table). The
  `ReturnItemCollectionMetrics` row was not: it needs a write to an LSI table, which I did not run
  against a real account. It rests on AWS's own statement that DynamoDB local returns nulls for
  item collection metrics.
- **The stream pump is the design decision I would most like reviewed.** It polls the container's
  stream and replays into `DynamoDbStreamService`. It resumes with `AFTER_SEQUENCE_NUMBER` after a
  lost iterator so a reopen cannot re-fire event source mappings, but persisted ESM checkpoints
  (#2076) and container-issued sequence numbers are two independent sequences, and I have not
  stress-tested them against each other.
- **TTL deletion timing** and stream sequence-number stability across a container restart were not
  probed.

## Out of scope, deliberately

- **CloudFormation-created tables are not mirrored.** `AWS::DynamoDB::Table` goes through
  `DynamoDbService.createTable` rather than the JSON handler, as do the legacy
  `states:::dynamodb:*` task path and IoT rule actions. Documented as a known limitation; use the
  native backend for those. Mirroring them means reconstructing a `CreateTable` request from
  `TableDefinition`, which I would rather do in a follow-up than smuggle in here.
- **No persistence.** The container runs `-inMemory`. With a persistent storage mode Floci would
  reload table metadata across a restart while the container would not; documented, with the
  suggestion to run this mode with `FLOCI_STORAGE_SERVICES_DYNAMODB_MODE=memory`.

## Checklist

- [x] Follows the repository code style (braces on all conditionals, no empty catch blocks)
- [x] Conventional commit messages
- [x] Config added to `EmulatorConfig` and `application.yml`
- [x] Documentation updated (`docs/services/dynamodb.md`)
- [x] Automated tests added
- [x] Full test suite passes
- [x] `make docs-check` passes
- [x] Compatibility suite run, with failures attributed against a control image
- [x] Validated against the live AWS API (read-only; one row not covered — see Open questions)
