### PR TITLE
docs(cognito): add UpdateResourceServer to the Resource Servers table

### DIFF
--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -53,6 +53,7 @@ Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` 
 | CreateResourceServer | Registers a resource server and scopes for a user pool. |
 | DescribeResourceServer | Returns a registered resource server. |
 | ListResourceServers | Lists resource servers for a user pool. |
+| UpdateResourceServer | Updates a resource server's name and scopes. |
 | DeleteResourceServer | Deletes a resource server from a user pool. |
 
 ### User Pool Domains


### PR DESCRIPTION
## Summary

Adds the missing `UpdateResourceServer` row to the Resource Servers table in `docs/services/cognito.md`. The action is dispatched by `CognitoJsonHandler` and implemented in `CognitoService.updateResourceServer`, but the table only listed the other four actions, understating coverage.

The row is placed between `ListResourceServers` and `DeleteResourceServer`, matching the Create/Describe/List/Update/Delete ordering used elsewhere in the doc.

Docs-only change; Cognito is on the `tools/docs/services.yaml` exclusion list, so this table is hand-maintained and `make docs-check` does not cover it.

Fixes #2854