### PR TITLE
fix(apigatewayv2): provision integration, route and stage on quick create

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -124,6 +124,30 @@ public class ApiGatewayV2Service {
 
         apiStore.put(apiKey(region, api.getApiId()), api);
         LOG.infov("Created {0} API: {1} ({2}) in {3}", protocolType, api.getName(), api.getApiId(), region);
+
+        // Quick create: when the caller supplies Target (a Lambda ARN or HTTP URL), AWS
+        // auto-provisions an AWS_PROXY integration, a "$default" catch-all route pointing at
+        // it, and an auto-deploy "$default" stage — without this the API has no route and no
+        // stage, so ApiGatewayExecuteApiHostFilter's stage lookup fails and every invocation
+        // falls through to whichever other virtual-hosted-style filter claims the request next.
+        Object targetValue = request.get("target");
+        String target = targetValue != null ? String.valueOf(targetValue) : null;
+        if ("HTTP".equals(protocolType) && target != null && !target.isBlank()) {
+            Integration integration = createIntegration(region, apiId, Map.of(
+                    "integrationType", "AWS_PROXY",
+                    "integrationUri", target,
+                    "integrationMethod", "POST",
+                    "payloadFormatVersion", "2.0"));
+            createRoute(region, apiId, Map.of(
+                    "routeKey", "$default",
+                    "target", "integrations/" + integration.getIntegrationId()));
+            createStage(region, apiId, Map.of(
+                    "stageName", "$default",
+                    "autoDeploy", "true"));
+            LOG.infov("Quick create: provisioned AWS_PROXY integration, $default route and stage for API {0} -> {1}",
+                    apiId, target);
+        }
+
         return api;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -126,17 +126,18 @@ public class ApiGatewayV2Service {
         LOG.infov("Created {0} API: {1} ({2}) in {3}", protocolType, api.getName(), api.getApiId(), region);
 
         // Quick create: when the caller supplies Target (a Lambda ARN or HTTP URL), AWS
-        // auto-provisions an AWS_PROXY integration, a "$default" catch-all route pointing at
-        // it, and an auto-deploy "$default" stage — without this the API has no route and no
-        // stage, so ApiGatewayExecuteApiHostFilter's stage lookup fails and every invocation
-        // falls through to whichever other virtual-hosted-style filter claims the request next.
+        // auto-provisions an integration, a "$default" catch-all route pointing at it, and an
+        // auto-deploy "$default" stage. Without this the API has no route and no stage, so
+        // ApiGatewayExecuteApiHostFilter's stage lookup fails and every invocation falls
+        // through to whichever other virtual-hosted-style filter claims the request next.
         Object targetValue = request.get("target");
         String target = targetValue != null ? String.valueOf(targetValue) : null;
         if ("HTTP".equals(protocolType) && target != null && !target.isBlank()) {
+            boolean isLambdaTarget = target.startsWith("arn:");
             Integration integration = createIntegration(region, apiId, Map.of(
-                    "integrationType", "AWS_PROXY",
+                    "integrationType", isLambdaTarget ? "AWS_PROXY" : "HTTP_PROXY",
                     "integrationUri", target,
-                    "integrationMethod", "POST",
+                    "integrationMethod", isLambdaTarget ? "POST" : "ANY",
                     "payloadFormatVersion", "2.0"));
             createRoute(region, apiId, Map.of(
                     "routeKey", "$default",
@@ -144,8 +145,8 @@ public class ApiGatewayV2Service {
             createStage(region, apiId, Map.of(
                     "stageName", "$default",
                     "autoDeploy", "true"));
-            LOG.infov("Quick create: provisioned AWS_PROXY integration, $default route and stage for API {0} -> {1}",
-                    apiId, target);
+            LOG.infov("Quick create: provisioned {0} integration, $default route and stage for API {1} -> {2}",
+                    integration.getIntegrationType(), apiId, target);
         }
 
         return api;

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2QuickCreateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2QuickCreateTest.java
@@ -1,0 +1,90 @@
+package io.github.hectorvent.floci.services.apigatewayv2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * CreateApi's {@code target} parameter ("quick create") must provision an AWS_PROXY
+ * integration, a "$default" catch-all route, and an auto-deploy "$default" stage —
+ * exactly what AWS does — so the API is immediately invocable. Without a "$default"
+ * stage, {@code ApiGatewayExecuteApiHostFilter} can't resolve one and every invocation
+ * silently falls through to whichever other virtual-hosted-style filter (e.g. S3) claims
+ * the request next, instead of reaching the API. See issue #1902.
+ */
+@QuarkusTest
+class ApiGatewayV2QuickCreateTest {
+
+    private static final String TARGET =
+            "arn:aws:lambda:us-east-1:000000000000:function:quick-create-target";
+
+    @Test
+    void quickCreateProvisionsIntegrationRouteAndStage() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"quick-create-api","protocolType":"HTTP","target":"%s"}
+                        """.formatted(TARGET))
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(1))
+                .body("items[0].integrationType", equalTo("AWS_PROXY"))
+                .body("items[0].integrationUri", equalTo(TARGET));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(1))
+                .body("items[0].routeKey", equalTo("$default"))
+                .body("items[0].target", startsWith("integrations/"));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/stages/$default")
+                .then()
+                .statusCode(200)
+                .body("stageName", equalTo("$default"))
+                .body("autoDeploy", equalTo(true));
+    }
+
+    @Test
+    void createApiWithoutTargetProvisionsNothing() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"no-target-api","protocolType":"HTTP"}
+                        """)
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .extract().path("apiId");
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(0));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/routes")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(0));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/stages/$default")
+                .then()
+                .statusCode(404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2QuickCreateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2QuickCreateTest.java
@@ -8,26 +8,28 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 /**
- * CreateApi's {@code target} parameter ("quick create") must provision an AWS_PROXY
- * integration, a "$default" catch-all route, and an auto-deploy "$default" stage —
- * exactly what AWS does — so the API is immediately invocable. Without a "$default"
- * stage, {@code ApiGatewayExecuteApiHostFilter} can't resolve one and every invocation
- * silently falls through to whichever other virtual-hosted-style filter (e.g. S3) claims
- * the request next, instead of reaching the API. See issue #1902.
+ * CreateApi's {@code target} parameter ("quick create") must provision an integration
+ * (AWS_PROXY for a Lambda ARN, HTTP_PROXY for an HTTP URL), a "$default" catch-all route,
+ * and an auto-deploy "$default" stage, exactly what AWS does, so the API is immediately
+ * invocable. Without a "$default" stage, {@code ApiGatewayExecuteApiHostFilter} can't
+ * resolve one and every invocation silently falls through to whichever other
+ * virtual-hosted-style filter (e.g. S3) claims the request next, instead of reaching the
+ * API. See issue #1902.
  */
 @QuarkusTest
 class ApiGatewayV2QuickCreateTest {
 
-    private static final String TARGET =
+    private static final String LAMBDA_TARGET =
             "arn:aws:lambda:us-east-1:000000000000:function:quick-create-target";
+    private static final String HTTP_TARGET = "https://example.com/webhook";
 
     @Test
-    void quickCreateProvisionsIntegrationRouteAndStage() {
+    void quickCreateWithLambdaTargetProvisionsAwsProxyIntegration() {
         String apiId = given()
                 .contentType(ContentType.JSON)
                 .body("""
-                        {"name":"quick-create-api","protocolType":"HTTP","target":"%s"}
-                        """.formatted(TARGET))
+                        {"name":"quick-create-lambda-api","protocolType":"HTTP","target":"%s"}
+                        """.formatted(LAMBDA_TARGET))
                 .when().post("/v2/apis")
                 .then()
                 .statusCode(201)
@@ -40,7 +42,7 @@ class ApiGatewayV2QuickCreateTest {
                 .statusCode(200)
                 .body("items", hasSize(1))
                 .body("items[0].integrationType", equalTo("AWS_PROXY"))
-                .body("items[0].integrationUri", equalTo(TARGET));
+                .body("items[0].integrationUri", equalTo(LAMBDA_TARGET));
 
         given()
                 .when().get("/v2/apis/" + apiId + "/routes")
@@ -55,6 +57,35 @@ class ApiGatewayV2QuickCreateTest {
                 .then()
                 .statusCode(200)
                 .body("stageName", equalTo("$default"))
+                .body("autoDeploy", equalTo(true));
+    }
+
+    @Test
+    void quickCreateWithHttpUrlTargetProvisionsHttpProxyIntegration() {
+        String apiId = given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"name":"quick-create-http-api","protocolType":"HTTP","target":"%s"}
+                        """.formatted(HTTP_TARGET))
+                .when().post("/v2/apis")
+                .then()
+                .statusCode(201)
+                .body("apiId", notNullValue())
+                .extract().path("apiId");
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/integrations")
+                .then()
+                .statusCode(200)
+                .body("items", hasSize(1))
+                .body("items[0].integrationType", equalTo("HTTP_PROXY"))
+                .body("items[0].integrationUri", equalTo(HTTP_TARGET))
+                .body("items[0].integrationMethod", equalTo("ANY"));
+
+        given()
+                .when().get("/v2/apis/" + apiId + "/stages/$default")
+                .then()
+                .statusCode(200)
                 .body("autoDeploy", equalTo(true));
     }
 


### PR DESCRIPTION
## Summary

`CreateApi`'s `target` parameter ("quick create") was accepted but silently ignored — no `AWS_PROXY` integration, no `$default` route, and no `$default` stage were ever provisioned.

Without a stage, `ApiGatewayExecuteApiHostFilter.stageExists()` throws `Stage not found`, the filter returns without rewriting the request, and the invoke request falls through unmodified to whichever other virtual-hosted-style filter claims the `execute-api` host next (S3's virtual-hosted-bucket filter, in the common case) — instead of reaching the API. Repro from a fresh `floci/floci:latest` container:

```
aws apigatewayv2 create-api --name learning-api --protocol-type HTTP \
  --target arn:aws:lambda:us-east-1:000000000000:function:learning-fn
curl http://<apiId>.execute-api.localhost.floci.io:4566/
# -> S3 ListAllMyBucketsResult / NoSuchBucket, not the Lambda response
```

This reproduces even with matching region throughout (`us-east-1` create + invoke), so it's a separate cause from the cross-region dispatch bug #1906 targets.

## Fix

Provision the `AWS_PROXY` integration, `$default` catch-all route, and auto-deploy `$default` stage that real API Gateway creates for quick create, using the existing `createIntegration`/`createRoute`/`createStage` helpers — right after the `Api` itself is persisted in `createApi`.

Verified against a locally built image: the same repro now reaches the Lambda integration (`{"message":"Function not found: ..."}` for a missing function, and a real invoke for an existing one) instead of S3's XML error.

Fixes #1902

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Verified against `aws-cli/2.36.35` (`apigatewayv2 create-api --target`, `get-stages`, `get-routes`, `get-integrations`) and a real Lambda invocation through the resulting HTTP API endpoint.

## Checklist

- [x] `./mvnw test` passes locally (full `apigatewayv2`/`apigateway` suites: 1035 tests, 0 failures, 0 errors)
- [x] New integration test added (`ApiGatewayV2QuickCreateTest`)
- [x] Commit messages follow Conventional Commits