### PR TITLE
refactor(ses): extract the configuration-set domain into SesConfigurationSetService

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
@@ -1,0 +1,421 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ses.model.ArchivingOptions;
+import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfiguration;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.EventDestination;
+import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
+import io.github.hectorvent.floci.services.ses.model.VdmOptions;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Configuration sets, extracted from {@link SesService} as the next step of the store-based domain
+ * split: the store, key derivation, name validation, CRUD, the domain-pure option setters, and the
+ * event destinations live here.
+ *
+ * <p>The boundary follows the cross-domain seams: option validation that reads OTHER domains stays
+ * in the facade — tracking options check a verified domain identity, delivery options check a
+ * dedicated IP pool — which validates first (or resolves existence through {@link #get}) and then
+ * mutates through {@link #save}. The facade also keeps the send-path reads (pause check, event
+ * publishing, effective suppression reasons), the ARN-dispatched tagging, and the tenant
+ * delete-guard around {@link #remove}.
+ */
+@ApplicationScoped
+public class SesConfigurationSetService {
+
+    private static final Logger LOG = Logger.getLogger(SesConfigurationSetService.class);
+
+    private static final Pattern CONFIG_SET_NAME = Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
+    private static final Set<String> VDM_FEATURE_STATES = Set.of("ENABLED", "DISABLED");
+
+    private static final Pattern EVENT_DESTINATION_NAME_CHARS = Pattern.compile("^[A-Za-z0-9_-]+$");
+    private static final int MAX_EVENT_DESTINATION_NAME_LENGTH = 64;
+    private static final List<String> VALID_EVENT_TYPES = List.of(
+            "SEND", "REJECT", "BOUNCE", "COMPLAINT", "DELIVERY", "OPEN", "CLICK",
+            "RENDERING_FAILURE", "DELIVERY_DELAY", "SUBSCRIPTION");
+
+    private final StorageBackend<String, ConfigurationSet> configSetStore;
+
+    @Inject
+    public SesConfigurationSetService(StorageFactory storageFactory) {
+        this(storageFactory.create("ses", "ses-config-sets.json",
+                new TypeReference<Map<String, ConfigurationSet>>() {}));
+    }
+
+    SesConfigurationSetService(StorageBackend<String, ConfigurationSet> configSetStore) {
+        this.configSetStore = configSetStore;
+    }
+
+    /**
+     * Stores a validated configuration set. The option validation runs in the facade first — the
+     * cross-domain pieces (tracking's verified-domain check, delivery's dedicated-pool check) can't
+     * live here — so this owns only the duplicate check, the timestamp, and the write.
+     */
+    public ConfigurationSet create(ConfigurationSet configSet, String region) {
+        String key = configSetKey(region, configSet.getName());
+        if (configSetStore.get(key).isPresent()) {
+            throw new AwsException("ConfigurationSetAlreadyExists",
+                    "Configuration set " + configSet.getName() + " already exists.", 400);
+        }
+        if (configSet.getCreatedTimestamp() == null) {
+            configSet.setCreatedTimestamp(Instant.now());
+        }
+        configSetStore.put(key, configSet);
+        LOG.infov("Created SES configuration set: {0} in region {1}", configSet.getName(), region);
+        return configSet;
+    }
+
+    public ConfigurationSet get(String name, String region) {
+        return configSetStore.get(configSetKey(region, name))
+                .orElseThrow(() -> new AwsException("ConfigurationSetDoesNotExist",
+                        "Configuration set <" + name + "> does not exist.", 400));
+    }
+
+    public List<ConfigurationSet> list(String region) {
+        String prefix = "configSet::" + region + "::";
+        List<ConfigurationSet> all = new ArrayList<>(configSetStore.scan(k -> k.startsWith(prefix)));
+        all.sort(Comparator.comparing(ConfigurationSet::getCreatedTimestamp,
+                        Comparator.nullsLast(Comparator.naturalOrder()))
+                .thenComparing(ConfigurationSet::getName,
+                        Comparator.nullsLast(Comparator.naturalOrder())));
+        return all;
+    }
+
+    /** The raw removal; existence and the tenant delete-guard are the facade's orchestration. */
+    public void remove(String name, String region) {
+        configSetStore.delete(configSetKey(region, name));
+        LOG.infov("Deleted SES configuration set: {0} in region {1}", name, region);
+    }
+
+    /** Reads without throwing on absence (the name is still validated, as the key derivation always
+     * has), for the facade's send-path and tagging lookups. */
+    public Optional<ConfigurationSet> find(String name, String region) {
+        return configSetStore.get(configSetKey(region, name));
+    }
+
+    /** Persists a configuration set the facade mutated (cross-domain option setters, tagging). */
+    public void save(ConfigurationSet configSet, String region) {
+        configSetStore.put(configSetKey(region, configSet.getName()), configSet);
+    }
+
+    /** For guards that must not trip the key derivation's name validation (the tenant gate). */
+    static boolean isValidName(String name) {
+        return name != null && CONFIG_SET_NAME.matcher(name).matches();
+    }
+
+    // ──────────────────────── Domain-pure option setters ────────────────────────
+
+    public void setSendingEnabled(String configSetName, boolean enabled, String region) {
+        ConfigurationSet cs = get(configSetName, region);
+        cs.setSendingEnabled(enabled);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated SendingEnabled on configuration set {0} in region {1}: {2}",
+                configSetName, region, enabled);
+    }
+
+    public void setReputationMetricsEnabled(String configSetName, boolean metricsEnabled, String region) {
+        ConfigurationSet cs = get(configSetName, region);
+        cs.setReputationMetricsEnabled(metricsEnabled);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated ReputationMetricsEnabled on configuration set {0} in region {1}: {2}",
+                configSetName, region, metricsEnabled);
+    }
+
+    public void deleteTrackingOptions(String configSetName, String region) {
+        ConfigurationSet cs = get(configSetName, region);
+        if (cs.getTrackingOptions() == null || cs.getTrackingOptions().getCustomRedirectDomain() == null) {
+            throw new AwsException("TrackingOptionsDoesNotExistException",
+                    "There are no tracking options for configuration set <" + configSetName + ">", 400);
+        }
+        cs.setTrackingOptions(null);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Deleted TrackingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    public void setArchivingOptions(String configSetName, ArchivingOptions options, String region) {
+        ConfigurationSet cs = get(configSetName, region);
+        cs.setArchivingOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated ArchivingOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    public void setVdmOptions(String configSetName, VdmOptions options, String region) {
+        ConfigurationSet cs = get(configSetName, region);
+        validateVdmOptions(options);
+        cs.setVdmOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated VdmOptions on configuration set {0} in region {1}", configSetName, region);
+    }
+
+    static void validateVdmOptions(VdmOptions options) {
+        if (options == null) {
+            return;
+        }
+        // Enum values verified against real AWS 2026-06-19; messages use the
+        // nested member path and the [ENABLED, DISABLED] value set.
+        if (options.getDashboardOptions() != null
+                && options.getDashboardOptions().getEngagementMetrics() != null
+                && !VDM_FEATURE_STATES.contains(options.getDashboardOptions().getEngagementMetrics())) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'vdmOptions.dashboardOptions.engagementMetrics' "
+                            + "failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]", 400);
+        }
+        if (options.getGuardianOptions() != null
+                && options.getGuardianOptions().getOptimizedSharedDelivery() != null
+                && !VDM_FEATURE_STATES.contains(options.getGuardianOptions().getOptimizedSharedDelivery())) {
+            throw new AwsException("BadRequestException",
+                    "1 validation error detected: Value at 'vdmOptions.guardianOptions.optimizedSharedDelivery' "
+                            + "failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]", 400);
+        }
+    }
+
+    /**
+     * Stores per-configuration-set suppression overrides. Mirrors the AWS V2
+     * {@code PutConfigurationSetSuppressionOptions} contract: {@code reasons} may
+     * be {@code null} or empty (explicit "no filtering" for this set) or a subset
+     * of {@code [BOUNCE, COMPLAINT]}. Once set, the value is returned through
+     * {@link #get}; downstream callers resolve the effective reasons for a given
+     * send via the facade's {@code getEffectiveSuppressedReasons}.
+     */
+    public void putSuppressionOptions(String configSetName, List<String> reasons, String region) {
+        List<String> sanitized = new ArrayList<>();
+        if (reasons != null) {
+            for (String r : reasons) {
+                validateSuppressionReason(r);
+                sanitized.add(r);
+            }
+        }
+        ConfigurationSet cs = get(configSetName, region);
+        SuppressionOptions options = new SuppressionOptions();
+        options.setSuppressedReasons(sanitized);
+        cs.setSuppressionOptions(options);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated SuppressionOptions on configuration set {0} in region {1}: {2}",
+                configSetName, region, sanitized);
+    }
+
+    /**
+     * Validation message used by PutConfigurationSetSuppressionOptions. AWS
+     * V2 SES uses a different, simpler natural-language sentence on this
+     * endpoint than on the three older suppression APIs:
+     *   "Reason <X> is invalid, must be one of [BOUNCE, COMPLAINT]."
+     * (Verified against real AWS V2 SES on 2026-06-03.) CreateConfigurationSet
+     * reports the constraint-style validation message for invalid non-null
+     * values but falls back to this sentence for null elements, matching AWS
+     * (verified 2026-06-13); see the facade's {@code createConfigurationSet}.
+     */
+    private static void validateSuppressionReason(String reason) {
+        if (!isValidSuppressionReason(reason)) {
+            throw new AwsException("BadRequestException",
+                    invalidSuppressionReasonMessage(reason), 400);
+        }
+    }
+
+    static boolean isValidSuppressionReason(String reason) {
+        return "BOUNCE".equals(reason) || "COMPLAINT".equals(reason);
+    }
+
+    static String invalidSuppressionReasonMessage(String reason) {
+        return "Reason " + reason + " is invalid, must be one of [BOUNCE, COMPLAINT].";
+    }
+
+    // ──────────────────────────── Event destinations ────────────────────────────
+
+    public void createEventDestination(String configSetName, String eventDestinationName,
+                                       EventDestination dest, String region) {
+        validateEventDestinationName(eventDestinationName);
+        validateEventDestination(dest);
+        ConfigurationSet cs = get(configSetName, region);
+        if (indexOfEventDestination(cs.getEventDestinations(), eventDestinationName) >= 0) {
+            throw new AwsException("AlreadyExists",
+                    "An event destination with name <" + eventDestinationName
+                            + "> already exists for configuration set <" + configSetName + ">.", 400);
+        }
+        dest.setName(eventDestinationName);
+        cs.getEventDestinations().add(dest);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Created SES event destination {0} on configuration set {1} in region {2}",
+                eventDestinationName, configSetName, region);
+    }
+
+    public List<EventDestination> getEventDestinations(String configSetName, String region) {
+        return List.copyOf(get(configSetName, region).getEventDestinations());
+    }
+
+    public void updateEventDestination(String configSetName, String eventDestinationName,
+                                       EventDestination dest, String region) {
+        validateEventDestinationName(eventDestinationName);
+        validateEventDestination(dest);
+        ConfigurationSet cs = get(configSetName, region);
+        int index = indexOfEventDestination(cs.getEventDestinations(), eventDestinationName);
+        if (index < 0) {
+            throw new AwsException("NotFoundException",
+                    "An event destination with name <" + eventDestinationName
+                            + "> does not exist for configuration set <" + configSetName + ">.", 404);
+        }
+        dest.setName(eventDestinationName);
+        cs.getEventDestinations().set(index, dest);
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Updated SES event destination {0} on configuration set {1} in region {2}",
+                eventDestinationName, configSetName, region);
+    }
+
+    public void deleteEventDestination(String configSetName, String eventDestinationName, String region) {
+        validateEventDestinationName(eventDestinationName);
+        ConfigurationSet cs = get(configSetName, region);
+        boolean removed = cs.getEventDestinations().removeIf(ed -> eventDestinationName.equals(ed.getName()));
+        if (!removed) {
+            throw new AwsException("NotFoundException",
+                    "An event destination with name <" + eventDestinationName
+                            + "> does not exist for configuration set <" + configSetName + ">.", 404);
+        }
+        configSetStore.put(configSetKey(region, configSetName), cs);
+        LOG.infov("Deleted SES event destination {0} on configuration set {1} in region {2}",
+                eventDestinationName, configSetName, region);
+    }
+
+    private static int indexOfEventDestination(List<EventDestination> destinations, String name) {
+        for (int i = 0; i < destinations.size(); i++) {
+            if (name != null && name.equals(destinations.get(i).getName())) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    static void validateEventDestinationName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "EventDestinationName is required.", 400);
+        }
+        if (!EVENT_DESTINATION_NAME_CHARS.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid event destination name <" + name + ">: only alphanumeric ASCII characters, "
+                            + "'_', and '-' are allowed.", 400);
+        }
+        if (name.length() > MAX_EVENT_DESTINATION_NAME_LENGTH) {
+            throw new AwsException("InvalidParameterValue",
+                    "Event destination name cannot exceed 64 characters.", 400);
+        }
+    }
+
+    static void validateEventDestination(EventDestination dest) {
+        if (dest == null) {
+            throw new AwsException("InvalidParameterValue", "EventDestination is required.", 400);
+        }
+        List<String> types = dest.getMatchingEventTypes();
+        if (types == null || types.isEmpty()) {
+            throw new AwsException("InvalidParameterValue", "At least one event type must be specified.", 400);
+        }
+        for (String t : types) {
+            if (t == null || !VALID_EVENT_TYPES.contains(t)) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid event type: " + t + ". Valid values are " + VALID_EVENT_TYPES + ".", 400);
+            }
+        }
+        int destinationCount = countDestinations(dest);
+        if (destinationCount == 0) {
+            throw new AwsException("InvalidParameterValue", "Event destination is not provided.", 400);
+        }
+        if (destinationCount > 1) {
+            throw new AwsException("InvalidParameterValue",
+                    "Please provide only one destination with each request. Either a Firehose Destination "
+                            + "or a Cloudwatch Destination or an SNS Destination or an EventBridge Destination.", 400);
+        }
+        if (dest.getSnsDestination() != null
+                && (dest.getSnsDestination().getTopicArn() == null
+                || dest.getSnsDestination().getTopicArn().isBlank())) {
+            throw new AwsException("InvalidParameterValue",
+                    "SnsDestination requires a non-blank TopicArn.", 400);
+        }
+        if (dest.getKinesisFirehoseDestination() != null
+                && (dest.getKinesisFirehoseDestination().getIamRoleArn() == null
+                || dest.getKinesisFirehoseDestination().getIamRoleArn().isBlank()
+                || dest.getKinesisFirehoseDestination().getDeliveryStreamArn() == null
+                || dest.getKinesisFirehoseDestination().getDeliveryStreamArn().isBlank())) {
+            throw new AwsException("InvalidParameterValue",
+                    "KinesisFirehoseDestination requires both IamRoleArn and DeliveryStreamArn.",
+                    400);
+        }
+        if (dest.getCloudWatchDestination() != null) {
+            List<CloudWatchDimensionConfiguration> dims =
+                    dest.getCloudWatchDestination().getDimensionConfigurations();
+            if (dims == null || dims.isEmpty()) {
+                throw new AwsException("InvalidParameterValue",
+                        "CloudWatch metrics dimension configuration list cannot be empty.", 400);
+            }
+            for (int i = 0; i < dims.size(); i++) {
+                CloudWatchDimensionConfiguration dim = dims.get(i);
+                if (dim == null
+                        || dim.getDimensionName() == null || dim.getDimensionName().isBlank()
+                        || dim.getDimensionValueSource() == null
+                        || dim.getDimensionValueSource().isBlank()
+                        || dim.getDefaultDimensionValue() == null
+                        || dim.getDefaultDimensionValue().isBlank()) {
+                    throw new AwsException("InvalidParameterValue",
+                            "CloudWatchDestination dimension configurations require "
+                                    + "DimensionName, DimensionValueSource, and DefaultDimensionValue "
+                                    + "(missing on member " + (i + 1) + ").", 400);
+                }
+            }
+        }
+        if (dest.getPinpointDestination() != null
+                && (dest.getPinpointDestination().getApplicationArn() == null
+                || dest.getPinpointDestination().getApplicationArn().isBlank())) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid Pinpoint application ARN provided: "
+                            + dest.getPinpointDestination().getApplicationArn() + ".", 400);
+        }
+    }
+
+    private static int countDestinations(EventDestination dest) {
+        int count = 0;
+        if (dest.getSnsDestination() != null) {
+            count++;
+        }
+        if (dest.getCloudWatchDestination() != null) {
+            count++;
+        }
+        if (dest.getKinesisFirehoseDestination() != null) {
+            count++;
+        }
+        if (dest.getEventBridgeDestination() != null) {
+            count++;
+        }
+        if (dest.getPinpointDestination() != null) {
+            count++;
+        }
+        return count;
+    }
+
+    static void validateConfigurationSetName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new AwsException("InvalidParameterValue",
+                    "ConfigurationSetName is required.", 400);
+        }
+        if (!CONFIG_SET_NAME.matcher(name).matches()) {
+            throw new AwsException("InvalidParameterValue",
+                    "ConfigurationSetName must be 1-64 characters and may only contain "
+                            + "alphanumeric characters, underscores, and hyphens.", 400);
+        }
+    }
+
+    private static String configSetKey(String region, String name) {
+        validateConfigurationSetName(name);
+        return "configSet::" + region + "::" + name;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
@@ -29,8 +29,8 @@ import java.util.regex.Pattern;
  * event destinations live here.
  *
  * <p>The boundary follows the cross-domain seams: option validation that reads OTHER domains stays
- * in the facade — tracking options check a verified domain identity, delivery options check a
- * dedicated IP pool — which validates first (or resolves existence through {@link #get}) and then
+ * in the facade (tracking options check a verified domain identity, delivery options check a
+ * dedicated IP pool), which validates first (or resolves existence through {@link #get}) and then
  * mutates through {@link #save}. The facade also keeps the send-path reads (pause check, event
  * publishing, effective suppression reasons), the ARN-dispatched tagging, and the tenant
  * delete-guard around {@link #remove}.
@@ -62,9 +62,9 @@ public class SesConfigurationSetService {
     }
 
     /**
-     * Stores a validated configuration set. The option validation runs in the facade first — the
-     * cross-domain pieces (tracking's verified-domain check, delivery's dedicated-pool check) can't
-     * live here — so this owns only the duplicate check, the timestamp, and the write.
+     * Stores a validated configuration set. The option validation runs in the facade first, since
+     * the cross-domain pieces (tracking's verified-domain check, delivery's dedicated-pool check)
+     * can't live here, so this owns only the duplicate check, the timestamp, and the write.
      */
     public ConfigurationSet create(ConfigurationSet configSet, String region) {
         String key = configSetKey(region, configSet.getName());

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -96,7 +96,10 @@ public class SesService {
     // Email templates extracted to SesTemplateService. The facade delegates; the templated-send path
     // reads via it, and ARN-dispatched tagging reads/writes via its find/save.
     private final SesTemplateService templateService;
-    private final StorageBackend<String, ConfigurationSet> configSetStore;
+    // Configuration sets extracted to SesConfigurationSetService. The facade delegates; the
+    // cross-domain option validation (tracking's verified domain, delivery's dedicated pool), the
+    // send-path reads, and the ARN-dispatched tagging go through its get/find/save.
+    private final SesConfigurationSetService configSetService;
     // Account suppression attributes + the per-address suppression list (two stores) extracted to
     // SesSuppressionService. The facade delegates; its send filters read via it.
     private final SesSuppressionService suppressionService;
@@ -135,7 +138,8 @@ public class SesService {
                        SesPolicyService policyService, SesContactService contactService,
                        SesSuppressionService suppressionService, SesDedicatedIpService dedicatedIpService,
                        SesTemplateService templateService, SesSentEmailService sentEmailService,
-                       SesTenantService tenantService, SmtpRelay smtpRelay, ObjectMapper objectMapper,
+                       SesTenantService tenantService, SesConfigurationSetService configSetService,
+                       SmtpRelay smtpRelay, ObjectMapper objectMapper,
                        SesEventPublisher eventPublisher, EmulatorConfig config, Route53Service route53Service,
                        RegionResolver regionResolver, Clock clock) {
         this.identityStore = storageFactory.create("ses", "ses-identities.json",
@@ -143,8 +147,7 @@ public class SesService {
         this.sentEmailService = sentEmailService;
         this.accountService = accountService;
         this.templateService = templateService;
-        this.configSetStore = storageFactory.create("ses", "ses-config-sets.json",
-                new TypeReference<Map<String, ConfigurationSet>>() {});
+        this.configSetService = configSetService;
         this.suppressionService = suppressionService;
         this.dedicatedIpService = dedicatedIpService;
         this.contactService = contactService;
@@ -166,7 +169,7 @@ public class SesService {
                SesSentEmailService sentEmailService,
                SesAccountService accountService,
                SesTemplateService templateService,
-               StorageBackend<String, ConfigurationSet> configSetStore,
+               SesConfigurationSetService configSetService,
                SesSuppressionService suppressionService,
                SesDedicatedIpService dedicatedIpService,
                SesContactService contactService,
@@ -177,7 +180,7 @@ public class SesService {
                SmtpRelay smtpRelay,
                ObjectMapper objectMapper,
                Clock clock) {
-        this(identityStore, sentEmailService, accountService, templateService, configSetStore, suppressionService,
+        this(identityStore, sentEmailService, accountService, templateService, configSetService, suppressionService,
                 dedicatedIpService, contactService, policyService,
                 receiptRuleService, cvetService, tenantService, smtpRelay, objectMapper, null, clock);
     }
@@ -186,7 +189,7 @@ public class SesService {
                SesSentEmailService sentEmailService,
                SesAccountService accountService,
                SesTemplateService templateService,
-               StorageBackend<String, ConfigurationSet> configSetStore,
+               SesConfigurationSetService configSetService,
                SesSuppressionService suppressionService,
                SesDedicatedIpService dedicatedIpService,
                SesContactService contactService,
@@ -202,7 +205,7 @@ public class SesService {
         this.sentEmailService = sentEmailService;
         this.accountService = accountService;
         this.templateService = templateService;
-        this.configSetStore = configSetStore;
+        this.configSetService = configSetService;
         this.suppressionService = suppressionService;
         this.dedicatedIpService = dedicatedIpService;
         this.contactService = contactService;
@@ -482,9 +485,7 @@ public class SesService {
         if (configurationSetName == null || configurationSetName.isBlank()) {
             return;
         }
-        ConfigurationSet cs = configSetStore.get(configSetKey(region, configurationSetName))
-                .orElseThrow(() -> new AwsException("ConfigurationSetDoesNotExist",
-                        "Configuration set <" + configurationSetName + "> does not exist.", 400));
+        ConfigurationSet cs = configSetService.get(configurationSetName, region);
         if (cs.getSendingEnabled() != null && !cs.getSendingEnabled()) {
             throw new AwsException("ConfigurationSetSendingPausedException",
                     "Sending is paused for configuration set " + configurationSetName, 400);
@@ -503,7 +504,7 @@ public class SesService {
         }
         ConfigurationSet cs = null;
         if (configurationSetName != null && !configurationSetName.isBlank()) {
-            cs = configSetStore.get(configSetKey(region, configurationSetName)).orElse(null);
+            cs = configSetService.find(configurationSetName, region).orElse(null);
             if (cs == null) {
                 LOG.warnv("SES send references unknown ConfigurationSet <{0}>; configuration-set "
                         + "events not published (identity notifications, if any, still apply).",
@@ -1046,7 +1047,7 @@ public class SesService {
         }
         // AWS: deleting the configuration set that is an identity's default, then sending through
         // that identity, fails with a bad-request error rather than silently sending without it.
-        if (configSetStore.get(configSetKey(region, cs)).isEmpty()) {
+        if (configSetService.find(cs, region).isEmpty()) {
             throw new AwsException("BadRequestException",
                     "Configuration set <" + cs + "> does not exist.", 400);
         }
@@ -1166,11 +1167,7 @@ public class SesService {
     }
 
     public void setConfigurationSetSendingEnabled(String configSetName, boolean enabled, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        cs.setSendingEnabled(enabled);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Updated SendingEnabled on configuration set {0} in region {1}: {2}",
-                configSetName, region, enabled);
+        configSetService.setSendingEnabled(configSetName, enabled, region);
     }
 
     // ──────────────────────────── Templates ────────────────────────────
@@ -1393,16 +1390,16 @@ public class SesService {
             throw new AwsException("InvalidParameterValue",
                     "ConfigurationSetName is required.", 400);
         }
-        String key = configSetKey(region, configSet.getName());
+        SesConfigurationSetService.validateConfigurationSetName(configSet.getName());
         SesTags.validate(configSet.getTags());
         if (configSet.getSuppressionOptions() != null
                 && configSet.getSuppressionOptions().getSuppressedReasons() != null) {
             for (String reason : configSet.getSuppressionOptions().getSuppressedReasons()) {
                 if (reason == null) {
                     throw new AwsException("BadRequestException",
-                            invalidSuppressionReasonMessage(null), 400);
+                            SesConfigurationSetService.invalidSuppressionReasonMessage(null), 400);
                 }
-                if (!isValidConfigSetSuppressionReason(reason)) {
+                if (!SesConfigurationSetService.isValidSuppressionReason(reason)) {
                     throw new AwsException("BadRequestException",
                             "1 validation error detected: Value at "
                                     + "'suppressionOptions.suppressedReasons' failed to satisfy "
@@ -1414,41 +1411,32 @@ public class SesService {
         }
         validateTrackingOptions(configSet.getTrackingOptions(), region);
         validateDeliveryOptions(configSet.getDeliveryOptions(), region);
-        validateVdmOptions(configSet.getVdmOptions());
-        if (configSetStore.get(key).isPresent()) {
-            throw new AwsException("ConfigurationSetAlreadyExists",
-                    "Configuration set " + configSet.getName() + " already exists.", 400);
-        }
-        if (configSet.getCreatedTimestamp() == null) {
-            configSet.setCreatedTimestamp(Instant.now());
-        }
-        configSetStore.put(key, configSet);
-        LOG.infov("Created SES configuration set: {0} in region {1}", configSet.getName(), region);
-        return configSet;
+        SesConfigurationSetService.validateVdmOptions(configSet.getVdmOptions());
+        return configSetService.create(configSet, region);
     }
 
+    // The tracking and delivery setters stay here: their validation reads other domains (a verified
+    // domain identity, a dedicated IP pool), so the facade resolves existence through the service,
+    // validates, and writes back through save.
+
     public void setConfigurationSetTrackingOptions(String configSetName, TrackingOptions options, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        ConfigurationSet cs = configSetService.get(configSetName, region);
         validateTrackingOptions(options, region);
         cs.setTrackingOptions(options);
-        configSetStore.put(configSetKey(region, configSetName), cs);
+        configSetService.save(cs, region);
         LOG.infov("Updated TrackingOptions on configuration set {0} in region {1}", configSetName, region);
     }
 
     public void setConfigurationSetDeliveryOptions(String configSetName, DeliveryOptions options, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        ConfigurationSet cs = configSetService.get(configSetName, region);
         validateDeliveryOptions(options, region);
         cs.setDeliveryOptions(options);
-        configSetStore.put(configSetKey(region, configSetName), cs);
+        configSetService.save(cs, region);
         LOG.infov("Updated DeliveryOptions on configuration set {0} in region {1}", configSetName, region);
     }
 
     public void setConfigurationSetReputationOptions(String configSetName, boolean metricsEnabled, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        cs.setReputationMetricsEnabled(metricsEnabled);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Updated ReputationMetricsEnabled on configuration set {0} in region {1}: {2}",
-                configSetName, region, metricsEnabled);
+        configSetService.setReputationMetricsEnabled(configSetName, metricsEnabled, region);
     }
 
     private boolean isVerifiedDomainIdentity(String domain, String region) {
@@ -1476,7 +1464,7 @@ public class SesService {
     public void createConfigurationSetTrackingOptions(String configSetName, String customRedirectDomain,
                                                       String region) {
         requireVerifiedRedirectDomain(customRedirectDomain, region);
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        ConfigurationSet cs = configSetService.get(configSetName, region);
         if (cs.getTrackingOptions() != null && cs.getTrackingOptions().getCustomRedirectDomain() != null) {
             throw new AwsException("TrackingOptionsAlreadyExistsException",
                     "Configuration set <" + configSetName + "> already has tracking options.", 400);
@@ -1484,71 +1472,33 @@ public class SesService {
         TrackingOptions options = new TrackingOptions();
         options.setCustomRedirectDomain(customRedirectDomain);
         cs.setTrackingOptions(options);
-        configSetStore.put(configSetKey(region, configSetName), cs);
+        configSetService.save(cs, region);
         LOG.infov("Created TrackingOptions on configuration set {0} in region {1}", configSetName, region);
     }
 
     public void updateConfigurationSetTrackingOptions(String configSetName, String customRedirectDomain,
                                                       String region) {
         requireVerifiedRedirectDomain(customRedirectDomain, region);
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
+        ConfigurationSet cs = configSetService.get(configSetName, region);
         if (cs.getTrackingOptions() == null || cs.getTrackingOptions().getCustomRedirectDomain() == null) {
             throw new AwsException("TrackingOptionsDoesNotExistException",
                     "There are no tracking options for configuration set <" + configSetName + ">", 400);
         }
         cs.getTrackingOptions().setCustomRedirectDomain(customRedirectDomain);
-        configSetStore.put(configSetKey(region, configSetName), cs);
+        configSetService.save(cs, region);
         LOG.infov("Updated TrackingOptions on configuration set {0} in region {1}", configSetName, region);
     }
 
     public void deleteConfigurationSetTrackingOptions(String configSetName, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        if (cs.getTrackingOptions() == null || cs.getTrackingOptions().getCustomRedirectDomain() == null) {
-            throw new AwsException("TrackingOptionsDoesNotExistException",
-                    "There are no tracking options for configuration set <" + configSetName + ">", 400);
-        }
-        cs.setTrackingOptions(null);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Deleted TrackingOptions on configuration set {0} in region {1}", configSetName, region);
+        configSetService.deleteTrackingOptions(configSetName, region);
     }
 
     public void setConfigurationSetArchivingOptions(String configSetName, ArchivingOptions options, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        cs.setArchivingOptions(options);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Updated ArchivingOptions on configuration set {0} in region {1}", configSetName, region);
+        configSetService.setArchivingOptions(configSetName, options, region);
     }
-
-    private static final java.util.Set<String> VDM_FEATURE_STATES = java.util.Set.of("ENABLED", "DISABLED");
 
     public void setConfigurationSetVdmOptions(String configSetName, VdmOptions options, String region) {
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        validateVdmOptions(options);
-        cs.setVdmOptions(options);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Updated VdmOptions on configuration set {0} in region {1}", configSetName, region);
-    }
-
-    private void validateVdmOptions(VdmOptions options) {
-        if (options == null) {
-            return;
-        }
-        // Enum values verified against real AWS 2026-06-19; messages use the
-        // nested member path and the [ENABLED, DISABLED] value set.
-        if (options.getDashboardOptions() != null
-                && options.getDashboardOptions().getEngagementMetrics() != null
-                && !VDM_FEATURE_STATES.contains(options.getDashboardOptions().getEngagementMetrics())) {
-            throw new AwsException("BadRequestException",
-                    "1 validation error detected: Value at 'vdmOptions.dashboardOptions.engagementMetrics' "
-                            + "failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]", 400);
-        }
-        if (options.getGuardianOptions() != null
-                && options.getGuardianOptions().getOptimizedSharedDelivery() != null
-                && !VDM_FEATURE_STATES.contains(options.getGuardianOptions().getOptimizedSharedDelivery())) {
-            throw new AwsException("BadRequestException",
-                    "1 validation error detected: Value at 'vdmOptions.guardianOptions.optimizedSharedDelivery' "
-                            + "failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]", 400);
-        }
+        configSetService.setVdmOptions(configSetName, options, region);
     }
 
     private static final java.util.Set<String> HTTPS_POLICIES =
@@ -1620,39 +1570,17 @@ public class SesService {
     }
 
     public ConfigurationSet getConfigurationSet(String name, String region) {
-        return configSetStore.get(configSetKey(region, name))
-                .orElseThrow(() -> new AwsException("ConfigurationSetDoesNotExist",
-                        "Configuration set <" + name + "> does not exist.", 400));
+        return configSetService.get(name, region);
     }
 
     public List<ConfigurationSet> listConfigurationSets(String region) {
-        String prefix = "configSet::" + region + "::";
-        List<ConfigurationSet> all = new ArrayList<>(configSetStore.scan(k -> k.startsWith(prefix)));
-        all.sort(Comparator.comparing(ConfigurationSet::getCreatedTimestamp,
-                        Comparator.nullsLast(Comparator.naturalOrder()))
-                .thenComparing(ConfigurationSet::getName,
-                        Comparator.nullsLast(Comparator.naturalOrder())));
-        return all;
+        return configSetService.list(region);
     }
 
     public void deleteConfigurationSet(String name, String region) {
-        String key = configSetKey(region, name);
-        if (configSetStore.get(key).isEmpty()) {
-            throw new AwsException("ConfigurationSetDoesNotExist",
-                    "Configuration set <" + name + "> does not exist.", 400);
-        }
+        configSetService.get(name, region);
         tenantService.deleteBackingResource(SesTenantService.RESOURCE_TYPE_CONFIGURATION_SET, name,
-                region, () -> {
-                    configSetStore.delete(key);
-                    LOG.infov("Deleted SES configuration set: {0} in region {1}", name, region);
-                });
-    }
-
-    private static final Pattern CONFIG_SET_NAME = Pattern.compile("^[A-Za-z0-9_-]{1,64}$");
-
-    private static String configSetKey(String region, String name) {
-        validateConfigurationSetName(name);
-        return "configSet::" + region + "::" + name;
+                region, () -> configSetService.remove(name, region));
     }
 
     // ──────────────────────── Tenants (multi-tenancy) ────────────────────────
@@ -1817,8 +1745,8 @@ public class SesService {
             case SesTenantService.RESOURCE_TYPE_IDENTITY ->
                     identityStore.get(identityKey(region, ref.name())).isPresent();
             case SesTenantService.RESOURCE_TYPE_CONFIGURATION_SET ->
-                    CONFIG_SET_NAME.matcher(ref.name()).matches()
-                            && configSetStore.get(configSetKey(region, ref.name())).isPresent();
+                    SesConfigurationSetService.isValidName(ref.name())
+                            && configSetService.find(ref.name(), region).isPresent();
             case SesTenantService.RESOURCE_TYPE_TEMPLATE ->
                     templateService.find(ref.name(), region).isPresent();
             default -> false;
@@ -2004,104 +1932,28 @@ public class SesService {
 
 
 
-    static void validateConfigurationSetName(String name) {
-        if (name == null || name.isBlank()) {
-            throw new AwsException("InvalidParameterValue",
-                    "ConfigurationSetName is required.", 400);
-        }
-        if (!CONFIG_SET_NAME.matcher(name).matches()) {
-            throw new AwsException("InvalidParameterValue",
-                    "ConfigurationSetName must be 1-64 characters and may only contain "
-                            + "alphanumeric characters, underscores, and hyphens.", 400);
-        }
-    }
-
-    private static final Pattern EVENT_DESTINATION_NAME_CHARS = Pattern.compile("^[A-Za-z0-9_-]+$");
-
-    private static final int MAX_EVENT_DESTINATION_NAME_LENGTH = 64;
-
-    private static final List<String> VALID_EVENT_TYPES = List.of(
-            "SEND", "REJECT", "BOUNCE", "COMPLAINT", "DELIVERY", "OPEN", "CLICK",
-            "RENDERING_FAILURE", "DELIVERY_DELAY", "SUBSCRIPTION");
-
     public void createConfigurationSetEventDestination(String configSetName, String eventDestinationName,
                                                        EventDestination dest, String region) {
-        validateEventDestinationName(eventDestinationName);
-        validateEventDestination(dest);
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        if (indexOfEventDestination(cs.getEventDestinations(), eventDestinationName) >= 0) {
-            throw new AwsException("AlreadyExists",
-                    "An event destination with name <" + eventDestinationName
-                            + "> already exists for configuration set <" + configSetName + ">.", 400);
-        }
-        dest.setName(eventDestinationName);
-        cs.getEventDestinations().add(dest);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Created SES event destination {0} on configuration set {1} in region {2}",
-                eventDestinationName, configSetName, region);
+        configSetService.createEventDestination(configSetName, eventDestinationName, dest, region);
     }
 
     public List<EventDestination> getConfigurationSetEventDestinations(String configSetName, String region) {
-        return List.copyOf(getConfigurationSet(configSetName, region).getEventDestinations());
+        return configSetService.getEventDestinations(configSetName, region);
     }
 
     public void updateConfigurationSetEventDestination(String configSetName, String eventDestinationName,
                                                        EventDestination dest, String region) {
-        validateEventDestinationName(eventDestinationName);
-        validateEventDestination(dest);
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        int index = indexOfEventDestination(cs.getEventDestinations(), eventDestinationName);
-        if (index < 0) {
-            throw new AwsException("NotFoundException",
-                    "An event destination with name <" + eventDestinationName
-                            + "> does not exist for configuration set <" + configSetName + ">.", 404);
-        }
-        dest.setName(eventDestinationName);
-        cs.getEventDestinations().set(index, dest);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Updated SES event destination {0} on configuration set {1} in region {2}",
-                eventDestinationName, configSetName, region);
+        configSetService.updateEventDestination(configSetName, eventDestinationName, dest, region);
     }
 
     public void deleteConfigurationSetEventDestination(String configSetName, String eventDestinationName,
                                                        String region) {
-        validateEventDestinationName(eventDestinationName);
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        boolean removed = cs.getEventDestinations().removeIf(ed -> eventDestinationName.equals(ed.getName()));
-        if (!removed) {
-            throw new AwsException("NotFoundException",
-                    "An event destination with name <" + eventDestinationName
-                            + "> does not exist for configuration set <" + configSetName + ">.", 404);
-        }
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Deleted SES event destination {0} on configuration set {1} in region {2}",
-                eventDestinationName, configSetName, region);
+        configSetService.deleteEventDestination(configSetName, eventDestinationName, region);
     }
 
-    /**
-     * Stores per-configuration-set suppression overrides. Mirrors the AWS V2
-     * {@code PutConfigurationSetSuppressionOptions} contract: {@code reasons} may
-     * be {@code null} or empty (explicit "no filtering" for this set) or a subset
-     * of {@code [BOUNCE, COMPLAINT]}. Once set, the value is returned through
-     * {@link #getConfigurationSet}; downstream callers can resolve the effective
-     * reasons for a given send via {@link #getEffectiveSuppressedReasons}.
-     */
     public void putConfigurationSetSuppressionOptions(String configSetName,
                                                       List<String> reasons, String region) {
-        List<String> sanitized = new ArrayList<>();
-        if (reasons != null) {
-            for (String r : reasons) {
-                validateConfigSetSuppressionReason(r);
-                sanitized.add(r);
-            }
-        }
-        ConfigurationSet cs = getConfigurationSet(configSetName, region);
-        SuppressionOptions options = new SuppressionOptions();
-        options.setSuppressedReasons(sanitized);
-        cs.setSuppressionOptions(options);
-        configSetStore.put(configSetKey(region, configSetName), cs);
-        LOG.infov("Updated SuppressionOptions on configuration set {0} in region {1}: {2}",
-                configSetName, region, sanitized);
+        configSetService.putSuppressionOptions(configSetName, reasons, region);
     }
 
     /**
@@ -2125,118 +1977,6 @@ public class SesService {
         return List.copyOf(getAccountSuppressionAttributes(region).getSuppressedReasons());
     }
 
-    private static int indexOfEventDestination(List<EventDestination> destinations, String name) {
-        for (int i = 0; i < destinations.size(); i++) {
-            if (name != null && name.equals(destinations.get(i).getName())) {
-                return i;
-            }
-        }
-        return -1;
-    }
-
-    static void validateEventDestinationName(String name) {
-        if (name == null || name.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "EventDestinationName is required.", 400);
-        }
-        if (!EVENT_DESTINATION_NAME_CHARS.matcher(name).matches()) {
-            throw new AwsException("InvalidParameterValue",
-                    "Invalid event destination name <" + name + ">: only alphanumeric ASCII characters, "
-                            + "'_', and '-' are allowed.", 400);
-        }
-        if (name.length() > MAX_EVENT_DESTINATION_NAME_LENGTH) {
-            throw new AwsException("InvalidParameterValue",
-                    "Event destination name cannot exceed 64 characters.", 400);
-        }
-    }
-
-    static void validateEventDestination(EventDestination dest) {
-        if (dest == null) {
-            throw new AwsException("InvalidParameterValue", "EventDestination is required.", 400);
-        }
-        List<String> types = dest.getMatchingEventTypes();
-        if (types == null || types.isEmpty()) {
-            throw new AwsException("InvalidParameterValue", "At least one event type must be specified.", 400);
-        }
-        for (String t : types) {
-            if (t == null || !VALID_EVENT_TYPES.contains(t)) {
-                throw new AwsException("InvalidParameterValue",
-                        "Invalid event type: " + t + ". Valid values are " + VALID_EVENT_TYPES + ".", 400);
-            }
-        }
-        int destinationCount = countDestinations(dest);
-        if (destinationCount == 0) {
-            throw new AwsException("InvalidParameterValue", "Event destination is not provided.", 400);
-        }
-        if (destinationCount > 1) {
-            throw new AwsException("InvalidParameterValue",
-                    "Please provide only one destination with each request. Either a Firehose Destination "
-                            + "or a Cloudwatch Destination or an SNS Destination or an EventBridge Destination.", 400);
-        }
-        if (dest.getSnsDestination() != null
-                && (dest.getSnsDestination().getTopicArn() == null
-                || dest.getSnsDestination().getTopicArn().isBlank())) {
-            throw new AwsException("InvalidParameterValue",
-                    "SnsDestination requires a non-blank TopicArn.", 400);
-        }
-        if (dest.getKinesisFirehoseDestination() != null
-                && (dest.getKinesisFirehoseDestination().getIamRoleArn() == null
-                || dest.getKinesisFirehoseDestination().getIamRoleArn().isBlank()
-                || dest.getKinesisFirehoseDestination().getDeliveryStreamArn() == null
-                || dest.getKinesisFirehoseDestination().getDeliveryStreamArn().isBlank())) {
-            throw new AwsException("InvalidParameterValue",
-                    "KinesisFirehoseDestination requires both IamRoleArn and DeliveryStreamArn.",
-                    400);
-        }
-        if (dest.getCloudWatchDestination() != null) {
-            List<CloudWatchDimensionConfiguration> dims =
-                    dest.getCloudWatchDestination().getDimensionConfigurations();
-            if (dims == null || dims.isEmpty()) {
-                throw new AwsException("InvalidParameterValue",
-                        "CloudWatch metrics dimension configuration list cannot be empty.", 400);
-            }
-            for (int i = 0; i < dims.size(); i++) {
-                CloudWatchDimensionConfiguration dim = dims.get(i);
-                if (dim == null
-                        || dim.getDimensionName() == null || dim.getDimensionName().isBlank()
-                        || dim.getDimensionValueSource() == null
-                        || dim.getDimensionValueSource().isBlank()
-                        || dim.getDefaultDimensionValue() == null
-                        || dim.getDefaultDimensionValue().isBlank()) {
-                    throw new AwsException("InvalidParameterValue",
-                            "CloudWatchDestination dimension configurations require "
-                                    + "DimensionName, DimensionValueSource, and DefaultDimensionValue "
-                                    + "(missing on member " + (i + 1) + ").", 400);
-                }
-            }
-        }
-        if (dest.getPinpointDestination() != null
-                && (dest.getPinpointDestination().getApplicationArn() == null
-                || dest.getPinpointDestination().getApplicationArn().isBlank())) {
-            throw new AwsException("InvalidParameterValue",
-                    "Invalid Pinpoint application ARN provided: "
-                            + dest.getPinpointDestination().getApplicationArn() + ".", 400);
-        }
-    }
-
-    private static int countDestinations(EventDestination dest) {
-        int count = 0;
-        if (dest.getSnsDestination() != null) {
-            count++;
-        }
-        if (dest.getCloudWatchDestination() != null) {
-            count++;
-        }
-        if (dest.getKinesisFirehoseDestination() != null) {
-            count++;
-        }
-        if (dest.getEventBridgeDestination() != null) {
-            count++;
-        }
-        if (dest.getPinpointDestination() != null) {
-            count++;
-        }
-        return count;
-    }
 
     public List<Tag> listResourceTags(String arn, String region) {
         ResourceRef ref = parseSesArn(arn);
@@ -2310,25 +2050,23 @@ public class SesService {
     }
 
     private List<Tag> listConfigurationSetTags(String name, String region) {
-        ConfigurationSet cs = configSetStore.get(configSetKey(region, name))
+        ConfigurationSet cs = configSetService.find(name, region)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "No ConfigurationSet present with name: " + name, 404));
         return new ArrayList<>(cs.getTags());
     }
 
     private void tagConfigurationSet(String name, String region, List<Tag> newTags) {
-        String key = configSetKey(region, name);
-        ConfigurationSet cs = configSetStore.get(key)
+        ConfigurationSet cs = configSetService.find(name, region)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "No ConfigurationSet present with name: " + name, 404));
         cs.setTags(SesTags.merge(cs.getTags(), newTags));
-        configSetStore.put(key, cs);
+        configSetService.save(cs, region);
         LOG.infov("Tagged SES configuration set: {0} (region {1}, +{2} tags)", name, region, newTags.size());
     }
 
     private void untagConfigurationSet(String name, String region, List<String> tagKeys) {
-        String key = configSetKey(region, name);
-        ConfigurationSet cs = configSetStore.get(key)
+        ConfigurationSet cs = configSetService.find(name, region)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "No ConfigurationSet present with name: " + name, 404));
         Set<String> toRemove = new HashSet<>(tagKeys);
@@ -2336,7 +2074,7 @@ public class SesService {
         List<Tag> remaining = new ArrayList<>(cs.getTags());
         remaining.removeIf(t -> toRemove.contains(t.key()));
         cs.setTags(remaining);
-        configSetStore.put(key, cs);
+        configSetService.save(cs, region);
         LOG.infov("Untagged SES configuration set: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
     }
 
@@ -2719,7 +2457,7 @@ public class SesService {
      * callers (publishSendEvents) to map the recipient to a synthetic Bounce / Complaint
      * event without consulting the store again. Both the per-address suppression entries
      * and the account-level / per-CS {@code suppressedReasons} go through
-     * {@link SesSuppressionService}'s reason validation / {@link #validateConfigSetSuppressionReason},
+     * {@link SesSuppressionService}'s reason validation / {@link SesConfigurationSetService}'s,
      * which enforce exact case-sensitive equality with the two canonical values, so
      * {@code entry.getReason()} is guaranteed to be canonical and downstream
      * {@code .equals("BOUNCE")} / {@code .equals("COMPLAINT")} checks are safe.
@@ -2743,30 +2481,6 @@ public class SesService {
     }
 
 
-    /**
-     * Validation message used by PutConfigurationSetSuppressionOptions. AWS
-     * V2 SES uses a different, simpler natural-language sentence on this
-     * endpoint than on the three older suppression APIs above:
-     *   "Reason <X> is invalid, must be one of [BOUNCE, COMPLAINT]."
-     * (Verified against real AWS V2 SES on 2026-06-03.) CreateConfigurationSet
-     * reports the constraint-style validation message for invalid non-null
-     * values but falls back to this sentence for null elements, matching AWS
-     * (verified 2026-06-13); see {@link #createConfigurationSet}.
-     */
-    private static void validateConfigSetSuppressionReason(String reason) {
-        if (!isValidConfigSetSuppressionReason(reason)) {
-            throw new AwsException("BadRequestException",
-                    invalidSuppressionReasonMessage(reason), 400);
-        }
-    }
-
-    private static boolean isValidConfigSetSuppressionReason(String reason) {
-        return "BOUNCE".equals(reason) || "COMPLAINT".equals(reason);
-    }
-
-    private static String invalidSuppressionReasonMessage(String reason) {
-        return "Reason " + reason + " is invalid, must be one of [BOUNCE, COMPLAINT].";
-    }
 
     public String sendTemplatedEmail(String source, List<String> toAddresses, List<String> ccAddresses,
                                      List<String> bccAddresses, List<String> replyToAddresses,

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -2456,9 +2456,9 @@ public class SesService {
      * <p>The returned value is one of {@code "BOUNCE"} / {@code "COMPLAINT"}, allowing
      * callers (publishSendEvents) to map the recipient to a synthetic Bounce / Complaint
      * event without consulting the store again. Both the per-address suppression entries
-     * and the account-level / per-CS {@code suppressedReasons} go through
-     * {@link SesSuppressionService}'s reason validation / {@link SesConfigurationSetService}'s,
-     * which enforce exact case-sensitive equality with the two canonical values, so
+     * and the account-level / per-CS {@code suppressedReasons} go through reason validation
+     * (in {@link SesSuppressionService} and {@link SesConfigurationSetService} respectively),
+     * which enforces exact case-sensitive equality with the two canonical values, so
      * {@code entry.getReason()} is guaranteed to be canonical and downstream
      * {@code .equals("BOUNCE")} / {@code .equals("COMPLAINT")} checks are safe.
      */

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * pure logic and live here rather than in the integration test. Error
  * messages mirror the real AWS SESv2 wire responses.
  */
-class SesServiceEventDestinationTest {
+class SesConfigurationSetEventDestinationTest {
 
     private static EventDestination withSns(List<String> matchingEventTypes) {
         EventDestination ed = new EventDestination();

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetServiceTest.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,9 +63,20 @@ class SesConfigurationSetServiceTest {
         service.create(cs("b-cs"), REGION);
         service.create(cs("a-cs"), REGION);
         service.create(cs("other"), "eu-west-1");
+        // create() stamps Instant.now(), which can collide within one clock tick and fall back to
+        // the name tie-break; pin distinct timestamps through the escape hatch so the
+        // creation-order assertion stays deterministic.
+        stampCreated("b-cs", Instant.parse("2026-01-01T00:00:00Z"));
+        stampCreated("a-cs", Instant.parse("2026-01-02T00:00:00Z"));
         List<ConfigurationSet> list = service.list(REGION);
         assertEquals(2, list.size());
         assertEquals("b-cs", list.get(0).getName());
+    }
+
+    private void stampCreated(String name, Instant timestamp) {
+        ConfigurationSet loaded = service.find(name, REGION).orElseThrow();
+        loaded.setCreatedTimestamp(timestamp);
+        service.save(loaded, REGION);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetServiceTest.java
@@ -1,0 +1,91 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for the extracted configuration-set domain: store ownership, key derivation and name
+ * validation, CRUD semantics, and the find/save escape hatches the facade's cross-domain
+ * orchestration relies on. The option setters and event destinations keep their coverage in the
+ * existing facade-level unit and integration tests, which now exercise them through the delegation.
+ */
+class SesConfigurationSetServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private SesConfigurationSetService service;
+
+    private static ConfigurationSet cs(String name) {
+        ConfigurationSet cs = new ConfigurationSet();
+        cs.setName(name);
+        return cs;
+    }
+
+    @BeforeEach
+    void setUp() {
+        service = new SesConfigurationSetService(new InMemoryStorage<>());
+    }
+
+    @Test
+    void create_get_roundTrips_andStampsTimestamp() {
+        service.create(cs("my-cs"), REGION);
+        ConfigurationSet got = service.get("my-cs", REGION);
+        assertEquals("my-cs", got.getName());
+        assertTrue(got.getCreatedTimestamp() != null);
+    }
+
+    @Test
+    void create_duplicateThrows() {
+        service.create(cs("my-cs"), REGION);
+        AwsException e = assertThrows(AwsException.class, () -> service.create(cs("my-cs"), REGION));
+        assertEquals("ConfigurationSetAlreadyExists", e.getErrorCode());
+    }
+
+    @Test
+    void get_missingThrows_withV1Code() {
+        AwsException e = assertThrows(AwsException.class, () -> service.get("ghost", REGION));
+        assertEquals("ConfigurationSetDoesNotExist", e.getErrorCode());
+        assertEquals("Configuration set <ghost> does not exist.", e.getMessage());
+    }
+
+    @Test
+    void list_isPerRegion_sortedByCreation() {
+        service.create(cs("b-cs"), REGION);
+        service.create(cs("a-cs"), REGION);
+        service.create(cs("other"), "eu-west-1");
+        List<ConfigurationSet> list = service.list(REGION);
+        assertEquals(2, list.size());
+        assertEquals("b-cs", list.get(0).getName());
+    }
+
+    @Test
+    void findAndSave_backTheFacadeOrchestration_removeDeletes() {
+        assertTrue(service.find("my-cs", REGION).isEmpty());
+        service.create(cs("my-cs"), REGION);
+        ConfigurationSet loaded = service.find("my-cs", REGION).orElseThrow();
+        loaded.setSendingEnabled(false);
+        service.save(loaded, REGION);
+        assertEquals(false, service.get("my-cs", REGION).getSendingEnabled());
+
+        service.remove("my-cs", REGION);
+        assertTrue(service.find("my-cs", REGION).isEmpty());
+    }
+
+    @Test
+    void nameValidation_guardsKeysAndTenantGate() {
+        AwsException e = assertThrows(AwsException.class, () -> service.get("bad name!", REGION));
+        assertEquals("InvalidParameterValue", e.getErrorCode());
+        assertTrue(SesConfigurationSetService.isValidName("my-cs"));
+        assertFalse(SesConfigurationSetService.isValidName("bad name!"));
+        assertFalse(SesConfigurationSetService.isValidName(null));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceEventDestinationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceEventDestinationTest.java
@@ -34,20 +34,20 @@ class SesServiceEventDestinationTest {
 
     @Test
     void validName_passes() {
-        assertDoesNotThrow(() -> SesService.validateEventDestinationName("my-dest_1"));
+        assertDoesNotThrow(() -> SesConfigurationSetService.validateEventDestinationName("my-dest_1"));
     }
 
     @Test
     void blankName_throwsInvalidParameterValue() {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestinationName("   "));
+                () -> SesConfigurationSetService.validateEventDestinationName("   "));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
     }
 
     @Test
     void invalidNameCharacters_throws() {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestinationName("bad name!"));
+                () -> SesConfigurationSetService.validateEventDestinationName("bad name!"));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("Invalid event destination name <bad name!>: only alphanumeric ASCII characters, "
                 + "'_', and '-' are allowed.", ex.getMessage());
@@ -56,20 +56,20 @@ class SesServiceEventDestinationTest {
     @Test
     void nameTooLong_throws() {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestinationName("a".repeat(65)));
+                () -> SesConfigurationSetService.validateEventDestinationName("a".repeat(65)));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("Event destination name cannot exceed 64 characters.", ex.getMessage());
     }
 
     @Test
     void validDestination_passes() {
-        assertDoesNotThrow(() -> SesService.validateEventDestination(withSns(List.of("SEND", "BOUNCE"))));
+        assertDoesNotThrow(() -> SesConfigurationSetService.validateEventDestination(withSns(List.of("SEND", "BOUNCE"))));
     }
 
     @Test
     void emptyMatchingEventTypes_throws() {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(withSns(List.of())));
+                () -> SesConfigurationSetService.validateEventDestination(withSns(List.of())));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("At least one event type must be specified.", ex.getMessage());
     }
@@ -77,7 +77,7 @@ class SesServiceEventDestinationTest {
     @Test
     void invalidEventType_throws() {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(withSns(List.of("SEND", "NOPE"))));
+                () -> SesConfigurationSetService.validateEventDestination(withSns(List.of("SEND", "NOPE"))));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("Invalid event type: NOPE. Valid values are [SEND, REJECT, BOUNCE, COMPLAINT, "
                 + "DELIVERY, OPEN, CLICK, RENDERING_FAILURE, DELIVERY_DELAY, SUBSCRIPTION].", ex.getMessage());
@@ -88,7 +88,7 @@ class SesServiceEventDestinationTest {
         EventDestination ed = new EventDestination();
         ed.setMatchingEventTypes(List.of("SEND"));
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("Event destination is not provided.", ex.getMessage());
     }
@@ -98,7 +98,7 @@ class SesServiceEventDestinationTest {
         EventDestination ed = withSns(List.of("SEND"));
         ed.setCloudWatchDestination(cloudWatch());
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("Please provide only one destination with each request. Either a Firehose Destination "
                 + "or a Cloudwatch Destination or an SNS Destination or an EventBridge Destination.",
@@ -111,7 +111,7 @@ class SesServiceEventDestinationTest {
         ed.setMatchingEventTypes(List.of("SEND"));
         ed.setCloudWatchDestination(new CloudWatchDestination());
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("CloudWatch metrics dimension configuration list cannot be empty.", ex.getMessage());
     }
@@ -121,7 +121,7 @@ class SesServiceEventDestinationTest {
         EventDestination ed = new EventDestination();
         ed.setMatchingEventTypes(List.of("SEND"));
         ed.setCloudWatchDestination(cloudWatch());
-        assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+        assertDoesNotThrow(() -> SesConfigurationSetService.validateEventDestination(ed));
     }
 
     @Test
@@ -130,7 +130,7 @@ class SesServiceEventDestinationTest {
         ed.setMatchingEventTypes(List.of("SEND"));
         ed.setPinpointDestination(new PinpointDestination());
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("Invalid Pinpoint application ARN provided: null.", ex.getMessage());
     }
@@ -142,7 +142,7 @@ class SesServiceEventDestinationTest {
         PinpointDestination pp = new PinpointDestination();
         pp.setApplicationArn("arn:aws:mobiletargeting:us-east-1:000000000000:apps/abc");
         ed.setPinpointDestination(pp);
-        assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+        assertDoesNotThrow(() -> SesConfigurationSetService.validateEventDestination(ed));
     }
 
     @Test
@@ -153,7 +153,7 @@ class SesServiceEventDestinationTest {
         sns.setTopicArn("");
         ed.setSnsDestination(sns);
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("SnsDestination requires a non-blank TopicArn.", ex.getMessage());
     }
@@ -164,7 +164,7 @@ class SesServiceEventDestinationTest {
         ed.setMatchingEventTypes(List.of("SEND"));
         ed.setSnsDestination(new SnsDestination()); // TopicArn left null
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("SnsDestination requires a non-blank TopicArn.", ex.getMessage());
     }
@@ -178,7 +178,7 @@ class SesServiceEventDestinationTest {
         // DeliveryStreamArn left null
         ed.setKinesisFirehoseDestination(fh);
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         assertEquals("KinesisFirehoseDestination requires both IamRoleArn and DeliveryStreamArn.",
                 ex.getMessage());
@@ -192,7 +192,7 @@ class SesServiceEventDestinationTest {
         fh.setDeliveryStreamArn("arn:aws:firehose:us-east-1:000000000000:deliverystream/ses");
         // IamRoleArn left null
         ed.setKinesisFirehoseDestination(fh);
-        assertThrows(AwsException.class, () -> SesService.validateEventDestination(ed));
+        assertThrows(AwsException.class, () -> SesConfigurationSetService.validateEventDestination(ed));
     }
 
     @Test
@@ -203,7 +203,7 @@ class SesServiceEventDestinationTest {
         fh.setIamRoleArn("arn:aws:iam::000000000000:role/ses-firehose");
         fh.setDeliveryStreamArn("arn:aws:firehose:us-east-1:000000000000:deliverystream/ses");
         ed.setKinesisFirehoseDestination(fh);
-        assertDoesNotThrow(() -> SesService.validateEventDestination(ed));
+        assertDoesNotThrow(() -> SesConfigurationSetService.validateEventDestination(ed));
     }
 
     @Test
@@ -218,7 +218,7 @@ class SesServiceEventDestinationTest {
         cw.setDimensionConfigurations(List.of(dim));
         ed.setCloudWatchDestination(cw);
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.validateEventDestination(ed));
+                () -> SesConfigurationSetService.validateEventDestination(ed));
         assertEquals("InvalidParameterValue", ex.getErrorCode());
         // Member index 1-based for callers, included in the error message.
         assertEquals("CloudWatchDestination dimension configurations require "
@@ -237,7 +237,7 @@ class SesServiceEventDestinationTest {
         dim.setDefaultDimensionValue("default");
         cw.setDimensionConfigurations(List.of(dim));
         ed.setCloudWatchDestination(cw);
-        assertThrows(AwsException.class, () -> SesService.validateEventDestination(ed));
+        assertThrows(AwsException.class, () -> SesConfigurationSetService.validateEventDestination(ed));
     }
 
     @Test
@@ -251,7 +251,7 @@ class SesServiceEventDestinationTest {
         // DefaultDimensionValue left null
         cw.setDimensionConfigurations(List.of(dim));
         ed.setCloudWatchDestination(cw);
-        assertThrows(AwsException.class, () -> SesService.validateEventDestination(ed));
+        assertThrows(AwsException.class, () -> SesConfigurationSetService.validateEventDestination(ed));
     }
 
     private static CloudWatchDestination cloudWatch() {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
@@ -120,7 +120,7 @@ final class SesServiceTestBuilder {
                 new SesSentEmailService(emailStore),
                 new SesAccountService(accountSettingsStore, accountVdmStore, accountDetailsStore),
                 new SesTemplateService(templateStore),
-                configSetStore,
+                new SesConfigurationSetService(configSetStore),
                 new SesSuppressionService(suppressionStore, accountSuppressionStore, new InMemoryStorage<>()),
                 new SesDedicatedIpService(dedicatedIpPoolStore),
                 new SesContactService(contactListStore, contactStore, clock),


### PR DESCRIPTION
## Summary

Follow-up to #2356: extracts one of the two stores the strangler refactor (#2357) deliberately
deferred until the tenant work (#2643) landed. The configuration-set domain moves out of the
`SesService` facade into a dedicated `SesConfigurationSetService` — the store and its key scheme,
name validation, CRUD (create/get/list/delete), the pure option setters, suppression options, and
event destinations with their validators. The facade keeps what is genuinely cross-domain: the
`CreateConfigurationSet` validation sequence, the tracking/delivery setters (they consult other
domains), send-path reads, the tag helpers (via the find/save escape hatches), and the tenant
delete guard.

No behavior change — request/response shapes, error messages, and validation order are untouched.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Pure code motion behind the facade; no wire-visible change. The full SES test suite (1019 tests —
unit, integration, and the v1/v2 protocol tests) passes unchanged, pinning the existing
probe-confirmed shapes and messages.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added — not applicable: behavior-preserving refactor, existing tests pin the behavior
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
