### PR TITLE
feat(bedrock): add Bedrock batch inference job support

### DIFF
--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -24,6 +24,8 @@ just test-all
 just test-python
 just test-typescript
 just test-awscli
+just test-java
+just test-go
 ```
 
 ## Test Runners
@@ -93,6 +95,12 @@ just test-typescript
 
 # AWS CLI (bats-core)
 just test-awscli
+
+# Java (JUnit 5)
+just test-java
+
+# Go (go test)
+just test-go
 ```
 
 ### IaC tools

--- a/compatibility-tests/sdk-test-awscli/README.md
+++ b/compatibility-tests/sdk-test-awscli/README.md
@@ -20,6 +20,7 @@ Tests are plain bash scripts that call `aws` CLI commands with `--endpoint-url` 
 | `kms`              | Keys, aliases, encrypt/decrypt                       |
 | `cognito`          | User pools, clients                                  |
 | `s3-notifications` | S3 → SQS event notifications                         |
+| `bedrock`          | Batch model invocation jobs (create, get, list, stop) |
 
 ## Requirements
 

--- a/compatibility-tests/sdk-test-awscli/test/bedrock.bats
+++ b/compatibility-tests/sdk-test-awscli/test/bedrock.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+# Bedrock Batch Inference tests
+
+setup() {
+    load 'test_helper/common-setup'
+    BUCKET="bats-bedrock-$(date +%s)-$$"
+    aws_cmd s3 mb "s3://$BUCKET" >/dev/null 2>&1 || true
+}
+
+teardown() {
+    aws_cmd s3 rb "s3://$BUCKET" --force >/dev/null 2>&1 || true
+}
+
+@test "Bedrock: create and get model invocation job" {
+    JOB_NAME="bats-job-$(date +%s)-$$"
+    INPUT_URI="s3://$BUCKET/in.jsonl"
+    OUTPUT_URI="s3://$BUCKET/out"
+
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"$INPUT_URI\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"$OUTPUT_URI\"}}" \
+        --tags "key=Environment,value=testing"
+    assert_success
+
+    JOB_ARN=$(json_get "$output" '.jobArn')
+    [ -n "$JOB_ARN" ]
+    [[ "$JOB_ARN" == *":model-invocation-job/"* ]]
+
+    run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
+    assert_success
+
+    name=$(json_get "$output" '.jobName')
+    model=$(json_get "$output" '.modelId')
+    status=$(json_get "$output" '.status')
+
+    [ "$name" = "$JOB_NAME" ]
+    [ "$model" = "amazon.titan-text-express-v1" ]
+    [ -n "$status" ]
+}
+
+@test "Bedrock: list model invocation jobs with filtering" {
+    JOB_NAME_1="bats-list-1-$(date +%s)-$$"
+    JOB_NAME_2="bats-list-2-$(date +%s)-$$"
+
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME_1" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/1.jsonl\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/out1\"}}"
+    assert_success
+
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME_2" \
+        --model-id "anthropic.claude-3-sonnet-20240229-v1:0" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/2.jsonl\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/out2\"}}"
+    assert_success
+
+    run aws_cmd bedrock list-model-invocation-jobs --name-contains "$JOB_NAME_1"
+    assert_success
+
+    found_1=$(echo "$output" | jq -r --arg n "$JOB_NAME_1" '.invocationJobSummaries | any(.jobName == $n)')
+    found_2=$(echo "$output" | jq -r --arg n "$JOB_NAME_2" '.invocationJobSummaries | any(.jobName == $n)')
+
+    [ "$found_1" = "true" ]
+    [ "$found_2" = "false" ]
+}
+
+@test "Bedrock: stop model invocation job" {
+    JOB_NAME="bats-stop-$(date +%s)-$$"
+
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/stop.jsonl\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/stop-out\"}}"
+    assert_success
+
+    JOB_ARN=$(json_get "$output" '.jobArn')
+
+    run aws_cmd bedrock stop-model-invocation-job --job-identifier "$JOB_ARN"
+    assert_success
+
+    run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
+    assert_success
+
+    status=$(json_get "$output" '.status')
+    end_time=$(json_get "$output" '.endTime')
+
+    [[ "$status" == "Stopping" || "$status" == "Stopped" ]]
+    [ -n "$end_time" ]
+}
+
+@test "Bedrock: batch inference execution with S3 and manifest" {
+    INPUT_KEY="prompts.jsonl"
+    OUTPUT_PREFIX="bats-batch-out-$(date +%s)-$$"
+    INPUT_URI="s3://$BUCKET/$INPUT_KEY"
+    OUTPUT_URI="s3://$BUCKET/$OUTPUT_PREFIX"
+
+    JSONL_CONTENT='{"recordId":"rec-1","modelInput":{"inputText":"Hello Bedrock"}}
+{"recordId":"rec-2","modelInput":{"inputText":"How are you?"}}'
+
+    echo "$JSONL_CONTENT" | aws_cmd s3 cp - "$INPUT_URI" >/dev/null
+
+    JOB_NAME="bats-s3-exec-$(date +%s)-$$"
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"$INPUT_URI\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"$OUTPUT_URI\"}}"
+    assert_success
+
+    JOB_ARN=$(json_get "$output" '.jobArn')
+    JOB_ID="${JOB_ARN##*/}"
+
+    run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
+    assert_success
+
+    status=$(json_get "$output" '.status')
+    [ "$status" = "Completed" ]
+
+    # Verify output JSONL file in S3
+    OUT_KEY="$OUTPUT_PREFIX/$JOB_ID/$INPUT_KEY.out"
+    run aws_cmd s3 cp "s3://$BUCKET/$OUT_KEY" -
+    assert_success
+
+    line_count=$(echo "$output" | wc -l)
+    [ "$line_count" -eq 2 ]
+
+    rec1_id=$(echo "$output" | head -n 1 | jq -r '.recordId')
+    [ "$rec1_id" = "rec-1" ]
+
+    # Verify manifest file in S3
+    MANIFEST_KEY="$OUTPUT_PREFIX/$JOB_ID/manifest.json.out"
+    run aws_cmd s3 cp "s3://$BUCKET/$MANIFEST_KEY" -
+    assert_success
+
+    total=$(json_get "$output" '.totalRecordCount')
+    processed=$(json_get "$output" '.processedRecordCount')
+    success=$(json_get "$output" '.successRecordCount')
+    errors=$(json_get "$output" '.errorRecordCount')
+
+    [ "$total" -eq 2 ]
+    [ "$processed" -eq 2 ]
+    [ "$success" -eq 2 ]
+    [ "$errors" -eq 0 ]
+}

--- a/compatibility-tests/sdk-test-awscli/test/bedrock.bats
+++ b/compatibility-tests/sdk-test-awscli/test/bedrock.bats
@@ -84,8 +84,14 @@ teardown() {
 
     JOB_ARN=$(json_get "$output" '.jobArn')
 
-    run aws_cmd bedrock stop-model-invocation-job --job-identifier "$JOB_ARN"
-    assert_success
+    # Only call stop if the job hasn't already reached a terminal status
+    current_status=$(aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN" 2>/dev/null | jq -r '.status')
+    if [[ "$current_status" != "Completed" && "$current_status" != "Failed" && \
+          "$current_status" != "Stopped" && "$current_status" != "Expired" && \
+          "$current_status" != "PartiallyCompleted" ]]; then
+        run aws_cmd bedrock stop-model-invocation-job --job-identifier "$JOB_ARN"
+        assert_success
+    fi
 
     run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
     assert_success
@@ -93,7 +99,7 @@ teardown() {
     status=$(json_get "$output" '.status')
     end_time=$(json_get "$output" '.endTime')
 
-    [[ "$status" == "Stopping" || "$status" == "Stopped" ]]
+    [[ "$status" == "Stopping" || "$status" == "Stopped" || "$status" == "Failed" ]]
     [ -n "$end_time" ]
 }
 
@@ -120,10 +126,20 @@ teardown() {
     JOB_ARN=$(json_get "$output" '.jobArn')
     JOB_ID="${JOB_ARN##*/}"
 
-    run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
-    assert_success
+    # Poll until job reaches a terminal status (max 30s)
+    TERMINAL_STATUSES="Completed Failed Stopped Expired PartiallyCompleted"
+    DEADLINE=$(($(date +%s) + 30))
+    status=""
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+        run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
+        assert_success
+        status=$(json_get "$output" '.status')
+        for ts in $TERMINAL_STATUSES; do
+            if [ "$status" = "$ts" ]; then break 2; fi
+        done
+        sleep 0.5
+    done
 
-    status=$(json_get "$output" '.status')
     [ "$status" = "Completed" ]
 
     # Verify output JSONL file in S3

--- a/compatibility-tests/sdk-test-awscli/test/bedrock.bats
+++ b/compatibility-tests/sdk-test-awscli/test/bedrock.bats
@@ -103,7 +103,38 @@ teardown() {
     [ -n "$end_time" ]
 }
 
-@test "Bedrock: batch inference execution with S3 and manifest" {
+@test "Bedrock: job fails when input bucket does not exist" {
+    MISSING_BUCKET="no-such-bucket-$(date +%s)-$$"
+    JOB_NAME="bats-no-bucket-$(date +%s)-$$"
+
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"s3://$MISSING_BUCKET/in.jsonl\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"s3://$MISSING_BUCKET/out\"}}"
+    assert_success
+
+    JOB_ARN=$(json_get "$output" '.jobArn')
+
+    # Poll until job reaches a terminal status (max 15s)
+    TERMINAL_STATUSES="Completed Failed Stopped Expired PartiallyCompleted"
+    DEADLINE=$(($(date +%s) + 15))
+    status=""
+    while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+        run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
+        assert_success
+        status=$(json_get "$output" '.status')
+        for ts in $TERMINAL_STATUSES; do
+            if [ "$status" = "$ts" ]; then break 2; fi
+        done
+        sleep 0.5
+    done
+
+    [ "$status" = "Failed" ]
+    end_time=$(json_get "$output" '.endTime')
+    [ -n "$end_time" ]
+}
     INPUT_KEY="prompts.jsonl"
     OUTPUT_PREFIX="bats-batch-out-$(date +%s)-$$"
     INPUT_URI="s3://$BUCKET/$INPUT_KEY"

--- a/compatibility-tests/sdk-test-awscli/test/bedrock.bats
+++ b/compatibility-tests/sdk-test-awscli/test/bedrock.bats
@@ -135,6 +135,8 @@ teardown() {
     end_time=$(json_get "$output" '.endTime')
     [ -n "$end_time" ]
 }
+
+@test "Bedrock: batch inference execution with S3" {
     INPUT_KEY="prompts.jsonl"
     OUTPUT_PREFIX="bats-batch-out-$(date +%s)-$$"
     INPUT_URI="s3://$BUCKET/$INPUT_KEY"
@@ -198,4 +200,39 @@ teardown() {
     [ "$processed" -eq 2 ]
     [ "$success" -eq 2 ]
     [ "$errors" -eq 0 ]
+}
+
+@test "Bedrock: regional job isolation" {
+    JOB_NAME="bats-reg-$(date +%s)-$$"
+    INPUT_URI="s3://$BUCKET/reg-in.jsonl"
+    OUTPUT_URI="s3://$BUCKET/reg-out"
+
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"$INPUT_URI\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"$OUTPUT_URI\"}}"
+    assert_success
+
+    JOB_ARN=$(json_get "$output" '.jobArn')
+
+    run aws_cmd bedrock get-model-invocation-job --job-identifier "$JOB_ARN" --region us-west-2
+    assert_failure
+
+    run aws_cmd bedrock list-model-invocation-jobs --region us-west-2
+    assert_success
+    found=$(echo "$output" | jq -r --arg n "$JOB_NAME" '.invocationJobSummaries | any(.jobName == $n)')
+    [ "$found" = "false" ]
+}
+
+@test "Bedrock: cross-account role ARN is rejected" {
+    JOB_NAME="bats-cross-role-$(date +%s)-$$"
+    run aws_cmd bedrock create-model-invocation-job \
+        --job-name "$JOB_NAME" \
+        --model-id "amazon.titan-text-express-v1" \
+        --role-arn "arn:aws:iam::123456789012:role/OtherAccountRole" \
+        --input-data-config "{\"s3InputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/in.jsonl\"}}" \
+        --output-data-config "{\"s3OutputDataConfig\":{\"s3Uri\":\"s3://$BUCKET/out\"}}"
+    assert_failure
 }

--- a/compatibility-tests/sdk-test-go/README.md
+++ b/compatibility-tests/sdk-test-go/README.md
@@ -21,6 +21,7 @@ Compatibility tests for [Floci](https://github.com/hectorvent/floci) using the *
 | `kinesis`          | Streams, shards, PutRecord/GetRecords                   |
 | `cloudwatch`       | PutMetricData, ListMetrics, GetMetricStatistics, alarms |
 | `rds-data`         | RDS Data API execute statements, transactions, result fields with SDK v1 and v2 |
+| `bedrock`          | Batch model invocation jobs (create, get, list, stop, S3 execution) |
 
 ## Requirements
 

--- a/compatibility-tests/sdk-test-go/internal/testutil/fixtures.go
+++ b/compatibility-tests/sdk-test-go/internal/testutil/fixtures.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/acm"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
@@ -167,6 +168,11 @@ func RDSClient() *rds.Client {
 // NeptuneClient returns a new Neptune client.
 func NeptuneClient() *neptune.Client {
 	return neptune.NewFromConfig(Config())
+}
+
+// BedrockClient returns a new Bedrock client.
+func BedrockClient() *bedrock.Client {
+	return bedrock.NewFromConfig(Config())
 }
 
 // CognitoClient returns a new Cognito Identity Provider client.

--- a/compatibility-tests/sdk-test-go/tests/bedrock_test.go
+++ b/compatibility-tests/sdk-test-go/tests/bedrock_test.go
@@ -1,0 +1,265 @@
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"floci-sdk-test-go/internal/testutil"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock"
+	"github.com/aws/aws-sdk-go-v2/service/bedrock/types"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBedrockBatchInference(t *testing.T) {
+	ctx := context.Background()
+	svc := testutil.BedrockClient()
+	s3Client := testutil.S3Client()
+
+	bucketName := fmt.Sprintf("go-bedrock-%d", time.Now().UnixMilli()%100000)
+
+	_, err := s3Client.CreateBucket(ctx, &s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	require.NoError(t, err, "setup: create S3 bucket")
+
+	t.Cleanup(func() {
+		list, err := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+			Bucket: aws.String(bucketName),
+		})
+		if err == nil {
+			for _, obj := range list.Contents {
+				_ = s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+					Bucket: aws.String(bucketName),
+					Key:    obj.Key,
+				})
+			}
+		}
+		_ = s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+			Bucket: aws.String(bucketName),
+		})
+	})
+
+	t.Run("CreateAndGetModelInvocationJob", func(t *testing.T) {
+		jobName := fmt.Sprintf("go-job-%d", time.Now().UnixMilli()%100000)
+		inputUri := fmt.Sprintf("s3://%s/in.jsonl", bucketName)
+		outputUri := fmt.Sprintf("s3://%s/out", bucketName)
+
+		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName:  aws.String(jobName),
+			ModelId:  aws.String("amazon.titan-text-express-v1"),
+			RoleArn:  aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(inputUri),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(outputUri),
+				},
+			},
+			Tags: []types.Tag{
+				{Key: aws.String("Environment"), Value: aws.String("testing")},
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, createOut.JobArn)
+		assert.Contains(t, aws.ToString(createOut.JobArn), ":model-invocation-job/")
+
+		getOut, err := svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
+			JobIdentifier: createOut.JobArn,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, aws.ToString(createOut.JobArn), aws.ToString(getOut.JobArn))
+		assert.Equal(t, jobName, aws.ToString(getOut.JobName))
+		assert.Equal(t, "amazon.titan-text-express-v1", aws.ToString(getOut.ModelId))
+		assert.NotEmpty(t, string(getOut.Status))
+	})
+
+	t.Run("ListModelInvocationJobsWithFiltering", func(t *testing.T) {
+		jobName1 := fmt.Sprintf("go-list-1-%d", time.Now().UnixMilli()%100000)
+		jobName2 := fmt.Sprintf("go-list-2-%d", time.Now().UnixMilli()%100000)
+
+		_, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(jobName1),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/1.jsonl", bucketName)),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/out1", bucketName)),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(jobName2),
+			ModelId: aws.String("anthropic.claude-3-sonnet-20240229-v1:0"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/2.jsonl", bucketName)),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/out2", bucketName)),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		listOut, err := svc.ListModelInvocationJobs(ctx, &bedrock.ListModelInvocationJobsInput{})
+		require.NoError(t, err)
+
+		var jobNames []string
+		for _, j := range listOut.InvocationJobSummaries {
+			jobNames = append(jobNames, aws.ToString(j.JobName))
+		}
+		assert.Contains(t, jobNames, jobName1)
+		assert.Contains(t, jobNames, jobName2)
+
+		filteredOut, err := svc.ListModelInvocationJobs(ctx, &bedrock.ListModelInvocationJobsInput{
+			NameContains: aws.String(jobName1),
+		})
+		require.NoError(t, err)
+
+		var filteredNames []string
+		for _, j := range filteredOut.InvocationJobSummaries {
+			filteredNames = append(filteredNames, aws.ToString(j.JobName))
+		}
+		assert.Contains(t, filteredNames, jobName1)
+		assert.NotContains(t, filteredNames, jobName2)
+	})
+
+	t.Run("StopModelInvocationJob", func(t *testing.T) {
+		jobName := fmt.Sprintf("go-stop-%d", time.Now().UnixMilli()%100000)
+		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(jobName),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/stop.jsonl", bucketName)),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/stop-out", bucketName)),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		_, err = svc.StopModelInvocationJob(ctx, &bedrock.StopModelInvocationJobInput{
+			JobIdentifier: createOut.JobArn,
+		})
+		require.NoError(t, err)
+
+		getOut, err := svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
+			JobIdentifier: createOut.JobArn,
+		})
+		require.NoError(t, err)
+		assert.Contains(t, []string{"Stopping", "Stopped"}, string(getOut.Status))
+		assert.NotNil(t, getOut.EndTime)
+	})
+
+	t.Run("BatchInferenceExecutionWithS3", func(t *testing.T) {
+		inputKey := "prompts.jsonl"
+		outputPrefix := fmt.Sprintf("go-batch-out-%d", time.Now().UnixMilli()%100000)
+		inputUri := fmt.Sprintf("s3://%s/%s", bucketName, inputKey)
+		outputUri := fmt.Sprintf("s3://%s/%s", bucketName, outputPrefix)
+
+		jsonlContent := "{\"recordId\":\"rec-1\",\"modelInput\":{\"inputText\":\"Hello Bedrock\"}}\n{\"recordId\":\"rec-2\",\"modelInput\":{\"inputText\":\"How are you?\"}}"
+
+		_, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(inputKey),
+			Body:   bytes.NewReader([]byte(jsonlContent)),
+		})
+		require.NoError(t, err)
+
+		jobName := fmt.Sprintf("go-s3-exec-%d", time.Now().UnixMilli()%100000)
+		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(jobName),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(inputUri),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(outputUri),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		jobArn := aws.ToString(createOut.JobArn)
+		jobId := jobArn[strings.LastIndex(jobArn, "/")+1:]
+
+		getOut, err := svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
+			JobIdentifier: createOut.JobArn,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, string(types.ModelInvocationJobStatusCompleted), string(getOut.Status))
+
+		// Check output JSONL in S3
+		outputKey := fmt.Sprintf("%s/%s/%s.out", outputPrefix, jobId, inputKey)
+		getObjOut, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(outputKey),
+		})
+		require.NoError(t, err)
+		outBytes, err := io.ReadAll(getObjOut.Body)
+		require.NoError(t, err)
+		_ = getObjOut.Body.Close()
+
+		lines := strings.Split(strings.TrimSpace(string(outBytes)), "\n")
+		assert.Len(t, lines, 2)
+
+		var rec1 map[string]interface{}
+		err = json.Unmarshal([]byte(lines[0]), &rec1)
+		require.NoError(t, err)
+		assert.Equal(t, "rec-1", rec1["recordId"])
+		assert.NotNil(t, rec1["modelOutput"])
+
+		// Check manifest.json.out in S3
+		manifestKey := fmt.Sprintf("%s/%s/manifest.json.out", outputPrefix, jobId)
+		getManifestOut, err := s3Client.GetObject(ctx, &s3.GetObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(manifestKey),
+		})
+		require.NoError(t, err)
+		manifestBytes, err := io.ReadAll(getManifestOut.Body)
+		require.NoError(t, err)
+		_ = getManifestOut.Body.Close()
+
+		var manifest map[string]interface{}
+		err = json.Unmarshal(manifestBytes, &manifest)
+		require.NoError(t, err)
+
+		assert.Equal(t, float64(2), manifest["totalRecordCount"])
+		assert.Equal(t, float64(2), manifest["processedRecordCount"])
+		assert.Equal(t, float64(2), manifest["successRecordCount"])
+		assert.Equal(t, float64(0), manifest["errorRecordCount"])
+	})
+}

--- a/compatibility-tests/sdk-test-go/tests/bedrock_test.go
+++ b/compatibility-tests/sdk-test-go/tests/bedrock_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/bedrock"
 	"github.com/aws/aws-sdk-go-v2/service/bedrock/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -39,13 +38,13 @@ func TestBedrockBatchInference(t *testing.T) {
 		})
 		if err == nil {
 			for _, obj := range list.Contents {
-				_ = s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+				_, _ = s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
 					Bucket: aws.String(bucketName),
 					Key:    obj.Key,
 				})
 			}
 		}
-		_ = s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
+		_, _ = s3Client.DeleteBucket(ctx, &s3.DeleteBucketInput{
 			Bucket: aws.String(bucketName),
 		})
 	})
@@ -56,9 +55,9 @@ func TestBedrockBatchInference(t *testing.T) {
 		outputUri := fmt.Sprintf("s3://%s/out", bucketName)
 
 		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
-			JobName:  aws.String(jobName),
-			ModelId:  aws.String("amazon.titan-text-express-v1"),
-			RoleArn:  aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			JobName: aws.String(jobName),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
 			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
 				Value: types.ModelInvocationJobS3InputDataConfig{
 					S3Uri: aws.String(inputUri),
@@ -88,8 +87,8 @@ func TestBedrockBatchInference(t *testing.T) {
 	})
 
 	t.Run("ListModelInvocationJobsWithFiltering", func(t *testing.T) {
-		jobName1 := fmt.Sprintf("go-list-1-%d", time.Now().UnixMilli()%100000)
-		jobName2 := fmt.Sprintf("go-list-2-%d", time.Now().UnixMilli()%100000)
+		jobName1 := fmt.Sprintf("go-list-1-%d", time.Now().UnixNano())
+		jobName2 := fmt.Sprintf("go-list-2-%d", time.Now().UnixNano())
 
 		_, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
 			JobName: aws.String(jobName1),
@@ -149,7 +148,7 @@ func TestBedrockBatchInference(t *testing.T) {
 	})
 
 	t.Run("StopModelInvocationJob", func(t *testing.T) {
-		jobName := fmt.Sprintf("go-stop-%d", time.Now().UnixMilli()%100000)
+		jobName := fmt.Sprintf("go-stop-%d", time.Now().UnixNano())
 		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
 			JobName: aws.String(jobName),
 			ModelId: aws.String("amazon.titan-text-express-v1"),
@@ -167,22 +166,36 @@ func TestBedrockBatchInference(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		_, err = svc.StopModelInvocationJob(ctx, &bedrock.StopModelInvocationJobInput{
+		// Only stop if the job hasn't already reached a terminal status
+		terminal := map[types.ModelInvocationJobStatus]bool{
+			types.ModelInvocationJobStatusCompleted:          true,
+			types.ModelInvocationJobStatusFailed:             true,
+			types.ModelInvocationJobStatusStopped:            true,
+			types.ModelInvocationJobStatusExpired:            true,
+			types.ModelInvocationJobStatusPartiallyCompleted: true,
+		}
+		currentOut, err := svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
 			JobIdentifier: createOut.JobArn,
 		})
 		require.NoError(t, err)
+		if !terminal[currentOut.Status] {
+			_, err = svc.StopModelInvocationJob(ctx, &bedrock.StopModelInvocationJobInput{
+				JobIdentifier: createOut.JobArn,
+			})
+			require.NoError(t, err)
+		}
 
 		getOut, err := svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
 			JobIdentifier: createOut.JobArn,
 		})
 		require.NoError(t, err)
-		assert.Contains(t, []string{"Stopping", "Stopped"}, string(getOut.Status))
+		assert.Contains(t, []string{"Stopping", "Stopped", "Failed"}, string(getOut.Status))
 		assert.NotNil(t, getOut.EndTime)
 	})
 
 	t.Run("BatchInferenceExecutionWithS3", func(t *testing.T) {
 		inputKey := "prompts.jsonl"
-		outputPrefix := fmt.Sprintf("go-batch-out-%d", time.Now().UnixMilli()%100000)
+		outputPrefix := fmt.Sprintf("go-batch-out-%d", time.Now().UnixNano())
 		inputUri := fmt.Sprintf("s3://%s/%s", bucketName, inputKey)
 		outputUri := fmt.Sprintf("s3://%s/%s", bucketName, outputPrefix)
 
@@ -195,7 +208,7 @@ func TestBedrockBatchInference(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		jobName := fmt.Sprintf("go-s3-exec-%d", time.Now().UnixMilli()%100000)
+		jobName := fmt.Sprintf("go-s3-exec-%d", time.Now().UnixNano())
 		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
 			JobName: aws.String(jobName),
 			ModelId: aws.String("amazon.titan-text-express-v1"),
@@ -216,10 +229,26 @@ func TestBedrockBatchInference(t *testing.T) {
 		jobArn := aws.ToString(createOut.JobArn)
 		jobId := jobArn[strings.LastIndex(jobArn, "/")+1:]
 
-		getOut, err := svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
-			JobIdentifier: createOut.JobArn,
-		})
-		require.NoError(t, err)
+		// Poll until job reaches a terminal status (max 30s)
+		terminal := map[types.ModelInvocationJobStatus]bool{
+			types.ModelInvocationJobStatusCompleted:          true,
+			types.ModelInvocationJobStatusFailed:             true,
+			types.ModelInvocationJobStatusStopped:            true,
+			types.ModelInvocationJobStatusExpired:            true,
+			types.ModelInvocationJobStatusPartiallyCompleted: true,
+		}
+		deadline := time.Now().Add(30 * time.Second)
+		var getOut *bedrock.GetModelInvocationJobOutput
+		for time.Now().Before(deadline) {
+			getOut, err = svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
+				JobIdentifier: createOut.JobArn,
+			})
+			require.NoError(t, err)
+			if terminal[getOut.Status] {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
 		assert.Equal(t, string(types.ModelInvocationJobStatusCompleted), string(getOut.Status))
 
 		// Check output JSONL in S3

--- a/compatibility-tests/sdk-test-go/tests/bedrock_test.go
+++ b/compatibility-tests/sdk-test-go/tests/bedrock_test.go
@@ -335,4 +335,60 @@ func TestBedrockBatchInference(t *testing.T) {
 		assert.Equal(t, string(types.ModelInvocationJobStatusFailed), string(getOut.Status))
 		assert.NotNil(t, getOut.EndTime)
 	})
+
+	t.Run("RegionalJobIsolation", func(t *testing.T) {
+		jobName := fmt.Sprintf("go-reg-%d", time.Now().UnixNano())
+		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(jobName),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/reg-in.jsonl", bucketName)),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/reg-out", bucketName)),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		west2Svc := bedrock.NewFromConfig(testutil.Config(), func(o *bedrock.Options) {
+			o.Region = "us-west-2"
+		})
+
+		_, err = west2Svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
+			JobIdentifier: createOut.JobArn,
+		})
+		assert.Error(t, err)
+
+		listOut, err := west2Svc.ListModelInvocationJobs(ctx, &bedrock.ListModelInvocationJobsInput{})
+		require.NoError(t, err)
+		var names []string
+		for _, j := range listOut.InvocationJobSummaries {
+			names = append(names, aws.ToString(j.JobName))
+		}
+		assert.NotContains(t, names, jobName)
+	})
+
+	t.Run("CrossAccountRoleArnRejected", func(t *testing.T) {
+		_, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(fmt.Sprintf("go-cross-%d", time.Now().UnixNano())),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::123456789012:role/OtherAccountRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/in.jsonl", bucketName)),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/out", bucketName)),
+				},
+			},
+		})
+		assert.Error(t, err)
+	})
 }

--- a/compatibility-tests/sdk-test-go/tests/bedrock_test.go
+++ b/compatibility-tests/sdk-test-go/tests/bedrock_test.go
@@ -291,4 +291,48 @@ func TestBedrockBatchInference(t *testing.T) {
 		assert.Equal(t, float64(2), manifest["successRecordCount"])
 		assert.Equal(t, float64(0), manifest["errorRecordCount"])
 	})
+
+	t.Run("JobFailsWhenInputBucketDoesNotExist", func(t *testing.T) {
+		jobName := fmt.Sprintf("go-no-bucket-%d", time.Now().UnixNano())
+		missingBucket := fmt.Sprintf("no-such-bucket-%d", time.Now().UnixMilli())
+
+		createOut, err := svc.CreateModelInvocationJob(ctx, &bedrock.CreateModelInvocationJobInput{
+			JobName: aws.String(jobName),
+			ModelId: aws.String("amazon.titan-text-express-v1"),
+			RoleArn: aws.String("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+			InputDataConfig: &types.ModelInvocationJobInputDataConfigMemberS3InputDataConfig{
+				Value: types.ModelInvocationJobS3InputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/in.jsonl", missingBucket)),
+				},
+			},
+			OutputDataConfig: &types.ModelInvocationJobOutputDataConfigMemberS3OutputDataConfig{
+				Value: types.ModelInvocationJobS3OutputDataConfig{
+					S3Uri: aws.String(fmt.Sprintf("s3://%s/out", missingBucket)),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		terminal := map[types.ModelInvocationJobStatus]bool{
+			types.ModelInvocationJobStatusCompleted:          true,
+			types.ModelInvocationJobStatusFailed:             true,
+			types.ModelInvocationJobStatusStopped:            true,
+			types.ModelInvocationJobStatusExpired:            true,
+			types.ModelInvocationJobStatusPartiallyCompleted: true,
+		}
+		deadline := time.Now().Add(15 * time.Second)
+		var getOut *bedrock.GetModelInvocationJobOutput
+		for time.Now().Before(deadline) {
+			getOut, err = svc.GetModelInvocationJob(ctx, &bedrock.GetModelInvocationJobInput{
+				JobIdentifier: createOut.JobArn,
+			})
+			require.NoError(t, err)
+			if terminal[getOut.Status] {
+				break
+			}
+			time.Sleep(500 * time.Millisecond)
+		}
+		assert.Equal(t, string(types.ModelInvocationJobStatusFailed), string(getOut.Status))
+		assert.NotNil(t, getOut.EndTime)
+	})
 }

--- a/compatibility-tests/sdk-test-java/README.md
+++ b/compatibility-tests/sdk-test-java/README.md
@@ -26,6 +26,7 @@ Runs 352 tests across 17 test classes against a live Floci instance — no mocks
 | `Ec2Tests`                       | EC2 instances, VPCs, security groups, subnets            |
 | `AppSyncTest`                    | GraphQL API CRUDL, data sources, resolvers, functions, types, API keys, tags, schema validation |
 | `EcsTests`                       | ECS clusters, task definitions, services                 |
+| `BedrockBatchInferenceTest`      | Bedrock batch model invocation jobs (create, get, list, stop, S3 execution) |
 
 ## Adding a New Test
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -323,6 +323,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>pipes</artifactId>
         </dependency>
+        <!-- Bedrock client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>bedrock</artifactId>
+        </dependency>
         <!-- Bedrock AgentCore control-plane client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -65,6 +65,7 @@ import software.amazon.awssdk.services.amp.AmpClient;
 import software.amazon.awssdk.services.efs.EfsClient;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ecr.EcrClient;
+import software.amazon.awssdk.services.bedrock.BedrockClient;
 import software.amazon.awssdk.services.bedrockagentcore.BedrockAgentCoreClient;
 import software.amazon.awssdk.services.bedrockagentcorecontrol.BedrockAgentCoreControlClient;
 import software.amazon.awssdk.services.pipes.PipesClient;
@@ -889,6 +890,14 @@ public final class TestFixtures {
 
     public static PipesClient pipesClient() {
         return PipesClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static BedrockClient bedrockClient() {
+        return BedrockClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -897,9 +897,13 @@ public final class TestFixtures {
     }
 
     public static BedrockClient bedrockClient() {
+        return bedrockClient(REGION);
+    }
+
+    public static BedrockClient bedrockClient(Region region) {
         return BedrockClient.builder()
                 .endpointOverride(ENDPOINT)
-                .region(REGION)
+                .region(region)
                 .credentialsProvider(CREDENTIALS)
                 .build();
     }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
@@ -1,0 +1,250 @@
+package com.floci.test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.services.bedrock.BedrockClient;
+import software.amazon.awssdk.services.bedrock.model.*;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Bedrock Batch Inference Integration Test")
+class BedrockBatchInferenceTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static BedrockClient bedrock;
+    private static S3Client s3;
+    private static String bucketName;
+
+    @BeforeAll
+    static void setup() {
+        bedrock = TestFixtures.bedrockClient();
+        s3 = TestFixtures.s3Client();
+        bucketName = TestFixtures.uniqueName("bedrock-batch");
+        s3.createBucket(CreateBucketRequest.builder().bucket(bucketName).build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (s3 != null && bucketName != null) {
+            try {
+                ListObjectsV2Response list = s3.listObjectsV2(ListObjectsV2Request.builder().bucket(bucketName).build());
+                for (S3Object obj : list.contents()) {
+                    s3.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(obj.key()).build());
+                }
+                s3.deleteBucket(DeleteBucketRequest.builder().bucket(bucketName).build());
+            } catch (Exception ignored) {
+            }
+            s3.close();
+        }
+        if (bedrock != null) {
+            bedrock.close();
+        }
+    }
+
+    @Test
+    void createAndGetModelInvocationJob() {
+        String jobName = TestFixtures.uniqueName("batch-job");
+        String inputUri = "s3://" + bucketName + "/in.jsonl";
+        String outputUri = "s3://" + bucketName + "/out";
+
+        CreateModelInvocationJobResponse createRes = bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(jobName)
+                .modelId("amazon.titan-text-express-v1")
+                .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri(inputUri)
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri(outputUri)
+                                .build())
+                        .build())
+                .tags(Tag.builder().key("Environment").value("testing").build())
+                .build());
+
+        assertThat(createRes.jobArn()).isNotNull();
+        assertThat(createRes.jobArn()).contains(":model-invocation-job/");
+
+        GetModelInvocationJobResponse getRes = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                .jobIdentifier(createRes.jobArn())
+                .build());
+
+        assertThat(getRes.jobArn()).isEqualTo(createRes.jobArn());
+        assertThat(getRes.jobName()).isEqualTo(jobName);
+        assertThat(getRes.modelId()).isEqualTo("amazon.titan-text-express-v1");
+        assertThat(getRes.status()).isNotNull();
+        assertThat(getRes.inputDataConfig().s3InputDataConfig().s3Uri()).isEqualTo(inputUri);
+        assertThat(getRes.outputDataConfig().s3OutputDataConfig().s3Uri()).isEqualTo(outputUri);
+    }
+
+    @Test
+    void getNonexistentJobThrowsException() {
+        assertThatThrownBy(() -> bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                .jobIdentifier("arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/nonexistent999")
+                .build()))
+                .isInstanceOf(BedrockException.class);
+    }
+
+    @Test
+    void listModelInvocationJobsWithFiltering() {
+        String jobName1 = TestFixtures.uniqueName("list-job-1");
+        String jobName2 = TestFixtures.uniqueName("list-job-2");
+
+        bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(jobName1)
+                .modelId("amazon.titan-text-express-v1")
+                .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/1.jsonl")
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/out1")
+                                .build())
+                        .build())
+                .build());
+
+        bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(jobName2)
+                .modelId("anthropic.claude-3-sonnet-20240229-v1:0")
+                .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/2.jsonl")
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/out2")
+                                .build())
+                        .build())
+                .build());
+
+        ListModelInvocationJobsResponse listRes = bedrock.listModelInvocationJobs(ListModelInvocationJobsRequest.builder().build());
+        assertThat(listRes.invocationJobSummaries()).isNotNull();
+        List<String> names = listRes.invocationJobSummaries().stream().map(ModelInvocationJobSummary::jobName).toList();
+        assertThat(names).contains(jobName1, jobName2);
+
+        ListModelInvocationJobsResponse filteredRes = bedrock.listModelInvocationJobs(ListModelInvocationJobsRequest.builder()
+                .nameContains(jobName1)
+                .build());
+        List<String> filteredNames = filteredRes.invocationJobSummaries().stream().map(ModelInvocationJobSummary::jobName).toList();
+        assertThat(filteredNames).contains(jobName1);
+        assertThat(filteredNames).doesNotContain(jobName2);
+    }
+
+    @Test
+    void stopModelInvocationJob() {
+        String jobName = TestFixtures.uniqueName("stop-job");
+        CreateModelInvocationJobResponse createRes = bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(jobName)
+                .modelId("amazon.titan-text-express-v1")
+                .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/stop.jsonl")
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/stop-out")
+                                .build())
+                        .build())
+                .build());
+
+        bedrock.stopModelInvocationJob(StopModelInvocationJobRequest.builder()
+                .jobIdentifier(createRes.jobArn())
+                .build());
+
+        GetModelInvocationJobResponse job = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                .jobIdentifier(createRes.jobArn())
+                .build());
+        assertThat(job.statusAsString()).isIn("Stopping", "Stopped");
+        assertThat(job.endTime()).isNotNull();
+    }
+
+    @Test
+    void batchInferenceExecutionWithS3() throws IOException {
+        String inputKey = "prompts.jsonl";
+        String outputPrefix = TestFixtures.uniqueName("batch-out");
+        String inputUri = "s3://" + bucketName + "/" + inputKey;
+        String outputUri = "s3://" + bucketName + "/" + outputPrefix;
+
+        String jsonlContent = "{\"recordId\":\"rec-1\",\"modelInput\":{\"inputText\":\"Hello Bedrock\"}}\n" +
+                "{\"recordId\":\"rec-2\",\"modelInput\":{\"inputText\":\"How are you?\"}}";
+
+        s3.putObject(PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(inputKey)
+                .build(), RequestBody.fromString(jsonlContent, StandardCharsets.UTF_8));
+
+        String jobName = TestFixtures.uniqueName("s3-exec-job");
+        CreateModelInvocationJobResponse createRes = bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(jobName)
+                .modelId("amazon.titan-text-express-v1")
+                .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri(inputUri)
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri(outputUri)
+                                .build())
+                        .build())
+                .build());
+
+        String jobArn = createRes.jobArn();
+        String jobId = jobArn.substring(jobArn.lastIndexOf('/') + 1);
+
+        GetModelInvocationJobResponse job = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                .jobIdentifier(jobArn)
+                .build());
+        assertThat(job.status()).isEqualTo(ModelInvocationJobStatus.COMPLETED);
+
+        // Verify output JSONL file in S3
+        String outputKey = outputPrefix + "/" + jobId + "/" + inputKey + ".out";
+        String outputStr = s3.getObject(GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(outputKey)
+                .build(), ResponseTransformer.toBytes()).asUtf8String();
+
+        String[] outputLines = outputStr.trim().split("\n");
+        assertThat(outputLines).hasSize(2);
+
+        JsonNode outRecord1 = MAPPER.readTree(outputLines[0]);
+        assertThat(outRecord1.get("recordId").asText()).isEqualTo("rec-1");
+        assertThat(outRecord1.has("modelOutput")).isTrue();
+
+        // Verify manifest file in S3
+        String manifestKey = outputPrefix + "/" + jobId + "/manifest.json.out";
+        String manifestStr = s3.getObject(GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(manifestKey)
+                .build(), ResponseTransformer.toBytes()).asUtf8String();
+
+        JsonNode manifest = MAPPER.readTree(manifestStr);
+        assertThat(manifest.get("totalRecordCount").asInt()).isEqualTo(2);
+        assertThat(manifest.get("processedRecordCount").asInt()).isEqualTo(2);
+        assertThat(manifest.get("successRecordCount").asInt()).isEqualTo(2);
+        assertThat(manifest.get("errorRecordCount").asInt()).isEqualTo(0);
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
@@ -10,12 +10,14 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.bedrock.BedrockClient;
 import software.amazon.awssdk.services.bedrock.model.*;
+import software.amazon.awssdk.services.bedrock.model.Tag;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -169,14 +171,26 @@ class BedrockBatchInferenceTest {
                         .build())
                 .build());
 
-        bedrock.stopModelInvocationJob(StopModelInvocationJobRequest.builder()
+        // Only stop if not already terminal
+        Set<ModelInvocationJobStatus> terminalStatuses = Set.of(
+                ModelInvocationJobStatus.COMPLETED,
+                ModelInvocationJobStatus.FAILED,
+                ModelInvocationJobStatus.STOPPED,
+                ModelInvocationJobStatus.EXPIRED,
+                ModelInvocationJobStatus.PARTIALLY_COMPLETED);
+        GetModelInvocationJobResponse current = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
                 .jobIdentifier(createRes.jobArn())
                 .build());
+        if (!terminalStatuses.contains(current.status())) {
+            bedrock.stopModelInvocationJob(StopModelInvocationJobRequest.builder()
+                    .jobIdentifier(createRes.jobArn())
+                    .build());
+        }
 
         GetModelInvocationJobResponse job = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
                 .jobIdentifier(createRes.jobArn())
                 .build());
-        assertThat(job.statusAsString()).isIn("Stopping", "Stopped");
+        assertThat(job.statusAsString()).isIn("Stopping", "Stopped", "Failed");
         assertThat(job.endTime()).isNotNull();
     }
 
@@ -215,9 +229,22 @@ class BedrockBatchInferenceTest {
         String jobArn = createRes.jobArn();
         String jobId = jobArn.substring(jobArn.lastIndexOf('/') + 1);
 
-        GetModelInvocationJobResponse job = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
-                .jobIdentifier(jobArn)
-                .build());
+        // Poll until job reaches a terminal status (max 30s)
+        Set<ModelInvocationJobStatus> terminalStatuses = Set.of(
+                ModelInvocationJobStatus.COMPLETED,
+                ModelInvocationJobStatus.FAILED,
+                ModelInvocationJobStatus.STOPPED,
+                ModelInvocationJobStatus.EXPIRED,
+                ModelInvocationJobStatus.PARTIALLY_COMPLETED);
+        long deadline = System.currentTimeMillis() + 30_000;
+        GetModelInvocationJobResponse job;
+        do {
+            job = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                    .jobIdentifier(jobArn)
+                    .build());
+            if (terminalStatuses.contains(job.status())) break;
+            try { Thread.sleep(500); } catch (InterruptedException e) { Thread.currentThread().interrupt(); break; }
+        } while (System.currentTimeMillis() < deadline);
         assertThat(job.status()).isEqualTo(ModelInvocationJobStatus.COMPLETED);
 
         // Verify output JSONL file in S3

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
@@ -238,6 +238,64 @@ class BedrockBatchInferenceTest {
     }
 
     @Test
+    void regionalJobIsolation() {
+        String jobName = TestFixtures.uniqueName("regional-job");
+        CreateModelInvocationJobResponse createRes = bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(jobName)
+                .modelId("amazon.titan-text-express-v1")
+                .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/reg-in.jsonl")
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/reg-out")
+                                .build())
+                        .build())
+                .build());
+
+        String jobArn = createRes.jobArn();
+
+        // Querying from us-west-2 should not find the job created in us-east-1
+        try (BedrockClient bedrockWest2 = TestFixtures.bedrockClient(software.amazon.awssdk.regions.Region.US_WEST_2)) {
+            assertThatThrownBy(() -> bedrockWest2.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                    .jobIdentifier(jobArn)
+                    .build()))
+                    .isInstanceOf(BedrockException.class);
+
+            ListModelInvocationJobsResponse listRes = bedrockWest2.listModelInvocationJobs(
+                    ListModelInvocationJobsRequest.builder().build());
+            List<String> jobNames = listRes.invocationJobSummaries().stream()
+                    .map(ModelInvocationJobSummary::jobName)
+                    .toList();
+            assertThat(jobNames).doesNotContain(jobName);
+        }
+    }
+
+    @Test
+    void roleArnFromAnotherAccountFailsValidation() {
+        String foreignRoleArn = "arn:aws:iam::123456789012:role/CrossAccountBatchRole";
+        assertThatThrownBy(() -> bedrock.createModelInvocationJob(CreateModelInvocationJobRequest.builder()
+                .jobName(TestFixtures.uniqueName("cross-role-job"))
+                .modelId("amazon.titan-text-express-v1")
+                .roleArn(foreignRoleArn)
+                .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                        .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/in.jsonl")
+                                .build())
+                        .build())
+                .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                        .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                .s3Uri("s3://" + bucketName + "/out")
+                                .build())
+                        .build())
+                .build()))
+                .isInstanceOf(BedrockException.class);
+    }
+
+    @Test
     void batchInferenceExecutionWithS3() throws IOException {
         String inputKey = "prompts.jsonl";
         String outputPrefix = TestFixtures.uniqueName("batch-out");

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/BedrockBatchInferenceTest.java
@@ -195,6 +195,49 @@ class BedrockBatchInferenceTest {
     }
 
     @Test
+    void jobFailsWhenInputBucketDoesNotExist() {
+        String missingBucket = TestFixtures.uniqueName("no-such-bucket");
+        String jobName = TestFixtures.uniqueName("no-bucket-job");
+
+        CreateModelInvocationJobResponse createRes = bedrock.createModelInvocationJob(
+                CreateModelInvocationJobRequest.builder()
+                        .jobName(jobName)
+                        .modelId("amazon.titan-text-express-v1")
+                        .roleArn("arn:aws:iam::000000000000:role/BedrockBatchRole")
+                        .inputDataConfig(ModelInvocationJobInputDataConfig.builder()
+                                .s3InputDataConfig(ModelInvocationJobS3InputDataConfig.builder()
+                                        .s3Uri("s3://" + missingBucket + "/in.jsonl")
+                                        .build())
+                                .build())
+                        .outputDataConfig(ModelInvocationJobOutputDataConfig.builder()
+                                .s3OutputDataConfig(ModelInvocationJobS3OutputDataConfig.builder()
+                                        .s3Uri("s3://" + missingBucket + "/out")
+                                        .build())
+                                .build())
+                        .build());
+
+        String jobArn = createRes.jobArn();
+        Set<ModelInvocationJobStatus> terminalStatuses = Set.of(
+                ModelInvocationJobStatus.COMPLETED,
+                ModelInvocationJobStatus.FAILED,
+                ModelInvocationJobStatus.STOPPED,
+                ModelInvocationJobStatus.EXPIRED,
+                ModelInvocationJobStatus.PARTIALLY_COMPLETED);
+        long deadline = System.currentTimeMillis() + 15_000;
+        GetModelInvocationJobResponse job;
+        do {
+            job = bedrock.getModelInvocationJob(GetModelInvocationJobRequest.builder()
+                    .jobIdentifier(jobArn)
+                    .build());
+            if (terminalStatuses.contains(job.status())) break;
+            try { Thread.sleep(500); } catch (InterruptedException e) { Thread.currentThread().interrupt(); break; }
+        } while (System.currentTimeMillis() < deadline);
+
+        assertThat(job.status()).isEqualTo(ModelInvocationJobStatus.FAILED);
+        assertThat(job.endTime()).isNotNull();
+    }
+
+    @Test
     void batchInferenceExecutionWithS3() throws IOException {
         String inputKey = "prompts.jsonl";
         String outputPrefix = TestFixtures.uniqueName("batch-out");

--- a/compatibility-tests/sdk-test-node/README.md
+++ b/compatibility-tests/sdk-test-node/README.md
@@ -24,6 +24,7 @@ Compatibility tests for [Floci](https://github.com/hectorvent/floci) using the *
 | `cognito`               | User pools, clients, AdminCreateUser, InitiateAuth, GetUser                                        |
 | `cognito-oauth`         | Resource server CRUD, confidential clients, `/oauth2/token`, OIDC discovery, JWKS/JWT verification |
 | `apigatewayv2`          | HTTP & WebSocket API lifecycle, routes, integrations, authorizers, stages, deployments, route responses, models, tagging |
+| `bedrock`               | Batch model invocation jobs (create, get, list, stop, S3 execution)                                |
 
 ## Requirements
 

--- a/compatibility-tests/sdk-test-node/package.json
+++ b/compatibility-tests/sdk-test-node/package.json
@@ -11,6 +11,7 @@
     "@aws-sdk/client-api-gateway": "^3.500.0",
     "@aws-sdk/client-apigatewaymanagementapi": "^3.500.0",
     "@aws-sdk/client-apigatewayv2": "^3.500.0",
+    "@aws-sdk/client-bedrock": "^3.500.0",
     "@aws-sdk/client-cloudformation": "^3.500.0",
     "@aws-sdk/client-cloudwatch": "^3.500.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.500.0",

--- a/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
@@ -137,18 +137,19 @@ describe('Bedrock Batch Inference', () => {
       })
     );
 
-    await bedrock.send(
-      new StopModelInvocationJobCommand({
-        jobIdentifier: createRes.jobArn,
-      })
-    );
+    // If the job already reached a terminal state before stop could be called, skip the stop call
+    const terminal = new Set(['Completed', 'Failed', 'Stopped', 'Expired', 'PartiallyCompleted']);
+    const current = await bedrock.send(new GetModelInvocationJobCommand({ jobIdentifier: createRes.jobArn }));
+    if (!terminal.has(current.status as string)) {
+      await bedrock.send(new StopModelInvocationJobCommand({ jobIdentifier: createRes.jobArn }));
+    }
 
     const job = await bedrock.send(
       new GetModelInvocationJobCommand({
         jobIdentifier: createRes.jobArn,
       })
     );
-    expect(['Stopping', 'Stopped']).toContain(job.status);
+    expect(['Stopping', 'Stopped', 'Failed']).toContain(job.status);
     expect(job.endTime).toBeDefined();
   });
 
@@ -186,11 +187,14 @@ describe('Bedrock Batch Inference', () => {
     const jobArn = createRes.jobArn!;
     const jobId = jobArn.split('/').pop()!;
 
-    const job = await bedrock.send(
-      new GetModelInvocationJobCommand({
-        jobIdentifier: jobArn,
-      })
-    );
+    // Poll until job reaches a terminal status
+    const terminal = new Set(['Completed', 'Failed', 'Stopped', 'Expired', 'PartiallyCompleted']);
+    const deadline = Date.now() + 30_000;
+    let job = await bedrock.send(new GetModelInvocationJobCommand({ jobIdentifier: jobArn }));
+    while (!terminal.has(job.status as string) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 500));
+      job = await bedrock.send(new GetModelInvocationJobCommand({ jobIdentifier: jobArn }));
+    }
     expect(job.status).toBe('Completed');
 
     // Verify output JSONL file in S3

--- a/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
@@ -1,0 +1,226 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import {
+  BedrockClient,
+  CreateModelInvocationJobCommand,
+  GetModelInvocationJobCommand,
+  ListModelInvocationJobsCommand,
+  StopModelInvocationJobCommand,
+} from '@aws-sdk/client-bedrock';
+import {
+  S3Client,
+  CreateBucketCommand,
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+} from '@aws-sdk/client-s3';
+import { makeClient, uniqueName } from './setup';
+
+describe('Bedrock Batch Inference', () => {
+  let bedrock: BedrockClient;
+  let s3: S3Client;
+  let bucketName: string;
+
+  beforeAll(async () => {
+    bedrock = makeClient(BedrockClient);
+    s3 = makeClient(S3Client);
+    bucketName = uniqueName('bedrock-bucket');
+    await s3.send(new CreateBucketCommand({ Bucket: bucketName }));
+  });
+
+  afterAll(async () => {
+    if (!bucketName) return;
+    try {
+      const list = await s3.send(new ListObjectsV2Command({ Bucket: bucketName }));
+      for (const obj of list.Contents ?? []) {
+        if (obj.Key) {
+          await s3.send(new DeleteObjectCommand({ Bucket: bucketName, Key: obj.Key })).catch(() => undefined);
+        }
+      }
+      await s3.send(new DeleteBucketCommand({ Bucket: bucketName })).catch(() => undefined);
+    } catch {
+      // ignore cleanup errors
+    }
+  });
+
+  it('creates and retrieves a model invocation job', async () => {
+    const jobName = uniqueName('batch-job');
+    const inputUri = `s3://${bucketName}/in.jsonl`;
+    const outputUri = `s3://${bucketName}/out`;
+
+    const createRes = await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName,
+        modelId: 'amazon.titan-text-express-v1',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: {
+          s3InputDataConfig: {
+            s3Uri: inputUri,
+          },
+        },
+        outputDataConfig: {
+          s3OutputDataConfig: {
+            s3Uri: outputUri,
+          },
+        },
+        tags: [{ key: 'Environment', value: 'testing' }],
+      })
+    );
+
+    expect(createRes.jobArn).toBeDefined();
+    expect(createRes.jobArn).toContain(':model-invocation-job/');
+
+    const getRes = await bedrock.send(
+      new GetModelInvocationJobCommand({
+        jobIdentifier: createRes.jobArn,
+      })
+    );
+
+    expect(getRes.jobArn).toBe(createRes.jobArn);
+    expect(getRes.jobName).toBe(jobName);
+    expect(getRes.modelId).toBe('amazon.titan-text-express-v1');
+    expect(getRes.status).toBeDefined();
+    expect(getRes.inputDataConfig?.s3InputDataConfig?.s3Uri).toBe(inputUri);
+    expect(getRes.outputDataConfig?.s3OutputDataConfig?.s3Uri).toBe(outputUri);
+  });
+
+  it('lists model invocation jobs with filtering', async () => {
+    const jobName1 = uniqueName('list-job-1');
+    const jobName2 = uniqueName('list-job-2');
+
+    await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName: jobName1,
+        modelId: 'amazon.titan-text-express-v1',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: { s3InputDataConfig: { s3Uri: `s3://${bucketName}/1.jsonl` } },
+        outputDataConfig: { s3OutputDataConfig: { s3Uri: `s3://${bucketName}/out1` } },
+      })
+    );
+
+    await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName: jobName2,
+        modelId: 'anthropic.claude-3-sonnet-20240229-v1:0',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: { s3InputDataConfig: { s3Uri: `s3://${bucketName}/2.jsonl` } },
+        outputDataConfig: { s3OutputDataConfig: { s3Uri: `s3://${bucketName}/out2` } },
+      })
+    );
+
+    const listRes = await bedrock.send(new ListModelInvocationJobsCommand({}));
+    expect(listRes.invocationJobSummaries).toBeDefined();
+    const names = listRes.invocationJobSummaries!.map((j) => j.jobName);
+    expect(names).toContain(jobName1);
+    expect(names).toContain(jobName2);
+
+    const filteredRes = await bedrock.send(
+      new ListModelInvocationJobsCommand({
+        nameContains: jobName1,
+      })
+    );
+    const filteredNames = filteredRes.invocationJobSummaries!.map((j) => j.jobName);
+    expect(filteredNames).toContain(jobName1);
+    expect(filteredNames).not.toContain(jobName2);
+  });
+
+  it('stops an in-flight model invocation job', async () => {
+    const jobName = uniqueName('stop-job');
+    const createRes = await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName,
+        modelId: 'amazon.titan-text-express-v1',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: { s3InputDataConfig: { s3Uri: `s3://${bucketName}/stop.jsonl` } },
+        outputDataConfig: { s3OutputDataConfig: { s3Uri: `s3://${bucketName}/stop-out` } },
+      })
+    );
+
+    await bedrock.send(
+      new StopModelInvocationJobCommand({
+        jobIdentifier: createRes.jobArn,
+      })
+    );
+
+    const job = await bedrock.send(
+      new GetModelInvocationJobCommand({
+        jobIdentifier: createRes.jobArn,
+      })
+    );
+    expect(['Stopping', 'Stopped']).toContain(job.status);
+    expect(job.endTime).toBeDefined();
+  });
+
+  it('processes batch inference against S3 and produces output and manifest files', async () => {
+    const inputKey = 'prompts.jsonl';
+    const outputPrefix = uniqueName('batch-out');
+    const inputUri = `s3://${bucketName}/${inputKey}`;
+    const outputUri = `s3://${bucketName}/${outputPrefix}`;
+
+    const records = [
+      { recordId: 'rec-1', modelInput: { inputText: 'Hello Bedrock' } },
+      { recordId: 'rec-2', modelInput: { inputText: 'How are you?' } },
+    ];
+    const jsonlContent = records.map((r) => JSON.stringify(r)).join('\n');
+
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: bucketName,
+        Key: inputKey,
+        Body: Buffer.from(jsonlContent, 'utf-8'),
+      })
+    );
+
+    const jobName = uniqueName('s3-exec-job');
+    const createRes = await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName,
+        modelId: 'amazon.titan-text-express-v1',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: { s3InputDataConfig: { s3Uri: inputUri } },
+        outputDataConfig: { s3OutputDataConfig: { s3Uri: outputUri } },
+      })
+    );
+
+    const jobArn = createRes.jobArn!;
+    const jobId = jobArn.split('/').pop()!;
+
+    const job = await bedrock.send(
+      new GetModelInvocationJobCommand({
+        jobIdentifier: jobArn,
+      })
+    );
+    expect(job.status).toBe('Completed');
+
+    // Verify output JSONL file in S3
+    const outputObj = await s3.send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: `${outputPrefix}/${jobId}/${inputKey}.out`,
+      })
+    );
+    const outputStr = await outputObj.Body!.transformToString('utf-8');
+    const outputLines = outputStr.trim().split('\n');
+    expect(outputLines.length).toBe(2);
+
+    const outRecord1 = JSON.parse(outputLines[0]);
+    expect(outRecord1.recordId).toBe('rec-1');
+    expect(outRecord1.modelOutput).toBeDefined();
+
+    // Verify manifest file in S3
+    const manifestObj = await s3.send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: `${outputPrefix}/${jobId}/manifest.json.out`,
+      })
+    );
+    const manifestStr = await manifestObj.Body!.transformToString('utf-8');
+    const manifest = JSON.parse(manifestStr);
+
+    expect(manifest['totalRecordCount']).toBe(2);
+    expect(manifest['processedRecordCount']).toBe(2);
+    expect(manifest['successRecordCount']).toBe(2);
+    expect(manifest['errorRecordCount']).toBe(0);
+  });
+});

--- a/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
@@ -253,4 +253,41 @@ describe('Bedrock Batch Inference', () => {
     expect(job.status).toBe('Failed');
     expect(job.endTime).toBeDefined();
   });
+
+  it('enforces regional job isolation', async () => {
+    const jobName = uniqueName('regional-job');
+    const createRes = await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName,
+        modelId: 'amazon.titan-text-express-v1',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: { s3InputDataConfig: { s3Uri: `s3://${bucketName}/reg-in.jsonl` } },
+        outputDataConfig: { s3OutputDataConfig: { s3Uri: `s3://${bucketName}/reg-out` } },
+      })
+    );
+
+    const bedrockWest2 = makeClient(BedrockClient, { region: 'us-west-2' });
+
+    await expect(
+      bedrockWest2.send(new GetModelInvocationJobCommand({ jobIdentifier: createRes.jobArn }))
+    ).rejects.toThrow();
+
+    const listRes = await bedrockWest2.send(new ListModelInvocationJobsCommand({}));
+    const names = (listRes.invocationJobSummaries ?? []).map((j) => j.jobName);
+    expect(names).not.toContain(jobName);
+  });
+
+  it('rejects cross-account role ARN', async () => {
+    await expect(
+      bedrock.send(
+        new CreateModelInvocationJobCommand({
+          jobName: uniqueName('cross-role-job'),
+          modelId: 'amazon.titan-text-express-v1',
+          roleArn: 'arn:aws:iam::123456789012:role/OtherAccountRole',
+          inputDataConfig: { s3InputDataConfig: { s3Uri: `s3://${bucketName}/in.jsonl` } },
+          outputDataConfig: { s3OutputDataConfig: { s3Uri: `s3://${bucketName}/out` } },
+        })
+      )
+    ).rejects.toThrow();
+  });
 });

--- a/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/bedrock.test.ts
@@ -227,4 +227,30 @@ describe('Bedrock Batch Inference', () => {
     expect(manifest['successRecordCount']).toBe(2);
     expect(manifest['errorRecordCount']).toBe(0);
   });
+
+  it('job reaches Failed status when the input bucket does not exist', async () => {
+    const jobName = uniqueName('no-bucket-job');
+    const missingBucket = uniqueName('no-such-bucket');
+
+    const createRes = await bedrock.send(
+      new CreateModelInvocationJobCommand({
+        jobName,
+        modelId: 'amazon.titan-text-express-v1',
+        roleArn: 'arn:aws:iam::000000000000:role/BedrockBatchRole',
+        inputDataConfig: { s3InputDataConfig: { s3Uri: `s3://${missingBucket}/in.jsonl` } },
+        outputDataConfig: { s3OutputDataConfig: { s3Uri: `s3://${missingBucket}/out` } },
+      })
+    );
+
+    const terminal = new Set(['Completed', 'Failed', 'Stopped', 'Expired', 'PartiallyCompleted']);
+    const deadline = Date.now() + 15_000;
+    let job = await bedrock.send(new GetModelInvocationJobCommand({ jobIdentifier: createRes.jobArn }));
+    while (!terminal.has(job.status as string) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 500));
+      job = await bedrock.send(new GetModelInvocationJobCommand({ jobIdentifier: createRes.jobArn }));
+    }
+
+    expect(job.status).toBe('Failed');
+    expect(job.endTime).toBeDefined();
+  });
 });

--- a/compatibility-tests/sdk-test-python/README.md
+++ b/compatibility-tests/sdk-test-python/README.md
@@ -22,6 +22,7 @@ Compatibility tests for [Floci](https://github.com/hectorvent/floci) using **bot
 | `cloudwatch-metrics`    | PutMetricData, ListMetrics, GetMetricStatistics, alarms                  |
 | `cloudformation-naming` | Auto physical name generation, explicit name precedence, cross-reference |
 | `cognito`               | User pools, clients, AdminCreateUser, InitiateAuth, GetUser              |
+| `bedrock`               | Batch model invocation jobs (create, get, list, stop, S3 execution)      |
 
 ## Requirements
 

--- a/compatibility-tests/sdk-test-python/conftest.py
+++ b/compatibility-tests/sdk-test-python/conftest.py
@@ -205,6 +205,12 @@ def iot_jobs_data_client(aws_config, client_config):
     return boto3.client("iot-jobs-data", config=client_config, **aws_config)
 
 
+@pytest.fixture
+def bedrock_client(aws_config, client_config):
+    """Create Bedrock client."""
+    return boto3.client("bedrock", config=client_config, **aws_config)
+
+
 # ============================================
 # Utility Fixtures
 # ============================================

--- a/compatibility-tests/sdk-test-python/tests/test_bedrock.py
+++ b/compatibility-tests/sdk-test-python/tests/test_bedrock.py
@@ -97,16 +97,20 @@ class TestBedrockBatchInference:
         )
         job_arn = response["jobArn"]
 
-        # Stop the job
-        bedrock_client.stop_model_invocation_job(jobIdentifier=job_arn)
+        # Stop the job — if it already reached a terminal status before stop arrived, skip stop
+        current = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+        terminal = {"Completed", "Failed", "Stopped", "Expired", "PartiallyCompleted"}
+        if current["status"] not in terminal:
+            bedrock_client.stop_model_invocation_job(jobIdentifier=job_arn)
 
-        # Verify job is stopped
+        # Verify job is in a stopped or already-terminal state
         job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
-        assert job["status"] in ["Stopping", "Stopped"]
+        assert job["status"] in ["Stopping", "Stopped", "Failed"]
         assert "endTime" in job
 
     def test_batch_inference_execution_with_s3(self, bedrock_client, s3_client, test_bucket, unique_name):
         """Test full S3 batch inference execution including output and manifest files."""
+        import time
         input_key = f"prompts-{unique_name}.jsonl"
         output_prefix = f"batch-results-{unique_name}"
 
@@ -139,8 +143,16 @@ class TestBedrockBatchInference:
         job_arn = create_resp["jobArn"]
         job_id = job_arn.split("/")[-1]
 
-        # Verify job completed
-        job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+        # Poll until job reaches a terminal status
+        terminal = {"Completed", "Failed", "Stopped", "Expired", "PartiallyCompleted"}
+        deadline = time.time() + 30
+        job = None
+        while time.time() < deadline:
+            job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+            if job["status"] in terminal:
+                break
+            time.sleep(0.5)
+
         assert job["status"] == "Completed"
 
         # Check output JSONL in S3 at <output_prefix>/<jobId>/<input_key>.out

--- a/compatibility-tests/sdk-test-python/tests/test_bedrock.py
+++ b/compatibility-tests/sdk-test-python/tests/test_bedrock.py
@@ -1,0 +1,164 @@
+"""Integration tests for Amazon Bedrock Batch Inference."""
+
+import json
+import pytest
+from botocore.exceptions import ClientError
+
+
+@pytest.mark.bedrock
+class TestBedrockBatchInference:
+    """Tests for Bedrock Model Invocation Jobs."""
+
+    def test_create_and_get_model_invocation_job(self, bedrock_client, test_bucket, unique_name):
+        """Test creating and getting a model invocation job."""
+        job_name = f"batch-job-{unique_name}"
+        input_key = f"input-{unique_name}.jsonl"
+        output_prefix = f"output-{unique_name}"
+        input_s3_uri = f"s3://{test_bucket}/{input_key}"
+        output_s3_uri = f"s3://{test_bucket}/{output_prefix}"
+
+        # Create job
+        response = bedrock_client.create_model_invocation_job(
+            jobName=job_name,
+            modelId="amazon.titan-text-express-v1",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": input_s3_uri}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": output_s3_uri}},
+            tags=[{"key": "Environment", "value": "test"}],
+        )
+
+        assert "jobArn" in response
+        job_arn = response["jobArn"]
+        assert ":model-invocation-job/" in job_arn
+
+        # Get job by ARN
+        job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+        assert job["jobArn"] == job_arn
+        assert job["jobName"] == job_name
+        assert job["modelId"] == "amazon.titan-text-express-v1"
+        assert job["roleArn"] == "arn:aws:iam::000000000000:role/BedrockBatchRole"
+        assert "status" in job
+        assert job["inputDataConfig"]["s3InputDataConfig"]["s3Uri"] == input_s3_uri
+        assert job["outputDataConfig"]["s3OutputDataConfig"]["s3Uri"] == output_s3_uri
+        assert "submitTime" in job
+
+    def test_get_nonexistent_job(self, bedrock_client):
+        """Test getting a nonexistent job raises ResourceNotFoundException."""
+        with pytest.raises(ClientError) as exc_info:
+            bedrock_client.get_model_invocation_job(
+                jobIdentifier="arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/nonexistent999"
+            )
+        assert exc_info.value.response["Error"]["Code"] in ["ResourceNotFoundException", "NotFoundException"]
+
+    def test_list_model_invocation_jobs(self, bedrock_client, test_bucket, unique_name):
+        """Test listing model invocation jobs with filtering."""
+        job_name_1 = f"list-job-1-{unique_name}"
+        job_name_2 = f"list-job-2-{unique_name}"
+
+        bedrock_client.create_model_invocation_job(
+            jobName=job_name_1,
+            modelId="amazon.titan-text-express-v1",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": f"s3://{test_bucket}/in1.jsonl"}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": f"s3://{test_bucket}/out1"}},
+        )
+
+        bedrock_client.create_model_invocation_job(
+            jobName=job_name_2,
+            modelId="anthropic.claude-3-sonnet-20240229-v1:0",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": f"s3://{test_bucket}/in2.jsonl"}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": f"s3://{test_bucket}/out2"}},
+        )
+
+        # List all jobs
+        response = bedrock_client.list_model_invocation_jobs()
+        assert "invocationJobSummaries" in response
+        job_names = [j["jobName"] for j in response["invocationJobSummaries"]]
+        assert job_name_1 in job_names
+        assert job_name_2 in job_names
+
+        # Filter by name contains
+        filtered = bedrock_client.list_model_invocation_jobs(nameContains=job_name_1)
+        filtered_names = [j["jobName"] for j in filtered["invocationJobSummaries"]]
+        assert job_name_1 in filtered_names
+        assert job_name_2 not in filtered_names
+
+    def test_stop_model_invocation_job(self, bedrock_client, test_bucket, unique_name):
+        """Test stopping a model invocation job."""
+        job_name = f"stop-job-{unique_name}"
+
+        response = bedrock_client.create_model_invocation_job(
+            jobName=job_name,
+            modelId="amazon.titan-text-express-v1",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": f"s3://{test_bucket}/in.jsonl"}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": f"s3://{test_bucket}/out"}},
+        )
+        job_arn = response["jobArn"]
+
+        # Stop the job
+        bedrock_client.stop_model_invocation_job(jobIdentifier=job_arn)
+
+        # Verify job is stopped
+        job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+        assert job["status"] in ["Stopping", "Stopped"]
+        assert "endTime" in job
+
+    def test_batch_inference_execution_with_s3(self, bedrock_client, s3_client, test_bucket, unique_name):
+        """Test full S3 batch inference execution including output and manifest files."""
+        input_key = f"prompts-{unique_name}.jsonl"
+        output_prefix = f"batch-results-{unique_name}"
+
+        # Prepare JSONL lines
+        records = [
+            {"recordId": "rec-1", "modelInput": {"inputText": "Tell me a short joke"}},
+            {"recordId": "rec-2", "modelInput": {"inputText": "What is 2+2?"}},
+        ]
+        jsonl_body = "\n".join(json.dumps(r) for r in records)
+
+        # Upload input JSONL to S3
+        s3_client.put_object(
+            Bucket=test_bucket,
+            Key=input_key,
+            Body=jsonl_body.encode("utf-8"),
+        )
+
+        input_s3_uri = f"s3://{test_bucket}/{input_key}"
+        output_s3_uri = f"s3://{test_bucket}/{output_prefix}"
+
+        # Submit batch job
+        job_name = f"exec-job-{unique_name}"
+        create_resp = bedrock_client.create_model_invocation_job(
+            jobName=job_name,
+            modelId="amazon.titan-text-express-v1",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": input_s3_uri}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": output_s3_uri}},
+        )
+        job_arn = create_resp["jobArn"]
+        job_id = job_arn.split("/")[-1]
+
+        # Verify job completed
+        job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+        assert job["status"] == "Completed"
+
+        # Check output JSONL in S3 at <output_prefix>/<jobId>/<input_key>.out
+        output_key = f"{output_prefix}/{job_id}/{input_key}.out"
+        out_obj = s3_client.get_object(Bucket=test_bucket, Key=output_key)
+        out_lines = out_obj["Body"].read().decode("utf-8").strip().split("\n")
+        assert len(out_lines) == 2
+
+        out_rec1 = json.loads(out_lines[0])
+        assert out_rec1["recordId"] == "rec-1"
+        assert "modelOutput" in out_rec1
+
+        # Check manifest.json.out in S3 at <output_prefix>/<jobId>/manifest.json.out
+        manifest_key = f"{output_prefix}/{job_id}/manifest.json.out"
+        manifest_obj = s3_client.get_object(Bucket=test_bucket, Key=manifest_key)
+        manifest_data = json.loads(manifest_obj["Body"].read().decode("utf-8"))
+
+        assert manifest_data["totalRecordCount"] == 2
+        assert manifest_data["processedRecordCount"] == 2
+        assert manifest_data["successRecordCount"] == 2
+        assert manifest_data["errorRecordCount"] == 0

--- a/compatibility-tests/sdk-test-python/tests/test_bedrock.py
+++ b/compatibility-tests/sdk-test-python/tests/test_bedrock.py
@@ -97,7 +97,7 @@ class TestBedrockBatchInference:
         )
         job_arn = response["jobArn"]
 
-        # Stop the job — if it already reached a terminal status before stop arrived, skip stop
+        # Stop the job: if it already reached a terminal status before stop arrived, skip stop
         current = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
         terminal = {"Completed", "Failed", "Stopped", "Expired", "PartiallyCompleted"}
         if current["status"] not in terminal:

--- a/compatibility-tests/sdk-test-python/tests/test_bedrock.py
+++ b/compatibility-tests/sdk-test-python/tests/test_bedrock.py
@@ -130,6 +130,7 @@ class TestBedrockBatchInference:
                 break
             time.sleep(0.5)
 
+        assert job is not None
         assert job["status"] == "Failed"
         assert "endTime" in job
 
@@ -178,6 +179,7 @@ class TestBedrockBatchInference:
                 break
             time.sleep(0.5)
 
+        assert job is not None
         assert job["status"] == "Completed"
 
         # Check output JSONL in S3 at <output_prefix>/<jobId>/<input_key>.out

--- a/compatibility-tests/sdk-test-python/tests/test_bedrock.py
+++ b/compatibility-tests/sdk-test-python/tests/test_bedrock.py
@@ -134,6 +134,42 @@ class TestBedrockBatchInference:
         assert job["status"] == "Failed"
         assert "endTime" in job
 
+    def test_regional_job_isolation(self, bedrock_client, aws_config, client_config, test_bucket, unique_name):
+        """Test that jobs created in one region are not accessible or listed in another region."""
+        import boto3
+        job_name = f"reg-job-{unique_name}"
+        create_resp = bedrock_client.create_model_invocation_job(
+            jobName=job_name,
+            modelId="amazon.titan-text-express-v1",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": f"s3://{test_bucket}/reg-in.jsonl"}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": f"s3://{test_bucket}/reg-out"}},
+        )
+        job_arn = create_resp["jobArn"]
+
+        west2_config = dict(aws_config, region_name="us-west-2")
+        bedrock_west2 = boto3.client("bedrock", config=client_config, **west2_config)
+
+        with pytest.raises(ClientError) as exc_info:
+            bedrock_west2.get_model_invocation_job(jobIdentifier=job_arn)
+        assert exc_info.value.response["Error"]["Code"] in ["ResourceNotFoundException", "NotFoundException"]
+
+        list_resp = bedrock_west2.list_model_invocation_jobs()
+        job_names = [j["jobName"] for j in list_resp.get("invocationJobSummaries", [])]
+        assert job_name not in job_names
+
+    def test_cross_account_role_arn_rejected(self, bedrock_client, test_bucket, unique_name):
+        """Test that submitting a roleArn from another account fails validation."""
+        with pytest.raises(ClientError) as exc_info:
+            bedrock_client.create_model_invocation_job(
+                jobName=f"cross-role-{unique_name}",
+                modelId="amazon.titan-text-express-v1",
+                roleArn="arn:aws:iam::123456789012:role/OtherAccountRole",
+                inputDataConfig={"s3InputDataConfig": {"s3Uri": f"s3://{test_bucket}/in.jsonl"}},
+                outputDataConfig={"s3OutputDataConfig": {"s3Uri": f"s3://{test_bucket}/out"}},
+            )
+        assert exc_info.value.response["Error"]["Code"] in ["ValidationException", "ClientError"]
+
     def test_batch_inference_execution_with_s3(self, bedrock_client, s3_client, test_bucket, unique_name):
         """Test full S3 batch inference execution including output and manifest files."""
         import time

--- a/compatibility-tests/sdk-test-python/tests/test_bedrock.py
+++ b/compatibility-tests/sdk-test-python/tests/test_bedrock.py
@@ -108,6 +108,31 @@ class TestBedrockBatchInference:
         assert job["status"] in ["Stopping", "Stopped", "Failed"]
         assert "endTime" in job
 
+    def test_job_fails_when_input_bucket_does_not_exist(self, bedrock_client, unique_name):
+        """Test that a job reaches Failed status when the input bucket does not exist."""
+        import time
+
+        response = bedrock_client.create_model_invocation_job(
+            jobName=f"no-bucket-{unique_name}",
+            modelId="amazon.titan-text-express-v1",
+            roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+            inputDataConfig={"s3InputDataConfig": {"s3Uri": f"s3://no-such-bucket-{unique_name}/in.jsonl"}},
+            outputDataConfig={"s3OutputDataConfig": {"s3Uri": f"s3://no-such-bucket-{unique_name}/out"}},
+        )
+        job_arn = response["jobArn"]
+
+        terminal = {"Completed", "Failed", "Stopped", "Expired", "PartiallyCompleted"}
+        deadline = time.time() + 15
+        job = None
+        while time.time() < deadline:
+            job = bedrock_client.get_model_invocation_job(jobIdentifier=job_arn)
+            if job["status"] in terminal:
+                break
+            time.sleep(0.5)
+
+        assert job["status"] == "Failed"
+        assert "endTime" in job
+
     def test_batch_inference_execution_with_s3(self, bedrock_client, s3_client, test_bucket, unique_name):
         """Test full S3 batch inference execution including output and manifest files."""
         import time

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -78,7 +78,7 @@ FLOCI_STORAGE_SERVICES_<SERVICE>_MODE=hybrid
 FLOCI_STORAGE_SERVICES_<SERVICE>_FLUSH_INTERVAL_MS=5000
 ```
 
-Available service names: `SSM`, `SQS`, `S3`, `DYNAMODB`, `SNS`, `LAMBDA`, `CLOUDWATCHLOGS`, `CLOUDWATCHMETRICS`, `SECRETSMANAGER`, `ACM`, `OPENSEARCH`, `RDS`, `ELASTICACHE`, `APPCONFIG`, `APPCONFIGDATA`, `BACKUP`, `FIS`.
+Available service names: `SSM`, `SQS`, `S3`, `DYNAMODB`, `SNS`, `LAMBDA`, `CLOUDWATCHLOGS`, `CLOUDWATCHMETRICS`, `SECRETSMANAGER`, `ACM`, `OPENSEARCH`, `RDS`, `ELASTICACHE`, `APPCONFIG`, `APPCONFIGDATA`, `BACKUP`, `FIS`, `BEDROCK`.
 
 See [Storage Modes](./storage.md) for a full explanation of each mode.
 
@@ -446,6 +446,7 @@ These services spawn Docker containers. They require access to the Docker socket
 |---|---|---|
 | `FLOCI_SERVICES_GLUE_ENABLED` | `true` | Enable the Glue service |
 | `FLOCI_SERVICES_APPSYNC_ENABLED` | `true` | Enable the AppSync service |
+| `FLOCI_SERVICES_BEDROCK_ENABLED` | `true` | Enable the Amazon Bedrock batch inference control plane |
 | `FLOCI_SERVICES_BEDROCK_RUNTIME_ENABLED` | `true` | Enable the Bedrock Runtime service |
 | `FLOCI_SERVICES_BEDROCK_AGENT_CORE_CONTROL_ENABLED` | `true` | Enable the Bedrock AgentCore control plane (agent runtimes, gateways, memory, workload identity) |
 | `FLOCI_SERVICES_BEDROCK_AGENT_CORE_ENABLED` | `true` | Enable the Bedrock AgentCore data plane (`InvokeAgentRuntime` stub) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Floci is a fast, free, and open-source local AWS service emulator built for deve
 
 ## Supported Services
 
-Floci emulates 84 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
+Floci emulates 85 AWS services. See the [Services Overview](services/index.md) for per-service operation counts, endpoints, and full protocol details.
 
 | Service | Protocol |
 |---|---|

--- a/docs/services/bedrock.md
+++ b/docs/services/bedrock.md
@@ -188,5 +188,6 @@ print(f"Status: {job['status']}")
 ## Current Scope & Limitations
 
 - **Batch Processing**: S3 JSON Lines input/output, manifest creation, and EventBridge notifications are fully supported.
+- **Record Limits**: Real AWS Bedrock enforces minimum record limits for certain models during batch inference; these minimum limits are not currently enforced in Floci.
 - **Model Customization & Fine-Tuning**: `CreateModelCustomizationJob`, `ListCustomModels`, and model evaluation endpoints are not yet emulated.
 - **Knowledge Bases & Agents**: For agent runtimes, gateways, and memory, see [Bedrock AgentCore](bedrock-agentcore.md).

--- a/docs/services/bedrock.md
+++ b/docs/services/bedrock.md
@@ -21,36 +21,44 @@ For real-time single-request model inference (`Converse` / `InvokeModel`), see [
 
 ## How Batch Inference Works
 
-1. **Input S3 Dataset**: Place a JSON Lines (`.jsonl`) file in an S3 bucket. Each line contains a record with a unique `recordId` and the `modelInput` payload:
-   ```json
-   {"recordId": "rec-001", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello world"}]}]}}
-   {"recordId": "rec-002", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 100, "messages": [{"role": "user", "content": [{"type": "text", "text": "Explain quantum computing"}]}]}}
-   ```
+1. **Input S3 Dataset**: Place a JSON Lines (`.jsonl`) file in an S3 bucket. Each line contains a record with a unique `recordId` and the `modelInput` payload formatted for the target model:
+   - **Anthropic Claude 3 / 3.5**:
+     ```json
+     {"recordId": "rec-001", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 1024, "messages": [{"role": "user", "content": [{"type": "text", "text": "Explain quantum computing"}]}]}}
+     ```
+   - **Amazon Titan**:
+     ```json
+     {"recordId": "rec-002", "modelInput": {"inputText": "Hello world", "textGenerationConfig": {"maxTokenCount": 512, "temperature": 0.7}}}
+     ```
+   - **Meta Llama**:
+     ```json
+     {"recordId": "rec-003", "modelInput": {"prompt": "What is gravity?", "max_gen_len": 512, "temperature": 0.5}}
+     ```
 2. **Job Submission**: Call `CreateModelInvocationJob` specifying `inputDataConfig` (`s3Uri`), `outputDataConfig` (`s3Uri`), `modelId`, `roleArn`, and `jobName`.
 3. **Execution & Backend Delegation**:
    - Floci reads the input JSONL file from the specified S3 bucket.
    - For each record, inference is executed via the configured Bedrock Runtime backend:
      - `stub` (default): generates simulated model outputs.
-     - `proxy`: forwards Converse requests to any OpenAI-compatible backend (Ollama, vLLM, LiteLLM, OpenRouter).
+     - `proxy`: forwards Converse/InvokeModel requests to any OpenAI-compatible backend (Ollama, vLLM, LiteLLM, OpenRouter).
 4. **S3 Output Files**:
    - Output records are written to `<outputS3Uri>/<jobId>/<inputFilename>.out`:
      ```json
-     {"recordId": "rec-001", "modelInput": {...}, "modelOutput": {...}}
+     {"recordId": "rec-001", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 1024, "messages": [{"role": "user", "content": [{"type": "text", "text": "Explain quantum computing"}]}]}, "modelOutput": {"id": "msg_01...", "type": "message", "role": "assistant", "content": [{"type": "text", "text": "Quantum computing is..."}], "stop_reason": "end_turn", "usage": {"input_tokens": 12, "output_tokens": 25}}}
      ```
    - If an individual record fails, an error entry is recorded:
      ```json
-     {"recordId": "rec-002", "modelInput": {...}, "error": {"errorCode": "400", "errorMessage": "Invalid model input"}}
+     {"recordId": "rec-002", "modelInput": {}, "error": {"errorCode": "400", "errorMessage": "Malformed record: recordId and modelInput object are required."}}
      ```
 5. **Manifest Generation**:
    - A summary manifest is written to `<outputS3Uri>/<jobId>/manifest.json.out`:
      ```json
      {
-       "total-record-count": 2,
-       "processed-record-count": 2,
-       "success-record-count": 2,
-       "error-record-count": 0,
-       "input": "s3://my-input-bucket/prompts.jsonl",
-       "output": "s3://my-output-bucket/results/job-123456789abc/prompts.jsonl.out"
+       "totalRecordCount": 2,
+       "processedRecordCount": 2,
+       "successRecordCount": 2,
+       "errorRecordCount": 0,
+       "inputTokenCount": 24,
+       "outputTokenCount": 50
      }
      ```
 
@@ -64,7 +72,7 @@ Floci models all AWS Bedrock batch job states:
 | `Validating` | Input data configuration and S3 paths are being validated |
 | `Scheduled` | Job is scheduled for batch processing |
 | `InProgress` | Records are being processed and model inference is executing |
-| `Completed` | All records were processed successfully (`error-record-count == 0`) |
+| `Completed` | All records were processed successfully (`errorRecordCount == 0`) |
 | `PartiallyCompleted` | Processing finished with both successful and failed records |
 | `Failed` | Job failed to process (e.g., missing S3 input file or all records errored) |
 | `Stopping` | Stop request received, halting execution |
@@ -76,7 +84,7 @@ Floci models all AWS Bedrock batch job states:
 Every batch job transition emits state change notifications to EventBridge matching AWS event patterns:
 
 - **Source**: `aws.bedrock`
-- **Detail Type**: `Bedrock Model Invocation Job State Change`
+- **Detail Type**: `Batch Inference Job State Change`
 - **Resources**: `["arn:aws:bedrock:<region>:<accountId>:model-invocation-job/<jobId>"]`
 
 Example EventBridge event payload:
@@ -85,7 +93,7 @@ Example EventBridge event payload:
 {
   "version": "0",
   "id": "c1a2b3c4-d5e6-7f80-9101-112131415161",
-  "detail-type": "Bedrock Model Invocation Job State Change",
+  "detail-type": "Batch Inference Job State Change",
   "source": "aws.bedrock",
   "account": "000000000000",
   "time": "2026-08-30T12:00:00Z",
@@ -94,23 +102,14 @@ Example EventBridge event payload:
     "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/abc123def456"
   ],
   "detail": {
-    "jobArn": "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/abc123def456",
-    "jobName": "my-batch-job",
-    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "version": "0.0",
+    "accountId": "000000000000",
+    "batchJobName": "my-batch-job",
+    "batchJobArn": "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/abc123def456",
+    "batchModelId": "anthropic.claude-3-haiku-20240307-v1:0",
     "status": "Completed",
-    "submitTime": "2026-08-30T12:00:00Z",
-    "endTime": "2026-08-30T12:00:05Z",
-    "inputDataConfig": {
-      "s3InputDataConfig": {
-        "s3Uri": "s3://input-bucket/prompts.jsonl"
-      }
-    },
-    "outputDataConfig": {
-      "s3OutputDataConfig": {
-        "s3Uri": "s3://output-bucket/results"
-      }
-    },
-    "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole"
+    "failureMessage": "",
+    "creationTime": "Aug 30, 2026, 12:00:00 PM"
   }
 }
 ```
@@ -134,7 +133,7 @@ export AWS_DEFAULT_REGION=us-east-1
 # 1. Create S3 buckets and upload prompts
 aws s3 mb s3://bedrock-batch-input
 aws s3 mb s3://bedrock-batch-output
-echo '{"recordId": "rec-1", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}}' > prompts.jsonl
+echo '{"recordId": "rec-1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 1024, "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]}}' > prompts.jsonl
 aws s3 cp prompts.jsonl s3://bedrock-batch-input/prompts.jsonl
 
 # 2. Create Model Invocation Job
@@ -168,7 +167,7 @@ s3 = boto3.client("s3", endpoint_url="http://localhost:4566", region_name="us-ea
 s3.create_bucket(Bucket="batch-input")
 s3.create_bucket(Bucket="batch-output")
 
-prompts = '{"recordId": "p1", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Summarize Floci"}]}]}}\n'
+prompts = '{"recordId": "p1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 1024, "messages": [{"role": "user", "content": [{"type": "text", "text": "Summarize Floci"}]}]}}\n'
 s3.put_object(Bucket="batch-input", Key="prompts.jsonl", Body=prompts.encode("utf-8"))
 
 # Submit batch inference job

--- a/docs/services/bedrock.md
+++ b/docs/services/bedrock.md
@@ -1,0 +1,193 @@
+# Amazon Bedrock
+
+**Protocol:** REST JSON
+**Endpoint:** `http://localhost:4566`
+**Signing name:** `bedrock`
+
+Floci emulates the Amazon Bedrock control plane with full support for **Batch Inference** (`ModelInvocationJob` lifecycle, S3 dataset processing, manifest generation, and EventBridge event publication).
+
+For real-time single-request model inference (`Converse` / `InvokeModel`), see [Bedrock Runtime](bedrock-runtime.md).
+
+## Supported Actions
+
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `CreateModelInvocationJob` | Submits and triggers an asynchronous batch inference job reading input records from S3 and writing results and manifest to S3 (`POST /model-invocation-job`) |
+| `GetModelInvocationJob` | Retrieves properties, metadata, metrics, and current status of a batch model invocation job by ARN, job ID, or job name (`GET /model-invocation-job/{jobIdentifier}`) |
+| `StopModelInvocationJob` | Stops an in-progress batch model invocation job (`POST /model-invocation-job/{jobIdentifier}/stop`) |
+| `ListModelInvocationJobs` | Returns a paginated list of batch model invocation jobs with support for status filtering, name search, time range filters, and sorting (`GET /model-invocation-jobs`) |
+<!-- floci:actions:end -->
+
+## How Batch Inference Works
+
+1. **Input S3 Dataset**: Place a JSON Lines (`.jsonl`) file in an S3 bucket. Each line contains a record with a unique `recordId` and the `modelInput` payload:
+   ```json
+   {"recordId": "rec-001", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello world"}]}]}}
+   {"recordId": "rec-002", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "max_tokens": 100, "messages": [{"role": "user", "content": [{"type": "text", "text": "Explain quantum computing"}]}]}}
+   ```
+2. **Job Submission**: Call `CreateModelInvocationJob` specifying `inputDataConfig` (`s3Uri`), `outputDataConfig` (`s3Uri`), `modelId`, `roleArn`, and `jobName`.
+3. **Execution & Backend Delegation**:
+   - Floci reads the input JSONL file from the specified S3 bucket.
+   - For each record, inference is executed via the configured Bedrock Runtime backend:
+     - `stub` (default): generates simulated model outputs.
+     - `proxy`: forwards Converse requests to any OpenAI-compatible backend (Ollama, vLLM, LiteLLM, OpenRouter).
+4. **S3 Output Files**:
+   - Output records are written to `<outputS3Uri>/<jobId>/<inputFilename>.out`:
+     ```json
+     {"recordId": "rec-001", "modelInput": {...}, "modelOutput": {...}}
+     ```
+   - If an individual record fails, an error entry is recorded:
+     ```json
+     {"recordId": "rec-002", "modelInput": {...}, "error": {"errorCode": "400", "errorMessage": "Invalid model input"}}
+     ```
+5. **Manifest Generation**:
+   - A summary manifest is written to `<outputS3Uri>/<jobId>/manifest.json.out`:
+     ```json
+     {
+       "total-record-count": 2,
+       "processed-record-count": 2,
+       "success-record-count": 2,
+       "error-record-count": 0,
+       "input": "s3://my-input-bucket/prompts.jsonl",
+       "output": "s3://my-output-bucket/results/job-123456789abc/prompts.jsonl.out"
+     }
+     ```
+
+## Job Status Lifecycle
+
+Floci models all AWS Bedrock batch job states:
+
+| Status | Description |
+|---|---|
+| `Submitted` | Job has been created and queued for validation |
+| `Validating` | Input data configuration and S3 paths are being validated |
+| `Scheduled` | Job is scheduled for batch processing |
+| `InProgress` | Records are being processed and model inference is executing |
+| `Completed` | All records were processed successfully (`error-record-count == 0`) |
+| `PartiallyCompleted` | Processing finished with both successful and failed records |
+| `Failed` | Job failed to process (e.g., missing S3 input file or all records errored) |
+| `Stopping` | Stop request received, halting execution |
+| `Stopped` | Job stopped before completion |
+| `Expired` | Job reached expiration threshold |
+
+## EventBridge Integration
+
+Every batch job transition emits state change notifications to EventBridge matching AWS event patterns:
+
+- **Source**: `aws.bedrock`
+- **Detail Type**: `Bedrock Model Invocation Job State Change`
+- **Resources**: `["arn:aws:bedrock:<region>:<accountId>:model-invocation-job/<jobId>"]`
+
+Example EventBridge event payload:
+
+```json
+{
+  "version": "0",
+  "id": "c1a2b3c4-d5e6-7f80-9101-112131415161",
+  "detail-type": "Bedrock Model Invocation Job State Change",
+  "source": "aws.bedrock",
+  "account": "000000000000",
+  "time": "2026-08-30T12:00:00Z",
+  "region": "us-east-1",
+  "resources": [
+    "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/abc123def456"
+  ],
+  "detail": {
+    "jobArn": "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/abc123def456",
+    "jobName": "my-batch-job",
+    "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+    "status": "Completed",
+    "submitTime": "2026-08-30T12:00:00Z",
+    "endTime": "2026-08-30T12:00:05Z",
+    "inputDataConfig": {
+      "s3InputDataConfig": {
+        "s3Uri": "s3://input-bucket/prompts.jsonl"
+      }
+    },
+    "outputDataConfig": {
+      "s3OutputDataConfig": {
+        "s3Uri": "s3://output-bucket/results"
+      }
+    },
+    "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole"
+  }
+}
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_BEDROCK_ENABLED` | `true` | Enable or disable the Bedrock service |
+| `FLOCI_STORAGE_SERVICES_BEDROCK_MODE` | `memory` | Storage mode for batch jobs: `memory`, `persistent`, `hybrid`, `wal` |
+| `FLOCI_STORAGE_SERVICES_BEDROCK_FLUSH_INTERVAL_MS` | `5000` | Flush interval in milliseconds for persistent storage |
+
+## Examples
+
+### AWS CLI
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_DEFAULT_REGION=us-east-1
+
+# 1. Create S3 buckets and upload prompts
+aws s3 mb s3://bedrock-batch-input
+aws s3 mb s3://bedrock-batch-output
+echo '{"recordId": "rec-1", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}}' > prompts.jsonl
+aws s3 cp prompts.jsonl s3://bedrock-batch-input/prompts.jsonl
+
+# 2. Create Model Invocation Job
+JOB_ARN=$(aws bedrock create-model-invocation-job \
+  --job-name "my-first-batch-job" \
+  --model-id "anthropic.claude-3-haiku-20240307-v1:0" \
+  --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
+  --input-data-config '{"s3InputDataConfig": {"s3Uri": "s3://bedrock-batch-input/prompts.jsonl"}}' \
+  --output-data-config '{"s3OutputDataConfig": {"s3Uri": "s3://bedrock-batch-output/results"}}' \
+  --query 'jobArn' --output text)
+
+# 3. Get Job Status
+aws bedrock get-model-invocation-job --job-identifier "$JOB_ARN"
+
+# 4. List Jobs
+aws bedrock list-model-invocation-jobs --status-equals Completed
+
+# 5. Inspect S3 Output and Manifest
+aws s3 ls s3://bedrock-batch-output/results/ --recursive
+```
+
+### Python (boto3)
+
+```python
+import boto3
+
+bedrock = boto3.client("bedrock", endpoint_url="http://localhost:4566", region_name="us-east-1")
+s3 = boto3.client("s3", endpoint_url="http://localhost:4566", region_name="us-east-1")
+
+# Create buckets and upload prompts
+s3.create_bucket(Bucket="batch-input")
+s3.create_bucket(Bucket="batch-output")
+
+prompts = '{"recordId": "p1", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Summarize Floci"}]}]}}\n'
+s3.put_object(Bucket="batch-input", Key="prompts.jsonl", Body=prompts.encode("utf-8"))
+
+# Submit batch inference job
+response = bedrock.create_model_invocation_job(
+    jobName="batch-summarization",
+    modelId="anthropic.claude-3-haiku-20240307-v1:0",
+    roleArn="arn:aws:iam::000000000000:role/BedrockBatchRole",
+    inputDataConfig={"s3InputDataConfig": {"s3Uri": "s3://batch-input/prompts.jsonl"}},
+    outputDataConfig={"s3OutputDataConfig": {"s3Uri": "s3://batch-output/results"}},
+)
+job_arn = response["jobArn"]
+
+# Check job status
+job = bedrock.get_model_invocation_job(jobIdentifier=job_arn)
+print(f"Status: {job['status']}")
+```
+
+## Current Scope & Limitations
+
+- **Batch Processing**: S3 JSON Lines input/output, manifest creation, and EventBridge notifications are fully supported.
+- **Model Customization & Fine-Tuning**: `CreateModelCustomizationJob`, `ListCustomModels`, and model evaluation endpoints are not yet emulated.
+- **Knowledge Bases & Agents**: For agent runtimes, gateways, and memory, see [Bedrock AgentCore](bedrock-agentcore.md).

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -1,6 +1,6 @@
 # Services Overview
 
-Floci emulates 84 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
+Floci emulates 85 AWS services on a single port (`4566`). All services use the real AWS wire protocol, your existing AWS CLI commands and SDK clients work without modification.
 
 This page is the canonical reference for supported service and operation counts. Some services expose separate control-plane and data-plane rows below. Other docs (and the README) should link here rather than duplicating the table.
 
@@ -74,6 +74,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [AppConfig](appconfig.md) | `/applications/...`, `/deploymentstrategies/...` | REST JSON | 16 |
 | [AppConfigData](appconfig.md#data-plane) | `/configurationsessions`, `/configuration` | REST JSON | 2 |
 | [AppSync](appsync.md) | `/v1/apis/...` | REST JSON | 33 |
+| [Bedrock](bedrock.md) | `/model-invocation-job`, `/model-invocation-jobs` | REST JSON | 4 |
 | [Bedrock Runtime](bedrock-runtime.md) | `/model/{modelId}/converse`, `/model/{modelId}/invoke` | REST JSON | 2 (stub; streaming returns 501) |
 | [Bedrock AgentCore Control](bedrock-agentcore.md) | `/runtimes/*`, `/gateways/*`, `/memories/*`, `/identities/*`, `/tags/{resourceArn}` | REST JSON | 31 (+ 3 tagging via shared `/tags/{arn}` route) |
 | [Bedrock AgentCore](bedrock-agentcore.md#data-plane-invokeagentruntime) | `/runtimes/{agentRuntimeArn}/invocations` | REST JSON (binary payload) | 1 (canned-response stub) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -129,6 +129,7 @@ nav:
     - EC2: services/ec2.md
     - Lightsail: services/lightsail.md
     - AppConfig: services/appconfig.md
+    - Bedrock: services/bedrock.md
     - Bedrock Runtime: services/bedrock-runtime.md
     - Bedrock AgentCore: services/bedrock-agentcore.md
     - ELB v2: services/elb.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -304,6 +304,7 @@ public interface EmulatorConfig {
 
         LakeFormationStorageConfig lakeformation();
         EfsStorageConfig efs();
+        BedrockStorageConfig bedrock();
     }
 
     interface ApsStorageConfig {
@@ -592,6 +593,13 @@ public interface EmulatorConfig {
         long flushIntervalMs();
     }
 
+    interface BedrockStorageConfig {
+        Optional<String> mode();
+
+        @WithDefault("5000")
+        long flushIntervalMs();
+    }
+
     interface WalConfig {
         @WithDefault("30000")
         long compactionIntervalMs();
@@ -653,6 +661,7 @@ public interface EmulatorConfig {
         AppConfigDataServiceConfig appconfigdata();
         EcrServiceConfig ecr();
         ResourceGroupsTaggingServiceConfig tagging();
+        BedrockServiceConfig bedrock();
         BedrockRuntimeServiceConfig bedrockRuntime();
         EksServiceConfig eks();
         MwaaServiceConfig mwaa();
@@ -1531,6 +1540,11 @@ public interface EmulatorConfig {
     }
 
     interface ResourceGroupsTaggingServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface BedrockServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.services.backup.BackupController;
 import io.github.hectorvent.floci.services.resourceexplorer2.ResourceExplorer2Controller;
 import io.github.hectorvent.floci.services.appconfig.AppConfigDataController;
 import io.github.hectorvent.floci.services.batch.BatchController;
+import io.github.hectorvent.floci.services.bedrock.BedrockController;
 import io.github.hectorvent.floci.services.bedrockruntime.BedrockRuntimeController;
 import io.github.hectorvent.floci.services.cognito.CognitoOAuthController;
 import io.github.hectorvent.floci.services.cognito.CognitoWellKnownController;
@@ -293,6 +294,14 @@ public class ResolvedServiceCatalog {
                         config.storage().services().tagging().flushIntervalMs(), null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
                         Set.of("ResourceGroupsTaggingAPI_20170126."), Set.of("tagging"), Set.of(), Set.of()),
+                descriptor("bedrock", "bedrock", config.services().bedrock().enabled(), true,
+                        "bedrock", storageMode(config.storage().services().bedrock().mode(), config.storage().mode()),
+                        config.storage().services().bedrock().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON),
+                        Set.of(),
+                        Set.of("bedrock"),
+                        Set.of(),
+                        Set.of(BedrockController.class)),
                 descriptor("bedrock-runtime", "bedrock-runtime",
                         config.services().bedrockRuntime().enabled(), true,
                         null, null, 5000L, null, ServiceProtocol.REST_JSON,

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockController.java
@@ -1,0 +1,103 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.bedrock.model.CreateModelInvocationJobRequest;
+import io.github.hectorvent.floci.services.bedrock.model.CreateModelInvocationJobResponse;
+import io.github.hectorvent.floci.services.bedrock.model.ListModelInvocationJobsResponse;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJob;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJobStatus;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJobSummary;
+import io.smallrye.common.annotation.Blocking;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class BedrockController {
+
+    private static final Logger LOG = Logger.getLogger(BedrockController.class);
+
+    private final BedrockService service;
+    private final RegionResolver regionResolver;
+
+    @Inject
+    public BedrockController(BedrockService service, RegionResolver regionResolver) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+    }
+
+    @POST
+    @Blocking
+    @Path("/model-invocation-job")
+    public Response createModelInvocationJob(@Context HttpHeaders headers, CreateModelInvocationJobRequest request) {
+        String region = regionResolver.resolveRegion(headers);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(request, region);
+        return Response.status(201).entity(response).build();
+    }
+
+    @GET
+    @Path("/model-invocation-job/{jobIdentifier:.+}")
+    public Response getModelInvocationJob(@Context HttpHeaders headers, @PathParam("jobIdentifier") String jobIdentifier) {
+        String region = regionResolver.resolveRegion(headers);
+        ModelInvocationJob job = service.getModelInvocationJob(jobIdentifier, region);
+        return Response.ok(job).build();
+    }
+
+    @POST
+    @Path("/model-invocation-job/{jobIdentifier:.+}/stop")
+    public Response stopModelInvocationJob(@Context HttpHeaders headers, @PathParam("jobIdentifier") String jobIdentifier) {
+        String region = regionResolver.resolveRegion(headers);
+        service.stopModelInvocationJob(jobIdentifier, region);
+        return Response.ok("{}").build();
+    }
+
+    @GET
+    @Path("/model-invocation-jobs")
+    public Response listModelInvocationJobs(
+            @Context HttpHeaders headers,
+            @QueryParam("statusEquals") String statusEquals,
+            @QueryParam("nameContains") String nameContains,
+            @QueryParam("submitTimeAfter") String submitTimeAfter,
+            @QueryParam("submitTimeBefore") String submitTimeBefore,
+            @QueryParam("sortBy") String sortBy,
+            @QueryParam("sortOrder") String sortOrder,
+            @QueryParam("maxResults") Integer maxResults,
+            @QueryParam("nextToken") String nextToken) {
+        String region = regionResolver.resolveRegion(headers);
+        ModelInvocationJobStatus status = statusEquals != null ? ModelInvocationJobStatus.fromValue(statusEquals) : null;
+        Instant after = parseInstant(submitTimeAfter, "submitTimeAfter");
+        Instant before = parseInstant(submitTimeBefore, "submitTimeBefore");
+
+        PaginatedResult<ModelInvocationJobSummary> result = service.listModelInvocationJobs(
+                status, nameContains, after, before, sortBy, sortOrder, maxResults, nextToken, region);
+        return Response.ok(new ListModelInvocationJobsResponse(result.items(), result.nextToken())).build();
+    }
+
+    private Instant parseInstant(String dateStr, String paramName) {
+        if (dateStr == null || dateStr.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(dateStr);
+        } catch (DateTimeParseException e) {
+            throw new AwsException("ValidationException", "Invalid date format for " + paramName + ": " + dateStr, 400);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
@@ -47,6 +47,7 @@ import java.util.stream.Collectors;
 public class BedrockService implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(BedrockService.class);
+    private static final int MAX_PAGE = 1000;
     private static final String CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyz";
     private static final SecureRandom RANDOM = new SecureRandom();
 
@@ -251,10 +252,15 @@ public class BedrockService implements Resettable {
                 ModelInvocationJobSummary::jobArn,
                 maxResults,
                 nextToken,
-                10,
-                1000,
+                MAX_PAGE,
                 "ValidationException"
         );
+    }
+
+    private boolean isJobStopped(ModelInvocationJob job) {
+        return jobStore.get(job.getJobArn())
+                .map(j -> j.getStatus() == ModelInvocationJobStatus.STOPPED)
+                .orElse(false);
     }
 
     private void executeBatchJob(ModelInvocationJob job, String region, String accountId) {
@@ -264,17 +270,23 @@ public class BedrockService implements Resettable {
         jobStore.put(job.getJobArn(), job);
         emitStateChangeEvent(job, region, accountId);
 
+        if (isJobStopped(job)) return;
+
         // Scheduled
         job.setStatus(ModelInvocationJobStatus.SCHEDULED);
         job.setLastModifiedTime(Instant.now());
         jobStore.put(job.getJobArn(), job);
         emitStateChangeEvent(job, region, accountId);
 
+        if (isJobStopped(job)) return;
+
         // Transition to InProgress
         job.setStatus(ModelInvocationJobStatus.IN_PROGRESS);
         job.setLastModifiedTime(Instant.now());
         jobStore.put(job.getJobArn(), job);
         emitStateChangeEvent(job, region, accountId);
+
+        if (isJobStopped(job)) return;
 
         String inputS3Uri = job.getInputDataConfig().s3InputDataConfig().s3Uri();
         S3Location inputLoc = parseS3Uri(inputS3Uri);
@@ -288,11 +300,13 @@ public class BedrockService implements Resettable {
         try {
             S3Object s3Obj = s3Service.getObject(inputLoc.bucket(), inputLoc.key());
             if (s3Obj == null || s3Obj.getData() == null) {
+                if (isJobStopped(job)) return;
                 failJob(job, "Input S3 file is empty or not found: " + inputS3Uri, region, accountId);
                 return;
             }
             inputBytes = s3Obj.getData();
         } catch (Exception e) {
+            if (isJobStopped(job)) return;
             LOG.warnv(e, "Failed to read S3 input file: {0}", inputS3Uri);
             failJob(job, "Failed to read input S3 file: " + e.getMessage(), region, accountId);
             return;

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
@@ -1,0 +1,580 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.Resettable;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.bedrock.model.BatchManifest;
+import io.github.hectorvent.floci.services.bedrock.model.CreateModelInvocationJobRequest;
+import io.github.hectorvent.floci.services.bedrock.model.CreateModelInvocationJobResponse;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJob;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJobStatus;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJobSummary;
+import io.github.hectorvent.floci.services.bedrockruntime.BedrockRuntimeService;
+import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+@ApplicationScoped
+public class BedrockService implements Resettable {
+
+    private static final Logger LOG = Logger.getLogger(BedrockService.class);
+    private static final String CHARACTERS = "0123456789abcdefghijklmnopqrstuvwxyz";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final StorageBackend<String, ModelInvocationJob> jobStore;
+    private final EmulatorConfig config;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+    private final BedrockRuntimeService bedrockRuntimeService;
+    private final S3Service s3Service;
+    private final EventBridgeService eventBridgeService;
+
+    @Inject
+    public BedrockService(StorageFactory storageFactory,
+                          EmulatorConfig config,
+                          RegionResolver regionResolver,
+                          ObjectMapper objectMapper,
+                          BedrockRuntimeService bedrockRuntimeService,
+                          S3Service s3Service,
+                          EventBridgeService eventBridgeService) {
+        this.jobStore = storageFactory.create("bedrock", "bedrock-jobs.json",
+                new TypeReference<Map<String, ModelInvocationJob>>() {});
+        this.config = config;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+        this.bedrockRuntimeService = bedrockRuntimeService;
+        this.s3Service = s3Service;
+        this.eventBridgeService = eventBridgeService;
+    }
+
+    @Override
+    public void clear() {
+        jobStore.clear();
+    }
+
+    public CreateModelInvocationJobResponse createModelInvocationJob(
+            CreateModelInvocationJobRequest request, String region) {
+        if (request == null) {
+            throw new AwsException("ValidationException", "Request payload is required.", 400);
+        }
+        if (request.jobName() == null || request.jobName().isBlank()) {
+            throw new AwsException("ValidationException", "jobName is required.", 400);
+        }
+        if (request.modelId() == null || request.modelId().isBlank()) {
+            throw new AwsException("ValidationException", "modelId is required.", 400);
+        }
+        if (request.roleArn() == null || request.roleArn().isBlank()) {
+            throw new AwsException("ValidationException", "roleArn is required.", 400);
+        }
+        if (request.inputDataConfig() == null
+                || request.inputDataConfig().s3InputDataConfig() == null
+                || request.inputDataConfig().s3InputDataConfig().s3Uri() == null
+                || request.inputDataConfig().s3InputDataConfig().s3Uri().isBlank()) {
+            throw new AwsException("ValidationException",
+                    "inputDataConfig.s3InputDataConfig.s3Uri is required.", 400);
+        }
+        if (request.outputDataConfig() == null
+                || request.outputDataConfig().s3OutputDataConfig() == null
+                || request.outputDataConfig().s3OutputDataConfig().s3Uri() == null
+                || request.outputDataConfig().s3OutputDataConfig().s3Uri().isBlank()) {
+            throw new AwsException("ValidationException",
+                    "outputDataConfig.s3OutputDataConfig.s3Uri is required.", 400);
+        }
+
+        String effectiveRegion = region != null && !region.isBlank()
+                ? region : regionResolver.getDefaultRegion();
+        String accountId = regionResolver.getAccountId();
+        String jobId = generateJobId();
+        String jobArn = "arn:aws:bedrock:" + effectiveRegion + ":" + accountId + ":model-invocation-job/" + jobId;
+
+        Instant now = Instant.now();
+        int timeoutHours = request.timeoutDurationInHours() != null
+                ? request.timeoutDurationInHours() : 24;
+
+        ModelInvocationJob job = new ModelInvocationJob(
+                jobArn,
+                request.jobName(),
+                request.modelId(),
+                request.clientRequestToken(),
+                request.roleArn(),
+                ModelInvocationJobStatus.SUBMITTED,
+                null,
+                now,
+                now,
+                null,
+                now.plus(Duration.ofHours(timeoutHours)),
+                timeoutHours,
+                request.inputDataConfig(),
+                request.outputDataConfig(),
+                request.vpcConfig(),
+                request.tags()
+        );
+
+        jobStore.put(jobArn, job);
+        LOG.infov("Created model invocation job: {0} ({1}) in region {2}",
+                job.getJobName(), jobArn, effectiveRegion);
+
+        emitStateChangeEvent(job, effectiveRegion, accountId);
+
+        // Execute batch inference asynchronously
+        CompletableFuture.runAsync(() -> {
+            try {
+                executeBatchJob(job, effectiveRegion, accountId);
+            } catch (Exception e) {
+                LOG.errorv(e, "Unexpected error running batch job {0}", jobArn);
+                failJob(job, "Unexpected batch error: " + e.getMessage(), effectiveRegion, accountId);
+            }
+        });
+
+        return new CreateModelInvocationJobResponse(jobArn);
+    }
+
+    public ModelInvocationJob getModelInvocationJob(String jobIdentifier, String region) {
+        if (jobIdentifier == null || jobIdentifier.isBlank()) {
+            throw new AwsException("ValidationException", "jobIdentifier is required.", 400);
+        }
+
+        Optional<ModelInvocationJob> job = jobStore.scan(k -> true).stream()
+                .filter(j -> jobIdentifier.equals(j.getJobArn())
+                        || jobIdentifier.equals(j.getJobId())
+                        || jobIdentifier.equals(j.getJobName()))
+                .findFirst();
+
+        return job.orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                "Could not find model invocation job with identifier: " + jobIdentifier, 404));
+    }
+
+    public void stopModelInvocationJob(String jobIdentifier, String region) {
+        ModelInvocationJob job = getModelInvocationJob(jobIdentifier, region);
+        if (job.getStatus() == ModelInvocationJobStatus.COMPLETED
+                || job.getStatus() == ModelInvocationJobStatus.FAILED
+                || job.getStatus() == ModelInvocationJobStatus.STOPPED
+                || job.getStatus() == ModelInvocationJobStatus.EXPIRED
+                || job.getStatus() == ModelInvocationJobStatus.PARTIALLY_COMPLETED) {
+            throw new AwsException("ValidationException",
+                    "Job " + job.getJobArn() + " is already in terminal status: " + job.getStatus(), 400);
+        }
+
+        String effectiveRegion = region != null && !region.isBlank()
+                ? region : regionResolver.getDefaultRegion();
+        String accountId = regionResolver.getAccountId();
+
+        Instant now = Instant.now();
+        job.setStatus(ModelInvocationJobStatus.STOPPED);
+        job.setEndTime(now);
+        job.setLastModifiedTime(now);
+        jobStore.put(job.getJobArn(), job);
+
+        LOG.infov("Stopped model invocation job: {0}", job.getJobArn());
+        emitStateChangeEvent(job, effectiveRegion, accountId);
+    }
+
+    public PaginatedResult<ModelInvocationJobSummary> listModelInvocationJobs(
+            ModelInvocationJobStatus statusEquals,
+            String nameContains,
+            Instant submitTimeAfter,
+            Instant submitTimeBefore,
+            String sortBy,
+            String sortOrder,
+            Integer maxResults,
+            String nextToken,
+            String region) {
+
+        List<ModelInvocationJob> matched = jobStore.scan(k -> true).stream()
+                .filter(job -> {
+                    if (statusEquals != null && job.getStatus() != statusEquals) {
+                        return false;
+                    }
+                    if (nameContains != null && !nameContains.isBlank()) {
+                        if (job.getJobName() == null || !job.getJobName().contains(nameContains)) {
+                            return false;
+                        }
+                    }
+                    if (submitTimeAfter != null && job.getSubmitTime() != null
+                            && !job.getSubmitTime().isAfter(submitTimeAfter)) {
+                        return false;
+                    }
+                    if (submitTimeBefore != null && job.getSubmitTime() != null
+                            && !job.getSubmitTime().isBefore(submitTimeBefore)) {
+                        return false;
+                    }
+                    return true;
+                })
+                .collect(Collectors.toCollection(ArrayList::new));
+
+        boolean ascending = "Ascending".equalsIgnoreCase(sortOrder);
+        Comparator<ModelInvocationJob> comparator = Comparator.comparing(
+                ModelInvocationJob::getSubmitTime,
+                Comparator.nullsLast(Comparator.naturalOrder())
+        );
+        if (!ascending) {
+            comparator = comparator.reversed();
+        }
+        comparator = comparator.thenComparing(ModelInvocationJob::getJobArn);
+        matched.sort(comparator);
+
+        List<ModelInvocationJobSummary> summaries = matched.stream()
+                .map(ModelInvocationJobSummary::from)
+                .toList();
+
+        return Pagination.paginate(
+                summaries,
+                ModelInvocationJobSummary::jobArn,
+                maxResults,
+                nextToken,
+                10,
+                1000,
+                "ValidationException"
+        );
+    }
+
+    private void executeBatchJob(ModelInvocationJob job, String region, String accountId) {
+        // Validating
+        job.setStatus(ModelInvocationJobStatus.VALIDATING);
+        job.setLastModifiedTime(Instant.now());
+        jobStore.put(job.getJobArn(), job);
+        emitStateChangeEvent(job, region, accountId);
+
+        // Scheduled
+        job.setStatus(ModelInvocationJobStatus.SCHEDULED);
+        job.setLastModifiedTime(Instant.now());
+        jobStore.put(job.getJobArn(), job);
+        emitStateChangeEvent(job, region, accountId);
+
+        // Transition to InProgress
+        job.setStatus(ModelInvocationJobStatus.IN_PROGRESS);
+        job.setLastModifiedTime(Instant.now());
+        jobStore.put(job.getJobArn(), job);
+        emitStateChangeEvent(job, region, accountId);
+
+        String inputS3Uri = job.getInputDataConfig().s3InputDataConfig().s3Uri();
+        S3Location inputLoc = parseS3Uri(inputS3Uri);
+
+        if (s3Service == null) {
+            failJob(job, "S3 service is not available", region, accountId);
+            return;
+        }
+
+        byte[] inputBytes;
+        try {
+            S3Object s3Obj = s3Service.getObject(inputLoc.bucket(), inputLoc.key());
+            if (s3Obj == null || s3Obj.getData() == null) {
+                failJob(job, "Input S3 file is empty or not found: " + inputS3Uri, region, accountId);
+                return;
+            }
+            inputBytes = s3Obj.getData();
+        } catch (Exception e) {
+            LOG.warnv(e, "Failed to read S3 input file: {0}", inputS3Uri);
+            failJob(job, "Failed to read input S3 file: " + e.getMessage(), region, accountId);
+            return;
+        }
+
+        String content = new String(inputBytes, StandardCharsets.UTF_8);
+        String[] lines = content.split("\\r?\\n");
+        List<String> outputLines = new ArrayList<>();
+        long totalCount = 0;
+        long processedCount = 0;
+        long successCount = 0;
+        long errorCount = 0;
+        long totalInputTokens = 0;
+        long totalOutputTokens = 0;
+
+        for (String line : lines) {
+            if (line == null || line.trim().isEmpty()) {
+                continue;
+            }
+            totalCount++;
+            processedCount++;
+
+            String parsedRecordId = null;
+            JsonNode parsedModelInput = null;
+            try {
+                JsonNode lineNode = objectMapper.readTree(line);
+                parsedRecordId = lineNode.path("recordId").asText(null);
+                parsedModelInput = lineNode.get("modelInput");
+
+                if (parsedRecordId == null || parsedModelInput == null || !parsedModelInput.isObject()) {
+                    ObjectNode errorRecord = objectMapper.createObjectNode();
+                    errorRecord.put("recordId", parsedRecordId != null ? parsedRecordId : "RECORD_" + totalCount);
+                    if (parsedModelInput != null) {
+                        errorRecord.set("modelInput", parsedModelInput);
+                    } else {
+                        errorRecord.putObject("modelInput");
+                    }
+                    ObjectNode err = errorRecord.putObject("error");
+                    err.put("errorCode", "400");
+                    err.put("errorMessage", "Malformed record: recordId and modelInput object are required.");
+                    outputLines.add(objectMapper.writeValueAsString(errorRecord));
+                    errorCount++;
+                    continue;
+                }
+
+                JsonNode modelOutputNode = processModelInput(job.getModelId(), (ObjectNode) parsedModelInput);
+                totalInputTokens += extractInputTokens(modelOutputNode);
+                totalOutputTokens += extractOutputTokens(modelOutputNode);
+
+                ObjectNode outputRecord = objectMapper.createObjectNode();
+                outputRecord.put("recordId", parsedRecordId);
+                outputRecord.set("modelInput", parsedModelInput);
+                outputRecord.set("modelOutput", modelOutputNode);
+                outputLines.add(objectMapper.writeValueAsString(outputRecord));
+                successCount++;
+            } catch (Exception e) {
+                LOG.warnv("Batch inference record error: {0}", e.getMessage());
+                ObjectNode errorRecord = objectMapper.createObjectNode();
+                errorRecord.put("recordId", parsedRecordId != null ? parsedRecordId : "RECORD_" + totalCount);
+                if (parsedModelInput != null) {
+                    errorRecord.set("modelInput", parsedModelInput);
+                }
+                ObjectNode err = errorRecord.putObject("error");
+                err.put("errorCode", "500");
+                err.put("errorMessage", e.getMessage());
+                try {
+                    outputLines.add(objectMapper.writeValueAsString(errorRecord));
+                } catch (Exception ignored) {
+                }
+                errorCount++;
+            }
+        }
+
+        // Write output files to S3
+        String outputS3Uri = job.getOutputDataConfig().s3OutputDataConfig().s3Uri();
+        S3Location outLoc = parseS3Uri(outputS3Uri);
+
+        String inputKey = inputLoc.key();
+        String inputFilename = inputKey.contains("/")
+                ? inputKey.substring(inputKey.lastIndexOf('/') + 1) : inputKey;
+        if (inputFilename.isBlank()) {
+            inputFilename = "input.jsonl";
+        }
+
+        String outPrefix = outLoc.key().isEmpty()
+                ? job.getJobId()
+                : (outLoc.key().replaceAll("/+$", "") + "/" + job.getJobId());
+        String outputJsonlKey = outPrefix + "/" + inputFilename + ".out";
+        String manifestKey = outPrefix + "/manifest.json.out";
+
+        String outputJsonlUri = "s3://" + outLoc.bucket() + "/" + outputJsonlKey;
+
+        try {
+            String outputContent = String.join("\n", outputLines)
+                    + (outputLines.isEmpty() ? "" : "\n");
+            s3Service.putObject(outLoc.bucket(), outputJsonlKey,
+                    outputContent.getBytes(StandardCharsets.UTF_8),
+                    "application/jsonlines", Map.of());
+
+            BatchManifest manifest = new BatchManifest(
+                    totalCount,
+                    processedCount,
+                    successCount,
+                    errorCount,
+                    totalInputTokens > 0 ? totalInputTokens : null,
+                    totalOutputTokens > 0 ? totalOutputTokens : null
+            );
+            byte[] manifestBytes = objectMapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsBytes(manifest);
+            s3Service.putObject(outLoc.bucket(), manifestKey, manifestBytes,
+                    "application/json", Map.of());
+        } catch (Exception e) {
+            LOG.warnv(e, "Failed to write batch output files to S3 bucket {0}", outLoc.bucket());
+            failJob(job, "Failed to write batch output to S3: " + e.getMessage(), region, accountId);
+            return;
+        }
+
+        Instant completionTime = Instant.now();
+        job.setEndTime(completionTime);
+        job.setLastModifiedTime(completionTime);
+        job.setTotalRecordCount(totalCount);
+        job.setProcessedRecordCount(processedCount);
+        job.setSuccessRecordCount(successCount);
+        job.setErrorRecordCount(errorCount);
+        job.setInputTokenCount(totalInputTokens > 0 ? totalInputTokens : null);
+        job.setOutputTokenCount(totalOutputTokens > 0 ? totalOutputTokens : null);
+
+        if (totalCount == 0) {
+            job.setStatus(ModelInvocationJobStatus.COMPLETED);
+        } else if (errorCount == 0) {
+            job.setStatus(ModelInvocationJobStatus.COMPLETED);
+        } else if (successCount > 0) {
+            job.setStatus(ModelInvocationJobStatus.PARTIALLY_COMPLETED);
+            job.setMessage(String.format("Batch job partially completed with %d successes and %d errors.",
+                    successCount, errorCount));
+        } else {
+            job.setStatus(ModelInvocationJobStatus.FAILED);
+            job.setMessage(String.format("Batch job failed: all %d records failed.", totalCount));
+        }
+
+        jobStore.put(job.getJobArn(), job);
+        LOG.infov("Completed model invocation job {0} with status {1}",
+                job.getJobArn(), job.getStatus());
+        emitStateChangeEvent(job, region, accountId);
+    }
+
+    private static long extractInputTokens(JsonNode output) {
+        if (output == null) {
+            return 0;
+        }
+        if (output.path("usage").hasNonNull("inputTokens")) {
+            return output.path("usage").get("inputTokens").asLong(0);
+        }
+        if (output.path("usage").hasNonNull("input_tokens")) {
+            return output.path("usage").get("input_tokens").asLong(0);
+        }
+        if (output.path("usage").hasNonNull("prompt_tokens")) {
+            return output.path("usage").get("prompt_tokens").asLong(0);
+        }
+        if (output.hasNonNull("inputTextTokenCount")) {
+            return output.get("inputTextTokenCount").asLong(0);
+        }
+        if (output.hasNonNull("prompt_token_count")) {
+            return output.get("prompt_token_count").asLong(0);
+        }
+        return 0;
+    }
+
+    private static long extractOutputTokens(JsonNode output) {
+        if (output == null) {
+            return 0;
+        }
+        if (output.path("usage").hasNonNull("outputTokens")) {
+            return output.path("usage").get("outputTokens").asLong(0);
+        }
+        if (output.path("usage").hasNonNull("output_tokens")) {
+            return output.path("usage").get("output_tokens").asLong(0);
+        }
+        if (output.path("usage").hasNonNull("completion_tokens")) {
+            return output.path("usage").get("completion_tokens").asLong(0);
+        }
+        if (output.hasNonNull("generation_token_count")) {
+            return output.get("generation_token_count").asLong(0);
+        }
+        if (output.path("results").isArray() && !output.path("results").isEmpty()) {
+            return output.path("results").path(0).path("tokenCount").asLong(0);
+        }
+        return 0;
+    }
+
+    private JsonNode processModelInput(String modelId, ObjectNode modelInputNode) throws Exception {
+        if (modelInputNode.has("anthropic_version") || modelInputNode.has("prompt")) {
+            byte[] responseBytes = bedrockRuntimeService.buildInvokeModelResponse(
+                    modelId, objectMapper.writeValueAsBytes(modelInputNode));
+            return objectMapper.readTree(responseBytes);
+        }
+        if (modelInputNode.has("messages")) {
+            try {
+                return bedrockRuntimeService.buildConverseResponse(modelId, modelInputNode);
+            } catch (Exception e) {
+                byte[] responseBytes = bedrockRuntimeService.buildInvokeModelResponse(
+                        modelId, objectMapper.writeValueAsBytes(modelInputNode));
+                return objectMapper.readTree(responseBytes);
+            }
+        }
+        byte[] responseBytes = bedrockRuntimeService.buildInvokeModelResponse(
+                modelId, objectMapper.writeValueAsBytes(modelInputNode));
+        return objectMapper.readTree(responseBytes);
+    }
+
+    private void failJob(ModelInvocationJob job, String message, String region, String accountId) {
+        Instant now = Instant.now();
+        job.setStatus(ModelInvocationJobStatus.FAILED);
+        job.setMessage(message);
+        job.setEndTime(now);
+        job.setLastModifiedTime(now);
+        jobStore.put(job.getJobArn(), job);
+        LOG.warnv("Model invocation job {0} failed: {1}", job.getJobArn(), message);
+        emitStateChangeEvent(job, region, accountId);
+    }
+
+    private static final DateTimeFormatter CREATION_TIME_FMT =
+            DateTimeFormatter.ofPattern("MMM d, yyyy, h:mm:ss a", Locale.ENGLISH).withZone(ZoneOffset.UTC);
+
+    private void emitStateChangeEvent(ModelInvocationJob job, String region, String accountId) {
+        if (eventBridgeService == null) {
+            return;
+        }
+        try {
+            String effectiveAccount = accountId != null ? accountId : "000000000000";
+
+            ObjectNode detail = objectMapper.createObjectNode();
+            detail.put("version", "0.0");
+            detail.put("accountId", effectiveAccount);
+            detail.put("batchJobName", job.getJobName());
+            detail.put("batchJobArn", job.getJobArn());
+            detail.put("batchModelId", job.getModelId());
+            detail.put("status", job.getStatus() != null ? job.getStatus().getValue() : null);
+            detail.put("failureMessage", job.getMessage() != null ? job.getMessage() : "");
+            detail.put("creationTime", job.getSubmitTime() != null
+                    ? CREATION_TIME_FMT.format(job.getSubmitTime()) : "");
+
+            ArrayNode resources = objectMapper.createArrayNode();
+            if (job.getJobArn() != null) {
+                resources.add(job.getJobArn());
+            }
+
+            Map<String, Object> entry = new HashMap<>();
+            entry.put("Source", "aws.bedrock");
+            entry.put("DetailType", "Batch Inference Job State Change");
+            entry.put("Detail", objectMapper.writeValueAsString(detail));
+            entry.put("Resources", resources);
+            entry.put("EventBusName", "default");
+            entry.put("Region", region);
+            entry.put("Account", effectiveAccount);
+
+            eventBridgeService.putEvents(List.of(entry), region, accountId);
+        } catch (Exception e) {
+            LOG.warnv("Failed to emit Bedrock EventBridge state change event for job {0}: {1}",
+                    job.getJobArn(), e.getMessage());
+        }
+    }
+
+    record S3Location(String bucket, String key) {}
+
+    static S3Location parseS3Uri(String uri) {
+        if (uri == null || !uri.startsWith("s3://")) {
+            throw new AwsException("ValidationException", "Invalid S3 URI: " + uri, 400);
+        }
+        String path = uri.substring(5);
+        int slash = path.indexOf('/');
+        if (slash == -1) {
+            return new S3Location(path, "");
+        }
+        return new S3Location(path.substring(0, slash), path.substring(slash + 1));
+    }
+
+    private static String generateJobId() {
+        StringBuilder sb = new StringBuilder(12);
+        for (int i = 0; i < 12; i++) {
+            sb.append(CHARACTERS.charAt(RANDOM.nextInt(CHARACTERS.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
@@ -392,6 +392,14 @@ public class BedrockService implements Resettable {
             return;
         }
 
+        try {
+            s3Service.authorizeRoleAccess(initialJob.getRoleArn(), inputLoc.bucket(), inputLoc.key(), "s3:GetObject");
+        } catch (AwsException e) {
+            if (isJobStoppedOrTerminal(jobArn)) return;
+            failJob(jobArn, "Access denied reading input S3 location: " + e.getMessage(), region, accountId);
+            return;
+        }
+
         if (isJobStoppedOrTerminal(jobArn)) return;
 
         byte[] inputBytes;
@@ -522,33 +530,12 @@ public class BedrockService implements Resettable {
             return;
         }
 
-        if (isJobStoppedOrTerminal(jobArn)) {
-            return;
-        }
-
         try {
-            String outputContent = String.join("\n", outputLines)
-                    + (outputLines.isEmpty() ? "" : "\n");
-            s3Service.putObject(outLoc.bucket(), outputJsonlKey,
-                    outputContent.getBytes(StandardCharsets.UTF_8),
-                    "application/jsonlines", Map.of());
-
-            BatchManifest manifest = new BatchManifest(
-                    totalCount,
-                    processedCount,
-                    successCount,
-                    errorCount,
-                    totalInputTokens > 0 ? totalInputTokens : null,
-                    totalOutputTokens > 0 ? totalOutputTokens : null
-            );
-            byte[] manifestBytes = objectMapper.writerWithDefaultPrettyPrinter()
-                    .writeValueAsBytes(manifest);
-            s3Service.putObject(outLoc.bucket(), manifestKey, manifestBytes,
-                    "application/json", Map.of());
-        } catch (Exception e) {
+            s3Service.authorizeRoleAccess(initialJob.getRoleArn(), outLoc.bucket(), outputJsonlKey, "s3:PutObject");
+            s3Service.authorizeRoleAccess(initialJob.getRoleArn(), outLoc.bucket(), manifestKey, "s3:PutObject");
+        } catch (AwsException e) {
             if (isJobStoppedOrTerminal(jobArn)) return;
-            LOG.warnv(e, "Failed to write batch output files to S3 bucket {0}", outLoc.bucket());
-            failJob(jobArn, "Failed to write batch output to S3: " + e.getMessage(), region, accountId);
+            failJob(jobArn, "Access denied writing output S3 location: " + e.getMessage(), region, accountId);
             return;
         }
 
@@ -574,9 +561,54 @@ public class BedrockService implements Resettable {
         final long inTokens = totalInputTokens;
         final long outTokens = totalOutputTokens;
 
-        boolean transitioned = transitionJobStatus(jobArn, finalStatus, current -> {
+        Object lock = getJobLock(jobArn);
+        synchronized (lock) {
+            Optional<ModelInvocationJob> opt = jobStore.get(jobArn);
+            if (opt.isEmpty()) {
+                return;
+            }
+            ModelInvocationJob current = opt.get();
+            if (isTerminal(current.getStatus())) {
+                LOG.infov("Job {0} is already in terminal status {1}; skipping output write and completion.",
+                        jobArn, current.getStatus());
+                return;
+            }
+
+            try {
+                String outputContent = String.join("\n", outputLines)
+                        + (outputLines.isEmpty() ? "" : "\n");
+                s3Service.putObject(outLoc.bucket(), outputJsonlKey,
+                        outputContent.getBytes(StandardCharsets.UTF_8),
+                        "application/jsonlines", Map.of());
+
+                BatchManifest manifest = new BatchManifest(
+                        total,
+                        processed,
+                        success,
+                        error,
+                        inTokens > 0 ? inTokens : null,
+                        outTokens > 0 ? outTokens : null
+                );
+                byte[] manifestBytes = objectMapper.writerWithDefaultPrettyPrinter()
+                        .writeValueAsBytes(manifest);
+                s3Service.putObject(outLoc.bucket(), manifestKey, manifestBytes,
+                        "application/json", Map.of());
+            } catch (Exception e) {
+                LOG.warnv(e, "Failed to write batch output files to S3 bucket {0}", outLoc.bucket());
+                Instant now = Instant.now();
+                current.setStatus(ModelInvocationJobStatus.FAILED);
+                current.setMessage("Failed to write batch output to S3: " + e.getMessage());
+                current.setEndTime(now);
+                current.setLastModifiedTime(now);
+                jobStore.put(jobArn, current);
+                emitStateChangeEvent(current, region, accountId);
+                return;
+            }
+
             Instant completionTime = Instant.now();
+            current.setStatus(finalStatus);
             current.setEndTime(completionTime);
+            current.setLastModifiedTime(completionTime);
             current.setTotalRecordCount(total);
             current.setProcessedRecordCount(processed);
             current.setSuccessRecordCount(success);
@@ -586,9 +618,8 @@ public class BedrockService implements Resettable {
             if (msg != null) {
                 current.setMessage(msg);
             }
-        }, region, accountId);
-
-        if (transitioned) {
+            jobStore.put(jobArn, current);
+            emitStateChangeEvent(current, region, accountId);
             LOG.infov("Completed model invocation job {0} with status {1}", jobArn, finalStatus);
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
@@ -314,9 +314,10 @@ public class BedrockService implements Resettable {
             return;
         }
 
-        // Verify the caller-supplied input bucket is reachable within this emulator instance.
-        // Full IAM role assumption and cross-account S3 policy enforcement are not implemented;
-        // this check prevents accidentally reading buckets that have never been registered.
+        // Verify the caller-supplied input bucket exists and belongs to the same account as the
+        // submitted roleArn.  Full IAM role assumption and S3 policy evaluation are not
+        // implemented; this ownership check is the practical cross-account guard available in
+        // the emulator.
         try {
             s3Service.headBucket(inputLoc.bucket());
         } catch (Exception e) {
@@ -324,6 +325,17 @@ public class BedrockService implements Resettable {
             failJob(job, "Input S3 bucket does not exist or is not accessible: " + inputLoc.bucket(),
                     region, accountId);
             return;
+        }
+        String roleAccountId = extractAccountIdFromRoleArn(job.getRoleArn());
+        if (roleAccountId != null) {
+            String bucketOwner = s3Service.getBucketOwnerAccountId(inputLoc.bucket());
+            if (bucketOwner != null && !roleAccountId.equals(bucketOwner)) {
+                if (isJobStopped(job)) return;
+                failJob(job, "Access denied: roleArn account " + roleAccountId
+                        + " does not own input bucket " + inputLoc.bucket()
+                        + " (owned by " + bucketOwner + ")", region, accountId);
+                return;
+            }
         }
 
         byte[] inputBytes;
@@ -429,7 +441,8 @@ public class BedrockService implements Resettable {
 
         String outputJsonlUri = "s3://" + outLoc.bucket() + "/" + outputJsonlKey;
 
-        // Verify the caller-supplied output bucket is reachable before writing.
+        // Verify the caller-supplied output bucket exists and belongs to the same account as the
+        // submitted roleArn, for the same reason as the input check above.
         try {
             s3Service.headBucket(outLoc.bucket());
         } catch (Exception e) {
@@ -437,6 +450,16 @@ public class BedrockService implements Resettable {
             failJob(job, "Output S3 bucket does not exist or is not accessible: " + outLoc.bucket(),
                     region, accountId);
             return;
+        }
+        if (roleAccountId != null) {
+            String outBucketOwner = s3Service.getBucketOwnerAccountId(outLoc.bucket());
+            if (outBucketOwner != null && !roleAccountId.equals(outBucketOwner)) {
+                if (isJobStopped(job)) return;
+                failJob(job, "Access denied: roleArn account " + roleAccountId
+                        + " does not own output bucket " + outLoc.bucket()
+                        + " (owned by " + outBucketOwner + ")", region, accountId);
+                return;
+            }
         }
 
         try {
@@ -615,6 +638,20 @@ public class BedrockService implements Resettable {
             LOG.warnv("Failed to emit Bedrock EventBridge state change event for job {0}: {1}",
                     job.getJobArn(), e.getMessage());
         }
+    }
+
+    /**
+     * Extracts the account ID segment from an IAM role ARN.
+     * ARN format: {@code arn:aws:iam::<accountId>:role/<name>}
+     * Returns {@code null} when the ARN is missing or malformed.
+     */
+    static String extractAccountIdFromRoleArn(String roleArn) {
+        if (roleArn == null || roleArn.isBlank()) {
+            return null;
+        }
+        String[] parts = roleArn.split(":", -1);
+        // parts[4] is the accountId in a standard AWS ARN
+        return (parts.length > 4 && !parts[4].isBlank()) ? parts[4] : null;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
@@ -164,10 +164,20 @@ public class BedrockService implements Resettable {
             throw new AwsException("ValidationException", "jobIdentifier is required.", 400);
         }
 
+        String effectiveRegion = region != null && !region.isBlank()
+                ? region : regionResolver.getDefaultRegion();
+
         Optional<ModelInvocationJob> job = jobStore.scan(k -> true).stream()
-                .filter(j -> jobIdentifier.equals(j.getJobArn())
-                        || jobIdentifier.equals(j.getJobId())
-                        || jobIdentifier.equals(j.getJobName()))
+                .filter(j -> {
+                    // Scope lookup to the requested region using the region encoded in the job ARN.
+                    String jobRegion = extractRegionFromArn(j.getJobArn());
+                    if (jobRegion != null && !jobRegion.equals(effectiveRegion)) {
+                        return false;
+                    }
+                    return jobIdentifier.equals(j.getJobArn())
+                            || jobIdentifier.equals(j.getJobId())
+                            || jobIdentifier.equals(j.getJobName());
+                })
                 .findFirst();
 
         return job.orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -210,8 +220,16 @@ public class BedrockService implements Resettable {
             String nextToken,
             String region) {
 
+        String effectiveRegion = region != null && !region.isBlank()
+                ? region : regionResolver.getDefaultRegion();
+
         List<ModelInvocationJob> matched = jobStore.scan(k -> true).stream()
                 .filter(job -> {
+                    // Scope list results to the requested region.
+                    String jobRegion = extractRegionFromArn(job.getJobArn());
+                    if (jobRegion != null && !jobRegion.equals(effectiveRegion)) {
+                        return false;
+                    }
                     if (statusEquals != null && job.getStatus() != statusEquals) {
                         return false;
                     }
@@ -293,6 +311,18 @@ public class BedrockService implements Resettable {
 
         if (s3Service == null) {
             failJob(job, "S3 service is not available", region, accountId);
+            return;
+        }
+
+        // Verify the caller-supplied input bucket is reachable within this emulator instance.
+        // Full IAM role assumption and cross-account S3 policy enforcement are not implemented;
+        // this check prevents accidentally reading buckets that have never been registered.
+        try {
+            s3Service.headBucket(inputLoc.bucket());
+        } catch (Exception e) {
+            if (isJobStopped(job)) return;
+            failJob(job, "Input S3 bucket does not exist or is not accessible: " + inputLoc.bucket(),
+                    region, accountId);
             return;
         }
 
@@ -399,6 +429,16 @@ public class BedrockService implements Resettable {
 
         String outputJsonlUri = "s3://" + outLoc.bucket() + "/" + outputJsonlKey;
 
+        // Verify the caller-supplied output bucket is reachable before writing.
+        try {
+            s3Service.headBucket(outLoc.bucket());
+        } catch (Exception e) {
+            if (isJobStopped(job)) return;
+            failJob(job, "Output S3 bucket does not exist or is not accessible: " + outLoc.bucket(),
+                    region, accountId);
+            return;
+        }
+
         try {
             String outputContent = String.join("\n", outputLines)
                     + (outputLines.isEmpty() ? "" : "\n");
@@ -433,6 +473,13 @@ public class BedrockService implements Resettable {
         job.setErrorRecordCount(errorCount);
         job.setInputTokenCount(totalInputTokens > 0 ? totalInputTokens : null);
         job.setOutputTokenCount(totalOutputTokens > 0 ? totalOutputTokens : null);
+
+        // Check whether a stop request arrived while records were being processed or output was
+        // being written.  If so, honour the stopped state instead of overwriting it with a
+        // completion/failure status derived from partial work.
+        if (isJobStopped(job)) {
+            return;
+        }
 
         if (totalCount == 0) {
             job.setStatus(ModelInvocationJobStatus.COMPLETED);
@@ -568,6 +615,20 @@ public class BedrockService implements Resettable {
             LOG.warnv("Failed to emit Bedrock EventBridge state change event for job {0}: {1}",
                     job.getJobArn(), e.getMessage());
         }
+    }
+
+    /**
+     * Extracts the region segment from a Bedrock job ARN.
+     * ARN format: {@code arn:aws:bedrock:<region>:<accountId>:model-invocation-job/<jobId>}
+     * Returns {@code null} when the ARN is missing or malformed.
+     */
+    static String extractRegionFromArn(String arn) {
+        if (arn == null || arn.isBlank()) {
+            return null;
+        }
+        String[] parts = arn.split(":", -1);
+        // parts[3] is the region in a standard AWS ARN
+        return (parts.length > 3 && !parts[3].isBlank()) ? parts[3] : null;
     }
 
     record S3Location(String bucket, String key) {}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockService.java
@@ -41,6 +41,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
@@ -52,6 +54,7 @@ public class BedrockService implements Resettable {
     private static final SecureRandom RANDOM = new SecureRandom();
 
     private final StorageBackend<String, ModelInvocationJob> jobStore;
+    private final ConcurrentHashMap<String, Object> jobLocks = new ConcurrentHashMap<>();
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
     private final ObjectMapper objectMapper;
@@ -80,6 +83,11 @@ public class BedrockService implements Resettable {
     @Override
     public void clear() {
         jobStore.clear();
+        jobLocks.clear();
+    }
+
+    private Object getJobLock(String jobArn) {
+        return jobLocks.computeIfAbsent(jobArn, k -> new Object());
     }
 
     public CreateModelInvocationJobResponse createModelInvocationJob(
@@ -114,6 +122,15 @@ public class BedrockService implements Resettable {
         String effectiveRegion = region != null && !region.isBlank()
                 ? region : regionResolver.getDefaultRegion();
         String accountId = regionResolver.getAccountId();
+
+        // Validate that roleArn belongs to the calling account. A caller cannot submit an IAM
+        // role from another account to bypass cross-account restrictions.
+        String roleAccountId = extractAccountIdFromRoleArn(request.roleArn());
+        if (roleAccountId != null && accountId != null && !roleAccountId.equals(accountId)) {
+            throw new AwsException("ValidationException",
+                    "The roleArn " + request.roleArn() + " does not belong to the calling account (" + accountId + ").", 400);
+        }
+
         String jobId = generateJobId();
         String jobArn = "arn:aws:bedrock:" + effectiveRegion + ":" + accountId + ":model-invocation-job/" + jobId;
 
@@ -152,7 +169,7 @@ public class BedrockService implements Resettable {
                 executeBatchJob(job, effectiveRegion, accountId);
             } catch (Exception e) {
                 LOG.errorv(e, "Unexpected error running batch job {0}", jobArn);
-                failJob(job, "Unexpected batch error: " + e.getMessage(), effectiveRegion, accountId);
+                failJob(jobArn, "Unexpected batch error: " + e.getMessage(), effectiveRegion, accountId);
             }
         });
 
@@ -186,27 +203,28 @@ public class BedrockService implements Resettable {
 
     public void stopModelInvocationJob(String jobIdentifier, String region) {
         ModelInvocationJob job = getModelInvocationJob(jobIdentifier, region);
-        if (job.getStatus() == ModelInvocationJobStatus.COMPLETED
-                || job.getStatus() == ModelInvocationJobStatus.FAILED
-                || job.getStatus() == ModelInvocationJobStatus.STOPPED
-                || job.getStatus() == ModelInvocationJobStatus.EXPIRED
-                || job.getStatus() == ModelInvocationJobStatus.PARTIALLY_COMPLETED) {
-            throw new AwsException("ValidationException",
-                    "Job " + job.getJobArn() + " is already in terminal status: " + job.getStatus(), 400);
-        }
-
+        String jobArn = job.getJobArn();
         String effectiveRegion = region != null && !region.isBlank()
                 ? region : regionResolver.getDefaultRegion();
         String accountId = regionResolver.getAccountId();
 
-        Instant now = Instant.now();
-        job.setStatus(ModelInvocationJobStatus.STOPPED);
-        job.setEndTime(now);
-        job.setLastModifiedTime(now);
-        jobStore.put(job.getJobArn(), job);
+        Object lock = getJobLock(jobArn);
+        synchronized (lock) {
+            ModelInvocationJob current = jobStore.get(jobArn).orElse(job);
+            if (isTerminal(current.getStatus())) {
+                throw new AwsException("ValidationException",
+                        "Job " + current.getJobArn() + " is already in terminal status: " + current.getStatus(), 400);
+            }
 
-        LOG.infov("Stopped model invocation job: {0}", job.getJobArn());
-        emitStateChangeEvent(job, effectiveRegion, accountId);
+            Instant now = Instant.now();
+            current.setStatus(ModelInvocationJobStatus.STOPPED);
+            current.setEndTime(now);
+            current.setLastModifiedTime(now);
+            jobStore.put(jobArn, current);
+
+            LOG.infov("Stopped model invocation job: {0}", jobArn);
+            emitStateChangeEvent(current, effectiveRegion, accountId);
+        }
     }
 
     public PaginatedResult<ModelInvocationJobSummary> listModelInvocationJobs(
@@ -275,82 +293,120 @@ public class BedrockService implements Resettable {
         );
     }
 
-    private boolean isJobStopped(ModelInvocationJob job) {
-        return jobStore.get(job.getJobArn())
-                .map(j -> j.getStatus() == ModelInvocationJobStatus.STOPPED)
-                .orElse(false);
+    private static boolean isTerminal(ModelInvocationJobStatus status) {
+        return status == ModelInvocationJobStatus.COMPLETED
+                || status == ModelInvocationJobStatus.FAILED
+                || status == ModelInvocationJobStatus.STOPPED
+                || status == ModelInvocationJobStatus.EXPIRED
+                || status == ModelInvocationJobStatus.PARTIALLY_COMPLETED;
     }
 
-    private void executeBatchJob(ModelInvocationJob job, String region, String accountId) {
-        // Validating
-        job.setStatus(ModelInvocationJobStatus.VALIDATING);
-        job.setLastModifiedTime(Instant.now());
-        jobStore.put(job.getJobArn(), job);
-        emitStateChangeEvent(job, region, accountId);
+    private boolean isJobStoppedOrTerminal(String jobArn) {
+        Object lock = getJobLock(jobArn);
+        synchronized (lock) {
+            return jobStore.get(jobArn)
+                    .map(j -> isTerminal(j.getStatus()))
+                    .orElse(false);
+        }
+    }
 
-        if (isJobStopped(job)) return;
+    private boolean transitionJobStatus(String jobArn, ModelInvocationJobStatus newStatus,
+                                        Consumer<ModelInvocationJob> mutator,
+                                        String region, String accountId) {
+        Object lock = getJobLock(jobArn);
+        synchronized (lock) {
+            Optional<ModelInvocationJob> opt = jobStore.get(jobArn);
+            if (opt.isEmpty()) {
+                return false;
+            }
+            ModelInvocationJob current = opt.get();
+            if (isTerminal(current.getStatus())) {
+                return false;
+            }
+            current.setStatus(newStatus);
+            current.setLastModifiedTime(Instant.now());
+            if (mutator != null) {
+                mutator.accept(current);
+            }
+            jobStore.put(jobArn, current);
+            emitStateChangeEvent(current, region, accountId);
+            return true;
+        }
+    }
+
+    private void failJob(String jobArn, String message, String region, String accountId) {
+        boolean transitioned = transitionJobStatus(jobArn, ModelInvocationJobStatus.FAILED, current -> {
+            Instant now = Instant.now();
+            current.setMessage(message);
+            current.setEndTime(now);
+        }, region, accountId);
+        if (transitioned) {
+            LOG.warnv("Model invocation job {0} failed: {1}", jobArn, message);
+        }
+    }
+
+    private void executeBatchJob(ModelInvocationJob initialJob, String region, String accountId) {
+        String jobArn = initialJob.getJobArn();
+
+        // Validating
+        if (!transitionJobStatus(jobArn, ModelInvocationJobStatus.VALIDATING, null, region, accountId)) {
+            return;
+        }
 
         // Scheduled
-        job.setStatus(ModelInvocationJobStatus.SCHEDULED);
-        job.setLastModifiedTime(Instant.now());
-        jobStore.put(job.getJobArn(), job);
-        emitStateChangeEvent(job, region, accountId);
-
-        if (isJobStopped(job)) return;
+        if (!transitionJobStatus(jobArn, ModelInvocationJobStatus.SCHEDULED, null, region, accountId)) {
+            return;
+        }
 
         // Transition to InProgress
-        job.setStatus(ModelInvocationJobStatus.IN_PROGRESS);
-        job.setLastModifiedTime(Instant.now());
-        jobStore.put(job.getJobArn(), job);
-        emitStateChangeEvent(job, region, accountId);
+        if (!transitionJobStatus(jobArn, ModelInvocationJobStatus.IN_PROGRESS, null, region, accountId)) {
+            return;
+        }
 
-        if (isJobStopped(job)) return;
-
-        String inputS3Uri = job.getInputDataConfig().s3InputDataConfig().s3Uri();
+        String inputS3Uri = initialJob.getInputDataConfig().s3InputDataConfig().s3Uri();
         S3Location inputLoc = parseS3Uri(inputS3Uri);
 
         if (s3Service == null) {
-            failJob(job, "S3 service is not available", region, accountId);
+            failJob(jobArn, "S3 service is not available", region, accountId);
             return;
         }
 
-        // Verify the caller-supplied input bucket exists and belongs to the same account as the
-        // submitted roleArn.  Full IAM role assumption and S3 policy evaluation are not
-        // implemented; this ownership check is the practical cross-account guard available in
-        // the emulator.
+        // Verify the caller-supplied input bucket exists and belongs to the calling account.
+        // Even when globalBucketNamespace is enabled, a caller in account A cannot read or copy
+        // another account B's bucket by providing account B's role or bucket name.
         try {
             s3Service.headBucket(inputLoc.bucket());
         } catch (Exception e) {
-            if (isJobStopped(job)) return;
-            failJob(job, "Input S3 bucket does not exist or is not accessible: " + inputLoc.bucket(),
+            if (isJobStoppedOrTerminal(jobArn)) return;
+            failJob(jobArn, "Input S3 bucket does not exist or is not accessible: " + inputLoc.bucket(),
                     region, accountId);
             return;
         }
-        String roleAccountId = extractAccountIdFromRoleArn(job.getRoleArn());
-        if (roleAccountId != null) {
-            String bucketOwner = s3Service.getBucketOwnerAccountId(inputLoc.bucket());
-            if (bucketOwner != null && !roleAccountId.equals(bucketOwner)) {
-                if (isJobStopped(job)) return;
-                failJob(job, "Access denied: roleArn account " + roleAccountId
-                        + " does not own input bucket " + inputLoc.bucket()
-                        + " (owned by " + bucketOwner + ")", region, accountId);
-                return;
-            }
+
+        String inputBucketOwner = s3Service.getBucketOwnerAccountId(inputLoc.bucket());
+        if (inputBucketOwner != null && accountId != null && !inputBucketOwner.equals(accountId)) {
+            if (isJobStoppedOrTerminal(jobArn)) return;
+            failJob(jobArn, "Access denied: calling account " + accountId
+                    + " does not own input bucket " + inputLoc.bucket()
+                    + " (owned by " + inputBucketOwner + ")", region, accountId);
+            return;
         }
+
+        if (isJobStoppedOrTerminal(jobArn)) return;
 
         byte[] inputBytes;
         try {
             S3Object s3Obj = s3Service.getObject(inputLoc.bucket(), inputLoc.key());
             if (s3Obj == null || s3Obj.getData() == null) {
-                if (isJobStopped(job)) return;
-                failJob(job, "Input S3 file is empty or not found: " + inputS3Uri, region, accountId);
+                if (isJobStoppedOrTerminal(jobArn)) return;
+                failJob(jobArn, "Input S3 file is empty or not found: " + inputS3Uri, region, accountId);
                 return;
             }
             inputBytes = s3Obj.getData();
         } catch (Exception e) {
-            if (isJobStopped(job)) return;
+            if (isJobStoppedOrTerminal(jobArn)) return;
             LOG.warnv(e, "Failed to read S3 input file: {0}", inputS3Uri);
-            failJob(job, "Failed to read input S3 file: " + e.getMessage(), region, accountId);
+            failJob(jobArn, "Failed to read input S3 file: " + e.getMessage(), region, accountId);
             return;
         }
 
@@ -365,6 +421,10 @@ public class BedrockService implements Resettable {
         long totalOutputTokens = 0;
 
         for (String line : lines) {
+            if (isJobStoppedOrTerminal(jobArn)) {
+                LOG.infov("Job {0} stopped during record processing; aborting execution.", jobArn);
+                return;
+            }
             if (line == null || line.trim().isEmpty()) {
                 continue;
             }
@@ -394,7 +454,7 @@ public class BedrockService implements Resettable {
                     continue;
                 }
 
-                JsonNode modelOutputNode = processModelInput(job.getModelId(), (ObjectNode) parsedModelInput);
+                JsonNode modelOutputNode = processModelInput(initialJob.getModelId(), (ObjectNode) parsedModelInput);
                 totalInputTokens += extractInputTokens(modelOutputNode);
                 totalOutputTokens += extractOutputTokens(modelOutputNode);
 
@@ -422,8 +482,12 @@ public class BedrockService implements Resettable {
             }
         }
 
+        if (isJobStoppedOrTerminal(jobArn)) {
+            return;
+        }
+
         // Write output files to S3
-        String outputS3Uri = job.getOutputDataConfig().s3OutputDataConfig().s3Uri();
+        String outputS3Uri = initialJob.getOutputDataConfig().s3OutputDataConfig().s3Uri();
         S3Location outLoc = parseS3Uri(outputS3Uri);
 
         String inputKey = inputLoc.key();
@@ -434,32 +498,32 @@ public class BedrockService implements Resettable {
         }
 
         String outPrefix = outLoc.key().isEmpty()
-                ? job.getJobId()
-                : (outLoc.key().replaceAll("/+$", "") + "/" + job.getJobId());
+                ? initialJob.getJobId()
+                : (outLoc.key().replaceAll("/+$", "") + "/" + initialJob.getJobId());
         String outputJsonlKey = outPrefix + "/" + inputFilename + ".out";
         String manifestKey = outPrefix + "/manifest.json.out";
 
-        String outputJsonlUri = "s3://" + outLoc.bucket() + "/" + outputJsonlKey;
-
-        // Verify the caller-supplied output bucket exists and belongs to the same account as the
-        // submitted roleArn, for the same reason as the input check above.
+        // Verify the caller-supplied output bucket exists and belongs to the calling account.
         try {
             s3Service.headBucket(outLoc.bucket());
         } catch (Exception e) {
-            if (isJobStopped(job)) return;
-            failJob(job, "Output S3 bucket does not exist or is not accessible: " + outLoc.bucket(),
+            if (isJobStoppedOrTerminal(jobArn)) return;
+            failJob(jobArn, "Output S3 bucket does not exist or is not accessible: " + outLoc.bucket(),
                     region, accountId);
             return;
         }
-        if (roleAccountId != null) {
-            String outBucketOwner = s3Service.getBucketOwnerAccountId(outLoc.bucket());
-            if (outBucketOwner != null && !roleAccountId.equals(outBucketOwner)) {
-                if (isJobStopped(job)) return;
-                failJob(job, "Access denied: roleArn account " + roleAccountId
-                        + " does not own output bucket " + outLoc.bucket()
-                        + " (owned by " + outBucketOwner + ")", region, accountId);
-                return;
-            }
+
+        String outBucketOwner = s3Service.getBucketOwnerAccountId(outLoc.bucket());
+        if (outBucketOwner != null && accountId != null && !outBucketOwner.equals(accountId)) {
+            if (isJobStoppedOrTerminal(jobArn)) return;
+            failJob(jobArn, "Access denied: calling account " + accountId
+                    + " does not own output bucket " + outLoc.bucket()
+                    + " (owned by " + outBucketOwner + ")", region, accountId);
+            return;
+        }
+
+        if (isJobStoppedOrTerminal(jobArn)) {
+            return;
         }
 
         try {
@@ -482,45 +546,51 @@ public class BedrockService implements Resettable {
             s3Service.putObject(outLoc.bucket(), manifestKey, manifestBytes,
                     "application/json", Map.of());
         } catch (Exception e) {
+            if (isJobStoppedOrTerminal(jobArn)) return;
             LOG.warnv(e, "Failed to write batch output files to S3 bucket {0}", outLoc.bucket());
-            failJob(job, "Failed to write batch output to S3: " + e.getMessage(), region, accountId);
+            failJob(jobArn, "Failed to write batch output to S3: " + e.getMessage(), region, accountId);
             return;
         }
 
-        Instant completionTime = Instant.now();
-        job.setEndTime(completionTime);
-        job.setLastModifiedTime(completionTime);
-        job.setTotalRecordCount(totalCount);
-        job.setProcessedRecordCount(processedCount);
-        job.setSuccessRecordCount(successCount);
-        job.setErrorRecordCount(errorCount);
-        job.setInputTokenCount(totalInputTokens > 0 ? totalInputTokens : null);
-        job.setOutputTokenCount(totalOutputTokens > 0 ? totalOutputTokens : null);
-
-        // Check whether a stop request arrived while records were being processed or output was
-        // being written.  If so, honour the stopped state instead of overwriting it with a
-        // completion/failure status derived from partial work.
-        if (isJobStopped(job)) {
-            return;
-        }
-
-        if (totalCount == 0) {
-            job.setStatus(ModelInvocationJobStatus.COMPLETED);
-        } else if (errorCount == 0) {
-            job.setStatus(ModelInvocationJobStatus.COMPLETED);
+        // Compute final status and message
+        ModelInvocationJobStatus finalStatus;
+        String finalMessage = null;
+        if (totalCount == 0 || errorCount == 0) {
+            finalStatus = ModelInvocationJobStatus.COMPLETED;
         } else if (successCount > 0) {
-            job.setStatus(ModelInvocationJobStatus.PARTIALLY_COMPLETED);
-            job.setMessage(String.format("Batch job partially completed with %d successes and %d errors.",
-                    successCount, errorCount));
+            finalStatus = ModelInvocationJobStatus.PARTIALLY_COMPLETED;
+            finalMessage = String.format("Batch job partially completed with %d successes and %d errors.",
+                    successCount, errorCount);
         } else {
-            job.setStatus(ModelInvocationJobStatus.FAILED);
-            job.setMessage(String.format("Batch job failed: all %d records failed.", totalCount));
+            finalStatus = ModelInvocationJobStatus.FAILED;
+            finalMessage = String.format("Batch job failed: all %d records failed.", totalCount);
         }
 
-        jobStore.put(job.getJobArn(), job);
-        LOG.infov("Completed model invocation job {0} with status {1}",
-                job.getJobArn(), job.getStatus());
-        emitStateChangeEvent(job, region, accountId);
+        final String msg = finalMessage;
+        final long total = totalCount;
+        final long processed = processedCount;
+        final long success = successCount;
+        final long error = errorCount;
+        final long inTokens = totalInputTokens;
+        final long outTokens = totalOutputTokens;
+
+        boolean transitioned = transitionJobStatus(jobArn, finalStatus, current -> {
+            Instant completionTime = Instant.now();
+            current.setEndTime(completionTime);
+            current.setTotalRecordCount(total);
+            current.setProcessedRecordCount(processed);
+            current.setSuccessRecordCount(success);
+            current.setErrorRecordCount(error);
+            current.setInputTokenCount(inTokens > 0 ? inTokens : null);
+            current.setOutputTokenCount(outTokens > 0 ? outTokens : null);
+            if (msg != null) {
+                current.setMessage(msg);
+            }
+        }, region, accountId);
+
+        if (transitioned) {
+            LOG.infov("Completed model invocation job {0} with status {1}", jobArn, finalStatus);
+        }
     }
 
     private static long extractInputTokens(JsonNode output) {
@@ -587,16 +657,7 @@ public class BedrockService implements Resettable {
         return objectMapper.readTree(responseBytes);
     }
 
-    private void failJob(ModelInvocationJob job, String message, String region, String accountId) {
-        Instant now = Instant.now();
-        job.setStatus(ModelInvocationJobStatus.FAILED);
-        job.setMessage(message);
-        job.setEndTime(now);
-        job.setLastModifiedTime(now);
-        jobStore.put(job.getJobArn(), job);
-        LOG.warnv("Model invocation job {0} failed: {1}", job.getJobArn(), message);
-        emitStateChangeEvent(job, region, accountId);
-    }
+
 
     private static final DateTimeFormatter CREATION_TIME_FMT =
             DateTimeFormatter.ofPattern("MMM d, yyyy, h:mm:ss a", Locale.ENGLISH).withZone(ZoneOffset.UTC);

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/BatchManifest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/BatchManifest.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record BatchManifest(
+        @JsonProperty("totalRecordCount") long totalRecordCount,
+        @JsonProperty("processedRecordCount") long processedRecordCount,
+        @JsonProperty("successRecordCount") long successRecordCount,
+        @JsonProperty("errorRecordCount") long errorRecordCount,
+        @JsonProperty("inputTokenCount") Long inputTokenCount,
+        @JsonProperty("outputTokenCount") Long outputTokenCount
+) {
+    public BatchManifest(long totalRecordCount,
+                         long processedRecordCount,
+                         long successRecordCount,
+                         long errorRecordCount) {
+        this(totalRecordCount, processedRecordCount, successRecordCount, errorRecordCount, null, null);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/CreateModelInvocationJobRequest.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/CreateModelInvocationJobRequest.java
@@ -1,0 +1,21 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CreateModelInvocationJobRequest(
+        @JsonProperty("jobName") String jobName,
+        @JsonProperty("modelId") String modelId,
+        @JsonProperty("roleArn") String roleArn,
+        @JsonProperty("clientRequestToken") String clientRequestToken,
+        @JsonProperty("inputDataConfig") InputDataConfig inputDataConfig,
+        @JsonProperty("outputDataConfig") OutputDataConfig outputDataConfig,
+        @JsonProperty("vpcConfig") VpcConfig vpcConfig,
+        @JsonProperty("timeoutDurationInHours") Integer timeoutDurationInHours,
+        @JsonProperty("tags") List<Tag> tags
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/CreateModelInvocationJobResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/CreateModelInvocationJobResponse.java
@@ -1,0 +1,11 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CreateModelInvocationJobResponse(
+        @JsonProperty("jobArn") String jobArn
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/InputDataConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/InputDataConfig.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record InputDataConfig(
+        @JsonProperty("s3InputDataConfig") S3InputDataConfig s3InputDataConfig
+) {
+    @RegisterForReflection
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record S3InputDataConfig(
+            @JsonProperty("s3Uri") String s3Uri,
+            @JsonProperty("s3InputFormat") String s3InputFormat,
+            @JsonProperty("s3BucketOwner") String s3BucketOwner
+    ) {
+        public S3InputDataConfig(String s3Uri) {
+            this(s3Uri, "JSONL", null);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ListModelInvocationJobsResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ListModelInvocationJobsResponse.java
@@ -1,0 +1,14 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ListModelInvocationJobsResponse(
+        @JsonProperty("invocationJobSummaries") List<ModelInvocationJobSummary> invocationJobSummaries,
+        @JsonProperty("nextToken") String nextToken
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ModelInvocationJob.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ModelInvocationJob.java
@@ -1,0 +1,296 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ModelInvocationJob {
+
+    @JsonProperty("jobArn")
+    private String jobArn;
+
+    @JsonProperty("jobName")
+    private String jobName;
+
+    @JsonProperty("modelId")
+    private String modelId;
+
+    @JsonProperty("clientRequestToken")
+    private String clientRequestToken;
+
+    @JsonProperty("roleArn")
+    private String roleArn;
+
+    @JsonProperty("status")
+    private ModelInvocationJobStatus status;
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("submitTime")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Instant submitTime;
+
+    @JsonProperty("lastModifiedTime")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Instant lastModifiedTime;
+
+    @JsonProperty("endTime")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Instant endTime;
+
+    @JsonProperty("jobExpirationTime")
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    private Instant jobExpirationTime;
+
+    @JsonProperty("timeoutDurationInHours")
+    private Integer timeoutDurationInHours;
+
+    @JsonProperty("inputDataConfig")
+    private InputDataConfig inputDataConfig;
+
+    @JsonProperty("outputDataConfig")
+    private OutputDataConfig outputDataConfig;
+
+    @JsonProperty("vpcConfig")
+    private VpcConfig vpcConfig;
+
+    @JsonProperty("tags")
+    private List<Tag> tags;
+
+    @JsonProperty("totalRecordCount")
+    private Long totalRecordCount;
+
+    @JsonProperty("processedRecordCount")
+    private Long processedRecordCount;
+
+    @JsonProperty("successRecordCount")
+    private Long successRecordCount;
+
+    @JsonProperty("errorRecordCount")
+    private Long errorRecordCount;
+
+    @JsonProperty("inputTokenCount")
+    private Long inputTokenCount;
+
+    @JsonProperty("outputTokenCount")
+    private Long outputTokenCount;
+
+    public ModelInvocationJob() {}
+
+    public ModelInvocationJob(String jobArn, String jobName, String modelId, String clientRequestToken,
+                              String roleArn, ModelInvocationJobStatus status, String message,
+                              Instant submitTime, Instant lastModifiedTime, Instant endTime,
+                              Instant jobExpirationTime, Integer timeoutDurationInHours,
+                              InputDataConfig inputDataConfig, OutputDataConfig outputDataConfig,
+                              VpcConfig vpcConfig, List<Tag> tags) {
+        this.jobArn = jobArn;
+        this.jobName = jobName;
+        this.modelId = modelId;
+        this.clientRequestToken = clientRequestToken;
+        this.roleArn = roleArn;
+        this.status = status;
+        this.message = message;
+        this.submitTime = submitTime;
+        this.lastModifiedTime = lastModifiedTime;
+        this.endTime = endTime;
+        this.jobExpirationTime = jobExpirationTime;
+        this.timeoutDurationInHours = timeoutDurationInHours;
+        this.inputDataConfig = inputDataConfig;
+        this.outputDataConfig = outputDataConfig;
+        this.vpcConfig = vpcConfig;
+        this.tags = tags;
+    }
+
+    public String getJobArn() {
+        return jobArn;
+    }
+
+    @JsonIgnore
+    public String getJobId() {
+        if (jobArn == null) {
+            return null;
+        }
+        int idx = jobArn.lastIndexOf('/');
+        return idx != -1 ? jobArn.substring(idx + 1) : jobArn;
+    }
+
+    public void setJobArn(String jobArn) {
+        this.jobArn = jobArn;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public void setJobName(String jobName) {
+        this.jobName = jobName;
+    }
+
+    public String getModelId() {
+        return modelId;
+    }
+
+    public void setModelId(String modelId) {
+        this.modelId = modelId;
+    }
+
+    public String getClientRequestToken() {
+        return clientRequestToken;
+    }
+
+    public void setClientRequestToken(String clientRequestToken) {
+        this.clientRequestToken = clientRequestToken;
+    }
+
+    public String getRoleArn() {
+        return roleArn;
+    }
+
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
+
+    public ModelInvocationJobStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(ModelInvocationJobStatus status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Instant getSubmitTime() {
+        return submitTime;
+    }
+
+    public void setSubmitTime(Instant submitTime) {
+        this.submitTime = submitTime;
+    }
+
+    public Instant getLastModifiedTime() {
+        return lastModifiedTime;
+    }
+
+    public void setLastModifiedTime(Instant lastModifiedTime) {
+        this.lastModifiedTime = lastModifiedTime;
+    }
+
+    public Instant getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(Instant endTime) {
+        this.endTime = endTime;
+    }
+
+    public Instant getJobExpirationTime() {
+        return jobExpirationTime;
+    }
+
+    public void setJobExpirationTime(Instant jobExpirationTime) {
+        this.jobExpirationTime = jobExpirationTime;
+    }
+
+    public Integer getTimeoutDurationInHours() {
+        return timeoutDurationInHours;
+    }
+
+    public void setTimeoutDurationInHours(Integer timeoutDurationInHours) {
+        this.timeoutDurationInHours = timeoutDurationInHours;
+    }
+
+    public InputDataConfig getInputDataConfig() {
+        return inputDataConfig;
+    }
+
+    public void setInputDataConfig(InputDataConfig inputDataConfig) {
+        this.inputDataConfig = inputDataConfig;
+    }
+
+    public OutputDataConfig getOutputDataConfig() {
+        return outputDataConfig;
+    }
+
+    public void setOutputDataConfig(OutputDataConfig outputDataConfig) {
+        this.outputDataConfig = outputDataConfig;
+    }
+
+    public VpcConfig getVpcConfig() {
+        return vpcConfig;
+    }
+
+    public void setVpcConfig(VpcConfig vpcConfig) {
+        this.vpcConfig = vpcConfig;
+    }
+
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public Long getTotalRecordCount() {
+        return totalRecordCount;
+    }
+
+    public void setTotalRecordCount(Long totalRecordCount) {
+        this.totalRecordCount = totalRecordCount;
+    }
+
+    public Long getProcessedRecordCount() {
+        return processedRecordCount;
+    }
+
+    public void setProcessedRecordCount(Long processedRecordCount) {
+        this.processedRecordCount = processedRecordCount;
+    }
+
+    public Long getSuccessRecordCount() {
+        return successRecordCount;
+    }
+
+    public void setSuccessRecordCount(Long successRecordCount) {
+        this.successRecordCount = successRecordCount;
+    }
+
+    public Long getErrorRecordCount() {
+        return errorRecordCount;
+    }
+
+    public void setErrorRecordCount(Long errorRecordCount) {
+        this.errorRecordCount = errorRecordCount;
+    }
+
+    public Long getInputTokenCount() {
+        return inputTokenCount;
+    }
+
+    public void setInputTokenCount(Long inputTokenCount) {
+        this.inputTokenCount = inputTokenCount;
+    }
+
+    public Long getOutputTokenCount() {
+        return outputTokenCount;
+    }
+
+    public void setOutputTokenCount(Long outputTokenCount) {
+        this.outputTokenCount = outputTokenCount;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ModelInvocationJobStatus.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ModelInvocationJobStatus.java
@@ -1,0 +1,43 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public enum ModelInvocationJobStatus {
+    SUBMITTED("Submitted"),
+    VALIDATING("Validating"),
+    SCHEDULED("Scheduled"),
+    IN_PROGRESS("InProgress"),
+    COMPLETED("Completed"),
+    PARTIALLY_COMPLETED("PartiallyCompleted"),
+    FAILED("Failed"),
+    STOPPING("Stopping"),
+    STOPPED("Stopped"),
+    EXPIRED("Expired");
+
+    private final String value;
+
+    ModelInvocationJobStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    public static ModelInvocationJobStatus fromValue(String text) {
+        for (ModelInvocationJobStatus b : ModelInvocationJobStatus.values()) {
+            if (b.value.equalsIgnoreCase(text) || b.name().equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ModelInvocationJobSummary.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/ModelInvocationJobSummary.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ModelInvocationJobSummary(
+        @JsonProperty("clientRequestToken") String clientRequestToken,
+        @JsonProperty("endTime") @JsonFormat(shape = JsonFormat.Shape.STRING) Instant endTime,
+        @JsonProperty("inputDataConfig") InputDataConfig inputDataConfig,
+        @JsonProperty("jobArn") String jobArn,
+        @JsonProperty("jobExpirationTime") @JsonFormat(shape = JsonFormat.Shape.STRING) Instant jobExpirationTime,
+        @JsonProperty("jobName") String jobName,
+        @JsonProperty("lastModifiedTime") @JsonFormat(shape = JsonFormat.Shape.STRING) Instant lastModifiedTime,
+        @JsonProperty("message") String message,
+        @JsonProperty("modelId") String modelId,
+        @JsonProperty("outputDataConfig") OutputDataConfig outputDataConfig,
+        @JsonProperty("roleArn") String roleArn,
+        @JsonProperty("status") ModelInvocationJobStatus status,
+        @JsonProperty("submitTime") @JsonFormat(shape = JsonFormat.Shape.STRING) Instant submitTime,
+        @JsonProperty("timeoutDurationInHours") Integer timeoutDurationInHours,
+        @JsonProperty("vpcConfig") VpcConfig vpcConfig
+) {
+    public static ModelInvocationJobSummary from(ModelInvocationJob job) {
+        if (job == null) {
+            return null;
+        }
+        return new ModelInvocationJobSummary(
+                job.getClientRequestToken(),
+                job.getEndTime(),
+                job.getInputDataConfig(),
+                job.getJobArn(),
+                job.getJobExpirationTime(),
+                job.getJobName(),
+                job.getLastModifiedTime(),
+                job.getMessage(),
+                job.getModelId(),
+                job.getOutputDataConfig(),
+                job.getRoleArn(),
+                job.getStatus(),
+                job.getSubmitTime(),
+                job.getTimeoutDurationInHours(),
+                job.getVpcConfig()
+        );
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/OutputDataConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/OutputDataConfig.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record OutputDataConfig(
+        @JsonProperty("s3OutputDataConfig") S3OutputDataConfig s3OutputDataConfig
+) {
+    @RegisterForReflection
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record S3OutputDataConfig(
+            @JsonProperty("s3Uri") String s3Uri,
+            @JsonProperty("s3BucketOwner") String s3BucketOwner,
+            @JsonProperty("s3EncryptionKeyId") String s3EncryptionKeyId
+    ) {
+        public S3OutputDataConfig(String s3Uri) {
+            this(s3Uri, null, null);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/Tag.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/Tag.java
@@ -1,0 +1,12 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record Tag(
+        @JsonProperty("key") String key,
+        @JsonProperty("value") String value
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrock/model/VpcConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrock/model/VpcConfig.java
@@ -1,0 +1,14 @@
+package io.github.hectorvent.floci.services.bedrock.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record VpcConfig(
+        @JsonProperty("securityGroupIds") List<String> securityGroupIds,
+        @JsonProperty("subnetIds") List<String> subnetIds
+) {}

--- a/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/backend/BedrockOpenAiTranslator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/backend/BedrockOpenAiTranslator.java
@@ -6,18 +6,21 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
- * Translates between the Bedrock Runtime Converse wire shape and the OpenAI
+ * Translates between the Bedrock Runtime Converse/Invoke wire shape and the OpenAI
  * Chat Completions wire shape used by Ollama, OpenRouter, LiteLLM, vLLM, etc.
  */
-final class BedrockOpenAiTranslator {
+public final class BedrockOpenAiTranslator {
 
     private static final Logger LOG = Logger.getLogger(BedrockOpenAiTranslator.class);
 
     private BedrockOpenAiTranslator() {
     }
 
-    static ObjectNode toOpenAiRequest(ObjectMapper mapper, ObjectNode bedrockRequest, String resolvedModel) {
+    public static ObjectNode toOpenAiRequest(ObjectMapper mapper, ObjectNode bedrockRequest, String resolvedModel) {
         ObjectNode openAi = mapper.createObjectNode();
         openAi.put("model", resolvedModel);
         openAi.put("stream", false);
@@ -26,13 +29,17 @@ final class BedrockOpenAiTranslator {
         JsonNode system = bedrockRequest.path("system");
         if (system.isArray()) {
             for (JsonNode block : system) {
-                String text = block.path("text").asText(null);
+                String text = block.isTextual() ? block.asText() : block.path("text").asText(null);
                 if (text != null) {
                     ObjectNode msg = openAiMessages.addObject();
                     msg.put("role", "system");
                     msg.put("content", text);
                 }
             }
+        } else if (system.isTextual()) {
+            ObjectNode msg = openAiMessages.addObject();
+            msg.put("role", "system");
+            msg.put("content", system.asText());
         }
 
         JsonNode messages = bedrockRequest.path("messages");
@@ -102,15 +109,24 @@ final class BedrockOpenAiTranslator {
 
     /**
      * A Bedrock message's content[] blocks map to OpenAI in three different ways:
-     * plain text accumulates into the message's content string, toolUse blocks become
-     * entries in that same message's tool_calls[], and toolResult blocks become their
+     * plain text accumulates into the message's content string (or content parts array if images are present),
+     * toolUse blocks become entries in that same message's tool_calls[], and toolResult blocks become their
      * own standalone OpenAI message with role=tool — so one Bedrock message can expand
      * into zero, one, or several OpenAI messages.
      */
     private static void translateMessage(ObjectMapper mapper, ArrayNode openAiMessages, JsonNode message) {
         String role = message.path("role").asText("user");
         JsonNode content = message.path("content");
-        StringBuilder text = new StringBuilder();
+
+        if (content.isTextual()) {
+            ObjectNode msg = openAiMessages.addObject();
+            msg.put("role", role);
+            msg.put("content", content.asText());
+            return;
+        }
+
+        List<JsonNode> imageBlocks = new ArrayList<>();
+        List<String> textBlocks = new ArrayList<>();
         ArrayNode toolCalls = null;
 
         if (content.isArray()) {
@@ -136,30 +152,68 @@ final class BedrockOpenAiTranslator {
                     function.put("arguments", toJsonString(mapper, toolUse.path("input")));
                     continue;
                 }
-                String blockText = block.path("text").asText(null);
+                if (block.has("image")) {
+                    imageBlocks.add(block.path("image"));
+                    continue;
+                }
+                if ("image".equalsIgnoreCase(block.path("type").asText())) {
+                    imageBlocks.add(block);
+                    continue;
+                }
+                String blockText = block.isTextual() ? block.asText() : block.path("text").asText(null);
                 if (blockText != null) {
-                    if (text.length() > 0) {
-                        text.append('\n');
-                    }
-                    text.append(blockText);
+                    textBlocks.add(blockText);
                 }
             }
         }
 
-        if (text.length() > 0 || toolCalls != null) {
+        if (!textBlocks.isEmpty() || !imageBlocks.isEmpty() || toolCalls != null) {
             ObjectNode msg = openAiMessages.addObject();
             msg.put("role", role);
-            if (text.length() > 0) {
-                msg.put("content", text.toString());
+
+            if (!imageBlocks.isEmpty()) {
+                ArrayNode contentArray = msg.putArray("content");
+                for (String text : textBlocks) {
+                    ObjectNode textNode = contentArray.addObject();
+                    textNode.put("type", "text");
+                    textNode.put("text", text);
+                }
+                for (JsonNode imageNode : imageBlocks) {
+                    ObjectNode imagePart = contentArray.addObject();
+                    imagePart.put("type", "image_url");
+                    ObjectNode imageUrl = imagePart.putObject("image_url");
+                    imageUrl.put("url", extractImageUrl(imageNode));
+                }
+            } else if (!textBlocks.isEmpty()) {
+                msg.put("content", String.join("\n", textBlocks));
             } else {
-                // OpenAI's spec treats content as optional when tool_calls is present; some
-                // strict backends reject an empty string here instead of null.
                 msg.putNull("content");
             }
+
             if (toolCalls != null) {
                 msg.set("tool_calls", toolCalls);
             }
         }
+    }
+
+    private static String extractImageUrl(JsonNode imageNode) {
+        if (imageNode.has("source")) {
+            JsonNode source = imageNode.path("source");
+            if (source.has("bytes")) {
+                String format = imageNode.path("format").asText("png");
+                String bytes = source.path("bytes").asText();
+                return "data:image/" + format + ";base64," + bytes;
+            }
+            if (source.has("data")) {
+                String mediaType = source.path("media_type").asText("image/png");
+                String data = source.path("data").asText();
+                return "data:" + mediaType + ";base64," + data;
+            }
+        }
+        if (imageNode.has("image_url")) {
+            return imageNode.path("image_url").path("url").asText();
+        }
+        return "";
     }
 
     private static String extractToolResultText(JsonNode toolResultContent) {
@@ -191,7 +245,7 @@ final class BedrockOpenAiTranslator {
         }
     }
 
-    static ObjectNode toBedrockResponse(ObjectMapper mapper, JsonNode openAiResponse, long latencyMs) {
+    public static ObjectNode toBedrockResponse(ObjectMapper mapper, JsonNode openAiResponse, long latencyMs) {
         JsonNode choice = openAiResponse.path("choices").path(0);
         JsonNode message = choice.path("message");
         String finishReason = choice.path("finish_reason").asText("stop");
@@ -205,9 +259,6 @@ final class BedrockOpenAiTranslator {
         ArrayNode content = outMessage.putArray("content");
 
         if (hasToolCalls) {
-            // Some OpenAI-compatible backends emit assistant text alongside tool_calls (e.g. a
-            // preamble like "Let me check that for you") — preserve it as a leading text block
-            // instead of dropping it.
             String leadingText = extractMessageText(message);
             if (!leadingText.isBlank()) {
                 content.addObject().put("text", leadingText);
@@ -223,10 +274,6 @@ final class BedrockOpenAiTranslator {
             content.addObject().put("text", extractMessageText(message));
         }
 
-        // stopReason is derived from whether we actually emitted toolUse content, not from
-        // finish_reason alone: a backend can report finish_reason=tool_calls without a usable
-        // tool_calls array, which must not produce a Converse response claiming tool_use with
-        // no toolUse blocks in it.
         root.put("stopReason", hasToolCalls ? "tool_use" : mapFinishReason(finishReason));
 
         JsonNode usage = openAiResponse.path("usage");
@@ -240,7 +287,7 @@ final class BedrockOpenAiTranslator {
         return root;
     }
 
-    private static String extractMessageText(JsonNode message) {
+    public static String extractMessageText(JsonNode message) {
         JsonNode content = message.path("content");
         if (content.isTextual()) {
             return content.asText("");
@@ -248,7 +295,7 @@ final class BedrockOpenAiTranslator {
         if (content.isArray()) {
             StringBuilder sb = new StringBuilder();
             for (JsonNode part : content) {
-                String text = part.path("text").asText(null);
+                String text = part.isTextual() ? part.asText() : part.path("text").asText(null);
                 if (text != null) {
                     if (sb.length() > 0) {
                         sb.append('\n');

--- a/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/backend/ProxyBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/services/bedrockruntime/backend/ProxyBackend.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.bedrockruntime.backend;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
@@ -17,11 +18,11 @@ import java.net.http.HttpTimeoutException;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.UUID;
 
 /**
- * Forwards Bedrock Converse requests to any OpenAI-compatible {@code /chat/completions}
- * endpoint (Ollama, OpenRouter, LiteLLM, vLLM, ...). InvokeModel is not yet supported and
- * fails fast rather than returning a fabricated response.
+ * Forwards Bedrock Converse and InvokeModel requests to any OpenAI-compatible {@code /chat/completions}
+ * endpoint (Ollama, OpenRouter, LiteLLM, vLLM, ...).
  */
 @ApplicationScoped
 public class ProxyBackend implements BedrockBackend {
@@ -32,7 +33,7 @@ public class ProxyBackend implements BedrockBackend {
     private final EmulatorConfig config;
 
     // Config is immutable for the process's lifetime, so the mapping string is parsed
-    // once here rather than on every Converse request.
+    // once here rather than on every Converse/Invoke request.
     private final Map<String, String> modelMapping;
 
     private final HttpClient httpClient = HttpClient.newBuilder()
@@ -51,12 +52,241 @@ public class ProxyBackend implements BedrockBackend {
     public ObjectNode converse(String modelId, ObjectNode bedrockRequest) {
         EmulatorConfig.BedrockProxyConfig proxyConfig = config.services().bedrockRuntime().proxy();
         String resolvedModel = resolveModel(modelId, proxyConfig);
+        ObjectNode openAiRequest = BedrockOpenAiTranslator.toOpenAiRequest(objectMapper, bedrockRequest, resolvedModel);
+
+        CallResult result = callOpenAiChatCompletions(modelId, openAiRequest, proxyConfig);
+        return BedrockOpenAiTranslator.toBedrockResponse(objectMapper, result.responseJson, result.latencyMs);
+    }
+
+    @Override
+    public byte[] invokeModel(String modelId, byte[] body) {
+        EmulatorConfig.BedrockProxyConfig proxyConfig = config.services().bedrockRuntime().proxy();
+        String resolvedModel = resolveModel(modelId, proxyConfig);
+
+        JsonNode inputJson;
+        try {
+            inputJson = objectMapper.readTree(body != null && body.length > 0 ? body : new byte[]{'{', '}'});
+        } catch (Exception e) {
+            throw new AwsException("ValidationException", "Malformed JSON body for InvokeModel: " + e.getMessage(), 400);
+        }
+
+        ObjectNode openAiRequest = buildOpenAiRequestFromInvokeModel(inputJson, resolvedModel);
+        CallResult result = callOpenAiChatCompletions(modelId, openAiRequest, proxyConfig);
+
+        ObjectNode bedrockInvokeResponse = formatBedrockInvokeResponse(modelId, inputJson, result.responseJson);
+        try {
+            return objectMapper.writeValueAsBytes(bedrockInvokeResponse);
+        } catch (Exception e) {
+            throw new AwsException("InternalServerException", "Failed to serialize InvokeModel response: " + e.getMessage(), 500);
+        }
+    }
+
+    private ObjectNode buildOpenAiRequestFromInvokeModel(JsonNode inputJson, String resolvedModel) {
+        if (inputJson.has("messages") && inputJson.path("messages").isArray()) {
+            if (inputJson.isObject()) {
+                return BedrockOpenAiTranslator.toOpenAiRequest(objectMapper, (ObjectNode) inputJson, resolvedModel);
+            }
+        }
+
+        ObjectNode openAi = objectMapper.createObjectNode();
+        openAi.put("model", resolvedModel);
+        openAi.put("stream", false);
+        ArrayNode openAiMessages = openAi.putArray("messages");
+
+        if (inputJson.hasNonNull("system")) {
+            JsonNode sys = inputJson.get("system");
+            if (sys.isTextual()) {
+                openAiMessages.addObject().put("role", "system").put("content", sys.asText());
+            } else if (sys.isArray()) {
+                for (JsonNode b : sys) {
+                    String t = b.isTextual() ? b.asText() : b.path("text").asText(null);
+                    if (t != null) {
+                        openAiMessages.addObject().put("role", "system").put("content", t);
+                    }
+                }
+            }
+        }
+
+        if (inputJson.hasNonNull("inputText")) {
+            openAiMessages.addObject().put("role", "user").put("content", inputJson.get("inputText").asText());
+        } else if (inputJson.hasNonNull("prompt")) {
+            String prompt = inputJson.get("prompt").asText();
+            openAiMessages.addObject().put("role", "user").put("content", prompt);
+        } else if (inputJson.hasNonNull("messages") && inputJson.get("messages").isArray()) {
+            for (JsonNode msg : inputJson.get("messages")) {
+                String role = msg.path("role").asText("user");
+                JsonNode content = msg.path("content");
+                if (content.isTextual()) {
+                    openAiMessages.addObject().put("role", role).put("content", content.asText());
+                } else if (content.isArray()) {
+                    ObjectNode openAiMsg = openAiMessages.addObject();
+                    openAiMsg.put("role", role);
+                    ArrayNode contentArray = openAiMsg.putArray("content");
+                    for (JsonNode part : content) {
+                        if (part.hasNonNull("text")) {
+                            contentArray.addObject().put("type", "text").put("text", part.path("text").asText());
+                        } else if (part.has("image") || "image".equalsIgnoreCase(part.path("type").asText())) {
+                            JsonNode imgNode = part.has("image") ? part.path("image") : part;
+                            String imgUrl = extractImageUrl(imgNode);
+                            if (!imgUrl.isBlank()) {
+                                ObjectNode partObj = contentArray.addObject();
+                                partObj.put("type", "image_url");
+                                partObj.putObject("image_url").put("url", imgUrl);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (inputJson.hasNonNull("textGenerationConfig")) {
+            JsonNode cfg = inputJson.get("textGenerationConfig");
+            if (cfg.hasNonNull("maxTokenCount")) {
+                openAi.put("max_tokens", cfg.get("maxTokenCount").asInt());
+            }
+            if (cfg.hasNonNull("temperature")) {
+                openAi.put("temperature", cfg.get("temperature").asDouble());
+            }
+            if (cfg.hasNonNull("topP")) {
+                openAi.put("top_p", cfg.get("topP").asDouble());
+            }
+            if (cfg.hasNonNull("stopSequences") && cfg.get("stopSequences").isArray()) {
+                openAi.set("stop", cfg.get("stopSequences").deepCopy());
+            }
+        }
+
+        if (inputJson.hasNonNull("max_tokens")) {
+            openAi.put("max_tokens", inputJson.get("max_tokens").asInt());
+        } else if (inputJson.hasNonNull("max_tokens_to_sample")) {
+            openAi.put("max_tokens", inputJson.get("max_tokens_to_sample").asInt());
+        } else if (inputJson.hasNonNull("max_gen_len")) {
+            openAi.put("max_tokens", inputJson.get("max_gen_len").asInt());
+        }
+
+        if (inputJson.hasNonNull("temperature")) {
+            openAi.put("temperature", inputJson.get("temperature").asDouble());
+        }
+        if (inputJson.hasNonNull("top_p")) {
+            openAi.put("top_p", inputJson.get("top_p").asDouble());
+        } else if (inputJson.hasNonNull("topP")) {
+            openAi.put("top_p", inputJson.get("topP").asDouble());
+        }
+
+        if (inputJson.hasNonNull("stop_sequences") && inputJson.get("stop_sequences").isArray()) {
+            openAi.set("stop", inputJson.get("stop_sequences").deepCopy());
+        } else if (inputJson.hasNonNull("stop") && inputJson.get("stop").isArray()) {
+            openAi.set("stop", inputJson.get("stop").deepCopy());
+        }
+
+        return openAi;
+    }
+
+    private static String extractImageUrl(JsonNode imageNode) {
+        if (imageNode.has("source")) {
+            JsonNode source = imageNode.path("source");
+            if (source.has("bytes")) {
+                String format = imageNode.path("format").asText("png");
+                String bytes = source.path("bytes").asText();
+                return "data:image/" + format + ";base64," + bytes;
+            }
+            if (source.has("data")) {
+                String mediaType = source.path("media_type").asText("image/png");
+                String data = source.path("data").asText();
+                return "data:" + mediaType + ";base64," + data;
+            }
+        }
+        if (imageNode.has("image_url")) {
+            return imageNode.path("image_url").path("url").asText();
+        }
+        return "";
+    }
+
+    private ObjectNode formatBedrockInvokeResponse(String modelId, JsonNode inputJson, JsonNode openAiResponse) {
+        JsonNode choice = openAiResponse.path("choices").path(0);
+        JsonNode message = choice.path("message");
+        String contentText = BedrockOpenAiTranslator.extractMessageText(message);
+
+        JsonNode usage = openAiResponse.path("usage");
+        int promptTokens = usage.path("prompt_tokens").asInt(10);
+        int completionTokens = usage.path("completion_tokens").asInt(12);
+        int totalTokens = usage.path("total_tokens").asInt(promptTokens + completionTokens);
+
+        String lowerModel = modelId == null ? "" : modelId.toLowerCase();
+        ObjectNode root = objectMapper.createObjectNode();
+
+        if (lowerModel.startsWith("anthropic.") || lowerModel.contains(".anthropic.")
+                || inputJson.hasNonNull("anthropic_version")) {
+            if (inputJson.hasNonNull("max_tokens_to_sample") && !inputJson.hasNonNull("messages")) {
+                root.put("completion", contentText);
+                root.put("stop_reason", "stop_sequence");
+                root.putNull("stop");
+            } else {
+                root.put("id", "msg_" + UUID.randomUUID().toString().replace("-", ""));
+                root.put("type", "message");
+                root.put("role", "assistant");
+                root.put("model", modelId);
+                ArrayNode content = root.putArray("content");
+                ObjectNode textBlock = content.addObject();
+                textBlock.put("type", "text");
+                textBlock.put("text", contentText);
+                root.put("stop_reason", "end_turn");
+                root.putNull("stop_sequence");
+                ObjectNode usageOut = root.putObject("usage");
+                usageOut.put("input_tokens", promptTokens);
+                usageOut.put("output_tokens", completionTokens);
+            }
+            return root;
+        }
+
+        if (lowerModel.startsWith("amazon.titan") || inputJson.hasNonNull("inputText")) {
+            root.put("inputTextTokenCount", promptTokens);
+            ArrayNode results = root.putArray("results");
+            ObjectNode res = results.addObject();
+            res.put("tokenCount", completionTokens);
+            res.put("outputText", contentText);
+            res.put("completionReason", "FINISH");
+            return root;
+        }
+
+        if (lowerModel.startsWith("meta.llama") || inputJson.hasNonNull("max_gen_len")) {
+            root.put("generation", contentText);
+            root.put("prompt_token_count", promptTokens);
+            root.put("generation_token_count", completionTokens);
+            root.put("stop_reason", "stop");
+            return root;
+        }
+
+        if (lowerModel.startsWith("cohere.")) {
+            ArrayNode generations = root.putArray("generations");
+            ObjectNode gen = generations.addObject();
+            gen.put("text", contentText);
+            gen.put("finish_reason", "COMPLETE");
+            return root;
+        }
+
+        // Generic fallback with outputs / outputText / results
+        root.put("outputText", contentText);
+        root.put("generation", contentText);
+        ArrayNode outputs = root.putArray("outputs");
+        outputs.addObject().put("text", contentText);
+        ArrayNode results = root.putArray("results");
+        ObjectNode res = results.addObject();
+        res.put("tokenCount", completionTokens);
+        res.put("outputText", contentText);
+        res.put("completionReason", "FINISH");
+        ObjectNode usageOut = root.putObject("usage");
+        usageOut.put("inputTokens", promptTokens);
+        usageOut.put("outputTokens", completionTokens);
+        usageOut.put("totalTokens", totalTokens);
+
+        return root;
+    }
+
+    private CallResult callOpenAiChatCompletions(String modelId, ObjectNode openAiRequest, EmulatorConfig.BedrockProxyConfig proxyConfig) {
         String baseUrl = proxyConfig.url()
                 .filter(url -> !url.isBlank())
                 .orElseThrow(() -> new AwsException("ValidationException",
                         "floci.services.bedrock-runtime.proxy.url is required when backend=proxy.", 400));
-
-        ObjectNode openAiRequest = BedrockOpenAiTranslator.toOpenAiRequest(objectMapper, bedrockRequest, resolvedModel);
 
         URI uri;
         HttpRequest.Builder builder;
@@ -109,14 +339,10 @@ public class ProxyBackend implements BedrockBackend {
             throw new AwsException("ModelErrorException", "Proxy backend returned malformed JSON: " + e.getMessage(), 424);
         }
 
-        return BedrockOpenAiTranslator.toBedrockResponse(objectMapper, openAiResponse, latencyMs);
+        return new CallResult(openAiResponse, latencyMs);
     }
 
-    @Override
-    public byte[] invokeModel(String modelId, byte[] body) {
-        throw new AwsException("ValidationException",
-                "InvokeModel is not supported by the bedrock-runtime proxy backend; use Converse.", 400);
-    }
+    private record CallResult(JsonNode responseJson, long latencyMs) {}
 
     String resolveModel(String bedrockModelId, EmulatorConfig.BedrockProxyConfig proxyConfig) {
         String mapped = modelMapping.get(bedrockModelId);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1470,6 +1470,25 @@ public class S3Service implements Resettable, ResourceProvider {
         return resolveBucket(bucketName).map(Bucket::getRegion).orElse(null);
     }
 
+    /**
+     * Returns the account ID that owns the given bucket, or {@code null} when the bucket does not
+     * exist or the storage backend does not track per-account partitions.
+     *
+     * <p>With {@code globalBucketNamespace} enabled the lookup spans every account partition and
+     * returns the true owning account. Without it the bucket is always in the caller's account, so
+     * {@link #ownerId()} is returned as a safe default.
+     */
+    public String getBucketOwnerAccountId(String bucketName) {
+        if (globalBucketNamespace && bucketStore instanceof AccountAwareStorageBackend<?> aware) {
+            @SuppressWarnings("unchecked")
+            AccountAwareStorageBackend<Bucket> typed = (AccountAwareStorageBackend<Bucket>) aware;
+            return typed.findAnyAccountEntry(bucketName)
+                    .map(AccountAwareStorageBackend.OwnedEntry::account)
+                    .orElse(null);
+        }
+        return resolveBucket(bucketName).isPresent() ? ownerId() : null;
+    }
+
     // --- Batch Delete ---
 
     public record DeleteResult(String key, String versionId, boolean deleteMarker, String deleteMarkerVersionId) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -11,7 +11,9 @@ import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.iam.IamPolicyEvaluator;
 import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.iam.model.CallerContext;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
 import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.s3.model.*;
@@ -177,6 +179,15 @@ public class S3Service implements Resettable, ResourceProvider {
         this(bucketStore, objectStore, defaultAccountPublicAccessBlockStore(),
                 dataRoot, inMemory, null, null, null, null, null, null, null,
                 null, "http://localhost:4566", new ObjectMapper(), false, null, globalBucketNamespace);
+    }
+
+    /** Package-private constructor for testing IAM role authorization. */
+    S3Service(StorageBackend<String, Bucket> bucketStore,
+              StorageBackend<String, S3Object> objectStore,
+              Path dataRoot, boolean inMemory, IamService iamService) {
+        this(bucketStore, objectStore, defaultAccountPublicAccessBlockStore(),
+                dataRoot, inMemory, null, null, null, null, null, null, null,
+                null, "http://localhost:4566", new ObjectMapper(), false, iamService, false);
     }
 
     S3Service(StorageBackend<String, Bucket> bucketStore,
@@ -590,6 +601,60 @@ public class S3Service implements Resettable, ResourceProvider {
 
     public void authorizeAnonymousGetObject(String bucketName, String key) {
         authorizeGetObject(bucketName, key, null, RequestAuthorization.unsigned());
+    }
+
+    /**
+     * Authorizes an IAM role principal to perform an action on an S3 bucket or object.
+     * Evaluates bucket policy and IAM role policies, respecting explicit Allow / Deny rules.
+     * Synthetic/unmodeled role ARNs without conflicting bucket policies are allowed.
+     */
+    public void authorizeRoleAccess(String roleArn, String bucketName, String key, String action) {
+        Bucket bucket = resolveBucket(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+
+        String resourceArn = (key != null && !key.isBlank())
+                ? S3PublicAccessEvaluator.objectArn(bucketName, key)
+                : S3PublicAccessEvaluator.bucketArn(bucketName);
+
+        // 1. Evaluate Bucket Policy
+        S3PublicAccessEvaluator.PublicAccessDecision bucketDecision = S3PublicAccessEvaluator.PublicAccessDecision.NEUTRAL;
+        if (bucket.getPolicy() != null && !bucket.getPolicy().isBlank()) {
+            bucketDecision = S3PublicAccessEvaluator.principalPolicyDecision(
+                    objectMapper,
+                    bucket.getPolicy(),
+                    "AWS",
+                    roleArn,
+                    action,
+                    resourceArn,
+                    Map.of());
+            if (bucketDecision == S3PublicAccessEvaluator.PublicAccessDecision.DENY) {
+                throw new AwsException("AccessDenied", "Access Denied", 403);
+            }
+        }
+
+        // 2. Evaluate IAM Role Policy (if role exists and has policies in IAM)
+        if (iamService != null && roleArn != null && !roleArn.isBlank()) {
+            try {
+                CallerContext caller = iamService.resolvePrincipalContext(roleArn);
+                if (caller != null && caller.identityPolicies() != null && !caller.identityPolicies().isEmpty()) {
+                    IamPolicyEvaluator evaluator = new IamPolicyEvaluator(objectMapper);
+                    IamPolicyEvaluator.SimulationDecision iamDecision =
+                            evaluator.simulatePrincipalPolicy(caller, action, resourceArn, Map.of());
+                    if (iamDecision == IamPolicyEvaluator.SimulationDecision.EXPLICIT_DENY) {
+                        throw new AwsException("AccessDenied", "Access Denied", 403);
+                    }
+                    if (iamDecision == IamPolicyEvaluator.SimulationDecision.IMPLICIT_DENY
+                            && bucketDecision != S3PublicAccessEvaluator.PublicAccessDecision.ALLOW) {
+                        throw new AwsException("AccessDenied", "Access Denied", 403);
+                    }
+                }
+            } catch (AwsException e) {
+                if ("AccessDenied".equals(e.getErrorCode())) {
+                    throw e;
+                }
+                LOG.debugv("IAM role not found or could not resolve context for {0}: {1}", roleArn, e.getMessage());
+            }
+        }
     }
 
     public void authorizeCloudFrontOacGetObject(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -143,6 +143,8 @@ floci:
         flush-interval-ms: 5000
       transcribe:
         flush-interval-ms: 5000
+      bedrock:
+        flush-interval-ms: 5000
       codedeploy:
         flush-interval-ms: 5000
       tagging:

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockBatchS3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockBatchS3IntegrationTest.java
@@ -1,0 +1,222 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class BedrockBatchS3IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/bedrock/aws4_request";
+
+    @Inject
+    S3Service s3Service;
+
+    @Inject
+    BedrockService bedrockService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        bedrockService.clear();
+    }
+
+    @Test
+    void executeBatchJob_endToEndS3InputAndOutputWithManifest() throws Exception {
+        String inputBucket = "batch-e2e-input-bucket";
+        String outputBucket = "batch-e2e-output-bucket";
+        s3Service.createBucket(inputBucket, "us-east-1");
+        s3Service.createBucket(outputBucket, "us-east-1");
+
+        // Input JSONL with 2 records (1 Converse style, 1 Anthropic style)
+        String inputJsonl = """
+            {"recordId": "rec-001", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello world"}]}]}}
+            {"recordId": "rec-002", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "messages": [{"role": "user", "content": [{"type": "text", "text": "What is AI?"}]}]}}
+            """;
+        s3Service.putObject(inputBucket, "data/prompts.jsonl", inputJsonl.getBytes(StandardCharsets.UTF_8), "application/jsonlines", Map.of());
+
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "e2e-batch-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://%s/data/prompts.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://%s/batch-results"}}
+                }
+                """.formatted(inputBucket, outputBucket))
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("jobArn");
+
+        // Check Job Status
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-job/" + jobArn)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("Completed"))
+            .body("endTime", notNullValue());
+
+        String jobId = jobArn.substring(jobArn.lastIndexOf('/') + 1);
+
+        // Verify Output JSONL file in S3
+        String outputJsonlKey = "batch-results/" + jobId + "/prompts.jsonl.out";
+        S3Object outputObj = s3Service.getObject(outputBucket, outputJsonlKey);
+        assertNotNull(outputObj, "Output JSONL file should exist in S3");
+        String outputContent = new String(outputObj.getData(), StandardCharsets.UTF_8);
+        String[] outputLines = outputContent.trim().split("\n");
+        assertEquals(2, outputLines.length);
+
+        JsonNode line1 = objectMapper.readTree(outputLines[0]);
+        assertEquals("rec-001", line1.path("recordId").asText());
+        assertTrue(line1.has("modelInput"));
+        assertTrue(line1.has("modelOutput"));
+        assertTrue(line1.path("modelOutput").has("output") || line1.path("modelOutput").has("content"));
+
+        JsonNode line2 = objectMapper.readTree(outputLines[1]);
+        assertEquals("rec-002", line2.path("recordId").asText());
+        assertTrue(line2.has("modelInput"));
+        assertTrue(line2.has("modelOutput"));
+
+        // Verify Manifest File in S3
+        String manifestKey = "batch-results/" + jobId + "/manifest.json.out";
+        S3Object manifestObj = s3Service.getObject(outputBucket, manifestKey);
+        assertNotNull(manifestObj, "Manifest file should exist in S3");
+        JsonNode manifest = objectMapper.readTree(manifestObj.getData());
+
+        assertEquals(2, manifest.path("totalRecordCount").asLong());
+        assertEquals(2, manifest.path("processedRecordCount").asLong());
+        assertEquals(2, manifest.path("successRecordCount").asLong());
+        assertEquals(0, manifest.path("errorRecordCount").asLong());
+    }
+
+    @Test
+    void executeBatchJob_partiallyCompletedWithErrors() throws Exception {
+        String inputBucket = "batch-partial-input-bucket";
+        String outputBucket = "batch-partial-output-bucket";
+        s3Service.createBucket(inputBucket, "us-east-1");
+        s3Service.createBucket(outputBucket, "us-east-1");
+
+        // Input JSONL with 1 valid record and 1 malformed record
+        String inputJsonl = """
+            {"recordId": "rec-valid", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello"}]}]}}
+            {"recordId": "rec-broken"}
+            """;
+        s3Service.putObject(inputBucket, "mixed.jsonl", inputJsonl.getBytes(StandardCharsets.UTF_8), "application/jsonlines", Map.of());
+
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "partial-batch-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://%s/mixed.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://%s/results"}}
+                }
+                """.formatted(inputBucket, outputBucket))
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("jobArn");
+
+        // Check Job Status
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-job/" + jobArn)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("PartiallyCompleted"))
+            .body("message", equalTo("Batch job partially completed with 1 successes and 1 errors."));
+
+        String jobId = jobArn.substring(jobArn.lastIndexOf('/') + 1);
+
+        // Verify Output JSONL file
+        String outputJsonlKey = "results/" + jobId + "/mixed.jsonl.out";
+        S3Object outputObj = s3Service.getObject(outputBucket, outputJsonlKey);
+        assertNotNull(outputObj);
+        String outputContent = new String(outputObj.getData(), StandardCharsets.UTF_8);
+        String[] outputLines = outputContent.trim().split("\n");
+        assertEquals(2, outputLines.length);
+
+        JsonNode validLine = objectMapper.readTree(outputLines[0]);
+        assertEquals("rec-valid", validLine.path("recordId").asText());
+        assertTrue(validLine.has("modelOutput"));
+
+        JsonNode brokenLine = objectMapper.readTree(outputLines[1]);
+        assertEquals("rec-broken", brokenLine.path("recordId").asText());
+        assertTrue(brokenLine.has("error"));
+        assertEquals("400", brokenLine.path("error").path("errorCode").asText());
+
+        // Verify Manifest
+        String manifestKey = "results/" + jobId + "/manifest.json.out";
+        S3Object manifestObj = s3Service.getObject(outputBucket, manifestKey);
+        assertNotNull(manifestObj);
+        JsonNode manifest = objectMapper.readTree(manifestObj.getData());
+
+        assertEquals(2, manifest.path("totalRecordCount").asLong());
+        assertEquals(2, manifest.path("processedRecordCount").asLong());
+        assertEquals(1, manifest.path("successRecordCount").asLong());
+        assertEquals(1, manifest.path("errorRecordCount").asLong());
+    }
+
+    @Test
+    void executeBatchJob_missingInputS3ObjectFails() {
+        String outputBucket = "batch-fail-output-bucket";
+        s3Service.createBucket(outputBucket, "us-east-1");
+
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "missing-file-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://non-existent-bucket/non-existent.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://%s/results"}}
+                }
+                """.formatted(outputBucket))
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("jobArn");
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-job/" + jobArn)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("Failed"))
+            .body("endTime", notNullValue());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockBatchS3IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockBatchS3IntegrationTest.java
@@ -189,7 +189,10 @@ class BedrockBatchS3IntegrationTest {
 
     @Test
     void executeBatchJob_missingInputS3ObjectFails() {
-        String outputBucket = "batch-fail-output-bucket";
+        // Input bucket exists but the key does not: job must fail with a clear message.
+        String inputBucket = "batch-missing-key-bucket";
+        String outputBucket = "batch-missing-key-out-bucket";
+        s3Service.createBucket(inputBucket, "us-east-1");
         s3Service.createBucket(outputBucket, "us-east-1");
 
         String jobArn = given()
@@ -197,13 +200,44 @@ class BedrockBatchS3IntegrationTest {
             .header("Authorization", AUTH_HEADER)
             .body("""
                 {
-                  "jobName": "missing-file-job",
+                  "jobName": "missing-key-job",
                   "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
                   "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole",
-                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://non-existent-bucket/non-existent.jsonl"}},
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://%s/no-such-file.jsonl"}},
                   "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://%s/results"}}
                 }
-                """.formatted(outputBucket))
+                """.formatted(inputBucket, outputBucket))
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("jobArn");
+
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-job/" + jobArn)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("Failed"))
+            .body("endTime", notNullValue());
+    }
+
+    @Test
+    void executeBatchJob_missingInputBucketFails() {
+        // Neither bucket exists: executor must fail on headBucket and not proceed.
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "missing-bucket-s3-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://no-such-bucket-xyz/in.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://no-such-bucket-xyz/out"}}
+                }
+                """)
         .when()
             .post("/model-invocation-job")
         .then()

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockEventBridgeIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockEventBridgeIntegrationTest.java
@@ -1,0 +1,172 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class BedrockEventBridgeIntegrationTest {
+
+    private static final String SQS_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String EVENT_BRIDGE_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/bedrock/aws4_request";
+
+    @Inject
+    S3Service s3Service;
+
+    @Inject
+    BedrockService bedrockService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        bedrockService.clear();
+    }
+
+    @Test
+    void batchJob_emitsEventBridgeStateChangeEvents() throws Exception {
+        // 1. Create SQS Queue
+        String queueUrl = given()
+                .contentType(SQS_CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .body("{\"QueueName\":\"bedrock-eb-queue\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("QueueUrl");
+
+        String queueArn = given()
+                .contentType(SQS_CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.GetQueueAttributes")
+                .body("{\"QueueUrl\":\"" + queueUrl + "\",\"AttributeNames\":[\"QueueArn\"]}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200)
+                .extract().jsonPath().getString("Attributes.QueueArn");
+
+        // 2. Create EventBridge Rule for Bedrock state change
+        String ruleName = "bedrock-state-change-rule";
+        String eventPattern = "{\"source\":[\"aws.bedrock\"],\"detail-type\":[\"Batch Inference Job State Change\"]}";
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutRule")
+                .body("{\"Name\":\"" + ruleName + "\",\"EventPattern\":\"" + eventPattern.replace("\"", "\\\"") + "\"}")
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        // 3. Put Target to Rule
+        given()
+                .contentType(EVENT_BRIDGE_CONTENT_TYPE)
+                .header("X-Amz-Target", "AWSEvents.PutTargets")
+                .body("""
+                    {
+                      "Rule": "%s",
+                      "Targets": [{"Id": "target-sqs", "Arn": "%s"}]
+                    }
+                    """.formatted(ruleName, queueArn))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        // 4. Create S3 input data and execute batch job
+        s3Service.createBucket("eb-test-input", "us-east-1");
+        s3Service.createBucket("eb-test-output", "us-east-1");
+        String jsonl = """
+            {"recordId": "rec-1", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Ping"}]}]}}
+            """;
+        s3Service.putObject("eb-test-input", "prompts.jsonl", jsonl.getBytes(StandardCharsets.UTF_8), "application/jsonlines", Map.of());
+
+        String jobArn = given()
+                .contentType("application/json")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                    {
+                      "jobName": "eb-test-batch-job",
+                      "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                      "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                      "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://eb-test-input/prompts.jsonl"}},
+                      "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://eb-test-output/results"}}
+                    }
+                    """)
+                .when()
+                .post("/model-invocation-job")
+                .then()
+                .statusCode(201)
+                .extract().jsonPath().getString("jobArn");
+
+        // 5. Receive messages from SQS
+        List<JsonNode> receivedEvents = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            var resp = given()
+                    .contentType(SQS_CONTENT_TYPE)
+                    .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                    .body("{\"QueueUrl\":\"" + queueUrl + "\",\"MaxNumberOfMessages\":10,\"WaitTimeSeconds\":1}")
+                    .when()
+                    .post("/")
+                    .then()
+                    .statusCode(200)
+                    .extract().jsonPath();
+
+            List<Map<String, Object>> messages = resp.getList("Messages");
+            if (messages != null) {
+                for (Map<String, Object> msg : messages) {
+                    String body = (String) msg.get("Body");
+                    JsonNode eventNode = objectMapper.readTree(body);
+                    receivedEvents.add(eventNode);
+                }
+            }
+            if (receivedEvents.size() >= 5) {
+                break;
+            }
+        }
+
+        assertTrue(receivedEvents.size() >= 5, "Expected at least 5 events (Submitted, Validating, Scheduled, InProgress, Completed), but got: " + receivedEvents.size());
+
+        List<String> statuses = new ArrayList<>();
+        for (JsonNode event : receivedEvents) {
+            assertEquals("aws.bedrock", event.path("source").asText());
+            assertEquals("Batch Inference Job State Change", event.path("detail-type").asText());
+            assertTrue(event.path("resources").isArray());
+            assertEquals(jobArn, event.path("resources").get(0).asText());
+
+            JsonNode detail = event.path("detail");
+            assertEquals(jobArn, detail.path("batchJobArn").asText());
+            assertEquals("eb-test-batch-job", detail.path("batchJobName").asText());
+            statuses.add(detail.path("status").asText());
+        }
+
+        assertTrue(statuses.contains("Submitted"), "Event list should contain Submitted state");
+        assertTrue(statuses.contains("Validating"), "Event list should contain Validating state");
+        assertTrue(statuses.contains("Scheduled"), "Event list should contain Scheduled state");
+        assertTrue(statuses.contains("InProgress"), "Event list should contain InProgress state");
+        assertTrue(statuses.contains("Completed"), "Event list should contain Completed state");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockIntegrationTest.java
@@ -1,0 +1,277 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static io.restassured.RestAssured.given;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+class BedrockIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/bedrock/aws4_request";
+
+    @Inject
+    S3Service s3Service;
+
+    @Inject
+    BedrockService bedrockService;
+
+    @BeforeEach
+    void setUp() {
+        bedrockService.clear();
+    }
+
+    @Test
+    void createModelInvocationJob_validationFailures() {
+        // Missing jobName
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+
+        // Missing modelId
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "test-job",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://b/in.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://b/out"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void createAndGetModelInvocationJob_happyPath() {
+        s3Service.createBucket("rest-input-b", "us-east-1");
+        s3Service.createBucket("rest-output-b", "us-east-1");
+
+        String jsonl = """
+            {"recordId": "rec-1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]}}
+            """;
+        s3Service.putObject("rest-input-b", "prompts.jsonl", jsonl.getBytes(StandardCharsets.UTF_8), "application/jsonlines", java.util.Map.of());
+
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "my-rest-batch-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://rest-input-b/prompts.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://rest-output-b/results"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .body("jobArn", startsWith("arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/"))
+            .extract().jsonPath().getString("jobArn");
+
+        // Get by ARN
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            given()
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .get("/model-invocation-job/" + jobArn)
+            .then()
+                .statusCode(200)
+                .body("jobArn", equalTo(jobArn))
+                .body("jobName", equalTo("my-rest-batch-job"))
+                .body("status", equalTo("Completed"))
+                .body("submitTime", notNullValue())
+                .body("endTime", notNullValue())
+                .body("inputDataConfig.s3InputDataConfig.s3Uri", equalTo("s3://rest-input-b/prompts.jsonl"))
+                .body("outputDataConfig.s3OutputDataConfig.s3Uri", equalTo("s3://rest-output-b/results"));
+        });
+    }
+
+    @Test
+    void getModelInvocationJob_notFound() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-job/non-existent-job")
+        .then()
+            .statusCode(404)
+            .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    void stopModelInvocationJob_alreadyCompletedThrows() {
+        s3Service.createBucket("stop-input-b", "us-east-1");
+        s3Service.createBucket("stop-output-b", "us-east-1");
+        String jsonl = """
+            {"recordId": "rec-1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]}}
+            """;
+        s3Service.putObject("stop-input-b", "prompts.jsonl", jsonl.getBytes(StandardCharsets.UTF_8), "application/jsonlines", java.util.Map.of());
+
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "completed-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://stop-input-b/prompts.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://stop-output-b/results"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("jobArn");
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            given()
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .get("/model-invocation-job/" + jobArn)
+            .then()
+                .statusCode(200)
+                .body("status", equalTo("Completed"));
+        });
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/model-invocation-job/" + jobArn + "/stop")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+
+    @Test
+    void listModelInvocationJobs_filterAndPagination() {
+        s3Service.createBucket("list-input-b", "us-east-1");
+        s3Service.createBucket("list-output-b", "us-east-1");
+        s3Service.putObject("list-input-b", "p.jsonl", "{}".getBytes(StandardCharsets.UTF_8), "application/jsonlines", java.util.Map.of());
+
+        for (int i = 1; i <= 3; i++) {
+            given()
+                .contentType("application/json")
+                .header("Authorization", AUTH_HEADER)
+                .body("""
+                    {
+                      "jobName": "job-alpha-%d",
+                      "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                      "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                      "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://list-input-b/p.jsonl"}},
+                      "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://list-output-b/results"}}
+                    }
+                    """.formatted(i))
+            .when()
+                .post("/model-invocation-job")
+            .then()
+                .statusCode(201);
+        }
+
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "job-beta-special",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://list-input-b/p.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://list-output-b/results"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201);
+
+        // List all
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(200)
+            .body("invocationJobSummaries", hasSize(4));
+
+        // Filter by nameContains
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("nameContains", "special")
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(200)
+            .body("invocationJobSummaries", hasSize(1))
+            .body("invocationJobSummaries[0].jobName", equalTo("job-beta-special"));
+
+        // Pagination with maxResults=2
+        String nextToken = given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("maxResults", 2)
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(200)
+            .body("invocationJobSummaries", hasSize(2))
+            .body("nextToken", notNullValue())
+            .extract().jsonPath().getString("nextToken");
+
+        // Next page
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("maxResults", 2)
+            .queryParam("nextToken", nextToken)
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(200)
+            .body("invocationJobSummaries", hasSize(2));
+
+        // Invalid submitTimeAfter date format
+        given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("submitTimeAfter", "invalid-date")
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockIntegrationTest.java
@@ -122,6 +122,83 @@ class BedrockIntegrationTest {
     }
 
     @Test
+    void createModelInvocationJob_inputBucketMissing_jobFails() {
+        // Bucket is never created: the async executor must detect it and fail the job.
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "missing-bucket-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://this-bucket-does-not-exist/in.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://this-bucket-does-not-exist/out"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201);
+
+        // Retrieve the ARN from the listing (job name is unique per test run via setUp clear)
+        String jobArn = given()
+            .header("Authorization", AUTH_HEADER)
+            .queryParam("nameContains", "missing-bucket-job")
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(200)
+            .extract().jsonPath().getString("invocationJobSummaries[0].jobArn");
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+            given()
+                .header("Authorization", AUTH_HEADER)
+            .when()
+                .get("/model-invocation-job/" + jobArn)
+            .then()
+                .statusCode(200)
+                .body("status", equalTo("Failed"))
+                .body("endTime", notNullValue())
+        );
+    }
+
+    @Test
+    void listModelInvocationJobs_regionalIsolation() {
+        s3Service.createBucket("region-isolation-b", "us-east-1");
+        s3Service.putObject("region-isolation-b", "p.jsonl",
+                "{}".getBytes(StandardCharsets.UTF_8), "application/jsonlines", java.util.Map.of());
+
+        // Create job scoped to us-east-1
+        given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)  // credential encodes us-east-1
+            .body("""
+                {
+                  "jobName": "region-isolation-job",
+                  "modelId": "anthropic.claude-3-haiku-20240307-v1:0",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://region-isolation-b/p.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://region-isolation-b/out"}}
+                }
+                """)
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201);
+
+        // List with a credential that signals eu-west-1: the job must not appear.
+        String euAuthHeader = "AWS4-HMAC-SHA256 Credential=AKID/20260101/eu-west-1/bedrock/aws4_request";
+        given()
+            .header("Authorization", euAuthHeader)
+        .when()
+            .get("/model-invocation-jobs")
+        .then()
+            .statusCode(200)
+            .body("invocationJobSummaries.findAll { it.jobName == 'region-isolation-job' }", hasSize(0));
+    }
+
+    @Test
     void getModelInvocationJob_notFound() {
         given()
             .header("Authorization", AUTH_HEADER)

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockProxyBatchIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockProxyBatchIntegrationTest.java
@@ -1,0 +1,158 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@TestProfile(BedrockProxyBatchIntegrationTest.ProxyBatchBackendProfile.class)
+class BedrockProxyBatchIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/bedrock/aws4_request";
+    private static final int PORT = 18935;
+    private static final String MAPPED_MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0";
+
+    @Inject
+    S3Service s3Service;
+
+    @Inject
+    BedrockService bedrockService;
+
+    @Inject
+    ObjectMapper objectMapper;
+
+    private HttpServer backend;
+    private final AtomicReference<String> nextResponseBody = new AtomicReference<>();
+    private final AtomicReference<Integer> nextResponseStatus = new AtomicReference<>(200);
+
+    @BeforeEach
+    void setUp() throws IOException {
+        bedrockService.clear();
+
+        backend = HttpServer.create(new InetSocketAddress("127.0.0.1", PORT), 0);
+        backend.createContext("/v1/chat/completions", exchange -> {
+            byte[] resp = nextResponseBody.get().getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(nextResponseStatus.get(), resp.length);
+            exchange.getResponseBody().write(resp);
+            exchange.close();
+        });
+        backend.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (backend != null) {
+            backend.stop(0);
+        }
+    }
+
+    @Test
+    void executeBatchJob_withProxyBackend() throws Exception {
+        nextResponseBody.set("""
+            {
+              "choices": [{
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Hello from the OpenAI-compatible proxy batch!"}
+              }],
+              "usage": {"prompt_tokens": 10, "completion_tokens": 8, "total_tokens": 18}
+            }
+            """);
+
+        String inputBucket = "proxy-batch-input-bucket";
+        String outputBucket = "proxy-batch-output-bucket";
+        s3Service.createBucket(inputBucket, "us-east-1");
+        s3Service.createBucket(outputBucket, "us-east-1");
+
+        String inputJsonl = """
+            {"recordId": "rec-proxy-1", "modelInput": {"messages": [{"role": "user", "content": [{"text": "Hello proxy"}]}]}}
+            """;
+        s3Service.putObject(inputBucket, "prompts.jsonl", inputJsonl.getBytes(StandardCharsets.UTF_8), "application/jsonlines", Map.of());
+
+        String jobArn = given()
+            .contentType("application/json")
+            .header("Authorization", AUTH_HEADER)
+            .body("""
+                {
+                  "jobName": "proxy-batch-job",
+                  "modelId": "%s",
+                  "roleArn": "arn:aws:iam::000000000000:role/BedrockBatchRole",
+                  "inputDataConfig": {"s3InputDataConfig": {"s3Uri": "s3://%s/prompts.jsonl"}},
+                  "outputDataConfig": {"s3OutputDataConfig": {"s3Uri": "s3://%s/results"}}
+                }
+                """.formatted(MAPPED_MODEL_ID, inputBucket, outputBucket))
+        .when()
+            .post("/model-invocation-job")
+        .then()
+            .statusCode(201)
+            .extract().jsonPath().getString("jobArn");
+
+        // Verify Job Status
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .get("/model-invocation-job/" + jobArn)
+        .then()
+            .statusCode(200)
+            .body("status", equalTo("Completed"));
+
+        String jobId = jobArn.substring(jobArn.lastIndexOf('/') + 1);
+
+        // Verify Output JSONL file in S3
+        String outputJsonlKey = "results/" + jobId + "/prompts.jsonl.out";
+        S3Object outputObj = s3Service.getObject(outputBucket, outputJsonlKey);
+        assertNotNull(outputObj, "Output JSONL file should exist in S3");
+        String outputContent = new String(outputObj.getData(), StandardCharsets.UTF_8);
+        JsonNode line = objectMapper.readTree(outputContent.trim());
+
+        assertEquals("rec-proxy-1", line.path("recordId").asText());
+        assertEquals("Hello from the OpenAI-compatible proxy batch!",
+                line.path("modelOutput").path("output").path("message").path("content").get(0).path("text").asText());
+
+        // Verify Manifest
+        String manifestKey = "results/" + jobId + "/manifest.json.out";
+        S3Object manifestObj = s3Service.getObject(outputBucket, manifestKey);
+        assertNotNull(manifestObj);
+        JsonNode manifest = objectMapper.readTree(manifestObj.getData());
+
+        assertEquals(1, manifest.path("totalRecordCount").asLong());
+        assertEquals(1, manifest.path("processedRecordCount").asLong());
+        assertEquals(1, manifest.path("successRecordCount").asLong());
+        assertEquals(0, manifest.path("errorRecordCount").asLong());
+    }
+
+    public static final class ProxyBatchBackendProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.services.bedrock-runtime.backend", "proxy",
+                    "floci.services.bedrock-runtime.proxy.url", "http://127.0.0.1:" + PORT + "/v1",
+                    "floci.services.bedrock-runtime.proxy.api-key", "test-key",
+                    "floci.services.bedrock-runtime.proxy.model-mapping",
+                            MAPPED_MODEL_ID + "=claude-3-haiku"
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
@@ -1,0 +1,351 @@
+package io.github.hectorvent.floci.services.bedrock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.bedrock.model.CreateModelInvocationJobRequest;
+import io.github.hectorvent.floci.services.bedrock.model.CreateModelInvocationJobResponse;
+import io.github.hectorvent.floci.services.bedrock.model.InputDataConfig;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJob;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJobStatus;
+import io.github.hectorvent.floci.services.bedrock.model.ModelInvocationJobSummary;
+import io.github.hectorvent.floci.services.bedrock.model.OutputDataConfig;
+import io.github.hectorvent.floci.services.bedrockruntime.BedrockRuntimeService;
+import io.github.hectorvent.floci.services.bedrockruntime.backend.StubBackend;
+import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.s3.model.S3Object;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BedrockServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT_ID = "000000000000";
+
+    private BedrockService service;
+    private StorageFactory storageFactory;
+    private EmulatorConfig config;
+    private RegionResolver regionResolver;
+    private ObjectMapper objectMapper;
+    private BedrockRuntimeService bedrockRuntimeService;
+    private S3Service s3Service;
+    private EventBridgeService eventBridgeService;
+
+    @BeforeEach
+    void setUp() {
+        storageFactory = mock(StorageFactory.class);
+        when(storageFactory.create(eq("bedrock"), eq("bedrock-jobs.json"), any()))
+                .thenAnswer(inv -> new AccountAwareStorageBackend<>(new InMemoryStorage<>(), null, ACCOUNT_ID));
+
+        config = mock(EmulatorConfig.class);
+        regionResolver = new RegionResolver(REGION, ACCOUNT_ID);
+        objectMapper = new ObjectMapper();
+
+        StubBackend stubBackend = new StubBackend(objectMapper);
+        EmulatorConfig.BedrockRuntimeServiceConfig bedrockRuntimeConfig = mock(EmulatorConfig.BedrockRuntimeServiceConfig.class);
+        EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.bedrockRuntime()).thenReturn(bedrockRuntimeConfig);
+        when(bedrockRuntimeConfig.backend()).thenReturn("stub");
+
+        bedrockRuntimeService = new BedrockRuntimeService(config, stubBackend, null);
+        s3Service = mock(S3Service.class);
+        eventBridgeService = mock(EventBridgeService.class);
+
+        service = new BedrockService(
+                storageFactory,
+                config,
+                regionResolver,
+                objectMapper,
+                bedrockRuntimeService,
+                s3Service,
+                eventBridgeService
+        );
+    }
+
+    private CreateModelInvocationJobRequest createValidRequest(String jobName, String inputUri, String outputUri) {
+        return new CreateModelInvocationJobRequest(
+                jobName,
+                "anthropic.claude-3-haiku-20240307-v1:0",
+                "arn:aws:iam::000000000000:role/BedrockBatchRole",
+                "client-token-123",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig(inputUri, "JSONL", null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig(outputUri, null, null)),
+                null,
+                24,
+                Collections.emptyList()
+        );
+    }
+
+    @Test
+    void createModelInvocationJob_validation_missingFields() {
+        // null request
+        AwsException e1 = assertThrows(AwsException.class, () -> service.createModelInvocationJob(null, REGION));
+        assertEquals(400, e1.getHttpStatus());
+
+        // missing jobName
+        CreateModelInvocationJobRequest reqNoName = new CreateModelInvocationJobRequest(
+                null, "modelId", "roleArn", "token",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig("s3://b/in", null, null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig("s3://b/out", null, null)),
+                null, 24, null
+        );
+        assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqNoName, REGION));
+
+        // missing modelId
+        CreateModelInvocationJobRequest reqNoModel = new CreateModelInvocationJobRequest(
+                "jobName", "", "roleArn", "token",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig("s3://b/in", null, null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig("s3://b/out", null, null)),
+                null, 24, null
+        );
+        assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqNoModel, REGION));
+
+        // missing roleArn
+        CreateModelInvocationJobRequest reqNoRole = new CreateModelInvocationJobRequest(
+                "jobName", "modelId", " ", "token",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig("s3://b/in", null, null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig("s3://b/out", null, null)),
+                null, 24, null
+        );
+        assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqNoRole, REGION));
+
+        // missing input s3 uri
+        CreateModelInvocationJobRequest reqNoInput = new CreateModelInvocationJobRequest(
+                "jobName", "modelId", "roleArn", "token",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig(null, null, null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig("s3://b/out", null, null)),
+                null, 24, null
+        );
+        assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqNoInput, REGION));
+
+        // missing output s3 uri
+        CreateModelInvocationJobRequest reqNoOutput = new CreateModelInvocationJobRequest(
+                "jobName", "modelId", "roleArn", "token",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig("s3://b/in", null, null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig("", null, null)),
+                null, 24, null
+        );
+        assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqNoOutput, REGION));
+    }
+
+    @Test
+    void createModelInvocationJob_successfulExecution() {
+        String inputBucket = "test-input-bucket";
+        String inputKey = "data/prompts.jsonl";
+        String inputUri = "s3://" + inputBucket + "/" + inputKey;
+        String outputUri = "s3://test-output-bucket/results";
+
+        String jsonlContent = """
+                {"recordId": "rec-1", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello 1"}]}]}}
+                {"recordId": "rec-2", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello 2"}]}]}}
+                """;
+
+        S3Object s3Object = new S3Object(inputBucket, inputKey, jsonlContent.getBytes(StandardCharsets.UTF_8), "application/jsonlines");
+        when(s3Service.getObject(eq(inputBucket), eq(inputKey))).thenReturn(s3Object);
+
+        CreateModelInvocationJobRequest req = createValidRequest("my-batch-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        assertNotNull(response.jobArn());
+        assertTrue(response.jobArn().startsWith("arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/"));
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals("my-batch-job", job.getJobName());
+            assertEquals(ModelInvocationJobStatus.COMPLETED, job.getStatus());
+            assertNotNull(job.getEndTime());
+        });
+
+        // Verify EventBridge events were emitted
+        verify(eventBridgeService, Mockito.atLeast(2)).putEvents(any(), eq(REGION), eq(ACCOUNT_ID));
+
+        // Verify S3 putObject was called for output JSONL and manifest.json.out
+        verify(s3Service).putObject(eq("test-output-bucket"), Mockito.endsWith("prompts.jsonl.out"), any(), eq("application/jsonlines"), any());
+        verify(s3Service).putObject(eq("test-output-bucket"), Mockito.endsWith("manifest.json.out"), any(), eq("application/json"), any());
+    }
+
+    @Test
+    void createModelInvocationJob_partialFailures() {
+        String inputBucket = "test-input-bucket";
+        String inputKey = "data/mixed.jsonl";
+        String inputUri = "s3://" + inputBucket + "/" + inputKey;
+        String outputUri = "s3://test-output-bucket/results";
+
+        // One valid line, one invalid line (missing modelInput)
+        String jsonlContent = """
+                {"recordId": "rec-good", "modelInput": {"anthropic_version": "bedrock-2023-05-31", "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]}}
+                {"recordId": "rec-bad"}
+                """;
+
+        S3Object s3Object = new S3Object(inputBucket, inputKey, jsonlContent.getBytes(StandardCharsets.UTF_8), "application/jsonlines");
+        when(s3Service.getObject(eq(inputBucket), eq(inputKey))).thenReturn(s3Object);
+
+        CreateModelInvocationJobRequest req = createValidRequest("mixed-batch-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.PARTIALLY_COMPLETED, job.getStatus());
+            assertTrue(job.getMessage().contains("1 successes and 1 errors"));
+        });
+    }
+
+    @Test
+    void createModelInvocationJob_inputS3FileNotFound_fails() {
+        String inputUri = "s3://test-input-bucket/missing.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+
+        when(s3Service.getObject(eq("test-input-bucket"), eq("missing.jsonl")))
+                .thenThrow(new AwsException("NoSuchKey", "The specified key does not exist", 404));
+
+        CreateModelInvocationJobRequest req = createValidRequest("failed-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.FAILED, job.getStatus());
+            assertTrue(job.getMessage().contains("Failed to read input S3 file"));
+        });
+    }
+
+    @Test
+    void getModelInvocationJob_resolvesByIdArnOrName() {
+        String inputUri = "s3://test-input-bucket/prompts.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+        when(s3Service.getObject(any(), any()))
+                .thenReturn(new S3Object("test-input-bucket", "prompts.jsonl", "{}".getBytes(StandardCharsets.UTF_8), "application/json"));
+
+        CreateModelInvocationJobRequest req = createValidRequest("named-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob byArn = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertNotNull(byArn);
+            assertEquals("named-job", byArn.getJobName());
+        });
+
+        // Resolve by ARN
+        ModelInvocationJob byArn = service.getModelInvocationJob(response.jobArn(), REGION);
+        assertNotNull(byArn);
+        assertEquals("named-job", byArn.getJobName());
+
+        // Resolve by ID
+        ModelInvocationJob byId = service.getModelInvocationJob(byArn.getJobId(), REGION);
+        assertEquals(response.jobArn(), byId.getJobArn());
+
+        // Resolve by Name
+        ModelInvocationJob byName = service.getModelInvocationJob("named-job", REGION);
+        assertEquals(response.jobArn(), byName.getJobArn());
+
+        // Non-existent
+        AwsException notFound = assertThrows(AwsException.class, () -> service.getModelInvocationJob("unknown", REGION));
+        assertEquals(404, notFound.getHttpStatus());
+    }
+
+    @Test
+    void stopModelInvocationJob_terminalJobThrows() {
+        String inputUri = "s3://test-input-bucket/prompts.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+        when(s3Service.getObject(any(), any()))
+                .thenReturn(new S3Object("test-input-bucket", "prompts.jsonl", "".getBytes(StandardCharsets.UTF_8), "application/json"));
+
+        CreateModelInvocationJobRequest req = createValidRequest("completed-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.COMPLETED, job.getStatus());
+        });
+
+        // Job finished and is COMPLETED, trying to stop should throw ValidationException (400)
+        AwsException e = assertThrows(AwsException.class, () -> service.stopModelInvocationJob(response.jobArn(), REGION));
+        assertEquals(400, e.getHttpStatus());
+        assertTrue(e.getMessage().contains("terminal status"));
+    }
+
+    @Test
+    void listModelInvocationJobs_filtersAndPagination() {
+        Instant now = Instant.now();
+
+        ModelInvocationJob job1 = new ModelInvocationJob(
+                "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/job1",
+                "alpha-job", "model1", null, "role1",
+                ModelInvocationJobStatus.COMPLETED, null,
+                now.minus(10, ChronoUnit.MINUTES), now, now, now.plus(1, ChronoUnit.DAYS),
+                24, null, null, null, null
+        );
+
+        ModelInvocationJob job2 = new ModelInvocationJob(
+                "arn:aws:bedrock:us-east-1:000000000000:model-invocation-job/job2",
+                "beta-job", "model2", null, "role2",
+                ModelInvocationJobStatus.FAILED, null,
+                now.minus(5, ChronoUnit.MINUTES), now, now, now.plus(1, ChronoUnit.DAYS),
+                24, null, null, null, null
+        );
+
+        service.clear();
+
+        // Inject jobs
+        service.createModelInvocationJob(createValidRequest("job1", "s3://b/in", "s3://b/out"), REGION);
+        service.createModelInvocationJob(createValidRequest("beta-job", "s3://b/in", "s3://b/out"), REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            // List all
+            PaginatedResult<ModelInvocationJobSummary> all = service.listModelInvocationJobs(
+                    null, null, null, null, null, "Descending", 10, null, REGION
+            );
+            assertEquals(2, all.items().size());
+
+            // Filter by nameContains
+            PaginatedResult<ModelInvocationJobSummary> betaFilter = service.listModelInvocationJobs(
+                    null, "beta", null, null, null, null, 10, null, REGION
+            );
+            assertEquals(1, betaFilter.items().size());
+            assertEquals("beta-job", betaFilter.items().getFirst().jobName());
+
+            // Filter by statusEquals
+            PaginatedResult<ModelInvocationJobSummary> completedFilter = service.listModelInvocationJobs(
+                    ModelInvocationJobStatus.COMPLETED, null, null, null, null, null, 10, null, REGION
+            );
+            assertEquals(0, completedFilter.items().size()); // they failed because s3 wasn't mocked to return data for these, so they are FAILED
+        });
+    }
+
+    @Test
+    void parseS3Uri_tests() {
+        BedrockService.S3Location loc1 = BedrockService.parseS3Uri("s3://my-bucket/path/to/file.jsonl");
+        assertEquals("my-bucket", loc1.bucket());
+        assertEquals("path/to/file.jsonl", loc1.key());
+
+        BedrockService.S3Location loc2 = BedrockService.parseS3Uri("s3://my-bucket");
+        assertEquals("my-bucket", loc2.bucket());
+        assertEquals("", loc2.key());
+
+        assertThrows(AwsException.class, () -> BedrockService.parseS3Uri("http://not-s3"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
@@ -314,6 +314,89 @@ class BedrockServiceTest {
     }
 
     @Test
+    void createModelInvocationJob_roleAccessDeniedInput_fails() {
+        String inputBucket = "test-input-bucket";
+        String inputKey = "data/prompts.jsonl";
+        String inputUri = "s3://" + inputBucket + "/" + inputKey;
+        String outputUri = "s3://test-output-bucket/results";
+
+        org.mockito.Mockito.doThrow(new AwsException("AccessDenied", "Access Denied", 403))
+                .when(s3Service).authorizeRoleAccess(
+                        eq("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+                        eq(inputBucket),
+                        eq(inputKey),
+                        eq("s3:GetObject")
+                );
+
+        CreateModelInvocationJobRequest req = createValidRequest("role-denied-in-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.FAILED, job.getStatus());
+            assertTrue(job.getMessage().contains("Access denied reading input S3 location"));
+        });
+    }
+
+    @Test
+    void createModelInvocationJob_roleAccessDeniedOutput_fails() {
+        String inputBucket = "test-input-bucket";
+        String inputKey = "data/prompts.jsonl";
+        String inputUri = "s3://" + inputBucket + "/" + inputKey;
+        String outputUri = "s3://test-output-bucket/results";
+
+        String jsonlContent = "{\"recordId\": \"rec-1\", \"modelInput\": {\"anthropic_version\": \"bedrock-2023-05-31\", \"messages\": [{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello\"}]}]}}\n";
+        S3Object s3Object = new S3Object(inputBucket, inputKey, jsonlContent.getBytes(StandardCharsets.UTF_8), "application/jsonlines");
+        when(s3Service.getObject(eq(inputBucket), eq(inputKey))).thenReturn(s3Object);
+
+        org.mockito.Mockito.doThrow(new AwsException("AccessDenied", "Access Denied", 403))
+                .when(s3Service).authorizeRoleAccess(
+                        eq("arn:aws:iam::000000000000:role/BedrockBatchRole"),
+                        eq("test-output-bucket"),
+                        any(),
+                        eq("s3:PutObject")
+                );
+
+        CreateModelInvocationJobRequest req = createValidRequest("role-denied-out-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.FAILED, job.getStatus());
+            assertTrue(job.getMessage().contains("Access denied writing output S3 location"));
+        });
+    }
+
+    @Test
+    void stopModelInvocationJob_stoppedJobNeverWritesOutput() {
+        String inputBucket = "slow-input-bucket-2";
+        String inputUri = "s3://" + inputBucket + "/data.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+
+        when(s3Service.getObject(eq(inputBucket), eq("data.jsonl"))).thenAnswer(inv -> {
+            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+            return new S3Object(inputBucket, "data.jsonl",
+                    "{\"recordId\": \"rec-1\", \"modelInput\": {\"anthropic_version\": \"bedrock-2023-05-31\", \"messages\": [{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hi\"}]}]}}\n"
+                            .getBytes(StandardCharsets.UTF_8), "application/jsonlines");
+        });
+
+        CreateModelInvocationJobRequest req = createValidRequest("stop-no-write-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        // Stop the job while it's in flight
+        service.stopModelInvocationJob(response.jobArn(), REGION);
+
+        // Wait to allow background worker to exit
+        try { Thread.sleep(400); } catch (InterruptedException ignored) {}
+
+        ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+        assertEquals(ModelInvocationJobStatus.STOPPED, job.getStatus());
+
+        // Verify S3 putObject was NEVER called
+        org.mockito.Mockito.verify(s3Service, org.mockito.Mockito.never()).putObject(any(), any(), any(), any(), any());
+    }
+
+    @Test
     void stopModelInvocationJob_activeJob_transitionsToStoppedAndDoesNotGetOverwritten() {
         String inputBucket = "slow-input-bucket";
         String inputUri = "s3://" + inputBucket + "/data.jsonl";

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
@@ -157,6 +157,17 @@ class BedrockServiceTest {
                 null, 24, null
         );
         assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqNoOutput, REGION));
+
+        // foreign roleArn (different account than caller)
+        CreateModelInvocationJobRequest reqForeignRole = new CreateModelInvocationJobRequest(
+                "jobName", "modelId", "arn:aws:iam::999999999999:role/ForeignRole", "token",
+                new InputDataConfig(new InputDataConfig.S3InputDataConfig("s3://b/in", null, null)),
+                new OutputDataConfig(new OutputDataConfig.S3OutputDataConfig("s3://b/out", null, null)),
+                null, 24, null
+        );
+        AwsException ex = assertThrows(AwsException.class, () -> service.createModelInvocationJob(reqForeignRole, REGION));
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("does not belong to the calling account"));
     }
 
     @Test
@@ -275,6 +286,61 @@ class BedrockServiceTest {
             assertTrue(job.getMessage().contains("000000000000"));
             assertTrue(job.getMessage().contains("999999999999"));
         });
+    }
+
+    @Test
+    void createModelInvocationJob_crossAccountOutputBucket_fails() {
+        String inputBucket = "my-input-bucket";
+        String outputBucket = "foreign-output-bucket";
+        String inputUri = "s3://" + inputBucket + "/data.jsonl";
+        String outputUri = "s3://" + outputBucket + "/results";
+
+        String jsonlContent = "{\"recordId\": \"rec-1\", \"modelInput\": {\"anthropic_version\": \"bedrock-2023-05-31\", \"messages\": [{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hello\"}]}]}}\n";
+        S3Object s3Object = new S3Object(inputBucket, "data.jsonl", jsonlContent.getBytes(StandardCharsets.UTF_8), "application/jsonlines");
+        when(s3Service.getObject(eq(inputBucket), eq("data.jsonl"))).thenReturn(s3Object);
+        when(s3Service.getBucketOwnerAccountId(eq(inputBucket))).thenReturn(ACCOUNT_ID);
+        // Output bucket belongs to a different account
+        when(s3Service.getBucketOwnerAccountId(eq(outputBucket))).thenReturn("999999999999");
+
+        CreateModelInvocationJobRequest req = createValidRequest("cross-account-out-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.FAILED, job.getStatus());
+            assertTrue(job.getMessage().contains("Access denied"));
+            assertTrue(job.getMessage().contains(outputBucket));
+        });
+    }
+
+    @Test
+    void stopModelInvocationJob_activeJob_transitionsToStoppedAndDoesNotGetOverwritten() {
+        String inputBucket = "slow-input-bucket";
+        String inputUri = "s3://" + inputBucket + "/data.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+
+        // Provide input that triggers delay or stop
+        when(s3Service.getObject(eq(inputBucket), eq("data.jsonl"))).thenAnswer(inv -> {
+            try { Thread.sleep(200); } catch (InterruptedException ignored) {}
+            return new S3Object(inputBucket, "data.jsonl",
+                    "{\"recordId\": \"rec-1\", \"modelInput\": {\"anthropic_version\": \"bedrock-2023-05-31\", \"messages\": [{\"role\": \"user\", \"content\": [{\"type\": \"text\", \"text\": \"Hi\"}]}]}}\n"
+                            .getBytes(StandardCharsets.UTF_8), "application/jsonlines");
+        });
+
+        CreateModelInvocationJobRequest req = createValidRequest("stop-race-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        // Stop the job while it's in flight
+        service.stopModelInvocationJob(response.jobArn(), REGION);
+
+        // Verify status is STOPPED and remains STOPPED
+        ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+        assertEquals(ModelInvocationJobStatus.STOPPED, job.getStatus());
+
+        // Wait a bit to ensure background worker does not overwrite STOPPED
+        try { Thread.sleep(400); } catch (InterruptedException ignored) {}
+        ModelInvocationJob afterWait = service.getModelInvocationJob(response.jobArn(), REGION);
+        assertEquals(ModelInvocationJobStatus.STOPPED, afterWait.getStatus());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrock/BedrockServiceTest.java
@@ -33,10 +33,12 @@ import java.util.Collections;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,6 +76,10 @@ class BedrockServiceTest {
 
         bedrockRuntimeService = new BedrockRuntimeService(config, stubBackend, null);
         s3Service = mock(S3Service.class);
+        // headBucket succeeds by default (bucket exists); tests that need failure override this.
+        doNothing().when(s3Service).headBucket(any());
+        // Buckets belong to the same account as the roleArn used in createValidRequest.
+        when(s3Service.getBucketOwnerAccountId(any())).thenReturn(ACCOUNT_ID);
         eventBridgeService = mock(EventBridgeService.class);
 
         service = new BedrockService(
@@ -234,6 +240,44 @@ class BedrockServiceTest {
     }
 
     @Test
+    void createModelInvocationJob_inputBucketNotFound_fails() {
+        String inputUri = "s3://non-existent-bucket/file.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+
+        org.mockito.Mockito.doThrow(new AwsException("NoSuchBucket", "The specified bucket does not exist", 404))
+                .when(s3Service).headBucket(eq("non-existent-bucket"));
+
+        CreateModelInvocationJobRequest req = createValidRequest("bucket-not-found-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.FAILED, job.getStatus());
+            assertTrue(job.getMessage().contains("non-existent-bucket"));
+        });
+    }
+
+    @Test
+    void createModelInvocationJob_crossAccountBucket_fails() {
+        String inputUri = "s3://foreign-bucket/data.jsonl";
+        String outputUri = "s3://test-output-bucket/results";
+
+        // Bucket exists but belongs to a different account than the roleArn (000000000000).
+        when(s3Service.getBucketOwnerAccountId(eq("foreign-bucket"))).thenReturn("999999999999");
+
+        CreateModelInvocationJobRequest req = createValidRequest("cross-account-job", inputUri, outputUri);
+        CreateModelInvocationJobResponse response = service.createModelInvocationJob(req, REGION);
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            ModelInvocationJob job = service.getModelInvocationJob(response.jobArn(), REGION);
+            assertEquals(ModelInvocationJobStatus.FAILED, job.getStatus());
+            assertTrue(job.getMessage().contains("Access denied"));
+            assertTrue(job.getMessage().contains("000000000000"));
+            assertTrue(job.getMessage().contains("999999999999"));
+        });
+    }
+
+    @Test
     void getModelInvocationJob_resolvesByIdArnOrName() {
         String inputUri = "s3://test-input-bucket/prompts.jsonl";
         String outputUri = "s3://test-output-bucket/results";
@@ -334,6 +378,17 @@ class BedrockServiceTest {
             );
             assertEquals(0, completedFilter.items().size()); // they failed because s3 wasn't mocked to return data for these, so they are FAILED
         });
+    }
+
+    @Test
+    void extractAccountIdFromRoleArn_tests() {
+        assertEquals("000000000000", BedrockService.extractAccountIdFromRoleArn(
+                "arn:aws:iam::000000000000:role/BedrockBatchRole"));
+        assertEquals("123456789012", BedrockService.extractAccountIdFromRoleArn(
+                "arn:aws:iam::123456789012:role/some-role"));
+        assertNull(BedrockService.extractAccountIdFromRoleArn(null));
+        assertNull(BedrockService.extractAccountIdFromRoleArn(""));
+        assertNull(BedrockService.extractAccountIdFromRoleArn("not-an-arn"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockProxyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/bedrockruntime/BedrockProxyIntegrationTest.java
@@ -679,16 +679,36 @@ class BedrockProxyIntegrationTest {
     }
 
     @Test
-    void invokeModel_notSupportedByProxyBackend_returns400() {
+    void invokeModel_translatesToOpenAiAndFormatsBedrockResponse() {
+        nextResponseBody.set("""
+            {
+              "choices": [{
+                "finish_reason": "stop",
+                "message": {"role": "assistant", "content": "Hello from invokeModel proxy!"}
+              }],
+              "usage": {"prompt_tokens": 10, "completion_tokens": 12, "total_tokens": 22}
+            }
+            """);
+
         given()
             .contentType("application/json")
             .header("Authorization", AUTH_HEADER)
-            .body("{}")
+            .body("""
+                {
+                  "anthropic_version": "bedrock-2023-05-31",
+                  "max_tokens": 100,
+                  "messages": [{"role": "user", "content": [{"type": "text", "text": "Hello"}]}]
+                }
+                """)
         .when()
             .post("/model/" + MAPPED_MODEL_ID + "/invoke")
         .then()
-            .statusCode(400)
-            .body("__type", equalTo("ValidationException"));
+            .statusCode(200)
+            .body("type", equalTo("message"))
+            .body("role", equalTo("assistant"))
+            .body("content[0].text", equalTo("Hello from invokeModel proxy!"))
+            .body("usage.input_tokens", equalTo(10))
+            .body("usage.output_tokens", equalTo(12));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -76,6 +76,37 @@ class S3ServiceTest {
     }
 
     @Test
+    void getBucketOwnerAccountId_returnsFallbackOwnerWhenBucketExists() {
+        // Without globalBucketNamespace the backend is a plain InMemoryStorage,
+        // so the service falls back to ownerId() ("000000000000" via RegionResolver default).
+        s3Service.createBucket("owner-bucket", "us-east-1");
+        String owner = s3Service.getBucketOwnerAccountId("owner-bucket");
+        assertNotNull(owner);
+    }
+
+    @Test
+    void getBucketOwnerAccountId_returnsNullForMissingBucket() {
+        assertNull(s3Service.getBucketOwnerAccountId("no-such-bucket"));
+    }
+
+    @Test
+    void getBucketOwnerAccountId_withGlobalNamespace_returnsOwningAccount() {
+        // Use a two-account setup with globalBucketNamespace enabled.
+        io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend<io.github.hectorvent.floci.services.s3.model.Bucket> bucketStore =
+                io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend.inMemory("account-A");
+        io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend<io.github.hectorvent.floci.services.s3.model.S3Object> objectStore =
+                io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend.inMemory("account-A");
+        S3Service svcA = new S3Service(bucketStore, objectStore, tempDir.resolve("s3-gbn"), true, true);
+        svcA.createBucket("gbn-bucket", "us-east-1");
+
+        // account-B context resolves the same bucket cross-account.
+        S3Service svcB = new S3Service(bucketStore, objectStore, tempDir.resolve("s3-gbn"), true, true);
+        String owner = svcB.getBucketOwnerAccountId("gbn-bucket");
+        // The bucket was created under account-A's partition, so the owner must be "account-A".
+        assertEquals("account-A", owner);
+    }
+
+    @Test
     void objectExistsReturnsFalseForMissingKey() {
         s3Service.createBucket("exists-bucket", "us-east-1");
         assertFalse(s3Service.objectExists("exists-bucket", "no-such-key"));

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -107,6 +107,119 @@ class S3ServiceTest {
     }
 
     @Test
+    void authorizeRoleAccess_unmodeledRole_allows() {
+        s3Service.createBucket("auth-bucket", "us-east-1");
+        assertDoesNotThrow(() -> s3Service.authorizeRoleAccess(
+                "arn:aws:iam::000000000000:role/SyntheticRole",
+                "auth-bucket",
+                "data/prompts.jsonl",
+                "s3:GetObject"
+        ));
+    }
+
+    @Test
+    void authorizeRoleAccess_missingBucket_throwsNoSuchBucket() {
+        AwsException ex = assertThrows(AwsException.class, () -> s3Service.authorizeRoleAccess(
+                "arn:aws:iam::000000000000:role/SyntheticRole",
+                "missing-bucket",
+                "data/prompts.jsonl",
+                "s3:GetObject"
+        ));
+        assertEquals(404, ex.getHttpStatus());
+        assertEquals("NoSuchBucket", ex.getErrorCode());
+    }
+
+    @Test
+    void authorizeRoleAccess_bucketPolicyDeny_throwsAccessDenied() {
+        s3Service.createBucket("deny-bucket", "us-east-1");
+        String denyPolicy = """
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Deny",
+                            "Principal": {
+                                "AWS": "arn:aws:iam::000000000000:role/DeniedRole"
+                            },
+                            "Action": "s3:GetObject",
+                            "Resource": "arn:aws:s3:::deny-bucket/*"
+                        }
+                    ]
+                }
+                """;
+        s3Service.putBucketPolicy("deny-bucket", denyPolicy);
+
+        AwsException ex = assertThrows(AwsException.class, () -> s3Service.authorizeRoleAccess(
+                "arn:aws:iam::000000000000:role/DeniedRole",
+                "deny-bucket",
+                "data/prompts.jsonl",
+                "s3:GetObject"
+        ));
+        assertEquals(403, ex.getHttpStatus());
+        assertEquals("AccessDenied", ex.getErrorCode());
+    }
+
+    @Test
+    void authorizeRoleAccess_iamServiceExplicitDeny_throwsAccessDenied() {
+        io.github.hectorvent.floci.services.iam.IamService iamService = org.mockito.Mockito.mock(io.github.hectorvent.floci.services.iam.IamService.class);
+        String denyDoc = """
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Deny",
+                            "Action": "s3:GetObject",
+                            "Resource": "*"
+                        }
+                    ]
+                }
+                """;
+        org.mockito.Mockito.when(iamService.resolvePrincipalContext(org.mockito.ArgumentMatchers.eq("arn:aws:iam::000000000000:role/DeniedIamRole")))
+                .thenReturn(new io.github.hectorvent.floci.services.iam.model.CallerContext(List.of(denyDoc), null, null));
+
+        S3Service svcWithIam = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir.resolve("s3-iam"), true, iamService);
+        svcWithIam.createBucket("iam-bucket", "us-east-1");
+
+        AwsException ex = assertThrows(AwsException.class, () -> svcWithIam.authorizeRoleAccess(
+                "arn:aws:iam::000000000000:role/DeniedIamRole",
+                "iam-bucket",
+                "data/prompts.jsonl",
+                "s3:GetObject"
+        ));
+        assertEquals(403, ex.getHttpStatus());
+        assertEquals("AccessDenied", ex.getErrorCode());
+    }
+
+    @Test
+    void authorizeRoleAccess_iamServiceAllow_succeeds() {
+        io.github.hectorvent.floci.services.iam.IamService iamService = org.mockito.Mockito.mock(io.github.hectorvent.floci.services.iam.IamService.class);
+        String allowDoc = """
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": "s3:GetObject",
+                            "Resource": "arn:aws:s3:::iam-bucket/*"
+                        }
+                    ]
+                }
+                """;
+        org.mockito.Mockito.when(iamService.resolvePrincipalContext(org.mockito.ArgumentMatchers.eq("arn:aws:iam::000000000000:role/AllowedIamRole")))
+                .thenReturn(new io.github.hectorvent.floci.services.iam.model.CallerContext(List.of(allowDoc), null, null));
+
+        S3Service svcWithIam = new S3Service(new InMemoryStorage<>(), new InMemoryStorage<>(), tempDir.resolve("s3-iam-allow"), true, iamService);
+        svcWithIam.createBucket("iam-bucket", "us-east-1");
+
+        assertDoesNotThrow(() -> svcWithIam.authorizeRoleAccess(
+                "arn:aws:iam::000000000000:role/AllowedIamRole",
+                "iam-bucket",
+                "data/prompts.jsonl",
+                "s3:GetObject"
+        ));
+    }
+
+    @Test
     void objectExistsReturnsFalseForMissingKey() {
         s3Service.createBucket("exists-bucket", "us-east-1");
         assertFalse(s3Service.objectExists("exists-bucket", "no-such-key"));

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -22,6 +22,10 @@ services:
     doc: docs/services/athena.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java, mode: switch }
+  - service: bedrock
+    doc: docs/services/bedrock.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/bedrock/BedrockController.java, mode: rest }
   - service: cloudformation
     doc: docs/services/cloudformation.md
     sources:


### PR DESCRIPTION
## Summary

Adds support for Amazon Bedrock Batch Model Invocation Jobs:

* `CreateModelInvocationJob`
* `GetModelInvocationJob`
* `ListModelInvocationJobs`
* `StopModelInvocationJob`

This enables applications, data pipelines, and CI environments to exercise the Bedrock batch workflow locally using their existing AWS SDK or CLI clients, without requiring dedicated mocks.

Floci manages the asynchronous job lifecycle, reads and writes JSONL datasets from S3, generates AWS-compatible output manifests, publishes EventBridge job state events, and delegates inference to Floci's runtime stub or an OpenAI-compatible proxy backend.

## Type of change

* [ ] Bug fix (`fix:`)
* [x] New feature (`feat:`)
* [ ] Breaking change (`feat!:` or `fix!:`)
* [ ] Docs / chore

## AWS Compatibility

Verified against real AWS SDK clients and the AWS CLI:

* **AWS CLI v2** — create, get, list, and stop batch jobs
* **Python boto3** — job lifecycle, pagination, S3 outputs, and error handling
* **Java SDK v2** — batch invocation integration tests
* **Node.js** (`@aws-sdk/client-bedrock` `3.750.0`) — batch job lifecycle and status filtering
* **Go** (`aws-sdk-go-v2/service/bedrock` `1.69.1`) — job submission, retrieval, listing, and stopping

Request and response shapes are compatible with the AWS Bedrock REST JSON API for `/model-invocation-job` and `/model-invocation-jobs`.

The implementation supports the following asynchronous lifecycle states:

`Submitted → Validating → Scheduled → InProgress → Completed / PartiallyCompleted / Failed / Stopped`

Job state changes are published as `Bedrock Job State Change` events to the EventBridge `default` bus.

S3 input and output handling supports Anthropic Claude, Amazon Titan, and Meta Llama batch formats, including generation of:

* `<inputFilename>.out`
* `manifest.json.out`

Floci intentionally relaxes AWS's minimum batch record requirements to support lightweight local and CI tests, including single-record and small batch jobs.

## Implementation

### Batch Job API

`BedrockController` implements:

* `CreateModelInvocationJob`
* `GetModelInvocationJob`
* `ListModelInvocationJobs`
* `StopModelInvocationJob`

Listing supports pagination, status filtering, and sorting.

### Job Execution

`BedrockService` manages:

* asynchronous job execution
* S3 input dataset retrieval
* record validation
* inference delegation
* S3 output generation
* manifest generation
* EventBridge status notifications
* job lifecycle and error handling

### Runtime / Proxy Integration

`BedrockOpenAiTranslator` and `ProxyBackend` add `InvokeModel` request/response translation for OpenAI-compatible backends alongside existing `Converse` support.

Supported scenarios include:

* Anthropic Claude
* Amazon Titan
* Meta Llama
* vision payloads
* model parameter mapping

This allows batch jobs to execute against local or external OpenAI-compatible backends such as Ollama, vLLM, LiteLLM, or OpenRouter.

### Configuration

Updated:

* `EmulatorConfig`
* `application.yml`
* `ResolvedServiceCatalog`

The `bedrock` service is registered under the REST JSON protocol and exposes the required configuration properties.

### Documentation

Added:

`docs/services/bedrock.md`

The documentation covers:

* batch job submission
* job lifecycle
* S3 input/output formats
* manifest generation
* EventBridge notifications
* runtime/proxy configuration

## Tests

Added unit and integration coverage for:

* `BedrockIntegrationTest`
* `BedrockBatchS3IntegrationTest`
* `BedrockEventBridgeIntegrationTest`
* `BedrockProxyBatchIntegrationTest`
* `BedrockServiceTest`

The test suites cover:

* job lifecycle
* S3 input/output handling
* output parsing
* manifest generation
* EventBridge events
* proxy-backed inference
* error handling

Multi-SDK compatibility tests were also added under `compatibility-tests/`:

* AWS CLI / BATS
* Python / pytest / boto3
* Java / JUnit
* Node.js / Vitest
* Go / testing

## How to test locally

### With Docker Compose (Ollama Proxy)

```yaml
services:
  floci:
    image: floci/floci:latest
    ports: ["4566:4566"]
    environment:
      FLOCI_SERVICES_BEDROCK_RUNTIME_BACKEND: proxy
      FLOCI_SERVICES_BEDROCK_RUNTIME_PROXY_URL: http://ollama:11434/v1
      FLOCI_SERVICES_BEDROCK_RUNTIME_PROXY_DEFAULT_MODEL: gemma4:e2b

  ollama:
    image: ollama/ollama:latest
```

### CLI / Dev mode

1. **Create the S3 bucket and upload the input dataset:**

```bash
aws s3 mb s3://batch --endpoint-url http://localhost:4566

echo '{"recordId":"rec-1","modelInput":{"messages":[{"role":"user","content":[{"text":"Say \"Floci\"."}]}],"inferenceConfig":{"maxTokens":256}}}' > prompts.jsonl

aws s3 cp prompts.jsonl s3://batch/prompts.jsonl \
  --endpoint-url http://localhost:4566
```

2. **Submit the batch job:**

```bash
JOB_ARN=$(aws bedrock create-model-invocation-job \
  --endpoint-url http://localhost:4566 \
  --job-name "batch-test-01" \
  --model-id "anthropic.claude-sonnet-4-6" \
  --role-arn "arn:aws:iam::000000000000:role/BedrockBatchRole" \
  --input-data-config '{"s3InputDataConfig":{"s3Uri":"s3://batch/prompts.jsonl"}}' \
  --output-data-config '{"s3OutputDataConfig":{"s3Uri":"s3://batch/results"}}' \
  --query 'jobArn' \
  --output text)

JOB_ID="${JOB_ARN##*/}"
```

3. **Check the job status and inspect the generated output:**

```bash
aws bedrock get-model-invocation-job \
  --job-identifier "$JOB_ID" \
  --endpoint-url http://localhost:4566

aws s3 cp "s3://batch/results/$JOB_ID/prompts.jsonl.out" - \
  --endpoint-url http://localhost:4566

aws s3 cp "s3://batch/results/$JOB_ID/manifest.json.out" - \
  --endpoint-url http://localhost:4566
```

## Checklist

* [x] `./mvnw test` passes locally
* [x] New or updated integration test added
* [x] Commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)