### PR TITLE
fix(ec2): guard null group entries in DescribeNetworkInterfaces group-id filter

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -5340,7 +5340,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 case "subnet-id" -> matchesValue(values, ni.getSubnetId());
                 case "vpc-id" -> matchesValue(values, ni.getVpcId());
                 case "group-id" -> ni.getGroups().stream()
-                        .anyMatch(g -> matchesValue(values, g.getGroupId()));
+                        .anyMatch(g -> g != null && matchesValue(values, g.getGroupId()));
                 case "status" -> matchesValue(values, ni.getStatus());
                 case "attachment.instance-id" -> ni.getAttachment() != null
                         && matchesValue(values, ni.getAttachment().getInstanceId());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ec2.model.EbsBlockDevice;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
 import io.github.hectorvent.floci.services.ec2.model.Image;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
+import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceListResult;
 import io.github.hectorvent.floci.services.ec2.model.IpPermission;
 import io.github.hectorvent.floci.services.ec2.model.Ipv6Range;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
@@ -81,6 +82,28 @@ class Ec2ServiceTest {
         service.terminateInstances("us-east-1", List.of(instanceId));
         assertFalse(service.isInstanceContainerRunning(instanceId));
         verifyNoInteractions(containerManager);
+    }
+
+    @Test
+    void describeNetworkInterfacesGroupIdFilterSkipsNullGroupEntry() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Reservation reservation = service.runInstances("us-east-1", "ami-1234567890abcdef0", "t3.micro",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+        Instance inst = reservation.getInstances().getFirst();
+        String groupId = inst.getNetworkInterfaces().getFirst().getGroups().getFirst().getGroupId();
+        // A null entry in an interface's group list must not crash the group-id filter: the interface
+        // is still matched on its real group and the null is skipped. Regression: matchesFilter
+        // dereferenced the entry with no null-guard, so DescribeNetworkInterfaces returned a 500 that
+        // hung a Terraform/Pulumi security-group delete (it polls this call until the group is gone).
+        inst.getNetworkInterfaces().getFirst().getGroups().add(null);
+
+        NetworkInterfaceListResult result = service.describeNetworkInterfaces("us-east-1", List.of(),
+                Map.of("group-id", List.of(groupId)), 0, null);
+
+        assertEquals(1, result.networkInterfaces().size());
     }
 
     @Test


### PR DESCRIPTION
The `group-id` filter in `DescribeNetworkInterfaces` dereferences every group entry on an interface without a null check, so a single null entry makes the whole call return a 500.

`matchesFilter` runs `ni.getGroups().stream().anyMatch(g -> matchesValue(values, g.getGroupId()))`. A null element throws NPE at `g.getGroupId()`. The sibling cases in the same switch already guard for this (`attachment.instance-id` checks `getAttachment() != null`); `group-id` was the one that did not.

Why it matters: a Terraform-based AWS provider polls `DescribeNetworkInterfaces` filtered by `group-id` while deleting a security group, to wait until no interface still references it. A 500 there is not retryable cleanly, so the delete spins in a retry loop until the client times out. I hit this deleting a security group against floci 2.0.0 through the Pulumi AWS provider (which bridges the Terraform AWS provider): the delete never completed, and `docker logs` showed the NPE looping on `Ec2Service.describeNetworkInterfaces` (the native image reports it at the inlined `matchesFilters` call site).

Fix: guard each group entry, matching the null-tolerant style of the adjacent filters. A malformed group entry now skips instead of crashing the request.

Test: `Ec2ServiceTest#describeNetworkInterfacesGroupIdFilterSkipsNullGroupEntry` launches an instance, adds a null entry to its interface's group list, and asserts the `group-id` filter still returns the interface (it errored with the NPE before the guard).

Verified locally: `mvn test -Dtest=Ec2ServiceTest` (121 pass) and `-Dtest=Ec2IntegrationTest` (182 pass) on JDK 25.
