### PR TITLE
feat(ec2): honour AmazonProvidedIpv6CidrBlock on a VPC

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -969,7 +969,8 @@ public class Ec2QueryHandler {
 
     private Response handleCreateVpc(MultivaluedMap<String, String> p, String region) {
         String cidrBlock = p.getFirst("CidrBlock");
-        Vpc vpc = service.createVpc(region, cidrBlock, false);
+        boolean amazonProvidedIpv6 = "true".equalsIgnoreCase(p.getFirst("AmazonProvidedIpv6CidrBlock"));
+        Vpc vpc = service.createVpc(region, cidrBlock, false, amazonProvidedIpv6);
         List<Tag> vpcTags = new ArrayList<>();
         for (int i = 1; ; i++) {
             String resType = p.getFirst("TagSpecification." + i + ".ResourceType");
@@ -2265,6 +2266,18 @@ public class Ec2QueryHandler {
     private Response handleAssociateVpcCidrBlock(MultivaluedMap<String, String> p, String region) {
         String vpcId = p.getFirst("VpcId");
         String cidrBlock = p.getFirst("CidrBlock");
+        if ("true".equalsIgnoreCase(p.getFirst("AmazonProvidedIpv6CidrBlock"))) {
+            VpcIpv6CidrBlockAssociation ipv6 = service.associateAmazonProvidedIpv6CidrBlock(region, vpcId);
+            XmlBuilder ipv6Xml = new XmlBuilder()
+                    .start("AssociateVpcCidrBlockResponse", AwsNamespaces.EC2)
+                    .elem("requestId", UUID.randomUUID().toString())
+                    .elem("vpcId", vpcId)
+                    .start("ipv6CidrBlockAssociation")
+                    .raw(vpcIpv6AssociationXml(ipv6))
+                    .end("ipv6CidrBlockAssociation")
+                    .end("AssociateVpcCidrBlockResponse");
+            return xmlResponse(ipv6Xml.build());
+        }
         VpcCidrBlockAssociation assoc = service.associateVpcCidrBlock(region, vpcId, cidrBlock);
         XmlBuilder xml = new XmlBuilder()
                 .start("AssociateVpcCidrBlockResponse", AwsNamespaces.EC2)
@@ -2277,6 +2290,16 @@ public class Ec2QueryHandler {
                 .end("cidrBlockAssociation")
                 .end("AssociateVpcCidrBlockResponse");
         return xmlResponse(xml.build());
+    }
+
+    private String vpcIpv6AssociationXml(VpcIpv6CidrBlockAssociation assoc) {
+        return new XmlBuilder()
+                .elem("associationId", assoc.getAssociationId())
+                .elem("ipv6CidrBlock", assoc.getIpv6CidrBlock())
+                .start("ipv6CidrBlockState").elem("state", assoc.getIpv6CidrBlockState()).end("ipv6CidrBlockState")
+                .elem("ipv6Pool", assoc.getIpv6Pool())
+                .elem("networkBorderGroup", assoc.getNetworkBorderGroup())
+                .build();
     }
 
     private Response handleDisassociateVpcCidrBlock(MultivaluedMap<String, String> p, String region) {
@@ -3717,7 +3740,12 @@ public class Ec2QueryHandler {
                     .start("cidrBlockState").elem("state", assoc.getCidrBlockState()).end("cidrBlockState")
                     .end("item");
         }
-        xml.end("cidrBlockAssociationSet")
+        xml.end("cidrBlockAssociationSet");
+        xml.start("ipv6CidrBlockAssociationSet");
+        for (VpcIpv6CidrBlockAssociation assoc : vpc.getIpv6CidrBlockAssociationSet()) {
+            xml.start("item").raw(vpcIpv6AssociationXml(assoc)).end("item");
+        }
+        xml.end("ipv6CidrBlockAssociationSet")
                 .raw(tagSetXml(vpc.getTags()));
         return xml.build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2810,7 +2810,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     }
 
     /**
-     * Associates an Amazon-provided IPv6 block with an existing VPC — the AssociateVpcCidrBlock
+     * Associates an Amazon-provided IPv6 block with an existing VPC: the AssociateVpcCidrBlock
      * half of {@code AmazonProvidedIpv6CidrBlock}, which the Terraform provider issues when
      * assign_generated_ipv6_cidr_block is turned on for a VPC that already exists.
      */
@@ -2826,7 +2826,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     /**
      * Allocates a /56 the way an Amazon-provided association looks on the wire. AWS hands out a
      * block from its own pool with no say from the caller, so the exact prefix is not something a
-     * client can predict or assert on — what matters is that one is returned at all, that it is a
+     * client can predict or assert on, what matters is that one is returned at all, that it is a
      * well-formed /56, and that it comes back unchanged on every later read.
      */
     private VpcIpv6CidrBlockAssociation amazonProvidedIpv6Association(String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -94,6 +94,7 @@ import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
 import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcCidrBlockAssociation;
+import io.github.hectorvent.floci.services.ec2.model.VpcIpv6CidrBlockAssociation;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
 import io.github.hectorvent.floci.services.ec2.model.VpcPeeringConnection;
 import io.github.hectorvent.floci.services.ec2.model.VpcPeeringConnectionStateReason;
@@ -2717,6 +2718,11 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     // ─── VPCs ──────────────────────────────────────────────────────────────────
 
     public Vpc createVpc(String region, String cidrBlock, boolean isDefault) {
+        return createVpc(region, cidrBlock, isDefault, false);
+    }
+
+    public Vpc createVpc(String region, String cidrBlock, boolean isDefault,
+                         boolean amazonProvidedIpv6CidrBlock) {
         ensureDefaultResources(region);
         String vpcId = "vpc-" + randomHex(8);
         Vpc vpc = new Vpc();
@@ -2728,6 +2734,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         vpc.setRegion(region);
         vpc.getCidrBlockAssociationSet().add(
                 new VpcCidrBlockAssociation("vpc-cidr-assoc-" + randomHex(8), cidrBlock));
+        if (amazonProvidedIpv6CidrBlock) {
+            vpc.getIpv6CidrBlockAssociationSet().add(amazonProvidedIpv6Association(region));
+        }
         vpcs.put(key(region, vpcId), vpc);
 
         createDefaultSecurityGroup(region, vpcId, "sg-" + randomHex(17));
@@ -2800,11 +2809,39 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         return assoc;
     }
 
+    /**
+     * Associates an Amazon-provided IPv6 block with an existing VPC — the AssociateVpcCidrBlock
+     * half of {@code AmazonProvidedIpv6CidrBlock}, which the Terraform provider issues when
+     * assign_generated_ipv6_cidr_block is turned on for a VPC that already exists.
+     */
+    public VpcIpv6CidrBlockAssociation associateAmazonProvidedIpv6CidrBlock(String region, String vpcId) {
+        ensureDefaultResources(region);
+        Vpc vpc = getRequiredVpc(region, vpcId);
+        VpcIpv6CidrBlockAssociation assoc = amazonProvidedIpv6Association(region);
+        vpc.getIpv6CidrBlockAssociationSet().add(assoc);
+        vpcs.put(key(region, vpcId), vpc);
+        return assoc;
+    }
+
+    /**
+     * Allocates a /56 the way an Amazon-provided association looks on the wire. AWS hands out a
+     * block from its own pool with no say from the caller, so the exact prefix is not something a
+     * client can predict or assert on — what matters is that one is returned at all, that it is a
+     * well-formed /56, and that it comes back unchanged on every later read.
+     */
+    private VpcIpv6CidrBlockAssociation amazonProvidedIpv6Association(String region) {
+        String block = "2600:1f18:" + randomHex(4) + ":" + randomHex(2) + "00::/56";
+        return new VpcIpv6CidrBlockAssociation("vpc-cidr-assoc-" + randomHex(8), block, region);
+    }
+
     public void disassociateVpcCidrBlock(String region, String associationId) {
         ensureDefaultResources(region);
         for (Vpc vpc : vpcs.scan(k -> true)) {
             if (vpc.getRegion().equals(region)) {
                 vpc.getCidrBlockAssociationSet().removeIf(a -> a.getAssociationId().equals(associationId));
+                // The same operation disassociates either family; AWS takes one association id and
+                // does not ask which set it belongs to.
+                vpc.getIpv6CidrBlockAssociationSet().removeIf(a -> a.getAssociationId().equals(associationId));
                 vpcs.put(key(region, vpc.getVpcId()), vpc);
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/Vpc.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/Vpc.java
@@ -19,6 +19,7 @@ public class Vpc {
     private String ownerId;
     private String region;
     private List<VpcCidrBlockAssociation> cidrBlockAssociationSet = new ArrayList<>();
+    private List<VpcIpv6CidrBlockAssociation> ipv6CidrBlockAssociationSet = new ArrayList<>();
     private boolean enableDnsSupport = true;
     private boolean enableDnsHostnames = false;
     private boolean enableNetworkAddressUsageMetrics = false;
@@ -52,6 +53,9 @@ public class Vpc {
 
     public List<VpcCidrBlockAssociation> getCidrBlockAssociationSet() { return cidrBlockAssociationSet; }
     public void setCidrBlockAssociationSet(List<VpcCidrBlockAssociation> cidrBlockAssociationSet) { this.cidrBlockAssociationSet = cidrBlockAssociationSet; }
+
+    public List<VpcIpv6CidrBlockAssociation> getIpv6CidrBlockAssociationSet() { return ipv6CidrBlockAssociationSet; }
+    public void setIpv6CidrBlockAssociationSet(List<VpcIpv6CidrBlockAssociation> ipv6CidrBlockAssociationSet) { this.ipv6CidrBlockAssociationSet = ipv6CidrBlockAssociationSet; }
 
     public boolean isEnableDnsSupport() { return enableDnsSupport; }
     public void setEnableDnsSupport(boolean enableDnsSupport) { this.enableDnsSupport = enableDnsSupport; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcIpv6CidrBlockAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcIpv6CidrBlockAssociation.java
@@ -5,8 +5,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
  * An IPv6 CIDR block associated with a VPC. Separate from {@link VpcCidrBlockAssociation} because
- * AWS keeps the two in separate response members — {@code cidrBlockAssociationSet} and
- * {@code ipv6CidrBlockAssociationSet} — with different member names inside each, and a client
+ * AWS keeps the two in separate response members, {@code cidrBlockAssociationSet} and
+ * {@code ipv6CidrBlockAssociationSet}, with different member names inside each, and a client
  * reading one must not find IPv6 blocks in it.
  */
 @RegisterForReflection

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcIpv6CidrBlockAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/VpcIpv6CidrBlockAssociation.java
@@ -1,0 +1,45 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * An IPv6 CIDR block associated with a VPC. Separate from {@link VpcCidrBlockAssociation} because
+ * AWS keeps the two in separate response members — {@code cidrBlockAssociationSet} and
+ * {@code ipv6CidrBlockAssociationSet} — with different member names inside each, and a client
+ * reading one must not find IPv6 blocks in it.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VpcIpv6CidrBlockAssociation {
+
+    private String associationId;
+    private String ipv6CidrBlock;
+    private String ipv6CidrBlockState = "associated";
+    /** Amazon's own pool, the only one an AmazonProvidedIpv6CidrBlock request can draw from. */
+    private String ipv6Pool = "Amazon";
+    private String networkBorderGroup;
+
+    public VpcIpv6CidrBlockAssociation() {}
+
+    public VpcIpv6CidrBlockAssociation(String associationId, String ipv6CidrBlock, String networkBorderGroup) {
+        this.associationId = associationId;
+        this.ipv6CidrBlock = ipv6CidrBlock;
+        this.networkBorderGroup = networkBorderGroup;
+    }
+
+    public String getAssociationId() { return associationId; }
+    public void setAssociationId(String associationId) { this.associationId = associationId; }
+
+    public String getIpv6CidrBlock() { return ipv6CidrBlock; }
+    public void setIpv6CidrBlock(String ipv6CidrBlock) { this.ipv6CidrBlock = ipv6CidrBlock; }
+
+    public String getIpv6CidrBlockState() { return ipv6CidrBlockState; }
+    public void setIpv6CidrBlockState(String ipv6CidrBlockState) { this.ipv6CidrBlockState = ipv6CidrBlockState; }
+
+    public String getIpv6Pool() { return ipv6Pool; }
+    public void setIpv6Pool(String ipv6Pool) { this.ipv6Pool = ipv6Pool; }
+
+    public String getNetworkBorderGroup() { return networkBorderGroup; }
+    public void setNetworkBorderGroup(String networkBorderGroup) { this.networkBorderGroup = networkBorderGroup; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcIpv6CidrBlockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcIpv6CidrBlockIntegrationTest.java
@@ -83,13 +83,13 @@ class Ec2VpcIpv6CidrBlockIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            // The element is present but empty — no association inside it.
+            // The element is present but empty, no association inside it.
             .body(not(containsString("<ipv6CidrBlock>")));
     }
 
     /**
      * Turning assign_generated_ipv6_cidr_block on for a VPC that already exists goes through
-     * AssociateVpcCidrBlock, not CreateVpc — the same flag on a different operation.
+     * AssociateVpcCidrBlock, not CreateVpc: the same flag on a different operation.
      */
     @Test
     void anExistingVpcCanBeGivenAnAmazonProvidedBlock() {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcIpv6CidrBlockIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcIpv6CidrBlockIntegrationTest.java
@@ -1,0 +1,153 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.emptyOrNullString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * CreateVpc ignored AmazonProvidedIpv6CidrBlock and no response carried an
+ * ipv6CidrBlockAssociationSet at all, so aws_vpc's assign_generated_ipv6_cidr_block never
+ * converged: Terraform asks for a block, reads none back, and plans the same change forever.
+ *
+ * <p>The prefix itself is Amazon's to choose and a client cannot predict it, so these tests
+ * assert the shape and the round trip rather than a literal block.
+ */
+@QuarkusTest
+class Ec2VpcIpv6CidrBlockIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    /** A /56 out of Amazon's pool, in the notation the API returns. */
+    private static final String IPV6_CIDR = "[0-9a-f:]+::/56";
+
+    @Test
+    void createVpcWithAnAmazonProvidedBlockReturnsOneAndKeepsIt() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.91.0.0/16")
+            .formParam("AmazonProvidedIpv6CidrBlock", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateVpcResponse.vpc.ipv6CidrBlockAssociationSet.item.ipv6CidrBlock",
+                    matchesRegex(IPV6_CIDR))
+            .body("CreateVpcResponse.vpc.ipv6CidrBlockAssociationSet.item.ipv6CidrBlockState.state",
+                    equalTo("associated"))
+            .body("CreateVpcResponse.vpc.ipv6CidrBlockAssociationSet.item.ipv6Pool", equalTo("Amazon"))
+            .body("CreateVpcResponse.vpc.ipv6CidrBlockAssociationSet.item.networkBorderGroup",
+                    equalTo("us-east-1"))
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        // The convergence half: the same block has to come back on a later read, unchanged.
+        String created = given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("VpcId.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.ipv6CidrBlockAssociationSet.item.ipv6CidrBlock",
+                    matchesRegex(IPV6_CIDR))
+            .extract().path("DescribeVpcsResponse.vpcSet.item.ipv6CidrBlockAssociationSet.item.ipv6CidrBlock");
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("VpcId.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.ipv6CidrBlockAssociationSet.item.ipv6CidrBlock",
+                    equalTo(created));
+    }
+
+    @Test
+    void aVpcThatDidNotAskForOneHasNoIpv6Block() {
+        given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.92.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            // The element is present but empty — no association inside it.
+            .body(not(containsString("<ipv6CidrBlock>")));
+    }
+
+    /**
+     * Turning assign_generated_ipv6_cidr_block on for a VPC that already exists goes through
+     * AssociateVpcCidrBlock, not CreateVpc — the same flag on a different operation.
+     */
+    @Test
+    void anExistingVpcCanBeGivenAnAmazonProvidedBlock() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.93.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String associationId = given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("AmazonProvidedIpv6CidrBlock", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AssociateVpcCidrBlockResponse.ipv6CidrBlockAssociation.ipv6CidrBlock",
+                    matchesRegex(IPV6_CIDR))
+            .extract().path("AssociateVpcCidrBlockResponse.ipv6CidrBlockAssociation.associationId");
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("VpcId.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.ipv6CidrBlockAssociationSet.item.associationId",
+                    equalTo(associationId))
+            // The IPv4 set is a separate member and must not have gained an entry.
+            .body("DescribeVpcsResponse.vpcSet.item.cidrBlockAssociationSet.item.cidrBlock",
+                    equalTo("10.93.0.0/16"));
+
+        given()
+            .formParam("Action", "DisassociateVpcCidrBlock")
+            .formParam("AssociationId", associationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("VpcId.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<ipv6CidrBlock>")))
+            .body("DescribeVpcsResponse.vpcSet.item.cidrBlock", not(emptyOrNullString()));
+    }
+}


### PR DESCRIPTION
## Summary

`CreateVpc` ignored `AmazonProvidedIpv6CidrBlock`, and no VPC response carried an `ipv6CidrBlockAssociationSet` at all. So `aws_vpc`'s `assign_generated_ipv6_cidr_block` never converges: Terraform asks for a block, reads none back, and plans the same change on every run — the apply "succeeds" and the config is still dirty.

`CreateVpc` and `AssociateVpcCidrBlock` now both accept the flag. Both are needed, not one: the provider sends it on `CreateVpc` when the setting is on from the start, and on `AssociateVpcCidrBlock` when it is turned on for a VPC that already exists — implementing one would leave the other class of configuration exactly as broken.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Three modelling decisions, all taken from how the API reference separates these:

**IPv6 associations live in their own set.** AWS returns `cidrBlockAssociationSet` and `ipv6CidrBlockAssociationSet` as distinct members with different member names inside each (`cidrBlock`/`cidrBlockState` vs `ipv6CidrBlock`/`ipv6CidrBlockState`/`ipv6Pool`/`networkBorderGroup`). Folding IPv6 into the existing set would have been less code and would have put IPv6 blocks where a client reading the IPv4 set finds them.

**`DisassociateVpcCidrBlock` takes an id from either set.** AWS's operation accepts one `AssociationId` and does not ask which family it belongs to, so this one removes from both.

**The prefix is not predictable, and the tests don't pretend otherwise.** AWS allocates the /56 from its own pool with no caller input, so the tests assert the shape (`[0-9a-f:]+::/56`), the state (`associated`), the pool (`Amazon`), the network border group, and — the part that actually fixes convergence — that the *same* block comes back on every subsequent `DescribeVpcs`.

Three integration tests in `Ec2VpcIpv6CidrBlockIntegrationTest`: create-with-block plus round trip, a VPC that asked for nothing getting nothing, and the associate/disassociate path on an existing VPC (which also asserts the IPv4 set did not gain an entry).

**Out of scope, deliberately:** subnet-level IPv6 (`Ipv6CidrBlock` on `CreateSubnet`). This is the VPC-level association only; the subnet half is a separate piece of work and I would rather file it than grow this PR.

## Checklist

- [x] `./mvnw test -Dtest='Ec2*,CloudFormation*,CloudControlIntegrationTest'` — 1082 tests, 0 failures (CloudFormation and CloudControl both create VPCs through this path); full suite left to CI
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make docs-check` clean

Found by a compatibility survey that runs the Gruntwork Terraform corpus against Floci; tracked there as `floci-ezf`, and re-verified against `main` before this PR.
