### PR TITLE
fix(ec2): report a NAT gateway's addresses, not just its allocation id

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -3899,7 +3899,7 @@ public class Ec2QueryHandler {
                     .end("item");
         }
         // A gateway restored from a store written before addresses were modelled has none, but
-        // still knows its allocation id — report what it does know rather than an empty set.
+        // still knows its allocation id, report what it does know rather than an empty set.
         if (natGateway.getNatGatewayAddresses().isEmpty() && natGateway.getAllocationId() != null) {
             xml.start("item")
                     .elem("allocationId", natGateway.getAllocationId())

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -3880,15 +3880,32 @@ public class Ec2QueryHandler {
         if (natGateway.getCreateTime() != null) {
             xml.elem("createTime", ISO_FMT.format(natGateway.getCreateTime()));
         }
-        if (natGateway.getAllocationId() != null) {
-            xml.start("natGatewayAddressSet")
-                    .start("item")
-                    .elem("allocationId", natGateway.getAllocationId())
-                    .end("item")
-                    .end("natGatewayAddressSet");
-        } else {
-            xml.start("natGatewayAddressSet").end("natGatewayAddressSet");
+        xml.start("natGatewayAddressSet");
+        for (NatGatewayAddress address : natGateway.getNatGatewayAddresses()) {
+            xml.start("item");
+            if (address.getAllocationId() != null) {
+                xml.elem("allocationId", address.getAllocationId());
+            }
+            if (address.getAssociationId() != null) {
+                xml.elem("associationId", address.getAssociationId());
+            }
+            xml.elem("networkInterfaceId", address.getNetworkInterfaceId())
+                    .elem("privateIp", address.getPrivateIp());
+            if (address.getPublicIp() != null) {
+                xml.elem("publicIp", address.getPublicIp());
+            }
+            xml.elem("isPrimary", String.valueOf(address.isPrimary()))
+                    .elem("status", address.getStatus())
+                    .end("item");
         }
+        // A gateway restored from a store written before addresses were modelled has none, but
+        // still knows its allocation id — report what it does know rather than an empty set.
+        if (natGateway.getNatGatewayAddresses().isEmpty() && natGateway.getAllocationId() != null) {
+            xml.start("item")
+                    .elem("allocationId", natGateway.getAllocationId())
+                    .end("item");
+        }
+        xml.end("natGatewayAddressSet");
         xml.raw(tagSetXml(natGateway.getTags()));
         return xml.build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -65,6 +65,7 @@ import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplateData;
 import io.github.hectorvent.floci.services.ec2.model.ManagedPrefixList;
 import io.github.hectorvent.floci.services.ec2.model.NatGateway;
+import io.github.hectorvent.floci.services.ec2.model.NatGatewayAddress;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAcl;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAclAssociation;
 import io.github.hectorvent.floci.services.ec2.model.NetworkAclEntry;
@@ -5206,12 +5207,35 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         natGateway.setConnectivityType(connectivityType != null && !connectivityType.isBlank() ? connectivityType : "public");
         natGateway.setCreateTime(Instant.now());
         natGateway.setRegion(region);
+        natGateway.getNatGatewayAddresses().add(natGatewayAddress(region, subnetId, allocationId));
         if (natGatewayTags != null && !natGatewayTags.isEmpty()) {
             natGateway.setTags(new ArrayList<>(natGatewayTags));
             tags.put(natGateway.getNatGatewayId(), new ArrayList<>(natGatewayTags));
         }
         natGateways.put(key(region, natGateway.getNatGatewayId()), natGateway);
         return natGateway;
+    }
+
+    /**
+     * The address a NAT gateway reports. AWS gives every gateway an interface in its subnet with a
+     * private address, and a public one additionally carries the Elastic IP it was created with —
+     * aws_nat_gateway exposes all three as resource outputs (public_ip, private_ip,
+     * network_interface_id), and Gruntwork's VPC modules re-export nat_gateway_public_ips, so an
+     * address carrying only an allocation id propagates empty values into dependent modules.
+     */
+    private NatGatewayAddress natGatewayAddress(String region, String subnetId, String allocationId) {
+        NatGatewayAddress address = new NatGatewayAddress();
+        address.setNetworkInterfaceId("eni-" + randomHex(17));
+        address.setPrivateIp(assignPrivateIp(region, subnetId));
+        if (isSet(allocationId)) {
+            address.setAllocationId(allocationId);
+            address.setAssociationId("eipassoc-" + randomHex(17));
+            // The allocation was validated above, so this resolves; a private gateway has no EIP
+            // and therefore reports no public address at all, which is what AWS returns for one.
+            addresses.get(key(region, allocationId))
+                    .ifPresent(eip -> address.setPublicIp(eip.getPublicIp()));
+        }
+        return address;
     }
 
     public List<NatGateway> describeNatGateways(String region, List<String> natGatewayIds,

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -5195,7 +5195,15 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                                        String connectivityType, List<Tag> natGatewayTags) {
         ensureDefaultResources(region);
         Subnet subnet = requireSubnet(region, subnetId);
-        if (allocationId != null && !allocationId.isBlank()) {
+        boolean privateGateway = "private".equalsIgnoreCase(connectivityType);
+        if (privateGateway && isSet(allocationId)) {
+            // A private NAT gateway has no route to the internet and so nothing to attach an
+            // Elastic IP to. Accepting the pair would have the response report a public address
+            // on a gateway that cannot have one.
+            throw new AwsException("InvalidParameterCombination",
+                    "Elastic IP addresses cannot be associated with private NAT gateways.", 400);
+        }
+        if (isSet(allocationId)) {
             getRequiredAddress(region, allocationId);
         }
 
@@ -5218,7 +5226,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
 
     /**
      * The address a NAT gateway reports. AWS gives every gateway an interface in its subnet with a
-     * private address, and a public one additionally carries the Elastic IP it was created with —
+     * private address, and a public one additionally carries the Elastic IP it was created with,
      * aws_nat_gateway exposes all three as resource outputs (public_ip, private_ip,
      * network_interface_id), and Gruntwork's VPC modules re-export nat_gateway_public_ips, so an
      * address carrying only an allocation id propagates empty values into dependent modules.

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NatGateway.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NatGateway.java
@@ -19,6 +19,7 @@ public class NatGateway {
     private String connectivityType = "public";
     private Instant createTime;
     private String region;
+    private List<NatGatewayAddress> natGatewayAddresses = new ArrayList<>();
     private List<Tag> tags = new ArrayList<>();
 
     public NatGateway() {}
@@ -46,6 +47,9 @@ public class NatGateway {
 
     public String getRegion() { return region; }
     public void setRegion(String region) { this.region = region; }
+
+    public List<NatGatewayAddress> getNatGatewayAddresses() { return natGatewayAddresses; }
+    public void setNatGatewayAddresses(List<NatGatewayAddress> natGatewayAddresses) { this.natGatewayAddresses = natGatewayAddresses; }
 
     public List<Tag> getTags() { return tags; }
     public void setTags(List<Tag> tags) { this.tags = tags; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/NatGatewayAddress.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/NatGatewayAddress.java
@@ -1,0 +1,45 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * One entry of a NAT gateway's {@code natGatewayAddressSet}. A public gateway's entry carries the
+ * Elastic IP it was given plus the private address and interface AWS creates for it; a private
+ * gateway has no Elastic IP and so no {@code publicIp} or {@code associationId}.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NatGatewayAddress {
+
+    private String allocationId;
+    private String associationId;
+    private String networkInterfaceId;
+    private String privateIp;
+    private String publicIp;
+    private boolean primary = true;
+    private String status = "succeeded";
+
+    public NatGatewayAddress() {}
+
+    public String getAllocationId() { return allocationId; }
+    public void setAllocationId(String allocationId) { this.allocationId = allocationId; }
+
+    public String getAssociationId() { return associationId; }
+    public void setAssociationId(String associationId) { this.associationId = associationId; }
+
+    public String getNetworkInterfaceId() { return networkInterfaceId; }
+    public void setNetworkInterfaceId(String networkInterfaceId) { this.networkInterfaceId = networkInterfaceId; }
+
+    public String getPrivateIp() { return privateIp; }
+    public void setPrivateIp(String privateIp) { this.privateIp = privateIp; }
+
+    public String getPublicIp() { return publicIp; }
+    public void setPublicIp(String publicIp) { this.publicIp = publicIp; }
+
+    public boolean isPrimary() { return primary; }
+    public void setPrimary(boolean primary) { this.primary = primary; }
+
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2NatGatewayAddressIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2NatGatewayAddressIntegrationTest.java
@@ -14,7 +14,7 @@ import io.quarkus.test.junit.QuarkusTest;
 /**
  * A NAT gateway's natGatewayAddressSet carried only an allocation id. aws_nat_gateway exposes
  * public_ip, private_ip and network_interface_id as resource outputs, and Gruntwork's VPC modules
- * re-export nat_gateway_public_ips, so the omission does not merely diff — it propagates empty
+ * re-export nat_gateway_public_ips, so the omission does not merely diff, it propagates empty
  * values into whatever consumes those outputs.
  */
 @QuarkusTest
@@ -105,8 +105,34 @@ class Ec2NatGatewayAddressIntegrationTest {
                     matchesRegex("10\\.94\\.1\\.\\d+"))
             .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.networkInterfaceId",
                     startsWith("eni-"))
-            // No Elastic IP was requested, so there is none to report — and no association either.
+            // No Elastic IP was requested, so there is none to report, and no association either.
             .body(not(containsString("<publicIp>")))
             .body(not(containsString("<associationId>")));
+    }
+
+    /**
+     * A private gateway has no route to the internet and nothing to attach an Elastic IP to, so
+     * asking for both is refused rather than answered with an impossible public association.
+     */
+    @Test
+    void aPrivateGatewayCannotBeGivenAnElasticIp() {
+        String allocationId = given()
+            .formParam("Action", "AllocateAddress")
+            .formParam("Domain", "vpc")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("AllocateAddressResponse.allocationId");
+
+        given()
+            .formParam("Action", "CreateNatGateway")
+            .formParam("SubnetId", subnetId())
+            .formParam("ConnectivityType", "private")
+            .formParam("AllocationId", allocationId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterCombination"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2NatGatewayAddressIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2NatGatewayAddressIntegrationTest.java
@@ -1,0 +1,112 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.matchesRegex;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * A NAT gateway's natGatewayAddressSet carried only an allocation id. aws_nat_gateway exposes
+ * public_ip, private_ip and network_interface_id as resource outputs, and Gruntwork's VPC modules
+ * re-export nat_gateway_public_ips, so the omission does not merely diff — it propagates empty
+ * values into whatever consumes those outputs.
+ */
+@QuarkusTest
+class Ec2NatGatewayAddressIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private String subnetId() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.94.0.0/16")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        return given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.94.1.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateSubnetResponse.subnet.subnetId");
+    }
+
+    @Test
+    void aPublicGatewayReportsItsElasticIpPrivateIpAndInterface() {
+        String subnetId = subnetId();
+        io.restassured.response.Response allocation = given()
+            .formParam("Action", "AllocateAddress")
+            .formParam("Domain", "vpc")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200).extract().response();
+        String allocationId = allocation.path("AllocateAddressResponse.allocationId");
+        String publicIp = allocation.path("AllocateAddressResponse.publicIp");
+
+        String natGatewayId = given()
+            .formParam("Action", "CreateNatGateway")
+            .formParam("SubnetId", subnetId)
+            .formParam("AllocationId", allocationId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.allocationId",
+                    equalTo(allocationId))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.publicIp",
+                    equalTo(publicIp))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.privateIp",
+                    matchesRegex("10\\.94\\.1\\.\\d+"))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.networkInterfaceId",
+                    startsWith("eni-"))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.associationId",
+                    startsWith("eipassoc-"))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.status",
+                    equalTo("succeeded"))
+            .extract().path("CreateNatGatewayResponse.natGateway.natGatewayId");
+
+        // Describe is the read Terraform refreshes from, so it has to agree, not just Create.
+        given()
+            .formParam("Action", "DescribeNatGateways")
+            .formParam("NatGatewayId.1", natGatewayId)
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeNatGatewaysResponse.natGatewaySet.item.natGatewayAddressSet.item.publicIp",
+                    equalTo(publicIp))
+            .body("DescribeNatGatewaysResponse.natGatewaySet.item.natGatewayAddressSet.item.networkInterfaceId",
+                    startsWith("eni-"));
+    }
+
+    @Test
+    void aPrivateGatewayHasAPrivateAddressAndNoElasticIp() {
+        given()
+            .formParam("Action", "CreateNatGateway")
+            .formParam("SubnetId", subnetId())
+            .formParam("ConnectivityType", "private")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateNatGatewayResponse.natGateway.connectivityType", equalTo("private"))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.privateIp",
+                    matchesRegex("10\\.94\\.1\\.\\d+"))
+            .body("CreateNatGatewayResponse.natGateway.natGatewayAddressSet.item.networkInterfaceId",
+                    startsWith("eni-"))
+            // No Elastic IP was requested, so there is none to report — and no association either.
+            .body(not(containsString("<publicIp>")))
+            .body(not(containsString("<associationId>")));
+    }
+}


### PR DESCRIPTION
## Summary

`CreateNatGateway` and `DescribeNatGateways` returned `natGatewayAddressSet` entries carrying an `allocationId` and nothing else. Real AWS also returns `publicIp`, `privateIp`, `networkInterfaceId`, `associationId` and `status`.

`aws_nat_gateway` exposes the first three as resource outputs, and Gruntwork's VPC modules re-export `nat_gateway_public_ips` from them — so this does not stop at a diff on one resource, it propagates empty values into every module downstream that consumes those outputs.

A gateway now gets an interface in its subnet with a private address from the same allocator instances use, and a public gateway additionally reports the Elastic IP it was created with plus an association id. A private gateway (`ConnectivityType=private`) has no Elastic IP, so it reports neither `publicIp` nor `associationId` — which is what AWS returns for one, rather than empty elements.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The addresses are **stored on the gateway** rather than derived at serialization time. That matters for the private address and the interface id: derived values would change under a client that merely refreshes, which is the same class of bug as returning nothing. The tests assert the values from a subsequent `DescribeNatGateways`, not only from the create response, since Describe is what Terraform refreshes from.

Two integration tests in `Ec2NatGatewayAddressIntegrationTest`: a public gateway reporting all five members with the Elastic IP matching the one `AllocateAddress` handed out, and a private gateway with a private address and interface but no public IP or association.

**One honest limitation:** the `networkInterfaceId` is a well-formed id that `DescribeNetworkInterfaces` does not know about — this PR reports the interface a NAT gateway has, it does not create a queryable ENI for it. `aws_nat_gateway` only surfaces the id as an output, so this covers the Terraform path; making the interface independently describable is a larger change and I would rather file it separately than smuggle it in here. Likewise the Elastic IP is not marked as in-use by the gateway.

A gateway restored from a store written before this change has no address list but still knows its allocation id, and reports that much rather than an empty set.

## Checklist

- [x] `./mvnw test -Dtest='Ec2*,CloudFormation*'` — 1075 tests, 0 failures; full suite left to CI
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make docs-check` clean

Found by a compatibility survey that runs the Gruntwork Terraform corpus against Floci; tracked there as `floci-eu7`.
