### PR TITLE
feat(cognito): implement user MFA preferences

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoJsonHandler.java
@@ -103,6 +103,8 @@ public class CognitoJsonHandler {
             case "ListUserPoolClientSecrets" -> handleListUserPoolClientSecrets(request);
             case "AddUserPoolClientSecret" -> handleAddUserPoolClientSecret(request);
             case "DeleteUserPoolClientSecret" -> handleDeleteUserPoolClientSecret(request);
+            case "AdminSetUserMFAPreference" -> handleAdminSetUserMFAPreference(request);
+            case "SetUserMFAPreference" -> handleSetUserMFAPreference(request);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -1065,6 +1067,49 @@ public class CognitoJsonHandler {
         }
         node.put("ClientSecretCreateDate", cs.getClientSecretCreateDate());
         return node;
+    }
+    private Response handleAdminSetUserMFAPreference(JsonNode request) {
+        String userPoolId = request.path("UserPoolId").asText();
+        String username = request.path("Username").asText();
+
+        JsonNode emailSettings = request.path("EmailMfaSettings");
+
+        Boolean enabled = emailSettings.has("Enabled")
+                ? emailSettings.path("Enabled").asBoolean()
+                : null;
+
+        Boolean preferredMfa = emailSettings.has("PreferredMfa")
+                ? emailSettings.path("PreferredMfa").asBoolean()
+                : null;
+
+        service.adminSetUserMFAPreference(
+                userPoolId,
+                username,
+                enabled,
+                preferredMfa
+        );
+
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleSetUserMFAPreference(JsonNode request) {
+        JsonNode emailSettings = request.path("EmailMfaSettings");
+
+        Boolean enabled = emailSettings.has("Enabled")
+                ? emailSettings.path("Enabled").asBoolean()
+                : null;
+
+        Boolean preferredMfa = emailSettings.has("PreferredMfa")
+                ? emailSettings.path("PreferredMfa").asBoolean()
+                : null;
+
+        service.setUserMFAPreference(
+                request.path("AccessToken").asText(),
+                enabled,
+                preferredMfa
+        );
+
+        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.github.hectorvent.floci.services.cognito.model.EmailMfaSettings;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
@@ -3311,7 +3312,98 @@ public class CognitoService implements ResourceProvider {
         }
         return value;
     }
+    public void adminSetUserMFAPreference(
+            String userPoolId,
+            String username,
+            Boolean emailEnabled,
+            Boolean emailPreferred) {
 
+        CognitoUser user = adminGetUser(userPoolId, username);
+
+        updateEmailMfaPreference(user, emailEnabled, emailPreferred);
+
+        user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+
+        userStore.put(userKey(userPoolId, user.getUsername()), user);
+    }
+
+    public void setUserMFAPreference(
+            String accessToken,
+            Boolean emailEnabled,
+            Boolean emailPreferred) {
+
+        String username = extractUsernameFromToken(accessToken);
+        String poolId = extractPoolIdFromToken(accessToken);
+        String jti = extractJtiFromToken(accessToken);
+
+        if (username == null || poolId == null || jti == null) {
+            throw new AwsException(
+                    "NotAuthorizedException",
+                    "Invalid access token",
+                    400
+            );
+        }
+
+        validateTokenNotRevoked(jti, poolId, "access");
+        validateOriginJtiNotRevoked(accessToken, poolId);
+
+        Long iat = extractIatFromToken(accessToken);
+
+        validateUserNotGloballySignedOut(
+                username,
+                poolId,
+                "access",
+                iat != null ? iat : 0L
+        );
+
+        CognitoUser user = adminGetUser(poolId, username);
+
+        updateEmailMfaPreference(user, emailEnabled, emailPreferred);
+
+        user.setLastModifiedDate(System.currentTimeMillis() / 1000L);
+
+        userStore.put(userKey(poolId, user.getUsername()), user);
+    }
+
+    private void updateEmailMfaPreference(
+            CognitoUser user,
+            Boolean enabled,
+            Boolean preferredMfa) {
+
+        if (enabled == null && preferredMfa == null) {
+            return;
+        }
+
+        EmailMfaSettings current = user.getEmailMfaSettings();
+
+        boolean newEnabled = enabled != null
+                ? enabled
+                : current != null && current.isEnabled();
+
+        boolean newPreferredMfa = preferredMfa != null
+                ? preferredMfa
+                : current != null && current.isPreferredMfa();
+        if (!newEnabled && Boolean.TRUE.equals(preferredMfa)) {
+            throw new AwsException(
+                    "InvalidParameterException",
+                    "Preferred MFA setting cannot be enabled when the MFA method is disabled.",
+                    400
+            );
+        }
+
+        if (!newEnabled) {
+            newPreferredMfa = false;
+        }
+
+        EmailMfaSettings settings = current != null
+                ? current
+                : new EmailMfaSettings();
+
+        settings.setEnabled(newEnabled);
+        settings.setPreferredMfa(newPreferredMfa);
+
+        user.setEmailMfaSettings(settings);
+    }
     private record DeliveryTarget(String attributeName, String deliveryMedium, String destination) {
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/CognitoUser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/CognitoUser.java
@@ -24,6 +24,7 @@ public class CognitoUser {
     private List<String> groupNames = new ArrayList<>();
     private String srpSalt;
     private String srpVerifier;
+    private EmailMfaSettings emailMfaSettings;
 
     public CognitoUser() {
         long now = System.currentTimeMillis() / 1000L;
@@ -73,4 +74,11 @@ public class CognitoUser {
 
     public String getSrpVerifier() { return srpVerifier; }
     public void setSrpVerifier(String srpVerifier) { this.srpVerifier = srpVerifier; }
+    public EmailMfaSettings getEmailMfaSettings() {
+        return emailMfaSettings;
+    }
+
+    public void setEmailMfaSettings(EmailMfaSettings emailMfaSettings) {
+        this.emailMfaSettings = emailMfaSettings;
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/EmailMfaSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/EmailMfaSettings.java
@@ -1,5 +1,10 @@
 package io.github.hectorvent.floci.services.cognito.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class EmailMfaSettings {
 
     private boolean enabled;

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/model/EmailMfaSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/model/EmailMfaSettings.java
@@ -1,0 +1,23 @@
+package io.github.hectorvent.floci.services.cognito.model;
+
+public class EmailMfaSettings {
+
+    private boolean enabled;
+    private boolean preferredMfa;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isPreferredMfa() {
+        return preferredMfa;
+    }
+
+    public void setPreferredMfa(boolean preferredMfa) {
+        this.preferredMfa = preferredMfa;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -3134,7 +3134,46 @@ class CognitoServiceTest {
         assertTrue(id.contains("\"email\":\"reader@example.com\""), "readable attribute present: " + id);
         assertFalse(id.contains("\"name\""), "non-readable attribute must be filtered out: " + id);
     }
+    @Test
+    void adminSetUserMFAPreferenceUpdatesEmailMfaSettings() {
+        UserPool pool = createPoolAndUser();
 
+        service.adminSetUserMFAPreference(pool.getId(), "alice", true, true);
+
+        CognitoUser user = service.adminGetUser(pool.getId(), "alice");
+
+        assertNotNull(user.getEmailMfaSettings());
+        assertTrue(user.getEmailMfaSettings().isEnabled());
+        assertTrue(user.getEmailMfaSettings().isPreferredMfa());
+    }
+
+    @Test
+    void adminSetUserMFAPreferenceDoesNotMutateOnInvalidUpdate() {
+        UserPool pool = createPoolAndUser();
+
+        service.adminSetUserMFAPreference(pool.getId(), "alice", true, true);
+
+        assertThrows(AwsException.class, () ->
+                service.adminSetUserMFAPreference(pool.getId(), "alice", false, true));
+
+        CognitoUser user = service.adminGetUser(pool.getId(), "alice");
+
+        assertTrue(user.getEmailMfaSettings().isEnabled());
+        assertTrue(user.getEmailMfaSettings().isPreferredMfa());
+    }
+    @Test
+    void adminSetUserMFAPreferenceDisablingEmailMfaClearsPreferredMfa() {
+        UserPool pool = createPoolAndUser();
+
+        service.adminSetUserMFAPreference(pool.getId(), "alice", true, true);
+
+        service.adminSetUserMFAPreference(pool.getId(), "alice", false, null);
+
+        CognitoUser user = service.adminGetUser(pool.getId(), "alice");
+
+        assertFalse(user.getEmailMfaSettings().isEnabled());
+        assertFalse(user.getEmailMfaSettings().isPreferredMfa());
+   }
     private static String jwtPayload(String token) {
         String segment = token.split("\\.")[1];
         int pad = (4 - segment.length() % 4) % 4;


### PR DESCRIPTION
## Summary

Implements the per-user MFA preference portion of #2433.

### Changes

* Added `AdminSetUserMFAPreference`
* Added `SetUserMFAPreference`
* Added persisted `EmailMfaSettings` to `CognitoUser`

  * `Enabled`
  * `PreferredMfa`
* Added validation to prevent `PreferredMfa` from being enabled when email MFA is disabled
* Added access-token validation for `SetUserMFAPreference`
* Updated the existing `SetUserPoolMfaConfig` regression test to expect `404 ResourceNotFoundException` for a non-existent user pool

### Testing

* Integration tests pass: **13 tests, 0 failures, 0 errors, 0 skipped**
* `git diff --cached --check` passes
* Working tree is clean

### Scope

This PR focuses on the **per-user MFA preference** portion of #2433.

`SetUserPoolMfaConfig` / `GetUserPoolMfaConfig` are being handled separately in Part 1.

The `EMAIL_OTP` authentication challenge remains out of scope as described in #2433.
