### PR TITLE
ci(compat): fail the build when compat-opentofu drifts from compat-terraform

### DIFF
--- a/.github/ci/compat-opentofu-allowlist-otf-only.txt
+++ b/.github/ci/compat-opentofu-allowlist-otf-only.txt
@@ -1,0 +1,9 @@
+# Resource addresses allowed to exist ONLY in compat-opentofu/main.tf (not
+# in compat-terraform/main.tf), checked by compat-opentofu-drift-check.py.
+# One "type.name" per line; `#` starts a trailing comment. The reverse
+# direction -- addresses allowed only in compat-terraform -- lives in
+# compat-opentofu-allowlist-tf-only.txt; an address moving from one side to
+# the other must move between these files or CI fails it as unreviewed drift.
+#
+# Empty for now: every currently-accepted gap runs the other way (see
+# compat-opentofu-allowlist-tf-only.txt).

--- a/.github/ci/compat-opentofu-allowlist-tf-only.txt
+++ b/.github/ci/compat-opentofu-allowlist-tf-only.txt
@@ -1,0 +1,21 @@
+# Resource addresses allowed to exist ONLY in compat-terraform/main.tf (not
+# in compat-opentofu/main.tf), checked by compat-opentofu-drift-check.py.
+# One "type.name" per line; `#` starts a trailing comment. The reverse
+# direction -- addresses allowed only in compat-opentofu -- lives in
+# compat-opentofu-allowlist-otf-only.txt; an address moving from one side to
+# the other must move between these files or CI fails it as unreviewed drift.
+#
+# These are pre-existing gaps, not deliberate provider-specific fixtures --
+# see https://github.com/floci-io/floci/issues/2263. Remove an entry once its
+# resource (and matching bats coverage) is ported to compat-opentofu.
+aws_appautoscaling_policy.ecs_alb_requests                            # Application Auto Scaling not yet in compat-opentofu
+aws_appautoscaling_policy.ecs_cpu                                     # Application Auto Scaling not yet in compat-opentofu
+aws_appautoscaling_target.ecs_service                                 # Application Auto Scaling not yet in compat-opentofu
+aws_cloudwatch_metric_alarm.cpu                                       # CloudWatch alarm coverage not yet in compat-opentofu
+aws_db_instance.app                                                   # RDS coverage not yet in compat-opentofu
+aws_guardduty_organization_configuration_feature.runtime_monitoring   # GuardDuty org feature not yet in compat-opentofu
+aws_iam_policy.tagged                                                 # IAM tag coverage not yet in compat-opentofu
+aws_iam_role.managed_policy_attach                                    # IAM managed-policy attach path not yet in compat-opentofu
+aws_iam_role_policy_attachment.ec2_read_only                          # IAM managed-policy attach path not yet in compat-opentofu
+aws_iam_role_policy_attachment.emr_service_role                       # IAM managed-policy attach path not yet in compat-opentofu
+aws_iam_role.tagged                                                   # IAM tag coverage not yet in compat-opentofu

--- a/.github/ci/compat-opentofu-drift-check.py
+++ b/.github/ci/compat-opentofu-drift-check.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Fail if compat-terraform and compat-opentofu resource lists diverge unexpectedly.
+
+Usage: compat-opentofu-drift-check.py
+
+Parses the top-level `resource "TYPE" "NAME" {` blocks out of both
+compatibility-tests/compat-terraform/main.tf and
+compatibility-tests/compat-opentofu/main.tf and fails if either config
+declares a resource address the other doesn't, unless that address is listed
+in the matching direction's allowlist:
+  .github/ci/compat-opentofu-allowlist-tf-only.txt   (terraform-only)
+  .github/ci/compat-opentofu-allowlist-otf-only.txt  (opentofu-only)
+(one "type.name" per line, `#`-comments and blank lines ignored). Allowlists
+are directional so a resource that flips sides -- dropped from one config and
+added to the other under the same address -- is still reported as unreviewed
+drift rather than silently matching a stale entry from the old direction.
+
+Also fails if an allowlist contains an address that is no longer one-sided
+in its direction, so accepted gaps get removed once they're closed instead
+of accumulating.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TF_MAIN = REPO_ROOT / 'compatibility-tests/compat-terraform/main.tf'
+OTF_MAIN = REPO_ROOT / 'compatibility-tests/compat-opentofu/main.tf'
+ALLOWLIST_TF_ONLY = REPO_ROOT / '.github/ci/compat-opentofu-allowlist-tf-only.txt'
+ALLOWLIST_OTF_ONLY = REPO_ROOT / '.github/ci/compat-opentofu-allowlist-otf-only.txt'
+
+RESOURCE_RE = re.compile(r'^resource\s+"([A-Za-z0-9_]+)"\s+"([A-Za-z0-9_]+)"', re.MULTILINE)
+
+
+def resource_addresses(path):
+    return {f'{t}.{n}' for t, n in RESOURCE_RE.findall(path.read_text())}
+
+
+def load_allowlist(path):
+    if not path.exists():
+        return set()
+    addrs = set()
+    for line in path.read_text().splitlines():
+        addr = line.split('#', 1)[0].strip()
+        if addr:
+            addrs.add(addr)
+    return addrs
+
+
+def check_direction(label, only_in, allowlist_path):
+    """Report unexpected and stale entries for one direction. Returns True if clean."""
+    allowed = load_allowlist(allowlist_path)
+    unexpected = sorted(only_in - allowed)
+    stale = sorted(allowed - only_in)
+    ok = True
+    if unexpected:
+        ok = False
+        print(f'::error::resources in {label} not allowlisted in '
+              f'{allowlist_path.relative_to(REPO_ROOT)}:')
+        for a in unexpected:
+            print(f'  {a}')
+    if stale:
+        ok = False
+        print(f'::error::stale entries in {allowlist_path.relative_to(REPO_ROOT)} '
+              f'(no longer one-sided in this direction, remove them):')
+        for a in stale:
+            print(f'  {a}')
+    return ok, allowed
+
+
+def main():
+    tf = resource_addresses(TF_MAIN)
+    otf = resource_addresses(OTF_MAIN)
+
+    tf_ok, tf_allowed = check_direction('compat-terraform/main.tf but not compat-opentofu/main.tf',
+                                         tf - otf, ALLOWLIST_TF_ONLY)
+    otf_ok, otf_allowed = check_direction('compat-opentofu/main.tf but not compat-terraform/main.tf',
+                                           otf - tf, ALLOWLIST_OTF_ONLY)
+
+    if not (tf_ok and otf_ok):
+        print('\nPort the resource to the other config, or add it to the matching-direction '
+              'allowlist if the gap is intentional.')
+        sys.exit(1)
+    print(f'compat-terraform and compat-opentofu resource lists match '
+          f'({len(tf & otf)} shared, {len(tf_allowed)} tf-only allowlisted, '
+          f'{len(otf_allowed)} otf-only allowlisted).')
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -11,6 +11,9 @@ on:
       - 'docker/localstack-parity.sh'
       - 'compatibility-tests/**'
       - '.github/ci/compat-timing-report.py'
+      - '.github/ci/compat-opentofu-drift-check.py'
+      - '.github/ci/compat-opentofu-allowlist-tf-only.txt'
+      - '.github/ci/compat-opentofu-allowlist-otf-only.txt'
       - '.github/workflows/compatibility.yml'
 
 permissions:
@@ -84,6 +87,20 @@ jobs:
           echo "$out"
           echo "$out" | grep -q "other.example.com" \
             || { echo "::error::post-subcommand --endpoint-url flag was not honored over AWS_ENDPOINT_URL"; exit 1; }
+
+  compat-opentofu-drift-check:
+    name: compat / opentofu resource parity
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          sparse-checkout: |
+            compatibility-tests
+            .github/ci
+
+      - name: Compare compat-terraform and compat-opentofu resource lists
+        run: python3 .github/ci/compat-opentofu-drift-check.py
 
   build-native:
     name: Build native floci image

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -1,4 +1,11 @@
-# NOTE: Keep resource definitions in sync with ../compat-terraform/main.tf
+# NOTE: Keep resource definitions in sync with ../compat-terraform/main.tf.
+# Enforced by .github/ci/compat-opentofu-drift-check.py -- a resource added
+# here and not there (or vice versa) fails CI unless listed in
+# .github/ci/compat-opentofu-allowlist-tf-only.txt (or -otf-only.txt for the
+# reverse direction) as a deliberate gap. Currently allowlisted: Application
+# Auto Scaling, RDS, the CloudWatch alarm, the IAM managed-policy-attach
+# path, IAM tag coverage, and the GuardDuty org feature -- see the allowlist
+# files and https://github.com/floci-io/floci/issues/2263 for status.
 
 # ── S3 Bucket ──────────────────────────────────────────────────────────────
 resource "aws_s3_bucket" "app" {

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -1,4 +1,7 @@
-# NOTE: Keep resource definitions in sync with ../compat-opentofu/main.tf
+# NOTE: Keep resource definitions in sync with ../compat-opentofu/main.tf.
+# Enforced by .github/ci/compat-opentofu-drift-check.py -- a resource added
+# here and not there (or vice versa) fails CI unless listed in
+# .github/ci/compat-opentofu-allowlist-tf-only.txt as a deliberate gap.
 
 # -- S3 Bucket ------------------------------------------------------------------
 resource "aws_s3_bucket" "app" {


### PR DESCRIPTION
## Summary

`compat-opentofu/main.tf` opens with a note asking contributors to keep it in sync with `compat-terraform/main.tf`, but nothing enforced it. The two had drifted to 53 vs 64 resources — Application Auto Scaling, RDS, the CloudWatch alarm, the IAM managed-policy-attach path, IAM tag coverage, and the GuardDuty org feature are all exercised by compat-terraform with no OpenTofu equivalent, so that gap has zero cross-provider coverage while the note implies otherwise.

This adds a CI job that parses the `resource "type" "name"` addresses out of both `main.tf` files and fails if either config declares one the other doesn't. The 11 resources currently only in compat-terraform are recorded in a new `.github/ci/compat-opentofu-allowlist-tf-only.txt` as accepted gaps rather than ported here, so today's build stays green; the OpenTofu-only counterpart, `.github/ci/compat-opentofu-allowlist-otf-only.txt`, starts out empty. Any *new* one-sided resource fails immediately instead of widening the gap silently, and a resource that moves from one side to the other is caught too, since each direction only ever subtracts its own allowlist. The check also fails if an allowlist entry stops being one-sided, so accepted gaps get removed once they're closed rather than accumulating.

Closes #2263

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A — CI tooling only, no service behavior changed.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
