### PR TITLE
fix(elbv2): report the attribute defaults, not only what was modified

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributes.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributes.java
@@ -1,0 +1,98 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import io.github.hectorvent.floci.services.elbv2.model.LoadBalancer;
+import io.github.hectorvent.floci.services.elbv2.model.TargetGroup;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The attribute defaults AWS reports for a load balancer or target group that has never been
+ * modified. DescribeLoadBalancerAttributes and DescribeTargetGroupAttributes always answer with
+ * the full set: a key is absent only because the resource type does not have it, never because
+ * nobody set it. That matters beyond tidiness, because the Terraform provider reads these on
+ * every refresh to populate aws_lb's idle_timeout, enable_http2, enable_deletion_protection and
+ * access_logs, and aws_lb_target_group's stickiness, deregistration_delay and
+ * load_balancing_algorithm_type. An empty list leaves each of them a permanent diff.
+ *
+ * <p>Which keys apply is decided by the load balancer's type and the target group's protocol,
+ * the same way AWS decides it: an NLB has no idle timeout, an ALB has no proxy protocol.
+ */
+final class ElbV2DefaultAttributes {
+
+    /** Target group protocols that belong to an Application Load Balancer. */
+    private static final Set<String> APPLICATION_PROTOCOLS = Set.of("HTTP", "HTTPS");
+
+    private ElbV2DefaultAttributes() {}
+
+    static Map<String, String> forLoadBalancer(LoadBalancer lb) {
+        String type = lb.getType() == null ? "application" : lb.getType().toLowerCase();
+        Map<String, String> defaults = new LinkedHashMap<>();
+        defaults.put("deletion_protection.enabled", "false");
+        defaults.put("access_logs.s3.enabled", "false");
+        defaults.put("access_logs.s3.bucket", "");
+        defaults.put("access_logs.s3.prefix", "");
+        // Cross-zone load balancing is on for an ALB and off for the others, which is the one
+        // default that differs by type rather than the key simply not existing.
+        defaults.put("load_balancing.cross_zone.enabled", "application".equals(type) ? "true" : "false");
+
+        if ("application".equals(type)) {
+            defaults.put("idle_timeout.timeout_seconds", "60");
+            defaults.put("client_keep_alive.seconds", "3600");
+            defaults.put("routing.http2.enabled", "true");
+            defaults.put("routing.http.desync_mitigation_mode", "defensive");
+            defaults.put("routing.http.drop_invalid_header_fields.enabled", "false");
+            defaults.put("routing.http.preserve_host_header.enabled", "false");
+            defaults.put("routing.http.x_amzn_tls_version_and_cipher_suite.enabled", "false");
+            defaults.put("routing.http.xff_client_port.enabled", "false");
+            defaults.put("routing.http.xff_header_processing.mode", "append");
+            defaults.put("waf.fail_open.enabled", "false");
+            defaults.put("connection_logs.s3.enabled", "false");
+            defaults.put("connection_logs.s3.bucket", "");
+            defaults.put("connection_logs.s3.prefix", "");
+        } else if ("network".equals(type)) {
+            defaults.put("dns_record.client_routing_policy", "any_availability_zone");
+        }
+        return defaults;
+    }
+
+    static Map<String, String> forTargetGroup(TargetGroup tg) {
+        Map<String, String> defaults = new LinkedHashMap<>();
+        if ("lambda".equalsIgnoreCase(tg.getTargetType())) {
+            // A Lambda target group has one attribute and none of the connection-oriented ones:
+            // there is no instance to drain, no cookie to pin and no algorithm to choose.
+            defaults.put("lambda.multi_value_headers.enabled", "false");
+            return defaults;
+        }
+
+        boolean application = tg.getProtocol() != null
+                && APPLICATION_PROTOCOLS.contains(tg.getProtocol().toUpperCase());
+        defaults.put("deregistration_delay.timeout_seconds", "300");
+        defaults.put("stickiness.enabled", "false");
+        defaults.put("load_balancing.cross_zone.enabled", "use_load_balancer_configuration");
+
+        if (application) {
+            defaults.put("stickiness.type", "lb_cookie");
+            defaults.put("stickiness.lb_cookie.duration_seconds", "86400");
+            defaults.put("stickiness.app_cookie.duration_seconds", "86400");
+            defaults.put("stickiness.app_cookie.cookie_name", "");
+            defaults.put("load_balancing.algorithm.type", "round_robin");
+            defaults.put("slow_start.duration_seconds", "0");
+        } else {
+            defaults.put("stickiness.type", "source_ip");
+            defaults.put("proxy_protocol_v2.enabled", "false");
+        }
+        return defaults;
+    }
+
+    /**
+     * The stored values win over the defaults, so a key that was modified reports what it was set
+     * to and every other key still reports the value AWS would.
+     */
+    static Map<String, String> merge(Map<String, String> defaults, Map<String, String> stored) {
+        Map<String, String> merged = new LinkedHashMap<>(defaults);
+        merged.putAll(stored);
+        return merged;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributes.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributes.java
@@ -29,13 +29,20 @@ final class ElbV2DefaultAttributes {
     static Map<String, String> forLoadBalancer(LoadBalancer lb) {
         String type = lb.getType() == null ? "application" : lb.getType().toLowerCase();
         Map<String, String> defaults = new LinkedHashMap<>();
+        // Supported by every type: deletion protection and cross-zone load balancing, and nothing
+        // else. Cross-zone is on for an ALB and off for the others, which is the one default that
+        // differs by type rather than the key simply not existing.
         defaults.put("deletion_protection.enabled", "false");
-        defaults.put("access_logs.s3.enabled", "false");
-        defaults.put("access_logs.s3.bucket", "");
-        defaults.put("access_logs.s3.prefix", "");
-        // Cross-zone load balancing is on for an ALB and off for the others, which is the one
-        // default that differs by type rather than the key simply not existing.
         defaults.put("load_balancing.cross_zone.enabled", "application".equals(type) ? "true" : "false");
+
+        // Access logs are an Application and Network Load Balancer attribute. A Gateway Load
+        // Balancer does not have them, and reporting them for one would hand a client a schema
+        // AWS never returns.
+        if ("application".equals(type) || "network".equals(type)) {
+            defaults.put("access_logs.s3.enabled", "false");
+            defaults.put("access_logs.s3.bucket", "");
+            defaults.put("access_logs.s3.prefix", "");
+        }
 
         if ("application".equals(type)) {
             defaults.put("idle_timeout.timeout_seconds", "60");

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2Service.java
@@ -277,7 +277,7 @@ public class ElbV2Service implements ResourceProvider {
 
     public Map<String, String> describeLoadBalancerAttributes(String region, String arn) {
         LoadBalancer lb = requireLoadBalancer(region, arn);
-        return new LinkedHashMap<>(lb.getAttributes());
+        return ElbV2DefaultAttributes.merge(ElbV2DefaultAttributes.forLoadBalancer(lb), lb.getAttributes());
     }
 
     public void modifyLoadBalancerAttributes(String region, String arn, Map<String, String> newAttrs) {
@@ -446,7 +446,7 @@ public class ElbV2Service implements ResourceProvider {
 
     public Map<String, String> describeTargetGroupAttributes(String region, String arn) {
         TargetGroup tg = requireTargetGroup(region, arn);
-        return new LinkedHashMap<>(tg.getAttributes());
+        return ElbV2DefaultAttributes.merge(ElbV2DefaultAttributes.forTargetGroup(tg), tg.getAttributes());
     }
 
     public void modifyTargetGroupAttributes(String region, String arn, Map<String, String> newAttrs) {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributesIntegrationTest.java
@@ -106,6 +106,32 @@ class ElbV2DefaultAttributesIntegrationTest {
                     not(hasItem("idle_timeout.timeout_seconds")));
     }
 
+    /**
+     * Access logs are an Application and Network Load Balancer attribute. A Gateway Load Balancer
+     * has only the two every type shares, and reporting more would hand a client a schema AWS
+     * never returns for it.
+     */
+    @Test
+    void aGatewayLoadBalancerGetsOnlyTheAttributesEveryTypeShares() {
+        String arn = createLoadBalancer("attrs-gwlb", "gateway", "10.100.");
+
+        given()
+            .formParam("Action", "DescribeLoadBalancerAttributes")
+            .formParam("LoadBalancerArn", arn)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
+                    hasItem("deletion_protection.enabled"))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'load_balancing.cross_zone.enabled' }.Value",
+                    equalTo("false"))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
+                    not(hasItem("access_logs.s3.enabled")))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
+                    not(hasItem("idle_timeout.timeout_seconds")));
+    }
+
     @Test
     void aModifiedAttributeWinsOverItsDefaultAndTheRestStillReport() {
         String arn = createLoadBalancer("attrs-modified", "application", "10.99.");

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2DefaultAttributesIntegrationTest.java
@@ -1,0 +1,202 @@
+package io.github.hectorvent.floci.services.elbv2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * A load balancer or target group that has never been modified used to answer with an empty
+ * attribute list: only keys somebody had explicitly Modify-d ever appeared. AWS always returns
+ * the full set with its defaults, and the Terraform provider reads those on every refresh into
+ * aws_lb's idle_timeout, enable_http2, enable_deletion_protection and access_logs, and
+ * aws_lb_target_group's stickiness, deregistration_delay and load_balancing_algorithm_type, so an
+ * empty list leaves every one of them a permanent diff.
+ */
+@QuarkusTest
+class ElbV2DefaultAttributesIntegrationTest {
+
+    private static final String AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/elasticloadbalancing/aws4_request";
+
+    private static final String EC2_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private String createVpc(String cidr) {
+        return given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", cidr)
+            .header("Authorization", EC2_AUTH)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+    }
+
+    private String createSubnet(String vpcId, String cidr, String zone) {
+        return given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", cidr)
+            .formParam("AvailabilityZone", zone)
+            .header("Authorization", EC2_AUTH)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateSubnetResponse.subnet.subnetId");
+    }
+
+    /** An ALB needs subnets in two availability zones, so every load balancer here gets two. */
+    private String createLoadBalancer(String name, String type, String base) {
+        String vpcId = createVpc(base + "0.0/16");
+        return given()
+            .formParam("Action", "CreateLoadBalancer")
+            .formParam("Version", "2015-12-01")
+            .formParam("Name", name)
+            .formParam("Type", type)
+            .formParam("Subnets.member.1", createSubnet(vpcId, base + "1.0/24", "us-east-1a"))
+            .formParam("Subnets.member.2", createSubnet(vpcId, base + "2.0/24", "us-east-1b"))
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+    }
+
+    @Test
+    void aFreshApplicationLoadBalancerReportsTheDocumentedDefaults() {
+        String arn = createLoadBalancer("attrs-alb", "application", "10.95.");
+
+        given()
+            .formParam("Action", "DescribeLoadBalancerAttributes")
+            .formParam("LoadBalancerArn", arn)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'idle_timeout.timeout_seconds' }.Value",
+                    equalTo("60"))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'routing.http2.enabled' }.Value",
+                    equalTo("true"))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'deletion_protection.enabled' }.Value",
+                    equalTo("false"))
+            // Cross-zone load balancing is on for an ALB, off for an NLB. Same key, different default.
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'load_balancing.cross_zone.enabled' }.Value",
+                    equalTo("true"));
+    }
+
+    @Test
+    void aNetworkLoadBalancerGetsItsOwnKeysAndNotTheApplicationOnes() {
+        String arn = createLoadBalancer("attrs-nlb", "network", "10.98.");
+
+        given()
+            .formParam("Action", "DescribeLoadBalancerAttributes")
+            .formParam("LoadBalancerArn", arn)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
+                    hasItem("dns_record.client_routing_policy"))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'load_balancing.cross_zone.enabled' }.Value",
+                    equalTo("false"))
+            // An NLB has no idle timeout: the key is absent, not present and empty.
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
+                    not(hasItem("idle_timeout.timeout_seconds")));
+    }
+
+    @Test
+    void aModifiedAttributeWinsOverItsDefaultAndTheRestStillReport() {
+        String arn = createLoadBalancer("attrs-modified", "application", "10.99.");
+
+        given()
+            .formParam("Action", "ModifyLoadBalancerAttributes")
+            .formParam("LoadBalancerArn", arn)
+            .formParam("Attributes.member.1.Key", "idle_timeout.timeout_seconds")
+            .formParam("Attributes.member.1.Value", "120")
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeLoadBalancerAttributes")
+            .formParam("LoadBalancerArn", arn)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'idle_timeout.timeout_seconds' }.Value",
+                    equalTo("120"))
+            .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.find { it.Key == 'routing.http2.enabled' }.Value",
+                    equalTo("true"));
+    }
+
+    @Test
+    void aFreshTargetGroupReportsTheDocumentedDefaults() {
+        String vpcId = createVpc("10.96.0.0/16");
+
+        String tgArn = given()
+            .formParam("Action", "CreateTargetGroup")
+            .formParam("Version", "2015-12-01")
+            .formParam("Name", "attrs-tg")
+            .formParam("Protocol", "HTTP")
+            .formParam("Port", "80")
+            .formParam("VpcId", vpcId)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetGroupArn");
+
+        given()
+            .formParam("Action", "DescribeTargetGroupAttributes")
+            .formParam("TargetGroupArn", tgArn)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.find { it.Key == 'deregistration_delay.timeout_seconds' }.Value",
+                    equalTo("300"))
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.find { it.Key == 'stickiness.enabled' }.Value",
+                    equalTo("false"))
+            // An HTTP target group belongs to an ALB, so it gets the cookie stickiness type and
+            // an algorithm, not the NLB's source_ip and proxy protocol.
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.find { it.Key == 'stickiness.type' }.Value",
+                    equalTo("lb_cookie"))
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.find { it.Key == 'load_balancing.algorithm.type' }.Value",
+                    equalTo("round_robin"))
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.Key",
+                    not(hasItem("proxy_protocol_v2.enabled")));
+    }
+
+    @Test
+    void aTcpTargetGroupGetsTheNetworkDefaults() {
+        String vpcId = createVpc("10.97.0.0/16");
+
+        String tgArn = given()
+            .formParam("Action", "CreateTargetGroup")
+            .formParam("Version", "2015-12-01")
+            .formParam("Name", "attrs-tcp-tg")
+            .formParam("Protocol", "TCP")
+            .formParam("Port", "80")
+            .formParam("VpcId", vpcId)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("CreateTargetGroupResponse.CreateTargetGroupResult.TargetGroups.member.TargetGroupArn");
+
+        given()
+            .formParam("Action", "DescribeTargetGroupAttributes")
+            .formParam("TargetGroupArn", tgArn)
+            .header("Authorization", AUTH)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.find { it.Key == 'stickiness.type' }.Value",
+                    equalTo("source_ip"))
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.find { it.Key == 'proxy_protocol_v2.enabled' }.Value",
+                    equalTo("false"))
+            .body("DescribeTargetGroupAttributesResponse.DescribeTargetGroupAttributesResult.Attributes.member.Key",
+                    not(hasItem("load_balancing.algorithm.type")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2IntegrationTest.java
@@ -135,6 +135,8 @@ class ElbV2IntegrationTest {
     @Test
     @Order(6)
     void describeLoadBalancerAttributes() {
+        // AWS answers with the full attribute set, not just the keys somebody modified, so the
+        // modified key is asserted among them rather than as the only one.
         given()
                 .formParam("Action", "DescribeLoadBalancerAttributes")
                 .formParam("LoadBalancerArn", lbArn)
@@ -144,7 +146,9 @@ class ElbV2IntegrationTest {
             .then()
                 .statusCode(200)
                 .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
-                        equalTo("deletion_protection.enabled"));
+                        hasItem("deletion_protection.enabled"))
+                .body("DescribeLoadBalancerAttributesResponse.DescribeLoadBalancerAttributesResult.Attributes.member.Key",
+                        hasItem("idle_timeout.timeout_seconds"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`DescribeLoadBalancerAttributes` and `DescribeTargetGroupAttributes` returned `{"Attributes": []}` for any load balancer or target group nobody had modified. A key appeared only once something had explicitly set it. AWS always answers with the full set: a key is absent only when the resource type does not have it, never because nobody touched it.

That is not cosmetic. The Terraform provider reads these on every refresh — into `aws_lb`'s `idle_timeout`, `enable_http2`, `enable_deletion_protection` and `access_logs`, and into `aws_lb_target_group`'s `stickiness`, `deregistration_delay` and `load_balancing_algorithm_type`. An empty list leaves every one of them a permanent diff, on every ALB and NLB.

Which keys apply is decided the way AWS decides it, by load balancer type and target group protocol rather than one flat list: an NLB has no idle timeout, an ALB has no proxy protocol, a Lambda target group has neither and only `lambda.multi_value_headers.enabled`. Stored values win over defaults, so a modified key still reports what it was set to and everything else reports what AWS would.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Where the values come from, and what I could not verify.** The defaults are AWS's documented ones for each attribute (`idle_timeout.timeout_seconds` 60, `routing.http2.enabled` true, `routing.http.desync_mitigation_mode` defensive, `deregistration_delay.timeout_seconds` 300, `stickiness.type` `lb_cookie` for HTTP/HTTPS and `source_ip` for the TCP family, and so on). They are transcribed from the reference, not measured against a live account — I would rather say that plainly than imply otherwise, and each constant is one line in `ElbV2DefaultAttributes` precisely so it can be checked against the docs without reading any logic.

The one default that differs by type rather than simply not existing is `load_balancing.cross_zone.enabled`: on for an ALB, off for an NLB and GWLB. That asymmetry is asserted directly in the tests.

**Deliberately left out:** the `target_group_health.*` family. Their defaults (`minimum_healthy_targets.count` / `.percentage`) I am not confident enough about to assert, and the provider only reads them for a newer feature none of the surveyed modules use. I would rather omit a key than publish a wrong value for it, since a wrong default is as much a permanent diff as a missing one. Same reasoning for `zonal_shift.config.enabled` and the regional/multi-AZ attributes.

Five integration tests in `ElbV2DefaultAttributesIntegrationTest`: a fresh ALB, a fresh NLB (asserting it gets `dns_record.client_routing_policy` and does *not* get `idle_timeout.timeout_seconds`), a modified attribute winning over its default while the rest still report, an HTTP target group, and a TCP one.

**One existing test changed.** `ElbV2IntegrationTest.describeLoadBalancerAttributes` asserted the modified key was the *only* one returned, which pinned the bug. It now asserts that key is among the set, which is what it was really establishing.

## Checklist

- [x] `./mvnw test -Dtest='ElbV2*,AutoScaling*,Ecs*,CloudFormation*'` — 751 tests, 0 failures (the other suites create load balancers through this path); full suite left to CI
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `make docs-check` clean

Found by a compatibility survey that runs the Gruntwork Terraform corpus against Floci, where this was recorded as the widest single omission the model-driven audit found: it affects most of `terraform-aws-load-balancer`, `-ecs`, `-asg` and `-service-catalog`. Tracked there as `floci-0p8`, and re-verified against `main` before this PR.
