### PR TITLE
refactor(config): move max-request-size and ecr-base-uri into sub-mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ docker run -d --name floci \
 | `FLOCI_SERVICES_EKS_DEFAULT_IMAGE` | `rancher/k3s:latest` |
 | `FLOCI_SERVICES_MWAA_DEFAULT_POSTGRES_IMAGE` | `postgres:16-alpine` |
 | `FLOCI_SERVICES_ECR_REGISTRY_IMAGE` | `registry:2` |
-| `FLOCI_ECR_BASE_URI` | `public.ecr.aws` |
+| `FLOCI_SERVICES_LAMBDA_ECR_BASE_URI` | `public.ecr.aws` |
 
 ## Persistence and Storage Modes
 
@@ -788,7 +788,7 @@ All settings are overridable through environment variables with the `FLOCI_` pre
 | `FLOCI_HOSTNAME` | Unset | Hostname used in returned URLs when Floci runs inside Docker Compose |
 | `FLOCI_STORAGE_MODE` | `memory` | Storage mode: `memory`, `persistent`, `hybrid`, or `wal` |
 | `FLOCI_STORAGE_PERSISTENT_PATH` | `./data` | Directory used for persisted state |
-| `FLOCI_ECR_BASE_URI` | `public.ecr.aws` | ECR base URI used when pulling container images |
+| `FLOCI_SERVICES_LAMBDA_ECR_BASE_URI` | `public.ecr.aws` | ECR base URI used when pulling Lambda runtime images (legacy name `FLOCI_ECR_BASE_URI` still works) |
 | `FLOCI_SERVICES_S3_ENFORCE_AUTH` | `false` | Enforce S3 public/private read access and reject unknown signed S3 access keys |
 
 Full reference: [configuration docs](https://floci.io/floci/configuration/advanced/application-yml)

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -36,7 +36,6 @@ The block below mirrors `src/main/resources/application.yml`, it's the effective
 
 ```yaml
 floci:
-  max-request-size: 2048             # Max HTTP request body size in MB
   base-url: "http://localhost:4566"  # Used to build response URLs (SQS QueueUrl, SNS endpoints, etc.)
   # hostname: ""                     # When set, overrides the host in base-url for multi-container Docker
   default-region: us-east-1
@@ -98,6 +97,9 @@ floci:
     # key-path: ""                           # FLOCI_TLS_KEY_PATH — PEM private key file path
     self-signed: true                        # FLOCI_TLS_SELF_SIGNED — auto-generate cert when no paths provided
 
+  protocols:
+    max-request-size: 2048                   # FLOCI_PROTOCOLS_MAX_REQUEST_SIZE — max HTTP request body size in MB (legacy: floci.max-request-size / FLOCI_MAX_REQUEST_SIZE)
+
   docker:
     log-max-size: "10m"                      # Max size per container log file before rotation
     log-max-file: "3"                        # Number of rotated log files to retain
@@ -129,6 +131,7 @@ floci:
     lambda:
       enabled: true
       ephemeral: false                        # true = remove container after each invocation
+      ecr-base-uri: public.ecr.aws            # Registry for Lambda runtime images (legacy: floci.ecr-base-uri / FLOCI_ECR_BASE_URI)
       default-memory-mb: 128
       default-timeout-seconds: 3
       runtime-api-base-port: 12000            # Port range for Lambda Runtime API
@@ -283,11 +286,11 @@ All keys in this table are declared on `EmulatorConfig` and accept environment v
 
 | Variable                                           | Default          | Description                                                   |
 |----------------------------------------------------|------------------|---------------------------------------------------------------|
-| `FLOCI_MAX_REQUEST_SIZE`                           | `512`            | Max HTTP request body size in MB                              |
+| `FLOCI_PROTOCOLS_MAX_REQUEST_SIZE`                 | `2048`           | Max HTTP request body size in MB (legacy: `FLOCI_MAX_REQUEST_SIZE`) |
 | `FLOCI_DEFAULT_REGION`                             | `us-east-1`      | Default AWS region used in ARNs and response URLs             |
 | `FLOCI_DEFAULT_AVAILABILITY_ZONE`                  | `us-east-1a`     | Default AZ reported by EC2, RDS, and other AZ-aware services  |
 | `FLOCI_DEFAULT_ACCOUNT_ID`                         | `000000000000`   | Default AWS account ID used in ARNs                           |
-| `FLOCI_ECR_BASE_URI`                               | `public.ecr.aws` | Base URI used when pulling container images (e.g. Lambda)     |
+| `FLOCI_SERVICES_LAMBDA_ECR_BASE_URI`               | `public.ecr.aws` | Registry used when pulling Lambda runtime images (legacy: `FLOCI_ECR_BASE_URI`) |
 | `FLOCI_DNS_EXTRA_SUFFIXES`                         | *(unset)*        | Comma-separated extra hostname suffixes the embedded DNS server resolves to Floci's container IP. E.g. `localhost.localstack.cloud,localhost.example.internal` |
 | `FLOCI_SERVICES_SSM_MAX_PARAMETER_HISTORY`         | `5`              | Max parameter versions kept                                   |
 | `FLOCI_SERVICES_SQS_DEFAULT_VISIBILITY_TIMEOUT`    | `30`             | Default visibility timeout (seconds)                          |
@@ -314,7 +317,9 @@ All keys in this table are declared on `EmulatorConfig` and accept environment v
 
 Per-queue SQS redrive policy (`maxReceiveCount`) is configured at queue creation time via `SetQueueAttributes` / `CreateQueue`, not as a global default.
 
-`FLOCI_DEFAULT_AVAILABILITY_ZONE` and `FLOCI_ECR_BASE_URI` are declared in `EmulatorConfig` but not in the shipped `application.yml`, so they fall through to the `@WithDefault` values above when unset.
+`FLOCI_DEFAULT_AVAILABILITY_ZONE` is declared in `EmulatorConfig` but not in the shipped `application.yml`, so it falls through to the `@WithDefault` value above when unset.
+
+The flat keys `floci.max-request-size` / `FLOCI_MAX_REQUEST_SIZE` and `floci.ecr-base-uri` / `FLOCI_ECR_BASE_URI` moved into sub-structures in 2.x (`floci.protocols.max-request-size` and `floci.services.lambda.ecr-base-uri`). The old names still resolve — a `FlociConfigRelocationsInterceptor` maps them onto the new keys — so existing configs and env vars keep working.
 
 ## Disabling Services
 

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -13,8 +13,6 @@ Floci is configured exclusively through environment variables. Every option belo
 | `FLOCI_DEFAULT_REGION` | `us-east-1` | AWS region used in ARNs and API responses |
 | `FLOCI_DEFAULT_ACCOUNT_ID` | `000000000000` | Fallback account ID used in ARNs when the request's access key is not exactly 12 digits. When the access key IS 12 digits, it is used directly as the account ID — see [Multi-Account Isolation](./multi-account.md) |
 | `FLOCI_DEFAULT_AVAILABILITY_ZONE` | `us-east-1a` | Availability zone reported in EC2 and other responses |
-| `FLOCI_MAX_REQUEST_SIZE` | `512` | Maximum HTTP request body size in megabytes |
-| `FLOCI_ECR_BASE_URI` | `public.ecr.aws` | Base URI for public ECR image references |
 
 ---
 
@@ -54,6 +52,7 @@ See [TLS / HTTPS](./tls.md) for SDK configuration examples and WebSocket (`wss:/
 
 | Variable | Default | Description |
 |---|---|---|
+| `FLOCI_PROTOCOLS_MAX_REQUEST_SIZE` | `2048` | Maximum HTTP request body size in megabytes (feeds `quarkus.http.limits.max-body-size`). Legacy name `FLOCI_MAX_REQUEST_SIZE` still works |
 | `FLOCI_PROTOCOLS_STRICT_CLAIMING` | `false` | Reject RPC-signaled requests that no supported wire protocol claims, per the [Smithy wire-protocol-selection guide](https://smithy.io/2.0/guides/wire-protocol-selection.html) (e.g. an unknown `Smithy-Protocol` header value or an unimplemented `rpc-v2-json` request). When disabled such requests are logged and pass through |
 | `FLOCI_PROTOCOLS_REJECT_UNKNOWN_SERVICE_SCOPE` | `true` | Reject REST requests whose SigV4 credential scope names a service Floci does not implement, with `UnknownOperationException` instead of letting them fall through to S3's path-style routes and return a misleading `NoSuchBucket`. Set to `false` if Floci serves a route whose signing scope is not yet enumerated: the request then falls through as before instead of failing with a 404 |
 
@@ -188,6 +187,7 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 |---|---|---|
 | `FLOCI_SERVICES_LAMBDA_ENABLED` | `true` | Enable the Lambda service |
 | `FLOCI_SERVICES_LAMBDA_EPHEMERAL` | `false` | Remove Lambda containers immediately after each invocation |
+| `FLOCI_SERVICES_LAMBDA_ECR_BASE_URI` | `public.ecr.aws` | Registry (optionally with a path prefix) the Lambda runtime images are pulled from, e.g. `public.ecr.aws/lambda/python:3.12`. Legacy name `FLOCI_ECR_BASE_URI` still works |
 | `FLOCI_SERVICES_LAMBDA_DEFAULT_MEMORY_MB` | `128` | Default memory allocation for functions that don't specify one |
 | `FLOCI_SERVICES_LAMBDA_DEFAULT_TIMEOUT_SECONDS` | `3` | Default invocation timeout in seconds |
 | `FLOCI_SERVICES_LAMBDA_RUNTIME_API_BASE_PORT` | `12000` | First port in the Lambda Runtime API port range |

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -51,12 +51,6 @@ public interface EmulatorConfig {
     @WithDefault("000000000000")
     String defaultAccountId();
 
-    @WithDefault("2048")
-    int maxRequestSize();
-
-    @WithDefault("public.ecr.aws")
-    String ecrBaseUri();
-
     /**
      * Path to a shared mock-response configuration file used by the fixed-stub AI services
      * (Textract, Comprehend, Rekognition) to return a caller-configured response instead of
@@ -86,6 +80,17 @@ public interface EmulatorConfig {
     ProtocolsConfig protocols();
 
     interface ProtocolsConfig {
+        /**
+         * Maximum HTTP request body size, in megabytes. Feeds
+         * {@code quarkus.http.limits.max-body-size} in {@code application.yml}.
+         *
+         * <p>Moved here from the {@code floci} root in 2.x. The former flat key
+         * {@code floci.max-request-size} (env {@code FLOCI_MAX_REQUEST_SIZE}) still works
+         * (see {@link FlociConfigRelocationsInterceptor}), but is deprecated.
+         */
+        @WithDefault("2048")
+        int maxRequestSize();
+
         /**
          * When enabled, requests carrying an RPC protocol signal that no
          * supported wire protocol claims are rejected per the Smithy
@@ -584,7 +589,7 @@ public interface EmulatorConfig {
         @WithDefault("5000")
         long flushIntervalMs();
     }
-  
+
     interface CodeDeployStorageConfig {
         Optional<String> mode();
 
@@ -812,7 +817,7 @@ public interface EmulatorConfig {
         @WithDefault("true")
         boolean enabled();
     }
-  
+
     interface EfsServiceConfig {
         @WithDefault("true")
         boolean enabled();
@@ -1791,6 +1796,18 @@ public interface EmulatorConfig {
     interface LambdaServiceConfig {
         @WithDefault("true")
         boolean enabled();
+
+        /**
+         * Registry host (optionally with a path prefix) that Lambda runtime images are pulled
+         * from, e.g. {@code public.ecr.aws} produces {@code public.ecr.aws/lambda/python:3.12}.
+         * Point it at a private mirror to avoid depending on ECR Public.
+         *
+         * <p>Moved here from the {@code floci} root in 2.x. The former flat key
+         * {@code floci.ecr-base-uri} (env {@code FLOCI_ECR_BASE_URI}) still works
+         * (see {@link FlociConfigRelocationsInterceptor}), but is deprecated.
+         */
+        @WithDefault("public.ecr.aws")
+        String ecrBaseUri();
 
         @WithDefault("128")
         int defaultMemoryMb();

--- a/src/main/java/io/github/hectorvent/floci/config/FlociConfigRelocationsInterceptor.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociConfigRelocationsInterceptor.java
@@ -1,0 +1,98 @@
+package io.github.hectorvent.floci.config;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigValue;
+import io.smallrye.config.Priorities;
+import jakarta.annotation.Priority;
+
+import java.io.Serial;
+import java.util.*;
+import java.util.Map.Entry;
+
+import static java.util.Map.entry;
+import static java.util.stream.Collectors.toUnmodifiableMap;
+
+/**
+ * Keeps configuration keys working after they have been moved to a new place in the
+ * {@code floci} config tree, typically when a flat {@code floci.*} property is pulled down
+ * into a sub-mapping ({@code floci.protocols.*}, {@code floci.services.lambda.*}, …).
+ *
+ * <p>A hand-rolled equivalent of SmallRye's {@code RelocateConfigSourceInterceptor}: whenever
+ * the <em>new</em> key is requested, the <em>legacy</em> key is consulted too, and the legacy
+ * value only wins when the new key was left untouched (i.e. its value is just the
+ * {@code @WithDefault}) or the legacy value comes from a higher-priority source.
+ *
+ * <p>{@link #iterateNames(ConfigSourceInterceptorContext)} rewrites any legacy key it sees to
+ * the new name, so config-mapping validation and {@code getPropertyNames()} never treat the
+ * legacy keys as unknown properties.
+ *
+ * <p><strong>Adding a relocation:</strong> append a {@code legacy -> current} entry to
+ * {@link #RELOCATIONS}. Everything else (both lookup directions, name iteration) is derived
+ * from that single list. Each key (legacy or current) must appear at most once.
+ *
+ * <p>Registered via {@code META-INF/services/io.smallrye.config.ConfigSourceInterceptor}. The
+ * priority places it inside the expression interceptor so an expression such as
+ * <code>${floci.protocols.max-request-size}</code> in {@code application.yml} also picks up a
+ * value set under the legacy key.
+ */
+@Priority(Priorities.LIBRARY + 200 - 5)
+public class FlociConfigRelocationsInterceptor implements ConfigSourceInterceptor {
+
+    @Serial
+    private static final long serialVersionUID = 2446657606783245344L;
+
+    /**
+     * The relocations, as {@code legacy key -> current key}. This is the only place a
+     * relocation is declared; the lookup maps below are built from it.
+     */
+    static final List<Entry<String, String>> RELOCATIONS = List.of(
+            entry("floci.max-request-size", "floci.protocols.max-request-size"),
+            entry("floci.ecr-base-uri", "floci.services.lambda.ecr-base-uri")
+    );
+
+    /**
+     * current key &rarr; legacy key, consulted while resolving a value.
+     */
+    private static final Map<String, String> CURRENT_TO_LEGACY = RELOCATIONS.stream()
+            .collect(toUnmodifiableMap(Entry::getValue, Entry::getKey));
+
+    /**
+     * legacy key &rarr; current key, applied while iterating property names.
+     */
+    private static final Map<String, String> LEGACY_TO_CURRENT = RELOCATIONS.stream()
+            .collect(toUnmodifiableMap(Entry::getKey, Entry::getValue));
+
+    @Override
+    public ConfigValue getValue(final ConfigSourceInterceptorContext context, final String name) {
+        final ConfigValue value = context.proceed(name);
+
+        final String legacyName = CURRENT_TO_LEGACY.get(name);
+        if (legacyName == null) {
+            return value;
+        }
+
+        final ConfigValue legacyValue = context.proceed(legacyName);
+        if (legacyValue == null || legacyValue.getValue() == null) {
+            return value;
+        }
+
+        if (value == null
+                || value.getValue() == null
+                || legacyValue.getConfigSourceOrdinal() > value.getConfigSourceOrdinal()) {
+            return legacyValue.withName(name);
+        }
+        return value;
+    }
+
+    @Override
+    public Iterator<String> iterateNames(final ConfigSourceInterceptorContext context) {
+        final Set<String> names = new HashSet<>();
+        final Iterator<String> iterator = context.iterateNames();
+        while (iterator.hasNext()) {
+            final String name = iterator.next();
+            names.add(LEGACY_TO_CURRENT.getOrDefault(name, name));
+        }
+        return names.iterator();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolver.java
@@ -47,7 +47,7 @@ public class ImageResolver {
     private final String baseUri;
 
     public ImageResolver(EmulatorConfig config) {
-        this.baseUri = config.ecrBaseUri();
+        this.baseUri = config.services().lambda().ecrBaseUri();
     }
 
     public String resolve(String runtime) {

--- a/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
+++ b/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceInterceptor
@@ -1,0 +1,1 @@
+io.github.hectorvent.floci.config.FlociConfigRelocationsInterceptor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,7 +14,7 @@ quarkus:
     port: ${floci.port}
     host: 0.0.0.0
     limits:
-      max-body-size: ${floci.max-request-size}M
+      max-body-size: ${floci.protocols.max-request-size}M
   datasource:
     active: false
   kubernetes-client:
@@ -78,7 +78,6 @@ quarkus:
 
 floci:
   port: 4566
-  max-request-size: 2048
   base-url: "http://localhost:4566"
   # hostname: ""  # When set, overrides the hostname in response URLs (e.g. SQS QueueUrl).
                    # Needed for multi-container Docker setups. Example: FLOCI_HOSTNAME=floci
@@ -213,6 +212,7 @@ floci:
     aws-https-port: 443                # FLOCI_TLS_AWS_HTTPS_PORT — also bind 443 so CDK cfn-response/AWS-on-443 callbacks reach Floci (0 disables)
 
   protocols:
+    max-request-size: 2048             # FLOCI_PROTOCOLS_MAX_REQUEST_SIZE: max HTTP request body size in MB (legacy: floci.max-request-size / FLOCI_MAX_REQUEST_SIZE)
     strict-claiming: false             # FLOCI_PROTOCOLS_STRICT_CLAIMING — reject RPC-signaled requests that no supported wire protocol claims
     reject-unknown-service-scope: true # FLOCI_PROTOCOLS_REJECT_UNKNOWN_SERVICE_SCOPE — reject REST requests signed for a service Floci does not implement
 
@@ -249,6 +249,7 @@ floci:
     lambda:
       enabled: true
       ephemeral: false
+      ecr-base-uri: public.ecr.aws            # FLOCI_SERVICES_LAMBDA_ECR_BASE_URI — registry for Lambda runtime images (legacy: floci.ecr-base-uri / FLOCI_ECR_BASE_URI)
       default-memory-mb: 128
       default-timeout-seconds: 3
       # 500 ports, not the former 100 (9200-9299): one port is held per running Lambda

--- a/src/test/java/io/github/hectorvent/floci/config/ApplicationDefaultsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/ApplicationDefaultsTest.java
@@ -35,7 +35,7 @@ class ApplicationDefaultsTest {
         JsonNode config = new YAMLMapper().readTree(Path.of("src/main/resources/application.yml").toFile());
 
         assertEquals(2048,
-                config.path("floci").path("max-request-size").asInt(),
+                config.path("floci").path("protocols").path("max-request-size").asInt(),
                 "production application.yml should allow 2048 MB request bodies by default");
     }
 

--- a/src/test/java/io/github/hectorvent/floci/config/FlociConfigRelocationsInterceptorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/FlociConfigRelocationsInterceptorTest.java
@@ -1,0 +1,74 @@
+package io.github.hectorvent.floci.config;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static java.util.stream.StreamSupport.stream;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FlociConfigRelocationsInterceptorTest {
+
+    private static SmallRyeConfig config(Map<String, String> properties) {
+        return new SmallRyeConfigBuilder()
+                .addDefaultInterceptors()
+                .withInterceptors(new FlociConfigRelocationsInterceptor())
+                .withSources(new PropertiesConfigSource(properties, "test", 250))
+                .withDefaultValue("floci.protocols.max-request-size", "2048")
+                .withDefaultValue("floci.services.lambda.ecr-base-uri", "public.ecr.aws")
+                .build();
+    }
+
+    @Test
+    void legacyMaxRequestSizeKeyResolvesToTheRelocatedKey() {
+        SmallRyeConfig config = config(Map.of("floci.max-request-size", "4096"));
+
+        assertEquals(4096, config.getValue("floci.protocols.max-request-size", Integer.class));
+    }
+
+    @Test
+    void legacyEcrBaseUriKeyResolvesToTheRelocatedKey() {
+        SmallRyeConfig config = config(Map.of("floci.ecr-base-uri", "my.registry.example/mirror"));
+
+        assertEquals("my.registry.example/mirror",
+                config.getValue("floci.services.lambda.ecr-base-uri", String.class));
+    }
+
+    @Test
+    void theRelocatedKeyWinsOverTheLegacyKeyFromTheSameSource() {
+        SmallRyeConfig config = config(Map.of(
+                "floci.max-request-size", "4096",
+                "floci.protocols.max-request-size", "8192"));
+
+        assertEquals(8192, config.getValue("floci.protocols.max-request-size", Integer.class));
+    }
+
+    @Test
+    void theWithDefaultValueAppliesWhenNeitherKeyIsSet() {
+        SmallRyeConfig config = config(Map.of());
+
+        assertEquals(2048, config.getValue("floci.protocols.max-request-size", Integer.class));
+        assertEquals("public.ecr.aws",
+                config.getValue("floci.services.lambda.ecr-base-uri", String.class));
+    }
+
+    @Test
+    void nameIterationPresentsOnlyTheRelocatedKey() {
+        SmallRyeConfig config = config(Map.of("floci.max-request-size", "4096"));
+
+        var names = stream(config.getPropertyNames().spliterator(), false).toList();
+        assertTrue(names.contains("floci.protocols.max-request-size"));
+        assertFalse(names.contains("floci.max-request-size"));
+    }
+
+    @Test
+    void expressionExpansionSeesTheLegacyKeyWhenResolvingTheRelocatedKey() {
+        SmallRyeConfig config = config(Map.of(
+                "quarkus.http.limits.max-body-size", "${floci.protocols.max-request-size}M",
+                "floci.max-request-size", "4096"));
+        assertEquals("4096M", config.getValue("quarkus.http.limits.max-body-size", String.class));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeSchedulerIntegrationTest.java
@@ -296,10 +296,6 @@ class EventBridgeSchedulerIntegrationTest {
             @Override
             public String defaultAccountId() { return ACCOUNT; }
             @Override
-            public int maxRequestSize() { return 512; }
-            @Override
-            public String ecrBaseUri() { return ""; }
-            @Override
             public Optional<String> aiMockConfigFile() { return Optional.empty(); }
             @Override
             public StorageConfig storage() { return null; }
@@ -327,6 +323,7 @@ class EventBridgeSchedulerIntegrationTest {
             @Override
             public ProtocolsConfig protocols() {
                 return new ProtocolsConfig() {
+                    @Override public int maxRequestSize() { return 512; }
                     @Override public boolean strictClaiming() { return false; }
                     @Override public boolean rejectUnknownServiceScope() { return true; }
                 };

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageResolverTest.java
@@ -11,11 +11,11 @@ import static org.mockito.Mockito.*;
 
 class ImageResolverTest {
 
-    private final EmulatorConfig config = mock(EmulatorConfig.class);
+    private final EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
     private final ImageResolver resolver;
 
     ImageResolverTest() {
-        when(config.ecrBaseUri()).thenReturn("public.ecr.aws");
+        when(config.services().lambda().ecrBaseUri()).thenReturn("public.ecr.aws");
         this.resolver = new ImageResolver(config);
     }
 
@@ -86,8 +86,8 @@ class ImageResolverTest {
             "provided, my.custom.host/lambda/provided:latest"
     })
     void resolvesKnownRuntimesWithHostOverride(String runtime, String expectedImage) {
-        EmulatorConfig customConfig = mock(EmulatorConfig.class);
-        when(customConfig.ecrBaseUri()).thenReturn("my.custom.host");
+        EmulatorConfig customConfig = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        when(customConfig.services().lambda().ecrBaseUri()).thenReturn("my.custom.host");
         ImageResolver customResolver = new ImageResolver(customConfig);
         assertEquals(expectedImage, customResolver.resolve(runtime));
     }
@@ -124,8 +124,8 @@ class ImageResolverTest {
             "provided, my.custom.host/path/lambda/provided:latest"
     })
     void resolvesKnownRuntimesWithHostAndPathOverride(String runtime, String expectedImage) {
-        EmulatorConfig customConfig = mock(EmulatorConfig.class);
-        when(customConfig.ecrBaseUri()).thenReturn("my.custom.host/path");
+        EmulatorConfig customConfig = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        when(customConfig.services().lambda().ecrBaseUri()).thenReturn("my.custom.host/path");
         ImageResolver customResolver = new ImageResolver(customConfig);
         assertEquals(expectedImage, customResolver.resolve(runtime));
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -3,7 +3,7 @@ quarkus:
     port: 0
     test-port: 0
     limits:
-      max-body-size: ${floci.max-request-size}M
+      max-body-size: ${floci.protocols.max-request-size}M
   datasource:
     active: false
   kubernetes-client:


### PR DESCRIPTION
## Summary

floci.max-request-size and floci.ecr-base-uri sat at the config root but belong with related settings. Relocate them:

- max-request-size -> floci.protocols.max-request-size (ProtocolsConfig)
- ecr-base-uri      -> floci.services.lambda.ecr-base-uri (LambdaServiceConfig)

A new FlociConfigRelocationsInterceptor (SmallRye ConfigSourceInterceptor, registered via META-INF/services) keeps the old flat keys and their FLOCI_MAX_REQUEST_SIZE / FLOCI_ECR_BASE_URI env vars working: the legacy key is consulted when the new key is requested, and iterateNames() rewrites it so config-mapping validation does not flag it as unknown. Future relocations are one entry in its RELOCATIONS list.

ImageResolver, both application.yml files, the affected tests and the configuration docs are updated to the new keys.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

