### PR TITLE
feat(cloudtrail): implement AddTags, RemoveTags and ListTags

### DIFF
--- a/docs/services/cloudtrail.md
+++ b/docs/services/cloudtrail.md
@@ -26,6 +26,9 @@ ${prefix}AWSLogs/${accountId}/CloudTrail/${region}/yyyy/MM/dd/${accountId}_Cloud
 | `StopLogging` | Stops logging for a trail |
 | `GetTrailStatus` | Returns the logging status of a trail |
 | `LookupEvents` | - |
+| `AddTags` | Adds or overwrites tags on a trail, identified by ARN |
+| `RemoveTags` | Removes the given tag keys from a trail, identified by ARN |
+| `ListTags` | Returns the tags for one or more trails, identified by ARN |
 <!-- floci:actions:end -->
 
 Selector matching honors `ReadWriteType` (`All`, `ReadOnly`, `WriteOnly`)

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailEntry.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailEntry.java
@@ -6,7 +6,10 @@ import io.github.hectorvent.floci.services.cloudtrail.model.EventSelector;
 import io.github.hectorvent.floci.services.cloudtrail.model.Trail;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @RegisterForReflection
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -16,10 +19,17 @@ public record CloudTrailEntry(
         List<EventSelector> selectors,
         boolean logging,
         Long startLoggingTime,
-        Long stopLoggingTime) {
+        Long stopLoggingTime,
+        Map<String, String> tags) {
+
+    // Not Map.copyOf: AWS allows a tag with a null value (AddTags omitting "Value"),
+    // and Map.copyOf/Map.of reject null values.
+    public CloudTrailEntry {
+        tags = tags == null ? Map.of() : Collections.unmodifiableMap(new LinkedHashMap<>(tags));
+    }
 
     public CloudTrailEntry withTrail(Trail updated) {
-        return new CloudTrailEntry(updated, selectors, logging, startLoggingTime, stopLoggingTime);
+        return new CloudTrailEntry(updated, selectors, logging, startLoggingTime, stopLoggingTime, tags);
     }
 
     public CloudTrailEntry withSelectors(List<EventSelector> updated, boolean hasCustomSelectors) {
@@ -28,14 +38,23 @@ public record CloudTrailEntry(
                 trail.snsTopicArn(), trail.includeGlobalServiceEvents(), trail.isMultiRegionTrail(),
                 trail.homeRegion(), trail.logFileValidationEnabled(), hasCustomSelectors,
                 trail.hasInsightSelectors(), trail.isOrganizationTrail());
-        return new CloudTrailEntry(updatedTrail, updated, logging, startLoggingTime, stopLoggingTime);
+        return new CloudTrailEntry(updatedTrail, updated, logging, startLoggingTime, stopLoggingTime, tags);
     }
 
     public CloudTrailEntry startLogging(long time) {
-        return new CloudTrailEntry(trail, selectors, true, time, stopLoggingTime);
+        return new CloudTrailEntry(trail, selectors, true, time, stopLoggingTime, tags);
     }
 
     public CloudTrailEntry stopLogging(long time) {
-        return new CloudTrailEntry(trail, selectors, false, startLoggingTime, time);
+        return new CloudTrailEntry(trail, selectors, false, startLoggingTime, time, tags);
+    }
+
+    public CloudTrailEntry withTags(Map<String, String> updated) {
+        return new CloudTrailEntry(trail, selectors, logging, startLoggingTime, stopLoggingTime, updated);
+    }
+
+    /** Returns a mutable copy suitable for merging in new tags. */
+    public Map<String, String> mutableTags() {
+        return new LinkedHashMap<>(tags);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cloudtrail;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.cloudtrail.model.DataResource;
@@ -12,7 +13,9 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @ApplicationScoped
 public class CloudTrailJsonHandler {
@@ -38,6 +41,9 @@ public class CloudTrailJsonHandler {
             case "StopLogging" -> stopLogging(request, region);
             case "GetTrailStatus" -> getTrailStatus(request, region);
             case "LookupEvents" -> lookupEvents(request, region);
+            case "AddTags" -> addTags(request);
+            case "RemoveTags" -> removeTags(request);
+            case "ListTags" -> listTags(request);
             default -> throw new AwsException(
                     "InvalidAction", "Could not find operation " + action, 400);
         };
@@ -182,7 +188,42 @@ public class CloudTrailJsonHandler {
         return Response.ok(resp).build();
     }
 
+    private Response addTags(JsonNode req) {
+        String resourceId = req.path("ResourceId").asText(null);
+        service.addTags(resourceId, parseTagsList(req.path("TagsList")));
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response removeTags(JsonNode req) {
+        String resourceId = req.path("ResourceId").asText(null);
+        List<String> keys = new ArrayList<>(parseTagsList(req.path("TagsList")).keySet());
+        service.removeTags(resourceId, keys);
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response listTags(JsonNode req) {
+        List<String> resourceIdList = extractStringList(req, "ResourceIdList");
+        ObjectNode resp = mapper.createObjectNode();
+        ArrayNode resourceTagList = resp.putArray("ResourceTagList");
+        for (String resourceId : resourceIdList) {
+            Map<String, String> tags = service.listTags(resourceId);
+            ObjectNode entry = resourceTagList.addObject();
+            entry.put("ResourceId", resourceId);
+            ArrayNode tagsList = entry.putArray("TagsList");
+            tags.forEach((k, v) -> tagsList.addObject().put("Key", k).put("Value", v));
+        }
+        return Response.ok(resp).build();
+    }
+
     // --- Helpers ---
+
+    private Map<String, String> parseTagsList(JsonNode tagsNode) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (tagsNode != null && tagsNode.isArray()) {
+            tagsNode.forEach(t -> tags.put(t.path("Key").asText(), t.path("Value").asText(null)));
+        }
+        return tags;
+    }
 
     private List<EventSelector> parseEventSelectors(JsonNode selectorsNode) {
         List<EventSelector> result = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailJsonHandler.java
@@ -210,7 +210,12 @@ public class CloudTrailJsonHandler {
             ObjectNode entry = resourceTagList.addObject();
             entry.put("ResourceId", resourceId);
             ArrayNode tagsList = entry.putArray("TagsList");
-            tags.forEach((k, v) -> tagsList.addObject().put("Key", k).put("Value", v));
+            tags.forEach((k, v) -> {
+                ObjectNode tag = tagsList.addObject().put("Key", k);
+                if (v != null) {
+                    tag.put("Value", v);
+                }
+            });
         }
         return Response.ok(resp).build();
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
@@ -76,7 +76,7 @@ public class CloudTrailService {
                 name, arn, s3BucketName, s3KeyPrefix, snsTopicArn,
                 includeGlobalServiceEvents, isMultiRegionTrail, region,
                 enableLogFileValidation, false, false, isOrganizationTrail);
-        store.put(key, new CloudTrailEntry(trail, List.of(), false, null, null));
+        store.put(key, new CloudTrailEntry(trail, List.of(), false, null, null, Map.of()));
         return trail;
     }
 
@@ -163,6 +163,59 @@ public class CloudTrailService {
         return store.get(regionKey(trail.homeRegion(), trail.name()))
                 .map(e -> new TrailStatus(e.logging(), e.startLoggingTime(), e.stopLoggingTime()))
                 .orElse(new TrailStatus(false, null, null));
+    }
+
+    // --- Tagging ---
+    //
+    // AddTags/RemoveTags/ListTags identify the trail solely by ARN (ResourceId /
+    // ResourceIdList), unlike every other CloudTrail action here which also accepts a
+    // bare trail name — so these don't take a `region` parameter.
+
+    private static final int MAX_TAGS_PER_RESOURCE = 50;
+
+    public void addTags(String resourceId, Map<String, String> tagsToAdd) {
+        CloudTrailEntry entry = findEntryByArnOrThrow(resourceId);
+        Map<String, String> merged = entry.mutableTags();
+        merged.putAll(tagsToAdd);
+        if (merged.size() > MAX_TAGS_PER_RESOURCE) {
+            throw new AwsException("TagsLimitExceededException",
+                    "Tag limit exceeded for resource " + resourceId
+                            + ". Maximum allowed: " + MAX_TAGS_PER_RESOURCE + ".", 400);
+        }
+        store.put(regionKey(entry.trail().homeRegion(), entry.trail().name()), entry.withTags(merged));
+    }
+
+    public void removeTags(String resourceId, List<String> tagKeys) {
+        CloudTrailEntry entry = findEntryByArnOrThrow(resourceId);
+        Map<String, String> remaining = entry.mutableTags();
+        tagKeys.forEach(remaining::remove);
+        store.put(regionKey(entry.trail().homeRegion(), entry.trail().name()), entry.withTags(remaining));
+    }
+
+    public Map<String, String> listTags(String resourceId) {
+        return findEntryByArnOrThrow(resourceId).tags();
+    }
+
+    private CloudTrailEntry findEntryByArnOrThrow(String resourceId) {
+        AwsArnUtils.Arn arn;
+        try {
+            arn = AwsArnUtils.parse(resourceId);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("CloudTrailARNInvalidException",
+                    resourceId + " is not a valid ARN.", 400);
+        }
+        if (!"cloudtrail".equals(arn.service()) || !arn.resource().startsWith("trail/")) {
+            throw new AwsException("CloudTrailARNInvalidException",
+                    resourceId + " is not a valid trail ARN.", 400);
+        }
+        for (String k : store.keys()) {
+            CloudTrailEntry entry = store.get(k).orElse(null);
+            if (entry != null && resourceId.equals(entry.trail().trailArn())) {
+                return entry;
+            }
+        }
+        throw new AwsException("ResourceNotFoundException",
+                "Resource not found: " + resourceId, 400);
     }
 
     // --- Data plane: called by S3 (and other services) when an op happens ---

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailIntegrationTest.java
@@ -16,6 +16,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -350,6 +351,34 @@ class CloudTrailIntegrationTest {
             .then().statusCode(200)
                 .body("ResourceTagList[0].TagsList", hasSize(1))
                 .body("ResourceTagList[0].TagsList[0].Key", equalTo("team"));
+    }
+
+    @Test
+    void listTagsOmitsValueForTagWithNoValue() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String trailName = "novalue-" + suffix;
+        String destBucket = "novalue-logs-" + suffix;
+
+        createBucket(destBucket);
+        String trailArn = invokeCloudTrail("CreateTrail", String.format("""
+                {"Name":"%s","S3BucketName":"%s"}
+                """, trailName, destBucket))
+            .then().statusCode(200)
+            .extract().path("TrailARN");
+
+        invokeCloudTrail("AddTags", String.format("""
+                {"ResourceId":"%s","TagsList":[{"Key":"novalue"}]}
+                """, trailArn))
+            .then().statusCode(200);
+
+        // AWS omits absent optionals: a valueless tag must come back as
+        // {"Key":"novalue"} with no "Value" member at all, not "Value":null.
+        invokeCloudTrail("ListTags", String.format("""
+                {"ResourceIdList":["%s"]}
+                """, trailArn))
+            .then().statusCode(200)
+                .body(containsString("{\"Key\":\"novalue\"}"))
+                .body(not(containsString("\"Value\":null")));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailIntegrationTest.java
@@ -14,6 +14,7 @@ import java.util.zip.GZIPInputStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -290,6 +291,92 @@ class CloudTrailIntegrationTest {
                 String.format("{\"trailNameList\":[\"%s\"]}", trailName))
             .then().statusCode(200)
                 .body(containsString(newBucket));
+    }
+
+    @Test
+    void tagLifecycleAddsListsAndRemovesTags() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String trailName = "tag-" + suffix;
+        String destBucket = "tag-logs-" + suffix;
+
+        createBucket(destBucket);
+        String trailArn = invokeCloudTrail("CreateTrail", String.format("""
+                {"Name":"%s","S3BucketName":"%s"}
+                """, trailName, destBucket))
+            .then().statusCode(200)
+            .extract().path("TrailARN");
+
+        // A trail with no tags yet returns an entry with an empty TagsList, not an
+        // omitted entry.
+        invokeCloudTrail("ListTags", String.format("""
+                {"ResourceIdList":["%s"]}
+                """, trailArn))
+            .then().statusCode(200)
+                .body("ResourceTagList[0].ResourceId", equalTo(trailArn))
+                .body("ResourceTagList[0].TagsList", hasSize(0));
+
+        invokeCloudTrail("AddTags", String.format("""
+                {"ResourceId":"%s","TagsList":[{"Key":"env","Value":"prod"},{"Key":"team","Value":"sec"}]}
+                """, trailArn))
+            .then().statusCode(200);
+
+        invokeCloudTrail("ListTags", String.format("""
+                {"ResourceIdList":["%s"]}
+                """, trailArn))
+            .then().statusCode(200)
+                .body("ResourceTagList[0].TagsList", hasSize(2));
+
+        // AddTags overwrites an existing key's value rather than duplicating it.
+        invokeCloudTrail("AddTags", String.format("""
+                {"ResourceId":"%s","TagsList":[{"Key":"env","Value":"staging"}]}
+                """, trailArn))
+            .then().statusCode(200);
+
+        invokeCloudTrail("ListTags", String.format("""
+                {"ResourceIdList":["%s"]}
+                """, trailArn))
+            .then().statusCode(200)
+                .body("ResourceTagList[0].TagsList", hasSize(2))
+                .body("ResourceTagList[0].TagsList.find { it.Key == 'env' }.Value", equalTo("staging"));
+
+        invokeCloudTrail("RemoveTags", String.format("""
+                {"ResourceId":"%s","TagsList":[{"Key":"env"}]}
+                """, trailArn))
+            .then().statusCode(200);
+
+        invokeCloudTrail("ListTags", String.format("""
+                {"ResourceIdList":["%s"]}
+                """, trailArn))
+            .then().statusCode(200)
+                .body("ResourceTagList[0].TagsList", hasSize(1))
+                .body("ResourceTagList[0].TagsList[0].Key", equalTo("team"));
+    }
+
+    @Test
+    void listTagsForUnknownTrailArnReturnsResourceNotFound() {
+        invokeCloudTrail("ListTags", """
+                {"ResourceIdList":["arn:aws:cloudtrail:us-east-1:000000000000:trail/does-not-exist"]}
+                """)
+            .then().statusCode(400)
+                .body(containsString("ResourceNotFoundException"));
+    }
+
+    @Test
+    void addTagsWithMalformedArnReturnsCloudTrailArnInvalid() {
+        invokeCloudTrail("AddTags", """
+                {"ResourceId":"not-an-arn","TagsList":[{"Key":"env","Value":"prod"}]}
+                """)
+            .then().statusCode(400)
+                .body(containsString("CloudTrailARNInvalidException"));
+    }
+
+    @Test
+    void addTagsWithNonTrailArnReturnsCloudTrailArnInvalid() {
+        invokeCloudTrail("AddTags", """
+                {"ResourceId":"arn:aws:s3:::some-bucket","TagsList":[{"Key":"env","Value":"prod"}]}
+                """)
+            .then().statusCode(400)
+                .body(containsString("CloudTrailARNInvalidException"));
     }
 
     // --- Helpers ---


### PR DESCRIPTION
## Summary

Adds the three CloudTrail tag actions — `AddTags`, `RemoveTags`, `ListTags` — which `CloudTrailJsonHandler` didn't dispatch at all, so any call to them fell through to the handler's unsupported-action path and returned a hard 400. That includes the Terraform AWS provider's transparent-tagging interceptor, which calls `ListTags` on every read of `aws_cloudtrail`, not just when tags change — so refresh/plan/destroy broke for any state containing a trail, regardless of whether it was tagged.

Closes #2297

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Wire shapes verified against the AWS API Reference (`AddTags`, `RemoveTags`, `ListTags`): `ResourceId`/`TagsList` for AddTags/RemoveTags, and the plural `ResourceIdList` request / nested `ResourceTagList` response for ListTags. Tags are resolved by ARN only, matching these three actions' actual request shape (unlike every other CloudTrail action here, which also accepts a bare trail name). An ARN that isn't a well-formed CloudTrail trail ARN raises `CloudTrailARNInvalidException`; a well-formed ARN with no matching trail raises `ResourceNotFoundException` rather than returning an empty tag list, so a stale Terraform state entry surfaces as a real error instead of silently succeeding. Also added the documented 50-tags-per-resource cap (`TagsLimitExceededException`).

Tags are tracked on the internal `CloudTrailEntry` rather than the wire-serialized `Trail` record, since real `DescribeTrails`/`Trail` responses never include tags — those are only ever returned via `ListTags`.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
