### PR TITLE
fix(lambda): apply Architectures on UpdateFunctionCode

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -533,6 +533,15 @@ public class LambdaService implements ResourceProvider {
             }
         }
 
+        if (request.containsKey("Architectures")) {
+            @SuppressWarnings("unchecked")
+            List<String> archs = request.get("Architectures") instanceof List
+                    ? (List<String>) request.get("Architectures") : null;
+            if (archs != null && !archs.isEmpty()) {
+                fn.setArchitectures(new ArrayList<>(archs));
+            }
+        }
+
         fn.setLastModified(System.currentTimeMillis());
         fn.setRevisionId(UUID.randomUUID().toString());
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -580,6 +580,28 @@ class LambdaServiceTest {
     }
 
     @Test
+    void updateFunctionCodeAppliesArchitectures() {
+        Map<String, Object> req = baseRequest("arch-fn");
+        req.put("Architectures", List.of("arm64"));
+        service.createFunction(REGION, req);
+
+        LambdaFunction updated = service.updateFunctionCode(REGION, "arch-fn",
+                Map.of("Architectures", List.of("x86_64")));
+        assertEquals(List.of("x86_64"), updated.getArchitectures());
+        assertEquals(List.of("x86_64"), service.getFunction(REGION, "arch-fn").getArchitectures());
+    }
+
+    @Test
+    void updateFunctionCodeWithoutArchitecturesKeepsExisting() {
+        Map<String, Object> req = baseRequest("arch-keep-fn");
+        req.put("Architectures", List.of("arm64"));
+        service.createFunction(REGION, req);
+
+        LambdaFunction updated = service.updateFunctionCode(REGION, "arch-keep-fn", Map.of());
+        assertEquals(List.of("arm64"), updated.getArchitectures());
+    }
+
+    @Test
     void rehydrateConcurrency_restoresReservedFromStore() {
         // Simulate a persisted state: functions already live in the store
         // with reserved values before the limiter is populated.


### PR DESCRIPTION
## Summary

`UpdateFunctionCode` accepted the `Architectures` parameter, returned 200, and silently dropped it — the function kept its original architecture on the response and on every subsequent read. `LambdaService.updateFunctionCode` never read the member; the create and configuration-update paths both did.

This applies `Architectures` in the code-update path with the same guard the configuration-update path uses, so the new architecture shows up on the `UpdateFunctionCode` response and on later `GetFunctionConfiguration` reads, matching the real-AWS transcript in the issue.

Closes #2839

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `update-function-code --architectures x86_64` on an `arm64` function returned `["arm64"]` and left the stored function unchanged. Real AWS (verified in the issue against `lambda.ap-southeast-1.amazonaws.com`) returns and persists the new architecture.

## Checklist

- [x] `./mvnw test` passes locally (`LambdaServiceTest`: 59 tests, 0 failures)
- [x] New or updated integration test added — two unit tests in `LambdaServiceTest`: architecture applied on code update, and preserved when the parameter is omitted
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
