### PR TITLE
refactor(rds): split PostgresProtocolHandler into authenticate and bridge primitives

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -44,17 +44,17 @@ public class PostgresProtocolHandler {
     private static final int SSL_REQUEST_CODE = 80877103;
     private static final int STARTUP_PROTOCOL_VERSION = 196608; // v3.0
 
-    public static void handleAuth(Socket client, Socket backend,
-                                  String masterUsername, String masterPassword, String dbName,
-                                  boolean iamEnabled, RdsSigV4Validator sigV4,
-                                  RdsProxyTlsCertificates tlsCertificates,
-                                  PasswordValidator passwordValidator) throws IOException {
+    public static Socket authenticate(Socket client, Socket backend,
+                                      String masterUsername, String masterPassword, String dbName,
+                                      boolean iamEnabled, RdsSigV4Validator sigV4,
+                                      RdsProxyTlsCertificates tlsCertificates,
+                                      PasswordValidator passwordValidator) throws IOException {
 
         // Phase 1: Read client startup message (possibly preceded by SSL request)
         StartupMessage startup = readStartupMessage(client, tlsCertificates);
         if (startup == null) {
             closeQuietly(client);
-            return;
+            return null;
         }
         client = startup.socket();
         String clientUsername = startup.username();
@@ -69,7 +69,7 @@ public class PostgresProtocolHandler {
         String clientPassword = readPasswordMessage(clientIn);
         if (clientPassword == null) {
             closeQuietly(client);
-            return;
+            return null;
         }
 
         // Phase 4: Validate credentials.
@@ -87,7 +87,7 @@ public class PostgresProtocolHandler {
                 clientOut.flush();
                 closeQuietly(client);
                 closeQuietly(backend);
-                return;
+                return null;
             }
         } else if (isMaster) {
             if (!passwordValidator.validate(clientUsername, clientPassword)) {
@@ -96,7 +96,7 @@ public class PostgresProtocolHandler {
                 clientOut.flush();
                 closeQuietly(client);
                 closeQuietly(backend);
-                return;
+                return null;
             }
         }
 
@@ -119,7 +119,7 @@ public class PostgresProtocolHandler {
             clientOut.flush();
             closeQuietly(client);
             closeQuietly(backend);
-            return;
+            return null;
         }
 
         // Buffer all backend messages until ReadyForQuery ('Z')
@@ -133,7 +133,7 @@ public class PostgresProtocolHandler {
             clientOut.flush();
             closeQuietly(client);
             closeQuietly(backend);
-            return;
+            return null;
         }
 
         sendMessage(clientOut, 'R', intBytes(0)); // AuthenticationOK
@@ -142,7 +142,7 @@ public class PostgresProtocolHandler {
         }
         clientOut.flush();
 
-        bridge(client, backend);
+        return client;
     }
 
     // ── Startup ───────────────────────────────────────────────────────────────
@@ -536,9 +536,7 @@ public class PostgresProtocolHandler {
         return messages;
     }
 
-    // ── Bridge ────────────────────────────────────────────────────────────────
-
-    private static void bridge(Socket client, Socket backend) {
+    public static void bridge(Socket client, Socket backend) {
         InputStream clientIn, backendIn;
         OutputStream clientOut, backendOut;
         try {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
@@ -100,9 +100,14 @@ public class RdsAuthProxy {
             backend.setTcpNoDelay(true);
 
             switch (engine) {
-                case POSTGRES -> PostgresProtocolHandler.handleAuth(
-                        client, backend, masterUsername, masterPassword, dbName,
-                        iamEnabled, sigV4, tlsCertificates, passwordValidator::validate);
+                case POSTGRES -> {
+                    Socket activeClient = PostgresProtocolHandler.authenticate(
+                            client, backend, masterUsername, masterPassword, dbName,
+                            iamEnabled, sigV4, tlsCertificates, passwordValidator::validate);
+                    if (activeClient != null) {
+                        PostgresProtocolHandler.bridge(activeClient, backend);
+                    }
+                }
                 case MYSQL, MARIADB -> MySqlProtocolHandler.handleAuth(
                         client, backend, masterUsername, masterPassword,
                         iamEnabled, sigV4, tlsCertificates, passwordValidator::validate);

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftAuthProxy.java
@@ -137,14 +137,17 @@ public class RedshiftAuthProxy {
             client.setTcpNoDelay(true);
             backend = new Socket(backendHost, backendPort);
             backend.setTcpNoDelay(true);
-            // iamEnabled = false: the SigV4 branch inside handleAuth is never taken.
-            PostgresProtocolHandler.handleAuth(
+            // iamEnabled = false: the SigV4 branch inside authenticate is never taken.
+            Socket activeClient = PostgresProtocolHandler.authenticate(
                     client, backend, masterUsername, masterPassword, dbName,
                     false, sigV4, tlsCertificates, passwordValidator::validate);
+            if (activeClient != null) {
+                PostgresProtocolHandler.bridge(activeClient, backend);
+            }
         } catch (Exception e) {
             LOG.debugv("Redshift connection error for cluster {0}: {1}", clusterKey, e.getMessage());
         } finally {
-            // handleAuth's success path bridges then closes both sockets; every other path
+            // authenticate's success path returns the client to bridge; every other path
             // (early return on a bare probe, auth failure, thrown IOException) can leave the
             // backend connection to Postgres open. Closing here is idempotent.
             closeQuietly(client);

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -81,11 +81,14 @@ class PostgresProtocolHandlerTest {
 
                 Thread authThread = Thread.ofVirtual().start(() -> {
                     try {
-                        PostgresProtocolHandler.handleAuth(
+                        Socket activeClient = PostgresProtocolHandler.authenticate(
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
                                 (user, pass) -> true);
+                        if (activeClient != null) {
+                            PostgresProtocolHandler.bridge(activeClient, backend);
+                        }
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -135,11 +138,14 @@ class PostgresProtocolHandlerTest {
 
                 Thread authThread = Thread.ofVirtual().start(() -> {
                     try {
-                        PostgresProtocolHandler.handleAuth(
+                        Socket activeClient = PostgresProtocolHandler.authenticate(
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
                                 (user, pass) -> true);
+                        if (activeClient != null) {
+                            PostgresProtocolHandler.bridge(activeClient, backend);
+                        }
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -189,11 +195,14 @@ class PostgresProtocolHandlerTest {
 
                 Thread authThread = Thread.ofVirtual().start(() -> {
                     try {
-                        PostgresProtocolHandler.handleAuth(
+                        Socket activeClient = PostgresProtocolHandler.authenticate(
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
                                 (user, pass) -> true);
+                        if (activeClient != null) {
+                            PostgresProtocolHandler.bridge(activeClient, backend);
+                        }
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -252,11 +261,14 @@ class PostgresProtocolHandlerTest {
 
                 Thread authThread = Thread.ofVirtual().start(() -> {
                     try {
-                        PostgresProtocolHandler.handleAuth(
+                        Socket activeClient = PostgresProtocolHandler.authenticate(
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), tlsCertificates,
                                 (user, pass) -> true);
+                        if (activeClient != null) {
+                            PostgresProtocolHandler.bridge(activeClient, backend);
+                        }
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -302,11 +314,14 @@ class PostgresProtocolHandlerTest {
 
                 Thread authThread = Thread.ofVirtual().start(() -> {
                     try {
-                        PostgresProtocolHandler.handleAuth(
+                        Socket activeClient = PostgresProtocolHandler.authenticate(
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), tlsCertificates,
                                 (user, pass) -> true);
+                        if (activeClient != null) {
+                            PostgresProtocolHandler.bridge(activeClient, backend);
+                        }
                     } catch (IOException ignored) {
                         // Client aborts the handshake below — the handler observing that is expected.
                     }
@@ -348,11 +363,14 @@ class PostgresProtocolHandlerTest {
 
                 Thread authThread = Thread.ofVirtual().start(() -> {
                     try {
-                        PostgresProtocolHandler.handleAuth(
+                        Socket activeClient = PostgresProtocolHandler.authenticate(
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
                                 (user, pass) -> true);
+                        if (activeClient != null) {
+                            PostgresProtocolHandler.bridge(activeClient, backend);
+                        }
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
## What this is

Part 1 of splitting #2836 (`feat/redshift-sql-interceptor`) into smaller, independently reviewable PRs, as requested in that PR's review.

This PR carries only the RDS PostgreSQL proxy refactor. It has no dependency on the rest of #2836 and changes no behaviour.

## What changed and why

`PostgresProtocolHandler.handleAuth(...)` did two jobs: run the auth handshake, then relay bytes until close. #2836 needs to keep the handshake but replace the relay with a Redshift SQL interceptor. This splits the method:

- `handleAuth(...)` becomes `authenticate(...)`, which returns the post-startup client `Socket` on success (it may be an SSL-upgraded socket), or `null` when the handshake ended early (bare probe, auth failure, thrown `IOException`).
- The relay body becomes a `public bridge(Socket, Socket)`.
- Callers now do `authenticate(...)` then, if the result is non-null, `bridge(...)`.

Call sites updated:
- `RdsAuthProxy` (POSTGRES case)
- `RedshiftAuthProxy` (rename ripple: it also called `handleAuth`; kept on the plain `bridge`, no interceptor here)
- `PostgresProtocolHandlerTest` (6 sites)

Every early-return in the old `handleAuth` that did `return;` now does `return null;`; the terminal `bridge(client, backend)` becomes `return client;`. Pure mechanical extract, no logic moved between the two methods, no relay behaviour change for RDS or Redshift.

## Source

The three RDS files are taken verbatim from #2836's commit `792aa570` (`refactor(rds): split PostgresProtocolHandler ...`). The one-line `RedshiftAuthProxy` call-site update is new here, needed so `main` compiles after the rename (that file did not exist yet when `792aa570` was written on the branch).

## Testing

`./mvnw test -Dtest=PostgresProtocolHandlerTest,RedshiftAuthProxyTest` -> 14 passing, 0 failures. (The stderr SSL-abort stack traces from `PostgresProtocolHandlerTest` are pre-existing: they come from deliberate handshake-abort cases running on background virtual threads; the JUnit summary is clean.)

## The rest of the split (for context)

Planned follow-up PRs, each stacked on the previous and opened once its predecessor merges:

1. **This PR** - RDS proxy `authenticate` / `bridge` primitives.
2. **DDL keyword rewrite** - `RedshiftSqlInterceptor`: strip `DISTSTYLE` / `DISTKEY` / `SORTKEY` / `ENCODE` from Redshift table DDL, fail-open.
3. **Wire decoder + intercepting bridge** - `PostgresWireDecoder` and the framed `RedshiftInterceptingBridge` (DDL path only), wired into `RedshiftAuthProxy` / `RedshiftProxyManager`.
4. **S3 COPY simulator** - `CopyStatementParser` + `S3CopySimulator.runCopyFrom`, plus a fix: the injected backend query now uses `FORMAT text` unless the statement carries the `CSV` keyword, so a bare pipe-delimited Redshift file loads under TEXT quoting and `\N` NULL rules rather than CSV.
5. **S3 UNLOAD simulator** - `S3CopySimulator.runUnload`, the same TEXT-vs-CSV fix for UNLOAD, and docs for the S3 authorization model (including the residual non-atomic window between the pre-write re-check and `putObject`, kept as-is by design since the emulator has no real IAM).

#2836 stays open as the reference until the split lands.
