### PR TITLE
fix(lambda): replace the fabric8 kubernetes client with a plain REST client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,12 +147,6 @@
             <artifactId>snappy-java</artifactId>
         </dependency>
 
-        <!-- Kubernetes client for the Lambda kubernetes executor -->
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-kubernetes-client</artifactId>
-        </dependency>
-
         <!-- Docker client for Lambda container lifecycle management -->
         <dependency>
             <groupId>com.github.docker-java</groupId>
@@ -308,6 +302,15 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- kubernetes-server-mock declares this as optional, so it must be pulled in
+             explicitly for the kubernetes Lambda executor's tests, which use it as a fake
+             API server (never shipped: KubernetesApiClient is a plain HTTP client, not a
+             Kubernetes SDK, see issue #2914). -->
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiClient.java
@@ -11,6 +11,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -32,6 +33,7 @@ import java.security.KeyStore;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -61,8 +63,10 @@ import java.util.stream.Collectors;
  *       every request since projected service account tokens rotate.</li>
  *   <li>Otherwise, a kubeconfig ({@code $KUBECONFIG}, first entry if multiple; else
  *       {@code ~/.kube/config}), current-context only, with a static bearer token or a
- *       client-certificate/client-key credential (PKCS#8 only). exec/auth-provider plugins
- *       (e.g. {@code aws eks get-token}) are not supported and fail with a clear error.</li>
+ *       client-certificate/client-key credential (PKCS#8 only). {@code insecure-skip-tls-verify}
+ *       is honored (skips both chain and hostname validation, matching kubectl), which covers
+ *       most kind/minikube configs. exec/auth-provider plugins (e.g. {@code aws eks get-token})
+ *       are not supported and fail with a clear error.</li>
  * </ul>
  */
 @ApplicationScoped
@@ -72,6 +76,22 @@ public class KubernetesApiClient {
     private static final Path SERVICE_ACCOUNT_TOKEN = SERVICE_ACCOUNT_DIR.resolve("token");
     private static final Path SERVICE_ACCOUNT_CA = SERVICE_ACCOUNT_DIR.resolve("ca.crt");
     private static final long POLL_INTERVAL_MS = 500;
+
+    /** Backs kubeconfig's {@code insecure-skip-tls-verify: true} (kind/minikube dev configs). */
+    private static final X509TrustManager INSECURE_TRUST_MANAGER = new X509TrustManager() {
+        @Override
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        }
+
+        @Override
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+    };
 
     private final ObjectMapper mapper = new ObjectMapper();
     private final Object lock = new Object();
@@ -257,7 +277,7 @@ public class KubernetesApiClient {
             if (isRunningInCluster()) {
                 resolveInCluster();
             } else {
-                resolveFromKubeconfig();
+                resolveFromKubeconfig(kubeconfigPath());
             }
             initialized = true;
         }
@@ -265,6 +285,15 @@ public class KubernetesApiClient {
 
     private static boolean isRunningInCluster() {
         return System.getenv("KUBERNETES_SERVICE_HOST") != null || Files.exists(SERVICE_ACCOUNT_TOKEN);
+    }
+
+    /**
+     * Test-only: resolves from an explicit kubeconfig and marks the client ready, bypassing the
+     * in-cluster/{@code $KUBECONFIG} auto-detection {@link #ensureInitialized()} would otherwise do.
+     */
+    void initializeFromKubeconfigForTest(Path path) {
+        resolveFromKubeconfig(path);
+        this.initialized = true;
     }
 
     private void resolveInCluster() {
@@ -287,8 +316,7 @@ public class KubernetesApiClient {
         };
     }
 
-    private void resolveFromKubeconfig() {
-        var path = kubeconfigPath();
+    private void resolveFromKubeconfig(Path path) {
         if (!Files.exists(path)) {
             throw new IllegalStateException(
                     "The kubernetes Lambda executor needs either an in-cluster service account or a "
@@ -324,8 +352,16 @@ public class KubernetesApiClient {
         }
         this.baseUri = URI.create(server);
 
-        var caBytes = pemBytes(cluster, "certificate-authority", "certificate-authority-data", path);
-        var trustManager = caBytes != null ? trustManagerFromPem(caBytes) : defaultTrustManager();
+        // Matches kubectl: when set, this wins over any certificate-authority (chain
+        // validation is skipped either way, so a CA to validate against is moot).
+        var insecureSkipTlsVerify = cluster.path("insecure-skip-tls-verify").asBoolean(false);
+        X509TrustManager trustManager;
+        if (insecureSkipTlsVerify) {
+            trustManager = INSECURE_TRUST_MANAGER;
+        } else {
+            var caBytes = pemBytes(cluster, "certificate-authority", "certificate-authority-data", path);
+            trustManager = caBytes != null ? trustManagerFromPem(caBytes) : defaultTrustManager();
+        }
 
         var certBytes = pemBytes(user, "client-certificate", "client-certificate-data", path);
         var keyBytes = pemBytes(user, "client-key", "client-key-data", path);
@@ -346,10 +382,18 @@ public class KubernetesApiClient {
                     + "' has no supported credential (token or client-certificate/client-key) in " + path);
         }
 
-        this.http = HttpClient.newBuilder()
+        var httpBuilder = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(5))
-                .sslContext(sslContext(trustManager, keyManagers))
-                .build();
+                .sslContext(sslContext(trustManager, keyManagers));
+        if (insecureSkipTlsVerify) {
+            // The trust manager above already skips chain validation; this additionally
+            // skips hostname verification, matching kubectl's --insecure-skip-tls-verify
+            // (otherwise a kind/minikube server cert with no matching SAN still fails).
+            var sslParameters = new SSLParameters();
+            sslParameters.setEndpointIdentificationAlgorithm("");
+            httpBuilder.sslParameters(sslParameters);
+        }
+        this.http = httpBuilder.build();
         this.tokenSupplier = token == null ? null : () -> token;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiClient.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiClient.java
@@ -1,0 +1,513 @@
+package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.GeneralSecurityException;
+import java.security.KeyFactory;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Thin REST client for the subset of the Kubernetes API the Lambda kubernetes executor needs:
+ * create/get/list/delete pods, create-or-update a ConfigMap, and stream a pod's logs. Uses the
+ * JDK {@link HttpClient} (as the rest of Floci does for outbound calls, e.g.
+ * {@code FlinkRestClient}) instead of a Kubernetes SDK, so the executor adds no dependency
+ * beyond what Floci already ships: see issue #2914, where the fabric8 client (unconditionally
+ * on the classpath through {@code quarkus-kubernetes-client}) was reachable in every native
+ * image regardless of whether the kubernetes executor was ever used.
+ *
+ * <p>Connection resolution mirrors kubectl's, minus exec/auth-provider credential plugins:
+ * <ul>
+ *   <li>In-cluster: the mounted service account token and CA cert. The token is re-read on
+ *       every request since projected service account tokens rotate.</li>
+ *   <li>Otherwise, a kubeconfig ({@code $KUBECONFIG}, first entry if multiple; else
+ *       {@code ~/.kube/config}), current-context only, with a static bearer token or a
+ *       client-certificate/client-key credential (PKCS#8 only). exec/auth-provider plugins
+ *       (e.g. {@code aws eks get-token}) are not supported and fail with a clear error.</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class KubernetesApiClient {
+
+    private static final Path SERVICE_ACCOUNT_DIR = Path.of("/var/run/secrets/kubernetes.io/serviceaccount");
+    private static final Path SERVICE_ACCOUNT_TOKEN = SERVICE_ACCOUNT_DIR.resolve("token");
+    private static final Path SERVICE_ACCOUNT_CA = SERVICE_ACCOUNT_DIR.resolve("ca.crt");
+    private static final long POLL_INTERVAL_MS = 500;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Object lock = new Object();
+    private volatile boolean initialized;
+    private URI baseUri;
+    private HttpClient http;
+    private Supplier<String> tokenSupplier;
+
+    public KubernetesApiClient() {
+    }
+
+    /** Test-only: points the client at an explicit, already-configured endpoint. */
+    KubernetesApiClient(URI baseUri, HttpClient http, Supplier<String> tokenSupplier) {
+        this.baseUri = baseUri;
+        this.http = http;
+        this.tokenSupplier = tokenSupplier;
+        this.initialized = true;
+    }
+
+    /** Resolves the connection (in-cluster or kubeconfig) now, so bad config fails fast. */
+    public void initialize() {
+        ensureInitialized();
+    }
+
+    public JsonNode createPod(String namespace, JsonNode pod) {
+        return send("POST", podsPath(namespace), pod, 201);
+    }
+
+    public Optional<JsonNode> getPod(String namespace, String name) {
+        return getOptional(podPath(namespace, name));
+    }
+
+    public List<JsonNode> listPods(String namespace, Map<String, String> labelSelector) {
+        var selector = labelSelector.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining(","));
+        var path = podsPath(namespace) + "?labelSelector=" + URLEncoder.encode(selector, StandardCharsets.UTF_8);
+        var items = new ArrayList<JsonNode>();
+        send("GET", path, null, 200).path("items").forEach(items::add);
+        return items;
+    }
+
+    /** No-op if the pod is already gone. */
+    public void deletePod(String namespace, String name) {
+        try {
+            send("DELETE", podPath(namespace, name) + "?gracePeriodSeconds=0", null, 200);
+        } catch (KubernetesApiException e) {
+            if (e.getStatusCode() != 404) {
+                throw e;
+            }
+        }
+    }
+
+    /**
+     * Polls the pod every {@value #POLL_INTERVAL_MS}ms (a plain {@code GET}, not a watch) until
+     * {@code condition} is true, passing {@code null} once the pod no longer exists. Returns the
+     * value that satisfied the condition.
+     *
+     * @throws IllegalStateException if {@code condition} is not satisfied within {@code timeoutSeconds}
+     */
+    public JsonNode waitForPod(String namespace, String name, Predicate<JsonNode> condition, int timeoutSeconds) {
+        var deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+        while (true) {
+            var pod = getPod(namespace, name).orElse(null);
+            if (condition.test(pod)) {
+                return pod;
+            }
+            if (System.nanoTime() >= deadline) {
+                throw new IllegalStateException("timed out after " + timeoutSeconds + "s waiting for pod " + name);
+            }
+            try {
+                Thread.sleep(POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("interrupted while waiting for pod " + name, e);
+            }
+        }
+    }
+
+    /**
+     * Creates the ConfigMap, or replaces its data in place if one by that name already exists.
+     * Never deletes, matching what {@code ensureCaConfigMap} needs: publish-once, refresh-on-restart.
+     */
+    public void createOrUpdateConfigMap(String namespace, ObjectNode configMap) {
+        try {
+            send("POST", configMapsPath(namespace), configMap, 201);
+        } catch (KubernetesApiException e) {
+            if (e.getStatusCode() != 409) {
+                throw e;
+            }
+            var name = configMap.path("metadata").path("name").asText();
+            var existing = getOptional(configMapPath(namespace, name)).orElseThrow(() -> e);
+            ((ObjectNode) configMap.path("metadata"))
+                    .put("resourceVersion", existing.path("metadata").path("resourceVersion").asText());
+            send("PUT", configMapPath(namespace, name), configMap, 200);
+        }
+    }
+
+    /**
+     * Opens a following log stream ({@code GET .../log?follow=true}), same shape as
+     * {@code kubectl logs -f}. The caller reads and closes the stream; closing it ends the
+     * underlying connection and the kubelet stops the follow.
+     */
+    public InputStream openPodLogStream(String namespace, String podName, String containerName) {
+        ensureInitialized();
+        var path = podPath(namespace, podName) + "/log?container="
+                + URLEncoder.encode(containerName, StandardCharsets.UTF_8) + "&follow=true";
+        try {
+            var response = http.send(requestBuilder(path).GET().build(), HttpResponse.BodyHandlers.ofInputStream());
+            if (response.statusCode() != 200) {
+                var body = new String(response.body().readAllBytes(), StandardCharsets.UTF_8);
+                throw new KubernetesApiException("GET", path, response.statusCode(), body);
+            }
+            return response.body();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not open log stream for pod " + podName, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted opening log stream for pod " + podName, e);
+        }
+    }
+
+    private JsonNode send(String method, String path, JsonNode body, int expectedStatus) {
+        ensureInitialized();
+        try {
+            var builder = requestBuilder(path);
+            if (body != null) {
+                builder.header("Content-Type", "application/json")
+                        .method(method, HttpRequest.BodyPublishers.ofByteArray(mapper.writeValueAsBytes(body)));
+            } else {
+                builder.method(method, HttpRequest.BodyPublishers.noBody());
+            }
+            var response = http.send(builder.build(), HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != expectedStatus) {
+                throw new KubernetesApiException(method, path, response.statusCode(),
+                        new String(response.body(), StandardCharsets.UTF_8));
+            }
+            return response.body().length == 0 ? NullNode.getInstance() : mapper.readTree(response.body());
+        } catch (IOException e) {
+            throw new UncheckedIOException("Kubernetes API " + method + " " + path + " failed: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted calling Kubernetes API " + method + " " + path, e);
+        }
+    }
+
+    private Optional<JsonNode> getOptional(String path) {
+        ensureInitialized();
+        try {
+            var response = http.send(requestBuilder(path).GET().build(), HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() == 404) {
+                return Optional.empty();
+            }
+            if (response.statusCode() != 200) {
+                throw new KubernetesApiException("GET", path, response.statusCode(),
+                        new String(response.body(), StandardCharsets.UTF_8));
+            }
+            return Optional.of(mapper.readTree(response.body()));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Kubernetes API GET " + path + " failed: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted calling Kubernetes API GET " + path, e);
+        }
+    }
+
+    private HttpRequest.Builder requestBuilder(String path) {
+        var builder = HttpRequest.newBuilder(baseUri.resolve(path)).timeout(Duration.ofSeconds(30));
+        if (tokenSupplier != null) {
+            builder.header("Authorization", "Bearer " + tokenSupplier.get());
+        }
+        return builder;
+    }
+
+    private void ensureInitialized() {
+        if (initialized) {
+            return;
+        }
+        synchronized (lock) {
+            if (initialized) {
+                return;
+            }
+            if (isRunningInCluster()) {
+                resolveInCluster();
+            } else {
+                resolveFromKubeconfig();
+            }
+            initialized = true;
+        }
+    }
+
+    private static boolean isRunningInCluster() {
+        return System.getenv("KUBERNETES_SERVICE_HOST") != null || Files.exists(SERVICE_ACCOUNT_TOKEN);
+    }
+
+    private void resolveInCluster() {
+        var host = System.getenv("KUBERNETES_SERVICE_HOST");
+        var port = System.getenv("KUBERNETES_SERVICE_PORT");
+        var authority = (host != null && port != null) ? host + ":" + port : "kubernetes.default.svc";
+        this.baseUri = URI.create("https://" + authority);
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .sslContext(sslContext(trustManagerFromCaFile(SERVICE_ACCOUNT_CA), null))
+                .build();
+        this.tokenSupplier = () -> {
+            try {
+                return Files.readString(SERVICE_ACCOUNT_TOKEN, StandardCharsets.UTF_8).strip();
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Could not read in-cluster service account token at " + SERVICE_ACCOUNT_TOKEN
+                                + ": " + e.getMessage(), e);
+            }
+        };
+    }
+
+    private void resolveFromKubeconfig() {
+        var path = kubeconfigPath();
+        if (!Files.exists(path)) {
+            throw new IllegalStateException(
+                    "The kubernetes Lambda executor needs either an in-cluster service account or a "
+                            + "kubeconfig, and found neither: no service account at " + SERVICE_ACCOUNT_DIR
+                            + " and no kubeconfig at " + path + ". Set KUBECONFIG or place one at ~/.kube/config.");
+        }
+        JsonNode root;
+        try (var in = Files.newInputStream(path)) {
+            root = new ObjectMapper(new YAMLFactory()).readTree(in);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read kubeconfig at " + path + ": " + e.getMessage(), e);
+        }
+
+        var currentContextName = root.path("current-context").asText(null);
+        if (currentContextName == null || currentContextName.isBlank()) {
+            throw new IllegalStateException("kubeconfig at " + path + " has no current-context set");
+        }
+        var context = findNamed(root.path("contexts"), currentContextName, "context")
+                .orElseThrow(() -> new IllegalStateException(
+                        "kubeconfig context '" + currentContextName + "' not found in " + path));
+        var clusterName = context.path("cluster").asText(null);
+        var cluster = findNamed(root.path("clusters"), clusterName, "cluster")
+                .orElseThrow(() -> new IllegalStateException(
+                        "kubeconfig cluster '" + clusterName + "' not found in " + path));
+        var userName = context.path("user").asText(null);
+        var user = userName == null ? JsonNodeFactory.instance.objectNode()
+                : findNamed(root.path("users"), userName, "user")
+                        .orElseGet(JsonNodeFactory.instance::objectNode);
+
+        var server = cluster.path("server").asText(null);
+        if (server == null || server.isBlank()) {
+            throw new IllegalStateException("kubeconfig cluster '" + clusterName + "' has no server URL in " + path);
+        }
+        this.baseUri = URI.create(server);
+
+        var caBytes = pemBytes(cluster, "certificate-authority", "certificate-authority-data", path);
+        var trustManager = caBytes != null ? trustManagerFromPem(caBytes) : defaultTrustManager();
+
+        var certBytes = pemBytes(user, "client-certificate", "client-certificate-data", path);
+        var keyBytes = pemBytes(user, "client-key", "client-key-data", path);
+        KeyManager[] keyManagers = null;
+        if (certBytes != null && keyBytes != null) {
+            keyManagers = keyManagersFromPem(certBytes, keyBytes);
+        }
+
+        var token = user.path("token").asText(null);
+        if (token == null && keyManagers == null) {
+            if (user.has("exec") || user.has("auth-provider")) {
+                throw new IllegalStateException(
+                        "kubeconfig user '" + userName + "' uses an exec or auth-provider credential "
+                                + "plugin, which the kubernetes Lambda executor does not support. Use a "
+                                + "static token or client-certificate/client-key credential instead.");
+            }
+            throw new IllegalStateException("kubeconfig user '" + userName
+                    + "' has no supported credential (token or client-certificate/client-key) in " + path);
+        }
+
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .sslContext(sslContext(trustManager, keyManagers))
+                .build();
+        this.tokenSupplier = token == null ? null : () -> token;
+    }
+
+    private static Path kubeconfigPath() {
+        var envValue = System.getenv("KUBECONFIG");
+        if (envValue != null && !envValue.isBlank()) {
+            var separator = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win") ? ";" : ":";
+            return Path.of(envValue.split(Pattern.quote(separator))[0]);
+        }
+        return Path.of(System.getProperty("user.home"), ".kube", "config");
+    }
+
+    private static Optional<JsonNode> findNamed(JsonNode array, String name, String childKey) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        for (var entry : array) {
+            if (name.equals(entry.path("name").asText(null))) {
+                return Optional.of(entry.path(childKey));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Reads a `<field>` (a path, resolved relative to the kubeconfig) or `<field>-data` (base64) entry. */
+    private static byte[] pemBytes(JsonNode node, String fileField, String dataField, Path kubeconfigPath) {
+        var data = node.path(dataField).asText(null);
+        if (data != null && !data.isBlank()) {
+            return Base64.getDecoder().decode(data);
+        }
+        var file = node.path(fileField).asText(null);
+        if (file == null || file.isBlank()) {
+            return null;
+        }
+        var resolved = Path.of(file).isAbsolute() ? Path.of(file) : kubeconfigPath.getParent().resolve(file);
+        try {
+            return Files.readAllBytes(resolved);
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Could not read kubeconfig-referenced file " + resolved + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static X509TrustManager trustManagerFromCaFile(Path caFile) {
+        try {
+            return trustManagerFromPem(Files.readAllBytes(caFile));
+        } catch (IOException e) {
+            throw new IllegalStateException(
+                    "Could not read in-cluster CA certificate at " + caFile + ": " + e.getMessage(), e);
+        }
+    }
+
+    private static X509TrustManager trustManagerFromPem(byte[] pem) {
+        try {
+            var certs = CertificateFactory.getInstance("X.509").generateCertificates(new ByteArrayInputStream(pem));
+            var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, null);
+            var i = 0;
+            for (var cert : certs) {
+                keyStore.setCertificateEntry("ca" + (i++), cert);
+            }
+            var trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(keyStore);
+            return firstX509(trustManagerFactory.getTrustManagers(),
+                    "No X509TrustManager produced from the supplied CA certificate(s)");
+        } catch (GeneralSecurityException | IOException e) {
+            throw new IllegalStateException(
+                    "Could not build a trust manager from the supplied CA certificate: " + e.getMessage(), e);
+        }
+    }
+
+    private static X509TrustManager defaultTrustManager() {
+        try {
+            var trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init((KeyStore) null);
+            return firstX509(trustManagerFactory.getTrustManagers(), "No default X509TrustManager available");
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Could not load the default trust manager: " + e.getMessage(), e);
+        }
+    }
+
+    private static X509TrustManager firstX509(TrustManager[] managers, String errorIfNone) {
+        for (var manager : managers) {
+            if (manager instanceof X509TrustManager x509) {
+                return x509;
+            }
+        }
+        throw new IllegalStateException(errorIfNone);
+    }
+
+    private static KeyManager[] keyManagersFromPem(byte[] certPem, byte[] keyPem) {
+        try {
+            var cert = CertificateFactory.getInstance("X.509").generateCertificate(new ByteArrayInputStream(certPem));
+            var privateKey = privateKeyFromPem(keyPem);
+            var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+            keyStore.load(null, null);
+            keyStore.setKeyEntry("client", privateKey, new char[0], new Certificate[]{cert});
+            var keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+            keyManagerFactory.init(keyStore, new char[0]);
+            return keyManagerFactory.getKeyManagers();
+        } catch (GeneralSecurityException | IOException e) {
+            throw new IllegalStateException(
+                    "Could not build a key manager from the kubeconfig client certificate/key: " + e.getMessage(), e);
+        }
+    }
+
+    private static PrivateKey privateKeyFromPem(byte[] pem) {
+        var text = new String(pem, StandardCharsets.US_ASCII);
+        if (text.contains("BEGIN RSA PRIVATE KEY") || text.contains("BEGIN EC PRIVATE KEY")) {
+            throw new IllegalStateException(
+                    "kubeconfig client-key is in PKCS#1 format (BEGIN RSA/EC PRIVATE KEY); only PKCS#8 "
+                            + "(BEGIN PRIVATE KEY) is supported. Convert it with: openssl pkcs8 -topk8 "
+                            + "-nocrypt -in key.pem -out key-pkcs8.pem");
+        }
+        var base64 = text.replaceAll("-----BEGIN [^-]+-----", "")
+                .replaceAll("-----END [^-]+-----", "")
+                .replaceAll("\\s", "");
+        var keySpec = new PKCS8EncodedKeySpec(Base64.getDecoder().decode(base64));
+        GeneralSecurityException last = null;
+        for (var algorithm : new String[]{"RSA", "EC"}) {
+            try {
+                return KeyFactory.getInstance(algorithm).generatePrivate(keySpec);
+            } catch (GeneralSecurityException e) {
+                last = e;
+            }
+        }
+        throw new IllegalStateException("Could not parse kubeconfig client-key as an RSA or EC private key: "
+                + (last == null ? "unknown format" : last.getMessage()));
+    }
+
+    private static SSLContext sslContext(X509TrustManager trustManager, KeyManager[] keyManagers) {
+        try {
+            var context = SSLContext.getInstance("TLS");
+            context.init(keyManagers, new TrustManager[]{trustManager}, null);
+            return context;
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Could not initialize TLS for the Kubernetes API client: "
+                    + e.getMessage(), e);
+        }
+    }
+
+    private static String podsPath(String namespace) {
+        return "/api/v1/namespaces/" + encode(namespace) + "/pods";
+    }
+
+    private static String podPath(String namespace, String name) {
+        return podsPath(namespace) + "/" + encode(name);
+    }
+
+    private static String configMapsPath(String namespace) {
+        return "/api/v1/namespaces/" + encode(namespace) + "/configmaps";
+    }
+
+    private static String configMapPath(String namespace, String name) {
+        return configMapsPath(namespace) + "/" + encode(name);
+    }
+
+    private static String encode(String segment) {
+        return URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiException.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiException.java
@@ -1,0 +1,17 @@
+package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
+
+/** A Kubernetes API server response outside 2xx (and, for a get, other than a plain 404). */
+public class KubernetesApiException extends RuntimeException {
+
+    private final int statusCode;
+
+    public KubernetesApiException(String method, String path, int statusCode, String body) {
+        super("Kubernetes API " + method + " " + path + " failed: HTTP " + statusCode
+                + (body == null || body.isBlank() ? "" : " " + body));
+        this.statusCode = statusCode;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesPodLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesPodLauncher.java
@@ -1,11 +1,7 @@
 package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
 
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.ContainerStatus;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.NonDeletingOperation;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
@@ -82,7 +78,7 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
             "ImagePullBackOff", "InvalidImageName", "CrashLoopBackOff",
             "CreateContainerError", "CreateContainerConfigError", "RunContainerError");
 
-    private final KubernetesClient client;
+    private final KubernetesApiClient client;
     private final EmulatorConfig config;
     private final RuntimeApiServerFactory runtimeApiServerFactory;
     private final ImageResolver imageResolver;
@@ -101,7 +97,7 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
     private final AtomicBoolean awsConfigPathWarned = new AtomicBoolean(false);
 
     @Inject
-    public KubernetesPodLauncher(KubernetesClient client,
+    public KubernetesPodLauncher(KubernetesApiClient client,
                                  EmulatorConfig config,
                                  RuntimeApiServerFactory runtimeApiServerFactory,
                                  ImageResolver imageResolver,
@@ -124,13 +120,12 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
     }
 
     /**
-     * Forces the lazy client bean (and its underlying Vert.x HTTP client) to be
-     * built on the caller's thread. Called from the startup observer so the HTTP
-     * client is not born on a request's Vert.x context, whose close at shutdown
-     * would leave every later Kubernetes API call failing with "Client is closed".
+     * Resolves the API client's connection (in-cluster or kubeconfig) on the caller's
+     * thread. Called from the startup observer so a misconfigured cluster connection
+     * fails startup instead of the first cold start.
      */
     public void initializeClient() {
-        client.getConfiguration();
+        client.initialize();
         // Resolve the address pods use to reach Floci now, so the most common
         // misconfiguration (running outside the cluster without a floci-address)
         // fails startup instead of every later cold start.
@@ -218,7 +213,7 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
                     imagePackage ? null : fn.getHandler(), imageConfig, fn.getMemorySize(), caConfigMap);
 
             ownPodNames.add(podName);
-            client.pods().inNamespace(namespace).resource(pod).create();
+            client.createPod(namespace, pod);
             LOG.infov("Created pod {0} for function {1}", podName, fn.getFunctionName());
 
             awaitRunning(namespace, podName, fn.getFunctionName());
@@ -310,13 +305,12 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
     @Override
     public boolean isAlive(ContainerHandle handle) {
         try {
-            var pod = client.pods().inNamespace(namespace()).withName(handle.getContainerId()).get();
+            var pod = client.getPod(namespace(), handle.getContainerId()).orElse(null);
             return pod != null
-                    && pod.getStatus() != null
-                    && "Running".equals(pod.getStatus().getPhase())
-                    && pod.getMetadata().getDeletionTimestamp() == null;
+                    && "Running".equals(pod.path("status").path("phase").asText(null))
+                    && isAbsent(pod.path("metadata").path("deletionTimestamp"));
         } catch (Exception e) {
-            // A missing pod comes back as null above; reaching here means the API server
+            // A missing pod comes back as empty above; reaching here means the API server
             // itself was unreachable. Unlike docker's local socket the API server is remote,
             // so a transient blip must not read as "dead" — that would cull the whole warm
             // pool at once. Assume alive; a genuinely dead pod fails the next invocation.
@@ -350,24 +344,19 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
                 return;
             }
             try {
-                var orphans = client.pods().inNamespace(namespace)
-                        .withLabels(LambdaPodSpecFactory.managedPodSelector())
-                        .list().getItems().stream()
-                        .filter(pod -> !ownPodNames.contains(pod.getMetadata().getName()))
+                var orphans = client.listPods(namespace, LambdaPodSpecFactory.managedPodSelector()).stream()
+                        .filter(pod -> !ownPodNames.contains(pod.path("metadata").path("name").asText()))
                         .toList();
                 if (!orphans.isEmpty()) {
                     LOG.infov("Deleting {0} orphaned Lambda pod(s) from a previous run in namespace {1}",
                             orphans.size(), namespace);
                     for (var orphan : orphans) {
-                        client.pods().inNamespace(namespace)
-                                .withName(orphan.getMetadata().getName())
-                                .withGracePeriod(0)
-                                .delete();
+                        client.deletePod(namespace, orphan.path("metadata").path("name").asText());
                     }
                 }
                 orphansSwept = true;
-            } catch (KubernetesClientException e) {
-                if (e.getCode() == 401 || e.getCode() == 403) {
+            } catch (KubernetesApiException e) {
+                if (e.getStatusCode() == 401 || e.getStatusCode() == 403) {
                     // A permission gap never heals within this process, so stop retrying
                     // it on every cold start; the ServiceAccount simply cannot sweep.
                     LOG.warnv("Orphaned Lambda pod sweep is not permitted in namespace {0} "
@@ -445,14 +434,12 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
 
     private void awaitRunning(String namespace, String podName, String functionName) {
         var timeoutSeconds = POD_STARTUP_TIMEOUT_SECONDS;
-        Pod pod;
+        JsonNode pod;
         try {
-            // A null pod (deleted out-of-band) is terminal too, otherwise the wait
+            // A missing pod (deleted out-of-band) is terminal too, otherwise the wait
             // would block the invocation for the full timeout.
-            pod = client.pods().inNamespace(namespace).withName(podName)
-                    .waitUntilCondition(p -> p == null
-                                    || (p.getStatus() != null && (isRunning(p) || hasTerminalFailure(p))),
-                            timeoutSeconds, TimeUnit.SECONDS);
+            pod = client.waitForPod(namespace, podName,
+                    p -> p == null || isRunning(p) || hasTerminalFailure(p), timeoutSeconds);
         } catch (Exception e) {
             throw new RuntimeException("Pod " + podName + " for function '" + functionName
                     + "' did not reach Running within " + timeoutSeconds + "s: " + e.getMessage(), e);
@@ -463,12 +450,12 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
         }
     }
 
-    private static boolean isRunning(Pod pod) {
-        return "Running".equals(pod.getStatus().getPhase());
+    private static boolean isRunning(JsonNode pod) {
+        return "Running".equals(pod.path("status").path("phase").asText(null));
     }
 
-    private static boolean hasTerminalFailure(Pod pod) {
-        var phase = pod.getStatus().getPhase();
+    private static boolean hasTerminalFailure(JsonNode pod) {
+        var phase = pod.path("status").path("phase").asText(null);
         // Succeeded means the runtime exited before serving — terminal for a server pod.
         if ("Failed".equals(phase) || "Succeeded".equals(phase)) {
             return true;
@@ -476,61 +463,54 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
         return unschedulableReason(pod) != null || describeTerminalReason(pod) != null;
     }
 
-    private static String unschedulableReason(Pod pod) {
-        if (pod.getStatus().getConditions() == null) {
-            return null;
-        }
-        for (var condition : pod.getStatus().getConditions()) {
+    private static String unschedulableReason(JsonNode pod) {
+        for (var condition : pod.path("status").path("conditions")) {
             // A pod the scheduler cannot place — e.g. a memory request above every node's
             // capacity — stays Pending with no container statuses; fail the cold start
             // instead of blocking the invoker for the full startup timeout.
-            if ("PodScheduled".equals(condition.getType()) && "False".equals(condition.getStatus())
-                    && "Unschedulable".equals(condition.getReason())) {
-                return "Unschedulable: " + condition.getMessage();
+            if ("PodScheduled".equals(condition.path("type").asText(null))
+                    && "False".equals(condition.path("status").asText(null))
+                    && "Unschedulable".equals(condition.path("reason").asText(null))) {
+                return "Unschedulable: " + condition.path("message").asText("");
             }
         }
         return null;
     }
 
-    private static String describeTerminalReason(Pod pod) {
-        var statuses = new ArrayList<ContainerStatus>();
-        if (pod.getStatus().getInitContainerStatuses() != null) {
-            statuses.addAll(pod.getStatus().getInitContainerStatuses());
-        }
-        if (pod.getStatus().getContainerStatuses() != null) {
-            statuses.addAll(pod.getStatus().getContainerStatuses());
-        }
-        for (var status : statuses) {
-            if (status.getState() == null) {
-                continue;
-            }
-            var waiting = status.getState().getWaiting();
-            // getReason() is null while a reason is absent; Set.of(...).contains(null)
-            // throws, which would abort an otherwise healthy cold start.
-            if (waiting != null && waiting.getReason() != null
-                    && TERMINAL_WAITING_REASONS.contains(waiting.getReason())) {
-                return status.getName() + ": " + waiting.getReason()
-                        + " (" + waiting.getMessage() + ")";
-            }
-            if (status.getState().getTerminated() != null
-                    && status.getState().getTerminated().getExitCode() != null
-                    && status.getState().getTerminated().getExitCode() != 0) {
-                return status.getName() + ": exited with code "
-                        + status.getState().getTerminated().getExitCode();
+    private static String describeTerminalReason(JsonNode pod) {
+        for (var statuses : List.of(pod.path("status").path("initContainerStatuses"),
+                pod.path("status").path("containerStatuses"))) {
+            for (var status : statuses) {
+                var waiting = status.path("state").path("waiting");
+                var waitingReason = waiting.path("reason").asText(null);
+                // A missing reason must never match; Set.of(...).contains(null) throws,
+                // which would abort an otherwise healthy cold start.
+                if (waitingReason != null && TERMINAL_WAITING_REASONS.contains(waitingReason)) {
+                    return status.path("name").asText() + ": " + waitingReason
+                            + " (" + waiting.path("message").asText("") + ")";
+                }
+                var exitCode = status.path("state").path("terminated").path("exitCode");
+                if (!exitCode.isMissingNode() && exitCode.asInt() != 0) {
+                    return status.path("name").asText() + ": exited with code " + exitCode.asInt();
+                }
             }
         }
         return null;
     }
 
-    private static String describeFailure(Pod pod) {
-        if (pod == null || pod.getStatus() == null) {
+    private static String describeFailure(JsonNode pod) {
+        if (pod == null || pod.path("status").isMissingNode()) {
             return "pod no longer exists";
         }
         var reason = describeTerminalReason(pod);
         if (reason == null) {
             reason = unschedulableReason(pod);
         }
-        return reason != null ? reason : "phase=" + pod.getStatus().getPhase();
+        return reason != null ? reason : "phase=" + pod.path("status").path("phase").asText("unknown");
+    }
+
+    private static boolean isAbsent(JsonNode node) {
+        return node.isMissingNode() || node.isNull();
     }
 
     /**
@@ -543,15 +523,15 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
         }
         try {
             var pem = Files.readString(caCertPath);
-            var configMap = new ConfigMapBuilder()
-                    .withNewMetadata()
-                    .withName(CA_CONFIG_MAP_NAME)
-                    .withLabels(LambdaPodSpecFactory.managedPodSelector())
-                    .endMetadata()
-                    .addToData(CA_CONFIG_MAP_KEY, pem)
-                    .build();
-            client.configMaps().inNamespace(namespace).resource(configMap)
-                    .createOr(NonDeletingOperation::update);
+            var nodes = JsonNodeFactory.instance;
+            var labels = nodes.objectNode();
+            LambdaPodSpecFactory.managedPodSelector().forEach(labels::put);
+            var metadata = nodes.objectNode().put("name", CA_CONFIG_MAP_NAME);
+            metadata.set("labels", labels);
+            var configMap = nodes.objectNode().put("apiVersion", "v1").put("kind", "ConfigMap");
+            configMap.set("metadata", metadata);
+            configMap.set("data", nodes.objectNode().put(CA_CONFIG_MAP_KEY, pem));
+            client.createOrUpdateConfigMap(namespace, configMap);
             caConfigMapApplied.set(true);
             return CA_CONFIG_MAP_NAME;
         } catch (Exception e) {
@@ -572,9 +552,8 @@ public class KubernetesPodLauncher implements LambdaRuntimeLauncher {
         // abandoned either way, and a retried orphan sweep may still collect it.
         ownPodNames.remove(podName);
         try {
-            client.pods().inNamespace(namespace).withName(podName).withGracePeriod(0).delete();
-            client.pods().inNamespace(namespace).withName(podName)
-                    .waitUntilCondition(p -> p == null, POD_DELETE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            client.deletePod(namespace, podName);
+            client.waitForPod(namespace, podName, pod -> pod == null, POD_DELETE_TIMEOUT_SECONDS);
             return true;
         } catch (Exception e) {
             LOG.warnv("Pod {0} was not confirmed deleted within {1}s: {2}",

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesPodLogStreamer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesPodLogStreamer.java
@@ -1,6 +1,5 @@
 package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
 
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.github.hectorvent.floci.core.common.docker.ContainerLogStreamer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -9,6 +8,7 @@ import org.jboss.logging.Logger;
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
@@ -23,11 +23,11 @@ public class KubernetesPodLogStreamer {
 
     private static final Logger LOG = Logger.getLogger(KubernetesPodLogStreamer.class);
 
-    private final KubernetesClient client;
+    private final KubernetesApiClient client;
     private final ContainerLogStreamer cloudWatchWriter;
 
     @Inject
-    public KubernetesPodLogStreamer(KubernetesClient client, ContainerLogStreamer cloudWatchWriter) {
+    public KubernetesPodLogStreamer(KubernetesApiClient client, ContainerLogStreamer cloudWatchWriter) {
         this.client = client;
         this.cloudWatchWriter = cloudWatchWriter;
     }
@@ -41,14 +41,11 @@ public class KubernetesPodLogStreamer {
                             String logStream, String region, String logPrefix) {
         cloudWatchWriter.ensureLogGroupAndStream(logGroup, logStream, region);
 
-        var watch = client.pods().inNamespace(namespace).withName(podName)
-                .inContainer("runtime")
-                .watchLog();
+        InputStream logStreamBody = client.openPodLogStream(namespace, podName, "runtime");
 
         // Virtual thread: one blocking reader per warm pod is near-free this way.
         var reader = Thread.ofVirtual().name("lambda-pod-logs-" + podName).start(() -> {
-            try (var lines = new BufferedReader(
-                    new InputStreamReader(watch.getOutput(), StandardCharsets.UTF_8))) {
+            try (var lines = new BufferedReader(new InputStreamReader(logStreamBody, StandardCharsets.UTF_8))) {
                 String line;
                 while ((line = lines.readLine()) != null) {
                     // Match the docker log path: trim trailing whitespace and drop blank
@@ -68,9 +65,9 @@ public class KubernetesPodLogStreamer {
 
         return () -> {
             try {
-                watch.close();
+                logStreamBody.close();
             } catch (Exception e) {
-                LOG.debugv("Closing log watch for pod {0} failed: {1}", podName, e.getMessage());
+                LOG.debugv("Closing log stream for pod {0} failed: {1}", podName, e.getMessage());
             }
             reader.interrupt();
         };

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/LambdaPodSpecFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/LambdaPodSpecFactory.java
@@ -1,22 +1,14 @@
 package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
 
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.lambda.launcher.ContainerLauncher;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -24,10 +16,10 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Builds the Pod manifest for one Lambda execution environment. Code cannot be
- * copied into a pod before it starts (no docker-cp equivalent), so an init
- * container downloads the deployment package (and layers) from Floci's S3 over
- * HTTP into an emptyDir mounted at /var/task before the runtime starts.
+ * Builds the Pod manifest for one Lambda execution environment, as a plain JSON tree (see
+ * {@link KubernetesApiClient}). Code cannot be copied into a pod before it starts (no docker-cp
+ * equivalent), so an init container downloads the deployment package (and layers) from Floci's
+ * S3 over HTTP into an emptyDir mounted at /var/task before the runtime starts.
  */
 @ApplicationScoped
 public class LambdaPodSpecFactory {
@@ -70,7 +62,7 @@ public class LambdaPodSpecFactory {
      * @param imageConfig      Image-package-type entrypoint/command/workingdir; empty lists/null when unset
      * @param caConfigMapName  ConfigMap holding Floci's CA cert, mounted at /etc/floci-ca.crt when present
      */
-    public Pod buildPod(String podName,
+    public ObjectNode buildPod(String podName,
                         String functionName,
                         String image,
                         List<String> env,
@@ -83,94 +75,102 @@ public class LambdaPodSpecFactory {
                         Optional<String> caConfigMapName) {
         var hasCode = codeDownloadUrl != null;
         var hasLayers = !layerDownloadUrls.isEmpty();
+        var nodes = JsonNodeFactory.instance;
 
-        var volumes = new ArrayList<Volume>();
-        var runtimeMounts = new ArrayList<VolumeMount>();
+        var volumes = nodes.arrayNode();
+        var runtimeMounts = nodes.arrayNode();
         if (hasCode) {
-            volumes.add(new VolumeBuilder().withName("task").withNewEmptyDir().endEmptyDir().build());
-            runtimeMounts.add(mount("task", TASK_DIR));
+            volumes.add(emptyDirVolume(nodes, "task"));
+            runtimeMounts.add(mount(nodes, "task", TASK_DIR));
         }
         if (hasLayers) {
-            volumes.add(new VolumeBuilder().withName("opt").withNewEmptyDir().endEmptyDir().build());
-            runtimeMounts.add(mount("opt", OPT_DIR));
+            volumes.add(emptyDirVolume(nodes, "opt"));
+            runtimeMounts.add(mount(nodes, "opt", OPT_DIR));
         }
         // The provided.* base images exec /var/runtime/bootstrap with no /var/task
         // fallback, and their /var/runtime ships empty, so masking it with an emptyDir
         // that the init container copies bootstrap into is safe and required.
         var needsRuntimeDir = providedRuntime && hasCode;
         if (needsRuntimeDir) {
-            volumes.add(new VolumeBuilder().withName("runtime").withNewEmptyDir().endEmptyDir().build());
-            runtimeMounts.add(mount("runtime", RUNTIME_DIR));
+            volumes.add(emptyDirVolume(nodes, "runtime"));
+            runtimeMounts.add(mount(nodes, "runtime", RUNTIME_DIR));
         }
         caConfigMapName.ifPresent(cm -> {
-            volumes.add(new VolumeBuilder().withName("floci-ca")
-                    .withNewConfigMap().withName(cm).endConfigMap().build());
-            runtimeMounts.add(new VolumeMountBuilder()
-                    .withName("floci-ca")
-                    .withMountPath(ContainerLauncher.FLOCI_CA_CONTAINER_PATH)
-                    .withSubPath(KubernetesPodLauncher.CA_CONFIG_MAP_KEY)
-                    .withReadOnly(true)
-                    .build());
+            volumes.add(nodes.objectNode().put("name", "floci-ca")
+                    .set("configMap", nodes.objectNode().put("name", cm)));
+            runtimeMounts.add(nodes.objectNode()
+                    .put("name", "floci-ca")
+                    .put("mountPath", ContainerLauncher.FLOCI_CA_CONTAINER_PATH)
+                    .put("subPath", KubernetesPodLauncher.CA_CONFIG_MAP_KEY)
+                    .put("readOnly", true));
         });
 
-        var runtime = new ContainerBuilder()
-                .withName("runtime")
-                .withImage(image)
+        var resources = nodes.objectNode();
+        var memory = memoryMb + "Mi";
+        resources.set("requests", nodes.objectNode().put("memory", memory));
+        resources.set("limits", nodes.objectNode().put("memory", memory));
+
+        var runtime = nodes.objectNode()
+                .put("name", "runtime")
+                .put("image", image)
                 // Explicit IfNotPresent: the default for :latest/untagged is Always,
                 // which breaks images pre-loaded onto nodes (kind load docker-image).
-                .withImagePullPolicy("IfNotPresent")
-                .withEnv(toEnvVars(env))
-                .withVolumeMounts(runtimeMounts)
-                .withNewResources()
-                .addToRequests("memory", new Quantity(memoryMb + "Mi"))
-                .addToLimits("memory", new Quantity(memoryMb + "Mi"))
-                .endResources();
+                .put("imagePullPolicy", "IfNotPresent");
+        runtime.set("env", toEnvVars(nodes, env));
+        runtime.set("volumeMounts", runtimeMounts);
+        runtime.set("resources", resources);
 
         if (imageConfig != null && !imageConfig.entryPoint().isEmpty()) {
-            runtime.withCommand(escapeDollars(imageConfig.entryPoint()));
+            runtime.set("command", stringArray(nodes, escapeDollars(imageConfig.entryPoint())));
         }
         if (imageConfig != null && !imageConfig.command().isEmpty()) {
-            runtime.withArgs(escapeDollars(imageConfig.command()));
+            runtime.set("args", stringArray(nodes, escapeDollars(imageConfig.command())));
         } else if (handlerOrNull != null && !handlerOrNull.isBlank()) {
-            runtime.withArgs(escapeDollar(handlerOrNull));
+            runtime.set("args", stringArray(nodes, List.of(escapeDollar(handlerOrNull))));
         }
         if (imageConfig != null && imageConfig.workingDirectory() != null
                 && !imageConfig.workingDirectory().isBlank()) {
-            runtime.withWorkingDir(imageConfig.workingDirectory());
+            runtime.put("workingDir", imageConfig.workingDirectory());
         }
 
-        var initContainers = new ArrayList<Container>();
+        var initContainers = nodes.arrayNode();
         if (hasCode) {
-            var initMounts = new ArrayList<VolumeMount>();
-            initMounts.add(mount("task", TASK_DIR));
+            var initMounts = nodes.arrayNode();
+            initMounts.add(mount(nodes, "task", TASK_DIR));
             if (hasLayers) {
-                initMounts.add(mount("opt", OPT_DIR));
+                initMounts.add(mount(nodes, "opt", OPT_DIR));
             }
             if (needsRuntimeDir) {
-                initMounts.add(mount("runtime", RUNTIME_DIR));
+                initMounts.add(mount(nodes, "runtime", RUNTIME_DIR));
             }
-            initContainers.add(new ContainerBuilder()
-                    .withName("code-download")
-                    .withImage(config.services().lambda().kubernetes().initImage())
-                    .withImagePullPolicy("IfNotPresent")
-                    .withCommand("sh", "-c", initScript(codeDownloadUrl, layerDownloadUrls, providedRuntime))
-                    .withVolumeMounts(initMounts)
-                    .build());
+            var init = nodes.objectNode()
+                    .put("name", "code-download")
+                    .put("image", config.services().lambda().kubernetes().initImage())
+                    .put("imagePullPolicy", "IfNotPresent");
+            init.set("command", stringArray(nodes,
+                    List.of("sh", "-c", initScript(codeDownloadUrl, layerDownloadUrls, providedRuntime))));
+            init.set("volumeMounts", initMounts);
+            initContainers.add(init);
         }
 
-        return new PodBuilder()
-                .withNewMetadata()
-                .withName(podName)
-                .withLabels(podLabels(functionName))
-                .endMetadata()
-                .withNewSpec()
-                .withRestartPolicy("Never")
-                .withTerminationGracePeriodSeconds(5L)
-                .withInitContainers(initContainers)
-                .withContainers(runtime.build())
-                .withVolumes(volumes)
-                .endSpec()
-                .build();
+        var metadata = nodes.objectNode().put("name", podName);
+        var labels = nodes.objectNode();
+        podLabels(functionName).forEach(labels::put);
+        metadata.set("labels", labels);
+
+        var spec = nodes.objectNode()
+                .put("restartPolicy", "Never")
+                .put("terminationGracePeriodSeconds", 5);
+        spec.set("initContainers", initContainers);
+        spec.set("containers", nodes.arrayNode().add(runtime));
+        spec.set("volumes", volumes);
+
+        var pod = nodes.objectNode()
+                .put("apiVersion", "v1")
+                .put("kind", "Pod");
+        pod.set("metadata", metadata);
+        pod.set("spec", spec);
+        return pod;
     }
 
     /** Entrypoint/command/workingdir of an Image-package-type function. */
@@ -262,8 +262,18 @@ public class LambdaPodSpecFactory {
         return sanitized;
     }
 
-    private static VolumeMount mount(String name, String path) {
-        return new VolumeMountBuilder().withName(name).withMountPath(path).build();
+    private static ObjectNode emptyDirVolume(JsonNodeFactory nodes, String name) {
+        return nodes.objectNode().put("name", name).set("emptyDir", nodes.objectNode());
+    }
+
+    private static ObjectNode mount(JsonNodeFactory nodes, String name, String path) {
+        return nodes.objectNode().put("name", name).put("mountPath", path);
+    }
+
+    private static ArrayNode stringArray(JsonNodeFactory nodes, List<String> values) {
+        var array = nodes.arrayNode();
+        values.forEach(array::add);
+        return array;
     }
 
     private static List<String> escapeDollars(List<String> values) {
@@ -276,8 +286,8 @@ public class LambdaPodSpecFactory {
         return value.replace("$", "$$");
     }
 
-    private static List<EnvVar> toEnvVars(List<String> env) {
-        var vars = new ArrayList<EnvVar>(env.size());
+    private static ArrayNode toEnvVars(JsonNodeFactory nodes, List<String> env) {
+        var vars = nodes.arrayNode();
         for (var entry : env) {
             var eq = entry.indexOf('=');
             var key = eq >= 0 ? entry.substring(0, eq) : entry;
@@ -289,7 +299,7 @@ public class LambdaPodSpecFactory {
             }
             // Kubernetes expands $(VAR) in env values and collapses $$ to $.
             // Escaping every $ delivers values byte-for-byte like the docker executor.
-            vars.add(new EnvVar(key, value.replace("$", "$$"), null));
+            vars.add(nodes.objectNode().put("name", key).put("value", value.replace("$", "$$")));
         }
         return vars;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,11 +17,6 @@ quarkus:
       max-body-size: ${floci.max-request-size}M
   datasource:
     active: false
-  kubernetes-client:
-    devservices:
-      # Never auto-start a test API server; the kubernetes Lambda executor
-      # connects to a real cluster (in-cluster config or kubeconfig) only.
-      enabled: false
   security:
      security-providers: BC
   shutdown:

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiClientKubeconfigTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesApiClientKubeconfigTest.java
@@ -1,0 +1,121 @@
+package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
+
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import io.github.hectorvent.floci.services.acm.CertificateGenerator;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Verifies kubeconfig's {@code insecure-skip-tls-verify} against a real self-signed HTTPS
+ * server, not just that the flag parses: without it, a self-signed server cert must still fail
+ * the handshake, or the flag would silently do nothing.
+ */
+class KubernetesApiClientKubeconfigTest {
+
+    private HttpsServer server;
+
+    @BeforeAll
+    static void registerBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void insecureSkipTlsVerifyTrustsASelfSignedServerCert(@TempDir Path tempDir) throws Exception {
+        startSelfSignedServer();
+        var kubeconfig = writeKubeconfig(tempDir, true);
+
+        var client = new KubernetesApiClient();
+        client.initializeFromKubeconfigForTest(kubeconfig);
+
+        assertThat(client.getPod("default", "whatever")).isEmpty();
+    }
+
+    @Test
+    void withoutInsecureSkipTlsVerifyASelfSignedServerCertFailsTheHandshake(@TempDir Path tempDir) throws Exception {
+        startSelfSignedServer();
+        var kubeconfig = writeKubeconfig(tempDir, false);
+
+        var client = new KubernetesApiClient();
+        client.initializeFromKubeconfigForTest(kubeconfig);
+
+        assertThatThrownBy(() -> client.getPod("default", "whatever"))
+                .hasMessageContaining("Kubernetes API GET");
+    }
+
+    private void startSelfSignedServer() throws Exception {
+        var generator = new CertificateGenerator();
+        var generated = generator.generateSelfSignedCertificate(
+                "127.0.0.1", List.of("127.0.0.1"), KeyAlgorithm.RSA_2048);
+        var cert = generator.parseCertificate(generated.certificatePem());
+        var privateKey = generator.parsePrivateKey(generated.privateKeyPem());
+
+        var keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        keyStore.load(null, null);
+        keyStore.setKeyEntry("server", privateKey, new char[0], new Certificate[]{cert});
+        var keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory.init(keyStore, new char[0]);
+        var sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
+
+        server = HttpsServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setHttpsConfigurator(new HttpsConfigurator(sslContext));
+        server.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(404, -1);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    private Path writeKubeconfig(Path tempDir, boolean insecureSkipTlsVerify) throws Exception {
+        var port = server.getAddress().getPort();
+        var config = """
+                apiVersion: v1
+                kind: Config
+                current-context: test
+                clusters:
+                  - name: c
+                    cluster:
+                      server: https://127.0.0.1:%d
+                      insecure-skip-tls-verify: %s
+                contexts:
+                  - name: test
+                    context:
+                      cluster: c
+                      user: u
+                users:
+                  - name: u
+                    user:
+                      token: test-token
+                """.formatted(port, insecureSkipTlsVerify);
+        var path = tempDir.resolve("config");
+        Files.writeString(path, config);
+        return path;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesPodLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/KubernetesPodLauncherTest.java
@@ -20,6 +20,13 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -31,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -42,10 +50,19 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * {@code client} (the fabric8 mock server injected by {@code @EnableKubernetesMockClient}) plays
+ * two roles here: it is the fake HTTPS API server {@link #apiClient} talks to (over a trust-all
+ * {@link HttpClient}, since the mock's cert is self-signed and per-run), and it is used directly
+ * to seed pods and play the kubelet (setting phases) exactly as a real cluster would. Reading
+ * pods back through it after {@link #apiClient} creates them works because both talk to the same
+ * backing store; only the mock's transport is fabric8, never Floci's own code.
+ */
 @EnableKubernetesMockClient(crud = true)
 class KubernetesPodLauncherTest {
     KubernetesClient client;
 
+    private KubernetesApiClient apiClient;
     private EmulatorConfig config;
     private RuntimeApiServerFactory runtimeApiServerFactory;
     private RuntimeApiServer runtimeApiServer;
@@ -100,9 +117,29 @@ class KubernetesPodLauncherTest {
         lenient().when(logStreamer.logStreamName(anyString())).thenReturn("2026/07/25/[$LATEST]test");
         s3Service = mock(S3Service.class);
 
-        launcher = new KubernetesPodLauncher(client, config, runtimeApiServerFactory, imageResolver,
+        apiClient = new KubernetesApiClient(
+                URI.create(client.getConfiguration().getMasterUrl()), trustAllHttpClient(), null);
+        launcher = new KubernetesPodLauncher(apiClient, config, runtimeApiServerFactory, imageResolver,
                 addressResolver, awsEnv, layerService, new LambdaPodSpecFactory(config),
                 logStreamer, s3Service);
+    }
+
+    /** The mock server's cert is self-signed and generated per run; trust it, not the JVM default. */
+    private static HttpClient trustAllHttpClient() {
+        try {
+            var trustAll = new X509TrustManager() {
+                public void checkClientTrusted(X509Certificate[] chain, String authType) { }
+                public void checkServerTrusted(X509Certificate[] chain, String authType) { }
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[0];
+                }
+            };
+            var context = SSLContext.getInstance("TLS");
+            context.init(null, new TrustManager[]{trustAll}, new SecureRandom());
+            return HttpClient.newBuilder().sslContext(context).build();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private LambdaFunction function() {
@@ -231,16 +268,9 @@ class KubernetesPodLauncherTest {
         // the cleanup delete can never confirm the pod is gone. The pod could still reach
         // Running later and poll AWS_LAMBDA_RUNTIME_API, so the port must stay reserved
         // instead of going back to the pool for another environment.
-        var failingClient = spy(client);
-        doAnswer(invocation -> {
-            var failedPodExists = client.pods().inNamespace("default").list().getItems().stream()
-                    .anyMatch(p -> p.getStatus() != null && "Failed".equals(p.getStatus().getPhase()));
-            if (failedPodExists) {
-                throw new RuntimeException("kube api down");
-            }
-            return invocation.callRealMethod();
-        }).when(failingClient).pods();
-        var failingLauncher = new KubernetesPodLauncher(failingClient, config,
+        var failingApiClient = spy(apiClient);
+        doThrow(new RuntimeException("kube api down")).when(failingApiClient).deletePod(anyString(), anyString());
+        var failingLauncher = new KubernetesPodLauncher(failingApiClient, config,
                 runtimeApiServerFactory, imageResolver, addressResolver, awsEnv, layerService,
                 new LambdaPodSpecFactory(config), logStreamer, s3Service);
         markPodPhaseInBackground("floci-lambda-my-fn-", "Failed");
@@ -383,14 +413,14 @@ class KubernetesPodLauncherTest {
 
         // First Kubernetes API access (the sweep's pod list) fails once.
         var failedOnce = new AtomicBoolean();
-        var flakyClient = spy(client);
+        var flakyApiClient = spy(apiClient);
         doAnswer(invocation -> {
             if (failedOnce.compareAndSet(false, true)) {
                 throw new RuntimeException("kube api down");
             }
             return invocation.callRealMethod();
-        }).when(flakyClient).pods();
-        var retryingLauncher = new KubernetesPodLauncher(flakyClient, config,
+        }).when(flakyApiClient).listPods(anyString(), anyMap());
+        var retryingLauncher = new KubernetesPodLauncher(flakyApiClient, config,
                 runtimeApiServerFactory, imageResolver, addressResolver, awsEnv, layerService,
                 new LambdaPodSpecFactory(config), logStreamer, s3Service);
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/LambdaPodSpecFactoryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/LambdaPodSpecFactoryTest.java
@@ -1,9 +1,6 @@
 package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
 
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.VolumeMount;
+import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,7 +10,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +48,7 @@ class LambdaPodSpecFactoryTest {
         factory = new LambdaPodSpecFactory(config);
     }
 
-    private Pod buildZipPod() {
+    private JsonNode buildZipPod() {
         return factory.buildPod("floci-lambda-my-fn-abc12345", "my-fn",
                 "public.ecr.aws/lambda/python:3.12",
                 List.of("AWS_LAMBDA_RUNTIME_API=10.0.0.5:9200", "_HANDLER=index.handler"),
@@ -56,42 +56,64 @@ class LambdaPodSpecFactoryTest {
                 List.of(), false, "index.handler", null, 256, Optional.empty());
     }
 
+    private static JsonNode spec(JsonNode pod) {
+        return pod.path("spec");
+    }
+
+    private static List<JsonNode> elements(JsonNode array) {
+        var list = new ArrayList<JsonNode>();
+        array.forEach(list::add);
+        return list;
+    }
+
+    private static List<String> texts(JsonNode array) {
+        return elements(array).stream().map(JsonNode::asText).toList();
+    }
+
+    private static Map<String, String> stringMap(JsonNode object) {
+        var map = new LinkedHashMap<String, String>();
+        object.fields().forEachRemaining(entry -> map.put(entry.getKey(), entry.getValue().asText()));
+        return map;
+    }
+
     @Test
     void zipFunctionPodHasInitContainerTaskVolumeAndEnv() {
-        var spec = buildZipPod().getSpec();
+        var spec = spec(buildZipPod());
 
-        assertThat(spec.getRestartPolicy()).isEqualTo("Never");
-        assertThat(spec.getTerminationGracePeriodSeconds()).isEqualTo(5L);
-        assertThat(spec.getInitContainers()).hasSize(1);
+        assertThat(spec.path("restartPolicy").asText()).isEqualTo("Never");
+        assertThat(spec.path("terminationGracePeriodSeconds").asLong()).isEqualTo(5L);
+        var initContainers = elements(spec.path("initContainers"));
+        assertThat(initContainers).hasSize(1);
 
-        var init = spec.getInitContainers().getFirst();
-        assertThat(init.getImage()).isEqualTo("busybox:1.36");
-        assertThat(init.getCommand().get(2))
+        var init = initContainers.getFirst();
+        assertThat(init.path("image").asText()).isEqualTo("busybox:1.36");
+        assertThat(texts(init.path("command")).get(2))
                 .contains("wget -q -O /tmp/code.zip")
                 .contains("unzip -oq /tmp/code.zip -d /var/task")
                 .doesNotContain("--no-check-certificate");
-        assertThat(init.getVolumeMounts())
-                .extracting(VolumeMount::getName, VolumeMount::getMountPath)
+        assertThat(elements(init.path("volumeMounts")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("mountPath").asText())
                 .containsExactly(tuple("task", "/var/task"));
 
-        var runtime = spec.getContainers().getFirst();
-        assertThat(runtime.getName()).isEqualTo("runtime");
-        assertThat(runtime.getArgs()).containsExactly("index.handler");
-        assertThat(runtime.getResources().getLimits().get("memory")).hasToString("256Mi");
-        assertThat(runtime.getResources().getRequests().get("memory")).hasToString("256Mi");
-        assertThat(runtime.getVolumeMounts())
-                .extracting(VolumeMount::getName, VolumeMount::getMountPath)
+        var runtime = elements(spec.path("containers")).getFirst();
+        assertThat(runtime.path("name").asText()).isEqualTo("runtime");
+        assertThat(texts(runtime.path("args"))).containsExactly("index.handler");
+        assertThat(runtime.path("resources").path("limits").path("memory").asText()).isEqualTo("256Mi");
+        assertThat(runtime.path("resources").path("requests").path("memory").asText()).isEqualTo("256Mi");
+        assertThat(elements(runtime.path("volumeMounts")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("mountPath").asText())
                 .contains(tuple("task", "/var/task"));
-        assertThat(runtime.getEnv())
-                .extracting(EnvVar::getName, EnvVar::getValue)
+        assertThat(elements(runtime.path("env")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("value").asText())
                 .contains(tuple("AWS_LAMBDA_RUNTIME_API", "10.0.0.5:9200"));
 
-        assertThat(spec.getVolumes()).extracting(Volume::getName).containsExactly("task");
+        assertThat(elements(spec.path("volumes"))).extracting(n -> n.path("name").asText())
+                .containsExactly("task");
     }
 
     @Test
     void standardLabelsAreApplied() {
-        var labels = buildZipPod().getMetadata().getLabels();
+        var labels = stringMap(buildZipPod().path("metadata").path("labels"));
         assertThat(labels)
                 .containsEntry("app.kubernetes.io/managed-by", "floci")
                 .containsEntry("floci.io/service", "lambda")
@@ -102,7 +124,7 @@ class LambdaPodSpecFactoryTest {
     void userLabelsAreParsedAndApplied() {
         when(kubernetes.labels()).thenReturn(Optional.of(
                 List.of("team=platform", "floci.io/env=ci", "empty-ok=")));
-        var labels = buildZipPod().getMetadata().getLabels();
+        var labels = stringMap(buildZipPod().path("metadata").path("labels"));
         assertThat(labels)
                 .containsEntry("team", "platform")
                 .containsEntry("floci.io/env", "ci")
@@ -115,7 +137,7 @@ class LambdaPodSpecFactoryTest {
         // such entries must never reach the pod spec.
         when(kubernetes.labels()).thenReturn(Optional.of(
                 List.of("malformed", "a=b=c", "bad key=x", "team=platform")));
-        var labels = buildZipPod().getMetadata().getLabels();
+        var labels = stringMap(buildZipPod().path("metadata").path("labels"));
         assertThat(labels)
                 .containsEntry("team", "platform")
                 .doesNotContainKeys("malformed", "a", "bad key");
@@ -130,16 +152,17 @@ class LambdaPodSpecFactoryTest {
                 List.of("http://10.0.0.5:4566/b/layers/1", "http://10.0.0.5:4566/b/layers/2"),
                 false, "index.handler", null, 128, Optional.empty());
 
-        var spec = pod.getSpec();
-        assertThat(spec.getVolumes()).extracting(Volume::getName).contains("opt");
-        assertThat(spec.getContainers().getFirst().getVolumeMounts())
-                .extracting(VolumeMount::getName, VolumeMount::getMountPath)
+        var spec = spec(pod);
+        assertThat(elements(spec.path("volumes"))).extracting(n -> n.path("name").asText()).contains("opt");
+        assertThat(elements(elements(spec.path("containers")).getFirst().path("volumeMounts")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("mountPath").asText())
                 .contains(tuple("opt", "/opt"));
-        assertThat(spec.getInitContainers().getFirst().getVolumeMounts())
-                .extracting(VolumeMount::getName, VolumeMount::getMountPath)
+        var init = elements(spec.path("initContainers")).getFirst();
+        assertThat(elements(init.path("volumeMounts")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("mountPath").asText())
                 .contains(tuple("opt", "/opt"));
 
-        assertThat(spec.getInitContainers().getFirst().getCommand().get(2))
+        assertThat(texts(init.path("command")).get(2))
                 .contains("unzip -oq /tmp/layer0.zip -d /opt")
                 .containsSubsequence(
                         "wget -q -O /tmp/layer0.zip 'http://10.0.0.5:4566/b/layers/1'",
@@ -156,15 +179,16 @@ class LambdaPodSpecFactoryTest {
                 "http://10.0.0.5:4566/awslambda-us-east-1-tasks/snapshots/000000000000/custom",
                 List.of(), true, "bootstrap", null, 128, Optional.empty());
 
-        var spec = pod.getSpec();
-        assertThat(spec.getVolumes()).extracting(Volume::getName).contains("runtime");
-        assertThat(spec.getContainers().getFirst().getVolumeMounts())
-                .extracting(VolumeMount::getName, VolumeMount::getMountPath)
+        var spec = spec(pod);
+        assertThat(elements(spec.path("volumes"))).extracting(n -> n.path("name").asText()).contains("runtime");
+        assertThat(elements(elements(spec.path("containers")).getFirst().path("volumeMounts")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("mountPath").asText())
                 .contains(tuple("runtime", "/var/runtime"));
-        assertThat(spec.getInitContainers().getFirst().getVolumeMounts())
-                .extracting(VolumeMount::getName)
+        var init = elements(spec.path("initContainers")).getFirst();
+        assertThat(elements(init.path("volumeMounts")))
+                .extracting(n -> n.path("name").asText())
                 .contains("runtime");
-        assertThat(spec.getInitContainers().getFirst().getCommand().get(2))
+        assertThat(texts(init.path("command")).get(2))
                 .contains("cp /var/task/bootstrap /var/runtime/bootstrap")
                 .contains("chmod +x /var/runtime/bootstrap");
     }
@@ -172,8 +196,8 @@ class LambdaPodSpecFactoryTest {
     @Test
     void nonProvidedRuntimeDoesNotMaskVarRuntime() {
         // Masking /var/runtime on a normal runtime would delete the runtime interface client.
-        assertThat(buildZipPod().getSpec().getVolumes())
-                .extracting(Volume::getName)
+        assertThat(elements(spec(buildZipPod()).path("volumes")))
+                .extracting(n -> n.path("name").asText())
                 .doesNotContain("runtime");
     }
 
@@ -181,7 +205,7 @@ class LambdaPodSpecFactoryTest {
     void managedLabelsCannotBeOverriddenByUserLabels() {
         when(kubernetes.labels()).thenReturn(Optional.of(
                 List.of("app.kubernetes.io/managed-by=evil", "floci.io/service=other")));
-        var labels = buildZipPod().getMetadata().getLabels();
+        var labels = stringMap(buildZipPod().path("metadata").path("labels"));
         assertThat(labels)
                 .containsEntry("app.kubernetes.io/managed-by", "floci")
                 .containsEntry("floci.io/service", "lambda");
@@ -193,8 +217,8 @@ class LambdaPodSpecFactoryTest {
                 "public.ecr.aws/lambda/python:3.12",
                 List.of("SECRET=pa$$word", "TEMPLATE=$(HOME)/x"),
                 "http://10.0.0.5:4566/b/k", List.of(), false, "h", null, 128, Optional.empty());
-        assertThat(pod.getSpec().getContainers().getFirst().getEnv())
-                .extracting(EnvVar::getName, EnvVar::getValue)
+        assertThat(elements(elements(spec(pod).path("containers")).getFirst().path("env")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("value").asText())
                 .contains(
                         tuple("SECRET", "pa$$$$word"),
                         tuple("TEMPLATE", "$$(HOME)/x"));
@@ -212,17 +236,20 @@ class LambdaPodSpecFactoryTest {
                 List.of(), false, "index.handler", null, 128,
                 Optional.of(KubernetesPodLauncher.CA_CONFIG_MAP_NAME));
 
-        var spec = pod.getSpec();
-        assertThat(spec.getVolumes()).anySatisfy(volume -> {
-            assertThat(volume.getName()).isEqualTo("floci-ca");
-            assertThat(volume.getConfigMap().getName()).isEqualTo(KubernetesPodLauncher.CA_CONFIG_MAP_NAME);
+        var spec = spec(pod);
+        assertThat(elements(spec.path("volumes"))).anySatisfy(volume -> {
+            assertThat(volume.path("name").asText()).isEqualTo("floci-ca");
+            assertThat(volume.path("configMap").path("name").asText())
+                    .isEqualTo(KubernetesPodLauncher.CA_CONFIG_MAP_NAME);
         });
-        assertThat(spec.getContainers().getFirst().getVolumeMounts()).anySatisfy(volumeMount -> {
-            assertThat(volumeMount.getName()).isEqualTo("floci-ca");
-            assertThat(volumeMount.getMountPath()).isEqualTo("/etc/floci-ca.crt");
-            assertThat(volumeMount.getSubPath()).isEqualTo(KubernetesPodLauncher.CA_CONFIG_MAP_KEY);
-        });
-        assertThat(spec.getInitContainers().getFirst().getCommand().get(2))
+        assertThat(elements(elements(spec.path("containers")).getFirst().path("volumeMounts")))
+                .anySatisfy(volumeMount -> {
+                    assertThat(volumeMount.path("name").asText()).isEqualTo("floci-ca");
+                    assertThat(volumeMount.path("mountPath").asText()).isEqualTo("/etc/floci-ca.crt");
+                    assertThat(volumeMount.path("subPath").asText())
+                            .isEqualTo(KubernetesPodLauncher.CA_CONFIG_MAP_KEY);
+                });
+        assertThat(texts(elements(spec.path("initContainers")).getFirst().path("command")).get(2))
                 .contains("wget -q")
                 .doesNotContain("--no-check-certificate");
     }
@@ -235,7 +262,7 @@ class LambdaPodSpecFactoryTest {
                 new LambdaPodSpecFactory.ImageConfig(
                         List.of("/entry.sh"), List.of("run('$(AWS_REGION)')", "pa$$word"), "/work"),
                 512, Optional.empty());
-        assertThat(pod.getSpec().getContainers().getFirst().getArgs())
+        assertThat(texts(elements(spec(pod).path("containers")).getFirst().path("args")))
                 .containsExactly("run('$$(AWS_REGION)')", "pa$$$$word");
     }
 
@@ -248,14 +275,14 @@ class LambdaPodSpecFactoryTest {
                         List.of("/entry.sh"), List.of("arg1", "arg2"), "/work"),
                 512, Optional.empty());
 
-        var spec = pod.getSpec();
-        assertThat(spec.getInitContainers()).isEmpty();
-        assertThat(spec.getVolumes()).isEmpty();
+        var spec = spec(pod);
+        assertThat(elements(spec.path("initContainers"))).isEmpty();
+        assertThat(elements(spec.path("volumes"))).isEmpty();
 
-        var runtime = spec.getContainers().getFirst();
-        assertThat(runtime.getCommand()).containsExactly("/entry.sh");
-        assertThat(runtime.getArgs()).containsExactly("arg1", "arg2");
-        assertThat(runtime.getWorkingDir()).isEqualTo("/work");
+        var runtime = elements(spec.path("containers")).getFirst();
+        assertThat(texts(runtime.path("command"))).containsExactly("/entry.sh");
+        assertThat(texts(runtime.path("args"))).containsExactly("arg1", "arg2");
+        assertThat(runtime.path("workingDir").asText()).isEqualTo("/work");
     }
 
     @Test
@@ -264,8 +291,8 @@ class LambdaPodSpecFactoryTest {
                 "public.ecr.aws/lambda/python:3.12",
                 List.of("KEY=a=b", "EMPTY="),
                 "http://10.0.0.5:4566/b/k", List.of(), false, "h", null, 128, Optional.empty());
-        assertThat(pod.getSpec().getContainers().getFirst().getEnv())
-                .extracting(EnvVar::getName, EnvVar::getValue)
+        assertThat(elements(elements(spec(pod).path("containers")).getFirst().path("env")))
+                .extracting(n -> n.path("name").asText(), n -> n.path("value").asText())
                 .contains(
                         tuple("KEY", "a=b"),
                         tuple("EMPTY", ""));
@@ -278,8 +305,8 @@ class LambdaPodSpecFactoryTest {
                 "public.ecr.aws/lambda/python:3.12",
                 List.of("=oops", "KEY=1"),
                 "http://10.0.0.5:4566/b/k", List.of(), false, "h", null, 128, Optional.empty());
-        assertThat(pod.getSpec().getContainers().getFirst().getEnv())
-                .extracting(EnvVar::getName)
+        assertThat(elements(elements(spec(pod).path("containers")).getFirst().path("env")))
+                .extracting(n -> n.path("name").asText())
                 .containsExactly("KEY");
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,9 +6,6 @@ quarkus:
       max-body-size: ${floci.max-request-size}M
   datasource:
     active: false
-  kubernetes-client:
-    devservices:
-      enabled: false
   # Groovy (a REST Assured dependency) starts DFA-cache-cleaner threads that never stop.
   # Loaded parent-first they live in the shared system classloader, so they cannot pin a
   # per-profile application classloader across the many app restarts of a test run.


### PR DESCRIPTION
## Summary

Closes #2914

`quarkus-kubernetes-client` was an always-on dependency, so the fabric8 client and its generated Kubernetes model classes were reachable in every native-image build regardless of whether `floci.services.lambda.executor` was ever set to `kubernetes`. That's what drove a ~20% native image size increase last month.

Rather than gating the existing fabric8-based code behind a build flag, this drops the dependency entirely. The kubernetes executor only ever needs a handful of plain REST calls against the Kubernetes API (create/get/list/delete pods, create-or-update a ConfigMap, stream logs) over plain JSON/HTTPS, the same shape Floci already talks to AWS in without an SDK. `KubernetesApiClient` replaces the fabric8 client with the JDK `HttpClient`, the same approach already used elsewhere in this codebase for another container orchestrator's REST API (`FlinkRestClient`). The dependency is gone from the packaged application entirely now, native or JVM, not just unused.

Connection resolution mirrors kubectl's for the common cases: in-cluster service account (token re-read per call since projected tokens rotate, CA loaded once), or a kubeconfig's current-context with a static bearer token or client-certificate/client-key (PKCS#8) credential. exec/auth-provider credential plugins (e.g. `aws eks get-token`) are not supported and fail with a clear error naming the limitation.

`LambdaPodSpecFactory` now builds the pod manifest as a plain JSON tree instead of fabric8 builders. Tests keep using fabric8's `kubernetes-server-mock` as a fake API server (test-scope only, so it never reaches the shipped artifact) and point `KubernetesApiClient` at it instead of constructing a fabric8 client directly.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not applicable, no wire protocol or API behavior changes. This replaces the Kubernetes API transport underneath the existing kubernetes Lambda executor; its observable behavior (pod lifecycle, logs, ConfigMap, orphan sweep) is unchanged.

## Checklist

- [x] `./mvnw test` passes locally (kubernetes-package and lambda-package suites, plus a full-suite pass; 49/49 lambda test classes green)
- [x] New or updated integration test added — `KubernetesPodLauncherTest` and `LambdaPodSpecFactoryTest` were updated to exercise `KubernetesApiClient` against fabric8's `kubernetes-server-mock` (a real fake API server), so pod/ConfigMap lifecycle and orphan-sweep behavior are still covered end to end.
- [x] Commit messages follow Conventional Commits
