### PR TITLE
fix(ec2): tolerate a null groupId in the network-interface group-id filter

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -5732,8 +5732,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     }
 
     private boolean matchesValue(List<String> patterns, String value) {
+        String normalizedValue = Objects.toString(value, "");
         return patterns.stream()
-                .anyMatch(pattern -> value.matches(wildcardToRegex(pattern)));
+                .anyMatch(pattern -> normalizedValue.matches(wildcardToRegex(pattern)));
     }
 
     private boolean matchesFilters(Object resource, Map<String, List<String>> filters, String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -162,6 +162,31 @@ class Ec2ServiceTest {
         assertEquals(1, retry.getInstances().size());
     }
 
+    /**
+     * A NetworkInterface can carry a real GroupIdentifier entry whose groupId is null (a name-only
+     * association). The group-id filter must skip that entry instead of NPE-ing on
+     * {@code null.matches(...)} in the shared value matcher, while a real group on the same interface
+     * still matches. The null entry is evaluated first so the filter actually exercises the null path.
+     */
+    @Test
+    void describeNetworkInterfacesGroupIdFilterToleratesNullGroupId() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class), mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class),
+                new Ec2InstanceTypeCatalog(), new InMemoryStorageFactory());
+        String subnetId = service.describeSubnets("us-east-1", List.of(), Map.of())
+                .getFirst().getSubnetId();
+        NetworkInterface eni = service.createNetworkInterface("us-east-1", subnetId, null,
+                null, List.of(), List.of(), List.of());
+        eni.getGroups().add(new GroupIdentifier(null, "name-only"));
+        eni.getGroups().add(new GroupIdentifier("sg-realgroup000000", "real"));
+
+        List<NetworkInterface> matched = service.describeNetworkInterfaces("us-east-1", List.of(),
+                Map.of("group-id", List.of("sg-realgroup000000")), 0, null).networkInterfaces();
+
+        assertTrue(matched.stream()
+                .anyMatch(n -> eni.getNetworkInterfaceId().equals(n.getNetworkInterfaceId())));
+    }
+
     @Test
     void runInstancesRequiresImageIdInsteadOfDefaulting() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),


### PR DESCRIPTION
## What

The `group-id` filter for `DescribeNetworkInterfaces` resolves to `matchesValue(List<String> patterns, String value)`, which calls `value.matches(...)` with no null guard. A real `GroupIdentifier` entry whose `groupId` is null (a name-only association) NPEs the whole request:

```
java.lang.NullPointerException: Cannot invoke "String.matches(String)" because "value" is null
```

The sibling overload `matchesValue(String resourceValue, List<String> filterValues)` already normalizes with `Objects.toString(..., "")`. This aligns the two so every network-interface leaf filter (`group-id`, `subnet-id`, `status`, `private-dns-name`, ...) tolerates a null field instead of failing.

## Fix

One line: normalize `value` with `Objects.toString(value, "")` before `.matches(...)`, mirroring the existing null-safe overload.

## Test

`describeNetworkInterfacesGroupIdFilterToleratesNullGroupId` puts a null-`groupId` entry **ahead of** a real group on the same interface, so `anyMatch` actually evaluates the null path (and the real group still matches). It errors with the NPE above before the fix and passes after. Full `Ec2ServiceTest` stays green (122 tests).

## Context

Spotted by @pgermosen while reviewing #2887 (null group *entries*). That PR guards a null *element* in the list; this guards a real element with a null `groupId`. The two are independent, so this is a separate PR off `main` rather than a change to #2887.