### PR TITLE
fix(dynamodb): reject unused ExpressionAttributeNames/Values on PutItem, DeleteItem, Scan, Query

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
@@ -817,11 +817,12 @@ class DynamoDbConformanceChangesTest {
 
     @Test @Order(101)
     void reservedWordWithAliasPasses() {
-        // Using #status alias should work fine
+        // Using the #st alias should work fine. The alias must be referenced by the
+        // expression: AWS rejects ExpressionAttributeNames entries left unused.
         assertThatCode(() -> ddb.putItem(r -> r
                 .tableName(TABLE)
                 .item(Map.of("pk", av("rw-alias"), "sk", av("s"), "status", av("ok")))
-                .conditionExpression("attribute_not_exists(pk)")
+                .conditionExpression("attribute_not_exists(#st)")
                 .expressionAttributeNames(Map.of("#st", "status"))))
                 .doesNotThrowAnyException();
     }

--- a/compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts
@@ -612,11 +612,12 @@ describe('DynamoDB — Phase 9: Reserved words', () => {
   });
 
   it('reserved word aliased via ExpressionAttributeNames passes', async () => {
-    // Using #st alias for the reserved word 'status'
+    // Using #st alias for the reserved word 'status'. The alias must be referenced
+    // by the expression: AWS rejects ExpressionAttributeNames entries left unused.
     await ddb.send(new PutItemCommand({
       TableName: table,
       Item: { pk: s('rw-ok'), sk: s('s'), status: s('active') },
-      ConditionExpression: 'attribute_not_exists(pk)',
+      ConditionExpression: 'attribute_not_exists(#st)',
       ExpressionAttributeNames: { '#st': 'status' },
     }));
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -328,10 +328,10 @@ public class DynamoDbJsonHandler {
                     + "Non-expression parameters: {Expected} Expression parameters: {ConditionExpression}", 400);
         }
 
-        if (exprAttrValues != null && conditionExpression == null) {
-            throw new AwsException("ValidationException",
-                    "ExpressionAttributeValues can only be specified when using expressions: ConditionExpression is null", 400);
-        }
+        // EAN/EAV with no expression to reference them: AWS reports "can only be specified
+        // when using expressions", not the "unused in expressions" wording (#2893).
+        rejectExprAttrsWithoutExpression(exprAttrNames, exprAttrValues,
+                conditionExpression != null, "ConditionExpression is null");
 
         ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
 
@@ -442,6 +442,11 @@ public class DynamoDbJsonHandler {
                     n + " validation error" + (n > 1 ? "s" : "") + " detected: "
                     + String.join("; ", delValidationErrors), 400);
         }
+
+        // EAN/EAV with no expression to reference them: AWS reports "can only be specified
+        // when using expressions", not the "unused in expressions" wording (#2893).
+        rejectExprAttrsWithoutExpression(exprAttrNames, exprAttrValues,
+                conditionExpression != null, "ConditionExpression is null");
 
         ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
 
@@ -1863,6 +1868,29 @@ public class DynamoDbJsonHandler {
         Set<String> tokens = new LinkedHashSet<>();
         for (String expr : expressions) extractPrefixedTokens(expr, ':', tokens);
         return tokens;
+    }
+
+    /**
+     * Rejects ExpressionAttributeNames/Values supplied when the request carries no expression to
+     * reference them. AWS answers this sub-case with "&lt;param&gt; can only be specified when using
+     * expressions: &lt;nullExpressionParams&gt;" rather than the "unused in expressions" wording used
+     * once an alias is merely unreferenced (#2893). {@code nullExpressionParams} must spell the absent
+     * expression parameter(s) exactly as AWS reports them for the operation, e.g. "ConditionExpression is null".
+     * EAV is checked before EAN to match the pre-existing PutItem guard.
+     */
+    private static void rejectExprAttrsWithoutExpression(JsonNode exprAttrNames, JsonNode exprAttrValues,
+            boolean hasAnyExpression, String nullExpressionParams) {
+        if (hasAnyExpression) {
+            return;
+        }
+        if (exprAttrValues != null) {
+            throw new AwsException("ValidationException",
+                    "ExpressionAttributeValues can only be specified when using expressions: " + nullExpressionParams, 400);
+        }
+        if (exprAttrNames != null) {
+            throw new AwsException("ValidationException",
+                    "ExpressionAttributeNames can only be specified when using expressions: " + nullExpressionParams, 400);
+        }
     }
 
     private static void checkUnusedEan(JsonNode exprAttrNames, Set<String> usedHashTokens) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -335,6 +335,10 @@ public class DynamoDbJsonHandler {
 
         ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
 
+        // Reject ExpressionAttributeNames/Values entries not referenced by ConditionExpression (AWS parity, #2893)
+        checkUnusedEan(exprAttrNames, extractHashTokens(conditionExpression));
+        checkUnusedEav(exprAttrValues, extractColonTokens(conditionExpression));
+
         validateItemSets(item);
 
         JsonNode oldItem = null;
@@ -440,6 +444,10 @@ public class DynamoDbJsonHandler {
         }
 
         ExpressionEvaluator.validateExpression(conditionExpression, "ConditionExpression", exprAttrNames, exprAttrValues);
+
+        // Reject ExpressionAttributeNames/Values entries not referenced by ConditionExpression (AWS parity, #2893)
+        checkUnusedEan(exprAttrNames, extractHashTokens(conditionExpression));
+        checkUnusedEav(exprAttrValues, extractColonTokens(conditionExpression));
 
         JsonNode expectedDel = request.has("Expected") ? request.get("Expected") : null;
         String condOpDel = request.has("ConditionalOperator")
@@ -890,6 +898,8 @@ public class DynamoDbJsonHandler {
             // Check unused EAN across all expressions (KCE + FE + PE)
             Set<String> hashTokens = extractHashTokens(keyConditionExpr, filterExpr, projectionExpression);
             checkUnusedEan(exprAttrNames, hashTokens);
+            // Reject ExpressionAttributeValues entries not referenced by KCE/FE (AWS parity, #2893)
+            checkUnusedEav(exprAttrValues, extractColonTokens(keyConditionExpr, filterExpr));
         }
 
         if (exclusiveStartKey != null) {
@@ -998,6 +1008,10 @@ public class DynamoDbJsonHandler {
 
         ExpressionEvaluator.validateExpression(filterExpr, "FilterExpression", exprAttrNames, exprAttrValues);
         ProjectionEvaluator.validateExpression(projectionExpressionScan);
+
+        // Reject ExpressionAttributeNames/Values entries not referenced by any expression (AWS parity, #2893)
+        checkUnusedEan(exprAttrNames, extractHashTokens(filterExpr, projectionExpressionScan));
+        checkUnusedEav(exprAttrValues, extractColonTokens(filterExpr));
 
         if (select != null && !VALID_SELECT.contains(select)) {
             throw new AwsException("ValidationException",

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -885,25 +885,22 @@ public class DynamoDbJsonHandler {
                 projectionExpression, attributesToGet, exprAttrNames);
         rejectConsistentReadOnGsi(request, queryAccessPath);
 
-        // Validate EAN/EAV usage when any expression parameter is present. FilterExpression
-        // may be combined with legacy KeyConditions, so this must not be gated on
-        // KeyConditionExpression alone (#2893).
-        if (keyConditionExpr != null || filterExpr != null || projectionExpression != null) {
-            // Check undefined #tokens in FilterExpression
-            if (filterExpr != null) {
-                for (String token : extractHashTokens(filterExpr)) {
-                    if (exprAttrNames == null || !exprAttrNames.has(token)) {
-                        throw new AwsException("ValidationException",
-                                "Invalid FilterExpression: An expression attribute name used in the document path is not defined; attribute name: " + token, 400);
-                    }
+        // Check undefined #tokens in FilterExpression
+        if (filterExpr != null) {
+            for (String token : extractHashTokens(filterExpr)) {
+                if (exprAttrNames == null || !exprAttrNames.has(token)) {
+                    throw new AwsException("ValidationException",
+                            "Invalid FilterExpression: An expression attribute name used in the document path is not defined; attribute name: " + token, 400);
                 }
             }
-            // Check unused EAN across all expressions (KCE + FE + PE)
-            Set<String> hashTokens = extractHashTokens(keyConditionExpr, filterExpr, projectionExpression);
-            checkUnusedEan(exprAttrNames, hashTokens);
-            // Reject ExpressionAttributeValues entries not referenced by KCE/FE (AWS parity, #2893)
-            checkUnusedEav(exprAttrValues, extractColonTokens(keyConditionExpr, filterExpr));
         }
+        // Reject ExpressionAttributeNames/Values entries not referenced by any expression
+        // (AWS parity, #2893). Unconditional: a legacy KeyConditions request that still
+        // carries EAN/EAV must be rejected, and either map can only be referenced from
+        // KeyConditionExpression, FilterExpression or (names only) ProjectionExpression.
+        Set<String> hashTokens = extractHashTokens(keyConditionExpr, filterExpr, projectionExpression);
+        checkUnusedEan(exprAttrNames, hashTokens);
+        checkUnusedEav(exprAttrValues, extractColonTokens(keyConditionExpr, filterExpr));
 
         if (exclusiveStartKey != null) {
             validateExclusiveStartKey(exclusiveStartKey, queryTable, queryAccessPath, false);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -884,8 +884,11 @@ public class DynamoDbJsonHandler {
         DynamoDbAccessPathValidator.validateSelection(queryTable, queryAccessPath, select,
                 projectionExpression, attributesToGet, exprAttrNames);
         rejectConsistentReadOnGsi(request, queryAccessPath);
-        // Validate EAN/EAV usage when using expression format
-        if (keyConditionExpr != null) {
+
+        // Validate EAN/EAV usage when any expression parameter is present. FilterExpression
+        // may be combined with legacy KeyConditions, so this must not be gated on
+        // KeyConditionExpression alone (#2893).
+        if (keyConditionExpr != null || filterExpr != null || projectionExpression != null) {
             // Check undefined #tokens in FilterExpression
             if (filterExpr != null) {
                 for (String token : extractHashTokens(filterExpr)) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3540,6 +3540,214 @@ given()
         deleteTable("NullKeyTable");
     }
 
+    // Reproduces #2893 — unused ExpressionAttributeNames/Values must be rejected on
+    // PutItem, DeleteItem, Scan and Query, matching AWS ValidationException behaviour.
+    @Test
+    void unusedExpressionAttributesAreRejected() {
+        String tableName = "UnusedExprAttrTable";
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        // PutItem: unused ExpressionAttributeNames entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "a"}},
+                    "ConditionExpression": "attribute_not_exists(pk)",
+                    "ExpressionAttributeNames": {"#st": "status"}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeNames "
+                    + "unused in expressions: keys: {#st}"));
+
+        // PutItem: unused ExpressionAttributeValues entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "a"}},
+                    "ConditionExpression": "attribute_not_exists(pk)",
+                    "ExpressionAttributeValues": {":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeValues "
+                    + "unused in expressions: keys: {:unused}"));
+
+        // DeleteItem: unused ExpressionAttributeNames entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "a"}},
+                    "ConditionExpression": "attribute_exists(pk)",
+                    "ExpressionAttributeNames": {"#st": "status"}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeNames "
+                    + "unused in expressions: keys: {#st}"));
+
+        // DeleteItem: unused ExpressionAttributeValues entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "a"}},
+                    "ConditionExpression": "attribute_exists(pk)",
+                    "ExpressionAttributeValues": {":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeValues "
+                    + "unused in expressions: keys: {:unused}"));
+
+        // Scan: unused ExpressionAttributeNames entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "FilterExpression": "#d = :d",
+                    "ExpressionAttributeNames": {"#d": "data", "#st": "status"},
+                    "ExpressionAttributeValues": {":d": {"S": "v"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeNames "
+                    + "unused in expressions: keys: {#st}"));
+
+        // Scan: unused ExpressionAttributeValues entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "FilterExpression": "#d = :d",
+                    "ExpressionAttributeNames": {"#d": "data"},
+                    "ExpressionAttributeValues": {":d": {"S": "v"}, ":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeValues "
+                    + "unused in expressions: keys: {:unused}"));
+
+        // Query: unused ExpressionAttributeValues entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {":pk": {"S": "a"}, ":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeValues "
+                    + "unused in expressions: keys: {:unused}"));
+
+        // Query: unused ExpressionAttributeNames entry
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeNames": {"#st": "status"},
+                    "ExpressionAttributeValues": {":pk": {"S": "a"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeNames "
+                    + "unused in expressions: keys: {#st}"));
+
+        // Only the unused entries are reported: #used is referenced, #a and #b are not.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "a"}},
+                    "ConditionExpression": "attribute_not_exists(#used)",
+                    "ExpressionAttributeNames": {"#used": "pk", "#a": "x", "#b": "y"}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeNames "
+                    + "unused in expressions: keys: {#a, #b}"));
+
+        // Control: fully-referenced expression attributes are still accepted.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "a"}, "data": {"S": "v"}},
+                    "ConditionExpression": "attribute_not_exists(#p)",
+                    "ExpressionAttributeNames": {"#p": "pk"}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        deleteTable(tableName);
+    }
+
     private void deleteTable(String tableName) {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3540,8 +3540,8 @@ given()
         deleteTable("NullKeyTable");
     }
 
-    // Reproduces #2893 — unused ExpressionAttributeNames/Values must be rejected on
-    // PutItem, DeleteItem, Scan and Query, matching AWS ValidationException behaviour.
+    // Reproduces #2893: unused ExpressionAttributeNames/Values must be rejected on
+    // PutItem, DeleteItem, Scan and Query, matching AWS ValidationException behavior.
     @Test
     void unusedExpressionAttributesAreRejected() {
         String tableName = "UnusedExprAttrTable";
@@ -3710,6 +3710,29 @@ given()
             .body("__type", containsString("ValidationException"))
             .body("message", equalTo("Value provided in ExpressionAttributeNames "
                     + "unused in expressions: keys: {#st}"));
+
+        // Query: legacy KeyConditions combined with FilterExpression, unused EAV entry.
+        // keyConditionExpr is null here, so the check must not be gated on it.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditions": {
+                        "pk": {"ComparisonOperator": "EQ", "AttributeValueList": [{"S": "a"}]}
+                    },
+                    "FilterExpression": "#d = :d",
+                    "ExpressionAttributeNames": {"#d": "data"},
+                    "ExpressionAttributeValues": {":d": {"S": "v"}, ":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeValues "
+                    + "unused in expressions: keys: {:unused}"));
 
         // Only the unused entries are reported: #used is referenced, #a and #b are not.
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3773,6 +3773,84 @@ given()
             .body("message", equalTo("Value provided in ExpressionAttributeNames "
                     + "unused in expressions: keys: {#a, #b}"));
 
+        // No expression parameter at all: AWS reports the alias map "can only be specified
+        // when using expressions", distinct from the "unused in expressions" wording above.
+        // PutItem and DeleteItem only accept ConditionExpression, so it is the named param.
+
+        // PutItem: ExpressionAttributeNames without ConditionExpression
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "a"}},
+                    "ExpressionAttributeNames": {"#st": "status"}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("ExpressionAttributeNames can only be specified "
+                    + "when using expressions: ConditionExpression is null"));
+
+        // PutItem: ExpressionAttributeValues without ConditionExpression (pre-existing guard)
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "a"}},
+                    "ExpressionAttributeValues": {":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("ExpressionAttributeValues can only be specified "
+                    + "when using expressions: ConditionExpression is null"));
+
+        // DeleteItem: ExpressionAttributeNames without ConditionExpression
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "a"}},
+                    "ExpressionAttributeNames": {"#st": "status"}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("ExpressionAttributeNames can only be specified "
+                    + "when using expressions: ConditionExpression is null"));
+
+        // DeleteItem: ExpressionAttributeValues without ConditionExpression; with both maps
+        // present the values message wins, matching the pre-existing PutItem guard order.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "a"}},
+                    "ExpressionAttributeNames": {"#st": "status"},
+                    "ExpressionAttributeValues": {":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("ExpressionAttributeValues can only be specified "
+                    + "when using expressions: ConditionExpression is null"));
+
         // Control: fully-referenced expression attributes are still accepted.
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.PutItem")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3734,6 +3734,26 @@ given()
             .body("message", equalTo("Value provided in ExpressionAttributeValues "
                     + "unused in expressions: keys: {:unused}"));
 
+        // Query: legacy KeyConditions with no expression parameter at all, stray EAV.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditions": {
+                        "pk": {"ComparisonOperator": "EQ", "AttributeValueList": [{"S": "a"}]}
+                    },
+                    "ExpressionAttributeValues": {":unused": {"S": "x"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Value provided in ExpressionAttributeValues "
+                    + "unused in expressions: keys: {:unused}"));
+
         // Only the unused entries are reported: #used is referenced, #a and #b are not.
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.PutItem")


### PR DESCRIPTION
## Summary

DynamoDB accepted unused `ExpressionAttributeNames` / `ExpressionAttributeValues` entries on `PutItem`, `DeleteItem`, `Scan` and `Query`, where real AWS returns `ValidationException`. The helpers `checkUnusedEan` / `checkUnusedEav` already
existed and produce the exact AWS messages, but were only wired into `handleUpdateItem` and (for names only) `handleQuery`. On the write paths this meant items AWS would have rejected were durably persisted.

- `handlePutItem` / `handleDeleteItem`: after `ExpressionEvaluator.validateExpression`, call `checkUnusedEan` / `checkUnusedEav` against the tokens referenced by `ConditionExpression` (the only expression these operations accept).
- `handleScan`: call both helpers against the tokens referenced by `FilterExpression` (plus `ProjectionExpression` for names).
- `handleQuery`: add the missing `checkUnusedEav` call alongside the existing `checkUnusedEan`, against `KeyConditionExpression` + `FilterExpression`. The check runs unconditionally so a legacy `KeyConditions` request carrying a stray alias map is validated too; the token sets are still derived only from the expressions that can legitimately reference those maps, so a correct request is unaffected.

Sub-case — no expression parameter at all, but `ExpressionAttributeNames` / `ExpressionAttributeValues` present:

- `handlePutItem` / `handleDeleteItem` return AWS's `<param> can only be specified when using expressions: ConditionExpression is null`. Both ops only accept `ConditionExpression`, so the named param is unambiguous, and the wording matches the pre-existing PutItem+EAV guard from #826. `checkUnusedEan` / `checkUnusedEav` still handle the case where an alias is merely unreferenced.
- `handleScan` / `handleQuery` still return `... unused in expressions: keys: {...}` for this sub-case. Those ops accept several expression parameters and AWS's exact wording when all are absent is unverified; tracked for a follow-up backed by a live measurement. The shared helper is parameterised on the message, so it is a one-line change per op once the strings are known.

Either way the request is now a `400 ValidationException` rather than silently accepted.

Closes #2893

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Bug fix. Incorrect behavior: `PutItem` / `DeleteItem` / `Scan` / `Query` accepted `ExpressionAttributeNames` / `ExpressionAttributeValues` entries not referenced by any expression and performed the operation (including durably writing items). After this change these requests return `400 ValidationException` with `Value provided in ExpressionAttributeNames unused in expressions: keys: {...}` / `Value provided in ExpressionAttributeValues unused in expressions: keys: {...}`, matching real DynamoDB. When no expression parameter is supplied at all, `PutItem` / `DeleteItem` return `<param> can only be specified when using expressions: ConditionExpression is null` (also matching real DynamoDB); the equivalent wording for `Scan` / `Query` is left to a follow-up. `UpdateItem` already behaved correctly and is unchanged.

## Checklist

- [x] `./mvnw test` passes locally (DynamoDb* + ExpressionEvaluatorTest: 555 run, 0 failures)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
