### PR TITLE
fix(iam): resolve DynamoDB table ARN from request body for IAM enforcement

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/IamEnforcementFilter.java
@@ -169,7 +169,7 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
             caller = caller.withScpLevels(scpLevels);
         }
 
-        String resource = arnBuilder.build(credentialScope, ctx, region, accountId);
+        List<String> resources = arnBuilder.buildResources(credentialScope, ctx, region, accountId);
 
         Map<String, String> conditionContext = conditionContextResolver.resolve(credentialScope, action, ctx);
 
@@ -187,15 +187,18 @@ public class IamEnforcementFilter implements ContainerRequestFilter {
             conditionContext.put("aws:PrincipalArn", principalArn.get());
         }
 
-        Decision decision = evaluator.evaluate(caller, null, action, resource, conditionContext);
-        if (decision == Decision.DENY) {
-            LOG.infov("IAM enforcement DENY: akid={0} action={1} resource={2}", akid, action, resource);
-            String denyMessage = "User: arn:aws:iam::" + accountId
-                    + ":user/" + akid + " is not authorized to perform: " + action
-                    + " on resource: \"" + resource + "\""
-                    + " because no identity-based policy allows the " + action + " action";
-            emitS3DenialIfApplicable(akid, action, resource, ctx, region, denyMessage);
-            ctx.abortWith(accessDeniedResponse(action, credentialScope, ctx.getMediaType()));
+        for (String resource : resources) {
+            Decision decision = evaluator.evaluate(caller, null, action, resource, conditionContext);
+            if (decision == Decision.DENY) {
+                LOG.infov("IAM enforcement DENY: akid={0} action={1} resource={2}", akid, action, resource);
+                String denyMessage = "User: arn:aws:iam::" + accountId
+                        + ":user/" + akid + " is not authorized to perform: " + action
+                        + " on resource: \"" + resource + "\""
+                        + " because no identity-based policy allows the " + action + " action";
+                emitS3DenialIfApplicable(akid, action, resource, ctx, region, denyMessage);
+                ctx.abortWith(accessDeniedResponse(action, credentialScope, ctx.getMediaType()));
+                return;
+            }
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParser.java
@@ -5,7 +5,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 
 import java.util.*;
 
-class DynamoDbPartiQLParser {
+public class DynamoDbPartiQLParser {
 
     enum TType {
         SELECT, FROM, WHERE, INSERT, INTO, VALUE,
@@ -20,11 +20,42 @@ class DynamoDbPartiQLParser {
 
     // --- AST node types ---
 
-    sealed interface Stmt permits Stmt.Select, Stmt.Insert, Stmt.Update, Stmt.Delete {
+    public sealed interface Stmt permits Stmt.Select, Stmt.Insert, Stmt.Update, Stmt.Delete {
+        String table();
         record Select(String table, List<String> columns, List<Cond> where) implements Stmt {}
         record Insert(String table, Map<String, PVal> item)                 implements Stmt {}
         record Update(String table, List<Assign> sets, List<String> removes, List<Cond> where) implements Stmt {}
         record Delete(String table, List<Cond> where)                       implements Stmt {}
+    }
+
+    /**
+     * Extracts the target table name from a PartiQL statement using the parser tokenizer,
+     * ensuring quoted attribute names containing SQL keywords are not mistakenly treated as table names.
+     */
+    public static String extractTable(String statement) {
+        if (statement == null || statement.isBlank()) {
+            return null;
+        }
+        try {
+            return parse(statement, List.of()).table();
+        } catch (Exception e) {
+            try {
+                List<Token> tokens = tokenize(statement.trim());
+                for (int i = 0; i < tokens.size(); i++) {
+                    Token t = tokens.get(i);
+                    if (t.type() == TType.FROM || t.type() == TType.INTO || t.type() == TType.UPDATE) {
+                        if (i + 1 < tokens.size()) {
+                            Token next = tokens.get(i + 1);
+                            if (next.type() == TType.IDENT || next.type() == TType.STRING) {
+                                return next.value();
+                            }
+                        }
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+            return null;
+        }
     }
 
     sealed interface PVal permits PVal.Str, PVal.Num, PVal.Bool, PVal.Null {

--- a/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
@@ -10,6 +10,10 @@ import jakarta.ws.rs.container.ContainerRequestContext;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Constructs the target resource ARN for a request so the policy evaluator
@@ -34,18 +38,27 @@ public class ResourceArnBuilder {
 
     public String build(String credentialScope, ContainerRequestContext ctx,
                         String region, String accountId) {
+        List<String> list = buildResources(credentialScope, ctx, region, accountId);
+        return list.isEmpty() ? "*" : list.getFirst();
+    }
+
+    public List<String> buildResources(String credentialScope, ContainerRequestContext ctx,
+                                       String region, String accountId) {
+        if (credentialScope == null) {
+            return List.of("*");
+        }
         String path = ctx.getUriInfo().getPath();
         return switch (credentialScope) {
-            case "s3"             -> buildS3Arn(path);
-            case "lambda"         -> buildLambdaArn(path, region, accountId);
-            case "sqs"            -> buildSqsArn(ctx, region, accountId);
-            case "sns"            -> buildSnsArn(ctx, region, accountId);
-            case "dynamodb"       -> buildDynamoDbArn(ctx, region, accountId);
-            case "kinesis"        -> buildKinesisArn(ctx, region, accountId);
-            case "secretsmanager" -> buildSecretsManagerArn(ctx, region, accountId);
-            case "ssm"            -> buildSsmArn(ctx, region, accountId);
-            case "kms"            -> buildKmsArn(path, region, accountId);
-            default               -> "*";
+            case "s3"             -> List.of(buildS3Arn(path));
+            case "lambda"         -> List.of(buildLambdaArn(path, region, accountId));
+            case "sqs"            -> List.of(buildSqsArn(ctx, region, accountId));
+            case "sns"            -> List.of(buildSnsArn(ctx, region, accountId));
+            case "dynamodb"       -> buildDynamoDbArns(ctx, region, accountId);
+            case "kinesis"        -> List.of(buildKinesisArn(ctx, region, accountId));
+            case "secretsmanager" -> List.of(buildSecretsManagerArn(ctx, region, accountId));
+            case "ssm"            -> List.of(buildSsmArn(ctx, region, accountId));
+            case "kms"            -> List.of(buildKmsArn(path, region, accountId));
+            default               -> List.of("*");
         };
     }
 
@@ -117,57 +130,59 @@ public class ResourceArnBuilder {
 
     // ── DynamoDB ─────────────────────────────────────────────────────────────────
     private String buildDynamoDbArn(ContainerRequestContext ctx, String region, String accountId) {
+        List<String> arns = buildDynamoDbArns(ctx, region, accountId);
+        return arns.isEmpty() ? "*" : arns.getFirst();
+    }
+
+    private List<String> buildDynamoDbArns(ContainerRequestContext ctx, String region, String accountId) {
         JsonNode json = readJsonBody(ctx);
         if (json != null && json.isObject()) {
             if (json.hasNonNull("TableName")) {
                 String tableName = json.get("TableName").asText().trim();
                 if (!tableName.isEmpty()) {
-                    if (tableName.startsWith("arn:aws:dynamodb:")) {
-                        return tableName;
-                    }
-                    return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + tableName).toString();
+                    return List.of(toDynamoDbTableArn(tableName, region, accountId));
                 }
             }
             if (json.hasNonNull("ResourceArn")) {
                 String resourceArn = json.get("ResourceArn").asText().trim();
                 if (!resourceArn.isEmpty()) {
-                    return resourceArn;
+                    return List.of(resourceArn);
                 }
             }
             if (json.hasNonNull("TableArn")) {
                 String tableArn = json.get("TableArn").asText().trim();
                 if (!tableArn.isEmpty()) {
-                    return tableArn;
+                    return List.of(tableArn);
                 }
             }
             if (json.hasNonNull("StreamArn")) {
                 String streamArn = json.get("StreamArn").asText().trim();
                 if (!streamArn.isEmpty()) {
-                    return streamArn;
+                    return List.of(streamArn);
                 }
             }
             if (json.hasNonNull("ExportArn")) {
                 String exportArn = json.get("ExportArn").asText().trim();
                 if (!exportArn.isEmpty()) {
-                    return exportArn;
+                    return List.of(exportArn);
                 }
             }
             if (json.hasNonNull("RequestItems") && json.get("RequestItems").isObject()) {
+                Set<String> arns = new LinkedHashSet<>();
                 var fieldNames = json.get("RequestItems").fieldNames();
-                if (fieldNames.hasNext()) {
-                    String firstTable = fieldNames.next();
-                    if (!fieldNames.hasNext() && !firstTable.isEmpty()) {
-                        if (firstTable.startsWith("arn:aws:dynamodb:")) {
-                            return firstTable;
-                        }
-                        return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + firstTable).toString();
+                while (fieldNames.hasNext()) {
+                    String table = fieldNames.next().trim();
+                    if (!table.isEmpty()) {
+                        arns.add(toDynamoDbTableArn(table, region, accountId));
                     }
+                }
+                if (!arns.isEmpty()) {
+                    return new ArrayList<>(arns);
                 }
             }
             if (json.hasNonNull("TransactItems") && json.get("TransactItems").isArray()) {
+                Set<String> arns = new LinkedHashSet<>();
                 JsonNode items = json.get("TransactItems");
-                String commonTable = null;
-                boolean allSame = true;
                 for (JsonNode item : items) {
                     String t = null;
                     if (item.hasNonNull("Put") && item.get("Put").hasNonNull("TableName")) {
@@ -181,24 +196,26 @@ public class ResourceArnBuilder {
                     } else if (item.hasNonNull("Get") && item.get("Get").hasNonNull("TableName")) {
                         t = item.get("Get").get("TableName").asText();
                     }
-                    if (t != null && !t.isEmpty()) {
-                        if (commonTable == null) {
-                            commonTable = t;
-                        } else if (!commonTable.equals(t)) {
-                            allSame = false;
-                            break;
+                    if (t != null) {
+                        t = t.trim();
+                        if (!t.isEmpty()) {
+                            arns.add(toDynamoDbTableArn(t, region, accountId));
                         }
                     }
                 }
-                if (allSame && commonTable != null && !commonTable.isEmpty()) {
-                    if (commonTable.startsWith("arn:aws:dynamodb:")) {
-                        return commonTable;
-                    }
-                    return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + commonTable).toString();
+                if (!arns.isEmpty()) {
+                    return new ArrayList<>(arns);
                 }
             }
         }
-        return "*";
+        return List.of("*");
+    }
+
+    private String toDynamoDbTableArn(String tableName, String region, String accountId) {
+        if (tableName.startsWith("arn:aws:dynamodb:")) {
+            return tableName;
+        }
+        return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + tableName).toString();
     }
 
     // ── Kinesis ──────────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
@@ -1,8 +1,15 @@
 package io.github.hectorvent.floci.services.iam;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
 /**
  * Constructs the target resource ARN for a request so the policy evaluator
@@ -13,6 +20,17 @@ import jakarta.ws.rs.container.ContainerRequestContext;
  */
 @ApplicationScoped
 public class ResourceArnBuilder {
+
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public ResourceArnBuilder(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public ResourceArnBuilder() {
+        this(new ObjectMapper());
+    }
 
     public String build(String credentialScope, ContainerRequestContext ctx,
                         String region, String accountId) {
@@ -63,7 +81,20 @@ public class ResourceArnBuilder {
             // Try form param for Query-protocol
             queueUrl = firstFormParam(ctx, "QueueUrl");
         }
-        if (queueUrl != null) {
+        if (queueUrl == null) {
+            JsonNode json = readJsonBody(ctx);
+            if (json != null && json.isObject()) {
+                if (json.hasNonNull("QueueUrl")) {
+                    queueUrl = json.get("QueueUrl").asText().trim();
+                } else if (json.hasNonNull("QueueName")) {
+                    String queueName = json.get("QueueName").asText().trim();
+                    if (!queueName.isEmpty()) {
+                        return AwsArnUtils.Arn.of("sqs", region, accountId, queueName).toString();
+                    }
+                }
+            }
+        }
+        if (queueUrl != null && !queueUrl.isEmpty()) {
             String queueName = queueUrl.substring(queueUrl.lastIndexOf('/') + 1);
             return AwsArnUtils.Arn.of("sqs", region, accountId, queueName).toString();
         }
@@ -73,27 +104,164 @@ public class ResourceArnBuilder {
     // ── SNS ─────────────────────────────────────────────────────────────────────
     private String buildSnsArn(ContainerRequestContext ctx, String region, String accountId) {
         String topicArn = firstFormParam(ctx, "TopicArn");
-        return topicArn != null ? topicArn : AwsArnUtils.Arn.of("sns", region, accountId, "*").toString();
+        if (topicArn == null) {
+            JsonNode json = readJsonBody(ctx);
+            if (json != null && json.isObject() && json.hasNonNull("TopicArn")) {
+                topicArn = json.get("TopicArn").asText().trim();
+            }
+        }
+        return (topicArn != null && !topicArn.isEmpty())
+                ? topicArn
+                : AwsArnUtils.Arn.of("sns", region, accountId, "*").toString();
     }
 
     // ── DynamoDB ─────────────────────────────────────────────────────────────────
     private String buildDynamoDbArn(ContainerRequestContext ctx, String region, String accountId) {
-        // TableName comes in the JSON body; use wildcard since we don't parse the body here
-        return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/*").toString();
+        JsonNode json = readJsonBody(ctx);
+        if (json != null && json.isObject()) {
+            if (json.hasNonNull("TableName")) {
+                String tableName = json.get("TableName").asText().trim();
+                if (!tableName.isEmpty()) {
+                    if (tableName.startsWith("arn:aws:dynamodb:")) {
+                        return tableName;
+                    }
+                    return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + tableName).toString();
+                }
+            }
+            if (json.hasNonNull("ResourceArn")) {
+                String resourceArn = json.get("ResourceArn").asText().trim();
+                if (!resourceArn.isEmpty()) {
+                    return resourceArn;
+                }
+            }
+            if (json.hasNonNull("TableArn")) {
+                String tableArn = json.get("TableArn").asText().trim();
+                if (!tableArn.isEmpty()) {
+                    return tableArn;
+                }
+            }
+            if (json.hasNonNull("StreamArn")) {
+                String streamArn = json.get("StreamArn").asText().trim();
+                if (!streamArn.isEmpty()) {
+                    return streamArn;
+                }
+            }
+            if (json.hasNonNull("ExportArn")) {
+                String exportArn = json.get("ExportArn").asText().trim();
+                if (!exportArn.isEmpty()) {
+                    return exportArn;
+                }
+            }
+            if (json.hasNonNull("RequestItems") && json.get("RequestItems").isObject()) {
+                var fieldNames = json.get("RequestItems").fieldNames();
+                if (fieldNames.hasNext()) {
+                    String firstTable = fieldNames.next();
+                    if (!fieldNames.hasNext() && !firstTable.isEmpty()) {
+                        if (firstTable.startsWith("arn:aws:dynamodb:")) {
+                            return firstTable;
+                        }
+                        return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + firstTable).toString();
+                    }
+                }
+            }
+            if (json.hasNonNull("TransactItems") && json.get("TransactItems").isArray()) {
+                JsonNode items = json.get("TransactItems");
+                String commonTable = null;
+                boolean allSame = true;
+                for (JsonNode item : items) {
+                    String t = null;
+                    if (item.hasNonNull("Put") && item.get("Put").hasNonNull("TableName")) {
+                        t = item.get("Put").get("TableName").asText();
+                    } else if (item.hasNonNull("Delete") && item.get("Delete").hasNonNull("TableName")) {
+                        t = item.get("Delete").get("TableName").asText();
+                    } else if (item.hasNonNull("Update") && item.get("Update").hasNonNull("TableName")) {
+                        t = item.get("Update").get("TableName").asText();
+                    } else if (item.hasNonNull("ConditionCheck") && item.get("ConditionCheck").hasNonNull("TableName")) {
+                        t = item.get("ConditionCheck").get("TableName").asText();
+                    } else if (item.hasNonNull("Get") && item.get("Get").hasNonNull("TableName")) {
+                        t = item.get("Get").get("TableName").asText();
+                    }
+                    if (t != null && !t.isEmpty()) {
+                        if (commonTable == null) {
+                            commonTable = t;
+                        } else if (!commonTable.equals(t)) {
+                            allSame = false;
+                            break;
+                        }
+                    }
+                }
+                if (allSame && commonTable != null && !commonTable.isEmpty()) {
+                    if (commonTable.startsWith("arn:aws:dynamodb:")) {
+                        return commonTable;
+                    }
+                    return AwsArnUtils.Arn.of("dynamodb", region, accountId, "table/" + commonTable).toString();
+                }
+            }
+        }
+        return "*";
     }
 
     // ── Kinesis ──────────────────────────────────────────────────────────────────
     private String buildKinesisArn(ContainerRequestContext ctx, String region, String accountId) {
+        JsonNode json = readJsonBody(ctx);
+        if (json != null && json.isObject()) {
+            if (json.hasNonNull("StreamARN")) {
+                String streamArn = json.get("StreamARN").asText().trim();
+                if (!streamArn.isEmpty()) {
+                    return streamArn;
+                }
+            }
+            if (json.hasNonNull("StreamName")) {
+                String streamName = json.get("StreamName").asText().trim();
+                if (!streamName.isEmpty()) {
+                    if (streamName.startsWith("arn:aws:kinesis:")) {
+                        return streamName;
+                    }
+                    return AwsArnUtils.Arn.of("kinesis", region, accountId, "stream/" + streamName).toString();
+                }
+            }
+            if (json.hasNonNull("ResourceARN")) {
+                String resourceArn = json.get("ResourceARN").asText().trim();
+                if (!resourceArn.isEmpty()) {
+                    return resourceArn;
+                }
+            }
+        }
         return AwsArnUtils.Arn.of("kinesis", region, accountId, "stream/*").toString();
     }
 
     // ── Secrets Manager ──────────────────────────────────────────────────────────
     private String buildSecretsManagerArn(ContainerRequestContext ctx, String region, String accountId) {
+        JsonNode json = readJsonBody(ctx);
+        if (json != null && json.isObject()) {
+            if (json.hasNonNull("SecretId")) {
+                String secretId = json.get("SecretId").asText().trim();
+                if (!secretId.isEmpty()) {
+                    if (secretId.startsWith("arn:aws:secretsmanager:")) {
+                        return secretId;
+                    }
+                    return AwsArnUtils.Arn.of("secretsmanager", region, accountId, "secret:" + secretId).toString();
+                }
+            }
+        }
         return AwsArnUtils.Arn.of("secretsmanager", region, accountId, "secret:*").toString();
     }
 
     // ── SSM ──────────────────────────────────────────────────────────────────────
     private String buildSsmArn(ContainerRequestContext ctx, String region, String accountId) {
+        JsonNode json = readJsonBody(ctx);
+        if (json != null && json.isObject()) {
+            if (json.hasNonNull("Name")) {
+                String name = json.get("Name").asText().trim();
+                if (!name.isEmpty()) {
+                    if (name.startsWith("arn:aws:ssm:")) {
+                        return name;
+                    }
+                    String paramResource = name.startsWith("/") ? "parameter" + name : "parameter/" + name;
+                    return AwsArnUtils.Arn.of("ssm", region, accountId, paramResource).toString();
+                }
+            }
+        }
         return AwsArnUtils.Arn.of("ssm", region, accountId, "parameter/*").toString();
     }
 
@@ -105,6 +273,34 @@ public class ResourceArnBuilder {
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────────
+
+    private JsonNode readJsonBody(ContainerRequestContext ctx) {
+        Object cached = ctx.getProperty("floci.bufferedJsonBody");
+        if (cached instanceof JsonNode node) {
+            return node;
+        }
+        InputStream in = ctx.getEntityStream();
+        if (in == null) {
+            return null;
+        }
+        byte[] body;
+        try {
+            body = in.readAllBytes();
+        } catch (IOException e) {
+            return null;
+        }
+        ctx.setEntityStream(new ByteArrayInputStream(body));
+        if (body.length == 0) {
+            return null;
+        }
+        try {
+            JsonNode node = objectMapper.readTree(body);
+            ctx.setProperty("floci.bufferedJsonBody", node);
+            return node;
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
     private String extractSegmentAfter(String path, String segment) {
         String marker = "/" + segment + "/";

--- a/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
@@ -246,24 +246,8 @@ public class ResourceArnBuilder {
         return List.of("*");
     }
 
-    private static final java.util.regex.Pattern PARTIQL_TABLE_PATTERN =
-            java.util.regex.Pattern.compile("(?i)\\b(?:FROM|INTO|UPDATE)\\s+(?:\"([^\"]+)\"|'([^']+)'|([a-zA-Z0-9_.-]+))");
-
     private static String extractDynamoDbTableFromPartiQL(String statement) {
-        if (statement == null || statement.isBlank()) {
-            return null;
-        }
-        var matcher = PARTIQL_TABLE_PATTERN.matcher(statement);
-        if (matcher.find()) {
-            if (matcher.group(1) != null) {
-                return matcher.group(1);
-            }
-            if (matcher.group(2) != null) {
-                return matcher.group(2);
-            }
-            return matcher.group(3);
-        }
-        return null;
+        return io.github.hectorvent.floci.services.dynamodb.DynamoDbPartiQLParser.extractTable(statement);
     }
 
     private String toDynamoDbTableArn(String tableName, String region, String accountId) {
@@ -359,6 +343,7 @@ public class ResourceArnBuilder {
         try {
             body = in.readAllBytes();
         } catch (IOException e) {
+            ctx.setEntityStream(new ByteArrayInputStream(new byte[0]));
             return null;
         }
         ctx.setEntityStream(new ByteArrayInputStream(body));

--- a/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
@@ -247,7 +247,7 @@ public class ResourceArnBuilder {
     }
 
     private static final java.util.regex.Pattern PARTIQL_TABLE_PATTERN =
-            java.util.regex.Pattern.compile("(?i)\\b(?:FROM|INTO|UPDATE)\\s+[\"']?([a-zA-Z0-9_.-]+)[\"']?");
+            java.util.regex.Pattern.compile("(?i)\\b(?:FROM|INTO|UPDATE)\\s+(?:\"([^\"]+)\"|'([^']+)'|([a-zA-Z0-9_.-]+))");
 
     private static String extractDynamoDbTableFromPartiQL(String statement) {
         if (statement == null || statement.isBlank()) {
@@ -255,7 +255,13 @@ public class ResourceArnBuilder {
         }
         var matcher = PARTIQL_TABLE_PATTERN.matcher(statement);
         if (matcher.find()) {
-            return matcher.group(1);
+            if (matcher.group(1) != null) {
+                return matcher.group(1);
+            }
+            if (matcher.group(2) != null) {
+                return matcher.group(2);
+            }
+            return matcher.group(3);
         }
         return null;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilder.java
@@ -207,8 +207,57 @@ public class ResourceArnBuilder {
                     return new ArrayList<>(arns);
                 }
             }
+            if (json.hasNonNull("Statement")) {
+                String stmt = json.get("Statement").asText().trim();
+                String table = extractDynamoDbTableFromPartiQL(stmt);
+                if (table != null && !table.isEmpty()) {
+                    return List.of(toDynamoDbTableArn(table, region, accountId));
+                }
+            }
+            if (json.hasNonNull("Statements") && json.get("Statements").isArray()) {
+                Set<String> arns = new LinkedHashSet<>();
+                for (JsonNode s : json.get("Statements")) {
+                    if (s.hasNonNull("Statement")) {
+                        String table = extractDynamoDbTableFromPartiQL(s.get("Statement").asText());
+                        if (table != null && !table.isEmpty()) {
+                            arns.add(toDynamoDbTableArn(table, region, accountId));
+                        }
+                    }
+                }
+                if (!arns.isEmpty()) {
+                    return new ArrayList<>(arns);
+                }
+            }
+            if (json.hasNonNull("TransactStatements") && json.get("TransactStatements").isArray()) {
+                Set<String> arns = new LinkedHashSet<>();
+                for (JsonNode s : json.get("TransactStatements")) {
+                    if (s.hasNonNull("Statement")) {
+                        String table = extractDynamoDbTableFromPartiQL(s.get("Statement").asText());
+                        if (table != null && !table.isEmpty()) {
+                            arns.add(toDynamoDbTableArn(table, region, accountId));
+                        }
+                    }
+                }
+                if (!arns.isEmpty()) {
+                    return new ArrayList<>(arns);
+                }
+            }
         }
         return List.of("*");
+    }
+
+    private static final java.util.regex.Pattern PARTIQL_TABLE_PATTERN =
+            java.util.regex.Pattern.compile("(?i)\\b(?:FROM|INTO|UPDATE)\\s+[\"']?([a-zA-Z0-9_.-]+)[\"']?");
+
+    private static String extractDynamoDbTableFromPartiQL(String statement) {
+        if (statement == null || statement.isBlank()) {
+            return null;
+        }
+        var matcher = PARTIQL_TABLE_PATTERN.matcher(statement);
+        if (matcher.find()) {
+            return matcher.group(1);
+        }
+        return null;
     }
 
     private String toDynamoDbTableArn(String tableName, String region, String accountId) {

--- a/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
@@ -129,6 +129,44 @@ class IamEnforcementFilterTest {
     }
 
     @Test
+    void filterBuildsResourceArnForDynamoDbTable() {
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+        String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260902/us-east-1/dynamodb/aws4_request, "
+                + "SignedHeaders=host, Signature=abc";
+        requestContext.setAccountId("000000000000");
+        requestContext.setRegion("us-east-1");
+
+        when(accountResolver.extractAccessKeyId(auth)).thenReturn("ASIASESSION");
+        when(accountResolver.resolve(auth)).thenReturn("000000000000");
+        when(containerRequest.getHeaderString("Authorization")).thenReturn(auth);
+        when(actionRegistry.resolve("dynamodb", containerRequest)).thenReturn("dynamodb:GetItem");
+        when(iamService.resolveCallerContext("ASIASESSION"))
+                .thenReturn(CallerContext.of(List.of("""
+                        {"Version":"2012-10-17","Statement":[
+                          {"Effect":"Allow","Action":"dynamodb:GetItem",
+                           "Resource":"arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable"}
+                        ]}""")));
+        when(arnBuilder.build("dynamodb", containerRequest, "us-east-1", "000000000000"))
+                .thenReturn("arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable");
+        when(evaluator.evaluate(
+                any(),
+                isNull(),
+                eq("dynamodb:GetItem"),
+                eq("arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable"),
+                isNull()))
+                .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+        when(conditionContextResolver.resolve("dynamodb", "dynamodb:GetItem", containerRequest))
+                .thenReturn(null);
+
+        IamEnforcementFilter filter = newFilter();
+
+        filter.filter(containerRequest);
+
+        verify(arnBuilder).build("dynamodb", containerRequest, "us-east-1", "000000000000");
+        verify(containerRequest, never()).abortWith(any());
+    }
+
+    @Test
     void getCallerIdentityBypassesPolicyEnforcement() {
         ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
         String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260720/us-east-1/sts/aws4_request, "

--- a/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/IamEnforcementFilterTest.java
@@ -73,6 +73,8 @@ class IamEnforcementFilterTest {
         when(services.iam()).thenReturn(iamConfig);
         when(iamConfig.enforcementEnabled()).thenReturn(true);
         when(config.defaultRegion()).thenReturn("us-east-1");
+        when(arnBuilder.buildResources(any(), any(), any(), any())).thenReturn(List.of("*"));
+        when(arnBuilder.build(any(), any(), any(), any())).thenReturn("*");
         // Default: scopes are already canonical. Alias handling is asserted explicitly below.
         when(catalog.canonicalCredentialScope(anyString())).thenAnswer(inv -> inv.getArgument(0));
     }
@@ -109,8 +111,8 @@ class IamEnforcementFilterTest {
                           {"Effect":"Allow","Action":"lambda:InvokeFunction",
                            "Resource":"arn:aws:lambda:us-east-1:222233334444:function:fn"}
                         ]}""")));
-        when(arnBuilder.build("lambda", containerRequest, "us-east-1", "222233334444"))
-                .thenReturn("arn:aws:lambda:us-east-1:222233334444:function:fn");
+        when(arnBuilder.buildResources("lambda", containerRequest, "us-east-1", "222233334444"))
+                .thenReturn(List.of("arn:aws:lambda:us-east-1:222233334444:function:fn"));
         when(evaluator.evaluate(
                 any(),
                 isNull(),
@@ -125,7 +127,7 @@ class IamEnforcementFilterTest {
 
         filter.filter(containerRequest);
 
-        verify(arnBuilder).build("lambda", containerRequest, "us-east-1", "222233334444");
+        verify(arnBuilder).buildResources("lambda", containerRequest, "us-east-1", "222233334444");
     }
 
     @Test
@@ -146,8 +148,8 @@ class IamEnforcementFilterTest {
                           {"Effect":"Allow","Action":"dynamodb:GetItem",
                            "Resource":"arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable"}
                         ]}""")));
-        when(arnBuilder.build("dynamodb", containerRequest, "us-east-1", "000000000000"))
-                .thenReturn("arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable");
+        when(arnBuilder.buildResources("dynamodb", containerRequest, "us-east-1", "000000000000"))
+                .thenReturn(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable"));
         when(evaluator.evaluate(
                 any(),
                 isNull(),
@@ -162,8 +164,74 @@ class IamEnforcementFilterTest {
 
         filter.filter(containerRequest);
 
-        verify(arnBuilder).build("dynamodb", containerRequest, "us-east-1", "000000000000");
+        verify(arnBuilder).buildResources("dynamodb", containerRequest, "us-east-1", "000000000000");
         verify(containerRequest, never()).abortWith(any());
+    }
+
+    @Test
+    void filterEvaluatesAllResourcesForMultiTableDynamoDbRequestAndAllowsWhenAllAllowed() {
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+        String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260902/us-east-1/dynamodb/aws4_request, "
+                + "SignedHeaders=host, Signature=abc";
+        requestContext.setAccountId("000000000000");
+        requestContext.setRegion("us-east-1");
+
+        when(accountResolver.extractAccessKeyId(auth)).thenReturn("ASIASESSION");
+        when(accountResolver.resolve(auth)).thenReturn("000000000000");
+        when(containerRequest.getHeaderString("Authorization")).thenReturn(auth);
+        when(actionRegistry.resolve("dynamodb", containerRequest)).thenReturn("dynamodb:BatchGetItem");
+        when(iamService.resolveCallerContext("ASIASESSION"))
+                .thenReturn(CallerContext.of(List.of("{}")));
+        when(arnBuilder.buildResources("dynamodb", containerRequest, "us-east-1", "000000000000"))
+                .thenReturn(List.of(
+                        "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",
+                        "arn:aws:dynamodb:us-east-1:000000000000:table/TableB"
+                ));
+        when(evaluator.evaluate(any(), isNull(), eq("dynamodb:BatchGetItem"), eq("arn:aws:dynamodb:us-east-1:000000000000:table/TableA"), isNull()))
+                .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+        when(evaluator.evaluate(any(), isNull(), eq("dynamodb:BatchGetItem"), eq("arn:aws:dynamodb:us-east-1:000000000000:table/TableB"), isNull()))
+                .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+        when(conditionContextResolver.resolve("dynamodb", "dynamodb:BatchGetItem", containerRequest))
+                .thenReturn(null);
+
+        IamEnforcementFilter filter = newFilter();
+        filter.filter(containerRequest);
+
+        verify(evaluator).evaluate(any(), isNull(), eq("dynamodb:BatchGetItem"), eq("arn:aws:dynamodb:us-east-1:000000000000:table/TableA"), isNull());
+        verify(evaluator).evaluate(any(), isNull(), eq("dynamodb:BatchGetItem"), eq("arn:aws:dynamodb:us-east-1:000000000000:table/TableB"), isNull());
+        verify(containerRequest, never()).abortWith(any());
+    }
+
+    @Test
+    void filterAbortsWhenAnyResourceInMultiTableRequestIsDenied() {
+        ContainerRequestContext containerRequest = mock(ContainerRequestContext.class);
+        String auth = "AWS4-HMAC-SHA256 Credential=ASIASESSION/20260902/us-east-1/dynamodb/aws4_request, "
+                + "SignedHeaders=host, Signature=abc";
+        requestContext.setAccountId("000000000000");
+        requestContext.setRegion("us-east-1");
+
+        when(accountResolver.extractAccessKeyId(auth)).thenReturn("ASIASESSION");
+        when(accountResolver.resolve(auth)).thenReturn("000000000000");
+        when(containerRequest.getHeaderString("Authorization")).thenReturn(auth);
+        when(actionRegistry.resolve("dynamodb", containerRequest)).thenReturn("dynamodb:BatchGetItem");
+        when(iamService.resolveCallerContext("ASIASESSION"))
+                .thenReturn(CallerContext.of(List.of("{}")));
+        when(arnBuilder.buildResources("dynamodb", containerRequest, "us-east-1", "000000000000"))
+                .thenReturn(List.of(
+                        "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",
+                        "arn:aws:dynamodb:us-east-1:000000000000:table/TableB"
+                ));
+        when(evaluator.evaluate(any(), isNull(), eq("dynamodb:BatchGetItem"), eq("arn:aws:dynamodb:us-east-1:000000000000:table/TableA"), isNull()))
+                .thenReturn(IamPolicyEvaluator.Decision.ALLOW);
+        when(evaluator.evaluate(any(), isNull(), eq("dynamodb:BatchGetItem"), eq("arn:aws:dynamodb:us-east-1:000000000000:table/TableB"), isNull()))
+                .thenReturn(IamPolicyEvaluator.Decision.DENY);
+        when(conditionContextResolver.resolve("dynamodb", "dynamodb:BatchGetItem", containerRequest))
+                .thenReturn(null);
+
+        IamEnforcementFilter filter = newFilter();
+        filter.filter(containerRequest);
+
+        verify(containerRequest).abortWith(any());
     }
 
     @Test
@@ -203,8 +271,8 @@ class IamEnforcementFilterTest {
                         {"Version":"2012-10-17","Statement":[
                           {"Effect":"Allow","Action":"s3:ListBucket","Resource":"*"}
                         ]}""")));
-        when(arnBuilder.build("s3", containerRequest, "us-east-1", "222233334444"))
-                .thenReturn("arn:aws:s3:::bucket");
+        when(arnBuilder.buildResources("s3", containerRequest, "us-east-1", "222233334444"))
+                .thenReturn(List.of("arn:aws:s3:::bucket"));
         when(conditionContextResolver.resolve("s3", "s3:ListBucket", containerRequest))
                 .thenReturn(conditions);
         when(evaluator.evaluate(any(), isNull(), eq("s3:ListBucket"), eq("arn:aws:s3:::bucket"), eq(conditions)))
@@ -239,8 +307,8 @@ class IamEnforcementFilterTest {
                         {"Version":"2012-10-17","Statement":[
                           {"Effect":"Allow","Action":"s3:PutObject","Resource":"*"}
                         ]}""")));
-        when(arnBuilder.build(eq("s3"), eq(containerRequest), anyString(), anyString()))
-                .thenReturn("arn:aws:s3:::bucket/key");
+        when(arnBuilder.buildResources(eq("s3"), eq(containerRequest), anyString(), anyString()))
+                .thenReturn(List.of("arn:aws:s3:::bucket/key"));
         when(evaluator.evaluate(any(), any(), any(), any(), any()))
                 .thenReturn(IamPolicyEvaluator.Decision.DENY);
 
@@ -248,7 +316,7 @@ class IamEnforcementFilterTest {
 
         // Everything keyed by scope must see the canonical name, not the alias.
         verify(actionRegistry).resolve("s3", containerRequest);
-        verify(arnBuilder).build(eq("s3"), eq(containerRequest), anyString(), anyString());
+        verify(arnBuilder).buildResources(eq("s3"), eq(containerRequest), anyString(), anyString());
         verify(conditionContextResolver).resolve("s3", "s3:GetObject", containerRequest);
         // The policy above grants only s3:PutObject, so a GetObject signed as s3express is denied.
         verify(containerRequest).abortWith(any(Response.class));
@@ -335,8 +403,8 @@ class IamEnforcementFilterTest {
         when(actionRegistry.resolve("organizations", containerRequest))
                 .thenReturn("organizations:DescribeOrganization");
         when(iamService.resolveCallerContext(account)).thenReturn(null);
-        when(arnBuilder.build(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account)))
-                .thenReturn("*");
+        when(arnBuilder.buildResources(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account)))
+                .thenReturn(List.of("*"));
         when(conditionContextResolver.resolve(eq("organizations"), anyString(), eq(containerRequest)))
                 .thenReturn(null);
 
@@ -350,10 +418,10 @@ class IamEnforcementFilterTest {
 
         verify(containerRequest, never()).abortWith(any());
         // Prove the request went THROUGH evaluation rather than taking the unknown-key bypass:
-        // arnBuilder.build sits after the caller-resolution branch, so it only fires for a request
+        // arnBuilder.buildResources sits after the caller-resolution branch, so it only fires for a request
         // that was actually evaluated. Without this, the never()-abort assertion would also pass on
         // a bypass, making it no stronger than the pre-fix behavior.
-        verify(arnBuilder).build(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account));
+        verify(arnBuilder).buildResources(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account));
     }
 
     // The realistic baseline guardrail from .temp/org-functional-test.sh: DenyLeaveOrg plus a
@@ -536,8 +604,8 @@ class IamEnforcementFilterTest {
                 .thenReturn(CallerContext.of(List.of(ALLOW_IF_IAM_USER_PRINCIPAL)));
         when(iamService.resolveCallerArn(akid))
                 .thenReturn(Optional.of("arn:aws:iam::" + account + ":user/bob"));
-        when(arnBuilder.build(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account)))
-                .thenReturn("*");
+        when(arnBuilder.buildResources(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account)))
+                .thenReturn(List.of("*"));
         when(conditionContextResolver.resolve(eq("organizations"), anyString(), eq(containerRequest)))
                 .thenReturn(null);
 
@@ -549,7 +617,7 @@ class IamEnforcementFilterTest {
 
         // aws:PrincipalArn matches arn:aws:iam::*:user/* → the conditional Allow grants access.
         verify(containerRequest, never()).abortWith(any());
-        verify(arnBuilder).build(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account));
+        verify(arnBuilder).buildResources(eq("organizations"), eq(containerRequest), eq("us-east-1"), eq(account));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamEnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamEnforcementIntegrationTest.java
@@ -103,6 +103,21 @@ class IamEnforcementIntegrationTest {
     }
 
     @Test
+    void resourceArnPatternMatchesDynamoDbTable() {
+        String policy = """
+            {"Version":"2012-10-17","Statement":[
+              {"Effect":"Allow","Action":"dynamodb:GetItem",
+               "Resource":"arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable"}
+            ]}""";
+        assertEquals(Decision.ALLOW,
+                evaluator.evaluate(List.of(policy), "dynamodb:GetItem",
+                        "arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable"));
+        assertEquals(Decision.DENY,
+                evaluator.evaluate(List.of(policy), "dynamodb:GetItem",
+                        "arn:aws:dynamodb:us-east-1:000000000000:table/OtherTable"));
+    }
+
+    @Test
     void actionListInStatement() {
         String policy = """
             {"Version":"2012-10-17","Statement":[

--- a/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
@@ -51,6 +51,7 @@ class ResourceArnBuilderTest {
     }
 
     private void setJsonBody(String json) {
+        contextProperties.clear();
         byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
         ByteArrayInputStream in = new ByteArrayInputStream(bytes);
         when(ctx.getEntityStream()).thenReturn(in);
@@ -137,6 +138,45 @@ class ResourceArnBuilderTest {
     @Test
     void dynamoDbBuildsArnsFromMultiTableTransactRequest() {
         setJsonBody("{\"TransactItems\":[{\"Put\":{\"TableName\":\"TableA\"}},{\"Delete\":{\"TableName\":\"TableB\"}},{\"Get\":{\"TableName\":\"TableA\"}}]}");
+        List<String> arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of(
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableB"
+        ), arns);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromPartiQLStatement() {
+        setJsonBody("{\"Statement\":\"SELECT * FROM \\\"UsersTable\\\" WHERE id = '1'\"}");
+        List<String> arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/UsersTable"), arns);
+
+        setJsonBody("{\"Statement\":\"INSERT INTO OrdersTable VALUE {'id': '1'}\"}");
+        arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/OrdersTable"), arns);
+
+        setJsonBody("{\"Statement\":\"UPDATE \\\"ProductsTable\\\" SET price=10 WHERE id='1'\"}");
+        arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/ProductsTable"), arns);
+
+        setJsonBody("{\"Statement\":\"DELETE FROM \\\"LogsTable\\\" WHERE id='1'\"}");
+        arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/LogsTable"), arns);
+    }
+
+    @Test
+    void dynamoDbBuildsArnsFromPartiQLBatchStatements() {
+        setJsonBody("{\"Statements\":[{\"Statement\":\"SELECT * FROM \\\"TableA\\\" WHERE id = '1'\"},{\"Statement\":\"SELECT * FROM TableB WHERE id = '2'\"}]}");
+        List<String> arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of(
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableB"
+        ), arns);
+    }
+
+    @Test
+    void dynamoDbBuildsArnsFromPartiQLTransactStatements() {
+        setJsonBody("{\"TransactStatements\":[{\"Statement\":\"INSERT INTO \\\"TableA\\\" VALUE {'id': '1'}\"},{\"Statement\":\"UPDATE \\\"TableB\\\" SET x=1 WHERE id='2'\"}]}");
         List<String> arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
         assertEquals(List.of(
                 "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",

--- a/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
@@ -1,0 +1,239 @@
+package io.github.hectorvent.floci.services.iam;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ResourceArnBuilderTest {
+
+    private ResourceArnBuilder builder;
+    private ContainerRequestContext ctx;
+    private UriInfo uriInfo;
+    private MultivaluedMap<String, String> queryParams;
+    private Map<String, Object> contextProperties;
+
+    @BeforeEach
+    void setUp() {
+        builder = new ResourceArnBuilder(new ObjectMapper());
+        ctx = mock(ContainerRequestContext.class);
+        uriInfo = mock(UriInfo.class);
+        queryParams = new MultivaluedHashMap<>();
+        contextProperties = new HashMap<>();
+
+        when(ctx.getUriInfo()).thenReturn(uriInfo);
+        when(uriInfo.getPath()).thenReturn("/");
+        when(uriInfo.getQueryParameters()).thenReturn(queryParams);
+
+        when(ctx.getProperty(any())).thenAnswer(inv -> contextProperties.get(inv.getArgument(0)));
+        doAnswer(inv -> {
+            contextProperties.put(inv.getArgument(0), inv.getArgument(1));
+            return null;
+        }).when(ctx).setProperty(any(), any());
+    }
+
+    private void setJsonBody(String json) {
+        byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+        ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+        when(ctx.getEntityStream()).thenReturn(in);
+        doAnswer(inv -> {
+            InputStream newIn = inv.getArgument(0);
+            when(ctx.getEntityStream()).thenReturn(newIn);
+            return null;
+        }).when(ctx).setEntityStream(any(InputStream.class));
+    }
+
+    // ── DynamoDB ─────────────────────────────────────────────────────────────────
+
+    @Test
+    void dynamoDbBuildsArnFromShortTableName() {
+        setJsonBody("{\"TableName\":\"FgacTable\"}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable", arn);
+    }
+
+    @Test
+    void dynamoDbReturnsExactArnIfTableNameIsAlreadyArn() {
+        String fullArn = "arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable";
+        setJsonBody("{\"TableName\":\"" + fullArn + "\"}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(fullArn, arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromResourceArn() {
+        String tagArn = "arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable";
+        setJsonBody("{\"ResourceArn\":\"" + tagArn + "\",\"Tags\":[{\"Key\":\"env\",\"Value\":\"dev\"}]}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(tagArn, arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromTableArn() {
+        String exportArn = "arn:aws:dynamodb:us-east-1:000000000000:table/ExportTable";
+        setJsonBody("{\"TableArn\":\"" + exportArn + "\",\"S3Bucket\":\"my-bucket\"}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(exportArn, arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromStreamArn() {
+        String streamArn = "arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable/stream/2026-09-01T00:00:00.000";
+        setJsonBody("{\"StreamArn\":\"" + streamArn + "\"}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(streamArn, arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromExportArn() {
+        String exportArn = "arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable/export/01693526400000-abcd";
+        setJsonBody("{\"ExportArn\":\"" + exportArn + "\"}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(exportArn, arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromSingleTableBatchRequest() {
+        setJsonBody("{\"RequestItems\":{\"MyTable\":{\"Keys\":[]}}}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:dynamodb:us-east-1:000000000000:table/MyTable", arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnFromSingleTableTransactRequest() {
+        setJsonBody("{\"TransactItems\":[{\"Put\":{\"TableName\":\"MyTable\"}},{\"Delete\":{\"TableName\":\"MyTable\"}}]}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:dynamodb:us-east-1:000000000000:table/MyTable", arn);
+    }
+
+    @Test
+    void dynamoDbReturnsWildcardWhenNoTableSpecified() {
+        setJsonBody("{}");
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals("*", arn);
+    }
+
+    @Test
+    void entityStreamRemainsReadableAfterResourceArnBuilding() throws IOException {
+        String json = "{\"TableName\":\"FgacTable\",\"Item\":{\"PK\":{\"S\":\"USER_1\"}}}";
+        setJsonBody(json);
+
+        String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable", arn);
+
+        InputStream entityStream = ctx.getEntityStream();
+        assertNotNull(entityStream);
+        byte[] readBack = entityStream.readAllBytes();
+        assertEquals(json, new String(readBack, StandardCharsets.UTF_8));
+    }
+
+    // ── Kinesis ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void kinesisBuildsArnFromStreamName() {
+        setJsonBody("{\"StreamName\":\"order-events\"}");
+        String arn = builder.build("kinesis", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:kinesis:us-east-1:000000000000:stream/order-events", arn);
+    }
+
+    @Test
+    void kinesisBuildsArnFromStreamArn() {
+        String fullArn = "arn:aws:kinesis:us-east-1:000000000000:stream/order-events";
+        setJsonBody("{\"StreamARN\":\"" + fullArn + "\"}");
+        String arn = builder.build("kinesis", ctx, "us-east-1", "000000000000");
+        assertEquals(fullArn, arn);
+    }
+
+    // ── Secrets Manager ──────────────────────────────────────────────────────────
+
+    @Test
+    void secretsManagerBuildsArnFromSecretId() {
+        setJsonBody("{\"SecretId\":\"app/prod/database\"}");
+        String arn = builder.build("secretsmanager", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:secretsmanager:us-east-1:000000000000:secret:app/prod/database", arn);
+    }
+
+    // ── SSM ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    void ssmBuildsArnFromNameWithLeadingSlash() {
+        setJsonBody("{\"Name\":\"/config/env\"}");
+        String arn = builder.build("ssm", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:ssm:us-east-1:000000000000:parameter/config/env", arn);
+    }
+
+    @Test
+    void ssmBuildsArnFromNameWithoutLeadingSlash() {
+        setJsonBody("{\"Name\":\"config-key\"}");
+        String arn = builder.build("ssm", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:ssm:us-east-1:000000000000:parameter/config-key", arn);
+    }
+
+    // ── SQS ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    void sqsBuildsArnFromJsonQueueName() {
+        setJsonBody("{\"QueueName\":\"order-queue\"}");
+        String arn = builder.build("sqs", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:order-queue", arn);
+    }
+
+    @Test
+    void sqsBuildsArnFromQueryParam() {
+        queryParams.putSingle("QueueUrl", "http://localhost:4566/000000000000/my-queue");
+        String arn = builder.build("sqs", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:sqs:us-east-1:000000000000:my-queue", arn);
+    }
+
+    // ── SNS ─────────────────────────────────────────────────────────────────────
+
+    @Test
+    void snsBuildsArnFromJsonTopicArn() {
+        String topicArn = "arn:aws:sns:us-east-1:000000000000:alerts";
+        setJsonBody("{\"TopicArn\":\"" + topicArn + "\"}");
+        String arn = builder.build("sns", ctx, "us-east-1", "000000000000");
+        assertEquals(topicArn, arn);
+    }
+
+    // ── S3 ──────────────────────────────────────────────────────────────────────
+
+    @Test
+    void s3BuildsBucketArn() {
+        when(uriInfo.getPath()).thenReturn("/my-bucket");
+        String arn = builder.build("s3", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:s3:::my-bucket", arn);
+    }
+
+    @Test
+    void s3BuildsObjectArn() {
+        when(uriInfo.getPath()).thenReturn("/my-bucket/folder/file.json");
+        String arn = builder.build("s3", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:s3:::my-bucket/folder/file.json", arn);
+    }
+
+    // ── Lambda ──────────────────────────────────────────────────────────────────
+
+    @Test
+    void lambdaBuildsFunctionArn() {
+        when(uriInfo.getPath()).thenReturn("/2015-03-31/functions/my-function/invocations");
+        String arn = builder.build("lambda", ctx, "us-east-1", "000000000000");
+        assertEquals("arn:aws:lambda:us-east-1:000000000000:function:my-function", arn);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
@@ -162,6 +162,14 @@ class ResourceArnBuilderTest {
         setJsonBody("{\"Statement\":\"DELETE FROM \\\"LogsTable\\\" WHERE id='1'\"}");
         arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
         assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/LogsTable"), arns);
+
+        setJsonBody("{\"Statement\":\"SELECT * FROM \\\"Table With Spaces & Special:Chars\\\" WHERE id = '1'\"}");
+        arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/Table With Spaces & Special:Chars"), arns);
+
+        setJsonBody("{\"Statement\":\"SELECT * FROM 'Table.With.Single.Quotes#1' WHERE id = '1'\"}");
+        arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/Table.With.Single.Quotes#1"), arns);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -117,10 +118,30 @@ class ResourceArnBuilderTest {
     }
 
     @Test
+    void dynamoDbBuildsArnsFromMultiTableBatchRequest() {
+        setJsonBody("{\"RequestItems\":{\"TableA\":{\"Keys\":[]},\"TableB\":{\"Keys\":[]}}}");
+        List<String> arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of(
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableB"
+        ), arns);
+    }
+
+    @Test
     void dynamoDbBuildsArnFromSingleTableTransactRequest() {
         setJsonBody("{\"TransactItems\":[{\"Put\":{\"TableName\":\"MyTable\"}},{\"Delete\":{\"TableName\":\"MyTable\"}}]}");
         String arn = builder.build("dynamodb", ctx, "us-east-1", "000000000000");
         assertEquals("arn:aws:dynamodb:us-east-1:000000000000:table/MyTable", arn);
+    }
+
+    @Test
+    void dynamoDbBuildsArnsFromMultiTableTransactRequest() {
+        setJsonBody("{\"TransactItems\":[{\"Put\":{\"TableName\":\"TableA\"}},{\"Delete\":{\"TableName\":\"TableB\"}},{\"Get\":{\"TableName\":\"TableA\"}}]}");
+        List<String> arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of(
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableA",
+                "arn:aws:dynamodb:us-east-1:000000000000:table/TableB"
+        ), arns);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/ResourceArnBuilderTest.java
@@ -170,6 +170,10 @@ class ResourceArnBuilderTest {
         setJsonBody("{\"Statement\":\"SELECT * FROM 'Table.With.Single.Quotes#1' WHERE id = '1'\"}");
         arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
         assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/Table.With.Single.Quotes#1"), arns);
+
+        setJsonBody("{\"Statement\":\"SELECT \\\"FROM TableEvil\\\" FROM \\\"TableA\\\" WHERE pk = 1\"}");
+        arns = builder.buildResources("dynamodb", ctx, "us-east-1", "000000000000");
+        assertEquals(List.of("arn:aws:dynamodb:us-east-1:000000000000:table/TableA"), arns);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Resolves DynamoDB table ARN from the request JSON body during IAM enforcement instead of returning a static wildcard table ARN (`arn:aws:dynamodb:<region>:<account>:table/*`).

Closes #2925

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- **Incorrect behavior**: `ResourceArnBuilder.buildDynamoDbArn` returned a static wildcard ARN (`arn:aws:dynamodb:<region>:<account>:table/*`). When evaluating table-scoped policies (e.g. `arn:aws:dynamodb:us-east-1:000000000000:table/FgacTable`), `IamPolicyEvaluator.globMatches` matched the literal policy ARN pattern against `table/*` and evaluated to `false`, causing unexpected `AccessDeniedException` 403 errors even when permissions were correctly granted.
- **Fixed behavior**: Parses the JSON request body in `ResourceArnBuilder` to extract `TableName` (supporting both short table names and full ARNs), `ResourceArn`, `TableArn`, `StreamArn`, `ExportArn`, as well as batch and transaction operations (`RequestItems`, `TransactItems`). If no specific table is targeted (such as in `ListTables`), it falls back to `*`. The request entity stream is buffered and reset so subsequent filters and endpoints read the payload intact.
- Enhanced JSON body resource resolution similarly for Kinesis, Secrets Manager, SSM, SQS, and SNS.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
