### PR TITLE
fix(dynamodb): name the table in the ResourceNotFoundException message

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -2866,7 +2866,8 @@ public class DynamoDbService implements ResourceProvider {
     }
 
     private AwsException resourceNotFoundException(String tableName) {
-        return new AwsException("ResourceNotFoundException", "Requested resource not found", 400);
+        return new AwsException("ResourceNotFoundException",
+                "Requested resource not found: Table: " + tableName + " not found", 400);
     }
 
     public record UpdateResult(JsonNode newItem, JsonNode oldItem) {}


### PR DESCRIPTION
## Summary

`ResourceNotFoundException` from DynamoDB table lookups returned a bare
`Requested resource not found`, omitting the table name real AWS includes. This names it,
matching the message AWS's own SDK tests assert.

One line, in the shared `resourceNotFoundException` helper. All fifteen call sites are table
lookups, so every one benefits and none needed touching. `findTableByArn` keeps its ARN-shaped
message, since it resolves by ARN rather than by name.

No linked issue: this came out of a parity comparison rather than a bug report, and no open issue
covers it (the closest, #575, is closed and about ARN-as-TableName, a different problem).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** `DescribeTable` (and every other table lookup) returned
`{"__type":"ResourceNotFoundException","message":"Requested resource not found"}` with no table
name. Test suites that assert on error text, which is common for DynamoDB, fail against Floci
where they pass against AWS.

**Expected text is not settled by the model.** botocore's `ResourceNotFoundException`
([dynamodb/2012-08-10](https://github.com/boto/botocore/blob/develop/botocore/data/dynamodb/2012-08-10/service-2.json))
declares only a `message` member with no template, so this is sourced from AWS's own SDK tests
instead:

- `aws-sdk-js-v3` DynamoDB e2e spec asserts `Requested resource not found: Table: DynamoDB not found`
- `aws-sdk-ruby` `client.feature` asserts the same shape against a real endpoint
- `aws-sdk-ruby` `client_spec.rb` carries a captured response body in that form
- `moto` composes the identical string (`moto/dynamodb/exceptions.py`)

**After:** `DescribeTable` on a missing table returns
`{"__type":"ResourceNotFoundException","message":"Requested resource not found: Table: nope not found"}`,
verified on the wire rather than inferred.

**Not changed:** when a caller passes an ARN as `TableName`, the message names the resolved table
rather than echoing the ARN. That matches moto and matches the e2e capture for name input, but no
source I could reach settles what AWS echoes for ARN input, so I left it alone rather than guess.

## Checklist

- [ ] `./mvnw test` passes locally — ran the DynamoDB suites (`-Dtest='DynamoDb*Test'`, 1362 tests,
      0 failures) plus an end-to-end wire check, not the full suite. Nothing outside DynamoDB reads
      this string: the only other repo-wide match is a comment in
      `CloudFormationDeleteIdempotencyIntegrationTest`, not an assertion.
- [ ] New or updated integration test added — none. No test asserted the old text either, so this
      changes no expectations. Worth knowing the new string is therefore unpinned, and a later
      refactor could revert it silently.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
