### PR TITLE
fix(kms): give ECC_NIST_EDWARDS25519 an actual Ed25519 key

### DIFF
--- a/compatibility-tests/sdk-test-python/tests/test_kms.py
+++ b/compatibility-tests/sdk-test-python/tests/test_kms.py
@@ -307,6 +307,26 @@ class TestKMSSigning:
                         SigningAlgorithm=algorithm,
                     )
                 assert excinfo.value.response["Error"]["Code"] == "ValidationException"
+
+            # A DIGEST for the pre-hash algorithm has to be one SHA-512 digest. Real KMS
+            # checks the length on Sign and on Verify.
+            with pytest.raises(ClientError) as excinfo:
+                kms_client.sign(
+                    KeyId=key_id,
+                    Message=b"not a sha-512 digest",
+                    MessageType="DIGEST",
+                    SigningAlgorithm="ED25519_PH_SHA_512",
+                )
+            assert "Digest is invalid length" in excinfo.value.response["Error"]["Message"]
+            with pytest.raises(ClientError) as excinfo:
+                kms_client.verify(
+                    KeyId=key_id,
+                    Message=b"not a sha-512 digest",
+                    MessageType="DIGEST",
+                    Signature=prehash_signature,
+                    SigningAlgorithm="ED25519_PH_SHA_512",
+                )
+            assert "Digest is invalid length" in excinfo.value.response["Error"]["Message"]
         finally:
             kms_client.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
 

--- a/compatibility-tests/sdk-test-python/tests/test_kms.py
+++ b/compatibility-tests/sdk-test-python/tests/test_kms.py
@@ -1,6 +1,10 @@
 """KMS integration tests."""
 
+import hashlib
+
 import pytest
+from botocore.exceptions import ClientError
+from cryptography.hazmat.primitives import serialization
 
 
 class TestKMSKey:
@@ -232,6 +236,77 @@ class TestKMSSigning:
                 SigningAlgorithm="RSASSA_PSS_SHA_256",
             )
             assert verify_response["SignatureValid"]
+        finally:
+            kms_client.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
+
+
+    def test_ed25519_sign_and_verify(self, kms_client):
+        """Test Ed25519 signing, checked against an outside library and real KMS rules."""
+        key_id = kms_client.create_key(
+            Description="pytest-ed25519-key",
+            KeyUsage="SIGN_VERIFY",
+            KeySpec="ECC_NIST_EDWARDS25519",
+        )["KeyMetadata"]["KeyId"]
+        message = b"message to sign"
+        digest = hashlib.sha512(message).digest()
+
+        try:
+            # Real KMS returns a 44 byte SubjectPublicKeyInfo holding a 32 byte Ed25519
+            # point. A NIST P-521 key, which this key spec used to produce, is far larger.
+            public_key = serialization.load_der_public_key(
+                kms_client.get_public_key(KeyId=key_id)["PublicKey"]
+            )
+            assert type(public_key).__name__ == "Ed25519PublicKey"
+
+            # ED25519_SHA_512 is pure Ed25519 over the message, so an outside library
+            # verifies it directly.
+            signature = kms_client.sign(
+                KeyId=key_id,
+                Message=message,
+                MessageType="RAW",
+                SigningAlgorithm="ED25519_SHA_512",
+            )["Signature"]
+            assert len(signature) == 64
+            public_key.verify(signature, message)
+            assert kms_client.verify(
+                KeyId=key_id,
+                Message=message,
+                MessageType="RAW",
+                Signature=signature,
+                SigningAlgorithm="ED25519_SHA_512",
+            )["SignatureValid"]
+
+            # ED25519_PH_SHA_512 requires DIGEST and pre-hashes the bytes it is given,
+            # so it is a different signature over the same input.
+            prehash_signature = kms_client.sign(
+                KeyId=key_id,
+                Message=digest,
+                MessageType="DIGEST",
+                SigningAlgorithm="ED25519_PH_SHA_512",
+            )["Signature"]
+            assert len(prehash_signature) == 64
+            assert prehash_signature != signature
+            assert kms_client.verify(
+                KeyId=key_id,
+                Message=digest,
+                MessageType="DIGEST",
+                Signature=prehash_signature,
+                SigningAlgorithm="ED25519_PH_SHA_512",
+            )["SignatureValid"]
+
+            # Each algorithm takes one message type, the way real KMS enforces it.
+            for algorithm, message_type in [
+                ("ED25519_SHA_512", "DIGEST"),
+                ("ED25519_PH_SHA_512", "RAW"),
+            ]:
+                with pytest.raises(ClientError) as excinfo:
+                    kms_client.sign(
+                        KeyId=key_id,
+                        Message=digest if message_type == "DIGEST" else message,
+                        MessageType=message_type,
+                        SigningAlgorithm=algorithm,
+                    )
+                assert excinfo.value.response["Error"]["Code"] == "ValidationException"
         finally:
             kms_client.schedule_key_deletion(KeyId=key_id, PendingWindowInDays=7)
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -782,6 +782,7 @@ public class KmsService implements ResourceProvider {
     // Legacy v1 (kms:<keyId>:<base64>) still accepted on Decrypt for persistent-store back-compat.
     private static final String BLOB_PREFIX_V2 = "kms:v2:";
     private static final String BLOB_PREFIX_V1 = "kms:";
+    private static final int SHA_512_DIGEST_BYTES = 64;
     private static final int NONCE_BYTES = 8;
     private static final int MIN_MAC_MESSAGE_BYTES = 1;
     private static final int MAX_MAC_MESSAGE_BYTES = 4096;
@@ -939,7 +940,7 @@ public class KmsService implements ResourceProvider {
 
         var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
         if (ed25519) {
-            validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType);
+            validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType, message);
         }
 
         try {
@@ -982,7 +983,7 @@ public class KmsService implements ResourceProvider {
 
         var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
         if (ed25519) {
-            validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType);
+            validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType, message);
         }
 
         try {
@@ -1191,10 +1192,13 @@ public class KmsService implements ResourceProvider {
      * Validates what an Ed25519 key accepts, matching the errors real KMS returns.
      *
      * <p>ED25519_SHA_512 only takes {@code MessageType=RAW} and ED25519_PH_SHA_512 only takes
-     * {@code MessageType=DIGEST}. Real KMS rejects the other pairing with a ValidationException
-     * and rejects any other signing algorithm with an InvalidKeyUsageException.
+     * {@code MessageType=DIGEST}, whose value has to be exactly one SHA-512 digest. Real KMS
+     * rejects the other pairing and a wrong digest length with a ValidationException, and rejects
+     * any other signing algorithm with an InvalidKeyUsageException. Sign and Verify both enforce
+     * all three.
      */
-    private static void validateEd25519Request(KmsKeySpec spec, String algorithm, KmsMessageType messageType) {
+    private static void validateEd25519Request(KmsKeySpec spec, String algorithm, KmsMessageType messageType,
+                                               byte[] message) {
         var algo = KmsKeySpec.getSignVerifyAlgorithm(algorithm);
         if (algo != KmsKeySpec.Algorithm.ED25519_SHA_512 && algo != KmsKeySpec.Algorithm.ED25519_PH_SHA_512) {
             throw new AwsException("InvalidKeyUsageException",
@@ -1204,6 +1208,10 @@ public class KmsService implements ResourceProvider {
         if (messageType != required) {
             throw new AwsException("ValidationException",
                     "Message type " + messageType + " is incompatible with algorithm " + algorithm + ".", 400);
+        }
+        if (algo == KmsKeySpec.Algorithm.ED25519_PH_SHA_512 && message.length != SHA_512_DIGEST_BYTES) {
+            throw new AwsException("ValidationException",
+                    "Digest is invalid length for algorithm " + algorithm + ".", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -30,10 +30,13 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.DigestInfo;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.crypto.params.ECDomainParameters;
+import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
+import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.signers.ECDSASigner;
+import org.bouncycastle.crypto.signers.Ed25519phSigner;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPublicKey;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi;
@@ -51,6 +54,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
+import java.security.interfaces.EdECPrivateKey;
 import java.security.spec.ECGenParameterSpec;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -192,6 +196,11 @@ public class KmsService implements ResourceProvider {
                     int size = Integer.parseInt(spec.name().substring(4));
                     generator.initialize(size);
                     KeyPair pair = generator.generateKeyPair();
+                    key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
+                    key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
+                }
+                case ED25519 -> {
+                    var pair = KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
                     key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
                     key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
                 }
@@ -928,8 +937,16 @@ public class KmsService implements ResourceProvider {
             throw new AwsException("UnsupportedOperationException", "Unsupported key spec for signing.", 400);
         }
 
+        var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
+        if (ed25519) {
+            validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType);
+        }
+
         try {
             PrivateKey privateKey = loadPrivateKey(kmsKey.getPrivateKeyEncoded(), kmsKey.getKeySpec());
+            if (ed25519) {
+                return signEd25519(privateKey, message, algorithm);
+            }
             String jcaAlgo = switch (messageType) {
                 // If message is already a digest, we need a "NONEwith..." algorithm
                 case DIGEST -> "NONEwith" + (kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.RSA ? "RSA" : "ECDSA");
@@ -963,8 +980,16 @@ public class KmsService implements ResourceProvider {
             return false;
         }
 
+        var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
+        if (ed25519) {
+            validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType);
+        }
+
         try {
             PublicKey publicKey = loadPublicKey(kmsKey.getPublicKeyEncoded(), kmsKey.getKeySpec());
+            if (ed25519) {
+                return verifyEd25519(publicKey, message, signature, algorithm);
+            }
             String jcaAlgo = KmsKeySpec.getSignVerifyAlgorithm(algorithm).getJavaName();
 
             if (DIGEST.equals(messageType)) {
@@ -1162,6 +1187,76 @@ public class KmsService implements ResourceProvider {
         return KmsKeySpec.ECC_SECG_P256K1 == spec;
     }
 
+    /**
+     * Validates what an Ed25519 key accepts, matching the errors real KMS returns.
+     *
+     * <p>ED25519_SHA_512 only takes {@code MessageType=RAW} and ED25519_PH_SHA_512 only takes
+     * {@code MessageType=DIGEST}. Real KMS rejects the other pairing with a ValidationException
+     * and rejects any other signing algorithm with an InvalidKeyUsageException.
+     */
+    private static void validateEd25519Request(KmsKeySpec spec, String algorithm, KmsMessageType messageType) {
+        var algo = KmsKeySpec.getSignVerifyAlgorithm(algorithm);
+        if (algo != KmsKeySpec.Algorithm.ED25519_SHA_512 && algo != KmsKeySpec.Algorithm.ED25519_PH_SHA_512) {
+            throw new AwsException("InvalidKeyUsageException",
+                    "Algorithm " + algorithm + " is incompatible with key spec " + spec.name() + ".", 400);
+        }
+        var required = algo == KmsKeySpec.Algorithm.ED25519_SHA_512 ? KmsMessageType.RAW : KmsMessageType.DIGEST;
+        if (messageType != required) {
+            throw new AwsException("ValidationException",
+                    "Message type " + messageType + " is incompatible with algorithm " + algorithm + ".", 400);
+        }
+    }
+
+    /**
+     * Signs with an Ed25519 key.
+     *
+     * <p>ED25519_SHA_512 is pure Ed25519 over the message. ED25519_PH_SHA_512 is RFC 8032
+     * Ed25519ph, and real KMS applies the SHA-512 pre-hash to the bytes the caller sends rather
+     * than treating them as an already computed digest. That is measurably different from
+     * MessageType=DIGEST on RSA and ECDSA keys, where the bytes are signed as they arrive.
+     *
+     * <p>The JDK has no Ed25519ph, so that branch uses BouncyCastle's lightweight signer,
+     * instantiated directly rather than resolved through a JCA provider, the same way the
+     * secp256k1 path does.
+     */
+    private static byte[] signEd25519(PrivateKey privateKey, byte[] message, String algorithm) throws Exception {
+        if (KmsKeySpec.Algorithm.ED25519_SHA_512.name().equals(algorithm)) {
+            var signature = Signature.getInstance("Ed25519");
+            signature.initSign(privateKey);
+            signature.update(message);
+            return signature.sign();
+        }
+        var signer = new Ed25519phSigner(new byte[0]);
+        signer.init(true, new Ed25519PrivateKeyParameters(ed25519Seed(privateKey), 0));
+        signer.update(message, 0, message.length);
+        return signer.generateSignature();
+    }
+
+    private static boolean verifyEd25519(PublicKey publicKey, byte[] message, byte[] signature, String algorithm)
+            throws Exception {
+        if (KmsKeySpec.Algorithm.ED25519_SHA_512.name().equals(algorithm)) {
+            var verifier = Signature.getInstance("Ed25519");
+            verifier.initVerify(publicKey);
+            verifier.update(message);
+            return verifier.verify(signature);
+        }
+        var verifier = new Ed25519phSigner(new byte[0]);
+        verifier.init(false, new Ed25519PublicKeyParameters(ed25519Point(publicKey), 0));
+        verifier.update(message, 0, message.length);
+        return verifier.verifySignature(signature);
+    }
+
+    private static byte[] ed25519Seed(PrivateKey privateKey) throws InvalidKeyException {
+        if (privateKey instanceof EdECPrivateKey edEC) {
+            return edEC.getBytes().orElseThrow(() -> new InvalidKeyException("Ed25519 private key is not extractable"));
+        }
+        throw new InvalidKeyException("Expected an Ed25519 private key but got " + privateKey.getAlgorithm());
+    }
+
+    private static byte[] ed25519Point(PublicKey publicKey) {
+        return SubjectPublicKeyInfo.getInstance(publicKey.getEncoded()).getPublicKeyData().getBytes();
+    }
+
     private static boolean isPKCS1v1_5(KmsKeySpec.Algorithm spec) {
         return spec == KmsKeySpec.Algorithm.RSASSA_PKCS1_V1_5_SHA_256
                 || spec == KmsKeySpec.Algorithm.RSASSA_PKCS1_V1_5_SHA_384
@@ -1226,7 +1321,11 @@ public class KmsService implements ResourceProvider {
     }
 
     private static KeyFactory buildKeyFactory(KmsKeySpec spec) throws Exception {
-        return KeyFactory.getInstance(spec.getKeyType() == KmsKeySpec.KeyType.RSA ? "RSA" : "EC");
+        return KeyFactory.getInstance(switch (spec.getKeyType()) {
+            case RSA -> "RSA";
+            case ED25519 -> "Ed25519";
+            default -> "EC";
+        });
     }
 
     private KmsKey resolveKey(String keyIdOrArn, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
@@ -18,7 +18,7 @@ public enum KmsKeySpec {
     ECC_NIST_P256(KeyType.ECC, Algorithm.ECDSA_SHA_256,"secp256r1"),
     ECC_NIST_P384(KeyType.ECC, Algorithm.ECDSA_SHA_384,"secp384r1"),
     ECC_NIST_P521(KeyType.ECC, Algorithm.ECDSA_SHA_512, "secp521r1"),
-    ECC_NIST_EDWARDS25519(KeyType.ECC, List.of(Algorithm.ED25519_SHA_512, Algorithm.ED25519_PH_SHA_512),"secp521r1"),
+    ECC_NIST_EDWARDS25519(KeyType.ED25519, List.of(Algorithm.ED25519_SHA_512, Algorithm.ED25519_PH_SHA_512)),
     ECC_SECG_P256K1(KeyType.ECC, Algorithm.ECDSA_SHA_256,"secp256k1"),
 
     HMAC_224(KeyType.HMAC, Algorithm.HMAC_SHA_224),
@@ -80,7 +80,7 @@ public enum KmsKeySpec {
         return curveName;
     }
     public enum KeyType {
-        RSA, ECC, SYMMETRIC, HMAC, ML_DSA, SM2
+        RSA, ECC, ED25519, SYMMETRIC, HMAC, ML_DSA, SM2
     }
 
     private static List<Algorithm> getRsaAlgos() {

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -1430,13 +1430,18 @@ class KmsIntegrationTest {
                 .extract().path("PublicKey");
         assertEquals(44, Base64.getDecoder().decode(publicKey).length);
 
-        String message = Base64.getEncoder().encodeToString("message".getBytes(StandardCharsets.UTF_8));
-        for (String[] pair : List.of(new String[]{"ED25519_SHA_512", "RAW"}, new String[]{"ED25519_PH_SHA_512", "DIGEST"})) {
+        // ED25519_PH_SHA_512 takes one SHA-512 digest, so the two algorithms are given
+        // different payloads here the way a caller would send them.
+        byte[] raw = "message".getBytes(StandardCharsets.UTF_8);
+        String message = Base64.getEncoder().encodeToString(raw);
+        String digest = Base64.getEncoder().encodeToString(sha512(raw));
+        for (String[] pair : List.of(new String[]{"ED25519_SHA_512", "RAW", message},
+                new String[]{"ED25519_PH_SHA_512", "DIGEST", digest})) {
             String signature = given()
                     .header("X-Amz-Target", "TrentService.Sign")
                     .contentType(KMS_CONTENT_TYPE)
                     .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"MessageType\":\"%s\",\"SigningAlgorithm\":\"%s\"}"
-                            .formatted(keyId, message, pair[1], pair[0]))
+                            .formatted(keyId, pair[2], pair[1], pair[0]))
                     .when().post("/")
                     .then().statusCode(200)
                     .body("SigningAlgorithm", equalTo(pair[0]))
@@ -1447,7 +1452,7 @@ class KmsIntegrationTest {
                     .header("X-Amz-Target", "TrentService.Verify")
                     .contentType(KMS_CONTENT_TYPE)
                     .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"MessageType\":\"%s\",\"Signature\":\"%s\",\"SigningAlgorithm\":\"%s\"}"
-                            .formatted(keyId, message, pair[1], signature, pair[0]))
+                            .formatted(keyId, pair[2], pair[1], signature, pair[0]))
                     .when().post("/")
                     .then().statusCode(200)
                     .body("SignatureValid", equalTo(true));
@@ -1479,5 +1484,42 @@ class KmsIntegrationTest {
                 .statusCode(400)
                 .body("__type", equalTo(error))
                 .body("message", equalTo(expectedMessage));
+    }
+
+    /**
+     * Real KMS checks that a DIGEST for ED25519_PH_SHA_512 is exactly one SHA-512 digest, on
+     * Sign and on Verify alike, and answers a wrong length with a ValidationException.
+     */
+    @ParameterizedTest
+    @CsvSource({"TrentService.Sign", "TrentService.Verify"})
+    void ed25519PrehashRejectsADigestOfTheWrongLength(String target) {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"SIGN_VERIFY\",\"KeySpec\":\"ECC_NIST_EDWARDS25519\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("KeyMetadata.KeyId");
+
+        String tooShort = Base64.getEncoder().encodeToString("not a sha-512 digest".getBytes(StandardCharsets.UTF_8));
+        String signature = Base64.getEncoder().encodeToString(new byte[64]);
+        given()
+                .header("X-Amz-Target", target)
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"MessageType\":\"DIGEST\",\"Signature\":\"%s\",\"SigningAlgorithm\":\"ED25519_PH_SHA_512\"}"
+                        .formatted(keyId, tooShort, signature))
+                .when().post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", equalTo("Digest is invalid length for algorithm ED25519_PH_SHA_512."));
+    }
+
+    private static byte[] sha512(byte[] value) {
+        try {
+            return java.security.MessageDigest.getInstance("SHA-512").digest(value);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -1397,4 +1397,87 @@ class KmsIntegrationTest {
                 .statusCode(400)
                 .body("__type", equalTo("ValidationException"));
     }
+
+    /**
+     * Ed25519 keys, checked against what real AWS KMS returns for the same calls.
+     *
+     * <p>ED25519_SHA_512 takes MessageType RAW and ED25519_PH_SHA_512 takes DIGEST. Real KMS
+     * rejects the other pairing, and rejects any other signing algorithm for the key spec. Note
+     * that ED25519_PH_SHA_512 pre-hashes the bytes it is given rather than signing them as a
+     * digest, so the two algorithms produce different signatures over the same input.
+     */
+    @Test
+    void ed25519KeyIsAnEd25519KeyAndSignsWithBothAlgorithms() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"SIGN_VERIFY\",\"KeySpec\":\"ECC_NIST_EDWARDS25519\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("KeyMetadata.KeySpec", equalTo("ECC_NIST_EDWARDS25519"))
+                .body("KeyMetadata.SigningAlgorithms", equalTo(List.of("ED25519_SHA_512", "ED25519_PH_SHA_512")))
+                .extract().path("KeyMetadata.KeyId");
+
+        // Real AWS returns a 44 byte SubjectPublicKeyInfo carrying a 32 byte Ed25519 point.
+        // A NIST P-521 key, which this used to be, is far larger.
+        String publicKey = given()
+                .header("X-Amz-Target", "TrentService.GetPublicKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"" + keyId + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("PublicKey");
+        assertEquals(44, Base64.getDecoder().decode(publicKey).length);
+
+        String message = Base64.getEncoder().encodeToString("message".getBytes(StandardCharsets.UTF_8));
+        for (String[] pair : List.of(new String[]{"ED25519_SHA_512", "RAW"}, new String[]{"ED25519_PH_SHA_512", "DIGEST"})) {
+            String signature = given()
+                    .header("X-Amz-Target", "TrentService.Sign")
+                    .contentType(KMS_CONTENT_TYPE)
+                    .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"MessageType\":\"%s\",\"SigningAlgorithm\":\"%s\"}"
+                            .formatted(keyId, message, pair[1], pair[0]))
+                    .when().post("/")
+                    .then().statusCode(200)
+                    .body("SigningAlgorithm", equalTo(pair[0]))
+                    .extract().path("Signature");
+            assertEquals(64, Base64.getDecoder().decode(signature).length);
+
+            given()
+                    .header("X-Amz-Target", "TrentService.Verify")
+                    .contentType(KMS_CONTENT_TYPE)
+                    .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"MessageType\":\"%s\",\"Signature\":\"%s\",\"SigningAlgorithm\":\"%s\"}"
+                            .formatted(keyId, message, pair[1], signature, pair[0]))
+                    .when().post("/")
+                    .then().statusCode(200)
+                    .body("SignatureValid", equalTo(true));
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "ED25519_SHA_512, DIGEST, ValidationException, Message type DIGEST is incompatible with algorithm ED25519_SHA_512.",
+            "ED25519_PH_SHA_512, RAW, ValidationException, Message type RAW is incompatible with algorithm ED25519_PH_SHA_512.",
+            "ECDSA_SHA_512, RAW, InvalidKeyUsageException, Algorithm ECDSA_SHA_512 is incompatible with key spec ECC_NIST_EDWARDS25519."
+    })
+    void ed25519RejectsTheCombinationsRealKmsRejects(String algorithm, String messageType, String error, String expectedMessage) {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"SIGN_VERIFY\",\"KeySpec\":\"ECC_NIST_EDWARDS25519\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.Sign")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"%s\",\"Message\":\"bWVzc2FnZQ==\",\"MessageType\":\"%s\",\"SigningAlgorithm\":\"%s\"}"
+                        .formatted(keyId, messageType, algorithm))
+                .when().post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo(error))
+                .body("message", equalTo(expectedMessage));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #2924

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The spec carried `secp521r1` from the line above it, so it made an EC key and every Sign failed.

Ed25519 now has its own key type.
Message type rules and errors match real KMS, measured in ap-northeast-1.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

