### PR TITLE
fix(dynamodb): reject ConsistentRead on GSI Scan

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbAccessPathValidationTest.java
@@ -193,6 +193,10 @@ class DynamoDbAccessPathValidationTest {
                 .keyConditionExpression("#status = :status")
                 .expressionAttributeNames(Map.of("#status", "status"))
                 .expressionAttributeValues(Map.of(":status", value("open")))));
+        assertValidationException(() -> ddb.scan(request -> request
+                .tableName(TABLE)
+                .indexName("status-index")
+                .consistentRead(true)));
     }
 
     @Test

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -870,16 +870,7 @@ public class DynamoDbJsonHandler {
                 keyConditionExpr, filterExpr, queryFilter, exprAttrNames, exprAttrValues);
         DynamoDbAccessPathValidator.validateSelection(queryTable, queryAccessPath, select,
                 projectionExpression, attributesToGet, exprAttrNames);
-
-        // ConsistentRead on GSI check
-        boolean consistentRead = request.path("ConsistentRead").asBoolean(false);
-        if (consistentRead && indexName != null) {
-            if (queryTable.findGsi(indexName).isPresent()) {
-                throw new AwsException("ValidationException",
-                        "Consistent reads are not supported on global secondary indexes", 400);
-            }
-        }
-
+        rejectConsistentReadOnGsi(request, queryAccessPath);
         // Validate EAN/EAV usage when using expression format
         if (keyConditionExpr != null) {
             // Check undefined #tokens in FilterExpression
@@ -944,6 +935,13 @@ public class DynamoDbJsonHandler {
         }
         addConsumedCapacity(response, request, tableName, queryItems.size(), false);
         return Response.ok(response).build();
+    }
+
+    private static void rejectConsistentReadOnGsi(JsonNode request, DynamoDbAccessPath accessPath) {
+        if (request.path("ConsistentRead").asBoolean(false) && accessPath.isGlobalSecondaryIndex()) {
+            throw new AwsException("ValidationException",
+                    "Consistent reads are not supported on global secondary indexes", 400);
+        }
     }
 
     private Response handleScan(JsonNode request, String region) {
@@ -1017,6 +1015,7 @@ public class DynamoDbJsonHandler {
         DynamoDbAccessPath scanAccessPath = DynamoDbAccessPath.resolve(scanTable, indexNameScan);
         DynamoDbAccessPathValidator.validateSelection(scanTable, scanAccessPath, select,
                 projectionExpressionScan, attributesToGetScan, exprAttrNames);
+        rejectConsistentReadOnGsi(request, scanAccessPath);
 
         if (exclusiveStartKey != null) {
             validateExclusiveStartKey(exclusiveStartKey, scanTable, scanAccessPath, true);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
@@ -287,6 +287,31 @@ class DynamoDbAccessPathIntegrationTest {
     }
 
     @Test
+    @Order(10)
+    void scanGsiRejectsConsistentReads() {
+        request("DynamoDB_20120810.Scan", """
+                {
+                  "TableName":"%s",
+                  "IndexName":"status-index",
+                  "ConsistentRead":true
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("Consistent reads are not supported on global secondary indexes"));
+
+        // Consistent reads stay legal on a local secondary index.
+        request("DynamoDB_20120810.Scan", """
+                {
+                  "TableName":"%s",
+                  "IndexName":"alternate-index",
+                  "ConsistentRead":true
+                }
+                """.formatted(TABLE))
+            .statusCode(200);
+    }
+
+    @Test
     @Order(9)
     void queryAndScanRejectWrongExclusiveStartKeyTypes() {
         request("DynamoDB_20120810.Query", """


### PR DESCRIPTION
## Summary

Scan with `ConsistentRead: true` on a global secondary index silently performed the read instead of being rejected. Query already rejected this case; this PR extracts that check into `rejectConsistentReadOnGsi` (now driven by `DynamoDbAccessPath.isGlobalSecondaryIndex()`) and applies it to both handlers. Strongly consistent reads on tables and LSIs remain legal, matching AWS.

Discovered while scoring emulators with the independent [paritysuite/dynamodb-conformance](https://github.com/paritysuite/dynamodb-conformance) suite — `tests/tier3/error-messages/indexReads.test.ts` fails on 2.0.1 for Scan and passes for Query.

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

**Incorrect behavior:** `Scan` + `IndexName` (GSI) + `ConsistentRead: true` returned 200 and executed the scan. Real AWS returns:

```
ValidationException: Consistent reads are not supported on global secondary indexes
```

**Verification:** the paritysuite conformance case (asserting the exact message above) fails against `floci/floci:2.0.1` and passes with this change — full suite moves 797/206 → 798/205 passed. In-repo wire-level test added in `DynamoDbAccessPathIntegrationTest#scanGsiRejectsConsistentReads` (rejection + LSI-acceptance guard), and the Java SDK compat twin `DynamoDbAccessPathValidationTest#gsiStillRejectsConsistentReads` now covers both operations.

Follow-up noticed while here (not in scope): `ExecuteStatement` (PartiQL) has no ConsistentRead-on-GSI check either.

## Checklist

- [x] `./mvnw test` passes locally (dynamodb package: 557 tests green)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)