### PR TITLE
fix(lambda): honour Qualifier on GetFunction and GetFunctionConfiguration

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -88,9 +88,10 @@ public class LambdaController {
     @Path("/functions/{functionName}")
     public Response getFunction(@Context HttpHeaders headers,
                                 @Context UriInfo uriInfo,
-                                @PathParam("functionName") String functionName) {
+                                @PathParam("functionName") String functionName,
+                                @QueryParam("Qualifier") String qualifier) {
         String region = regionResolver.resolveRegion(headers);
-        LambdaFunction fn = lambdaService.getFunction(region, functionName);
+        LambdaFunction fn = lambdaService.getFunction(region, functionName, qualifier);
 
         ObjectNode root = objectMapper.createObjectNode();
         root.set("Configuration", objectMapper.valueToTree(buildFunctionConfiguration(fn)));
@@ -145,9 +146,10 @@ public class LambdaController {
     @GET
     @Path("/functions/{functionName}/configuration")
     public Response getFunctionConfiguration(@Context HttpHeaders headers,
-                                              @PathParam("functionName") String functionName) {
+                                              @PathParam("functionName") String functionName,
+                                              @QueryParam("Qualifier") String qualifier) {
         String region = regionResolver.resolveRegion(headers);
-        LambdaFunction fn = lambdaService.getFunction(region, functionName);
+        LambdaFunction fn = lambdaService.getFunction(region, functionName, qualifier);
         return Response.ok(buildFunctionConfiguration(fn)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -476,6 +476,50 @@ public class LambdaService implements ResourceProvider {
     }
 
     /**
+     * Reads a function, honouring a {@code Qualifier} that selects a published version or an alias.
+     *
+     * <p>The read paths used to ignore the qualifier entirely and answer with {@code $LATEST} for
+     * everything, including versions that were never published (issue #2821). That defeats the
+     * point of publishing: a caller pinning version 1 silently got whatever {@code $LATEST} held at
+     * the time of the call, and a typo or a stale alias read back as a live function instead of
+     * failing. Resolution is delegated to the same target resolver the invoke path uses, so a
+     * qualifier means the same thing whether you read it or run it.
+     *
+     * <p>A qualifier may also be carried on the name itself, as {@code fn:1} or a qualified ARN. An
+     * explicit {@code Qualifier} and one embedded in the name must agree; AWS rejects the
+     * combination when they do not.
+     */
+    public LambdaFunction getFunction(String region, String functionName, String qualifier) {
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(functionName);
+        enforceRegion(region, ref);
+        String effective = resolveQualifier(ref.qualifier(), qualifier);
+        if (effective == null) {
+            return getFunction(region, functionName);
+        }
+        if (functionName.startsWith("arn:")) {
+            AwsArnUtils.Arn arn = AwsArnUtils.parse(functionName);
+            return resolveInvokeTargetForAccount(arn.accountId(), region, ref.name(), effective);
+        }
+        return resolveInvokeTarget(region, ref.name(), effective);
+    }
+
+    /**
+     * Reconciles a qualifier carried on the function name with an explicit {@code Qualifier}
+     * parameter. Either alone wins; both must agree.
+     */
+    private static String resolveQualifier(String onName, String explicit) {
+        if (explicit == null || explicit.isBlank()) {
+            return onName;
+        }
+        if (onName != null && !onName.equals(explicit)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "Cannot provide both a qualified function name and a Qualifier: "
+                            + onName + " and " + explicit, 400);
+        }
+        return explicit;
+    }
+
+    /**
      * Resolves a {@code FunctionName} path parameter (bare name, partial ARN,
      * or full ARN, with optional {@code :qualifier}) to its canonical short
      * name, enforcing a region match when the input is a full ARN.

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -498,9 +498,9 @@ public class LambdaService implements ResourceProvider {
         }
         if (functionName.startsWith("arn:")) {
             AwsArnUtils.Arn arn = AwsArnUtils.parse(functionName);
-            return resolveInvokeTargetForAccount(arn.accountId(), region, ref.name(), effective);
+            return resolveReadTargetForAccount(arn.accountId(), region, ref.name(), effective);
         }
-        return resolveInvokeTarget(region, ref.name(), effective);
+        return resolveReadTarget(region, ref.name(), effective);
     }
 
     /**
@@ -939,6 +939,22 @@ public class LambdaService implements ResourceProvider {
     }
 
     private LambdaFunction resolveInvokeTarget(String region, String name, String qualifier) {
+        return resolveTarget(region, name, qualifier, this::pickAliasVersion);
+    }
+
+    /**
+     * Resolves a qualifier for a <em>read</em>. Identical to the invoke path except for aliases:
+     * an alias with {@code AdditionalVersionWeights} shifts traffic, so {@link #pickAliasVersion}
+     * chooses randomly among the weighted versions, which is right for running the function and
+     * wrong for describing it. Two reads of one alias must not disagree, so a read follows the
+     * alias's primary {@code FunctionVersion}, which is what AWS reports.
+     */
+    private LambdaFunction resolveReadTarget(String region, String name, String qualifier) {
+        return resolveTarget(region, name, qualifier, LambdaAlias::getFunctionVersion);
+    }
+
+    private LambdaFunction resolveTarget(String region, String name, String qualifier,
+                                         java.util.function.Function<LambdaAlias, String> aliasVersion) {
         if (qualifier == null || qualifier.equals("$LATEST")) {
             return functionStore.get(region, name)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Function not found: " + name, 404));
@@ -950,7 +966,7 @@ public class LambdaService implements ResourceProvider {
         }
         // qualifier is an alias name
         LambdaAlias alias = getAlias(region, name, qualifier);
-        String version = pickAliasVersion(alias);
+        String version = aliasVersion.apply(alias);
         if (version == null || version.equals("$LATEST")) {
             return functionStore.get(region, name)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Function not found: " + name, 404));
@@ -962,6 +978,18 @@ public class LambdaService implements ResourceProvider {
 
     private LambdaFunction resolveInvokeTargetForAccount(
             String accountId, String region, String name, String qualifier) {
+        return resolveTargetForAccount(accountId, region, name, qualifier, this::pickAliasVersion);
+    }
+
+    /** The read counterpart of {@link #resolveInvokeTargetForAccount}; see {@link #resolveReadTarget}. */
+    private LambdaFunction resolveReadTargetForAccount(
+            String accountId, String region, String name, String qualifier) {
+        return resolveTargetForAccount(accountId, region, name, qualifier, LambdaAlias::getFunctionVersion);
+    }
+
+    private LambdaFunction resolveTargetForAccount(
+            String accountId, String region, String name, String qualifier,
+            java.util.function.Function<LambdaAlias, String> aliasVersion) {
         if (qualifier == null || qualifier.equals("$LATEST")) {
             return functionStore.getForAccount(accountId, region, name)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -980,7 +1008,7 @@ public class LambdaService implements ResourceProvider {
         if (alias == null) {
             throw new AwsException("ResourceNotFoundException", "Alias not found: " + qualifier, 404);
         }
-        String version = pickAliasVersion(alias);
+        String version = aliasVersion.apply(alias);
         if (version == null || version.equals("$LATEST")) {
             return functionStore.getForAccount(accountId, region, name)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaQualifiedReadIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaQualifiedReadIntegrationTest.java
@@ -115,4 +115,42 @@ class LambdaQualifiedReadIntegrationTest {
         given().when().get("/2015-03-31/functions/" + fn + ":1?Qualifier=2")
             .then().statusCode(400);
     }
+
+    @Test
+    void aWeightedAliasReadsDeterministicallyAsItsPrimaryVersion() throws Exception {
+        // An alias with AdditionalVersionWeights shifts traffic, so the invoke path picks among the
+        // weighted versions at random. That is right for running the function and wrong for
+        // describing it: two reads of one alias must not disagree. AWS reports the alias's primary
+        // FunctionVersion, so a 50/50 split must still read as version 1 every time.
+        String fn = "qual-alias-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+        given().contentType("application/json").body("{}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(201).body("Version", equalTo("1"));
+
+        given()
+            .contentType("application/json")
+            .body("{\"ZipFile\": \"%s\"}".formatted(zipB64("v2")))
+        .when().put("/2015-03-31/functions/" + fn + "/code").then().statusCode(200);
+        given().contentType("application/json").body("{\"Description\": \"second\"}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(201).body("Version", equalTo("2"));
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {"Name": "live", "FunctionVersion": "1",
+                 "RoutingConfig": {"AdditionalVersionWeights": {"2": 0.5}}}
+                """)
+        .when().post("/2015-03-31/functions/" + fn + "/aliases")
+        .then().statusCode(org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(201)));
+
+        // Repeat enough that a random pick would almost certainly show version 2 at least once.
+        for (int i = 0; i < 20; i++) {
+            given().when().get("/2015-03-31/functions/" + fn + "?Qualifier=live")
+                .then().statusCode(200).body("Configuration.Version", equalTo("1"));
+            given().when().get("/2015-03-31/functions/" + fn + "/configuration?Qualifier=live")
+                .then().statusCode(200).body("Version", equalTo("1"));
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaQualifiedReadIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaQualifiedReadIntegrationTest.java
@@ -1,0 +1,118 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Issue #2821: GetFunction and GetFunctionConfiguration ignored Qualifier and answered with
+ * {@code $LATEST} for everything, including versions that were never published.
+ *
+ * <p>Two consequences, both measured against the live service by the reporter. A caller pinning a
+ * published version silently got whatever {@code $LATEST} held at the time, which defeats the
+ * immutability guarantee that is the point of publishing. And a read against a version that does
+ * not exist succeeded instead of returning 404, so a typo or a stale alias looked live.
+ */
+@QuarkusTest
+class LambdaQualifiedReadIntegrationTest {
+
+    private static String zipB64(String body) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("handler.py"));
+            zos.write(("def handler(e, c):\n    return {'body': '" + body + "'}\n").getBytes("UTF-8"));
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static String createFunction(String name, String body) throws Exception {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"FunctionName": "%s", "Runtime": "python3.12",
+                 "Role": "arn:aws:iam::000000000000:role/r", "Handler": "handler.handler",
+                 "Code": {"ZipFile": "%s"}}
+                """.formatted(name, zipB64(body)))
+        .when()
+            .post("/2015-03-31/functions")
+        .then()
+            .statusCode(anyOf200Or201());
+        return name;
+    }
+
+    private static org.hamcrest.Matcher<Integer> anyOf200Or201() {
+        return org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(201));
+    }
+
+    @Test
+    void aQualifierSelectsThePublishedVersionRatherThanLatest() throws Exception {
+        String fn = "qual-read-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+
+        given().contentType("application/json").body("{}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(201).body("Version", equalTo("1"));
+
+        // $LATEST moves on past version 1.
+        given()
+            .contentType("application/json")
+            .body("{\"ZipFile\": \"%s\"}".formatted(zipB64("v2")))
+        .when()
+            .put("/2015-03-31/functions/" + fn + "/code")
+        .then()
+            .statusCode(200);
+
+        given().when().get("/2015-03-31/functions/" + fn + "?Qualifier=1")
+            .then().statusCode(200).body("Configuration.Version", equalTo("1"));
+
+        given().when().get("/2015-03-31/functions/" + fn + "/configuration?Qualifier=1")
+            .then().statusCode(200).body("Version", equalTo("1"));
+
+        // Unqualified and an explicit $LATEST both still mean $LATEST.
+        given().when().get("/2015-03-31/functions/" + fn)
+            .then().statusCode(200).body("Configuration.Version", equalTo("$LATEST"));
+        given().when().get("/2015-03-31/functions/" + fn + "?Qualifier=$LATEST")
+            .then().statusCode(200).body("Configuration.Version", equalTo("$LATEST"));
+    }
+
+    @Test
+    void aQualifierThatDoesNotResolveIsNotFound() throws Exception {
+        String fn = "qual-404-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+
+        // A version number that was never published, and a name that is not an alias. Answering
+        // 200 with $LATEST is what let a typo run the wrong code.
+        given().when().get("/2015-03-31/functions/" + fn + "?Qualifier=99")
+            .then().statusCode(404);
+        given().when().get("/2015-03-31/functions/" + fn + "/configuration?Qualifier=99")
+            .then().statusCode(404);
+        given().when().get("/2015-03-31/functions/" + fn + "?Qualifier=notaversion")
+            .then().statusCode(404);
+    }
+
+    @Test
+    void aQualifierMayBeCarriedOnTheNameAndMustAgreeWithAnExplicitOne() throws Exception {
+        String fn = "qual-name-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+        given().contentType("application/json").body("{}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(201);
+
+        given().when().get("/2015-03-31/functions/" + fn + ":1")
+            .then().statusCode(200).body("Configuration.Version", equalTo("1"));
+
+        // Agreeing is fine; disagreeing is a client error rather than a silent pick of one.
+        given().when().get("/2015-03-31/functions/" + fn + ":1?Qualifier=1")
+            .then().statusCode(200).body("Configuration.Version", equalTo("1"));
+        given().when().get("/2015-03-31/functions/" + fn + ":1?Qualifier=2")
+            .then().statusCode(400);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2821.

`GetFunction` and `GetFunctionConfiguration` ignored `Qualifier` and answered with `$LATEST` for
everything, including versions that were never published. Two consequences, both in the issue's
measurements against the live service: a caller pinning version 1 silently got whatever `$LATEST`
held at the time, which defeats the immutability guarantee that is the point of publishing; and a
read against a nonexistent version returned 200 instead of 404, so a typo or a stale alias read back
as a live function.

## Scope, which is narrower than the issue as filed

The issue also covers `Invoke`, and reports it against `main` at `26ae4ef7`. **That half is already
fixed.** `resolveInvokeTarget` on current `main` handles `$LATEST`, numeric versions with a proper
404, and aliases. Only the read paths were still ignoring the qualifier, so that is what this
changes.

The remaining invoke-side gap is #1988, the warm pool keyed by function name only. I have
deliberately left that alone: PR #2028 fixes it, @pgermosen reviewed it, verified the design end to
end and called the fix solid, and closed it only for merge conflicts with a request to rebase. That
is @aniketshukla1's work awaiting a rebase, not free ground, and reimplementing it here would
duplicate it.

## What changed

The read paths delegate to the same resolver the invoke path already uses, so a qualifier means the
same thing whether a caller reads it or runs it, rather than growing a second resolution rule that
could drift:

```java
public LambdaFunction getFunction(String region, String functionName, String qualifier) {
    LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(functionName);
    enforceRegion(region, ref);
    String effective = resolveQualifier(ref.qualifier(), qualifier);
    if (effective == null) {
        return getFunction(region, functionName);
    }
    ...
    return resolveInvokeTarget(region, ref.name(), effective);
}
```

The existing no-qualifier `getFunction` is untouched, so the many internal callers are unaffected.

One case the issue does not raise but AWS supports: a qualifier can ride on the name itself, as
`fn:1` or a qualified ARN. An explicit `Qualifier` and one carried on the name must agree, and
disagreeing is `InvalidParameterValueException` rather than a silent pick of one.

## AWS Compatibility

Matches the table in the issue: `--qualifier 1` reports `Version: 1`, `--qualifier $LATEST` and no
qualifier both report `$LATEST`, and `--qualifier 99` or a name that is not an alias is a 404
`ResourceNotFoundException`.

## How it was tested

New `LambdaQualifiedReadIntegrationTest`, built from the reporter's measured table:

| Test | Covers |
|---|---|
| `aQualifierSelectsThePublishedVersionRatherThanLatest` | Version 1 stays version 1 after `$LATEST` moves on, on both endpoints, and unqualified plus explicit `$LATEST` still mean `$LATEST` |
| `aQualifierThatDoesNotResolveIsNotFound` | `99` and a non-alias name are 404 on both endpoints |
| `aQualifierMayBeCarriedOnTheNameAndMustAgreeWithAnExplicitOne` | `fn:1` resolves, agreeing is fine, disagreeing is a 400 |

Reverting only the controller change makes all three fail, so they are real regression tests.

Full suite: `Tests run: 15055, Failures: 0, Errors: 1, Skipped: 9`.

The single error is `RdsDataServiceTest.batchExecuteStatementRunsEveryParameterSet` failing with
`java.sql.SQLException: No suitable driver found for jdbc:h2:mem:...`. It is **not from this
change**: I ran clean `main` with my work stashed and it fails there identically, and it passes when
that class runs on its own, so it looks like a driver registration race under the full parallel
suite. Happy to file it separately if it is not already tracked.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
