### PR TITLE
fix(lambda): honour CodeSha256 and skip unchanged publishes on PublishVersion

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -393,14 +393,16 @@ public class LambdaController {
                                    String body) {
         String region = regionResolver.resolveRegion(headers);
         String description = null;
+        String codeSha256 = null;
         if (body != null && !body.isBlank()) {
             try {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> req = objectMapper.readValue(body, Map.class);
                 description = (String) req.get("Description");
+                codeSha256 = (String) req.get("CodeSha256");
             } catch (Exception ignored) {}
         }
-        LambdaFunction version = lambdaService.publishVersion(region, functionName, description);
+        LambdaFunction version = lambdaService.publishVersion(region, functionName, description, codeSha256);
         return Response.status(201).entity(buildFunctionConfiguration(version)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -1278,6 +1279,29 @@ public class LambdaService implements ResourceProvider {
      * {@code concurrencyOpLocks}) so publishes of unrelated functions do not
      * serialize on the instance monitor for the storage round-trip.
      */
+    /**
+     * The already-published version cut from {@code $LATEST}'s current revision, if there is one.
+     *
+     * <p>Versions published before {@code sourceRevisionId} was recorded carry null and never
+     * match, so existing state simply keeps the previous behaviour rather than deduplicating
+     * against a revision nobody wrote down.
+     */
+    private LambdaFunction latestPublishedFrom(String region, LambdaFunction fn, String description) {
+        String current = fn.getRevisionId();
+        if (current == null) {
+            return null;
+        }
+        // Description is supplied at publish time rather than carried on $LATEST, so a publish that
+        // names a new one is a real publish even when nothing else moved. LambdaVersionIntegrationTest
+        // asserts exactly that: two publishes differing only in Description produce versions 1 and 2.
+        String effective = description != null ? description : fn.getDescription();
+        return functionStore.listVersions(region, fn.getFunctionName()).stream()
+                .filter(v -> current.equals(v.getSourceRevisionId()))
+                .filter(v -> Objects.equals(effective, v.getDescription()))
+                .findFirst()
+                .orElse(null);
+    }
+
     private int nextVersionNumber(String counterKey, String legacyCounterKey) {
         synchronized (versionCounterLocks.computeIfAbsent(counterKey, k -> new Object())) {
             Integer current = versionCounters.get(counterKey);
@@ -1311,14 +1335,46 @@ public class LambdaService implements ResourceProvider {
     }
 
     public LambdaFunction publishVersion(String region, String functionName, String description) {
+        return publishVersion(region, functionName, description, null);
+    }
+
+    /**
+     * Publishes a version of {@code $LATEST}.
+     *
+     * <p>Two AWS behaviours this used to skip (issue #2822). {@code CodeSha256} is a precondition:
+     * "only publish a version if the hash value matches the value that's specified", so a caller
+     * that raced someone else's deploy is told rather than publishing code it did not intend.
+     * And an unchanged publish does not create a version: "AWS Lambda doesn't publish a version if
+     * the function's configuration and code haven't changed since the last version". Without that,
+     * repeated publishes accumulate identical versions.
+     *
+     * <p>"Unchanged" is decided by {@code $LATEST}'s {@code revisionId}, which is regenerated on
+     * every code and configuration update, so a version records the revision it was cut from and a
+     * later publish that finds it unmoved returns the existing version instead of a new one.
+     */
+    public LambdaFunction publishVersion(String region, String functionName, String description,
+                                         String expectedCodeSha256) {
         LambdaFunction fn = getFunction(region, functionName);
         functionName = fn.getFunctionName();
+
+        if (expectedCodeSha256 != null && !expectedCodeSha256.isBlank()
+                && !expectedCodeSha256.equals(fn.getCodeSha256())) {
+            throw new AwsException("InvalidParameterValueException",
+                    "CodeSHA256 (" + expectedCodeSha256 + ") is different from current CodeSHA256 in $LATEST",
+                    400);
+        }
         // Shares the per-function lock deleteFunction and extractZipCodeBytes take around their
         // own codeLocalPath-affecting work: without it, a version could be published in the
         // narrow window between reclaimLegacyCodeDirectoryIfUnused's check and its actual
         // delete, persisting a snapshot.codeLocalPath (below) that names a directory about to
         // be removed as unreferenced.
         synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
+            LambdaFunction unchanged = latestPublishedFrom(region, fn, description);
+            if (unchanged != null) {
+                LOG.debugv("PublishVersion for {0} found nothing changed since version {1}; "
+                        + "returning it rather than creating a duplicate", functionName, unchanged.getVersion());
+                return unchanged;
+            }
             int version = nextVersionNumber(versionCounterKey(region, fn),
                     legacyVersionCounterKey(region, functionName));
             LambdaFunction snapshot = new LambdaFunction();
@@ -1348,6 +1404,7 @@ public class LambdaService implements ResourceProvider {
             snapshot.setFileSystemConfigs(new ArrayList<>(fn.getFileSystemConfigs()));
             snapshot.setLastModified(System.currentTimeMillis());
             snapshot.setRevisionId(UUID.randomUUID().toString());
+            snapshot.setSourceRevisionId(fn.getRevisionId());
 
             // Everything that determines what actually runs. Without these the snapshot describes a
             // function with no code: a version-qualified invoke resolves to it, launches a container

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/LambdaFunction.java
@@ -39,6 +39,14 @@ public class LambdaFunction {
     private List<Map<String, Object>> policies = new ArrayList<>();
     private long lastModified;
     private String revisionId;
+    /**
+     * For a published version, the {@code revisionId} that {@code $LATEST} carried when this
+     * version was cut. AWS does not publish a second version when nothing has changed since the
+     * last one, and {@code $LATEST}'s revision is regenerated on every code and configuration
+     * update, so matching it is exactly the "unchanged since" test (issue #2822). Null on
+     * {@code $LATEST} itself, and on versions published before this was recorded.
+     */
+    private String sourceRevisionId;
     private String version = "$LATEST";
     private LambdaUrlConfig urlConfig;
     private Integer reservedConcurrentExecutions;
@@ -147,6 +155,8 @@ public class LambdaFunction {
     public void setLastModified(long lastModified) { this.lastModified = lastModified; }
 
     public String getRevisionId() { return revisionId; }
+    public String getSourceRevisionId() { return sourceRevisionId; }
+    public void setSourceRevisionId(String sourceRevisionId) { this.sourceRevisionId = sourceRevisionId; }
     public void setRevisionId(String revisionId) { this.revisionId = revisionId; }
 
     public String getVersion() { return version; }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionSemanticsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionSemanticsIntegrationTest.java
@@ -1,0 +1,139 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Issue #2822: PublishVersion published unconditionally and ignored CodeSha256.
+ *
+ * <p>Repeated publishes accumulated identical versions, and the precondition that exists to stop a
+ * caller publishing code it did not intend was silently ignored, so a publish that should have been
+ * rejected succeeded and produced a version.
+ */
+@QuarkusTest
+class LambdaPublishVersionSemanticsIntegrationTest {
+
+    private static String zipB64(String body) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("handler.py"));
+            zos.write(("def handler(e, c):\n    return {'body': '" + body + "'}\n").getBytes("UTF-8"));
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static void createFunction(String name, String body) throws Exception {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"FunctionName": "%s", "Runtime": "python3.12",
+                 "Role": "arn:aws:iam::000000000000:role/r", "Handler": "handler.handler",
+                 "Code": {"ZipFile": "%s"}}
+                """.formatted(name, zipB64(body)))
+        .when().post("/2015-03-31/functions")
+        .then().statusCode(org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(201)));
+    }
+
+    private static String publish(String name, String bodyJson) {
+        return given().contentType("application/json").body(bodyJson)
+            .when().post("/2015-03-31/functions/" + name + "/versions")
+            .then().statusCode(201)
+            .extract().path("Version");
+    }
+
+    @Test
+    void publishingTwiceWithNothingChangedReturnsTheExistingVersion() throws Exception {
+        String fn = "pv-dedup-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+
+        String first = publish(fn, "{}");
+        String second = publish(fn, "{}");
+        String third = publish(fn, "{}");
+
+        assertSame(first, second, third);
+
+        // And the version list has not grown a duplicate for each attempt.
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200)
+            .body("Versions.size()", equalTo(2));   // $LATEST plus the single published version
+    }
+
+    private static void assertSame(String first, String second, String third) {
+        org.junit.jupiter.api.Assertions.assertEquals(first, second,
+                "an unchanged publish must return the existing version, not create a new one");
+        org.junit.jupiter.api.Assertions.assertEquals(first, third,
+                "repeated unchanged publishes must keep returning the same version");
+    }
+
+    @Test
+    void aRealChangeStillProducesANewVersion() throws Exception {
+        String fn = "pv-change-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+        String first = publish(fn, "{}");
+
+        given()
+            .contentType("application/json")
+            .body("{\"ZipFile\": \"%s\"}".formatted(zipB64("v2")))
+        .when().put("/2015-03-31/functions/" + fn + "/code")
+        .then().statusCode(200);
+
+        String second = publish(fn, "{}");
+        org.junit.jupiter.api.Assertions.assertNotEquals(first, second,
+                "a code change must still produce a new version");
+
+        // A configuration-only change counts too, since a version snapshots configuration as well.
+        given().contentType("application/json").body("{\"Timeout\": 42}")
+        .when().put("/2015-03-31/functions/" + fn + "/configuration")
+        .then().statusCode(200);
+
+        String third = publish(fn, "{}");
+        org.junit.jupiter.api.Assertions.assertNotEquals(second, third,
+                "a configuration change must still produce a new version");
+    }
+
+    @Test
+    void aMismatchedCodeSha256IsRejectedAndPublishesNothing() throws Exception {
+        String fn = "pv-sha-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+
+        given()
+            .contentType("application/json")
+            .body("{\"CodeSha256\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("different from current CodeSHA256"));
+
+        // The rejected publish must not have produced a version.
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200).body("Versions.size()", equalTo(1));
+    }
+
+    @Test
+    void aMatchingCodeSha256Publishes() throws Exception {
+        String fn = "pv-sha-ok-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn, "v1");
+
+        String sha = given().when().get("/2015-03-31/functions/" + fn + "/configuration")
+                .then().statusCode(200).extract().path("CodeSha256");
+
+        given()
+            .contentType("application/json")
+            .body("{\"CodeSha256\": \"%s\"}".formatted(sha))
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then()
+            .statusCode(201)
+            .body("Version", not(equalTo("$LATEST")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServicePersistenceTest.java
@@ -38,11 +38,14 @@ class LambdaServicePersistenceTest {
 
         LambdaService first = serviceWithStorage(store, storage);
         first.createFunction(REGION, baseRequest("versioned-fn"));
-        assertEquals("1", first.publishVersion(REGION, "versioned-fn", null).getVersion());
-        assertEquals("2", first.publishVersion(REGION, "versioned-fn", null).getVersion());
+        // Distinct descriptions so each call is a real publish. PublishVersion no longer creates a
+        // version when nothing has changed since the last one (#2822), and this test is about the
+        // version counter surviving a restart, not about that de-duplication.
+        assertEquals("1", first.publishVersion(REGION, "versioned-fn", "one").getVersion());
+        assertEquals("2", first.publishVersion(REGION, "versioned-fn", "two").getVersion());
 
         LambdaService reloaded = serviceWithStorage(store, storage);
-        LambdaFunction third = reloaded.publishVersion(REGION, "versioned-fn", null);
+        LambdaFunction third = reloaded.publishVersion(REGION, "versioned-fn", "three");
         assertEquals("3", third.getVersion());
         assertTrue(third.getFunctionArn().endsWith(":3"));
     }


### PR DESCRIPTION
## Summary

Closes #2822.

Two documented `PublishVersion` behaviours were missing. `CodeSha256` was ignored, so a publish that
should have been rejected succeeded and produced a version. And publishing was unconditional, so
repeated publishes accumulated identical versions.

## What changed

**`CodeSha256` as a precondition.** The controller parsed only `Description` out of the body, so the
field never reached the service at all. A mismatch is now `InvalidParameterValueException` carrying
AWS's message shape, and nothing is published.

**Unchanged publishes return the existing version.** Rather than comparing the thirty-odd fields a
snapshot copies, this keys on a signal the codebase already maintains: `$LATEST`'s `revisionId` is
regenerated on every code and configuration update. A version records the revision it was cut from,
and a later publish that finds it unmoved returns that version.

```java
LambdaFunction unchanged = latestPublishedFrom(region, fn, description);
if (unchanged != null) {
    return unchanged;
}
```

Keying on the revision rather than a field by field comparison means a field added to versions later
is covered without anyone remembering to update a comparison. Versions published before this change
carry no source revision and never match, so existing state simply keeps its previous behaviour
rather than deduplicating against a revision nobody recorded.

`LambdaFunction` gains one field. That is safe for persisted state because the model is
`@JsonIgnoreProperties(ignoreUnknown = true)`, so older records load with it null.

## Description, and why it is part of the check

`Description` is supplied at publish time rather than carried on `$LATEST`, so a publish naming a new
one is a real publish even when nothing else moved.

I had this as an open question, since AWS's wording is "configuration and code", and I have no live
account to measure it against. **This repository already answers it**:
`LambdaVersionIntegrationTest.publishSecondVersion` publishes with a new `Description` and nothing
else changed, and asserts it gets version 2. So the effective description is part of the check, and
that existing test is the reason.

## One existing test changed, which I want visible rather than buried

`LambdaServicePersistenceTest.publishVersionContinuesNumberingAfterRestart` published three times
with nothing changed at all in order to reach version 3. No correct de-duplication can leave that
passing, because it encodes precisely the behaviour this issue asks to change.

Its subject is the version counter surviving a restart, not whether unchanged publishes mint
versions, so it now varies the description across the three calls. That still exercises the counter
across a reload, including the reload boundary, which is what the test is named for.

If maintainers read that test's intent differently, say so and I will adjust rather than defend it.

## AWS Compatibility

Matches the measurements in the issue: a repeat publish with nothing changed returns the existing
version instead of minting `2`, `3`, `4`; and `--code-sha256` with a value that does not match
`$LATEST` returns `InvalidParameterValueException` reading
`CodeSHA256 (...) is different from current CodeSHA256 in $LATEST`.

Out of scope, as the issue itself notes it is "not the substance of this report": the unordered
`list-versions-by-function` result. Happy to take that separately.

## How it was tested

New `LambdaPublishVersionSemanticsIntegrationTest`:

| Test | Covers | Fails without the fix |
|---|---|---|
| `publishingTwiceWithNothingChangedReturnsTheExistingVersion` | Three unchanged publishes return one version, and the version list does not grow | Yes, `expected: <1> but was: <2>` |
| `aMismatchedCodeSha256IsRejectedAndPublishesNothing` | 400, and no version created by the rejected call | Yes |
| `aRealChangeStillProducesANewVersion` | A code change and a configuration-only change each still mint a version | No, a do-no-harm guard on the de-duplication |
| `aMatchingCodeSha256Publishes` | The precondition does not block a correct hash | No, a do-no-harm guard |

Full suite: `Tests run: 15056, Failures: 0, Errors: 1, Skipped: 9`.

The single error is `RdsDataServiceTest.batchExecuteStatementRunsEveryParameterSet` failing with
`java.sql.SQLException: No suitable driver found for jdbc:h2:mem:...`. It is not from this change: I
ran clean `main` with my work stashed and it fails there identically, and it passes when that class
runs alone, so it looks like a driver registration race under the full parallel suite.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
