### PR TITLE
fix(dynamodb): reject QueryFilter with KeyConditionExpression

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbConformanceChangesTest.java
@@ -547,8 +547,10 @@ class DynamoDbConformanceChangesTest {
     void queryWithQueryFilter() {
         QueryResponse resp = ddb.query(QueryRequest.builder()
                 .tableName(TABLE)
-                .keyConditionExpression("pk = :pk")
-                .expressionAttributeValues(Map.of(":pk", av("p1")))
+                .keyConditions(Map.of("pk", Condition.builder()
+                        .comparisonOperator(ComparisonOperator.EQ)
+                        .attributeValueList(av("p1"))
+                        .build()))
                 .queryFilter(Map.of("name", Condition.builder()
                         .comparisonOperator(ComparisonOperator.EQ)
                         .attributeValueList(av("Item-0"))

--- a/compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/dynamodb-conformance.test.ts
@@ -707,14 +707,32 @@ describe('DynamoDB — Phase 10: Legacy API', () => {
   it('QueryFilter (legacy) filters query results', async () => {
     const resp = await ddb.send(new QueryCommand({
       TableName: table,
-      KeyConditionExpression: 'pk = :pk',
-      ExpressionAttributeValues: { ':pk': s('p1') },
+      KeyConditions: {
+        pk: { ComparisonOperator: 'EQ', AttributeValueList: [s('p1')] },
+      },
       QueryFilter: {
         name: { ComparisonOperator: 'EQ', AttributeValueList: [s('Item-0')] },
       },
     }));
     expect(resp.Count).toBe(1);
     expect(resp.Items![0].name.S).toBe('Item-0');
+  });
+
+  it('QueryFilter and KeyConditionExpression are mutually exclusive', async () => {
+    const err = await ddb.send(new QueryCommand({
+      TableName: table,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': s('p1') },
+      QueryFilter: {
+        name: { ComparisonOperator: 'EQ', AttributeValueList: [s('Item-0')] },
+      },
+    })).catch(e => e);
+
+    expect(err.name).toBe('ValidationException');
+    expect(err.message).toBe(
+      'Can not use both expression and non-expression parameters in the same request: '
+      + 'Non-expression parameters: {QueryFilter} Expression parameters: {KeyConditionExpression}',
+    );
   });
 
   it('ScanFilter (legacy) filters scan results', async () => {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -826,6 +826,11 @@ public class DynamoDbJsonHandler {
                     "Can not use both expression and non-expression parameters in the same request: "
                     + "Non-expression parameters: {KeyConditions} Expression parameters: {KeyConditionExpression}", 400);
         }
+        if (keyConditionExpr != null && queryFilter != null) {
+            throw new AwsException("ValidationException",
+                    "Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {QueryFilter} Expression parameters: {KeyConditionExpression}", 400);
+        }
         if (filterExpr != null && queryFilter != null) {
             throw new AwsException("ValidationException",
                     "Can not use both expression and non-expression parameters in the same request: "

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -493,6 +493,36 @@ class DynamoDbIntegrationTest {
 
     @Test
     @Order(10)
+    void queryWithQueryFilterAndKeyConditionExpressionFails() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {
+                        ":pk": {"S": "user-1"}
+                    },
+                    "QueryFilter": {
+                        "name": {
+                            "ComparisonOperator": "EQ",
+                            "AttributeValueList": [{"S": "Alice"}]
+                        }
+                    }
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("Can not use both expression and non-expression parameters in the same request: "
+                    + "Non-expression parameters: {QueryFilter} Expression parameters: {KeyConditionExpression}"));
+    }
+
+    @Test
+    @Order(10)
     void queryWithBeginsWith() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Query")


### PR DESCRIPTION
## Summary

- reject Query requests that combine the legacy `QueryFilter` parameter with `KeyConditionExpression`
- preserve valid legacy `QueryFilter` coverage by pairing it with legacy `KeyConditions`
- add Java protocol and Node SDK regression coverage for the exact AWS validation response

Closes #2894

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, Floci accepted `QueryFilter` alongside `KeyConditionExpression` and executed the query. AWS rejects this mixed legacy/expression request with HTTP 400 `ValidationException`.

This change rejects the request before table lookup with the AWS-compatible message:

`Can not use both expression and non-expression parameters in the same request: Non-expression parameters: {QueryFilter} Expression parameters: {KeyConditionExpression}`

Verified locally:

- `./mvnw test -Dtest=DynamoDbIntegrationTest,DynamoDbJsonHandlerTest` (73 tests passed)
- `npm test -- tests/dynamodb-conformance.test.ts` (42 tests passed)
- focused TypeScript compilation of `dynamodb-conformance.test.ts`

## Checklist

- [ ] `./mvnw test` passes locally (scoped DynamoDB suites pass as listed above)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)