### PR TITLE
fix(cognito): name missing user pools in errors

### DIFF
--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -17,6 +17,8 @@ Floci strips reserved `floci:*` tags from stored and returned `UserPoolTags` on 
 
 Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` and `UntagResource` operate on the persisted user-pool tag map.
 
+An action given a user pool ID that does not resolve returns `ResourceNotFoundException` with the live service's wording, `User pool <poolId> does not exist.`, so tooling that matches Cognito error text behaves the same way locally.
+
 ## Supported Actions
 
 ### User Pools

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -350,7 +350,7 @@ public class CognitoService implements ResourceProvider {
 
     public UserPool describeUserPool(String id) {
         UserPool pool = poolStore.get(id)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool not found", 400));
+                .orElseThrow(() -> userPoolNotFound(id));
         boolean generatedKeys = ensureJwtSigningKeys(pool);
         boolean generatedSecret = ensureRefreshTokenSecret(pool);
         if (generatedKeys || generatedSecret) {
@@ -1144,7 +1144,7 @@ public class CognitoService implements ResourceProvider {
 
     public CognitoUser adminGetUser(String userPoolId, String username) {
         UserPool pool = poolStore.get(userPoolId).orElseThrow(
-                () -> new AwsException("ResourceNotFoundException", "User pool not found", 400));
+                () -> userPoolNotFound(userPoolId));
         LinkedHashMap<String, CognitoUser> matches = new LinkedHashMap<>();
         userStore.get(userKey(userPoolId, username))
                 .ifPresent(u -> matches.put(u.getUsername(), u));
@@ -1574,9 +1574,9 @@ public class CognitoService implements ResourceProvider {
         UserPoolClient client = clientStore.get(clientId)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found",
                         400));
-        UserPool pool = poolStore.get(client.getUserPoolId())
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "User pool not found", 400));
+        String userPoolId = client.getUserPoolId();
+        UserPool pool = poolStore.get(userPoolId)
+                .orElseThrow(() -> userPoolNotFound(userPoolId));
         CognitoUser user = adminGetUser(client.getUserPoolId(), username);
         if (verificationCodeService != null && isSignUpConfirmationEnabled(pool)) {
             try {
@@ -1937,6 +1937,11 @@ public class CognitoService implements ResourceProvider {
     }
 
     // ──────────────────────────── Private helpers ────────────────────────────
+
+    private static AwsException userPoolNotFound(String userPoolId) {
+        return new AwsException("ResourceNotFoundException",
+                "User pool " + userPoolId + " does not exist.", 400);
+    }
 
     UserPoolClient findClientById(String clientId) {
         return clientStore.get(clientId)

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoIntegrationTest.java
@@ -231,6 +231,20 @@ class CognitoIntegrationTest {
     }
 
     @Test
+    @Order(5)
+    void describeUnknownUserPoolNamesPoolInResourceNotFoundMessage() {
+        String missingPoolId = "us-east-1_000000000";
+
+        cognitoAction("DescribeUserPool", """
+                { "UserPoolId": "%s" }
+                """.formatted(missingPoolId))
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("ResourceNotFoundException"))
+                .body("message", equalTo("User pool " + missingPoolId + " does not exist."));
+    }
+
+    @Test
     @Order(6)
     void confirmForgotPasswordRejectsWrongConfirmationCode() throws Exception {
         JsonNode poolResponse = cognitoJson("CreateUserPool", """

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -1465,6 +1465,20 @@ class CognitoServiceTest {
         assertEquals(400, ex.getHttpStatus());
     }
 
+    @Test
+    void confirmSignUpNamesDeletedUserPoolInResourceNotFoundMessage() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "TestPool"), "us-east-1");
+        UserPoolClient client = service.createUserPoolClient(
+                pool.getId(), "test-client", false, false, List.of(), List.of());
+        service.deleteUserPool(pool.getId());
+
+        AwsException ex = assertThrows(AwsException.class, () ->
+                service.confirmSignUp(client.getClientId(), "carol", "123456"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals("User pool " + pool.getId() + " does not exist.", ex.getMessage());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
     @ParameterizedTest
     @CsvSource({"email_verified", "phone_number_verified"})
     @SuppressWarnings("unchecked")
@@ -1851,9 +1865,12 @@ class CognitoServiceTest {
 
     @Test
     void adminGetUserRejectsUnknownPoolWithResourceNotFound() {
+        String missingPoolId = "us-east-1_missing";
+
         AwsException ex = assertThrows(AwsException.class,
-                () -> service.adminGetUser("us-east-1_missing", "bob"));
+                () -> service.adminGetUser(missingPoolId, "bob"));
         assertEquals("ResourceNotFoundException", ex.getErrorCode());
+        assertEquals("User pool " + missingPoolId + " does not exist.", ex.getMessage());
         assertEquals(400, ex.getHttpStatus());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WellKnownKeyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WellKnownKeyIntegrationTest.java
@@ -88,7 +88,7 @@ class S3WellKnownKeyIntegrationTest {
         .then()
             .extract().asString();
 
-        if (body.contains("ResourceNotFoundException") || body.contains("User pool not found")) {
+        if (body.contains("ResourceNotFoundException") || body.contains("User pool ")) {
             throw new AssertionError(
                 "GET /" + BUCKET + "/" + JWKS_KEY
                 + " was routed to Cognito instead of S3. Response: " + body);


### PR DESCRIPTION
## Summary

- include the requested user pool ID in Cognito `ResourceNotFoundException` messages
- centralize missing-pool errors so shared and direct lookup paths stay consistent
- cover the exact JSON response plus direct `AdminGetUser` and `ConfirmSignUp` service paths

Closes #2853

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Missing pools previously returned the generic message `User pool not found`. Cognito names the requested pool: `User pool <poolId> does not exist.` The error remains `ResourceNotFoundException` with HTTP 400.

The integration test asserts the exact JSON `__type` and `message` returned by `DescribeUserPool`. Service tests also pin the direct-store paths used by `AdminGetUser` and `ConfirmSignUp`.

## Testing

- `CognitoServiceTest,CognitoIntegrationTest`: 243 tests, 0 failures, 0 errors
- `git diff --check`

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)