### PR TITLE
fix(lambda): honour the CodeSha256 precondition on PublishVersion

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -393,14 +393,16 @@ public class LambdaController {
                                    String body) {
         String region = regionResolver.resolveRegion(headers);
         String description = null;
+        String codeSha256 = null;
         if (body != null && !body.isBlank()) {
             try {
                 @SuppressWarnings("unchecked")
                 Map<String, Object> req = objectMapper.readValue(body, Map.class);
                 description = (String) req.get("Description");
+                codeSha256 = (String) req.get("CodeSha256");
             } catch (Exception ignored) {}
         }
-        LambdaFunction version = lambdaService.publishVersion(region, functionName, description);
+        LambdaFunction version = lambdaService.publishVersion(region, functionName, description, codeSha256);
         return Response.status(201).entity(buildFunctionConfiguration(version)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -395,16 +395,41 @@ public class LambdaController {
         String description = null;
         String codeSha256 = null;
         if (body != null && !body.isBlank()) {
+            Map<String, Object> req;
             try {
                 @SuppressWarnings("unchecked")
-                Map<String, Object> req = objectMapper.readValue(body, Map.class);
-                description = (String) req.get("Description");
-                codeSha256 = (String) req.get("CodeSha256");
-            } catch (Exception ignored) {}
+                Map<String, Object> parsed = objectMapper.readValue(body, Map.class);
+                req = parsed;
+            } catch (Exception e) {
+                // Swallowing this would treat a malformed body as an empty one, so a request whose
+                // CodeSha256 could not be read would publish instead of failing its precondition.
+                throw new AwsException("InvalidParameterValueException",
+                        "Could not parse request body: " + e.getMessage(), 400);
+            }
+            description = stringField(req, "Description");
+            codeSha256 = stringField(req, "CodeSha256");
         }
         LambdaFunction version = lambdaService.publishVersion(region, functionName, description, codeSha256);
         return Response.status(201).entity(buildFunctionConfiguration(version)).build();
     }
+
+    /**
+     * Reads a string field, rejecting a value of the wrong JSON type rather than letting a cast
+     * failure be swallowed. A {@code CodeSha256} that arrives as a number or an object is a
+     * malformed precondition, and treating it as absent would publish without checking anything.
+     */
+    private static String stringField(Map<String, Object> req, String name) {
+        Object value = req.get(name);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String text)) {
+            throw new AwsException("InvalidParameterValueException",
+                    name + " must be a string", 400);
+        }
+        return text;
+    }
+
 
     @GET
     @Path("/functions/{functionName}/versions")

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -406,6 +406,13 @@ public class LambdaController {
                 throw new AwsException("InvalidParameterValueException",
                         "Could not parse request body: " + e.getMessage(), 400);
             }
+            if (req == null) {
+                // A literal "null" body parses cleanly to a null map, so it never reaches the catch
+                // above. Checked here rather than inside the try, where this exception would be
+                // caught by that same catch and rewrapped as a parse failure it is not.
+                throw new AwsException("InvalidParameterValueException",
+                        "Request body must be a JSON object", 400);
+            }
             description = stringField(req, "Description");
             codeSha256 = stringField(req, "CodeSha256");
         }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1334,8 +1334,12 @@ public class LambdaService implements ResourceProvider {
             // Inside the lock UpdateFunctionCode takes, so the hash cannot be checked against one
             // version of $LATEST and the snapshot then taken from another. Checking it outside
             // would let an overlapping deploy publish code the caller never authorised.
-            if (expectedCodeSha256 != null && !expectedCodeSha256.isBlank()
-                    && !expectedCodeSha256.equals(fn.getCodeSha256())) {
+            // No isBlank() exclusion here. A present but empty value was previously treated as
+            // absent, so it skipped the comparison entirely and published without checking
+            // anything, which is the failure this precondition exists to prevent. It is simply
+            // compared like any other value and fails as a mismatch, which avoids inventing an
+            // error shape for the empty case that has not been measured against the live service.
+            if (expectedCodeSha256 != null && !expectedCodeSha256.equals(fn.getCodeSha256())) {
                 throw new AwsException("InvalidParameterValueException",
                         "CodeSHA256 (" + expectedCodeSha256 + ") is different from current CodeSHA256 in $LATEST",
                         400);

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1311,6 +1311,18 @@ public class LambdaService implements ResourceProvider {
     }
 
     public LambdaFunction publishVersion(String region, String functionName, String description) {
+        return publishVersion(region, functionName, description, null);
+    }
+
+    /**
+     * Publishes a version of {@code $LATEST}.
+     *
+     * <p>{@code CodeSha256} is a precondition: "only publish a version if the hash value matches the
+     * value that's specified". It was never parsed out of the request, so a caller that raced
+     * someone else's deploy published code it had not authorised, silently (issue #2822).
+     */
+    public LambdaFunction publishVersion(String region, String functionName, String description,
+                                         String expectedCodeSha256) {
         LambdaFunction fn = getFunction(region, functionName);
         functionName = fn.getFunctionName();
         // Shares the per-function lock deleteFunction and extractZipCodeBytes take around their
@@ -1319,6 +1331,16 @@ public class LambdaService implements ResourceProvider {
         // delete, persisting a snapshot.codeLocalPath (below) that names a directory about to
         // be removed as unreferenced.
         synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
+            // Inside the lock UpdateFunctionCode takes, so the hash cannot be checked against one
+            // version of $LATEST and the snapshot then taken from another. Checking it outside
+            // would let an overlapping deploy publish code the caller never authorised.
+            if (expectedCodeSha256 != null && !expectedCodeSha256.isBlank()
+                    && !expectedCodeSha256.equals(fn.getCodeSha256())) {
+                throw new AwsException("InvalidParameterValueException",
+                        "CodeSHA256 (" + expectedCodeSha256 + ") is different from current CodeSHA256 in $LATEST",
+                        400);
+            }
+
             int version = nextVersionNumber(versionCounterKey(region, fn),
                     legacyVersionCounterKey(region, functionName));
             LambdaFunction snapshot = new LambdaFunction();

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1996,12 +1996,24 @@ public class LambdaService implements ResourceProvider {
         Path codePath = codeStore.getCodePath(ownerAccount(fn), fn.getFunctionName());
         try {
             zipExtractor.extractTo(zipBytes, codePath);
-            fn.setCodeLocalPath(codePath.toAbsolutePath().normalize().toString());
-            fn.setCodeSizeBytes(zipBytes.length);
+            // Publish the new code identity under the same per-function lock publishVersion holds.
+            // PublishVersion's CodeSha256 precondition is a check-then-act: it compares the hash and
+            // then snapshots the code. Mutating these fields without the lock lets an overlapping
+            // deploy move $LATEST between those two steps, so a version would carry code whose hash
+            // the caller never authorised even though the check passed. Extraction to disk stays
+            // outside the lock; only the fields that decide what a snapshot copies are inside it.
+            String newSha256 = null;
             try {
                 byte[] digest = java.security.MessageDigest.getInstance("SHA-256").digest(zipBytes);
-                fn.setCodeSha256(Base64.getEncoder().encodeToString(digest));
+                newSha256 = Base64.getEncoder().encodeToString(digest);
             } catch (java.security.NoSuchAlgorithmException ignored) {}
+            synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
+                fn.setCodeLocalPath(codePath.toAbsolutePath().normalize().toString());
+                fn.setCodeSizeBytes(zipBytes.length);
+                if (newSha256 != null) {
+                    fn.setCodeSha256(newSha256);
+                }
+            }
 
             // For file-based runtimes, verify handler file exists (skip Java and .NET which use different handler formats)
             if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java") && !fn.getRuntime().startsWith("dotnet")) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
@@ -116,4 +116,20 @@ class LambdaPublishVersionCodeSha256IntegrationTest {
         given().when().get("/2015-03-31/functions/" + fn + "/versions")
             .then().statusCode(200).body("Versions.size()", equalTo(1));
     }
+
+    @Test
+    void aNullJsonBodyIsRejectedRatherThanPublished() throws Exception {
+        // "null" is valid JSON and parses cleanly to a null map, so it never reaches the parse
+        // failure path. Without a guard the field reads would throw a NullPointerException, and a
+        // guard placed inside the try would be caught and reported as a parse failure it is not.
+        String fn = "pv-nullbody-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        given().contentType("application/json").body("null")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(400);
+
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200).body("Versions.size()", equalTo(1));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
@@ -132,4 +132,22 @@ class LambdaPublishVersionCodeSha256IntegrationTest {
         given().when().get("/2015-03-31/functions/" + fn + "/versions")
             .then().statusCode(200).body("Versions.size()", equalTo(1));
     }
+
+    @Test
+    void aBlankCodeSha256IsRejectedRatherThanTreatedAsOmitted() throws Exception {
+        // An explicit empty string is a present value, not an absent one. It was excluded from the
+        // comparison by an isBlank() check and so published without checking anything. It is now
+        // compared like any other value and fails as a mismatch, rather than getting an error shape
+        // invented for the empty case that has not been measured against the live service.
+        String fn = "pv-blank-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        given().contentType("application/json").body("{\"CodeSha256\": \"\"}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(400)
+            .body("message", containsString("different from current CodeSHA256"));
+
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200).body("Versions.size()", equalTo(1));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
@@ -1,0 +1,90 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Issue #2822, the CodeSha256 half. The field is a precondition: "only publish a version if the
+ * hash value matches the value that's specified". It was never parsed out of the request, so a
+ * publish that should have been rejected succeeded and produced a version, which is how a caller
+ * racing someone else's deploy ends up publishing code it never authorised.
+ */
+@QuarkusTest
+class LambdaPublishVersionCodeSha256IntegrationTest {
+
+    private static String zipB64(String body) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("handler.py"));
+            zos.write(("def handler(e, c):\n    return {'body': '" + body + "'}\n").getBytes("UTF-8"));
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static void createFunction(String name) throws Exception {
+        given()
+            .contentType("application/json")
+            .body("""
+                {"FunctionName": "%s", "Runtime": "python3.12",
+                 "Role": "arn:aws:iam::000000000000:role/r", "Handler": "handler.handler",
+                 "Code": {"ZipFile": "%s"}}
+                """.formatted(name, zipB64("v1")))
+        .when().post("/2015-03-31/functions")
+        .then().statusCode(org.hamcrest.Matchers.anyOf(equalTo(200), equalTo(201)));
+    }
+
+    @Test
+    void aMismatchedCodeSha256IsRejectedAndPublishesNothing() throws Exception {
+        String fn = "pv-sha-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        given()
+            .contentType("application/json")
+            .body("{\"CodeSha256\": \"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\"}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then()
+            .statusCode(400)
+            .body("message", containsString("different from current CodeSHA256"));
+
+        // A rejected publish must not have produced a version: only $LATEST should be listed.
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200).body("Versions.size()", equalTo(1));
+    }
+
+    @Test
+    void aMatchingCodeSha256Publishes() throws Exception {
+        String fn = "pv-sha-ok-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        String sha = given().when().get("/2015-03-31/functions/" + fn + "/configuration")
+                .then().statusCode(200).extract().path("CodeSha256");
+
+        given()
+            .contentType("application/json")
+            .body("{\"CodeSha256\": \"%s\"}".formatted(sha))
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(201).body("Version", not(equalTo("$LATEST")));
+    }
+
+    @Test
+    void omittingCodeSha256StillPublishes() throws Exception {
+        // The precondition is opt in: a request without the field must behave exactly as before.
+        String fn = "pv-sha-none-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        given().contentType("application/json").body("{}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(201).body("Version", equalTo("1"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaPublishVersionCodeSha256IntegrationTest.java
@@ -87,4 +87,33 @@ class LambdaPublishVersionCodeSha256IntegrationTest {
         .when().post("/2015-03-31/functions/" + fn + "/versions")
         .then().statusCode(201).body("Version", equalTo("1"));
     }
+
+    @Test
+    void aMalformedBodyIsRejectedRatherThanPublished() throws Exception {
+        // The parse failure used to be swallowed, so a body whose CodeSha256 could not be read was
+        // treated as one that never sent it: the precondition was skipped and a version published.
+        String fn = "pv-badbody-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        given().contentType("application/json").body("{\"CodeSha256\": ")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(400);
+
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200).body("Versions.size()", equalTo(1));
+    }
+
+    @Test
+    void aNonStringCodeSha256IsRejectedRatherThanIgnored() throws Exception {
+        // A cast failure was swallowed the same way, so a hash sent as a number checked nothing.
+        String fn = "pv-badtype-" + Long.toString(System.nanoTime(), 36);
+        createFunction(fn);
+
+        given().contentType("application/json").body("{\"CodeSha256\": 12345}")
+        .when().post("/2015-03-31/functions/" + fn + "/versions")
+        .then().statusCode(400);
+
+        given().when().get("/2015-03-31/functions/" + fn + "/versions")
+            .then().statusCode(200).body("Versions.size()", equalTo(1));
+    }
 }


### PR DESCRIPTION
## Summary

Part of #2822. This is the safe half, split out so it can land on its own; the unchanged-publish
half follows separately because it changes behaviour for existing callers.

`CodeSha256` is documented as a precondition on `PublishVersion`: "only publish a version if the hash
value matches the value that's specified". The controller parsed only `Description` out of the
request body, so the field never reached the service at all. A publish that should have been
rejected succeeded and produced a version, which is how a caller racing someone else's deploy ends
up publishing code it never authorised, with nothing to say so.

## What changed

`PublishVersion` gains a `CodeSha256` parameter, threaded from the controller. A mismatch is
`InvalidParameterValueException` carrying the message shape AWS uses, and no version is created.

The check is atomic with `UpdateFunctionCode`, but that required fixing the writer, not just the
reader. An earlier revision of this PR claimed the check was safe because it sat inside the lock
`UpdateFunctionCode` takes. **That was wrong**, and @pgermosen caught it in review: the code mutation
path, `extractZipCodeBytes`, sets `codeLocalPath`, `codeSizeBytes` and `codeSha256` with no lock
held, and the only `synchronized` block in there wraps an unrelated legacy-directory cleanup further
down. `PublishVersion` holding its own lock serialised nothing.

The writer now takes the same per-function lock:

```java
zipExtractor.extractTo(zipBytes, codePath);
String newSha256 = null;
try {
    byte[] digest = MessageDigest.getInstance("SHA-256").digest(zipBytes);
    newSha256 = Base64.getEncoder().encodeToString(digest);
} catch (NoSuchAlgorithmException ignored) {}
synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
    fn.setCodeLocalPath(codePath.toAbsolutePath().normalize().toString());
    fn.setCodeSizeBytes(zipBytes.length);
    if (newSha256 != null) {
        fn.setCodeSha256(newSha256);
    }
}
```

Hashing and extraction to disk stay outside the lock, so a large package does not serialise unrelated
work on the same function. Only the fields that decide what a snapshot copies are inside it, which is
the window between the hash being read and the snapshot being taken.

**Malformed preconditions are rejected rather than skipped.** Also from review: `{"CodeSha256": 12345}`
threw a `ClassCastException` into the pre-existing body-parse catch, leaving the field null and
indistinguishable from omitted, so the precondition was skipped and the publish succeeded with 201. An
unparseable body behaved the same way. Both are now 400, via a helper that rejects a wrong JSON type
instead of letting the cast fail silently.

## What this precondition does not cover

Raised by @pgermosen in review, and recorded here so it is not silently assumed to be handled.

There is no per-version code isolation in the codebase. `CodeStore.getCodePath` derives a path from
account and function name only, `extractZipCodeBytes` overwrites that same directory in place on
every `UpdateFunctionCode`, and `publishVersion`'s snapshot stores a reference to that path rather
than copying the code. So a published version does not actually freeze its code: a later
`UpdateFunctionCode`, racing or not, changes what invoking an already-published version runs.

In their words, this precondition "can't actually deliver what it implies once you look past the
moment of publish". What it does deliver is real and worth having: at the moment of publish, a
caller can require that `$LATEST` still holds the code it expects, and that check is now atomic
against a concurrent deploy. What it cannot do is keep the resulting version pinned to those bytes
afterwards.

Filed separately as **#2958** with a measured reproduction, rather than taken on here: it is
pre-existing, orthogonal to the precondition, and fixing it means giving each version its own code
directory, which reaches into `CodeStore`, `ContainerLauncher` and the delete paths.

## Why this is safe to merge on its own

It is additive and opt in. A request without `CodeSha256` behaves exactly as before, which
`omittingCodeSha256StillPublishes` pins explicitly. **No existing test changes**, which is the
property that separates this from the other half.

## AWS Compatibility

Matches the measurement in the issue:

```
publish-version --code-sha256 <wrong hash>
# An error occurred (InvalidParameterValueException) when calling the PublishVersion operation:
# CodeSHA256 (...) is different from current CodeSHA256 in $LATEST
```

## How it was tested

New `LambdaPublishVersionCodeSha256IntegrationTest`:

| Test | Covers |
|---|---|
| `aMismatchedCodeSha256IsRejectedAndPublishesNothing` | 400 with the AWS message, and the rejected call created no version |
| `aMatchingCodeSha256Publishes` | A correct hash is not blocked |
| `omittingCodeSha256StillPublishes` | Callers that never send the field are unaffected |
| `aNonStringCodeSha256IsRejectedRatherThanIgnored` | `{"CodeSha256": 12345}` is a 400 and publishes nothing |
| `aMalformedBodyIsRejectedRatherThanPublished` | An unparseable body is a 400 and publishes nothing |
| `aNullJsonBodyIsRejectedRatherThanPublished` | A literal `null` body is a 400, not the 500 it used to be |
| `aBlankCodeSha256IsRejectedRatherThanTreatedAsOmitted` | An empty string is compared and fails as a mismatch, rather than skipping the check |

Full suite: `Tests run: 15059, Failures: 0, Errors: 1, Skipped: 9`. Docs gate: `make docs-test` 50
passed, `make docs-check` exit 0.

The single error is `RdsDataServiceTest.batchExecuteStatementRunsEveryParameterSet` failing with
`java.sql.SQLException: No suitable driver found for jdbc:h2:mem:...`. It is not from this change: it
fails identically on clean `main` with my work stashed, and passes when that class runs alone, so it
looks like a driver registration race under the full parallel suite. Happy to file it separately if
it is not already tracked.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
