### PR TITLE
perf(build): keep only the snappy JNI libraries the image will use

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -86,9 +86,20 @@ jobs:
             || { echo "::error::post-subcommand --endpoint-url flag was not honored over AWS_ENDPOINT_URL"; exit 1; }
 
   build-native:
-    name: Build native floci image
-    runs-on: ubuntu-24.04-arm
+    name: Build native floci image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    # Both published architectures. The native image is the only place an
+    # arch-specific resource can go missing (snappy-java's JNI library is
+    # registered per platform), and one arch cannot prove the other.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+          - arch: amd64
+            runner: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.1
 
@@ -108,7 +119,7 @@ jobs:
       # reads the ~/.m2 that ci.yml's shard 1 saves on every push to main. ci.yml
       # stays the single owner of the save; a second writer would just race it.
       # Two known partial-hit caveats, both cheap: `runner.os` is Linux for both
-      # but ci.yml runs x64 while this runs arm64 (Maven artifacts are
+      # but ci.yml runs x64 while the arm64 leg here does not (Maven artifacts are
       # arch-neutral, so only classifier-based natives re-download), and
       # `-Dnative` pulls native-image plugins that ci.yml's `mvn test` never
       # fetches. Expect most of the ~66s of cold resolution back, not all of it.
@@ -123,10 +134,10 @@ jobs:
 
       - name: Stage native binary for packaging
         run: |
-          mkdir -p native/arm64
-          cp target/*-runner native/arm64/application
+          mkdir -p native/${{ matrix.arch }}
+          cp target/*-runner native/${{ matrix.arch }}/application
           # include any sidecar .so the runtime image may need (matches nightly artifact set)
-          cp target/*.so native/arm64/ 2>/dev/null || true
+          cp target/*.so native/${{ matrix.arch }}/ 2>/dev/null || true
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
@@ -152,18 +163,21 @@ jobs:
       - name: Upload native floci image
         uses: actions/upload-artifact@v7
         with:
-          name: floci-native-image
+          name: floci-native-image-${{ matrix.arch }}
           path: /tmp/floci-native-image.tar.gz
           retention-days: 1
 
   native-compat-test:
-    name: native / ${{ matrix.test }}
+    name: native ${{ matrix.arch }} / ${{ matrix.test }}
     needs: build-native
-    runs-on: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - arm64
+          - amd64
         test:
           - sdk-test-node
           - sdk-test-python
@@ -173,12 +187,17 @@ jobs:
           - compat-cdk
           - compat-terraform
           - compat-opentofu
+        include:
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+          - arch: amd64
+            runner: ubuntu-latest
 
     steps:
       - name: Download native floci image
         uses: actions/download-artifact@v8
         with:
-          name: floci-native-image
+          name: floci-native-image-${{ matrix.arch }}
           path: /tmp
 
       - name: Load native floci image

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,27 @@ quarkus:
         - iam/*.yaml
         - i18n/*.properties
         - org/apache/velocity/runtime/defaults/*.properties
+      # snappy-java registers 27 JNI libraries, one per platform. Only the one
+      # for the running platform loads, so 23 are dropped. Linux x86_64 and
+      # aarch64 cover the published images, Mac covers a local native build.
+      excludes:
+        - org/xerial/snappy/native/AIX/**
+        - org/xerial/snappy/native/FreeBSD/**
+        - org/xerial/snappy/native/SunOS/**
+        - org/xerial/snappy/native/Windows/**
+        - org/xerial/snappy/native/Linux/android-aarch64/**
+        - org/xerial/snappy/native/Linux/android-arm/**
+        - org/xerial/snappy/native/Linux/arm/**
+        - org/xerial/snappy/native/Linux/armv6/**
+        - org/xerial/snappy/native/Linux/armv7/**
+        - org/xerial/snappy/native/Linux/loongarch64/**
+        - org/xerial/snappy/native/Linux/ppc/**
+        - org/xerial/snappy/native/Linux/ppc64/**
+        - org/xerial/snappy/native/Linux/ppc64le/**
+        - org/xerial/snappy/native/Linux/riscv64/**
+        - org/xerial/snappy/native/Linux/s390x/**
+        - org/xerial/snappy/native/Linux/x86/**
+        - org/xerial/snappy/native/Linux/x86_64-musl/**
     additional-build-args:
       - --report-unsupported-elements-at-runtime
       - --allow-incomplete-classpath


### PR DESCRIPTION
## Summary

This PR downsizes Docker image size from 274.4 to 267.5 MiB (uncompressed).
By preserving only four snappy-java's JNI libraries for linux (aarch64, amd64) and mac (aarch64, amd64) .

Adds linux/amd64 to compatibility matrix.

Floci uses snappy-java in

- FirehoseCompression. It writes the Snappy and HADOOP_SNAPPY formats for Firehose S3 delivery through SnappyOutputStream and SnappyHadoopCompatibleOutputStream. 
- Kafka-clients declares it at runtime scope. EventBridge Pipes reads MSK sources with a KafkaConsumer, so a topic
holding snappy-compressed records is decompressed through the same library.

In CI, only the Firehose path is exercised, by FirehoseCompressionDeliveryTest seemingly. The Kafka path has no test, but both need the same file, so a wrong exclusion still fails the Firehose test.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No change.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

