### PR TITLE
feat(redshift): rewrite Redshift table DDL keywords for a PostgreSQL backend

### DIFF
--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -135,10 +135,25 @@ cluster = redshift.create_cluster(
 print(cluster["Cluster"]["Endpoint"])
 ```
 
+## SQL Interceptor
+
+Floci's Redshift auth proxy intercepts frontend queries on the PostgreSQL wire protocol (Simple Query `'Q'` protocol) to emulate common Redshift-specific SQL syntax:
+
+### Supported Features
+
+- **DDL Compatibility:**
+  - Redshift-specific DDL keywords are automatically stripped before forwarding to PostgreSQL: `DISTSTYLE ALL|EVEN|KEY|AUTO`, `DISTKEY (<col>)`, `COMPOUND|INTERLEAVED SORTKEY (<cols>)`, and column encodings `ENCODE <codec>` (only the real Redshift encodings: `raw`, `az64`, `bytedict`, `delta`, `delta32k`, `lzo`, `mostly8/16/32`, `runlength`, `text255`, `text32k`, `zstd`, `auto`).
+  - The rewrite only runs when the query's first keyword is `CREATE TABLE` / `ALTER TABLE`; a `SELECT`, `INSERT`, etc. is forwarded byte-for-byte even if it mentions these keywords. String literals are masked before rewriting, so a keyword inside a quoted value (including in a later statement of a multi-statement query) is preserved.
+
+### Limitations
+
+- Emulation is supported on the **Simple Query protocol** (`'Q'`) only. Extended Query protocol statements (`Parse`/`Bind`/`Execute`) pass through untouched, including anything a JDBC `PreparedStatement` sends, and, with the pgjdbc default `preferQueryMode=extended`, plain `Statement` calls too. To exercise the interceptor from JDBC, connect with `preferQueryMode=simple`.
+- The DDL rewrite is textual (regex). It masks single-quoted string literals first, so `DEFAULT`/`CHECK` string values are safe. It is **not** comment-aware and does not recognise dollar-quoting (`$$ ... $$`) or escape strings (`E'...'`): an apostrophe inside a `--` or `/* */` comment can make the rewrite skip a Redshift clause. That fails safe: the statement then reaches PostgreSQL, which returns its own syntax error: but avoid apostrophes-in-comments and dollar-quoted bodies in `CREATE TABLE`.
+
 ## Out of Scope
 
-- Real Redshift SQL semantics — the data plane is stock PostgreSQL, so Redshift-only SQL (distribution/sort keys, `COPY`/`UNLOAD` from S3, `SUPER`/`SPECTRUM`) is not emulated.
-- Multi-node clusters — `NodeType` and `NumberOfNodes` are stored as metadata; every cluster is a single PostgreSQL container.
+- Real Redshift distributed execution: every cluster is a single PostgreSQL container; `NodeType` and `NumberOfNodes` are metadata only.
+- Redshift-specific data types and advanced features like `SUPER`, `SPECTRUM`, or columnar storage internals.
 - Parameter groups apply no real engine settings; values are stored and echoed back only.
 - Subnet groups, VPC routing, and security groups are metadata only.
 - Resize, pause/resume, IAM authentication, snapshot schedules, and cross-region snapshot copy.

--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -135,25 +135,10 @@ cluster = redshift.create_cluster(
 print(cluster["Cluster"]["Endpoint"])
 ```
 
-## SQL Interceptor
-
-Floci's Redshift auth proxy intercepts frontend queries on the PostgreSQL wire protocol (Simple Query `'Q'` protocol) to emulate common Redshift-specific SQL syntax:
-
-### Supported Features
-
-- **DDL Compatibility:**
-  - Redshift-specific DDL keywords are automatically stripped before forwarding to PostgreSQL: `DISTSTYLE ALL|EVEN|KEY|AUTO`, `DISTKEY (<col>)`, `COMPOUND|INTERLEAVED SORTKEY (<cols>)`, and column encodings `ENCODE <codec>` (only the real Redshift encodings: `raw`, `az64`, `bytedict`, `delta`, `delta32k`, `lzo`, `mostly8/16/32`, `runlength`, `text255`, `text32k`, `zstd`, `auto`).
-  - The rewrite only runs when the query's first keyword is `CREATE TABLE` / `ALTER TABLE`; a `SELECT`, `INSERT`, etc. is forwarded byte-for-byte even if it mentions these keywords. String literals are masked before rewriting, so a keyword inside a quoted value (including in a later statement of a multi-statement query) is preserved.
-
-### Limitations
-
-- Emulation is supported on the **Simple Query protocol** (`'Q'`) only. Extended Query protocol statements (`Parse`/`Bind`/`Execute`) pass through untouched, including anything a JDBC `PreparedStatement` sends, and, with the pgjdbc default `preferQueryMode=extended`, plain `Statement` calls too. To exercise the interceptor from JDBC, connect with `preferQueryMode=simple`.
-- The DDL rewrite is textual (regex). It masks single-quoted string literals first, so `DEFAULT`/`CHECK` string values are safe. It is **not** comment-aware and does not recognise dollar-quoting (`$$ ... $$`) or escape strings (`E'...'`): an apostrophe inside a `--` or `/* */` comment can make the rewrite skip a Redshift clause. That fails safe: the statement then reaches PostgreSQL, which returns its own syntax error: but avoid apostrophes-in-comments and dollar-quoted bodies in `CREATE TABLE`.
-
 ## Out of Scope
 
-- Real Redshift distributed execution: every cluster is a single PostgreSQL container; `NodeType` and `NumberOfNodes` are metadata only.
-- Redshift-specific data types and advanced features like `SUPER`, `SPECTRUM`, or columnar storage internals.
+- Real Redshift SQL semantics — the data plane is stock PostgreSQL, so Redshift-only SQL (distribution/sort keys, `COPY`/`UNLOAD` from S3, `SUPER`/`SPECTRUM`) is not emulated.
+- Multi-node clusters — `NodeType` and `NumberOfNodes` are stored as metadata; every cluster is a single PostgreSQL container.
 - Parameter groups apply no real engine settings; values are stored and echoed back only.
 - Subnet groups, VPC routing, and security groups are metadata only.
 - Resize, pause/resume, IAM authentication, snapshot schedules, and cross-region snapshot copy.

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
@@ -27,8 +27,9 @@ import java.util.regex.Pattern;
  *       encoding (or {@code AUTO}), so a column literally named {@code encode} of
  *       an ordinary type survives.</li>
  * </ul>
- * String-literal masking is <em>not</em> comment-aware and does not recognise
- * dollar-quoting ({@code $$ ... $$}) or escape strings ({@code E'...'}); an
+ * String-literal masking recognizes both single-quoted literals and
+ * dollar-quoted literals ({@code $$ ... $$}, {@code $tag$ ... $tag$}). It is
+ * <em>not</em> comment-aware and does not recognise escape strings ({@code E'...'}); an
  * apostrophe inside a {@code --} or block comment can therefore make the rewrite
  * skip a real clause. Every such case fails safe: the unrewritten statement
  * reaches PostgreSQL, which returns its own syntax error. The residual ambiguity
@@ -44,8 +45,9 @@ public final class RedshiftSqlInterceptor {
             "(?is)^\\s*(?:(?:--[^\\n]*\\n)|(?:/\\*.*?\\*/)|\\s)*(?:CREATE|ALTER)\\s+(?:(?:GLOBAL|LOCAL)\\s+)?"
                     + "(?:(?:TEMP|TEMPORARY|UNLOGGED)\\s+)?TABLE\\b");
 
-    /** Single-quoted string literal, PostgreSQL-style (doubled {@code ''} is an escaped quote). */
-    private static final Pattern STRING_LITERAL_PATTERN = Pattern.compile("'(?:[^']|'')*'");
+    /** Single-quoted string literal, untagged dollar quote ($$...$$), and tagged dollar quote ($tag$...$tag$). */
+    private static final Pattern STRING_LITERAL_PATTERN = Pattern.compile(
+            "'(?:[^']|'')*'|(?s)\\$\\$.*?\\$\\$|(?s)\\$([A-Za-z_][A-Za-z0-9_]*)\\$.*?\\$\\1\\$");
 
     private static final Pattern DISTSTYLE_PATTERN = Pattern.compile("(?i)\\bDISTSTYLE\\s+(ALL|EVEN|KEY|AUTO)\\b");
     private static final Pattern DISTKEY_PAREN_PATTERN = Pattern.compile("(?i)\\bDISTKEY\\s*\\([^)]*\\)");

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
@@ -1,0 +1,131 @@
+package io.github.hectorvent.floci.services.redshift.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Rewrites Redshift-specific table DDL so a plain PostgreSQL backend accepts it.
+ *
+ * <p>The rewrite is deliberately narrow so the "fail-open" contract stays honest:
+ * we must never silently drop a column or clause from a statement we do not
+ * fully understand:
+ * <ul>
+ *   <li>It only runs when the statement's first keyword is {@code CREATE TABLE}
+ *       or {@code ALTER TABLE}. A {@code SELECT}, an {@code INSERT}, a function
+ *       body or a string literal that merely contains {@code DISTKEY} is
+ *       returned untouched.</li>
+ *   <li>Single-quoted string literals are masked out before any pattern runs, so
+ *       a {@code DEFAULT 'a,)'} or {@code CHECK (x <> 'SORTKEY')} is never
+ *       mangled, including the second statement of a multi-statement {@code 'Q'}
+ *       whose batch begins with a {@code CREATE TABLE}.</li>
+ *   <li>Table-level {@code DISTKEY}/{@code SORTKEY} without parentheses is only
+ *       stripped after the column-list's closing {@code )}, not when it looks
+ *       like a column definition.</li>
+ *   <li>{@code ENCODE} is only stripped when followed by a real Redshift column
+ *       encoding (or {@code AUTO}), so a column literally named {@code encode} of
+ *       an ordinary type survives.</li>
+ * </ul>
+ * String-literal masking is <em>not</em> comment-aware and does not recognise
+ * dollar-quoting ({@code $$ ... $$}) or escape strings ({@code E'...'}); an
+ * apostrophe inside a {@code --} or block comment can therefore make the rewrite
+ * skip a real clause. Every such case fails safe: the unrewritten statement
+ * reaches PostgreSQL, which returns its own syntax error. The residual ambiguity
+ * (a column named {@code distkey}/{@code sortkey}/{@code encode} whose declared
+ * type is itself the bare keyword that would follow such a constraint)
+ * describes no valid PostgreSQL type, so in practice nothing legitimate is
+ * dropped.
+ */
+public final class RedshiftSqlInterceptor {
+
+    /** Leading whitespace / SQL comments, then CREATE|ALTER ... TABLE. */
+    private static final Pattern TABLE_DDL_PROBE = Pattern.compile(
+            "(?is)^\\s*(?:(?:--[^\\n]*\\n)|(?:/\\*.*?\\*/)|\\s)*(?:CREATE|ALTER)\\s+(?:(?:GLOBAL|LOCAL)\\s+)?"
+                    + "(?:(?:TEMP|TEMPORARY|UNLOGGED)\\s+)?TABLE\\b");
+
+    /** Single-quoted string literal, PostgreSQL-style (doubled {@code ''} is an escaped quote). */
+    private static final Pattern STRING_LITERAL_PATTERN = Pattern.compile("'(?:[^']|'')*'");
+
+    private static final Pattern DISTSTYLE_PATTERN = Pattern.compile("(?i)\\bDISTSTYLE\\s+(ALL|EVEN|KEY|AUTO)\\b");
+    private static final Pattern DISTKEY_PAREN_PATTERN = Pattern.compile("(?i)\\bDISTKEY\\s*\\([^)]*\\)");
+    private static final Pattern SORTKEY_PAREN_PATTERN = Pattern.compile("(?i)\\b(?:COMPOUND|INTERLEAVED)?\\s*SORTKEY\\s*\\([^)]*\\)");
+    /** Table-level {@code DISTKEY col} / {@code SORTKEY col}: only after the column list closes. */
+    private static final Pattern TABLE_LEVEL_KEY_IDENT_PATTERN = Pattern.compile(
+            "(?i)(?<=\\))\\s*(?:COMPOUND\\s+|INTERLEAVED\\s+)?(?:DISTKEY|SORTKEY)\\s+\"?\\w+\"?");
+    /**
+     * Bare {@code DISTKEY} / {@code SORTKEY} as a column-level constraint: it sits
+     * right after the column type and is followed by a comma, the closing paren of
+     * the column list, or another column attribute ({@code ENCODE ...}). The trailing
+     * lookahead is what stops this from matching a column literally <em>named</em>
+     * {@code distkey} (which would be followed by its type).
+     */
+    private static final Pattern KEY_COLUMN_CONSTRAINT_PATTERN = Pattern.compile(
+            "(?i)\\s+(?:COMPOUND\\s+|INTERLEAVED\\s+)?(?:DISTKEY|SORTKEY)\\s*(?=[,)]|\\s+ENCODE\\b)");
+    /** {@code ENCODE <codec>} where {@code <codec>} is an actual Redshift column encoding or {@code AUTO}. */
+    private static final Pattern ENCODE_PATTERN = Pattern.compile(
+            "(?i)\\bENCODE\\s+(RAW|AZ64|BYTEDICT|DELTA32K|DELTA|LZO|MOSTLY8|MOSTLY16|MOSTLY32|RUNLENGTH|TEXT255|TEXT32K|ZSTD|AUTO)\\b");
+    private static final Pattern DOUBLE_COMMA_PATTERN = Pattern.compile(",(?:\\s*,)+");
+    private static final Pattern COMMA_CLOSE_PAREN_PATTERN = Pattern.compile(",\\s*\\)");
+
+    /** Non-word, non-whitespace control char that cannot occur in a PostgreSQL statement. */
+    private static final String MASK_SENTINEL = String.valueOf((char) 1);
+    private static final Pattern MASK_PLACEHOLDER_PATTERN =
+            Pattern.compile(Pattern.quote(MASK_SENTINEL) + "(\\d+)" + Pattern.quote(MASK_SENTINEL));
+
+    private RedshiftSqlInterceptor() {
+    }
+
+    public static String rewrite(String sql) {
+        if (sql == null || sql.isEmpty()) {
+            return sql;
+        }
+        if (!TABLE_DDL_PROBE.matcher(sql).find()) {
+            return sql; // Not table DDL: never touch it.
+        }
+
+        List<String> literals = new ArrayList<>();
+        String masked = maskStringLiterals(sql, literals);
+
+        String s = DISTSTYLE_PATTERN.matcher(masked).replaceAll("");
+        s = DISTKEY_PAREN_PATTERN.matcher(s).replaceAll("");
+        s = SORTKEY_PAREN_PATTERN.matcher(s).replaceAll("");
+        s = TABLE_LEVEL_KEY_IDENT_PATTERN.matcher(s).replaceAll("");
+        s = KEY_COLUMN_CONSTRAINT_PATTERN.matcher(s).replaceAll("");
+        s = ENCODE_PATTERN.matcher(s).replaceAll("");
+
+        if (s.length() == masked.length()) {
+            return sql; // nothing matched: hand back the original instance
+        }
+        s = DOUBLE_COMMA_PATTERN.matcher(s).replaceAll(",");
+        s = COMMA_CLOSE_PAREN_PATTERN.matcher(s).replaceAll(")");
+        return unmaskStringLiterals(s.trim(), literals);
+    }
+
+    private static String maskStringLiterals(String sql, List<String> out) {
+        Matcher m = STRING_LITERAL_PATTERN.matcher(sql);
+        StringBuilder sb = new StringBuilder(sql.length());
+        while (m.find()) {
+            out.add(m.group());
+            m.appendReplacement(sb, Matcher.quoteReplacement(MASK_SENTINEL + (out.size() - 1) + MASK_SENTINEL));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+
+    /** Single pass so already-restored text is never re-scanned. */
+    private static String unmaskStringLiterals(String masked, List<String> literals) {
+        if (literals.isEmpty()) {
+            return masked;
+        }
+        Matcher m = MASK_PLACEHOLDER_PATTERN.matcher(masked);
+        StringBuilder sb = new StringBuilder(masked.length());
+        while (m.find()) {
+            int idx = Integer.parseInt(m.group(1));
+            String literal = (idx >= 0 && idx < literals.size()) ? literals.get(idx) : m.group();
+            m.appendReplacement(sb, Matcher.quoteReplacement(literal));
+        }
+        m.appendTail(sb);
+        return sb.toString();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
@@ -80,26 +80,39 @@ public final class RedshiftSqlInterceptor {
         if (sql == null || sql.isEmpty()) {
             return sql;
         }
-        if (!TABLE_DDL_PROBE.matcher(sql).find()) {
-            return sql; // Not table DDL: never touch it.
-        }
 
         List<String> literals = new ArrayList<>();
         String masked = maskStringLiterals(sql, literals);
 
-        String s = DISTSTYLE_PATTERN.matcher(masked).replaceAll("");
+        String[] statements = masked.split(";", -1);
+        boolean anyRewritten = false;
+        for (int i = 0; i < statements.length; i++) {
+            if (TABLE_DDL_PROBE.matcher(statements[i]).find()) {
+                String rewritten = rewriteTableDdl(statements[i]);
+                if (!rewritten.equals(statements[i])) {
+                    statements[i] = rewritten;
+                    anyRewritten = true;
+                }
+            }
+        }
+
+        if (!anyRewritten) {
+            return sql; // nothing matched: hand back the original instance
+        }
+        String joined = String.join(";", statements);
+        return unmaskStringLiterals(joined.trim(), literals);
+    }
+
+    private static String rewriteTableDdl(String maskedDdl) {
+        String s = DISTSTYLE_PATTERN.matcher(maskedDdl).replaceAll("");
         s = DISTKEY_PAREN_PATTERN.matcher(s).replaceAll("");
         s = SORTKEY_PAREN_PATTERN.matcher(s).replaceAll("");
         s = TABLE_LEVEL_KEY_IDENT_PATTERN.matcher(s).replaceAll("");
         s = KEY_COLUMN_CONSTRAINT_PATTERN.matcher(s).replaceAll("");
         s = ENCODE_PATTERN.matcher(s).replaceAll("");
-
-        if (s.length() == masked.length()) {
-            return sql; // nothing matched: hand back the original instance
-        }
         s = DOUBLE_COMMA_PATTERN.matcher(s).replaceAll(",");
         s = COMMA_CLOSE_PAREN_PATTERN.matcher(s).replaceAll(")");
-        return unmaskStringLiterals(s.trim(), literals);
+        return s;
     }
 
     private static String maskStringLiterals(String sql, List<String> out) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
@@ -45,9 +45,9 @@ public final class RedshiftSqlInterceptor {
             "(?is)^\\s*(?:(?:--[^\\n]*\\n)|(?:/\\*.*?\\*/)|\\s)*(?:CREATE|ALTER)\\s+(?:(?:GLOBAL|LOCAL)\\s+)?"
                     + "(?:(?:TEMP|TEMPORARY|UNLOGGED)\\s+)?TABLE\\b");
 
-    /** Single-quoted string literal, untagged dollar quote ($$...$$), and tagged dollar quote ($tag$...$tag$). */
+    /** Single-quoted string literal (doubled '' is escaped quote) and PostgreSQL dollar-quoted string literal ($tag$...$tag$). */
     private static final Pattern STRING_LITERAL_PATTERN = Pattern.compile(
-            "'(?:[^']|'')*'|(?s)\\$\\$.*?\\$\\$|(?s)\\$([A-Za-z_][A-Za-z0-9_]*)\\$.*?\\$\\1\\$");
+            "'(?:[^']|'')*'|(?s)\\$([^$\\s]*)\\$.*?\\$\\1\\$");
 
     private static final Pattern DISTSTYLE_PATTERN = Pattern.compile("(?i)\\bDISTSTYLE\\s+(ALL|EVEN|KEY|AUTO)\\b");
     private static final Pattern DISTKEY_PAREN_PATTERN = Pattern.compile("(?i)\\bDISTKEY\\s*\\([^)]*\\)");

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptor.java
@@ -54,16 +54,17 @@ public final class RedshiftSqlInterceptor {
     private static final Pattern SORTKEY_PAREN_PATTERN = Pattern.compile("(?i)\\b(?:COMPOUND|INTERLEAVED)?\\s*SORTKEY\\s*\\([^)]*\\)");
     /** Table-level {@code DISTKEY col} / {@code SORTKEY col}: only after the column list closes. */
     private static final Pattern TABLE_LEVEL_KEY_IDENT_PATTERN = Pattern.compile(
-            "(?i)(?<=\\))\\s*(?:COMPOUND\\s+|INTERLEAVED\\s+)?(?:DISTKEY|SORTKEY)\\s+\"?\\w+\"?");
+            "(?i)(?<=\\))\\s*(?:COMPOUND\\s+|INTERLEAVED\\s+)?(?:DISTKEY|SORTKEY)\\s+\"?[a-zA-Z_]\\w*\"?(?=\\s*(?:[;]|\\b(?:DISTSTYLE|DISTKEY|SORTKEY|ENCODE)\\b|$))");
     /**
-     * Bare {@code DISTKEY} / {@code SORTKEY} as a column-level constraint: it sits
+     * Bare {@code DISTKEY} / {@code SORTKEY} as a column-level attribute: it sits
      * right after the column type and is followed by a comma, the closing paren of
-     * the column list, or another column attribute ({@code ENCODE ...}). The trailing
+     * the column list, another column attribute ({@code ENCODE ...}), or a column
+     * constraint ({@code NOT NULL}, {@code PRIMARY KEY}, etc.). The trailing
      * lookahead is what stops this from matching a column literally <em>named</em>
      * {@code distkey} (which would be followed by its type).
      */
     private static final Pattern KEY_COLUMN_CONSTRAINT_PATTERN = Pattern.compile(
-            "(?i)\\s+(?:COMPOUND\\s+|INTERLEAVED\\s+)?(?:DISTKEY|SORTKEY)\\s*(?=[,)]|\\s+ENCODE\\b)");
+            "(?i)\\s+(?:COMPOUND\\s+|INTERLEAVED\\s+)?(?:DISTKEY|SORTKEY)\\s*(?=[,)]|\\s+(?:ENCODE|DISTKEY|SORTKEY|NOT\\s+NULL|NULL|UNIQUE|PRIMARY\\s+KEY|REFERENCES|DEFAULT|COLLATE|CHECK|CONSTRAINT|IDENTITY|GENERATED)\\b)");
     /** {@code ENCODE <codec>} where {@code <codec>} is an actual Redshift column encoding or {@code AUTO}. */
     private static final Pattern ENCODE_PATTERN = Pattern.compile(
             "(?i)\\bENCODE\\s+(RAW|AZ64|BYTEDICT|DELTA32K|DELTA|LZO|MOSTLY8|MOSTLY16|MOSTLY32|RUNLENGTH|TEXT255|TEXT32K|ZSTD|AUTO)\\b");
@@ -109,8 +110,8 @@ public final class RedshiftSqlInterceptor {
         String s = DISTSTYLE_PATTERN.matcher(maskedDdl).replaceAll("");
         s = DISTKEY_PAREN_PATTERN.matcher(s).replaceAll("");
         s = SORTKEY_PAREN_PATTERN.matcher(s).replaceAll("");
-        s = TABLE_LEVEL_KEY_IDENT_PATTERN.matcher(s).replaceAll("");
         s = KEY_COLUMN_CONSTRAINT_PATTERN.matcher(s).replaceAll("");
+        s = TABLE_LEVEL_KEY_IDENT_PATTERN.matcher(s).replaceAll("");
         s = ENCODE_PATTERN.matcher(s).replaceAll("");
         s = DOUBLE_COMMA_PATTERN.matcher(s).replaceAll(",");
         s = COMMA_CLOSE_PAREN_PATTERN.matcher(s).replaceAll(")");

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
@@ -50,6 +50,17 @@ class RedshiftSqlInterceptorTest {
         String sql4 = "CREATE TABLE t (id INT DISTKEY, name VARCHAR(50));";
         String rewritten4 = RedshiftSqlInterceptor.rewrite(sql4);
         assertTrue(!rewritten4.contains("DISTKEY"), "Should remove column-level DISTKEY: " + rewritten4);
+
+        String sql5 = "CREATE TABLE t (id INT DISTKEY NOT NULL, name VARCHAR(50));";
+        String rewritten5 = RedshiftSqlInterceptor.rewrite(sql5);
+        assertTrue(!rewritten5.contains("DISTKEY"), "Should remove column-level DISTKEY followed by NOT NULL: " + rewritten5);
+        assertTrue(rewritten5.contains("id INT NOT NULL"), "Should preserve 'id INT NOT NULL': " + rewritten5);
+
+        String sql6 = "CREATE TABLE t (id INT DISTKEY PRIMARY KEY, code VARCHAR(10) DISTKEY UNIQUE);";
+        String rewritten6 = RedshiftSqlInterceptor.rewrite(sql6);
+        assertTrue(!rewritten6.contains("DISTKEY"), "Should remove column-level DISTKEY before PRIMARY KEY/UNIQUE: " + rewritten6);
+        assertTrue(rewritten6.contains("id INT PRIMARY KEY"), "Should preserve PRIMARY KEY: " + rewritten6);
+        assertTrue(rewritten6.contains("code VARCHAR(10) UNIQUE"), "Should preserve UNIQUE: " + rewritten6);
     }
 
     @Test
@@ -75,6 +86,17 @@ class RedshiftSqlInterceptorTest {
         String sql5 = "CREATE TABLE t (id INT SORTKEY, name VARCHAR(50));";
         String rewritten5 = RedshiftSqlInterceptor.rewrite(sql5);
         assertTrue(!rewritten5.contains("SORTKEY"), "Should remove column-level SORTKEY: " + rewritten5);
+
+        String sql6 = "CREATE TABLE t (id INT SORTKEY NOT NULL, name VARCHAR(50));";
+        String rewritten6 = RedshiftSqlInterceptor.rewrite(sql6);
+        assertTrue(!rewritten6.contains("SORTKEY"), "Should remove column-level SORTKEY followed by NOT NULL: " + rewritten6);
+        assertTrue(rewritten6.contains("id INT NOT NULL"), "Should preserve 'id INT NOT NULL': " + rewritten6);
+
+        String sql7 = "CREATE TABLE t (id INT DISTKEY SORTKEY NOT NULL, name VARCHAR(50));";
+        String rewritten7 = RedshiftSqlInterceptor.rewrite(sql7);
+        assertTrue(!rewritten7.contains("DISTKEY") && !rewritten7.contains("SORTKEY"),
+                "Should remove both DISTKEY and SORTKEY: " + rewritten7);
+        assertTrue(rewritten7.contains("id INT NOT NULL"), "Should preserve 'id INT NOT NULL': " + rewritten7);
     }
 
     @ParameterizedTest
@@ -139,6 +161,11 @@ class RedshiftSqlInterceptorTest {
         assertTrue(rewritten.contains("distkey INT"), "column 'distkey' must survive: " + rewritten);
         assertTrue(!rewritten.contains("DISTKEY (") && !rewritten.contains("SORTKEY ("),
                 "table-level key clauses must be gone: " + rewritten);
+
+        String sqlWithConstraints = "CREATE TABLE t (distkey INT NOT NULL, sortkey VARCHAR(20) NOT NULL);";
+        String rewrittenWithConstraints = RedshiftSqlInterceptor.rewrite(sqlWithConstraints);
+        assertTrue(rewrittenWithConstraints.contains("distkey INT NOT NULL"), "column 'distkey INT NOT NULL' must survive: " + rewrittenWithConstraints);
+        assertTrue(rewrittenWithConstraints.contains("sortkey VARCHAR(20) NOT NULL"), "column 'sortkey VARCHAR(20) NOT NULL' must survive: " + rewrittenWithConstraints);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
@@ -211,6 +211,10 @@ class RedshiftSqlInterceptorTest {
         String rewrittenTagged = RedshiftSqlInterceptor.rewrite(sqlTagged);
         assertEquals(sqlTagged, rewrittenTagged, "Tagged dollar-quoted string must not be altered");
 
+        String sqlCustomTag = "CREATE TABLE t (code text DEFAULT $custom_tag$a; CREATE TABLE fake (id int DISTKEY)$custom_tag$);";
+        String rewrittenCustomTag = RedshiftSqlInterceptor.rewrite(sqlCustomTag);
+        assertEquals(sqlCustomTag, rewrittenCustomTag, "Custom-tagged dollar-quoted string must not be altered");
+
         String sqlWithDistkey = "CREATE TABLE t (code text DEFAULT $$a; CREATE TABLE fake (id int DISTKEY)$$, id int DISTKEY);";
         String rewrittenWithDistkey = RedshiftSqlInterceptor.rewrite(sqlWithDistkey);
         assertEquals("CREATE TABLE t (code text DEFAULT $$a; CREATE TABLE fake (id int DISTKEY)$$, id int);", rewrittenWithDistkey);

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
@@ -183,6 +183,25 @@ class RedshiftSqlInterceptorTest {
     }
 
     @Test
+    void shouldPreserveNonDdlStatementsInMultiStatementBatch() {
+        // Functions or column identifiers named like Redshift keywords in later statements must not be rewritten.
+        String sql = "CREATE TABLE t (x int DISTKEY); SELECT distkey(a), encode FROM s;";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertEquals("CREATE TABLE t (x int); SELECT distkey(a), encode FROM s;", rewritten);
+
+        String sql2 = "CREATE TABLE t (x int DISTKEY); SELECT a, distkey, b FROM s;";
+        String rewritten2 = RedshiftSqlInterceptor.rewrite(sql2);
+        assertEquals("CREATE TABLE t (x int); SELECT a, distkey, b FROM s;", rewritten2);
+    }
+
+    @Test
+    void shouldHandleSemicolonInsideStringLiteralInDdl() {
+        String sql = "CREATE TABLE t (x varchar DEFAULT ';', id int DISTKEY);";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertEquals("CREATE TABLE t (x varchar DEFAULT ';', id int);", rewritten);
+    }
+
+    @Test
     void shouldHandleComprehensiveComplexDdl() {
         String complexSql = """
                 CREATE TABLE public.orders (

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
@@ -202,6 +202,21 @@ class RedshiftSqlInterceptorTest {
     }
 
     @Test
+    void shouldPreserveDollarQuotedStringsWithDdlKeywordsAndSemicolons() {
+        String sql = "CREATE TABLE t (code text DEFAULT $$a; CREATE TABLE fake (id int DISTKEY)$$);";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertEquals(sql, rewritten, "Dollar-quoted string literal containing DDL text must not be altered");
+
+        String sqlTagged = "CREATE TABLE t (code text DEFAULT $tag$a; CREATE TABLE fake (id int DISTKEY)$tag$);";
+        String rewrittenTagged = RedshiftSqlInterceptor.rewrite(sqlTagged);
+        assertEquals(sqlTagged, rewrittenTagged, "Tagged dollar-quoted string must not be altered");
+
+        String sqlWithDistkey = "CREATE TABLE t (code text DEFAULT $$a; CREATE TABLE fake (id int DISTKEY)$$, id int DISTKEY);";
+        String rewrittenWithDistkey = RedshiftSqlInterceptor.rewrite(sqlWithDistkey);
+        assertEquals("CREATE TABLE t (code text DEFAULT $$a; CREATE TABLE fake (id int DISTKEY)$$, id int);", rewrittenWithDistkey);
+    }
+
+    @Test
     void shouldHandleComprehensiveComplexDdl() {
         String complexSql = """
                 CREATE TABLE public.orders (

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftSqlInterceptorTest.java
@@ -1,0 +1,209 @@
+package io.github.hectorvent.floci.services.redshift.proxy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedshiftSqlInterceptorTest {
+
+    @Test
+    void shouldReturnNullAndEmptyAsIs() {
+        assertNull(RedshiftSqlInterceptor.rewrite(null));
+        assertEquals("", RedshiftSqlInterceptor.rewrite(""));
+    }
+
+    @Test
+    void shouldReturnSameInstanceWhenNoMatchOccursFastPath() {
+        String sql = "SELECT * FROM my_table WHERE id = 1";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertSame(sql, rewritten, "Fast-path must return the identical string reference");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"ALL", "EVEN", "KEY", "AUTO", "all", "even", "key", "auto"})
+    void shouldRemoveDiststyle(String style) {
+        String sql = "CREATE TABLE users (id INT, name VARCHAR(50)) DISTSTYLE " + style + ";";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertTrue(!rewritten.contains("DISTSTYLE") && !rewritten.contains("diststyle"),
+                "Rewritten SQL should not contain DISTSTYLE: " + rewritten);
+    }
+
+    @Test
+    void shouldRemoveDistkeyParenAndIdent() {
+        String sql1 = "CREATE TABLE t (id INT) DISTKEY (id);";
+        String rewritten1 = RedshiftSqlInterceptor.rewrite(sql1);
+        assertTrue(!rewritten1.contains("DISTKEY"), "Should remove DISTKEY (col): " + rewritten1);
+
+        String sql2 = "CREATE TABLE t (id INT) DISTKEY id;";
+        String rewritten2 = RedshiftSqlInterceptor.rewrite(sql2);
+        assertTrue(!rewritten2.contains("DISTKEY"), "Should remove DISTKEY col: " + rewritten2);
+
+        String sql3 = "CREATE TABLE t (id INT) DISTKEY \"id\";";
+        String rewritten3 = RedshiftSqlInterceptor.rewrite(sql3);
+        assertTrue(!rewritten3.contains("DISTKEY"), "Should remove quoted DISTKEY \"col\": " + rewritten3);
+
+        String sql4 = "CREATE TABLE t (id INT DISTKEY, name VARCHAR(50));";
+        String rewritten4 = RedshiftSqlInterceptor.rewrite(sql4);
+        assertTrue(!rewritten4.contains("DISTKEY"), "Should remove column-level DISTKEY: " + rewritten4);
+    }
+
+    @Test
+    void shouldRemoveSortkeyVariants() {
+        String sql1 = "CREATE TABLE t (id INT, created_at TIMESTAMP) SORTKEY (created_at);";
+        String rewritten1 = RedshiftSqlInterceptor.rewrite(sql1);
+        assertTrue(!rewritten1.contains("SORTKEY"), "Should remove SORTKEY (col): " + rewritten1);
+
+        String sql2 = "CREATE TABLE t (id INT, c1 INT, c2 INT) COMPOUND SORTKEY (c1, c2);";
+        String rewritten2 = RedshiftSqlInterceptor.rewrite(sql2);
+        assertTrue(!rewritten2.contains("SORTKEY") && !rewritten2.contains("COMPOUND"),
+                "Should remove COMPOUND SORTKEY (c1, c2): " + rewritten2);
+
+        String sql3 = "CREATE TABLE t (id INT, c1 INT, c2 INT) INTERLEAVED SORTKEY (c1, c2);";
+        String rewritten3 = RedshiftSqlInterceptor.rewrite(sql3);
+        assertTrue(!rewritten3.contains("SORTKEY") && !rewritten3.contains("INTERLEAVED"),
+                "Should remove INTERLEAVED SORTKEY (c1, c2): " + rewritten3);
+
+        String sql4 = "CREATE TABLE t (id INT) SORTKEY id;";
+        String rewritten4 = RedshiftSqlInterceptor.rewrite(sql4);
+        assertTrue(!rewritten4.contains("SORTKEY"), "Should remove SORTKEY col: " + rewritten4);
+
+        String sql5 = "CREATE TABLE t (id INT SORTKEY, name VARCHAR(50));";
+        String rewritten5 = RedshiftSqlInterceptor.rewrite(sql5);
+        assertTrue(!rewritten5.contains("SORTKEY"), "Should remove column-level SORTKEY: " + rewritten5);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"zstd", "az64", "RAW", "raw", "lzo", "delta", "mostly8", "text255", "text32k"})
+    void shouldRemoveEncode(String codec) {
+        String sql = "CREATE TABLE t (id INT ENCODE " + codec + ", name VARCHAR(50) ENCODE " + codec + ");";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertTrue(!rewritten.contains("ENCODE") && !rewritten.contains("encode"),
+                "Should remove ENCODE " + codec + ": " + rewritten);
+    }
+
+    @Test
+    void shouldCleanOrphanedAndDoubleCommas() {
+        String sqlWithTrailingComma = "CREATE TABLE t (\n  id INT,\n  name VARCHAR(50),\n  DISTKEY (id)\n);";
+        String rewritten1 = RedshiftSqlInterceptor.rewrite(sqlWithTrailingComma);
+        assertTrue(!rewritten1.contains(",\n)") && !rewritten1.contains(", )") && !rewritten1.contains(",\n  )"),
+                "Should remove comma before closing parenthesis: " + rewritten1);
+
+        String sqlWithDoubleComma = "CREATE TABLE t (\n  id INT,\n  DISTKEY (id),\n  name VARCHAR(50)\n);";
+        String rewritten2 = RedshiftSqlInterceptor.rewrite(sqlWithDoubleComma);
+        assertTrue(!rewritten2.contains(",\n  ,") && !rewritten2.contains(", ,"),
+                "Should clean double commas: " + rewritten2);
+    }
+
+    @Test
+    void shouldBeIdempotent() {
+        String complexSql = """
+                CREATE TABLE sales (
+                    sale_id INT ENCODE az64,
+                    cust_id INT ENCODE zstd,
+                    sale_date DATE ENCODE raw,
+                    amount NUMERIC(10,2) ENCODE az64
+                )
+                DISTSTYLE KEY
+                DISTKEY (cust_id)
+                COMPOUND SORTKEY (sale_date, cust_id);
+                """;
+
+        String once = RedshiftSqlInterceptor.rewrite(complexSql);
+        String twice = RedshiftSqlInterceptor.rewrite(once);
+
+        assertEquals(once, twice, "Subsequent rewrite must produce identical result");
+    }
+
+    @Test
+    void shouldNotTouchNonTableDdlEvenIfItMentionsKeywords() {
+        // A query that merely contains the words distkey/sortkey/encode must pass through untouched.
+        String select = "SELECT distkey, sortkey FROM catalog WHERE encode = 'az64' ORDER BY distkey";
+        assertSame(select, RedshiftSqlInterceptor.rewrite(select));
+
+        String insert = "INSERT INTO audit (action) VALUES ('ran UNLOAD with ENCODE zstd')";
+        assertSame(insert, RedshiftSqlInterceptor.rewrite(insert));
+    }
+
+    @Test
+    void shouldKeepColumnNamedLikeAKeyword() {
+        // 'sortkey' / 'distkey' as real column names (followed by a type) survive;
+        // only the trailing table-level clause is stripped.
+        String sql = "CREATE TABLE t (id INT, sortkey VARCHAR(20), distkey INT) DISTKEY (id) SORTKEY (sortkey);";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertTrue(rewritten.contains("sortkey VARCHAR(20)"), "column 'sortkey' must survive: " + rewritten);
+        assertTrue(rewritten.contains("distkey INT"), "column 'distkey' must survive: " + rewritten);
+        assertTrue(!rewritten.contains("DISTKEY (") && !rewritten.contains("SORTKEY ("),
+                "table-level key clauses must be gone: " + rewritten);
+    }
+
+    @Test
+    void shouldNotStripEncodeWhenFollowedByAnOrdinaryType() {
+        // A column literally named 'encode' of type varchar is not a Redshift ENCODE clause.
+        String sql = "CREATE TABLE t (id INT, encode VARCHAR(50));";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertTrue(rewritten.contains("encode VARCHAR(50)"), "column 'encode' must survive: " + rewritten);
+    }
+
+    @Test
+    void shouldRemoveEncodeAuto() {
+        String col = RedshiftSqlInterceptor.rewrite("CREATE TABLE t (a int ENCODE AUTO, b text);");
+        assertTrue(!col.contains("ENCODE"), "column-level ENCODE AUTO must be stripped: " + col);
+        String table = RedshiftSqlInterceptor.rewrite("CREATE TABLE t (a int) ENCODE AUTO;");
+        assertTrue(!table.contains("ENCODE"), "table-level ENCODE AUTO must be stripped: " + table);
+    }
+
+    @Test
+    void shouldStripDistkeyRegardlessOfColumnAttributeOrder() {
+        String sql = "CREATE TABLE t (id INT DISTKEY ENCODE az64, d date);";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertTrue(!rewritten.contains("DISTKEY") && !rewritten.contains("ENCODE"),
+                "both column attributes must be stripped regardless of order: " + rewritten);
+        assertEquals(rewritten, RedshiftSqlInterceptor.rewrite(rewritten), "must be idempotent");
+    }
+
+    @Test
+    void shouldNotMangleStringLiteralsInsideDdl() {
+        String sql = "CREATE TABLE t (a text DEFAULT 'x,)' CHECK (a <> 'SORTKEY'), b int) DISTKEY (b);";
+        String rewritten = RedshiftSqlInterceptor.rewrite(sql);
+        assertTrue(rewritten.contains("DEFAULT 'x,)'"), "string default must be intact: " + rewritten);
+        assertTrue(rewritten.contains("'SORTKEY'"), "string literal must be intact: " + rewritten);
+        assertTrue(!rewritten.contains("DISTKEY (b)"), "table-level DISTKEY clause must be gone: " + rewritten);
+    }
+
+    @Test
+    void shouldNotTouchSecondStatementOfAMultiStatementBatch() {
+        // The batch starts with CREATE TABLE, but the INSERT's string literal must survive verbatim.
+        String sql = "CREATE TABLE a (x int); INSERT INTO log VALUES ('DISTKEY (y)');";
+        assertSame(sql, RedshiftSqlInterceptor.rewrite(sql));
+    }
+
+    @Test
+    void shouldHandleComprehensiveComplexDdl() {
+        String complexSql = """
+                CREATE TABLE public.orders (
+                    order_id BIGINT NOT NULL ENCODE az64,
+                    customer_id INT NOT NULL ENCODE zstd,
+                    order_status VARCHAR(20) ENCODE lzo,
+                    order_date TIMESTAMP WITHOUT TIME ZONE NOT NULL ENCODE raw,
+                    total_amount NUMERIC(12, 4) ENCODE az64,
+                    PRIMARY KEY (order_id)
+                )
+                DISTSTYLE AUTO
+                DISTKEY (customer_id)
+                INTERLEAVED SORTKEY (order_date, customer_id);
+                """;
+
+        String rewritten = RedshiftSqlInterceptor.rewrite(complexSql);
+        assertTrue(!rewritten.contains("ENCODE"), "Should not contain ENCODE: " + rewritten);
+        assertTrue(!rewritten.contains("DISTSTYLE"), "Should not contain DISTSTYLE: " + rewritten);
+        assertTrue(!rewritten.contains("DISTKEY"), "Should not contain DISTKEY: " + rewritten);
+        assertTrue(!rewritten.contains("SORTKEY"), "Should not contain SORTKEY: " + rewritten);
+        assertTrue(!rewritten.contains("INTERLEAVED"), "Should not contain INTERLEAVED: " + rewritten);
+        assertTrue(!rewritten.contains(",\n)"), "Should not contain trailing comma before parenthesis: " + rewritten);
+    }
+}


### PR DESCRIPTION
﻿## Summary

Part 2 of splitting #2836 (`feat/redshift-sql-interceptor`) into smaller, independently reviewable PRs.

Adds `RedshiftSqlInterceptor`: a pure, literal-aware function that rewrites Redshift-specific table DDL clauses (`DISTSTYLE`, `DISTKEY`, `SORTKEY`, `ENCODE`) for compatibility with a plain PostgreSQL backend.

Does not wire the interceptor into the proxy loop yet (deferred to Part 3).

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Rewrites Redshift-specific DDL syntax against the official Redshift `CREATE TABLE` / `ALTER TABLE` grammar (https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html):
- Strips `DISTSTYLE ALL|EVEN|KEY|AUTO`
- Strips `DISTKEY (<col>)`, `DISTKEY <col>`, and column-level `DISTKEY` (including when followed by column constraints `NOT NULL`, `PRIMARY KEY`, `UNIQUE`, `REFERENCES`, etc. or column attributes `ENCODE`)
- Strips `[COMPOUND|INTERLEAVED] SORTKEY (<cols>)`, `SORTKEY <col>`, and column-level `SORTKEY` (including before column constraints)
- Strips `ENCODE <codec>` for valid Redshift column encodings and `ENCODE AUTO`
- Cleans orphaned or double commas from stripped clauses
- Safe scoping and fail-open: only rewrites `CREATE TABLE` and `ALTER TABLE` statements, masks single-quoted and dollar-quoted literals (`$$...$$`, `$tag$...$tag$`) before evaluation, and preserves columns legitimately named `distkey`, `sortkey`, or `encode`

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Context

Part of the Redshift proxy split:
1. [x] **RDS proxy primitives** (#2913, merged)
2. **This PR** - `RedshiftSqlInterceptor`: strip `DISTSTYLE` / `DISTKEY` / `SORTKEY` / `ENCODE` from Redshift table DDL, fail-open.
3. **Wire decoder + intercepting bridge** - `PostgresWireDecoder` and the framed `RedshiftInterceptingBridge` (DDL path only), wired into `RedshiftAuthProxy` / `RedshiftProxyManager`.
4. **S3 COPY simulator** - `CopyStatementParser` + `S3CopySimulator.runCopyFrom`.
5. **S3 UNLOAD simulator** - `S3CopySimulator.runUnload`.
