### PR TITLE
fix(kinesis): handle minimum partition key hash

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -766,7 +766,7 @@ public class KinesisService implements ResourceProvider {
 
     private KinesisShard selectShard(KinesisStream stream, String partitionKey) {
         // Simple hash-based shard selection among ALL shards, then resolve to open one
-        int index = Math.floorMod(partitionKey.hashCode(), stream.getShards().size());
+        int index = (int) (Math.abs((long) partitionKey.hashCode()) % stream.getShards().size());
         KinesisShard shard = stream.getShards().get(index);
         
         // If closed, find the first open child (simplified)

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -766,7 +766,7 @@ public class KinesisService implements ResourceProvider {
 
     private KinesisShard selectShard(KinesisStream stream, String partitionKey) {
         // Simple hash-based shard selection among ALL shards, then resolve to open one
-        int index = Math.abs(partitionKey.hashCode()) % stream.getShards().size();
+        int index = Math.floorMod(partitionKey.hashCode(), stream.getShards().size());
         KinesisShard shard = stream.getShards().get(index);
         
         // If closed, find the first open child (simplified)

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -765,6 +765,29 @@ class KinesisIntegrationTest {
             .body("Records.size()", equalTo(0));
     }
 
+    @Test
+    @Order(43)
+    void putRecordAcceptsPartitionKeyWithMinimumHashCode() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "minimum-hash-partition-key-test", "ShardCount": 3}
+                """)
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.PutRecord")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "minimum-hash-partition-key-test", "Data": "dGVzdA==", "PartitionKey": "polygenelubricants"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
     // --- AT_TIMESTAMP iterator coverage ---
 
     private String atTimestampCreateStream(String name) {

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -788,6 +788,30 @@ class KinesisIntegrationTest {
             .statusCode(200);
     }
 
+    @Test
+    @Order(44)
+    void putRecordPreservesShardForNegativeHashCode() {
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "negative-hash-partition-key-test", "ShardCount": 3}
+                """)
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.PutRecord")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "negative-hash-partition-key-test", "Data": "dGVzdA==", "PartitionKey": "negative-hash"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ShardId", equalTo("shardId-000000000002"));
+    }
+
     // --- AT_TIMESTAMP iterator coverage ---
 
     private String atTimestampCreateStream(String name) {


### PR DESCRIPTION
## Summary

  Prevent Kinesis `PutRecord` from returning a `500` response when a partition key has the hash value `Integer.MIN_VALUE`.

  Use `Math.floorMod` to keep the selected shard index valid. Add an integration test that covers the failing partition key.

  ## Type of change

  - [x] Bug fix (`fix:`)
  - [ ] New feature (`feat:`)
  - [ ] Breaking change (`feat!:` or `fix!:`)
  - [ ] Docs / chore

  ## AWS Compatibility

  The valid partition key `polygenelubricants` previously produced a negative shard index on a multi-shard stream. This caused `PutRecord` to return a `500` response.

  Verified with the AWS CLI against a three-shard stream. `PutRecord` completed successfully and returned a valid shard ID.

  ## Checklist

  - [x] `./mvnw test` passes locally
  - [x] New or updated integration test added
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)