### PR TITLE
fix(cognito): name the user pool in the not-found message

### DIFF
--- a/docs/services/cognito.md
+++ b/docs/services/cognito.md
@@ -15,6 +15,8 @@ Floci serves pool-specific discovery and JWKS endpoints, plus a relaxed OAuth to
 
 Floci strips reserved `floci:*` tags from stored and returned `UserPoolTags` on both create and update paths, so the tag namespace acts as an input-only control channel and is never persisted as user-visible metadata.
 
+An action given a user pool id that does not resolve answers `ResourceNotFoundException` with the live service's own wording, `User pool <poolId> does not exist.`, rather than a generic string, so tooling that matches on Cognito error text behaves the same way locally.
+
 Standalone `TagResource` rejects reserved `floci:*` keys. `ListTagsForResource` and `UntagResource` operate on the persisted user-pool tag map.
 
 ## Supported Actions

--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -358,7 +358,7 @@ public class CognitoService implements ResourceProvider {
 
     public UserPool describeUserPool(String id) {
         UserPool pool = poolStore.get(id)
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException", "User pool not found", 400));
+                .orElseThrow(() -> userPoolNotFound(id));
         boolean generatedKeys = ensureJwtSigningKeys(pool);
         boolean generatedSecret = ensureRefreshTokenSecret(pool);
         if (generatedKeys || generatedSecret) {
@@ -1415,7 +1415,7 @@ public class CognitoService implements ResourceProvider {
 
     public CognitoUser adminGetUser(String userPoolId, String username) {
         UserPool pool = poolStore.get(userPoolId).orElseThrow(
-                () -> new AwsException("ResourceNotFoundException", "User pool not found", 400));
+                () -> userPoolNotFound(userPoolId));
         LinkedHashMap<String, CognitoUser> matches = new LinkedHashMap<>();
         userStore.get(userKey(userPoolId, username))
                 .ifPresent(u -> matches.put(u.getUsername(), u));
@@ -2034,8 +2034,7 @@ public class CognitoService implements ResourceProvider {
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException", "Client not found",
                         400));
         UserPool pool = poolStore.get(client.getUserPoolId())
-                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
-                        "User pool not found", 400));
+                .orElseThrow(() -> userPoolNotFound(client.getUserPoolId()));
         CognitoUser user = adminGetUser(client.getUserPoolId(), username);
         if (verificationCodeService != null && isSignUpConfirmationEnabled(pool)) {
             try {
@@ -3337,6 +3336,17 @@ public class CognitoService implements ResourceProvider {
         int end = json.indexOf('"', start);
         if (end < 0) return null;
         return json.substring(start, end);
+    }
+
+    /**
+     * The live service names the pool it could not find, and every action that resolves one
+     * answers with the same string. Measured in ap-southeast-1 against DescribeUserPool,
+     * ListUsers, ListGroups and ListUserPoolClients on an id that does not exist:
+     * {@code User pool ap-southeast-1_ZZZZZZZZZ does not exist.}
+     */
+    private static AwsException userPoolNotFound(String userPoolId) {
+        return new AwsException("ResourceNotFoundException",
+                "User pool " + userPoolId + " does not exist.", 400);
     }
 
     private String userKey(String poolId, String username) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoUserPoolNotFoundMessageIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoUserPoolNotFoundMessageIntegrationTest.java
@@ -1,0 +1,75 @@
+package io.github.hectorvent.floci.services.cognito;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.github.hectorvent.floci.services.cognito.CognitoRestAssuredUtils.cognitoAction;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * A missing user pool is named in the error message.
+ *
+ * <p>Measured against the live service in ap-southeast-1, which answers DescribeUserPool,
+ * ListUsers, ListGroups and ListUserPoolClients on an id that does not exist with the same
+ * string: {@code User pool ap-southeast-1_ZZZZZZZZZ does not exist.} The error code was already
+ * correct; only the message diverged.
+ */
+@QuarkusTest
+class CognitoUserPoolNotFoundMessageIntegrationTest {
+
+    private static final String ABSENT_POOL = "us-east-1_ZZZZZZZZZ";
+    private static final String EXPECTED = "User pool " + ABSENT_POOL + " does not exist.";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static void assertNamesThePool(String action, String body) {
+        cognitoAction(action, body)
+            .then()
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"))
+            .body("message", equalTo(EXPECTED));
+    }
+
+    @Test
+    void describeUserPoolNamesTheMissingPool() {
+        assertNamesThePool("DescribeUserPool", """
+            { "UserPoolId": "%s" }
+            """.formatted(ABSENT_POOL));
+    }
+
+    // ListUsers and ListUserPoolClients are deliberately absent: they answer an absent pool with
+    // an empty list rather than resolving it at all, so they never reach this message. That is a
+    // separate divergence from the live service and is filed on its own.
+
+    @Test
+    void listResourceServersNamesTheMissingPool() {
+        assertNamesThePool("ListResourceServers", """
+            {
+                "UserPoolId": "%s",
+                "MaxResults": 10
+            }
+            """.formatted(ABSENT_POOL));
+    }
+
+    @Test
+    void listGroupsNamesTheMissingPool() {
+        assertNamesThePool("ListGroups", """
+            { "UserPoolId": "%s" }
+            """.formatted(ABSENT_POOL));
+    }
+
+    @Test
+    void adminGetUserNamesTheMissingPool() {
+        assertNamesThePool("AdminGetUser", """
+            {
+                "UserPoolId": "%s",
+                "Username": "nobody"
+            }
+            """.formatted(ABSENT_POOL));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3WellKnownKeyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3WellKnownKeyIntegrationTest.java
@@ -88,7 +88,7 @@ class S3WellKnownKeyIntegrationTest {
         .then()
             .extract().asString();
 
-        if (body.contains("ResourceNotFoundException") || body.contains("User pool not found")) {
+        if (body.contains("ResourceNotFoundException") || body.contains("User pool ")) {
             throw new AssertionError(
                 "GET /" + BUCKET + "/" + JWKS_KEY
                 + " was routed to Cognito instead of S3. Response: " + body);


### PR DESCRIPTION
## Summary

Every Cognito action that resolves a user pool reported a missing one as `User pool not found`.
The live service names the pool. The error code (`ResourceNotFoundException`) and the status were
already correct; only the message diverged, which is enough to stop tooling and tests that match
on Cognito error text from behaving the same way locally, and Floci's own suites do assert on
messages elsewhere.

Three throw sites carried the literal. They now share one private helper, so the string has a
single home and cannot drift apart again.

Closes #2853

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reference:
[DescribeUserPool](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPool.html).
The reference lists `ResourceNotFoundException` but does not publish the message, so it was
measured rather than inferred.

Live service, `ap-southeast-1`, AWS CLI v2, on a pool id that does not exist. Four actions on the
same resolution path, all identical:

```
describe-user-pool      -> ResourceNotFoundException: User pool ap-southeast-1_ZZZZZZZZZ does not exist.
list-users              -> ResourceNotFoundException: User pool ap-southeast-1_ZZZZZZZZZ does not exist.
list-groups             -> ResourceNotFoundException: User pool ap-southeast-1_ZZZZZZZZZ does not exist.
list-user-pool-clients  -> ResourceNotFoundException: User pool ap-southeast-1_ZZZZZZZZZ does not exist.
list-resource-servers   -> ResourceNotFoundException: User pool ap-southeast-1_ZZZZZZZZZ does not exist.
```

Floci on `main`, same input:

```
describe-user-pool      -> ResourceNotFoundException: User pool not found
```

The trailing period is part of the live string and is reproduced.

### A malformed id is a different path, left alone

Worth stating so the change is not read as covering more than it does. AWS rejects an id that does
not match the pool-id pattern before resolving anything:

```
describe-user-pool --user-pool-id not-a-pool-id
  -> InvalidParameterException
     1 validation error detected: Value 'not-a-pool-id' at 'userPoolId' failed to satisfy
     constraint: Member must satisfy regular expression pattern: [\w-]+_[0-9a-zA-Z]+
```

Floci does not validate that pattern, so a malformed id falls through to the not-found path. This
PR does not change that: it is a pre-existing divergence in a different check, and adding
parameter validation across the service is a separate piece of work rather than a message fix.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Cognito package run, on the branch tip:

```
mvn -B test -Dtest='io.github.hectorvent.floci.services.cognito.**'
Tests run: 465, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

`make docs-check` exits 0. The full suite is left to CI rather than run locally.

New class `CognitoUserPoolNotFoundMessageIntegrationTest`, 4 tests, covering `DescribeUserPool`,
`ListGroups`, `ListResourceServers` and `AdminGetUser`.

One existing assertion moved. `S3WellKnownKeyIntegrationTest` used the old message as a
fingerprint for a request being misrouted to Cognito instead of S3. It now matches on
`"User pool "`, which fingerprints the same thing and survives the reword. Re-run with the change:

```
mvn -B test -Dtest='S3WellKnownKeyIntegrationTest,CognitoUserPoolNotFoundMessageIntegrationTest'
Tests run: 9, Failures: 0, Errors: 0, Skipped: 0
```

## Found while measuring, filed separately

`ListUsers` and `ListUserPoolClients` do not resolve the pool at all: given an id that does not
exist they answer `200` with an empty list, where the live service returns
`ResourceNotFoundException`. That is why those two are not in the new test, despite being in the
measurement above.

```
FLOCI  list-users             --user-pool-id us-east-1_ZZZZZZZZZ  -> {"Users": []}
FLOCI  list-user-pool-clients --user-pool-id us-east-1_ZZZZZZZZZ  -> {"UserPoolClients": []}
FLOCI  list-groups            --user-pool-id us-east-1_ZZZZZZZZZ  -> ResourceNotFoundException
FLOCI  list-resource-servers  --user-pool-id us-east-1_ZZZZZZZZZ  -> ResourceNotFoundException
```

That is a missing existence check rather than a message, so it is out of scope here and filed on
its own.
