### PR TITLE
feat(elasticache): add validation for cache parameter group existence in replication group operations

### DIFF
--- a/docs/services/elasticache.md
+++ b/docs/services/elasticache.md
@@ -113,6 +113,11 @@ than rejecting names a partial catalogue happens to be missing, which would refu
 AWS accepts. `DescribeCacheParameters` returns those parameters; a request for `system` or
 `engine-default` parameters returns none, and listings are unpaged.
 
+A replication group that names a parameter group is refused with `CacheParameterGroupNotFound` when
+no such group exists, and a parameter group still referenced by a replication group cannot be
+deleted: `DeleteCacheParameterGroup` answers `InvalidCacheParameterGroupState` until that
+replication group is gone.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -144,6 +144,9 @@ public class ElastiCacheService implements ResourceProvider {
         // resolved with the other validations, before a port is taken or a container started
         ReplicationGroupSettings resolvedSettings =
                 settings.withKmsKeyId(resolveKmsKeyArn(settings.kmsKeyId(), request.region()));
+        if (request.cacheParameterGroupName() != null && !request.cacheParameterGroupName().isBlank()) {
+            requireParameterGroup(request.cacheParameterGroupName());
+        }
         if (groups.get(groupId).isPresent()) {
             throw new AwsException("ReplicationGroupAlreadyExistsFault",
                     "Replication group " + groupId + " already exists.", 400);
@@ -1143,9 +1146,20 @@ public class ElastiCacheService implements ResourceProvider {
                 throw new AwsException("CacheParameterGroupNotFound",
                         "CacheParameterGroupnot found: " + name, 404);
             }
+            if (isParameterGroupInUse(name)) {
+                throw new AwsException("InvalidCacheParameterGroupState",
+                        "One or more cache clusters are still members of this parameter group "
+                                + name + ", so the group cannot be deleted.", 400);
+            }
             parameterGroups.delete(name);
         }
         LOG.infov("Deleted cache parameter group {0}", name);
+    }
+
+    /** Whether a stored replication group still references the parameter group by that name. */
+    private boolean isParameterGroupInUse(String name) {
+        return groups.scan(key -> true).stream()
+                .anyMatch(group -> name.equals(group.getCacheParameterGroupName()));
     }
 
     @Override

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
@@ -336,7 +336,7 @@ class ElastiCacheIntegrationTest {
                     equalTo(GROUP_ID + "-reused"));
     }
 
-    private static boolean isDockerAvailable() {
+    static boolean isDockerAvailable() {
         try {
             Process process = new ProcessBuilder("docker", "version", "--format", "{{.Server.Version}}")
                     .redirectErrorStream(true)

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheParameterGroupIntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.elasticache;
 
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -266,6 +267,75 @@ class ElastiCacheParameterGroupIntegrationTest {
         .then()
             .statusCode(404)
             .body(containsString("CacheParameterGroupnot found: absent-pg"));
+    }
+
+    @Test
+    @Order(4)
+    void aReplicationGroupCannotReferenceAnUnknownParameterGroup() {
+        // The lookup runs with the other validations, before any container is started, so the
+        // refusal carries the parameter group's own not-found rather than a provisioning failure.
+        query("CreateReplicationGroup")
+                .formParam("ReplicationGroupId", "pg-absent-rg")
+                .formParam("ReplicationGroupDescription", "references a missing group")
+                .formParam("CacheParameterGroupName", "absent-pg")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("<Code>CacheParameterGroupNotFound</Code>"))
+            .body(containsString("CacheParameterGroup absent-pg not found."));
+
+        query("DescribeReplicationGroups")
+                .formParam("ReplicationGroupId", "pg-absent-rg")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(4)
+    void aParameterGroupInUseByAReplicationGroupCannotBeDeleted() {
+        // The replication group is a real one behind a container, so this case needs Docker
+        // where the rest of the class does not.
+        Assumptions.assumeTrue(ElastiCacheIntegrationTest.isDockerAvailable(),
+                "Docker daemon must be available to create a replication group");
+        String replicationGroupId = "pg-in-use-rg";
+        query("CreateReplicationGroup")
+                .formParam("ReplicationGroupId", replicationGroupId)
+                .formParam("ReplicationGroupDescription", "holds the parameter group in use")
+                .formParam("CacheParameterGroupName", GROUP)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        try {
+            query("DeleteCacheParameterGroup")
+                    .formParam("CacheParameterGroupName", GROUP)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("<Code>InvalidCacheParameterGroupState</Code>"))
+                .body(containsString("One or more cache clusters are still members of this parameter group "
+                        + GROUP + ", so the group cannot be deleted."));
+
+            query("DescribeCacheParameterGroups")
+                    .formParam("CacheParameterGroupName", GROUP)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<CacheParameterGroupName>" + GROUP + "</CacheParameterGroupName>"));
+        } finally {
+            query("DeleteReplicationGroup")
+                    .formParam("ReplicationGroupId", replicationGroupId)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -677,4 +677,41 @@ class ElastiCacheServiceTest {
         assertThrows(AwsException.class, () -> svc.getReplicationGroup("g1"),
                 "the deleted group must not come back from the modify");
     }
+
+    private static ElastiCacheService.CreateReplicationGroupRequest requestWithParameterGroup(
+            String groupId, String parameterGroupName) {
+        return new ElastiCacheService.CreateReplicationGroupRequest(groupId, "test",
+                AuthMode.NO_AUTH, null, "us-east-1", null, null, null,
+                parameterGroupName, null, null, null, null,
+                null, null, null, ReplicationGroupSettings.defaults(), Map.of());
+    }
+
+    @Test
+    void createReferencingAnUnknownParameterGroupIsRefusedBeforeProvisioning() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.createReplicationGroup(requestWithParameterGroup("grp", "absent-pg")));
+
+        assertEquals("CacheParameterGroupNotFound", ex.getErrorCode());
+        assertEquals(404, ex.getHttpStatus());
+        verify(containerManager, never()).start(anyString(), anyString());
+        verify(containerManager, never()).start(anyString(), anyString(), any());
+        assertThrows(AwsException.class, () -> service.getReplicationGroup("grp"));
+    }
+
+    @Test
+    void aParameterGroupStillReferencedByAReplicationGroupCannotBeDeleted() {
+        service.createCacheParameterGroup("custom-pg", "redis7", "in use", Map.of());
+        service.createReplicationGroup(requestWithParameterGroup("grp", "custom-pg"));
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.deleteCacheParameterGroup("custom-pg"));
+        assertEquals("InvalidCacheParameterGroupState", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(service.findParameterGroup("custom-pg").isPresent(),
+                "a refused delete must leave the group in place");
+
+        service.deleteReplicationGroup("grp");
+        service.deleteCacheParameterGroup("custom-pg");
+        assertTrue(service.findParameterGroup("custom-pg").isEmpty());
+    }
 }


### PR DESCRIPTION
## Sumary
Closes #2303

Most of the issue was already delivered by #2392 (which closed the sibling #2375): the five
parameter group actions exist, with the ARN, `CacheNodeTypeSpecificParameters`, and
`CacheParameterGroupNotFound` for an unknown name. Two scope items were still open, and this PR
closes them:

- `DeleteCacheParameterGroup` deleted a group that a replication group still referenced. It now
  refuses with `InvalidCacheParameterGroupState` until that replication group is gone.
- `CreateReplicationGroup` accepted a `CacheParameterGroupName` that did not exist. It now refuses
  with `CacheParameterGroupNotFound`, checked with the other validations before a port is taken or
  a container is started, so nothing is left behind.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Both errors are the ones the API Reference documents for these cases:

| Action | Case | Documented error | floci |
| --- | --- | --- | --- |
| `CreateReplicationGroup` | `CacheParameterGroupName` names a group that does not exist | `CacheParameterGroupNotFound` (HTTP 404) | `CacheParameterGroupNotFound`, 404, *CacheParameterGroup &lt;name&gt; not found.* |
| `DeleteCacheParameterGroup` | the group is associated with one or more cache clusters | `InvalidCacheParameterGroupState` (HTTP 400) | `InvalidCacheParameterGroupState`, 400, *One or more cache clusters are still members of this parameter group &lt;name&gt;, so the group cannot be deleted.* |

References:
- https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_CreateReplicationGroup.html#API_CreateReplicationGroup_Errors
- https://docs.aws.amazon.com/AmazonElastiCache/latest/APIReference/API_DeleteCacheParameterGroup.html#API_DeleteCacheParameterGroup_Errors

Deliberate limits:
- "In use" means a stored replication group references the group. Memcached cache clusters do not
  carry a parameter group in floci's model, so they cannot hold one.
- The create-time check runs before provisioning; a parameter group deleted between that check and
  the replication group being stored is not re-checked.
- The message text of `InvalidCacheParameterGroupState` follows the wording AWS uses for
  parameter groups that are still associated with clusters; it was matched against the docs, not
  against a live account.

## Tests

- `ElastiCacheServiceTest`: create with an unknown group is refused before any container starts;
  delete of a referenced group is refused and the group survives, then succeeds once the
  replication group is deleted.
- `ElastiCacheParameterGroupIntegrationTest` (Query protocol, asserting the XML error body):
  `CreateReplicationGroup` with an unknown group returns the 404 and stores nothing;
  `DeleteCacheParameterGroup` of a group held by a replication group returns the 400, the group
  still describes, and the delete succeeds after the replication group is removed. The second case
  needs Docker for the replication group and skips via `Assumptions` without it.
- `docs/services/elasticache.md` documents both behaviours; the generated action table is
  unchanged since no action was added.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)



