### PR TITLE
feat(route53): update supported operations and add VPC association actions

### DIFF
--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -98,7 +98,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [AWS FIS](fis.md) | `/experimentTemplates/*`, `/experiments/*`, `/actions/*`, `/targetResourceTypes/*`, `/safetyLevers/*`, `/tags/*` | REST JSON | 26 |
 | [CodeGuru Reviewer](codegurureviewer.md) | `/associations`, `/associations/{associationArn}`, `/tags/*` | REST JSON | 7 |
 | [CloudFront](cloudfront.md) | `/2020-05-31/distribution/*`, `/2020-05-31/cache-policy/*`, `/2020-05-31/function/*` | REST XML | 50 |
-| [Route53](route53.md) | `/2013-04-01/hostedzone/*`, `/2013-04-01/healthcheck/*`, `/2013-04-01/change/*` | REST XML | 17 |
+| [Route53](route53.md) | `/2013-04-01/hostedzone/*`, `/2013-04-01/healthcheck/*`, `/2013-04-01/change/*` | REST XML | 25 |
 | [Route 53 Resolver](route53resolver.md) | `POST /` + `X-Amz-Target: Route53Resolver.*` | JSON 1.1 | 18 |
 | [Cloud Map](cloudmap.md) | `POST /` + `X-Amz-Target: Route53AutoNaming_v20170314.*` | JSON 1.1 | 22 |
 | [AWS Config](config.md) | `POST /` + `X-Amz-Target: StarlingDoveService.*` | JSON 1.1 | 33 |

--- a/docs/services/route53.md
+++ b/docs/services/route53.md
@@ -4,25 +4,35 @@ Route53 management-plane emulation. Supports hosted zones, resource record sets,
 
 ## Supported Operations
 
-| Operation | Method | Path |
-|---|---|---|
-| CreateHostedZone | POST | `/2013-04-01/hostedzone` |
-| GetHostedZone | GET | `/2013-04-01/hostedzone/{Id}` |
-| DeleteHostedZone | DELETE | `/2013-04-01/hostedzone/{Id}` |
-| ListHostedZones | GET | `/2013-04-01/hostedzone` |
-| ListHostedZonesByName | GET | `/2013-04-01/hostedzonesbyname` |
-| GetHostedZoneCount | GET | `/2013-04-01/hostedzonecount` |
-| ChangeResourceRecordSets | POST | `/2013-04-01/hostedzone/{Id}/rrset` |
-| ListResourceRecordSets | GET | `/2013-04-01/hostedzone/{Id}/rrset` |
-| GetChange | GET | `/2013-04-01/change/{Id}` |
-| CreateHealthCheck | POST | `/2013-04-01/healthcheck` |
-| GetHealthCheck | GET | `/2013-04-01/healthcheck/{HealthCheckId}` |
-| DeleteHealthCheck | DELETE | `/2013-04-01/healthcheck/{HealthCheckId}` |
-| ListHealthChecks | GET | `/2013-04-01/healthcheck` |
-| UpdateHealthCheck | POST | `/2013-04-01/healthcheck/{HealthCheckId}` |
-| ListTagsForResource | GET | `/2013-04-01/tags/{ResourceType}/{ResourceId}` |
-| ChangeTagsForResource | POST | `/2013-04-01/tags/{ResourceType}/{ResourceId}` |
-| GetAccountLimit | GET | `/2013-04-01/accountlimit/{Type}` |
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `CreateHostedZone` | `POST /2013-04-01/hostedzone`. A `<VPC>` element in the request creates a private zone and records the first VPC association. |
+| `GetHostedZone` | `GET /2013-04-01/hostedzone/{Id}`. Private zones include their `<VPCs>` list. |
+| `DeleteHostedZone` | `DELETE /2013-04-01/hostedzone/{Id}` |
+| `ListHostedZones` | `GET /2013-04-01/hostedzone` |
+| `ListHostedZonesByName` | `GET /2013-04-01/hostedzonesbyname` |
+| `AssociateVPCWithHostedZone` | `POST /2013-04-01/hostedzone/{Id}/associatevpc`. Private zones only; re-associating an attached VPC is a no-op. |
+| `DisassociateVPCFromHostedZone` | `POST /2013-04-01/hostedzone/{Id}/disassociatevpc`. Refuses to remove the last association (`LastVPCAssociation`). |
+| `CreateVPCAssociationAuthorization` | `POST /2013-04-01/hostedzone/{Id}/authorizevpcassociation`. Validates and echoes the VPC; zones are not account-scoped, so no authorization is enforced. |
+| `DeleteVPCAssociationAuthorization` | `POST /2013-04-01/hostedzone/{Id}/deauthorizevpcassociation` |
+| `ListHostedZonesByVPC` | `GET /2013-04-01/hostedzonesbyvpc?vpcid=…&vpcregion=…`. Paginates with `maxitems` / `nexttoken`. |
+| `GetHostedZoneCount` | `GET /2013-04-01/hostedzonecount` |
+| `ChangeResourceRecordSets` | `POST /2013-04-01/hostedzone/{Id}/rrset` |
+| `ListResourceRecordSets` | `GET /2013-04-01/hostedzone/{Id}/rrset` |
+| `GetChange` | `GET /2013-04-01/change/{Id}` |
+| `CreateHealthCheck` | `POST /2013-04-01/healthcheck` |
+| `GetHealthCheck` | `GET /2013-04-01/healthcheck/{HealthCheckId}` |
+| `DeleteHealthCheck` | `DELETE /2013-04-01/healthcheck/{HealthCheckId}` |
+| `ListHealthChecks` | `GET /2013-04-01/healthcheck` |
+| `UpdateHealthCheck` | `POST /2013-04-01/healthcheck/{HealthCheckId}` |
+| `ListTagsForResource` | `GET /2013-04-01/tags/{ResourceType}/{ResourceId}` |
+| `ChangeTagsForResource` | `POST /2013-04-01/tags/{ResourceType}/{ResourceId}` |
+| `GetAccountLimit` | `GET /2013-04-01/accountlimit/{Type}` |
+| `GetHealthCheckStatus` | `GET /2013-04-01/healthcheck/{HealthCheckId}/status` |
+| `GetDNSSEC` | `GET /2013-04-01/hostedzone/{Id}/dnssec`. Always reports signing as `NOT_SIGNING`. |
+| `GetHostedZoneLimit` | `GET /2013-04-01/hostedzonelimit/{HostedZoneId}/{Type}` |
+<!-- floci:actions:end -->
 
 ## Behavior
 
@@ -34,6 +44,9 @@ Route53 management-plane emulation. Supports hosted zones, resource record sets,
 - Hosted zone IDs are returned with the `/hostedzone/` prefix in XML responses (e.g. `/hostedzone/Z1PA6795UKMFR9`). The AWS SDK strips this prefix client-side.
 - Health check IDs are plain UUIDs without a prefix.
 - Tags are supported for both `hostedzone` and `healthcheck` resource types.
+- A hosted zone is private when `CreateHostedZone` carries a `<VPC>` element; `HostedZoneConfig.PrivateZone` is response-only.
+- `AssociateVPCWithHostedZone` rejects public zones with `PublicZoneVPCAssociation`, and `DisassociateVPCFromHostedZone` rejects removing the last VPC with `LastVPCAssociation`.
+- Associating a VPC that is already attached to another zone with the same name fails with `ConflictingDomainExists`.
 
 ## Default Nameservers
 
@@ -100,6 +113,26 @@ aws route53 create-health-check \
     "ResourcePath": "/health"
   }'
 
+# Create a private hosted zone attached to a VPC
+aws route53 create-hosted-zone \
+  --name internal.example.com \
+  --caller-reference "$(date +%s)" \
+  --vpc VPCRegion=us-east-1,VPCId=vpc-0123456789abcdef0
+
+# Attach a second VPC to the private zone
+aws route53 associate-vpc-with-hosted-zone \
+  --hosted-zone-id Z1PA6795UKMFR9 \
+  --vpc VPCRegion=us-east-1,VPCId=vpc-0fedcba9876543210
+
+# List the private zones attached to a VPC
+aws route53 list-hosted-zones-by-vpc \
+  --vpc-id vpc-0fedcba9876543210 --vpc-region us-east-1
+
+# Detach a VPC (the last association cannot be removed)
+aws route53 disassociate-vpc-from-hosted-zone \
+  --hosted-zone-id Z1PA6795UKMFR9 \
+  --vpc VPCRegion=us-east-1,VPCId=vpc-0fedcba9876543210
+
 # Delete a hosted zone
 aws route53 delete-hosted-zone --id Z1PA6795UKMFR9
 ```
@@ -108,7 +141,7 @@ aws route53 delete-hosted-zone --id Z1PA6795UKMFR9
 
 - Reusable delegation sets
 - Traffic policies and traffic policy instances
-- VPC association (private hosted zones)
+- Cross-account VPC association authorization (zones are not account-scoped, so `CreateVPCAssociationAuthorization` is accepted but not enforced)
 - Query logging configs
 - DNSSEC (key signing keys, enabling/disabling)
 - `TestDNSAnswer`

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -166,6 +166,18 @@ services:
     # SubnetIds / VpcSecurityGroupIds / TagKeys are labels of an inner member-name
     # switch (memberKeyRegex), not actions — same shape as the rds exclusions above.
     exclude_actions: [SubnetIds, VpcSecurityGroupIds, TagKeys]
+  - service: route53
+    doc: docs/services/route53.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java, mode: rest }
+    # JAX-RS method names use Java casing; map them onto the canonical Route 53 action names.
+    rename_actions:
+      AssociateVpcWithHostedZone: AssociateVPCWithHostedZone
+      DisassociateVpcFromHostedZone: DisassociateVPCFromHostedZone
+      CreateVpcAssociationAuthorization: CreateVPCAssociationAuthorization
+      DeleteVpcAssociationAuthorization: DeleteVPCAssociationAuthorization
+      ListHostedZonesByVpc: ListHostedZonesByVPC
+      GetDnssec: GetDNSSEC
   - service: route53resolver
     doc: docs/services/route53resolver.md
     sources:


### PR DESCRIPTION

## Summary

Closes: #2298 

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## AWS Compatibility

No wire-protocol changes in this PR. The three actions (AssociateVPCWithHostedZone,
DisassociateVPCFromHostedZone, ListHostedZonesByVPC) landed in #2638; this PR closes the
documentation gap that kept #2298 open and registers the Route53 controller with the docs
generator so the action table is maintained by `make docs-sync`.

The endpoint paths and error codes cited in the docs (PublicZoneVPCAssociation,
LastVPCAssociation, ConflictingDomainExists) were checked against the Route 53
2013-04-01 API reference. Behaviour is covered by
Route53VpcAssociationIntegrationTest (raw REST XML, 20 tests). The compatibility suite
in compatibility-tests/sdk-test-java pins AWS SDK for Java 2.52.0.

The three endpoints had already been implemented in the code via PR #2638, but the issue remained open because the documentation was never updated: the actions table in `docs/services/route53.md` still listed 17 operations with no VPC actions, and Route 53 wasn't even registered in the generator used by `make docs-sync`. I only modified the documentation and the generator registration.

