### PR TITLE
fix(cognito): fail listUsers/listUserPoolClients on an absent user pool

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cognito/CognitoService.java
@@ -594,6 +594,7 @@ public class CognitoService implements ResourceProvider {
     }
 
     public List<UserPoolClient> listUserPoolClients(String userPoolId) {
+        describeUserPool(userPoolId);
         return clientStore.scan(k -> clientStore.get(k).map(c -> c.getUserPoolId().equals(userPoolId)).orElse(false));
     }
 
@@ -1604,6 +1605,7 @@ public class CognitoService implements ResourceProvider {
     }
 
     public List<CognitoUser> listUsers(String userPoolId, String filter) {
+        describeUserPool(userPoolId);
         String prefix = userPoolId + "::";
         List<CognitoUser> all = userStore.scan(k -> k.startsWith(prefix));
         if (filter == null || filter.isBlank()) {

--- a/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cognito/CognitoServiceTest.java
@@ -1950,6 +1950,43 @@ class CognitoServiceTest {
         assertTrue(result.isEmpty());
     }
 
+    // =========================================================================
+    // Issue #2952 - listUsers/listUserPoolClients against an absent user pool
+    // =========================================================================
+
+    @Test
+    void listUsersAgainstAnAbsentUserPoolFails() {
+        // listUsers scanned by a "{poolId}::" prefix without ever touching poolStore, so an
+        // absent pool was indistinguishable from an empty one. list-groups and
+        // list-resource-servers already resolve the pool and are correct; this brought
+        // list-users in line with them.
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.listUsers("us-east-1_nonexistent", null));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void listUserPoolClientsAgainstAnAbsentUserPoolFails() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> service.listUserPoolClients("us-east-1_nonexistent"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void listUsersAgainstAnExistingEmptyPoolStillReturnsEmpty() {
+        // The existence check must not turn a real, merely-empty pool into an error.
+        UserPool pool = service.createUserPool(Map.of("PoolName", "EmptyPool"), "us-east-1");
+
+        assertTrue(service.listUsers(pool.getId(), null).isEmpty());
+    }
+
+    @Test
+    void listUserPoolClientsAgainstAnExistingEmptyPoolStillReturnsEmpty() {
+        UserPool pool = service.createUserPool(Map.of("PoolName", "EmptyPool"), "us-east-1");
+
+        assertTrue(service.listUserPoolClients(pool.getId()).isEmpty());
+    }
+
     /** Signs a hand-crafted {@code poolId|username|clientId|issuedAt|nonce} payload the same way buildRefreshToken does. */
     private static String signRawRefreshToken(UserPool pool, String raw) {
         String signature = CognitoService.hmacSha256(CognitoService.refreshTokenSecretBytes(pool), raw);


### PR DESCRIPTION
Fixes #2952

listUsers scanned its store by a "{poolId}::" prefix and listUserPoolClients by a userPoolId field, neither of which touched poolStore, so an absent pool was indistinguishable from an empty one: both returned 200 with an empty list instead of ResourceNotFoundException. list-groups and list-resource-servers already resolve the pool via describeUserPool and are correct; this brings the other two list actions in line with them and with real Cognito, where all four behave identically.

Verified by temporarily disabling each fix and confirming the corresponding new test fails with the exact expected error before restoring it. Full CognitoServiceTest suite (177 tests) passes clean.