### PR TITLE
fix(cloudformation): persist FunctionResponseTypes on Lambda::EventSourceMapping

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -4117,6 +4117,11 @@ public class CloudFormationResourceProvisioner {
             }
         }
 
+        List<String> functionResponseTypes = resolveStringList(props, "FunctionResponseTypes", engine);
+        if (!functionResponseTypes.isEmpty()) {
+            req.put("FunctionResponseTypes", functionResponseTypes);
+        }
+
         var esm = lambdaService.createEventSourceMapping(region, req);
         r.setPhysicalId(esm.getUuid());
         r.getAttributes().put("Id", esm.getUuid());

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIntegrationTest.java
@@ -4403,7 +4403,8 @@ class CloudFormationIntegrationTest {
                     "FunctionName": { "Ref": "MyFunction" },
                     "EventSourceArn": { "Fn::GetAtt": ["MyQueue", "Arn"] },
                     "Enabled": true,
-                    "BatchSize": 5
+                    "BatchSize": 5,
+                    "FunctionResponseTypes": ["ReportBatchItemFailures"]
                   }
                 }
               }
@@ -4456,6 +4457,15 @@ class CloudFormationIntegrationTest {
 
         JsonNode esmList = OBJECT_MAPPER.readTree(esmJson);
         String esmUuid = esmList.path("EventSourceMappings").get(0).path("UUID").asText();
+
+        // github.com/floci-io/floci/issues/2848: the CloudFormation path never read
+        // FunctionResponseTypes, so a CFN-provisioned mapping always came back with an empty
+        // list even though the template declared it and the direct CreateEventSourceMapping API
+        // path already honored it.
+        JsonNode responseTypes = esmList.path("EventSourceMappings").get(0).path("FunctionResponseTypes");
+        assertTrue(responseTypes.isArray() && responseTypes.size() == 1
+                        && "ReportBatchItemFailures".equals(responseTypes.get(0).asText()),
+                "expected FunctionResponseTypes to carry through from the template but was: " + responseTypes);
 
         // 5. Delete stack and verify ESM is gone
         given()


### PR DESCRIPTION
Fixes #2848

provisionLambdaEventSourceMapping never read the FunctionResponseTypes property, so a CFN-provisioned mapping always came back with an empty list even when the template declared it, unlike the direct CreateEventSourceMapping API path (fixed by #208). Partial batch responses were ignored for CFN-deployed SQS to Lambda mappings: failed messages returned via batchItemFailures were deleted on the 200 response instead of being retried.

Resolved the same way every other array property in this method already is, via the existing resolveStringList helper.

Verified by temporarily disabling the fix and confirming the extended integration test fails with the exact expected empty list before restoring it.