### PR TITLE
fix(stepfunctions): abort executions abandoned by a restart

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -417,12 +417,16 @@ from is empty and the state is never reached.
 An execution runs in the Floci process. When Floci restarts while an execution is `RUNNING`,
 no worker survives it, so at startup every execution still stored as `RUNNING` is aborted:
 `DescribeExecution` reports `status` `ABORTED`, a `stopDate`, `error` `ExecutionAbandoned` and
-`cause` `The emulator restarted while this execution was RUNNING; no worker survived it.`, and
-`GetExecutionHistory` reports a single `ExecutionAborted` event carrying the same error and cause.
-Executions of every account are swept, each written back under its own account.
+`cause` `The emulator restarted while this execution was RUNNING; no worker survived it.`
+Executions of every account are swept, each written back under its own account. Executions that
+already reached a terminal status are left untouched, and so is the status, error and cause of one
+this sweep aborted on an earlier boot.
 
-Execution histories are held in memory, so the events recorded before the restart are gone and the
-execution cannot be resumed. Executions that already reached a terminal status are left untouched.
+Execution histories are held in memory, not in storage. The events recorded before the restart are
+gone, so the execution cannot be resumed, and `GetExecutionHistory` reports a single
+`ExecutionAborted` event carrying the same error and cause only for the boot that aborted it: after
+a further restart the execution is already terminal, no event is written, and the history is empty
+while `DescribeExecution` still reports the status, error and cause.
 
 ## Configuration
 

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -412,6 +412,18 @@ Local, the execution starts and fails with `States.Runtime` only if the state th
 it is entered. This keeps a generated mock file usable when the collection it was built
 from is empty and the state is never reached.
 
+## Executions abandoned by a restart
+
+An execution runs in the Floci process. When Floci restarts while an execution is `RUNNING`,
+no worker survives it, so at startup every execution still stored as `RUNNING` is aborted:
+`DescribeExecution` reports `status` `ABORTED`, a `stopDate`, `error` `ExecutionAbandoned` and
+`cause` `The emulator restarted while this execution was RUNNING; no worker survived it.`, and
+`GetExecutionHistory` reports a single `ExecutionAborted` event carrying the same error and cause.
+Executions of every account are swept, each written back under its own account.
+
+Execution histories are held in memory, so the events recorded before the restart are gone and the
+execution cannot be resumed. Executions that already reached a terminal status are left untouched.
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -415,18 +415,19 @@ from is empty and the state is never reached.
 ## Executions abandoned by a restart
 
 An execution runs in the Floci process. When Floci restarts while an execution is `RUNNING`,
-no worker survives it, so at startup every execution still stored as `RUNNING` is aborted:
-`DescribeExecution` reports `status` `ABORTED`, a `stopDate`, `error` `ExecutionAbandoned` and
-`cause` `The emulator restarted while this execution was RUNNING; no worker survived it.`
-Executions of every account are swept, each written back under its own account. Executions that
-already reached a terminal status are left untouched, and so is the status, error and cause of one
-this sweep aborted on an earlier boot.
+no worker survives it, so at startup every execution still stored as `RUNNING` is aborted with no
+error and no cause, the shape AWS returns for `StopExecution` called without them:
+`DescribeExecution` reports `status` `ABORTED` and a `stopDate`, and leaves the `error` and `cause`
+keys out. How many executions the sweep retired is reported once, as a `WARN` log line. Executions
+of every account are swept, each written back under its own account. Executions that already
+reached a terminal status are left untouched, and so is the status and `stopDate` of one this sweep
+aborted on an earlier boot.
 
 Execution histories are held in memory, not in storage. The events recorded before the restart are
 gone, so the execution cannot be resumed, and `GetExecutionHistory` reports a single
-`ExecutionAborted` event carrying the same error and cause only for the boot that aborted it: after
-a further restart the execution is already terminal, no event is written, and the history is empty
-while `DescribeExecution` still reports the status, error and cause.
+`ExecutionAborted` event, with an empty `executionAbortedEventDetails`, only for the boot that
+aborted it: after a further restart the execution is already terminal, no event is written, and the
+history is empty while `DescribeExecution` still reports the status and `stopDate`.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycle.java
@@ -28,6 +28,7 @@ import io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker;
 import io.github.hectorvent.floci.services.elb.ElbClassicService;
 import io.github.hectorvent.floci.services.elbv2.ElbV2Service;
 import io.github.hectorvent.floci.services.rds.RdsService;
+import io.github.hectorvent.floci.services.stepfunctions.StepFunctionsService;
 import io.github.hectorvent.floci.services.memorydb.container.MemoryDbContainerManager;
 import io.github.hectorvent.floci.services.memorydb.proxy.MemoryDbProxyManager;
 import io.github.hectorvent.floci.services.rds.container.RdsContainerManager;
@@ -94,6 +95,7 @@ public class EmulatorLifecycle {
     private final FlociUiManager flociUiManager;
     private final InitLifecycleState initLifecycleState;
     private final SchemaCreationWorker schemaCreationWorker;
+    private final StepFunctionsService stepFunctionsService;
     private final jakarta.enterprise.inject.Instance<ContainerTeardown> containerTeardowns;
     private final PersistentPathValidator persistentPathValidator;
 
@@ -127,6 +129,7 @@ public class EmulatorLifecycle {
                              FlociUiManager flociUiManager,
                              InitLifecycleState initLifecycleState,
                              SchemaCreationWorker schemaCreationWorker,
+                             StepFunctionsService stepFunctionsService,
                              jakarta.enterprise.inject.Instance<ContainerTeardown> containerTeardowns,
                              PersistentPathValidator persistentPathValidator) {
         this.storageFactory = storageFactory;
@@ -159,6 +162,7 @@ public class EmulatorLifecycle {
         this.flociUiManager = flociUiManager;
         this.initLifecycleState = initLifecycleState;
         this.schemaCreationWorker = schemaCreationWorker;
+        this.stepFunctionsService = stepFunctionsService;
         this.containerTeardowns = containerTeardowns;
         this.persistentPathValidator = persistentPathValidator;
     }
@@ -191,6 +195,7 @@ public class EmulatorLifecycle {
         }
         schemaCreationWorker.recoverOrphans();
         schemaCreationWorker.rehydrateSchemas();
+        stepFunctionsService.abortAbandonedExecutions();
 
         sqsPoller.startPersistedPollers();
         kinesisPoller.startPersistedPollers();

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -693,7 +693,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
      */
     public void stopExecution(String arn, String cause, String error) {
         Execution exec = describeExecution(arn);
-        if (!markAborted(exec, error, cause)) {
+        if (!markAborted(arn, exec, error, cause)) {
             return;
         }
         executionStore.put(arn, exec);
@@ -713,7 +713,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         int abandonedCount = 0;
         for (AccountAwareStorageBackend.AccountEntry<Execution> entry
                 : executionStore.scanAllAccountEntries(key -> true)) {
-            if (!markAborted(entry.value(), ABANDONED_ERROR, ABANDONED_CAUSE)) {
+            if (!markAborted(entry.key(), entry.value(), ABANDONED_ERROR, ABANDONED_CAUSE)) {
                 continue;
             }
             executionStore.putForAccount(entry.accountId(), entry.key(), entry.value());
@@ -726,10 +726,12 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     }
 
     /**
-     * Writes the terminal ABORTED status on a running execution and seals its history with
-     * ExecutionAborted, returning false when the execution is already terminal. Persisting the
-     * execution is the caller's, because StopExecution writes it under the caller's account and the
-     * startup sweep writes it under the account the entry came from.
+     * Writes the terminal ABORTED status on a running execution and seals the history filed under
+     * {@code arn}, returning false when the execution is already terminal. The key is the caller's
+     * because it is the one GetExecutionHistory looks the history up by: StopExecution has the ARN
+     * it was called with, the startup sweep has the storage key the entry came under. Persisting
+     * the execution is the caller's too, because StopExecution writes it under the caller's account
+     * and the sweep writes it under the account that owns the entry.
      *
      * <p>The worker thread may still be inside a state when StopExecution runs. It shares this
      * Execution instance and reads the status published here, so the writes are made under the same
@@ -739,7 +741,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
      * is inside left to record, and those events belong to an execution the caller has already been
      * told is finished.
      */
-    private boolean markAborted(Execution exec, String error, String cause) {
+    private boolean markAborted(String arn, Execution exec, String error, String cause) {
         synchronized (exec) {
             if (!"RUNNING".equals(exec.getStatus())) {
                 return false;
@@ -760,7 +762,7 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
         // An execution can outlive its history: the executions are stored, the histories are held in
         // memory only, so a restart in persistent mode brings a RUNNING execution back with nothing
         // behind it. The abort still gets recorded, against a history that starts here.
-        historyCache.computeIfAbsent(exec.getExecutionArn(), key -> new ExecutionHistory())
+        historyCache.computeIfAbsent(arn, key -> new ExecutionHistory())
                 .sealWith("ExecutionAborted", details);
         return true;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -82,12 +82,6 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
             "arn:aws:states:::s3:listObjectsV2");
     private static final Set<String> ITEM_READER_INPUT_TYPES = Set.of(
             "MANIFEST", "JSON", "CSV", "JSONL", "PARQUET");
-    // What an execution abandoned by a restart reports. AWS documents error and cause on
-    // StopExecution as free-form caller strings, so this name takes no States. prefix, which is a
-    // namespace AWS reserves for state-machine errors.
-    private static final String ABANDONED_ERROR = "ExecutionAbandoned";
-    private static final String ABANDONED_CAUSE =
-            "The emulator restarted while this execution was RUNNING; no worker survived it.";
     private static final String RESULT_WRITER_RESOURCE = "arn:aws:states:::s3:putObject";
     private static final Set<String> RESULT_WRITER_TRANSFORMATIONS = Set.of("NONE", "COMPACT", "FLATTEN");
     private static final Set<String> RESULT_WRITER_OUTPUT_TYPES = Set.of("JSON", "JSONL");
@@ -708,12 +702,15 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
      * <p>Scans every account and writes each execution back under the account that owns it: startup
      * has no request context, so the account-scoped accessors would silently cover only the
      * configured default account.
+     *
+     * <p>Aborts with no error and no cause, the shape AWS returns for StopExecution called without
+     * them: the status is the whole report. The WARN below is where the reason lives.
      */
     public void abortAbandonedExecutions() {
         int abandonedCount = 0;
         for (AccountAwareStorageBackend.AccountEntry<Execution> entry
                 : executionStore.scanAllAccountEntries(key -> true)) {
-            if (!markAborted(entry.key(), entry.value(), ABANDONED_ERROR, ABANDONED_CAUSE)) {
+            if (!markAborted(entry.key(), entry.value(), null, null)) {
                 continue;
             }
             executionStore.putForAccount(entry.accountId(), entry.key(), entry.value());

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsService.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.resource.ExplorerResource;
 import io.github.hectorvent.floci.core.resource.ResourceProvider;
 import io.github.hectorvent.floci.core.resource.SupportedResourceType;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -43,7 +44,8 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     private static final Logger LOG = Logger.getLogger(StepFunctionsService.class);
 
     private final StorageBackend<String, StateMachine> stateMachineStore;
-    private final StorageBackend<String, Execution> executionStore;
+    // Account-aware: the startup sweep has no request context and must reach every account.
+    private final AccountAwareStorageBackend<Execution> executionStore;
     private final StorageBackend<String, Activity> activityStore;
     private final StorageBackend<String, MapRun> mapRunStore;
     private final Map<String, ExecutionHistory> historyCache = new ConcurrentHashMap<>();
@@ -80,6 +82,12 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
             "arn:aws:states:::s3:listObjectsV2");
     private static final Set<String> ITEM_READER_INPUT_TYPES = Set.of(
             "MANIFEST", "JSON", "CSV", "JSONL", "PARQUET");
+    // What an execution abandoned by a restart reports. AWS documents error and cause on
+    // StopExecution as free-form caller strings, so this name takes no States. prefix, which is a
+    // namespace AWS reserves for state-machine errors.
+    private static final String ABANDONED_ERROR = "ExecutionAbandoned";
+    private static final String ABANDONED_CAUSE =
+            "The emulator restarted while this execution was RUNNING; no worker survived it.";
     private static final String RESULT_WRITER_RESOURCE = "arn:aws:states:::s3:putObject";
     private static final Set<String> RESULT_WRITER_TRANSFORMATIONS = Set.of("NONE", "COMPACT", "FLATTEN");
     private static final Set<String> RESULT_WRITER_OUTPUT_TYPES = Set.of("JSON", "JSONL");
@@ -680,36 +688,81 @@ public class StepFunctionsService implements Resettable, ResourceProvider {
     /**
      * Aborts a running execution. The caller's {@code error} and {@code cause} land on the
      * Execution itself, not only on the history event, so DescribeExecution reports them.
-     *
-     * <p>The worker thread may still be inside a state when this runs. It shares this Execution
-     * instance and reads the status it publishes here, so the writes are made under the same
-     * monitor the worker's terminal write takes: ABORTED is the status that stands.
-     *
-     * <p>ExecutionAborted seals the history for the same reason: the worker still has the state it
-     * is inside left to record, and those events belong to an execution the caller has already
-     * been told is finished.
+     * {@link #markAborted} carries the terminal write and the reasons it is made under the
+     * Execution's own monitor.
      */
     public void stopExecution(String arn, String cause, String error) {
         Execution exec = describeExecution(arn);
+        if (!markAborted(exec, error, cause)) {
+            return;
+        }
+        executionStore.put(arn, exec);
+    }
+
+    /**
+     * Retires the executions a restart abandoned: they came back from storage as RUNNING with no
+     * worker behind them, and their only other writers, the worker and StopExecution, are gone.
+     * Called once at startup, before any request is served, so it takes no lock beyond the one
+     * {@link #markAborted} takes on each Execution.
+     *
+     * <p>Scans every account and writes each execution back under the account that owns it: startup
+     * has no request context, so the account-scoped accessors would silently cover only the
+     * configured default account.
+     */
+    public void abortAbandonedExecutions() {
+        int abandonedCount = 0;
+        for (AccountAwareStorageBackend.AccountEntry<Execution> entry
+                : executionStore.scanAllAccountEntries(key -> true)) {
+            if (!markAborted(entry.value(), ABANDONED_ERROR, ABANDONED_CAUSE)) {
+                continue;
+            }
+            executionStore.putForAccount(entry.accountId(), entry.key(), entry.value());
+            abandonedCount++;
+        }
+        if (abandonedCount > 0) {
+            LOG.warnv("Aborted {0} Step Functions execution(s) left RUNNING by a restart",
+                    abandonedCount);
+        }
+    }
+
+    /**
+     * Writes the terminal ABORTED status on a running execution and seals its history with
+     * ExecutionAborted, returning false when the execution is already terminal. Persisting the
+     * execution is the caller's, because StopExecution writes it under the caller's account and the
+     * startup sweep writes it under the account the entry came from.
+     *
+     * <p>The worker thread may still be inside a state when StopExecution runs. It shares this
+     * Execution instance and reads the status published here, so the writes are made under the same
+     * monitor the worker's terminal write takes: ABORTED is the status that stands.
+     *
+     * <p>ExecutionAborted seals the history for the same reason: the worker still has the state it
+     * is inside left to record, and those events belong to an execution the caller has already been
+     * told is finished.
+     */
+    private boolean markAborted(Execution exec, String error, String cause) {
         synchronized (exec) {
             if (!"RUNNING".equals(exec.getStatus())) {
-                return;
+                return false;
             }
             exec.setError(error);
             exec.setCause(cause);
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
             exec.setStatus("ABORTED");
         }
-        executionStore.put(arn, exec);
 
         Map<String, Object> details = new HashMap<>();
-        if (error != null) details.put("error", error);
-        if (cause != null) details.put("cause", cause);
+        if (error != null) {
+            details.put("error", error);
+        }
+        if (cause != null) {
+            details.put("cause", cause);
+        }
         // An execution can outlive its history: the executions are stored, the histories are held in
         // memory only, so a restart in persistent mode brings a RUNNING execution back with nothing
         // behind it. The abort still gets recorded, against a history that starts here.
-        historyCache.computeIfAbsent(arn, key -> new ExecutionHistory())
+        historyCache.computeIfAbsent(exec.getExecutionArn(), key -> new ExecutionHistory())
                 .sealWith("ExecutionAborted", details);
+        return true;
     }
 
     public List<HistoryEvent> getExecutionHistory(String arn) {

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -225,18 +225,6 @@ class EmulatorLifecycleTest {
     }
 
     @Test
-    @DisplayName("Should abort Step Functions executions abandoned by a restart on startup")
-    void shouldAbortAbandonedStepFunctionsExecutionsOnStartup() {
-        stubStorageConfig();
-        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
-        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
-
-        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
-
-        verify(stepFunctionsService).abortAbandonedExecutions();
-    }
-
-    @Test
     @DisplayName("Should abort abandoned Step Functions executions after loading storage")
     void shouldAbortAbandonedStepFunctionsExecutionsAfterStorageLoad() {
         stubStorageConfig();

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorLifecycleTest.java
@@ -91,6 +91,7 @@ class EmulatorLifecycleTest {
     @Mock private PersistentPathValidator persistentPathValidator;
     @Mock private EmulatorConfig.TlsConfig tlsConfig;
     @Mock private io.github.hectorvent.floci.services.appsync.graphql.SchemaCreationWorker schemaCreationWorker;
+    @Mock private io.github.hectorvent.floci.services.stepfunctions.StepFunctionsService stepFunctionsService;
     @Mock private jakarta.enterprise.inject.Instance<io.github.hectorvent.floci.core.common.ContainerTeardown> containerTeardowns;
 
     private EmulatorLifecycle emulatorLifecycle;
@@ -120,7 +121,7 @@ class EmulatorLifecycleTest {
                 rabbitMqManager, flinkContainerManager, rdsService, elbV2Service, elbClassicService,
                 initializationHooksRunner, sqsPoller, kinesisPoller, dynamodbStreamsPoller,
                 pipesService, ec2MetadataServer, ecrRegistryManager, flociUiManager, initLifecycleState,
-                schemaCreationWorker, containerTeardowns, persistentPathValidator);
+                schemaCreationWorker, stepFunctionsService, containerTeardowns, persistentPathValidator);
         Mockito.lenient().when(containerTeardowns.iterator())
                 .thenReturn(java.util.Collections.emptyIterator());
     }
@@ -221,6 +222,32 @@ class EmulatorLifecycleTest {
         inOrder.verify(storageFactory).loadAll();
         inOrder.verify(schemaCreationWorker).recoverOrphans();
         inOrder.verify(schemaCreationWorker).rehydrateSchemas();
+    }
+
+    @Test
+    @DisplayName("Should abort Step Functions executions abandoned by a restart on startup")
+    void shouldAbortAbandonedStepFunctionsExecutionsOnStartup() {
+        stubStorageConfig();
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        verify(stepFunctionsService).abortAbandonedExecutions();
+    }
+
+    @Test
+    @DisplayName("Should abort abandoned Step Functions executions after loading storage")
+    void shouldAbortAbandonedStepFunctionsExecutionsAfterStorageLoad() {
+        stubStorageConfig();
+        when(initializationHooksRunner.hasHooks(InitializationHook.START)).thenReturn(false);
+        when(initializationHooksRunner.hasHooks(InitializationHook.READY)).thenReturn(false);
+
+        emulatorLifecycle.onStart(Mockito.mock(StartupEvent.class));
+
+        var inOrder = Mockito.inOrder(storageFactory, stepFunctionsService);
+        inOrder.verify(storageFactory).loadAll();
+        inOrder.verify(stepFunctionsService).abortAbandonedExecutions();
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
@@ -38,6 +38,8 @@ class StepFunctionsServicePersistenceTest {
             "arn:aws:states:us-east-1:222222222222:execution:TestStateMachine:HelloWorld";
     private static final String STATE_MACHINE_ARN =
             "arn:aws:states:us-east-1:000000000000:stateMachine:TestStateMachine";
+    private static final double EPOCH_SECONDS_2023_11_14 = 1700000000.0;
+    private static final double EPOCH_SECONDS_2100_01_01 = 4102444800.0;
     private static final String ABANDONED_ERROR = "ExecutionAbandoned";
     private static final String ABANDONED_CAUSE =
             "The emulator restarted while this execution was RUNNING; no worker survived it.";
@@ -61,7 +63,7 @@ class StepFunctionsServicePersistenceTest {
         assertEquals("ABORTED", reloaded.getStatus());
         assertEquals(ABANDONED_ERROR, reloaded.getError());
         assertEquals(ABANDONED_CAUSE, reloaded.getCause());
-        assertNotNull(reloaded.getStopDate());
+        assertStopDateInEpochSeconds(reloaded.getStopDate());
 
         List<HistoryEvent> history = afterRestart.getExecutionHistory(EXECUTION_ARN);
         assertEquals(1, history.size());
@@ -92,13 +94,12 @@ class StepFunctionsServicePersistenceTest {
             serviceLogger.removeHandler(collector);
         }
 
-        // The level is compared by value: under JBoss LogManager the record carries its own WARN
-        // instance, not the java.util.logging constant.
-        assertTrue(logRecords.stream().anyMatch(record ->
-                        record.getLevel().intValue() == Level.WARNING.intValue()
-                        && formatted(record)
-                                .contains("Aborted 1 Step Functions execution(s) left RUNNING by a restart")),
-                "expected a WARN record naming how many executions the sweep aborted, got: " + logRecords);
+        List<LogRecord> warnings = warningsIn(logRecords);
+        assertEquals(1, warnings.size(),
+                "expected one WARN record for the sweep, got: " + formattedAll(logRecords));
+        assertTrue(formatted(warnings.getFirst()).contains("1"),
+                "expected the WARN record to name how many executions were aborted, got: "
+                        + formatted(warnings.getFirst()));
 
         Optional<Execution> owned =
                 executions.getForAccount(OTHER_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN);
@@ -106,7 +107,7 @@ class StepFunctionsServicePersistenceTest {
         assertEquals("ABORTED", owned.get().getStatus());
         assertEquals(ABANDONED_ERROR, owned.get().getError());
         assertEquals(ABANDONED_CAUSE, owned.get().getCause());
-        assertNotNull(owned.get().getStopDate());
+        assertStopDateInEpochSeconds(owned.get().getStopDate());
         assertEquals(Optional.empty(),
                 executions.getForAccount(DEFAULT_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN));
 
@@ -129,7 +130,21 @@ class StepFunctionsServicePersistenceTest {
         afterRestart.abortAbandonedExecutions();
         Double stopDateOfFirstSweep =
                 afterRestart.describeExecution(EXECUTION_ARN).getStopDate();
-        afterRestart.abortAbandonedExecutions();
+
+        // Nothing is RUNNING any more, so the second sweep retires nothing and says nothing: a WARN
+        // on every clean boot is the noise the repo's logging rule forbids.
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler collector = collectorInto(logRecords);
+        Logger serviceLogger = Logger.getLogger(StepFunctionsService.class.getName());
+        serviceLogger.addHandler(collector);
+        try {
+            afterRestart.abortAbandonedExecutions();
+        } finally {
+            serviceLogger.removeHandler(collector);
+        }
+        assertEquals(List.of(), warningsIn(logRecords),
+                "expected no WARN record from a sweep that found nothing RUNNING, got: "
+                        + formattedAll(logRecords));
 
         Execution untouched = afterRestart.describeExecution(succeeded.getExecutionArn());
         assertEquals("SUCCEEDED", untouched.getStatus());
@@ -162,6 +177,28 @@ class StepFunctionsServicePersistenceTest {
         };
         collector.setLevel(Level.ALL);
         return collector;
+    }
+
+    private static List<LogRecord> warningsIn(List<LogRecord> records) {
+        // The level is compared by value: under JBoss LogManager the record carries its own WARN
+        // instance, not the java.util.logging constant.
+        return records.stream()
+                .filter(record -> record.getLevel().intValue() == Level.WARNING.intValue())
+                .toList();
+    }
+
+    private static List<String> formattedAll(List<LogRecord> records) {
+        return records.stream().map(StepFunctionsServicePersistenceTest::formatted).toList();
+    }
+
+    /**
+     * A stopDate DescribeExecution can report: epoch seconds, between 2023-11-14 and 2100-01-01.
+     * Both bounds are literals, so a stopDate written in another unit fails here.
+     */
+    private static void assertStopDateInEpochSeconds(Double stopDate) {
+        assertNotNull(stopDate);
+        assertTrue(stopDate > EPOCH_SECONDS_2023_11_14 && stopDate < EPOCH_SECONDS_2100_01_01,
+                "stopDate is not a plausible epoch-seconds instant: " + stopDate);
     }
 
     /** The record as a reader sees it, whether the handler receives it formatted or as a pattern. */

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
@@ -11,10 +11,16 @@ import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.text.MessageFormat;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -76,7 +82,23 @@ class StepFunctionsServicePersistenceTest {
         executions.putForAccount(OTHER_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN,
                 running(OTHER_ACCOUNT_EXECUTION_ARN));
 
-        serviceWithStorage(storage).abortAbandonedExecutions();
+        List<LogRecord> logRecords = new ArrayList<>();
+        Handler collector = collectorInto(logRecords);
+        Logger serviceLogger = Logger.getLogger(StepFunctionsService.class.getName());
+        serviceLogger.addHandler(collector);
+        try {
+            serviceWithStorage(storage).abortAbandonedExecutions();
+        } finally {
+            serviceLogger.removeHandler(collector);
+        }
+
+        // The level is compared by value: under JBoss LogManager the record carries its own WARN
+        // instance, not the java.util.logging constant.
+        assertTrue(logRecords.stream().anyMatch(record ->
+                        record.getLevel().intValue() == Level.WARNING.intValue()
+                        && formatted(record)
+                                .contains("Aborted 1 Step Functions execution(s) left RUNNING by a restart")),
+                "expected a WARN record naming how many executions the sweep aborted, got: " + logRecords);
 
         Optional<Execution> owned =
                 executions.getForAccount(OTHER_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN);
@@ -121,6 +143,34 @@ class StepFunctionsServicePersistenceTest {
         assertEquals(1, afterRestart.getExecutionHistory(EXECUTION_ARN).size());
 
         verifyNoInteractions(aslExecutor, mockLoader, regionResolver);
+    }
+
+    private static Handler collectorInto(List<LogRecord> records) {
+        Handler collector = new Handler() {
+            @Override
+            public void publish(LogRecord record) {
+                records.add(record);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        collector.setLevel(Level.ALL);
+        return collector;
+    }
+
+    /** The record as a reader sees it, whether the handler receives it formatted or as a pattern. */
+    private static String formatted(LogRecord record) {
+        Object[] parameters = record.getParameters();
+        if (parameters == null || parameters.length == 0) {
+            return String.valueOf(record.getMessage());
+        }
+        return MessageFormat.format(record.getMessage(), parameters);
     }
 
     private static Execution running(String executionArn) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
@@ -1,0 +1,162 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+/** Verifies executions abandoned by a restart reach a terminal status when the emulator comes back. */
+class StepFunctionsServicePersistenceTest {
+
+    private static final String DEFAULT_ACCOUNT = "000000000000";
+    private static final String OTHER_ACCOUNT = "222222222222";
+    private static final String EXECUTION_ARN =
+            "arn:aws:states:us-east-1:000000000000:execution:TestStateMachine:HelloWorld";
+    private static final String OTHER_ACCOUNT_EXECUTION_ARN =
+            "arn:aws:states:us-east-1:222222222222:execution:TestStateMachine:HelloWorld";
+    private static final String STATE_MACHINE_ARN =
+            "arn:aws:states:us-east-1:000000000000:stateMachine:TestStateMachine";
+    private static final String ABANDONED_ERROR = "ExecutionAbandoned";
+    private static final String ABANDONED_CAUSE =
+            "The emulator restarted while this execution was RUNNING; no worker survived it.";
+
+    private final AslExecutor aslExecutor = Mockito.mock(AslExecutor.class);
+    private final SfnMockLoader mockLoader = Mockito.mock(SfnMockLoader.class);
+    private final RegionResolver regionResolver = Mockito.mock(RegionResolver.class);
+
+    @Test
+    void abandonedRunningExecutionIsAbortedOnRestart() {
+        SharedStorageFactory storage = new SharedStorageFactory();
+        AccountAwareStorageBackend<Execution> executions = executionStore(storage);
+        StepFunctionsService beforeRestart = serviceWithStorage(storage);
+        executions.putForAccount(DEFAULT_ACCOUNT, EXECUTION_ARN, running(EXECUTION_ARN));
+        assertEquals("RUNNING", beforeRestart.describeExecution(EXECUTION_ARN).getStatus());
+
+        StepFunctionsService afterRestart = serviceWithStorage(storage);
+        afterRestart.abortAbandonedExecutions();
+
+        Execution reloaded = afterRestart.describeExecution(EXECUTION_ARN);
+        assertEquals("ABORTED", reloaded.getStatus());
+        assertEquals(ABANDONED_ERROR, reloaded.getError());
+        assertEquals(ABANDONED_CAUSE, reloaded.getCause());
+        assertNotNull(reloaded.getStopDate());
+
+        List<HistoryEvent> history = afterRestart.getExecutionHistory(EXECUTION_ARN);
+        assertEquals(1, history.size());
+        HistoryEvent aborted = history.getFirst();
+        assertEquals("ExecutionAborted", aborted.getType());
+        assertEquals(1L, aborted.getId());
+        assertEquals(Long.valueOf(0L), aborted.getPreviousEventId());
+        assertEquals(ABANDONED_ERROR, aborted.getDetails().get("error"));
+        assertEquals(ABANDONED_CAUSE, aborted.getDetails().get("cause"));
+
+        verifyNoInteractions(aslExecutor, mockLoader, regionResolver);
+    }
+
+    @Test
+    void abandonedExecutionOfAnotherAccountStaysInItsOwnAccount() {
+        SharedStorageFactory storage = new SharedStorageFactory();
+        AccountAwareStorageBackend<Execution> executions = executionStore(storage);
+        executions.putForAccount(OTHER_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN,
+                running(OTHER_ACCOUNT_EXECUTION_ARN));
+
+        serviceWithStorage(storage).abortAbandonedExecutions();
+
+        Optional<Execution> owned =
+                executions.getForAccount(OTHER_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN);
+        assertTrue(owned.isPresent());
+        assertEquals("ABORTED", owned.get().getStatus());
+        assertEquals(ABANDONED_ERROR, owned.get().getError());
+        assertEquals(ABANDONED_CAUSE, owned.get().getCause());
+        assertNotNull(owned.get().getStopDate());
+        assertEquals(Optional.empty(),
+                executions.getForAccount(DEFAULT_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN));
+
+        verifyNoInteractions(aslExecutor, mockLoader, regionResolver);
+    }
+
+    @Test
+    void terminalExecutionsAreUntouchedAndTheSweepIsIdempotent() {
+        SharedStorageFactory storage = new SharedStorageFactory();
+        AccountAwareStorageBackend<Execution> executions = executionStore(storage);
+        Execution succeeded = running("arn:aws:states:us-east-1:000000000000:execution:"
+                + "TestStateMachine:HelloWorldDone");
+        succeeded.setStatus("SUCCEEDED");
+        succeeded.setOutput("{\"greeting\":\"hello\"}");
+        succeeded.setStopDate(1700000000.0);
+        executions.putForAccount(DEFAULT_ACCOUNT, succeeded.getExecutionArn(), succeeded);
+        executions.putForAccount(DEFAULT_ACCOUNT, EXECUTION_ARN, running(EXECUTION_ARN));
+
+        StepFunctionsService afterRestart = serviceWithStorage(storage);
+        afterRestart.abortAbandonedExecutions();
+        Double stopDateOfFirstSweep =
+                afterRestart.describeExecution(EXECUTION_ARN).getStopDate();
+        afterRestart.abortAbandonedExecutions();
+
+        Execution untouched = afterRestart.describeExecution(succeeded.getExecutionArn());
+        assertEquals("SUCCEEDED", untouched.getStatus());
+        assertEquals("{\"greeting\":\"hello\"}", untouched.getOutput());
+        assertEquals(Double.valueOf(1700000000.0), untouched.getStopDate());
+        assertEquals(List.of(), afterRestart.getExecutionHistory(succeeded.getExecutionArn()));
+
+        Execution abandoned = afterRestart.describeExecution(EXECUTION_ARN);
+        assertEquals("ABORTED", abandoned.getStatus());
+        assertEquals(stopDateOfFirstSweep, abandoned.getStopDate());
+        assertEquals(1, afterRestart.getExecutionHistory(EXECUTION_ARN).size());
+
+        verifyNoInteractions(aslExecutor, mockLoader, regionResolver);
+    }
+
+    private static Execution running(String executionArn) {
+        Execution execution = new Execution();
+        execution.setExecutionArn(executionArn);
+        execution.setStateMachineArn(STATE_MACHINE_ARN);
+        execution.setName("HelloWorld");
+        execution.setInput("{}");
+        execution.setStatus("RUNNING");
+        return execution;
+    }
+
+    private StepFunctionsService serviceWithStorage(StorageFactory storage) {
+        return new StepFunctionsService(storage, regionResolver, aslExecutor,
+                new ObjectMapper(), mockLoader);
+    }
+
+    private static AccountAwareStorageBackend<Execution> executionStore(SharedStorageFactory storage) {
+        return storage.create("stepfunctions", "sfn-executions.json",
+                new TypeReference<Map<String, Execution>>() {});
+    }
+
+    private static final class SharedStorageFactory extends StorageFactory {
+        private final Map<String, StorageBackend<String, ?>> stores = new HashMap<>();
+
+        private SharedStorageFactory() {
+            super(null, null);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <V> AccountAwareStorageBackend<V> create(String serviceName,
+                                                       String fileName,
+                                                       TypeReference<Map<String, V>> typeReference) {
+            return (AccountAwareStorageBackend<V>) stores.computeIfAbsent(
+                    fileName, ignored -> AccountAwareStorageBackend.inMemory(DEFAULT_ACCOUNT));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
@@ -24,6 +24,7 @@ import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -40,9 +41,6 @@ class StepFunctionsServicePersistenceTest {
             "arn:aws:states:us-east-1:000000000000:stateMachine:TestStateMachine";
     private static final double EPOCH_SECONDS_2023_11_14 = 1700000000.0;
     private static final double EPOCH_SECONDS_2100_01_01 = 4102444800.0;
-    private static final String ABANDONED_ERROR = "ExecutionAbandoned";
-    private static final String ABANDONED_CAUSE =
-            "The emulator restarted while this execution was RUNNING; no worker survived it.";
 
     private final AslExecutor aslExecutor = Mockito.mock(AslExecutor.class);
     private final SfnMockLoader mockLoader = Mockito.mock(SfnMockLoader.class);
@@ -59,10 +57,12 @@ class StepFunctionsServicePersistenceTest {
         StepFunctionsService afterRestart = serviceWithStorage(storage);
         afterRestart.abortAbandonedExecutions();
 
+        // The shape AWS returns for an execution stopped with no error and no cause: the status is
+        // the whole report, and error and cause are left off DescribeExecution and off the event.
         Execution reloaded = afterRestart.describeExecution(EXECUTION_ARN);
         assertEquals("ABORTED", reloaded.getStatus());
-        assertEquals(ABANDONED_ERROR, reloaded.getError());
-        assertEquals(ABANDONED_CAUSE, reloaded.getCause());
+        assertNull(reloaded.getError());
+        assertNull(reloaded.getCause());
         assertStopDateInEpochSeconds(reloaded.getStopDate());
 
         List<HistoryEvent> history = afterRestart.getExecutionHistory(EXECUTION_ARN);
@@ -71,8 +71,7 @@ class StepFunctionsServicePersistenceTest {
         assertEquals("ExecutionAborted", aborted.getType());
         assertEquals(1L, aborted.getId());
         assertEquals(Long.valueOf(0L), aborted.getPreviousEventId());
-        assertEquals(ABANDONED_ERROR, aborted.getDetails().get("error"));
-        assertEquals(ABANDONED_CAUSE, aborted.getDetails().get("cause"));
+        assertEquals(Map.of(), aborted.getDetails());
 
         verifyNoInteractions(aslExecutor, mockLoader, regionResolver);
     }
@@ -105,8 +104,8 @@ class StepFunctionsServicePersistenceTest {
                 executions.getForAccount(OTHER_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN);
         assertTrue(owned.isPresent());
         assertEquals("ABORTED", owned.get().getStatus());
-        assertEquals(ABANDONED_ERROR, owned.get().getError());
-        assertEquals(ABANDONED_CAUSE, owned.get().getCause());
+        assertNull(owned.get().getError());
+        assertNull(owned.get().getCause());
         assertStopDateInEpochSeconds(owned.get().getStopDate());
         assertEquals(Optional.empty(),
                 executions.getForAccount(DEFAULT_ACCOUNT, OTHER_ACCOUNT_EXECUTION_ARN));

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsStopExecutionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsStopExecutionIntegrationTest.java
@@ -15,6 +15,7 @@ import java.util.UUID;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Guards that {@code StopExecution} stops the execution instead of relabelling it: the status,
@@ -92,6 +93,40 @@ class StepFunctionsStopExecutionIntegrationTest {
         assertEquals("Manual", described.jsonPath().getString("error"));
         assertEquals("probe", described.jsonPath().getString("cause"));
         assertEquals(stopDate, described.jsonPath().getDouble("stopDate"));
+    }
+
+    /**
+     * Measured against us-east-1: an abort with no error and no cause leaves both keys out of
+     * {@code DescribeExecution} and carries an empty {@code executionAbortedEventDetails}. This is
+     * the terminal write the startup sweep of abandoned executions makes as well.
+     */
+    @Test
+    void abortWithNoReasonOmitsErrorAndCause() throws Exception {
+        String executionArn = startWaitingExecution("stop-without-reason");
+        Thread.sleep(300);
+
+        given()
+                .header("X-Amz-Target", "AWSStepFunctions.StopExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(executionArn))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+
+        Map<String, Object> described = describeExecution(executionArn).jsonPath().getMap("$");
+        assertEquals("ABORTED", described.get("status"));
+        // Absent, not null: a null value would leave the key in place and here it is gone.
+        assertFalse(described.containsKey("error"), "DescribeExecution kept error: " + described);
+        assertFalse(described.containsKey("cause"), "DescribeExecution kept cause: " + described);
+
+        List<Map<String, Object>> events =
+                getExecutionHistory(executionArn).jsonPath().getList("events");
+        Map<String, Object> aborted = events.get(events.size() - 1);
+        assertEquals("ExecutionAborted", aborted.get("type"));
+        assertEquals(Map.of(), aborted.get("executionAbortedEventDetails"));
     }
 
     @Test


### PR DESCRIPTION
Closes #2965

An execution persisted as `RUNNING` survives a restart with no worker driving it, so `DescribeExecution` reports `RUNNING` forever and the history stops at the last event written before the restart.

`EmulatorLifecycle.onStart` now sweeps Step Functions executions still marked `RUNNING` and closes each one exactly the way AWS closes an abort with no reason, which is the shape the issue records from a measured `StopExecution`:

- `status: ABORTED`
- `DescribeExecution` omits the `error` and `cause` keys rather than sending them as null
- the terminal event carries `executionAbortedEventDetails` present but empty

A restart has no AWS counterpart, so nothing here invents a status or an error code AWS cannot emit. The reason the execution ended lives in the WARN the sweep logs, not in the API response.

A suite waiting on such an execution now fails on a terminal status instead of hanging until its own timeout.

5 commits, 5 files, test-first.
