### PR TITLE
feat(cloudformation): report a stubbed unsupported resource type instead of hiding it

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -297,6 +297,8 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_CLOUDFORMATION_ENABLED` | `true` | Enable the CloudFormation service |
+| `FLOCI_SERVICES_CLOUDFORMATION_ALLOW_STUB_LAMBDA_CODE` | `false` | Fall back to the built-in stub handler for an `AWS::Lambda::Function` whose S3 code cannot be read. Off matches real CloudFormation, which fails the resource and rolls the stack back |
+| `FLOCI_SERVICES_CLOUDFORMATION_ALLOW_STUB_UNSUPPORTED_RESOURCE_TYPES` | `true` | Stub a resource whose type has no provisioner (synthetic physical ID, `arn:aws:stub:::` ARN attribute, `CREATE_COMPLETE`), logged at `WARN` with a resource status reason. Set `false` to fail the resource instead, which rolls the stack back |
 
 ### ACM (Certificate Manager)
 

--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -96,7 +96,18 @@ cross-resource references.
 
 All other resource types are accepted without error and assigned a synthetic physical ID (with an
 `arn:aws:stub:::<logicalId>` ARN attribute), so templates with unsupported types still reach
-`CREATE_COMPLETE` rather than failing.
+`CREATE_COMPLETE` rather than failing. Nothing is created for such a resource, so each one is
+logged at `WARN` and carries a resource status reason saying so, which `DescribeStackEvents`
+returns:
+
+```
+Resource type AWS::Fake::Thing is not supported by Floci. It was stubbed and nothing was created for it.
+```
+
+Set `floci.services.cloudformation.allow-stub-unsupported-resource-types` to `false`
+(`FLOCI_SERVICES_CLOUDFORMATION_ALLOW_STUB_UNSUPPORTED_RESOURCE_TYPES=false`) to fail such a
+resource instead: it reaches `CREATE_FAILED` and the stack rolls back. Use it in a pipeline that
+must not pass over a resource it never got.
 
 ## EventBridge Event Buses
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1415,6 +1415,20 @@ public interface EmulatorConfig {
          */
         @WithDefault("false")
         boolean allowStubLambdaCode();
+
+        /**
+         * Whether a resource whose type Floci has no provisioner for may be stubbed: a synthetic
+         * physical id, an {@code arn:aws:stub:::} ARN attribute and {@code CREATE_COMPLETE}.
+         *
+         * <p>Defaults to {@code true}, because Floci implements a fraction of the CloudFormation
+         * registry and failing every other type would reject templates that are valid to AWS. The
+         * stub is reported at warn and carries a resource status reason saying nothing was created,
+         * so a {@code CREATE_COMPLETE} stack can still be read as one where some resources exist
+         * only on paper. Set to {@code false} to fail such a resource instead, which rolls the
+         * stack back, for a pipeline that must not pass over a resource it never got.
+         */
+        @WithDefault("true")
+        boolean allowStubUnsupportedResourceTypes();
     }
 
     interface AcmServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -516,6 +516,13 @@ public class CloudFormationResourceProvisioner {
                         throw new IllegalStateException("No switch arm for declared legacy type "
                                 + resourceType + " — remove its LEGACY_SWITCH_TYPES entry when it "
                                 + "moves to a per-service provisioner.");
+                    } else if (!stubUnsupportedResourceTypesAllowed()) {
+                        // Before the physical id below is assigned, so the Cloud Control path sees
+                        // a resource with none and reports this message rather than a success. On
+                        // the stack path the catch below turns it into CREATE_FAILED with the same
+                        // sentence, which rolls the stack back.
+                        throw new AwsException("ValidationError",
+                                unsupportedResourceTypeMessage(resourceType), 400);
                     } else {
                         // Warn, not debug, and a status reason on the resource: the stub reports
                         // CREATE_COMPLETE while creating nothing, so without both the stack is
@@ -541,6 +548,15 @@ public class CloudFormationResourceProvisioner {
             resource.setStatusReason(e.getMessage());
         }
         return resource;
+    }
+
+    /**
+     * Whether a resource type with no provisioner may be stubbed. The provisioners hand-built in
+     * unit tests carry no config; absent configuration means the documented default, which here is
+     * the lenient behaviour, so the test reads {@code config == null ||}.
+     */
+    private boolean stubUnsupportedResourceTypesAllowed() {
+        return config == null || config.services().cloudformation().allowStubUnsupportedResourceTypes();
     }
 
     /** The one sentence Floci says about a resource type it has no provisioner for. */

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -374,7 +374,12 @@ public class CloudFormationResourceProvisioner {
 
     /**
      * Provisions a single resource. Returns the populated StackResource (physicalId + attributes set).
-     * Returns null and logs a warning for unsupported types.
+     *
+     * <p>A resource type with no provisioner is stubbed: a synthetic physical id, an
+     * {@code arn:aws:stub:::} ARN attribute and {@code CREATE_COMPLETE}, logged at warn and
+     * carrying a status reason saying nothing was created. With
+     * {@code floci.services.cloudformation.allow-stub-unsupported-resource-types} off it comes back
+     * {@code CREATE_FAILED} instead, with no physical id.
      */
     public StackResource provision(String logicalId, String resourceType, JsonNode properties,
                                    CloudFormationTemplateEngine engine, String region, String accountId,

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -774,8 +774,10 @@ public class CloudFormationResourceProvisioner {
             case "AWS::CloudFront::Distribution" -> cloudFrontService.removeDistribution(physicalId);
             // Warn for the same reason the create path does: the delete reports success over a
             // type nothing here removes, and at debug that is invisible at the default log level.
-            default -> LOG.warnv("Skipping delete of unsupported resource type {0}: nothing was "
-                    + "created for it.", resourceType);
+            // The create switch provisions types this one does not delete, so the line names the
+            // physical id left live in the service's store instead of claiming nothing was created.
+            default -> LOG.warnv("No delete implemented for resource type {0}: leaving {1} in "
+                    + "place.", resourceType, physicalId);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -774,10 +774,11 @@ public class CloudFormationResourceProvisioner {
             case "AWS::CloudFront::Distribution" -> cloudFrontService.removeDistribution(physicalId);
             // Warn for the same reason the create path does: the delete reports success over a
             // type nothing here removes, and at debug that is invisible at the default log level.
-            // The create switch provisions types this one does not delete, so the line names the
-            // physical id left live in the service's store instead of claiming nothing was created.
-            default -> LOG.warnv("No delete implemented for resource type {0}: leaving {1} in "
-                    + "place.", resourceType, physicalId);
+            // The line names the physical id without claiming a resource survives it: this arm
+            // takes both a type the create switch provisioned and one it only stubbed, and only
+            // the first leaves something behind.
+            default -> LOG.warnv("No delete implemented for resource type {0}: {1} is not removed "
+                    + "here.", resourceType, physicalId);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -517,7 +517,18 @@ public class CloudFormationResourceProvisioner {
                                 + resourceType + " — remove its LEGACY_SWITCH_TYPES entry when it "
                                 + "moves to a per-service provisioner.");
                     } else {
-                        LOG.debugv("Stubbing unsupported resource type: {0} ({1})", resourceType, logicalId);
+                        // Warn, not debug, and a status reason on the resource: the stub reports
+                        // CREATE_COMPLETE while creating nothing, so without both the stack is
+                        // indistinguishable from one where every resource was really provisioned.
+                        // The reason reaches DescribeStackEvents through the event
+                        // CloudFormationService already builds from it.
+                        LOG.warnv("Stubbing unsupported resource type {0} ({1}): nothing is created "
+                                        + "for it. Set floci.services.cloudformation."
+                                        + "allow-stub-unsupported-resource-types=false to fail the "
+                                        + "stack instead.",
+                                resourceType, logicalId);
+                        resource.setStatusReason(unsupportedResourceTypeMessage(resourceType)
+                                + " It was stubbed and nothing was created for it.");
                         resource.setPhysicalId(logicalId + "-" + UUID.randomUUID().toString().substring(0, 8));
                         resource.getAttributes().put("Arn", "arn:aws:stub:::" + logicalId);
                     }
@@ -530,6 +541,11 @@ public class CloudFormationResourceProvisioner {
             resource.setStatusReason(e.getMessage());
         }
         return resource;
+    }
+
+    /** The one sentence Floci says about a resource type it has no provisioner for. */
+    static String unsupportedResourceTypeMessage(String resourceType) {
+        return "Resource type " + resourceType + " is not supported by Floci.";
     }
 
     /**
@@ -735,7 +751,10 @@ public class CloudFormationResourceProvisioner {
             case "AWS::AutoScaling::AutoScalingGroup" ->
                     autoScalingService.deleteAutoScalingGroup(region, physicalId, true);
             case "AWS::CloudFront::Distribution" -> cloudFrontService.removeDistribution(physicalId);
-            default -> LOG.debugv("Skipping delete of unsupported resource type: {0}", resourceType);
+            // Warn for the same reason the create path does: the delete reports success over a
+            // type nothing here removes, and at debug that is invisible at the default log level.
+            default -> LOG.warnv("Skipping delete of unsupported resource type {0}: nothing was "
+                    + "created for it.", resourceType);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessor.java
@@ -127,7 +127,10 @@ class SamTransformProcessor {
                         // copyResourceLevelAttributes runs inside expandServerlessStateMachine
                         // itself (its one caller already owning the source resDef).
                         expandServerlessStateMachine(logicalId, resDef, expandedResources);
-                default -> LOG.debugv("Unsupported SAM resource type: {0} ({1})", type, logicalId);
+                // Warn: the type stays in the template and the provisioner stubs it, so at debug
+                // this is the first of two silences on one path and the stack still reports green.
+                default -> LOG.warnv("Unsupported SAM resource type {0} ({1}): left in the "
+                        + "template for the CloudFormation provisioner.", type, logicalId);
             }
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -385,6 +385,10 @@ floci:
       # Fail an AWS::Lambda::Function whose S3 code cannot be read, as real CloudFormation
       # does. Set true to fall back to the built-in stub handler instead (issue #2648).
       allow-stub-lambda-code: false
+      # Stub a resource whose type has no provisioner: synthetic physical id, arn:aws:stub:::
+      # ARN attribute, CREATE_COMPLETE, reported at warn with a resource status reason. Set
+      # false to fail such a resource instead, which rolls the stack back.
+      allow-stub-unsupported-resource-types: true
     acm:
       enabled: true
       validation-wait-seconds: 0

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeStrictIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeStrictIntegrationTest.java
@@ -1,0 +1,63 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.github.hectorvent.floci.services.cloudformation.CloudFormationLambdaMissingS3CodeIntegrationTest.CFN_AUTH;
+import static io.github.hectorvent.floci.services.cloudformation.CloudFormationLambdaMissingS3CodeIntegrationTest.createStack;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * The hard gate a pipeline can set: with
+ * {@code floci.services.cloudformation.allow-stub-unsupported-resource-types} off, a resource type
+ * Floci has no provisioner for fails instead of being stubbed, and the stack rolls back rather than
+ * reporting a green deployment of something that was never created.
+ *
+ * <p>A separate top-level class rather than a nested one, because {@code @TestProfile} applies per
+ * test class and Surefire discovers test classes by file name: a nested class carrying the profile
+ * compiles and passes when targeted directly, but is silently skipped in a full {@code mvn test}.
+ */
+@QuarkusTest
+@TestProfile(CloudFormationUnsupportedResourceTypeStrictIntegrationTest.StrictProfile.class)
+class CloudFormationUnsupportedResourceTypeStrictIntegrationTest {
+
+    public static final class StrictProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.cloudformation.allow-stub-unsupported-resource-types", "false");
+        }
+    }
+
+    @Test
+    void strictProfileRollsTheStackBack() {
+        String stackName = "cfn-unsupported-strict-" + Long.toString(System.nanoTime(), 36);
+
+        createStack(stackName, """
+                {
+                  "Resources": {
+                    "MyThing": {
+                      "Type": "AWS::Fake::Thing",
+                      "Properties": {}
+                    }
+                  }
+                }
+                """);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"))
+            .body(containsString("Resource type AWS::Fake::Thing is not supported by Floci."));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
@@ -52,7 +52,8 @@ class CloudFormationUnsupportedResourceTypeTest {
                     + "Set floci.services.cloudformation.allow-stub-unsupported-resource-types=false "
                     + "to fail the stack instead.";
     private static final String DELETE_WARNING =
-            "Skipping delete of unsupported resource type AWS::Fake::Thing: nothing was created for it.";
+            "No delete implemented for resource type AWS::Fake::Thing: "
+                    + "leaving MyThing-11a79dff in place.";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private CloudFormationResourceProvisioner provisioner;
@@ -113,6 +114,9 @@ class CloudFormationUnsupportedResourceTypeTest {
 
     @Test
     void deleteOfUnsupportedTypeDoesNotThrow() {
+        // The same arm catches a type no provisioner ever created and a type the create switch does
+        // provision and this switch does not remove, so the line says what it leaves behind rather
+        // than claiming nothing was created.
         List<LogRecord> logged = new CopyOnWriteArrayList<>();
 
         assertDoesNotThrow(() -> whileCapturingProvisionerLogs(logged, () -> {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
@@ -53,7 +53,7 @@ class CloudFormationUnsupportedResourceTypeTest {
                     + "to fail the stack instead.";
     private static final String DELETE_WARNING =
             "No delete implemented for resource type AWS::Fake::Thing: "
-                    + "leaving MyThing-11a79dff in place.";
+                    + "MyThing-11a79dff is not removed here.";
 
     private final ObjectMapper mapper = new ObjectMapper();
     private CloudFormationResourceProvisioner provisioner;

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cloudformation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,11 @@ import java.util.logging.LogRecord;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * A resource type Floci has no provisioner for is stubbed: a synthetic physical id, an
@@ -40,6 +45,8 @@ class CloudFormationUnsupportedResourceTypeTest {
     private static final String STUB_REASON =
             "Resource type AWS::Fake::Thing is not supported by Floci. "
                     + "It was stubbed and nothing was created for it.";
+    private static final String STRICT_REASON =
+            "Resource type AWS::Fake::Thing is not supported by Floci.";
     private static final String STUB_WARNING =
             "Stubbing unsupported resource type AWS::Fake::Thing (MyThing): nothing is created for it. "
                     + "Set floci.services.cloudformation.allow-stub-unsupported-resource-types=false "
@@ -80,6 +87,31 @@ class CloudFormationUnsupportedResourceTypeTest {
     }
 
     @Test
+    void unsupportedTypeFailsTheResourceWhenTheStubIsDisallowed() {
+        StackResource resource = provisionerWithStubAllowed(false)
+                .provision(LOGICAL_ID, UNSUPPORTED_TYPE, props(), engine(),
+                        REGION, ACCOUNT_ID, STACK_NAME);
+
+        assertEquals("CREATE_FAILED", resource.getStatus());
+        assertEquals(STRICT_REASON, resource.getStatusReason());
+        // The failure precedes the synthetic physical id, so Cloud Control's own "no physical id"
+        // branch reports the same message instead of a success over a resource that is not there.
+        assertNull(resource.getPhysicalId());
+    }
+
+    @Test
+    void absentConfigMeansTheDocumentedDefault() {
+        // A provisioner built in a unit test carries no config, and the knob defaults to true, so
+        // absent config has to mean the lenient behaviour. Reading it the other way round makes
+        // every config-less provisioner strict.
+        StackResource resource = provisionUnsupported();
+
+        assertEquals("CREATE_COMPLETE", resource.getStatus());
+        assertEquals(STUB_REASON, resource.getStatusReason());
+        assertNotNull(resource.getPhysicalId());
+    }
+
+    @Test
     void deleteOfUnsupportedTypeDoesNotThrow() {
         List<LogRecord> logged = new CopyOnWriteArrayList<>();
 
@@ -92,6 +124,17 @@ class CloudFormationUnsupportedResourceTypeTest {
                         r.getLevel().intValue() >= Level.WARNING.intValue()
                                 && DELETE_WARNING.equals(formatted(r))),
                 "expected the skipped delete to be reported at warn, got: " + rendered(logged));
+    }
+
+    private CloudFormationResourceProvisioner provisionerWithStubAllowed(boolean allowed) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.CloudFormationServiceConfig cloudformation =
+                mock(EmulatorConfig.CloudFormationServiceConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.cloudformation()).thenReturn(cloudformation);
+        when(cloudformation.allowStubUnsupportedResourceTypes()).thenReturn(allowed);
+        return CfnProvisionerFixture.builder().objectMapper(mapper).config(config).build();
     }
 
     private StackResource provisionUnsupported() {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationUnsupportedResourceTypeTest.java
@@ -1,0 +1,158 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A resource type Floci has no provisioner for is stubbed: a synthetic physical id, an
+ * {@code arn:aws:stub:::} ARN attribute and {@code CREATE_COMPLETE}. Stubbing it is the
+ * deliberate behaviour, but doing it silently is not: a green stack that created nothing reads
+ * exactly like a green stack that created everything.
+ *
+ * <p>These tests pin the two things that make the stub observable without changing what it
+ * builds: the resource status reason, which reaches DescribeStackEvents through the reason
+ * CloudFormationService already copies onto the event, and the warn-level log line.
+ */
+class CloudFormationUnsupportedResourceTypeTest {
+
+    private static final String ACCOUNT_ID = "000000000000";
+    private static final String REGION = "us-east-1";
+    private static final String STACK_NAME = "TestStack";
+    private static final String LOGICAL_ID = "MyThing";
+    private static final String UNSUPPORTED_TYPE = "AWS::Fake::Thing";
+
+    private static final String STUB_REASON =
+            "Resource type AWS::Fake::Thing is not supported by Floci. "
+                    + "It was stubbed and nothing was created for it.";
+    private static final String STUB_WARNING =
+            "Stubbing unsupported resource type AWS::Fake::Thing (MyThing): nothing is created for it. "
+                    + "Set floci.services.cloudformation.allow-stub-unsupported-resource-types=false "
+                    + "to fail the stack instead.";
+    private static final String DELETE_WARNING =
+            "Skipping delete of unsupported resource type AWS::Fake::Thing: nothing was created for it.";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private CloudFormationResourceProvisioner provisioner;
+
+    @BeforeEach
+    void setUp() {
+        provisioner = CfnProvisionerFixture.builder().objectMapper(mapper).build();
+    }
+
+    @Test
+    void stubbedResourceCarriesTheUnsupportedTypeReason() {
+        List<LogRecord> logged = new CopyOnWriteArrayList<>();
+        StackResource resource = whileCapturingProvisionerLogs(logged, this::provisionUnsupported);
+
+        assertEquals("CREATE_COMPLETE", resource.getStatus());
+        assertEquals(STUB_REASON, resource.getStatusReason());
+        assertTrue(logged.stream().anyMatch(r ->
+                        r.getLevel().intValue() >= Level.WARNING.intValue()
+                                && STUB_WARNING.equals(formatted(r))),
+                "expected the stub to be reported at warn, got: " + rendered(logged));
+    }
+
+    @Test
+    void stubbedResourceStillCarriesTheStubArn() {
+        // The stub's shape is a persisted contract: a stack created by an older build carries the
+        // synthetic physical id, and the next update has to recognise it.
+        StackResource resource = provisionUnsupported();
+
+        assertEquals("arn:aws:stub:::" + LOGICAL_ID, resource.getAttributes().get("Arn"));
+        assertTrue(resource.getPhysicalId().startsWith(LOGICAL_ID + "-"),
+                "expected the synthetic physical id shape, got: " + resource.getPhysicalId());
+    }
+
+    @Test
+    void deleteOfUnsupportedTypeDoesNotThrow() {
+        List<LogRecord> logged = new CopyOnWriteArrayList<>();
+
+        assertDoesNotThrow(() -> whileCapturingProvisionerLogs(logged, () -> {
+            provisioner.delete(UNSUPPORTED_TYPE, LOGICAL_ID + "-11a79dff", REGION);
+            return null;
+        }));
+
+        assertTrue(logged.stream().anyMatch(r ->
+                        r.getLevel().intValue() >= Level.WARNING.intValue()
+                                && DELETE_WARNING.equals(formatted(r))),
+                "expected the skipped delete to be reported at warn, got: " + rendered(logged));
+    }
+
+    private StackResource provisionUnsupported() {
+        return provisioner.provision(LOGICAL_ID, UNSUPPORTED_TYPE, props(), engine(),
+                REGION, ACCOUNT_ID, STACK_NAME);
+    }
+
+    /** Runs {@code action} with a handler on the provisioner's logger, collecting every record. */
+    private <T> T whileCapturingProvisionerLogs(List<LogRecord> collected,
+                                                java.util.function.Supplier<T> action) {
+        java.util.logging.Logger logger =
+                java.util.logging.Logger.getLogger(CloudFormationResourceProvisioner.class.getName());
+        Level original = logger.getLevel();
+        Handler handler = new Handler() {
+            @Override
+            public void publish(LogRecord logRecord) {
+                collected.add(logRecord);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        logger.addHandler(handler);
+        logger.setLevel(Level.ALL);
+        try {
+            return action.get();
+        } finally {
+            logger.setLevel(original);
+            logger.removeHandler(handler);
+        }
+    }
+
+    /**
+     * The record's text. Which logging backend is in play decides whether the parameters are
+     * already substituted or still carried alongside the pattern, so substitute them here when
+     * they are still there.
+     */
+    private static String formatted(LogRecord record) {
+        Object[] parameters = record.getParameters();
+        return parameters == null || parameters.length == 0
+                ? record.getMessage()
+                : MessageFormat.format(record.getMessage(), parameters);
+    }
+
+    private static List<String> rendered(List<LogRecord> records) {
+        return records.stream().map(r -> r.getLevel() + " " + formatted(r)).toList();
+    }
+
+    private JsonNode props() {
+        return mapper.createObjectNode();
+    }
+
+    private CloudFormationTemplateEngine engine() {
+        return new CloudFormationTemplateEngine(
+                ACCOUNT_ID, REGION, STACK_NAME, "stack/id",
+                Map.of(), Map.of(), Map.of(), Map.of(), Map.of(), mapper,
+                (Function<String, String>) name -> null);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SamTransformProcessorTest.java
@@ -1944,4 +1944,70 @@ class SamTransformProcessorTest {
                         + "'Definition' or 'DefinitionUri' property and not both.",
                 exception.getMessage());
     }
+
+    @Test
+    void unexpandedSamResourceTypeWarns() throws Exception {
+        // A SAM type this processor cannot expand is left in the template, where the provisioner
+        // stubs it. Reported at debug that is the first of two stacked silences on one path, so
+        // the type reaches the stub arm with nothing said about the expansion that never happened.
+        JsonNode template = objectMapper.readTree("""
+            {
+              "Transform": "AWS::Serverless-2016-10-31",
+              "Resources": {
+                "MyApp": {
+                  "Type": "AWS::Serverless::Application",
+                  "Properties": {
+                    "Location": "s3://example-templates/app.yaml"
+                  }
+                }
+              }
+            }
+            """);
+
+        java.util.List<java.util.logging.LogRecord> logged = new java.util.concurrent.CopyOnWriteArrayList<>();
+        java.util.logging.Logger logger =
+                java.util.logging.Logger.getLogger(SamTransformProcessor.class.getName());
+        java.util.logging.Level original = logger.getLevel();
+        java.util.logging.Handler handler = new java.util.logging.Handler() {
+            @Override
+            public void publish(java.util.logging.LogRecord logRecord) {
+                logged.add(logRecord);
+            }
+
+            @Override
+            public void flush() {
+            }
+
+            @Override
+            public void close() {
+            }
+        };
+        logger.addHandler(handler);
+        logger.setLevel(java.util.logging.Level.ALL);
+        try {
+            processor.expandSamTemplate(template);
+        } finally {
+            logger.setLevel(original);
+            logger.removeHandler(handler);
+        }
+
+        String expected = "Unsupported SAM resource type AWS::Serverless::Application (MyApp): "
+                + "left in the template for the CloudFormation provisioner.";
+        assertTrue(logged.stream().anyMatch(r ->
+                        r.getLevel().intValue() >= java.util.logging.Level.WARNING.intValue()
+                                && expected.equals(text(r))),
+                "expected the unexpanded SAM type to be reported at warn, got: "
+                        + logged.stream().map(r -> r.getLevel() + " " + text(r)).toList());
+    }
+
+    /**
+     * The record's text. Which logging backend is in play decides whether the parameters are
+     * already substituted or still carried alongside the pattern.
+     */
+    private static String text(java.util.logging.LogRecord record) {
+        Object[] parameters = record.getParameters();
+        return parameters == null || parameters.length == 0
+                ? record.getMessage()
+                : java.text.MessageFormat.format(record.getMessage(), parameters);
+    }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -223,6 +223,9 @@ floci:
       # Fail an AWS::Lambda::Function whose S3 code cannot be read, as real CloudFormation
       # does. Set true to fall back to the built-in stub handler instead (issue #2648).
       allow-stub-lambda-code: false
+      # Pinned to the shipped default so a test sees what a user sees; the strict-mode test
+      # overrides it with its own profile.
+      allow-stub-unsupported-resource-types: true
     acm:
       enabled: true
       validation-wait-seconds: 0


### PR DESCRIPTION
Closes #2967

An unsupported resource type was stubbed at `debug`, so the stack reached `CREATE_COMPLETE` and a green stack did not prove its resources existed.

Three changes:

- The stub is reported at `warn`, naming the type and the reason it was stubbed.
- A new `allow-stub-unsupported-resource-types` setting turns the stub into a stack failure, for suites that need a green stack to mean every resource exists.
- An unexpanded SAM resource type warns on its own, and the delete path names the resource it leaves in place when no delete is implemented.

The default behaviour is unchanged, so existing templates keep deploying. AWS rejects a registry-absent type at `validate-template` and never creates the stack; a registry-present type with no provisioner has no AWS counterpart, which is why this is a setting rather than a hardcoded failure. Both measurements are in the issue.

9 commits, 10 files, test-first.
