### PR TITLE
feat(autoscaling): warm pools, scheduled actions, traffic sources, and process suspension

### DIFF
--- a/docs/services/autoscaling.md
+++ b/docs/services/autoscaling.md
@@ -10,7 +10,7 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 - `arn:aws:autoscaling:<region>:<account>:launchConfiguration:<uuid>:launchConfigurationName/<name>`
 - `arn:aws:autoscaling:<region>:<account>:scalingPolicy:<uuid>:autoScalingGroupName/<group>/policyName/<name>`
 
-## Supported Operations (33 total)
+## Supported Operations (45 total)
 
 ### Launch Configurations
 
@@ -38,6 +38,8 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 | `AttachInstances` | Attaches existing EC2 instances to a group; sets lifecycle state to `InService` |
 | `DetachInstances` | Detaches instances from a group; optionally decrements desired capacity |
 | `TerminateInstanceInAutoScalingGroup` | Terminates a specific instance; optionally decrements desired capacity |
+| `SuspendProcesses` | Records suspended scaling processes (empty list suspends all); reported back by `DescribeAutoScalingGroups` |
+| `ResumeProcesses` | Clears suspended processes (empty list resumes all) |
 
 ### Load Balancer Attachment
 
@@ -49,6 +51,14 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 | `AttachLoadBalancers` | Classic ELB attachment (stored; no ELB v1 routing) |
 | `DetachLoadBalancers` | Classic ELB detachment |
 | `DescribeLoadBalancers` | Lists classic ELBs attached to a group |
+
+### Traffic Sources
+
+| Operation | Notes |
+|---|---|
+| `AttachTrafficSources` | Unified elb/elbv2/vpc-lattice attachment API; stored per identifier with its type |
+| `DetachTrafficSources` | Removes a traffic source by identifier |
+| `DescribeTrafficSources` | Lists attached sources, optionally filtered by type; every source reports `InService` |
 
 ### Lifecycle Hooks
 
@@ -67,6 +77,22 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 | `PutScalingPolicy` | Creates or updates a policy: `SimpleScaling` fields or `TargetTrackingScaling` with predefined metric, target value, and estimated warmup |
 | `DescribePolicies` | Lists policies filtered by group or policy name, including stored target tracking configuration |
 | `DeletePolicy` | Removes a scaling policy |
+
+### Scheduled Actions
+
+| Operation | Notes |
+|---|---|
+| `PutScheduledUpdateGroupAction` | Creates or updates a schedule: recurrence, time zone, start/end time, capacity bounds |
+| `DescribeScheduledActions` | Lists scheduled actions filtered by group or action name |
+| `DeleteScheduledAction` | Removes a scheduled action |
+
+### Warm Pools
+
+| Operation | Notes |
+|---|---|
+| `PutWarmPool` | Full replace per the wire model: omitted fields reset to defaults; `MaxGroupPreparedCapacity=-1` clears the value |
+| `DescribeWarmPool` | Returns the stored configuration; also embedded in `DescribeAutoScalingGroups` per the AutoScalingGroup shape |
+| `DeleteWarmPool` | Removes the configuration; idempotent when none exists |
 
 ### Activities
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -14,6 +14,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 
 @ApplicationScoped
@@ -1316,8 +1317,8 @@ public class AutoScalingQueryHandler {
         service.putScheduledUpdateGroupAction(region,
                 p.getFirst("AutoScalingGroupName"),
                 p.getFirst("ScheduledActionName"),
-                parseInstant(p.getFirst("StartTime")),
-                parseInstant(p.getFirst("EndTime")),
+                parseInstant("StartTime", p.getFirst("StartTime")),
+                parseInstant("EndTime", p.getFirst("EndTime")),
                 p.getFirst("Recurrence"),
                 p.getFirst("TimeZone"),
                 nullableIntParam(p, "MinSize"),
@@ -1369,12 +1370,13 @@ public class AutoScalingQueryHandler {
         return ok(xml.build());
     }
 
-    private Instant parseInstant(String value) {
+    private Instant parseInstant(String name, String value) {
         if (value == null || value.isBlank()) { return null; }
         try {
             return Instant.parse(value);
-        } catch (Exception e) {
-            return null;
+        } catch (DateTimeParseException e) {
+            throw new AwsException("ValidationError",
+                    name + " '" + value + "' is not a valid ISO 8601 timestamp.", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -11,6 +11,7 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -44,6 +45,11 @@ public class AutoScalingQueryHandler {
                 case "DeleteAutoScalingGroup"       -> handleDeleteAutoScalingGroup(p, region);
                 case "DescribeAutoScalingGroups"    -> handleDescribeAutoScalingGroups(p, region);
                 case "SetDesiredCapacity"           -> handleSetDesiredCapacity(p, region);
+                case "SuspendProcesses"             -> handleSuspendProcesses(p, region);
+                case "ResumeProcesses"              -> handleResumeProcesses(p, region);
+                case "PutWarmPool"                  -> handlePutWarmPool(p, region);
+                case "DescribeWarmPool"             -> handleDescribeWarmPool(p, region);
+                case "DeleteWarmPool"               -> handleDeleteWarmPool(p, region);
                 case "StartInstanceRefresh"         -> handleStartInstanceRefresh(p, region);
                 case "DescribeInstanceRefreshes"    -> handleDescribeInstanceRefreshes(p, region);
                 case "CreateOrUpdateTags"           -> handleCreateOrUpdateTags(p, region);
@@ -62,6 +68,9 @@ public class AutoScalingQueryHandler {
                 case "AttachLoadBalancers"               -> handleAttachLoadBalancers(p, region);
                 case "DetachLoadBalancers"               -> handleDetachLoadBalancers(p, region);
                 case "DescribeLoadBalancers"             -> handleDescribeLoadBalancers(p, region);
+                case "AttachTrafficSources"              -> handleAttachTrafficSources(p, region);
+                case "DetachTrafficSources"               -> handleDetachTrafficSources(p, region);
+                case "DescribeTrafficSources"             -> handleDescribeTrafficSources(p, region);
                 // Lifecycle hooks
                 case "PutLifecycleHook"             -> handlePutLifecycleHook(p, region);
                 case "DeleteLifecycleHook"          -> handleDeleteLifecycleHook(p, region);
@@ -72,6 +81,9 @@ public class AutoScalingQueryHandler {
                 case "PutScalingPolicy"             -> handlePutScalingPolicy(p, region);
                 case "DeletePolicy"                 -> handleDeletePolicy(p, region);
                 case "DescribePolicies"             -> handleDescribePolicies(p, region);
+                case "PutScheduledUpdateGroupAction" -> handlePutScheduledUpdateGroupAction(p, region);
+                case "DeleteScheduledAction"         -> handleDeleteScheduledAction(p, region);
+                case "DescribeScheduledActions"      -> handleDescribeScheduledActions(p, region);
                 // Activities
                 case "DescribeScalingActivities"    -> handleDescribeScalingActivities(p, region);
                 // Metadata
@@ -267,6 +279,11 @@ public class AutoScalingQueryHandler {
             xml.end("LaunchTemplate");
         }
         appendMixedInstancesPolicyXml(xml, asg.getMixedInstancesPolicy());
+        // Botocore's own AutoScalingGroup shape documents WarmPoolConfiguration as a member of
+        // DescribeAutoScalingGroups' response, not only reachable via DescribeWarmPool -
+        // terraform-aws-autoscaling's warm_pool example reads the group's warm pool state this
+        // way. Shared with handleDescribeWarmPool so the two never drift.
+        appendWarmPoolConfigurationXml(xml, service.describeWarmPool(asg.getRegion(), asg.getAutoScalingGroupName()));
 
         xml.start("AvailabilityZones");
         for (String az : asg.getAvailabilityZones()) { xml.elem("member", az); }
@@ -287,6 +304,12 @@ public class AutoScalingQueryHandler {
         xml.start("TerminationPolicies");
         for (String tp : asg.getTerminationPolicies()) { xml.elem("member", tp); }
         xml.end("TerminationPolicies");
+
+        xml.start("SuspendedProcesses");
+        for (String sp : asg.getSuspendedProcesses()) {
+            xml.start("member").elem("ProcessName", sp).end("member");
+        }
+        xml.end("SuspendedProcesses");
 
         xml.start("Instances");
         for (AsgInstance inst : asg.getInstances()) {
@@ -1142,6 +1165,217 @@ public class AutoScalingQueryHandler {
         String val = p.getFirst(key);
         if (val == null || val.isBlank()) { return defaultValue; }
         try { return Integer.parseInt(val); } catch (NumberFormatException e) { return defaultValue; }
+    }
+
+    // ── Suspend/resume scaling processes ────────────────────────────────────
+
+    private Response handleSuspendProcesses(MultivaluedMap<String, String> p, String region) {
+        service.suspendProcesses(region,
+                p.getFirst("AutoScalingGroupName"),
+                memberList(p, "ScalingProcesses"));
+        return ok(new XmlBuilder()
+                .start("SuspendProcessesResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("SuspendProcessesResponse").build());
+    }
+
+    private Response handleResumeProcesses(MultivaluedMap<String, String> p, String region) {
+        service.resumeProcesses(region,
+                p.getFirst("AutoScalingGroupName"),
+                memberList(p, "ScalingProcesses"));
+        return ok(new XmlBuilder()
+                .start("ResumeProcessesResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("ResumeProcessesResponse").build());
+    }
+
+    // ── Warm pools ──────────────────────────────────────────────────────────
+    // Parsed against botocore's autoscaling/2011-01-01/service-2.json
+    // (PutWarmPoolType, DescribeWarmPoolType, DescribeWarmPoolAnswer,
+    // DeleteWarmPoolType, WarmPoolConfiguration, InstanceReusePolicy) rather than
+    // docs prose - see AutoScalingService's warm-pool section for the
+    // full-replace-with-defaults rationale behind PutWarmPool's parsing here.
+
+    private Response handlePutWarmPool(MultivaluedMap<String, String> p, String region) {
+        service.putWarmPool(region,
+                p.getFirst("AutoScalingGroupName"),
+                nullableIntParam(p, "MaxGroupPreparedCapacity"),
+                nullableIntParam(p, "MinSize"),
+                p.getFirst("PoolState"),
+                nullableBoolParam(p, "InstanceReusePolicy.ReuseOnScaleIn"));
+        return ok(new XmlBuilder()
+                .start("PutWarmPoolResponse", NS)
+                  .start("PutWarmPoolResult").end("PutWarmPoolResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("PutWarmPoolResponse").build());
+    }
+
+    private Response handleDescribeWarmPool(MultivaluedMap<String, String> p, String region) {
+        WarmPoolConfiguration pool = service.describeWarmPool(region, p.getFirst("AutoScalingGroupName"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeWarmPoolResponse", NS)
+                  .start("DescribeWarmPoolResult");
+        appendWarmPoolConfigurationXml(xml, pool);
+        xml.start("Instances").end("Instances")
+           .end("DescribeWarmPoolResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeWarmPoolResponse");
+        return ok(xml.build());
+    }
+
+    private static void appendWarmPoolConfigurationXml(XmlBuilder xml, WarmPoolConfiguration pool) {
+        if (pool == null) {
+            return;
+        }
+        xml.start("WarmPoolConfiguration");
+        if (pool.getMaxGroupPreparedCapacity() != null) {
+            xml.elem("MaxGroupPreparedCapacity", String.valueOf(pool.getMaxGroupPreparedCapacity()));
+        }
+        xml.elem("MinSize", String.valueOf(pool.getMinSize()))
+           .elem("PoolState", pool.getPoolState())
+           .start("InstanceReusePolicy")
+             .elem("ReuseOnScaleIn", String.valueOf(pool.isReuseOnScaleIn()))
+           .end("InstanceReusePolicy")
+           .end("WarmPoolConfiguration");
+    }
+
+    private Response handleDeleteWarmPool(MultivaluedMap<String, String> p, String region) {
+        service.deleteWarmPool(region,
+                p.getFirst("AutoScalingGroupName"),
+                "true".equalsIgnoreCase(p.getFirst("ForceDelete")));
+        return ok(new XmlBuilder()
+                .start("DeleteWarmPoolResponse", NS)
+                  .start("DeleteWarmPoolResult").end("DeleteWarmPoolResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeleteWarmPoolResponse").build());
+    }
+
+    // ── Traffic sources ─────────────────────────────────────────────────────
+    // AWS's own DescribeTrafficSources doc page example shows a bare, unwrapped
+    // <TrafficSources> element per item, which reads as a flattened list - but
+    // botocore's actual service-2.json models the TrafficSources list WITHOUT
+    // "flattened": true and with member locationName "member" like every other
+    // list in this API, so the wire shape is the normal
+    // <TrafficSources><member>...</member></TrafficSources>. The doc page's
+    // example was simply wrong; trusting it verbatim left the AWS provider's own
+    // post-create waiter polling DescribeTrafficSources and never finding the
+    // resource it had just attached - the actual wire format, not the docs, is
+    // the source of truth here.
+
+    private Response handleAttachTrafficSources(MultivaluedMap<String, String> p, String region) {
+        service.attachTrafficSources(region, p.getFirst("AutoScalingGroupName"), parseTrafficSources(p));
+        return ok(new XmlBuilder()
+                .start("AttachTrafficSourcesResponse", NS)
+                  .start("AttachTrafficSourcesResult").end("AttachTrafficSourcesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("AttachTrafficSourcesResponse").build());
+    }
+
+    private Response handleDetachTrafficSources(MultivaluedMap<String, String> p, String region) {
+        service.detachTrafficSources(region, p.getFirst("AutoScalingGroupName"), parseTrafficSources(p));
+        return ok(new XmlBuilder()
+                .start("DetachTrafficSourcesResponse", NS)
+                  .start("DetachTrafficSourcesResult").end("DetachTrafficSourcesResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DetachTrafficSourcesResponse").build());
+    }
+
+    private Response handleDescribeTrafficSources(MultivaluedMap<String, String> p, String region) {
+        Map<String, String> sources = service.describeTrafficSources(region,
+                p.getFirst("AutoScalingGroupName"), p.getFirst("TrafficSourceType"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeTrafficSourcesResponse", NS)
+                  .start("DescribeTrafficSourcesResult")
+                    .start("TrafficSources");
+        sources.forEach((identifier, type) -> xml.start("member")
+               .elem("Identifier", identifier)
+               .elem("State", "InService")
+               .elem("Type", type)
+               .end("member"));
+        xml.end("TrafficSources")
+           .end("DescribeTrafficSourcesResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeTrafficSourcesResponse");
+        return ok(xml.build());
+    }
+
+    private List<AutoScalingService.TrafficSourceIdentifier> parseTrafficSources(MultivaluedMap<String, String> p) {
+        List<AutoScalingService.TrafficSourceIdentifier> result = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String identifier = p.getFirst("TrafficSources.member." + i + ".Identifier");
+            if (identifier == null) { break; }
+            String type = p.getFirst("TrafficSources.member." + i + ".Type");
+            result.add(new AutoScalingService.TrafficSourceIdentifier(identifier, type));
+        }
+        return result;
+    }
+
+    // ── Scheduled actions ───────────────────────────────────────────────────
+
+    private Response handlePutScheduledUpdateGroupAction(MultivaluedMap<String, String> p, String region) {
+        service.putScheduledUpdateGroupAction(region,
+                p.getFirst("AutoScalingGroupName"),
+                p.getFirst("ScheduledActionName"),
+                parseInstant(p.getFirst("StartTime")),
+                parseInstant(p.getFirst("EndTime")),
+                p.getFirst("Recurrence"),
+                p.getFirst("TimeZone"),
+                nullableIntParam(p, "MinSize"),
+                nullableIntParam(p, "MaxSize"),
+                nullableIntParam(p, "DesiredCapacity"));
+        return ok(new XmlBuilder()
+                .start("PutScheduledUpdateGroupActionResponse", NS)
+                  .start("PutScheduledUpdateGroupActionResult").end("PutScheduledUpdateGroupActionResult")
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("PutScheduledUpdateGroupActionResponse").build());
+    }
+
+    private Response handleDeleteScheduledAction(MultivaluedMap<String, String> p, String region) {
+        service.deleteScheduledAction(region,
+                p.getFirst("AutoScalingGroupName"), p.getFirst("ScheduledActionName"));
+        return ok(new XmlBuilder()
+                .start("DeleteScheduledActionResponse", NS)
+                  .raw(AwsQueryResponse.responseMetadata())
+                .end("DeleteScheduledActionResponse").build());
+    }
+
+    private Response handleDescribeScheduledActions(MultivaluedMap<String, String> p, String region) {
+        List<ScheduledAction> actions = service.describeScheduledActions(
+                region, p.getFirst("AutoScalingGroupName"), memberList(p, "ScheduledActionNames"));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeScheduledActionsResponse", NS)
+                  .start("DescribeScheduledActionsResult")
+                    .start("ScheduledUpdateGroupActions");
+        for (ScheduledAction action : actions) {
+            xml.start("member")
+               .elem("ScheduledActionName", action.getScheduledActionName())
+               .elem("ScheduledActionARN", action.getScheduledActionArn())
+               .elem("AutoScalingGroupName", action.getAutoScalingGroupName());
+            if (action.getStartTime() != null) { xml.elem("StartTime", ISO_FMT.format(action.getStartTime())); }
+            if (action.getEndTime() != null) { xml.elem("EndTime", ISO_FMT.format(action.getEndTime())); }
+            if (action.getRecurrence() != null) { xml.elem("Recurrence", action.getRecurrence()); }
+            if (action.getTimeZone() != null) { xml.elem("TimeZone", action.getTimeZone()); }
+            if (action.getMinSize() != null) { xml.elem("MinSize", String.valueOf(action.getMinSize())); }
+            if (action.getMaxSize() != null) { xml.elem("MaxSize", String.valueOf(action.getMaxSize())); }
+            if (action.getDesiredCapacity() != null) {
+                xml.elem("DesiredCapacity", String.valueOf(action.getDesiredCapacity()));
+            }
+            xml.end("member");
+        }
+        xml.end("ScheduledUpdateGroupActions")
+           .end("DescribeScheduledActionsResult")
+           .raw(AwsQueryResponse.responseMetadata())
+           .end("DescribeScheduledActionsResponse");
+        return ok(xml.build());
+    }
+
+    private Instant parseInstant(String value) {
+        if (value == null || value.isBlank()) { return null; }
+        try {
+            return Instant.parse(value);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     private Integer nullableIntParam(MultivaluedMap<String, String> p, String key) {

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -49,6 +49,8 @@ public class AutoScalingService {
     private Map<String, ScalingPolicy> policies = new ConcurrentHashMap<>();
     private Map<String, ScalingActivity> activities = new ConcurrentHashMap<>();
     private Map<String, InstanceRefresh> instanceRefreshes = new ConcurrentHashMap<>();
+    private Map<String, ScheduledAction> scheduledActions = new ConcurrentHashMap<>();
+    private Map<String, WarmPoolConfiguration> warmPools = new ConcurrentHashMap<>();
 
     @PostConstruct
     void initializeStorage()
@@ -62,6 +64,8 @@ public class AutoScalingService {
         this.policies = storageBacked("autoscaling-policies.json", new TypeReference<Map<String, ScalingPolicy>>() {});
         this.activities = storageBacked("autoscaling-activities.json", new TypeReference<Map<String, ScalingActivity>>() {});
         this.instanceRefreshes = storageBacked("autoscaling-instance-refreshes.json", new TypeReference<Map<String, InstanceRefresh>>() {});
+        this.scheduledActions = storageBacked("autoscaling-scheduled-actions.json", new TypeReference<Map<String, ScheduledAction>>() {});
+        this.warmPools = storageBacked("autoscaling-warm-pools.json", new TypeReference<Map<String, WarmPoolConfiguration>>() {});
     }
 
     private <V> Map<String, V> storageBacked(String fileName, TypeReference<Map<String, V>> typeReference)
@@ -302,6 +306,8 @@ public class AutoScalingService {
         hooks.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
         policies.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
         instanceRefreshes.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
+        scheduledActions.entrySet().removeIf(e -> name.equals(e.getValue().getAutoScalingGroupName()));
+        warmPools.remove(warmPoolKey(region, name));
     }
 
     public List<AutoScalingGroup> describeAutoScalingGroups(String region, List<String> names) {
@@ -356,6 +362,38 @@ public class AutoScalingService {
                     "Unsupported tag resource type '" + resourceType + "'.", 400);
         }
         return requireGroup(region, resourceId);
+    }
+
+    // Real AWS suspends the named scaling processes ("Launch", "Terminate", "HealthCheck", ...)
+    // so they stop running until resumed; an empty list suspends all of them. Floci has no
+    // scaling loop for these processes to pause, so this only needs to record which processes
+    // are suspended for DescribeAutoScalingGroups to report back - the same "accept and
+    // remember" shape as terminationPolicies. The AWS provider calls this unconditionally
+    // around ASG creation whenever wait_for_capacity_timeout is non-zero (the default), so an
+    // unimplemented SuspendProcesses fails ASG creation outright, not just a feature gap.
+    private static final List<String> ALL_SCALING_PROCESSES = List.of(
+            "Launch", "Terminate", "AddToLoadBalancer", "AlarmNotification", "AZRebalance",
+            "HealthCheck", "InstanceRefresh", "ReplaceUnhealthy", "ScheduledActions");
+
+    public void suspendProcesses(String region, String name, List<String> processes) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        List<String> toSuspend = processes.isEmpty() ? ALL_SCALING_PROCESSES : processes;
+        Set<String> suspended = new LinkedHashSet<>(asg.getSuspendedProcesses());
+        suspended.addAll(toSuspend);
+        asg.setSuspendedProcesses(new ArrayList<>(suspended));
+        groups.put(asgKey(region, name), asg);
+    }
+
+    public void resumeProcesses(String region, String name, List<String> processes) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        if (processes.isEmpty()) {
+            asg.setSuspendedProcesses(new ArrayList<>());
+        } else {
+            List<String> remaining = new ArrayList<>(asg.getSuspendedProcesses());
+            remaining.removeAll(processes);
+            asg.setSuspendedProcesses(remaining);
+        }
+        groups.put(asgKey(region, name), asg);
     }
 
     // ── Instance management ────────────────────────────────────────────────────
@@ -604,6 +642,47 @@ public class AutoScalingService {
         groups.put(asgKey(region, name), asg);
     }
 
+    // ── Traffic sources ─────────────────────────────────────────────────────────────
+    // AttachTrafficSources/DetachTrafficSources/DescribeTrafficSources is the modern,
+    // unified ASG-to-load-balancer wiring API (elb, elbv2, vpc-lattice), which
+    // aws_autoscaling_traffic_source_attachment uses instead of the older
+    // AttachLoadBalancerTargetGroups. "accept and remember" like the target-group
+    // attachment above - Floci has no real health-checking loop, so every attached
+    // traffic source is reported InService immediately.
+
+    public record TrafficSourceIdentifier(String identifier, String type) {}
+
+    public void attachTrafficSources(String region, String name, List<TrafficSourceIdentifier> sources) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        for (TrafficSourceIdentifier source : sources) {
+            asg.getTrafficSourceTypeByIdentifier().put(source.identifier(),
+                    source.type() != null ? source.type() : "elbv2");
+        }
+        groups.put(asgKey(region, name), asg);
+    }
+
+    public void detachTrafficSources(String region, String name, List<TrafficSourceIdentifier> sources) {
+        AutoScalingGroup asg = requireGroup(region, name);
+        for (TrafficSourceIdentifier source : sources) {
+            asg.getTrafficSourceTypeByIdentifier().remove(source.identifier());
+        }
+        groups.put(asgKey(region, name), asg);
+    }
+
+    public Map<String, String> describeTrafficSources(String region, String name, String trafficSourceType) {
+        Map<String, String> all = requireGroup(region, name).getTrafficSourceTypeByIdentifier();
+        if (trafficSourceType == null || trafficSourceType.isBlank()) {
+            return all;
+        }
+        Map<String, String> filtered = new LinkedHashMap<>();
+        all.forEach((identifier, type) -> {
+            if (trafficSourceType.equals(type)) {
+                filtered.put(identifier, type);
+            }
+        });
+        return filtered;
+    }
+
     // ── Lifecycle hooks ────────────────────────────────────────────────────────
 
     public void putLifecycleHook(String region, String asgName, String hookName,
@@ -751,6 +830,112 @@ public class AutoScalingService {
                 .filter(p -> asgName == null || asgName.equals(p.getAutoScalingGroupName()))
                 .filter(p -> policyNames == null || policyNames.isEmpty() || policyNames.contains(p.getPolicyName()))
                 .collect(Collectors.toList());
+    }
+
+    // ── Scheduled actions ───────────────────────────────────────────────────
+    // PutScheduledUpdateGroupAction/DescribeScheduledActions/DeleteScheduledAction -
+    // aws_autoscaling_schedule's whole lifecycle. Floci has no cron scheduler to
+    // actually run these, so - same "accept and remember" shape as scaling
+    // policies above - this only needs to record and read back the schedule
+    // definition itself; the AWS provider's own Read never expects a scheduled
+    // action to have fired inside an emulator.
+
+    public ScheduledAction putScheduledUpdateGroupAction(String region, String asgName, String actionName,
+                                                           Instant startTime, Instant endTime, String recurrence,
+                                                           String timeZone, Integer minSize, Integer maxSize,
+                                                           Integer desiredCapacity) {
+        requireGroup(region, asgName);
+        String key = scheduledActionKey(region, asgName, actionName);
+        ScheduledAction action = scheduledActions.computeIfAbsent(key, k -> new ScheduledAction());
+        action.setScheduledActionName(actionName);
+        action.setAutoScalingGroupName(asgName);
+        action.setScheduledActionArn(AwsArnUtils.Arn.of("autoscaling", region, regionResolver.getAccountId(),
+                "scheduledUpdateGroupAction:" + asgName + ":" + actionName).toString());
+        action.setStartTime(startTime);
+        action.setEndTime(endTime);
+        action.setRecurrence(recurrence);
+        action.setTimeZone(timeZone);
+        action.setMinSize(minSize);
+        action.setMaxSize(maxSize);
+        action.setDesiredCapacity(desiredCapacity);
+        action.setRegion(region);
+        scheduledActions.put(key, action);
+        return action;
+    }
+
+    public void deleteScheduledAction(String region, String asgName, String actionName) {
+        scheduledActions.remove(scheduledActionKey(region, asgName, actionName));
+    }
+
+    public List<ScheduledAction> describeScheduledActions(String region, String asgName, List<String> actionNames) {
+        return scheduledActions.values().stream()
+                .filter(a -> region.equals(a.getRegion()))
+                .filter(a -> asgName == null || asgName.equals(a.getAutoScalingGroupName()))
+                .filter(a -> actionNames == null || actionNames.isEmpty() || actionNames.contains(a.getScheduledActionName()))
+                .collect(Collectors.toList());
+    }
+
+    private static String scheduledActionKey(String region, String asgName, String actionName) {
+        return region + "::" + asgName + "::" + actionName;
+    }
+
+    // ── Warm pools ──────────────────────────────────────────────────────────
+    // PutWarmPool/DescribeWarmPool/DeleteWarmPool - aws_autoscaling_group's
+    // warm_pool block. Verified directly against botocore's
+    // autoscaling/2011-01-01/service-2.json wire model rather than docs prose:
+    // PutWarmPoolType/DeleteWarmPoolType/DescribeWarmPoolType
+    // and their *Answer response shapes, WarmPoolConfiguration, WarmPoolState,
+    // InstanceReusePolicy. PutWarmPool is a full replace: MinSize's own shape
+    // doc says "Defaults to 0 if not specified" and PoolState's says "Default is
+    // Stopped" - an omitted field resets to that default, it does not carry the
+    // prior value forward, which is why putWarmPool always rebuilds the
+    // configuration from scratch rather than mutating the stored one in place.
+    // MaxGroupPreparedCapacity has no default (absent unless set), and the shape
+    // doc calls out -1 as the caller's own documented sentinel for "clear a
+    // previously-set value" - not a real capacity, so it maps back to null and
+    // is never rendered as -1.
+    //
+    // Floci has no scaling loop that actually launches pre-initialized instances
+    // into the pool, so DescribeWarmPool's own Instances list is always empty
+    // and WarmPoolConfiguration.Status ("PendingDelete") is never set - the
+    // "accept and remember" shape scaling policies and scheduled actions above
+    // already use for AWS features with no local reconciler. DeleteWarmPool
+    // removes the stored configuration outright and is silently idempotent when
+    // no warm pool exists, matching deletePolicy above rather than throwing.
+
+    public WarmPoolConfiguration putWarmPool(String region, String asgName,
+                                              Integer maxGroupPreparedCapacity,
+                                              Integer minSize,
+                                              String poolState,
+                                              Boolean reuseOnScaleIn) {
+        requireGroup(region, asgName);
+        WarmPoolConfiguration pool = new WarmPoolConfiguration();
+        pool.setAutoScalingGroupName(asgName);
+        pool.setRegion(region);
+        // -1 is the wire model's own documented sentinel for "remove a
+        // previously-set value" - not a literal capacity.
+        pool.setMaxGroupPreparedCapacity(
+                maxGroupPreparedCapacity != null && maxGroupPreparedCapacity != -1
+                        ? maxGroupPreparedCapacity : null);
+        pool.setMinSize(minSize != null ? minSize : 0);
+        pool.setPoolState(poolState != null && !poolState.isBlank() ? poolState : "Stopped");
+        pool.setReuseOnScaleIn(Boolean.TRUE.equals(reuseOnScaleIn));
+        warmPools.put(warmPoolKey(region, asgName), pool);
+        return pool;
+    }
+
+    public WarmPoolConfiguration describeWarmPool(String region, String asgName) {
+        requireGroup(region, asgName);
+        return warmPools.get(warmPoolKey(region, asgName));
+    }
+
+    public void deleteWarmPool(String region, String asgName, boolean forceDelete) {
+        requireGroup(region, asgName);
+        warmPools.remove(warmPoolKey(region, asgName));
+    }
+
+    private static String warmPoolKey(String region, String asgName) {
+        return region + "::" + asgName;
     }
 
     // ── Scaling activities ─────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -306,7 +306,8 @@ public class AutoScalingService {
         hooks.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
         policies.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
         instanceRefreshes.entrySet().removeIf(e -> e.getValue().getAutoScalingGroupName().equals(name));
-        scheduledActions.entrySet().removeIf(e -> name.equals(e.getValue().getAutoScalingGroupName()));
+        scheduledActions.entrySet().removeIf(e -> region.equals(e.getValue().getRegion())
+                && name.equals(e.getValue().getAutoScalingGroupName()));
         warmPools.remove(warmPoolKey(region, name));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/AutoScalingGroup.java
@@ -32,6 +32,11 @@ public class AutoScalingGroup {
     private int healthCheckGracePeriod = 0;
     private List<AsgInstance> instances = new ArrayList<>();
     private List<String> terminationPolicies = new ArrayList<>();
+    private List<String> suspendedProcesses = new ArrayList<>();
+    // AttachTrafficSources (the modern elbv2/vpc-lattice ASG-to-load-balancer wiring API,
+    // which aws_autoscaling_traffic_source_attachment uses instead of the older
+    // AttachLoadBalancerTargetGroups) - identifier -> type ("elbv2", "elb", "vpc-lattice").
+    private Map<String, String> trafficSourceTypeByIdentifier = new ConcurrentHashMap<>();
     private Instant createdTime;
     private String region;
     private Map<String, String> tags = new ConcurrentHashMap<>();
@@ -96,6 +101,12 @@ public class AutoScalingGroup {
 
     public List<String> getTerminationPolicies() { return terminationPolicies; }
     public void setTerminationPolicies(List<String> v) { this.terminationPolicies = v; }
+
+    public List<String> getSuspendedProcesses() { return suspendedProcesses; }
+    public void setSuspendedProcesses(List<String> v) { this.suspendedProcesses = v; }
+
+    public Map<String, String> getTrafficSourceTypeByIdentifier() { return trafficSourceTypeByIdentifier; }
+    public void setTrafficSourceTypeByIdentifier(Map<String, String> v) { this.trafficSourceTypeByIdentifier = v; }
 
     public Instant getCreatedTime() { return createdTime; }
     public void setCreatedTime(Instant v) { this.createdTime = v; }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScheduledAction.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/ScheduledAction.java
@@ -1,0 +1,58 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ScheduledAction {
+
+    private String scheduledActionName;
+    private String scheduledActionArn;
+    private String autoScalingGroupName;
+    private Instant startTime;
+    private Instant endTime;
+    private String recurrence;
+    private String timeZone;
+    private Integer minSize;
+    private Integer maxSize;
+    private Integer desiredCapacity;
+    private String region;
+
+    public ScheduledAction() {}
+
+    public String getScheduledActionName() { return scheduledActionName; }
+    public void setScheduledActionName(String v) { this.scheduledActionName = v; }
+
+    public String getScheduledActionArn() { return scheduledActionArn; }
+    public void setScheduledActionArn(String v) { this.scheduledActionArn = v; }
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public Instant getStartTime() { return startTime; }
+    public void setStartTime(Instant v) { this.startTime = v; }
+
+    public Instant getEndTime() { return endTime; }
+    public void setEndTime(Instant v) { this.endTime = v; }
+
+    public String getRecurrence() { return recurrence; }
+    public void setRecurrence(String v) { this.recurrence = v; }
+
+    public String getTimeZone() { return timeZone; }
+    public void setTimeZone(String v) { this.timeZone = v; }
+
+    public Integer getMinSize() { return minSize; }
+    public void setMinSize(Integer v) { this.minSize = v; }
+
+    public Integer getMaxSize() { return maxSize; }
+    public void setMaxSize(Integer v) { this.maxSize = v; }
+
+    public Integer getDesiredCapacity() { return desiredCapacity; }
+    public void setDesiredCapacity(Integer v) { this.desiredCapacity = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/WarmPoolConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/WarmPoolConfiguration.java
@@ -1,0 +1,46 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * A warm pool attached to an Auto Scaling group (PutWarmPool/DescribeWarmPool/
+ * DeleteWarmPool). PutWarmPool is a full replace, not a merge - per botocore's
+ * own documentation on MinSize ("Defaults to 0 if not specified") and PoolState
+ * ("Default is Stopped"), a Put that omits a field resets it to that field's
+ * declared default rather than leaving a prior value in place. MaxGroupPreparedCapacity
+ * is the one field with no default: absent unless the caller sets it, and a caller
+ * passing exactly -1 clears a previously-set value back to absent (the wire model's
+ * own documented sentinel for "unset this").
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WarmPoolConfiguration {
+
+    private String autoScalingGroupName;
+    private Integer maxGroupPreparedCapacity;
+    private int minSize;
+    private String poolState = "Stopped";
+    private boolean reuseOnScaleIn;
+    private String region;
+
+    public WarmPoolConfiguration() {}
+
+    public String getAutoScalingGroupName() { return autoScalingGroupName; }
+    public void setAutoScalingGroupName(String v) { this.autoScalingGroupName = v; }
+
+    public Integer getMaxGroupPreparedCapacity() { return maxGroupPreparedCapacity; }
+    public void setMaxGroupPreparedCapacity(Integer v) { this.maxGroupPreparedCapacity = v; }
+
+    public int getMinSize() { return minSize; }
+    public void setMinSize(int v) { this.minSize = v; }
+
+    public String getPoolState() { return poolState; }
+    public void setPoolState(String v) { this.poolState = v; }
+
+    public boolean isReuseOnScaleIn() { return reuseOnScaleIn; }
+    public void setReuseOnScaleIn(boolean v) { this.reuseOnScaleIn = v; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String v) { this.region = v; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -777,8 +777,247 @@ class AutoScalingIntegrationTest {
         assertThat(overrides, not(containsString("<InstanceType>t4g.medium</InstanceType>")));
     }
 
+    // The AWS provider calls SuspendProcesses/ResumeProcesses unconditionally around ASG
+    // creation whenever wait_for_capacity_timeout is non-zero (the default), so an
+    // unimplemented SuspendProcesses fails ASG creation outright - found crossing
+    // terraform-aws-modules/terraform-aws-eks against floci.
     @Test
     @Order(31)
+    void suspendProcesses() {
+        given()
+                .formParam("Action", "SuspendProcesses")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("ScalingProcesses.member.1", "Launch")
+                .formParam("ScalingProcesses.member.2", "Terminate")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("SuspendProcessesResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<SuspendedProcesses>"))
+                .body(containsString("<ProcessName>Launch</ProcessName>"))
+                .body(containsString("<ProcessName>Terminate</ProcessName>"));
+    }
+
+    @Test
+    @Order(32)
+    void resumeProcesses() {
+        given()
+                .formParam("Action", "ResumeProcesses")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("ScalingProcesses.member.1", "Launch")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("ResumeProcessesResponse"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<ProcessName>Launch</ProcessName>")))
+                .body(containsString("<ProcessName>Terminate</ProcessName>"));
+    }
+
+    // AttachTrafficSources/DetachTrafficSources/DescribeTrafficSources - the modern,
+    // unified elbv2/vpc-lattice ASG-to-load-balancer wiring API that
+    // aws_autoscaling_traffic_source_attachment uses instead of the older
+    // AttachLoadBalancerTargetGroups above. Found crossing
+    // terraform-aws-modules/terraform-aws-autoscaling's "complete" example against
+    // floci (its traffic_source_attachments block wires an ALB target group this way).
+    @Test
+    @Order(33)
+    void attachDescribeAndDetachTrafficSources() {
+        given()
+                .formParam("Action", "AttachTrafficSources")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("TrafficSources.member.1.Identifier",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/ex-asg/abc123")
+                .formParam("TrafficSources.member.1.Type", "elbv2")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("AttachTrafficSourcesResponse"));
+
+        given()
+                .formParam("Action", "DescribeTrafficSources")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<Identifier>arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/ex-asg/abc123</Identifier>"))
+                .body(containsString("<Type>elbv2</Type>"))
+                .body(containsString("<State>InService</State>"));
+
+        given()
+                .formParam("Action", "DetachTrafficSources")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("TrafficSources.member.1.Identifier",
+                        "arn:aws:elasticloadbalancing:us-east-1:000000000000:targetgroup/ex-asg/abc123")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DetachTrafficSourcesResponse"));
+
+        given()
+                .formParam("Action", "DescribeTrafficSources")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<Identifier>")));
+    }
+
+    // PutScheduledUpdateGroupAction/DescribeScheduledActions/DeleteScheduledAction -
+    // aws_autoscaling_schedule's whole lifecycle. Found crossing
+    // terraform-aws-modules/terraform-aws-autoscaling's "complete" example.
+    @Test
+    @Order(34)
+    void putDescribeAndDeleteScheduledAction() {
+        given()
+                .formParam("Action", "PutScheduledUpdateGroupAction")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("ScheduledActionName", "morning")
+                .formParam("Recurrence", "0 7 * * 1-5")
+                .formParam("MinSize", "0")
+                .formParam("MaxSize", "1")
+                .formParam("DesiredCapacity", "1")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("PutScheduledUpdateGroupActionResponse"));
+
+        given()
+                .formParam("Action", "DescribeScheduledActions")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<ScheduledActionName>morning</ScheduledActionName>"))
+                .body(containsString("<Recurrence>0 7 * * 1-5</Recurrence>"))
+                .body(containsString("<MinSize>0</MinSize>"))
+                .body(containsString("<MaxSize>1</MaxSize>"))
+                .body(containsString("<DesiredCapacity>1</DesiredCapacity>"));
+
+        given()
+                .formParam("Action", "DeleteScheduledAction")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("ScheduledActionName", "morning")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteScheduledActionResponse"));
+
+        given()
+                .formParam("Action", "DescribeScheduledActions")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<ScheduledActionName>")));
+    }
+
+    // PutWarmPool/DescribeWarmPool/DeleteWarmPool - aws_autoscaling_group's warm_pool
+    // block. Botocore's AutoScalingGroup shape documents WarmPoolConfiguration as a
+    // member of DescribeAutoScalingGroups' own response too, not just the separate
+    // DescribeWarmPool action - terraform-aws-autoscaling's warm_pool example reads
+    // it that way, so both paths are asserted here.
+    @Test
+    @Order(35)
+    void putDescribeAndDeleteWarmPool() {
+        given()
+                .formParam("Action", "PutWarmPool")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("PoolState", "Stopped")
+                .formParam("MinSize", "1")
+                .formParam("MaxGroupPreparedCapacity", "2")
+                .formParam("InstanceReusePolicy.ReuseOnScaleIn", "true")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("PutWarmPoolResponse"));
+
+        given()
+                .formParam("Action", "DescribeWarmPool")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<PoolState>Stopped</PoolState>"))
+                .body(containsString("<MinSize>1</MinSize>"))
+                .body(containsString("<MaxGroupPreparedCapacity>2</MaxGroupPreparedCapacity>"))
+                .body(containsString("<ReuseOnScaleIn>true</ReuseOnScaleIn>"));
+
+        given()
+                .formParam("Action", "DescribeAutoScalingGroups")
+                .formParam("AutoScalingGroupNames.member.1", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<WarmPoolConfiguration>"))
+                .body(containsString("<PoolState>Stopped</PoolState>"));
+
+        given()
+                .formParam("Action", "DeleteWarmPool")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("DeleteWarmPoolResponse"));
+
+        given()
+                .formParam("Action", "DescribeWarmPool")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(not(containsString("<WarmPoolConfiguration>")));
+    }
+
+    @Test
+    @Order(36)
     void deleteLaunchTemplateAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -795,7 +1034,7 @@ class AutoScalingIntegrationTest {
     // ── Cleanup ───────────────────────────────────────────────────────────────
 
     @Test
-    @Order(32)
+    @Order(37)
     void deleteAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -810,7 +1049,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(33)
+    @Order(38)
     void deleteMixedInstancesAutoScalingGroup() {
         given()
                 .formParam("Action", "DeleteAutoScalingGroup")
@@ -825,7 +1064,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(34)
+    @Order(39)
     void deleteLaunchConfiguration() {
         given()
                 .formParam("Action", "DeleteLaunchConfiguration")
@@ -839,7 +1078,7 @@ class AutoScalingIntegrationTest {
     }
 
     @Test
-    @Order(35)
+    @Order(40)
     void describeAutoScalingGroupsEmpty() {
         given()
                 .formParam("Action", "DescribeAutoScalingGroups")

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -896,6 +896,23 @@ class AutoScalingIntegrationTest {
     // aws_autoscaling_schedule's whole lifecycle. Found crossing
     // terraform-aws-modules/terraform-aws-autoscaling's "complete" example.
     @Test
+    @Order(41)
+    void putScheduledActionRejectsMalformedStartTime() {
+        given()
+                .formParam("Action", "PutScheduledUpdateGroupAction")
+                .formParam("AutoScalingGroupName", "my-asg")
+                .formParam("ScheduledActionName", "bad-start")
+                .formParam("StartTime", "not-a-timestamp")
+                .formParam("DesiredCapacity", "1")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("<Code>ValidationError</Code>"));
+    }
+
+    @Test
     @Order(34)
     void putDescribeAndDeleteScheduledAction() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -885,10 +885,16 @@ class AutoScalingServiceTest {
         service.putScheduledUpdateGroupAction(REGION, "test-asg", "morning",
                 null, null, "0 7 * * 1-5", null, 0, 1, 1);
         service.putWarmPool(REGION, "test-asg", null, 1, "Stopped", false);
+        service.createAutoScalingGroup("eu-west-1", "test-asg", null, "lt-original", null, "1", null,
+                0, 3, 1, 300, List.of("eu-west-1a"), List.of("subnet-12345678"), List.of(), List.of(),
+                "EC2", 0, List.of("Default"), Map.of(), Map.of());
+        service.putScheduledUpdateGroupAction("eu-west-1", "test-asg", "morning",
+                null, null, "0 7 * * 1-5", null, 0, 1, 1);
 
         service.deleteAutoScalingGroup(REGION, "test-asg", true);
 
         assertEquals(List.of(), service.describeScheduledActions(REGION, "test-asg", List.of()));
         assertThrows(AwsException.class, () -> service.describeWarmPool(REGION, "test-asg"));
+        assertEquals(1, service.describeScheduledActions("eu-west-1", "test-asg", List.of()).size());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doThrow;
@@ -781,5 +782,113 @@ class AutoScalingServiceTest {
                     .getInstances()
                     .add(instance);
         }
+    }
+
+    // The AWS provider calls SuspendProcesses/ResumeProcesses unconditionally around ASG
+    // creation whenever wait_for_capacity_timeout is non-zero (the default), so an
+    // unimplemented SuspendProcesses fails ASG creation outright - found crossing
+    // terraform-aws-modules/terraform-aws-eks against floci.
+    @Test
+    void suspendProcessesRecordsNamedProcessesAndResumeClearsThem() {
+        service.suspendProcesses(REGION, "test-asg", List.of("Launch", "Terminate"));
+
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertEquals(List.of("Launch", "Terminate"), group.getSuspendedProcesses());
+
+        service.resumeProcesses(REGION, "test-asg", List.of("Launch"));
+        group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertEquals(List.of("Terminate"), group.getSuspendedProcesses());
+
+        service.resumeProcesses(REGION, "test-asg", List.of());
+        group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertEquals(List.of(), group.getSuspendedProcesses());
+    }
+
+    @Test
+    void suspendProcessesWithNoNamesSuspendsEveryScalingProcess() {
+        service.suspendProcesses(REGION, "test-asg", List.of());
+
+        var group = service.describeAutoScalingGroups(REGION, List.of("test-asg")).getFirst();
+        assertTrue(group.getSuspendedProcesses().contains("Launch"));
+        assertTrue(group.getSuspendedProcesses().contains("Terminate"));
+        assertTrue(group.getSuspendedProcesses().contains("HealthCheck"));
+    }
+
+    @Test
+    void attachTrafficSourcesRecordsIdentifierAndTypeAndDetachRemovesIt() {
+        service.attachTrafficSources(REGION, "test-asg", List.of(
+                new AutoScalingService.TrafficSourceIdentifier("arn:aws:elasticloadbalancing:...:tg/ex", "elbv2")));
+
+        assertEquals(Map.of("arn:aws:elasticloadbalancing:...:tg/ex", "elbv2"),
+                service.describeTrafficSources(REGION, "test-asg", null));
+
+        service.detachTrafficSources(REGION, "test-asg", List.of(
+                new AutoScalingService.TrafficSourceIdentifier("arn:aws:elasticloadbalancing:...:tg/ex", null)));
+
+        assertEquals(Map.of(), service.describeTrafficSources(REGION, "test-asg", null));
+    }
+
+    @Test
+    void describeTrafficSourcesFiltersByType() {
+        service.attachTrafficSources(REGION, "test-asg", List.of(
+                new AutoScalingService.TrafficSourceIdentifier("arn:elbv2-source", "elbv2"),
+                new AutoScalingService.TrafficSourceIdentifier("arn:lattice-source", "vpc-lattice")));
+
+        assertEquals(Map.of("arn:elbv2-source", "elbv2"),
+                service.describeTrafficSources(REGION, "test-asg", "elbv2"));
+    }
+
+    @Test
+    void putScheduledUpdateGroupActionRecordsScheduleAndDeleteRemovesIt() {
+        service.putScheduledUpdateGroupAction(REGION, "test-asg", "morning",
+                null, null, "0 7 * * 1-5", "Europe/Rome", 0, 1, 1);
+
+        var actions = service.describeScheduledActions(REGION, "test-asg", List.of());
+        assertEquals(1, actions.size());
+        assertEquals("morning", actions.getFirst().getScheduledActionName());
+        assertEquals("0 7 * * 1-5", actions.getFirst().getRecurrence());
+        assertEquals("Europe/Rome", actions.getFirst().getTimeZone());
+        assertEquals(0, actions.getFirst().getMinSize());
+        assertEquals(1, actions.getFirst().getMaxSize());
+        assertEquals(1, actions.getFirst().getDesiredCapacity());
+        assertNotNull(actions.getFirst().getScheduledActionArn());
+
+        service.deleteScheduledAction(REGION, "test-asg", "morning");
+        assertEquals(List.of(), service.describeScheduledActions(REGION, "test-asg", List.of()));
+    }
+
+    @Test
+    void putWarmPoolReplacesConfigurationAndMapsTheClearSentinel() {
+        service.putWarmPool(REGION, "test-asg", 2, 1, "Running", true);
+
+        var pool = service.describeWarmPool(REGION, "test-asg");
+        assertEquals(2, pool.getMaxGroupPreparedCapacity());
+        assertEquals(1, pool.getMinSize());
+        assertEquals("Running", pool.getPoolState());
+        assertTrue(pool.isReuseOnScaleIn());
+
+        // A Put that omits fields resets them to the wire model's documented defaults,
+        // and -1 is the documented sentinel for clearing MaxGroupPreparedCapacity.
+        service.putWarmPool(REGION, "test-asg", -1, null, null, null);
+        pool = service.describeWarmPool(REGION, "test-asg");
+        assertNull(pool.getMaxGroupPreparedCapacity());
+        assertEquals(0, pool.getMinSize());
+        assertEquals("Stopped", pool.getPoolState());
+        assertFalse(pool.isReuseOnScaleIn());
+
+        service.deleteWarmPool(REGION, "test-asg", false);
+        assertNull(service.describeWarmPool(REGION, "test-asg"));
+    }
+
+    @Test
+    void deleteAutoScalingGroupAlsoRemovesItsScheduledActionsAndWarmPool() {
+        service.putScheduledUpdateGroupAction(REGION, "test-asg", "morning",
+                null, null, "0 7 * * 1-5", null, 0, 1, 1);
+        service.putWarmPool(REGION, "test-asg", null, 1, "Stopped", false);
+
+        service.deleteAutoScalingGroup(REGION, "test-asg", true);
+
+        assertEquals(List.of(), service.describeScheduledActions(REGION, "test-asg", List.of()));
+        assertThrows(AwsException.class, () -> service.describeWarmPool(REGION, "test-asg"));
     }
 }


### PR DESCRIPTION
## Summary

Adds the AutoScaling operations the Terraform provider calls around every nontrivial group:

- SuspendProcesses and ResumeProcesses
- warm pools
- scheduled actions
- traffic sources

The provider calls SuspendProcesses unconditionally when wait_for_capacity_timeout is non-zero, so group creation failed without it. Floci has no scheduler or warm-instance loop, so all four families record and read back state, the same shape scaling policies already use. Deleting a group also removes its scheduled actions and warm pool.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire shapes follow botocore's autoscaling/2011-01-01 service model. PutWarmPool is a full replace whose omitted fields reset to defaults, with -1 as the modeled sentinel that clears MaxGroupPreparedCapacity. DescribeTrafficSources renders the member-wrapped list the model defines. The doc page example flattens it, and following the example leaves the provider's post-create waiter polling forever.

## Checklist

- [ ] `./mvnw test` passes locally (118 autoscaling tests pass locally)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
