### PR TITLE
feat(ec2): Capacity Reservation CRUD

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -476,12 +476,14 @@ Route table ids follow the live API's own inconsistency: an id that does not exi
 | ModifyCapacityReservation | Updates `InstanceCount`, `EndDate`, `EndDateType` or `InstanceMatchCriteria` in place. |
 | CancelCapacityReservation | Marks a Capacity Reservation `cancelled` and its available count `0`, matching real AWS's retain-but-cancel behaviour rather than deleting the record. |
 
-`InstanceType` and `AvailabilityZone` are required, matching the AWS API; a request missing
-either is rejected with `MissingParameter`. `InstanceCount` defaults to `1`,
-`InstanceMatchCriteria` defaults to `open`, `Tenancy` defaults to `default` and `EndDateType`
-defaults to `unlimited`. Creation is synchronous: the reservation comes back `active` on the
-create response rather than passing through `payment-pending`/`assessing`. `DescribeCapacityReservations`
-supports the `availability-zone`, `capacity-reservation-id`, `instance-platform`,
+`InstanceType`, `InstancePlatform` and `InstanceCount` are required, matching the AWS API, and
+one of `AvailabilityZone` or `AvailabilityZoneId` must be given; a request missing any of
+these is rejected with `MissingParameter`. `InstanceCount` must be greater than `0` on create
+and on modify, otherwise `InvalidParameterValue`. `InstanceMatchCriteria` defaults to `open`,
+`Tenancy` defaults to `default` and `EndDateType` defaults to `unlimited`. Creation is
+synchronous: the reservation comes back `active` on the create response rather than passing
+through `payment-pending`/`assessing`. `DescribeCapacityReservations` supports the
+`availability-zone`, `end-date-type`, `instance-match-criteria`, `instance-platform`,
 `instance-type`, `state` and `tenancy` filters alongside the shared `tag:`, `tag-key` and
 `tag-value` filters.
 

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -467,6 +467,24 @@ Route table ids follow the live API's own inconsistency: an id that does not exi
 | DescribeNatGateways | Lists or returns stored NAT gateways. |
 | DeleteNatGateway | Deletes a NAT gateway record. |
 
+### Capacity Reservations
+
+| Action | Description |
+|--------|-------------|
+| CreateCapacityReservation | Reserves EC2 instance capacity in a specific Availability Zone. |
+| DescribeCapacityReservations | Lists or returns stored Capacity Reservations. |
+| ModifyCapacityReservation | Updates `InstanceCount`, `EndDate`, `EndDateType` or `InstanceMatchCriteria` in place. |
+| CancelCapacityReservation | Marks a Capacity Reservation `cancelled` and its available count `0`, matching real AWS's retain-but-cancel behaviour rather than deleting the record. |
+
+`InstanceType` and `AvailabilityZone` are required, matching the AWS API; a request missing
+either is rejected with `MissingParameter`. `InstanceCount` defaults to `1`,
+`InstanceMatchCriteria` defaults to `open`, `Tenancy` defaults to `default` and `EndDateType`
+defaults to `unlimited`. Creation is synchronous: the reservation comes back `active` on the
+create response rather than passing through `payment-pending`/`assessing`. `DescribeCapacityReservations`
+supports the `availability-zone`, `capacity-reservation-id`, `instance-platform`,
+`instance-type`, `state` and `tenancy` filters alongside the shared `tag:`, `tag-key` and
+`tag-value` filters.
+
 ### Elastic IPs
 
 | Action | Description |

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -165,6 +165,8 @@ public class AwsQueryController {
             "CreateNetworkAclEntry", "ReplaceNetworkAclEntry", "DeleteNetworkAclEntry",
             "ReplaceNetworkAclAssociation",
             "CreateNatGateway", "DescribeNatGateways", "DeleteNatGateway",
+            "CreateCapacityReservation", "DescribeCapacityReservations",
+            "ModifyCapacityReservation", "CancelCapacityReservation",
             "AllocateAddress", "AssociateAddress", "DisassociateAddress", "ReleaseAddress", "DescribeAddresses",
             "DescribeAddressesAttribute",
             "DescribeIamInstanceProfileAssociations",

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -3226,6 +3226,7 @@ public class Ec2QueryHandler {
                 p.getFirst("InstanceType"),
                 p.getFirst("InstancePlatform"),
                 p.getFirst("AvailabilityZone"),
+                p.getFirst("AvailabilityZoneId"),
                 intOrNull(p, "InstanceCount"),
                 p.getFirst("Tenancy"),
                 p.getFirst("EbsOptimized") != null ? Boolean.valueOf(p.getFirst("EbsOptimized")) : null,
@@ -3280,6 +3281,7 @@ public class Ec2QueryHandler {
                 .elem("capacityReservationId", reservation.getCapacityReservationId())
                 .elem("ownerId", reservation.getOwnerId())
                 .elem("capacityReservationArn", reservation.getCapacityReservationArn())
+                .elem("availabilityZoneId", reservation.getAvailabilityZoneId())
                 .elem("availabilityZone", reservation.getAvailabilityZone())
                 .elem("instanceType", reservation.getInstanceType())
                 .elem("instancePlatform", reservation.getInstancePlatform())

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -209,6 +209,11 @@ public class Ec2QueryHandler {
                 case "CreateNatGateway" -> handleCreateNatGateway(params, region);
                 case "DescribeNatGateways" -> handleDescribeNatGateways(params, region);
                 case "DeleteNatGateway" -> handleDeleteNatGateway(params, region);
+                // Capacity Reservations
+                case "CreateCapacityReservation" -> handleCreateCapacityReservation(params, region);
+                case "DescribeCapacityReservations" -> handleDescribeCapacityReservations(params, region);
+                case "ModifyCapacityReservation" -> handleModifyCapacityReservation(params, region);
+                case "CancelCapacityReservation" -> handleCancelCapacityReservation(params, region);
                 // Elastic IPs
                 case "AllocateAddress" -> handleAllocateAddress(params, region);
                 case "AssociateAddress" -> handleAssociateAddress(params, region);
@@ -3211,6 +3216,103 @@ public class Ec2QueryHandler {
                 .start("natGateway").raw(natGatewayXml(natGateway)).end("natGateway")
                 .end("DeleteNatGatewayResponse");
         return xmlResponse(xml.build());
+    }
+
+    // ─── Capacity Reservation handlers ────────────────────────────────────────
+
+    private Response handleCreateCapacityReservation(MultivaluedMap<String, String> p, String region) {
+        CapacityReservation reservation = service.createCapacityReservation(
+                region,
+                p.getFirst("InstanceType"),
+                p.getFirst("InstancePlatform"),
+                p.getFirst("AvailabilityZone"),
+                intOrNull(p, "InstanceCount"),
+                p.getFirst("Tenancy"),
+                p.getFirst("EbsOptimized") != null ? Boolean.valueOf(p.getFirst("EbsOptimized")) : null,
+                p.getFirst("EphemeralStorage") != null ? Boolean.valueOf(p.getFirst("EphemeralStorage")) : null,
+                p.getFirst("EndDateType"),
+                instantOrNull(p, "EndDate"),
+                p.getFirst("InstanceMatchCriteria"),
+                p.getFirst("OutpostArn"),
+                p.getFirst("PlacementGroupArn"));
+        applyResourceTags(p, region, "capacity-reservation", reservation.getCapacityReservationId());
+        XmlBuilder xml = new XmlBuilder()
+                .start("CreateCapacityReservationResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("capacityReservation").raw(capacityReservationXml(reservation)).end("capacityReservation")
+                .end("CreateCapacityReservationResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleDescribeCapacityReservations(MultivaluedMap<String, String> p, String region) {
+        List<String> ids = getList(p, "CapacityReservationId");
+        Map<String, List<String>> filters = getFilters(p);
+        List<CapacityReservation> reservations = service.describeCapacityReservations(region, ids, filters);
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeCapacityReservationsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("capacityReservationSet");
+        for (CapacityReservation reservation : reservations) {
+            xml.start("item").raw(capacityReservationXml(reservation)).end("item");
+        }
+        xml.end("capacityReservationSet").end("DescribeCapacityReservationsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    private Response handleModifyCapacityReservation(MultivaluedMap<String, String> p, String region) {
+        service.modifyCapacityReservation(
+                region,
+                p.getFirst("CapacityReservationId"),
+                intOrNull(p, "InstanceCount"),
+                instantOrNull(p, "EndDate"),
+                p.getFirst("EndDateType"),
+                p.getFirst("InstanceMatchCriteria"));
+        return booleanResponse("ModifyCapacityReservation");
+    }
+
+    private Response handleCancelCapacityReservation(MultivaluedMap<String, String> p, String region) {
+        service.cancelCapacityReservation(region, p.getFirst("CapacityReservationId"));
+        return booleanResponse("CancelCapacityReservation");
+    }
+
+    private String capacityReservationXml(CapacityReservation reservation) {
+        XmlBuilder xml = new XmlBuilder()
+                .elem("capacityReservationId", reservation.getCapacityReservationId())
+                .elem("ownerId", reservation.getOwnerId())
+                .elem("capacityReservationArn", reservation.getCapacityReservationArn())
+                .elem("availabilityZone", reservation.getAvailabilityZone())
+                .elem("instanceType", reservation.getInstanceType())
+                .elem("instancePlatform", reservation.getInstancePlatform())
+                .elem("tenancy", reservation.getTenancy())
+                .elem("totalInstanceCount", reservation.getTotalInstanceCount())
+                .elem("availableInstanceCount", reservation.getAvailableInstanceCount())
+                .elem("ebsOptimized", reservation.isEbsOptimized())
+                .elem("ephemeralStorage", reservation.isEphemeralStorage())
+                .elem("state", reservation.getState())
+                .elem("startDate", reservation.getStartDate() != null ? ISO_FMT.format(reservation.getStartDate()) : null)
+                .elem("endDate", reservation.getEndDate() != null ? ISO_FMT.format(reservation.getEndDate()) : null)
+                .elem("endDateType", reservation.getEndDateType())
+                .elem("instanceMatchCriteria", reservation.getInstanceMatchCriteria())
+                .elem("createDate", reservation.getCreateDate() != null ? ISO_FMT.format(reservation.getCreateDate()) : null)
+                .elem("outpostArn", reservation.getOutpostArn())
+                .elem("placementGroupArn", reservation.getPlacementGroupArn())
+                .raw(tagSetXml(reservation.getTags()));
+        return xml.build();
+    }
+
+    // Unlike intOrNull's silent skip of absent values, a present but unparseable timestamp is a
+    // caller mistake and is rejected rather than coerced to null.
+    private java.time.Instant instantOrNull(MultivaluedMap<String, String> p, String name) {
+        String value = p.getFirst(name);
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return java.time.Instant.parse(value);
+        } catch (java.time.format.DateTimeParseException e) {
+            throw new AwsException("InvalidParameterValue",
+                    "The specified value for " + name + " is not valid.", 400);
+        }
     }
 
     // ─── Elastic IP handlers ──────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -43,6 +43,7 @@ import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ec2.model.Address;
 import io.github.hectorvent.floci.services.ec2.model.BlockDeviceMapping;
+import io.github.hectorvent.floci.services.ec2.model.CapacityReservation;
 import io.github.hectorvent.floci.services.ec2.model.EbsBlockDevice;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
 import io.github.hectorvent.floci.services.ec2.portforward.Ec2PortForwardManager;
@@ -179,6 +180,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     private final StorageBackend<String, NetworkInterface> networkInterfaces;
     // resourceId → List<Tag>
     private final StorageBackend<String, List<Tag>> tags;
+    private final StorageBackend<String, CapacityReservation> capacityReservations;
     private final Set<String> seededRegions = ConcurrentHashMap.newKeySet();
     // subnetId → counter for IP assignment (runtime-only, not persisted)
     private final Map<String, AtomicInteger> subnetIpCounters = new ConcurrentHashMap<>();
@@ -232,6 +234,8 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                         new TypeReference<Map<String, VpcPeeringConnection>>() {}),
                 storageFactory.create("ec2", "ec2-network-interfaces.json",
                         new TypeReference<Map<String, NetworkInterface>>() {}),
+                storageFactory.create("ec2", "ec2-capacity-reservations.json",
+                        new TypeReference<Map<String, CapacityReservation>>() {}),
                 requestContextInstance);
     }
 
@@ -265,7 +269,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 natGateways, spotInstanceRequests, networkAcls, managedPrefixLists, tags,
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
                 new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
-                new InMemoryStorage<>(), null);
+                new InMemoryStorage<>(), new InMemoryStorage<>(), null);
     }
 
     // Package-private for hermetic tests, transit-gateway-aware. The shorter overload above keeps its
@@ -305,7 +309,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 natGateways, spotInstanceRequests, networkAcls, managedPrefixLists, tags,
                 transitGateways, transitGatewayRouteTables, transitGatewayVpcAttachments,
                 transitGatewayPropagations, transitGatewayRoutes, vpcPeeringConnections,
-                new InMemoryStorage<>(), null);
+                new InMemoryStorage<>(), new InMemoryStorage<>(), null);
     }
 
     // Package-private for hermetic tests that also need to control which account a caller resolves
@@ -340,6 +344,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                StorageBackend<String, TransitGatewayRoute> transitGatewayRoutes,
                StorageBackend<String, VpcPeeringConnection> vpcPeeringConnections,
                StorageBackend<String, NetworkInterface> networkInterfaces,
+               StorageBackend<String, CapacityReservation> capacityReservations,
                jakarta.enterprise.inject.Instance<RequestContext> requestContextInstance) {
         this.accountId = config.defaultAccountId();
         this.requestContextInstance = requestContextInstance;
@@ -375,6 +380,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         this.transitGatewayRoutes = transitGatewayRoutes;
         this.vpcPeeringConnections = vpcPeeringConnections;
         this.networkInterfaces = networkInterfaces;
+        this.capacityReservations = capacityReservations;
     }
 
     @PostConstruct
@@ -4578,6 +4584,8 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         if (inst != null) { inst.setTags(new ArrayList<>(tagList)); instances.put(storeKey, inst); return; }
         Vpc vpc = vpcs.get(storeKey).orElse(null);
         if (vpc != null) { vpc.setTags(new ArrayList<>(tagList)); vpcs.put(storeKey, vpc); return; }
+        CapacityReservation cr = capacityReservations.get(storeKey).orElse(null);
+        if (cr != null) { cr.setTags(new ArrayList<>(tagList)); capacityReservations.put(storeKey, cr); return; }
         Subnet subnet = subnets.get(storeKey).orElse(null);
         if (subnet != null) { subnet.setTags(new ArrayList<>(tagList)); subnets.put(storeKey, subnet); return; }
         SecurityGroup sg = securityGroups.get(storeKey).orElse(null);
@@ -4667,6 +4675,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     private String inferResourceType(String resourceId) {
         if (resourceId.startsWith("i-")) {
             return "instance";
+        }
+        if (resourceId.startsWith("cr-")) {
+            return "capacity-reservation";
         }
         if (resourceId.startsWith("vpc-")) {
             return "vpc";
@@ -4772,6 +4783,121 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
             throw new AwsException("InvalidInternetGatewayID.NotFound", "The internet gateway '" + igwId + "' does not exist", 400);
 
         return igw;
+    }
+
+    // ─── Capacity Reservations ─────────────────────────────────────────────────
+
+    /**
+     * Creates a Capacity Reservation, {@code active} on the create response and on the first
+     * describe. Real AWS passes through {@code payment-pending}/{@code assessing} first;
+     * nothing about creating one is slow here, so the terminal state is reported immediately,
+     * the same synchronous-create simplification the other regional EC2 resources make.
+     */
+    public CapacityReservation createCapacityReservation(String region, String instanceType,
+            String instancePlatform, String availabilityZone, Integer instanceCount, String tenancy,
+            Boolean ebsOptimized, Boolean ephemeralStorage, String endDateType, java.time.Instant endDate,
+            String instanceMatchCriteria, String outpostArn, String placementGroupArn) {
+        ensureDefaultResources(region);
+        if (instanceType == null || instanceType.isBlank()) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter InstanceType.", 400);
+        }
+        if (availabilityZone == null || availabilityZone.isBlank()) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter AvailabilityZone.", 400);
+        }
+        int count = instanceCount != null ? instanceCount : 1;
+        CapacityReservation reservation = new CapacityReservation();
+        reservation.setCapacityReservationId("cr-" + randomHex(17));
+        reservation.setOwnerId(accountId);
+        reservation.setRegion(region);
+        reservation.setCapacityReservationArn(
+                AwsArnUtils.Arn.of("ec2", region, accountId, "capacity-reservation/" + reservation.getCapacityReservationId()).toString());
+        reservation.setAvailabilityZone(availabilityZone);
+        reservation.setInstanceType(instanceType);
+        reservation.setInstancePlatform(instancePlatform != null ? instancePlatform : "Linux/UNIX");
+        reservation.setTenancy(tenancy != null ? tenancy : "default");
+        reservation.setTotalInstanceCount(count);
+        reservation.setAvailableInstanceCount(count);
+        reservation.setEbsOptimized(Boolean.TRUE.equals(ebsOptimized));
+        reservation.setEphemeralStorage(Boolean.TRUE.equals(ephemeralStorage));
+        reservation.setState("active");
+        reservation.setStartDate(Instant.now());
+        reservation.setCreateDate(Instant.now());
+        reservation.setEndDate(endDate);
+        reservation.setEndDateType(endDateType != null ? endDateType : "unlimited");
+        reservation.setInstanceMatchCriteria(instanceMatchCriteria != null ? instanceMatchCriteria : "open");
+        reservation.setOutpostArn(outpostArn);
+        reservation.setPlacementGroupArn(placementGroupArn);
+        capacityReservations.put(key(region, reservation.getCapacityReservationId()), reservation);
+        return reservation;
+    }
+
+    public List<CapacityReservation> describeCapacityReservations(String region, List<String> ids,
+            Map<String, List<String>> filters) {
+        ensureDefaultResources(region);
+        for (String id : ids) {
+            getRequiredCapacityReservation(region, id);
+        }
+        return capacityReservations.scan(k -> true).stream()
+                .filter(r -> r.getRegion().equals(region))
+                .filter(r -> ids.isEmpty() || ids.contains(r.getCapacityReservationId()))
+                .filter(r -> matchesFilters(r, filters, region))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Applies an in-place update. AWS forbids changing instance type, EBS optimization,
+     * platform, instance store, Availability Zone or tenancy after creation, and the caller
+     * (the AWS provider's own update path) never asks for that, so nothing here re-checks it.
+     */
+    public CapacityReservation modifyCapacityReservation(String region, String capacityReservationId,
+            Integer instanceCount, java.time.Instant endDate, String endDateType, String instanceMatchCriteria) {
+        ensureDefaultResources(region);
+        CapacityReservation reservation = getRequiredCapacityReservation(region, capacityReservationId);
+        if (instanceCount != null) {
+            int delta = instanceCount - reservation.getTotalInstanceCount();
+            reservation.setTotalInstanceCount(instanceCount);
+            reservation.setAvailableInstanceCount(Math.max(0, reservation.getAvailableInstanceCount() + delta));
+        }
+        if (endDateType != null) {
+            reservation.setEndDateType(endDateType);
+        }
+        // AWS clears EndDate when EndDateType moves back to "unlimited"; ModifyCapacityReservation
+        // has no way to explicitly clear EndDate otherwise (CancelCapacityReservation is the only
+        // other transition), so mirror that here rather than leaving a stale date behind.
+        if ("unlimited".equals(reservation.getEndDateType())) {
+            reservation.setEndDate(null);
+        } else if (endDate != null) {
+            reservation.setEndDate(endDate);
+        }
+        if (instanceMatchCriteria != null) {
+            reservation.setInstanceMatchCriteria(instanceMatchCriteria);
+        }
+        capacityReservations.put(key(region, capacityReservationId), reservation);
+        return reservation;
+    }
+
+    /**
+     * Marks the reservation cancelled with zero available capacity rather than deleting the
+     * record, matching AWS's retain-but-cancel behaviour: a cancelled reservation still
+     * appears in DescribeCapacityReservations.
+     */
+    public void cancelCapacityReservation(String region, String capacityReservationId) {
+        ensureDefaultResources(region);
+        CapacityReservation reservation = getRequiredCapacityReservation(region, capacityReservationId);
+        reservation.setState("cancelled");
+        reservation.setAvailableInstanceCount(0);
+        capacityReservations.put(key(region, capacityReservationId), reservation);
+    }
+
+    private CapacityReservation getRequiredCapacityReservation(String region, String capacityReservationId) {
+        CapacityReservation reservation = capacityReservations.get(key(region, capacityReservationId)).orElse(null);
+        if (reservation == null) {
+            throw new AwsException("InvalidCapacityReservationId.NotFound",
+                    "The Capacity Reservation '" + capacityReservationId + "' does not exist.", 400);
+        }
+        return reservation;
     }
 
     // ─── Route Tables ──────────────────────────────────────────────────────────
@@ -6011,6 +6137,17 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 default -> true;
             };
         }
+        if (resource instanceof CapacityReservation cr) {
+            return switch (filterName) {
+                case "capacity-reservation-id" -> matchesValue(values, cr.getCapacityReservationId());
+                case "instance-type" -> matchesValue(values, cr.getInstanceType());
+                case "availability-zone" -> matchesValue(values, cr.getAvailabilityZone());
+                case "tenancy" -> matchesValue(values, cr.getTenancy());
+                case "state" -> matchesValue(values, cr.getState());
+                case "instance-platform" -> matchesValue(values, cr.getInstancePlatform());
+                default -> true;
+            };
+        }
         return true;
     }
 
@@ -6034,6 +6171,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         if (resource instanceof TransitGatewayRouteTable routeTable) return routeTable.getTags();
         if (resource instanceof TransitGatewayVpcAttachment attachment) return attachment.getTags();
         if (resource instanceof VpcPeeringConnection pcx) return pcx.getTags();
+        if (resource instanceof CapacityReservation cr) return cr.getTags();
         return Collections.emptyList();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4794,19 +4794,28 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
      * the same synchronous-create simplification the other regional EC2 resources make.
      */
     public CapacityReservation createCapacityReservation(String region, String instanceType,
-            String instancePlatform, String availabilityZone, Integer instanceCount, String tenancy,
-            Boolean ebsOptimized, Boolean ephemeralStorage, String endDateType, java.time.Instant endDate,
-            String instanceMatchCriteria, String outpostArn, String placementGroupArn) {
+            String instancePlatform, String availabilityZone, String availabilityZoneId, Integer instanceCount,
+            String tenancy, Boolean ebsOptimized, Boolean ephemeralStorage, String endDateType,
+            java.time.Instant endDate, String instanceMatchCriteria, String outpostArn, String placementGroupArn) {
         ensureDefaultResources(region);
         if (instanceType == null || instanceType.isBlank()) {
             throw new AwsException("MissingParameter",
                     "The request must contain the parameter InstanceType.", 400);
         }
-        if (availabilityZone == null || availabilityZone.isBlank()) {
+        if (instancePlatform == null || instancePlatform.isBlank()) {
             throw new AwsException("MissingParameter",
-                    "The request must contain the parameter AvailabilityZone.", 400);
+                    "The request must contain the parameter InstancePlatform.", 400);
         }
-        int count = instanceCount != null ? instanceCount : 1;
+        if (instanceCount == null) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter InstanceCount.", 400);
+        }
+        if ((availabilityZone == null || availabilityZone.isBlank())
+                && (availabilityZoneId == null || availabilityZoneId.isBlank())) {
+            throw new AwsException("MissingParameter",
+                    "The request must contain the parameter AvailabilityZone or AvailabilityZoneId.", 400);
+        }
+        int count = requirePositiveInstanceCount(instanceCount);
         CapacityReservation reservation = new CapacityReservation();
         reservation.setCapacityReservationId("cr-" + randomHex(17));
         reservation.setOwnerId(accountId);
@@ -4814,8 +4823,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         reservation.setCapacityReservationArn(
                 AwsArnUtils.Arn.of("ec2", region, accountId, "capacity-reservation/" + reservation.getCapacityReservationId()).toString());
         reservation.setAvailabilityZone(availabilityZone);
+        reservation.setAvailabilityZoneId(availabilityZoneId);
         reservation.setInstanceType(instanceType);
-        reservation.setInstancePlatform(instancePlatform != null ? instancePlatform : "Linux/UNIX");
+        reservation.setInstancePlatform(instancePlatform);
         reservation.setTenancy(tenancy != null ? tenancy : "default");
         reservation.setTotalInstanceCount(count);
         reservation.setAvailableInstanceCount(count);
@@ -4856,7 +4866,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         ensureDefaultResources(region);
         CapacityReservation reservation = getRequiredCapacityReservation(region, capacityReservationId);
         if (instanceCount != null) {
-            int delta = instanceCount - reservation.getTotalInstanceCount();
+            int delta = requirePositiveInstanceCount(instanceCount) - reservation.getTotalInstanceCount();
             reservation.setTotalInstanceCount(instanceCount);
             reservation.setAvailableInstanceCount(Math.max(0, reservation.getAvailableInstanceCount() + delta));
         }
@@ -4889,6 +4899,15 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         reservation.setState("cancelled");
         reservation.setAvailableInstanceCount(0);
         capacityReservations.put(key(region, capacityReservationId), reservation);
+    }
+
+    private int requirePositiveInstanceCount(int instanceCount) {
+        if (instanceCount <= 0) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value (" + instanceCount + ") for parameter InstanceCount is invalid. "
+                            + "InstanceCount must be greater than 0.", 400);
+        }
+        return instanceCount;
     }
 
     private CapacityReservation getRequiredCapacityReservation(String region, String capacityReservationId) {
@@ -6139,12 +6158,13 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         }
         if (resource instanceof CapacityReservation cr) {
             return switch (filterName) {
-                case "capacity-reservation-id" -> matchesValue(values, cr.getCapacityReservationId());
                 case "instance-type" -> matchesValue(values, cr.getInstanceType());
                 case "availability-zone" -> matchesValue(values, cr.getAvailabilityZone());
                 case "tenancy" -> matchesValue(values, cr.getTenancy());
                 case "state" -> matchesValue(values, cr.getState());
                 case "instance-platform" -> matchesValue(values, cr.getInstancePlatform());
+                case "instance-match-criteria" -> matchesValue(values, cr.getInstanceMatchCriteria());
+                case "end-date-type" -> matchesValue(values, cr.getEndDateType());
                 default -> true;
             };
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/CapacityReservation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/CapacityReservation.java
@@ -25,6 +25,7 @@ public class CapacityReservation {
     private String ownerId;
     private String capacityReservationArn;
     private String availabilityZone;
+    private String availabilityZoneId;
     private String instanceType;
     private String instancePlatform;
     private String tenancy = "default";
@@ -56,6 +57,8 @@ public class CapacityReservation {
 
     public String getAvailabilityZone() { return availabilityZone; }
     public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }
+    public String getAvailabilityZoneId() { return availabilityZoneId; }
+    public void setAvailabilityZoneId(String availabilityZoneId) { this.availabilityZoneId = availabilityZoneId; }
 
     public String getInstanceType() { return instanceType; }
     public void setInstanceType(String instanceType) { this.instanceType = instanceType; }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/CapacityReservation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/CapacityReservation.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.ec2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A reservation of EC2 instance capacity in a specific Availability Zone, created ahead of
+ * time so a later {@code RunInstances} (or an Auto Scaling warm pool / launch template) is
+ * guaranteed the capacity it targets.
+ *
+ * <p>Real AWS transitions a Capacity Reservation through {@code payment-pending}/
+ * {@code assessing} before {@code active}; nothing about creating one is slow here, so it is
+ * {@code active} on the create response and on the first describe, the same synchronous-create
+ * simplification the other regional EC2 resources make.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CapacityReservation {
+
+    private String capacityReservationId;
+    private String ownerId;
+    private String capacityReservationArn;
+    private String availabilityZone;
+    private String instanceType;
+    private String instancePlatform;
+    private String tenancy = "default";
+    private int totalInstanceCount;
+    private int availableInstanceCount;
+    private boolean ebsOptimized;
+    private boolean ephemeralStorage;
+    private String state = "active";
+    private Instant startDate;
+    private Instant endDate;
+    private String endDateType = "unlimited";
+    private String instanceMatchCriteria = "open";
+    private Instant createDate;
+    private String outpostArn;
+    private String placementGroupArn;
+    private String region;
+    private List<Tag> tags = new ArrayList<>();
+
+    public CapacityReservation() {}
+
+    public String getCapacityReservationId() { return capacityReservationId; }
+    public void setCapacityReservationId(String capacityReservationId) { this.capacityReservationId = capacityReservationId; }
+
+    public String getOwnerId() { return ownerId; }
+    public void setOwnerId(String ownerId) { this.ownerId = ownerId; }
+
+    public String getCapacityReservationArn() { return capacityReservationArn; }
+    public void setCapacityReservationArn(String capacityReservationArn) { this.capacityReservationArn = capacityReservationArn; }
+
+    public String getAvailabilityZone() { return availabilityZone; }
+    public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }
+
+    public String getInstanceType() { return instanceType; }
+    public void setInstanceType(String instanceType) { this.instanceType = instanceType; }
+
+    public String getInstancePlatform() { return instancePlatform; }
+    public void setInstancePlatform(String instancePlatform) { this.instancePlatform = instancePlatform; }
+
+    public String getTenancy() { return tenancy; }
+    public void setTenancy(String tenancy) { this.tenancy = tenancy; }
+
+    public int getTotalInstanceCount() { return totalInstanceCount; }
+    public void setTotalInstanceCount(int totalInstanceCount) { this.totalInstanceCount = totalInstanceCount; }
+
+    public int getAvailableInstanceCount() { return availableInstanceCount; }
+    public void setAvailableInstanceCount(int availableInstanceCount) { this.availableInstanceCount = availableInstanceCount; }
+
+    public boolean isEbsOptimized() { return ebsOptimized; }
+    public void setEbsOptimized(boolean ebsOptimized) { this.ebsOptimized = ebsOptimized; }
+
+    public boolean isEphemeralStorage() { return ephemeralStorage; }
+    public void setEphemeralStorage(boolean ephemeralStorage) { this.ephemeralStorage = ephemeralStorage; }
+
+    public String getState() { return state; }
+    public void setState(String state) { this.state = state; }
+
+    public Instant getStartDate() { return startDate; }
+    public void setStartDate(Instant startDate) { this.startDate = startDate; }
+
+    public Instant getEndDate() { return endDate; }
+    public void setEndDate(Instant endDate) { this.endDate = endDate; }
+
+    public String getEndDateType() { return endDateType; }
+    public void setEndDateType(String endDateType) { this.endDateType = endDateType; }
+
+    public String getInstanceMatchCriteria() { return instanceMatchCriteria; }
+    public void setInstanceMatchCriteria(String instanceMatchCriteria) { this.instanceMatchCriteria = instanceMatchCriteria; }
+
+    public Instant getCreateDate() { return createDate; }
+    public void setCreateDate(Instant createDate) { this.createDate = createDate; }
+
+    public String getOutpostArn() { return outpostArn; }
+    public void setOutpostArn(String outpostArn) { this.outpostArn = outpostArn; }
+
+    public String getPlacementGroupArn() { return placementGroupArn; }
+    public void setPlacementGroupArn(String placementGroupArn) { this.placementGroupArn = placementGroupArn; }
+
+    public String getRegion() { return region; }
+    public void setRegion(String region) { this.region = region; }
+
+    public List<Tag> getTags() { return tags; }
+    public void setTags(List<Tag> tags) { this.tags = tags; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2CapacityReservationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2CapacityReservationIntegrationTest.java
@@ -1,0 +1,306 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for EC2 Capacity Reservations over the Query protocol: create with inline
+ * tags, describe by id and by filter, modify in place, tag round trip through CreateTags, and
+ * cancel (lex00/floci#64 - previously entirely unimplemented, blocking
+ * terraform-aws-modules/terraform-aws-autoscaling's flagship "complete" example, which declares
+ * an {@code aws_ec2_capacity_reservation} targeted by a warm pool).
+ *
+ * <p>Ordered because the cases walk one reservation through its lifecycle.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class Ec2CapacityReservationIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    private static String capacityReservationId;
+
+    @Test
+    @Order(1)
+    void createReturnsActiveOnTheFirstRead() {
+        capacityReservationId = given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("InstanceType", "t3.micro")
+            .formParam("InstancePlatform", "Linux/UNIX")
+            .formParam("AvailabilityZone", "us-east-1a")
+            .formParam("InstanceCount", "3")
+            .formParam("InstanceMatchCriteria", "targeted")
+            .formParam("TagSpecification.1.ResourceType", "capacity-reservation")
+            .formParam("TagSpecification.1.Tag.1.Key", "Name")
+            .formParam("TagSpecification.1.Tag.1.Value", "warm-pool-reservation")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateCapacityReservationResponse.capacityReservation.state", equalTo("active"))
+            .body("CreateCapacityReservationResponse.capacityReservation.instanceType", equalTo("t3.micro"))
+            .body("CreateCapacityReservationResponse.capacityReservation.instancePlatform", equalTo("Linux/UNIX"))
+            .body("CreateCapacityReservationResponse.capacityReservation.availabilityZone", equalTo("us-east-1a"))
+            .body("CreateCapacityReservationResponse.capacityReservation.totalInstanceCount", equalTo("3"))
+            .body("CreateCapacityReservationResponse.capacityReservation.availableInstanceCount", equalTo("3"))
+            .body("CreateCapacityReservationResponse.capacityReservation.instanceMatchCriteria", equalTo("targeted"))
+            .body("CreateCapacityReservationResponse.capacityReservation.tenancy", equalTo("default"))
+            .body("CreateCapacityReservationResponse.capacityReservation.endDateType", equalTo("unlimited"))
+            .body("CreateCapacityReservationResponse.capacityReservation.capacityReservationArn",
+                    containsString(":capacity-reservation/cr-"))
+            .body("CreateCapacityReservationResponse.capacityReservation.tagSet.item.key", equalTo("Name"))
+            .body("CreateCapacityReservationResponse.capacityReservation.tagSet.item.value", equalTo("warm-pool-reservation"))
+            .extract().path("CreateCapacityReservationResponse.capacityReservation.capacityReservationId");
+
+        assertTrue(capacityReservationId.startsWith("cr-"), "id must use the cr- prefix");
+    }
+
+    @Test
+    @Order(2)
+    void describeByIdReturnsTheCreatedReservationStillActive() {
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("CapacityReservationId.1", capacityReservationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.capacityReservationId",
+                    equalTo(capacityReservationId))
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.state", equalTo("active"));
+    }
+
+    @Test
+    @Order(3)
+    void describeSupportsInstanceTypeAndTagFilters() {
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("Filter.1.Name", "instance-type")
+            .formParam("Filter.1.Value.1", "t3.micro")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.capacityReservationId",
+                    equalTo(capacityReservationId));
+
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("Filter.1.Name", "tag:Name")
+            .formParam("Filter.1.Value.1", "warm-pool-reservation")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.capacityReservationId",
+                    equalTo(capacityReservationId));
+    }
+
+    @Test
+    @Order(4)
+    void createTagsIsVisibleOnTheNextDescribe() {
+        given()
+            .formParam("Action", "CreateTags")
+            .formParam("ResourceId.1", capacityReservationId)
+            .formParam("Tag.1.Key", "env")
+            .formParam("Tag.1.Value", "staging")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("Filter.1.Name", "tag:env")
+            .formParam("Filter.1.Value.1", "staging")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.capacityReservationId",
+                    equalTo(capacityReservationId));
+    }
+
+    @Test
+    @Order(5)
+    void modifyChangesInstanceCountAndAvailableCountTogether() {
+        given()
+            .formParam("Action", "ModifyCapacityReservation")
+            .formParam("CapacityReservationId", capacityReservationId)
+            .formParam("InstanceCount", "5")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ModifyCapacityReservationResponse.return", equalTo("true"));
+
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("CapacityReservationId.1", capacityReservationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.totalInstanceCount", equalTo("5"))
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.availableInstanceCount", equalTo("5"));
+    }
+
+    @Test
+    @Order(6)
+    void createWithoutInstanceCountDefaultsToOne() {
+        String secondId = given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("InstanceType", "t3.nano")
+            .formParam("AvailabilityZone", "us-east-1b")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateCapacityReservationResponse.capacityReservation.totalInstanceCount", equalTo("1"))
+            .body("CreateCapacityReservationResponse.capacityReservation.instanceMatchCriteria", equalTo("open"))
+            .extract().path("CreateCapacityReservationResponse.capacityReservation.capacityReservationId");
+
+        given()
+            .formParam("Action", "CancelCapacityReservation")
+            .formParam("CapacityReservationId", secondId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CancelCapacityReservationResponse.return", equalTo("true"));
+    }
+
+    @Test
+    @Order(7)
+    void missingRequiredParameterIsRejected() {
+        given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("AvailabilityZone", "us-east-1a")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"));
+    }
+
+    @Test
+    @Order(8)
+    void cancelMarksTheReservationCancelledRatherThanDeletingIt() {
+        given()
+            .formParam("Action", "CancelCapacityReservation")
+            .formParam("CapacityReservationId", capacityReservationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CancelCapacityReservationResponse.return", equalTo("true"));
+
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("CapacityReservationId.1", capacityReservationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.state", equalTo("cancelled"))
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.availableInstanceCount", equalTo("0"));
+    }
+
+    @Test
+    @Order(9)
+    void describingAMissingReservationReturnsTheModelledError() {
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("CapacityReservationId.1", "cr-00000000000000000")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidCapacityReservationId.NotFound"))
+            .body("Response.Errors.Error.Message", containsString("cr-00000000000000000"));
+    }
+
+    /**
+     * lex00/floci#137: CreateCapacityReservation's own inline tag-specification parameter is the
+     * PLURAL "TagSpecifications.N.*", not the singular "TagSpecification.N.*" every other create
+     * action in this codebase uses - confirmed by capturing the real wire request a genuine
+     * hashicorp/terraform-provider-aws apply sends (TF_LOG=DEBUG), not by reading the docs alone.
+     * Order(1) above already exercises the singular spelling and would keep passing even if the
+     * plural one were never handled, which is exactly how this shipped unnoticed: the choudoufu
+     * corpus-autoscaling-complete/greenfield gauntlet unit caught it by reading
+     * DescribeCapacityReservations/DescribeTags directly against a real apply, with no terraform
+     * in the loop, and finding the tags simply absent right after create.
+     *
+     * <p>A separate, independent reservation and a follow-up Describe (not just the Create
+     * response's own echo) so this proves the tag is actually PERSISTED, not merely reflected in
+     * the same in-memory object the handler happens to still be holding.
+     */
+    @Test
+    @Order(10)
+    void createHonoursThePluralTagSpecificationsParameter() {
+        String id = given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("InstanceType", "t3.micro")
+            .formParam("InstancePlatform", "Linux/UNIX")
+            .formParam("AvailabilityZone", "us-east-1a")
+            .formParam("InstanceCount", "1")
+            .formParam("InstanceMatchCriteria", "targeted")
+            .formParam("TagSpecifications.1.ResourceType", "capacity-reservation")
+            .formParam("TagSpecifications.1.Tag.1.Key", "Name")
+            .formParam("TagSpecifications.1.Tag.1.Value", "plural-form-reservation")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateCapacityReservationResponse.capacityReservation.tagSet.item.key", equalTo("Name"))
+            .body("CreateCapacityReservationResponse.capacityReservation.tagSet.item.value", equalTo("plural-form-reservation"))
+            .extract().path("CreateCapacityReservationResponse.capacityReservation.capacityReservationId");
+
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("CapacityReservationId.1", id)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.tagSet.item.key", equalTo("Name"))
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.tagSet.item.value", equalTo("plural-form-reservation"));
+
+        given()
+            .formParam("Action", "DescribeTags")
+            .formParam("Filter.1.Name", "resource-id")
+            .formParam("Filter.1.Value.1", id)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeTagsResponse.tagSet.item.key", equalTo("Name"))
+            .body("DescribeTagsResponse.tagSet.item.value", equalTo("plural-form-reservation"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2CapacityReservationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2CapacityReservationIntegrationTest.java
@@ -164,33 +164,93 @@ class Ec2CapacityReservationIntegrationTest {
 
     @Test
     @Order(6)
-    void createWithoutInstanceCountDefaultsToOne() {
-        String secondId = given()
+    void createWithoutInstanceCountIsRejected() {
+        given()
             .formParam("Action", "CreateCapacityReservation")
             .formParam("InstanceType", "t3.nano")
+            .formParam("InstancePlatform", "Linux/UNIX")
             .formParam("AvailabilityZone", "us-east-1b")
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
         .then()
-            .statusCode(200)
-            .body("CreateCapacityReservationResponse.capacityReservation.totalInstanceCount", equalTo("1"))
-            .body("CreateCapacityReservationResponse.capacityReservation.instanceMatchCriteria", equalTo("open"))
-            .extract().path("CreateCapacityReservationResponse.capacityReservation.capacityReservationId");
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"))
+            .body("Response.Errors.Error.Message", containsString("InstanceCount"));
+    }
+
+    @Test
+    @Order(7)
+    void nonPositiveInstanceCountIsRejectedOnCreateAndModify() {
+        given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("InstanceType", "t3.nano")
+            .formParam("InstancePlatform", "Linux/UNIX")
+            .formParam("AvailabilityZone", "us-east-1b")
+            .formParam("InstanceCount", "0")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
 
         given()
-            .formParam("Action", "CancelCapacityReservation")
-            .formParam("CapacityReservationId", secondId)
+            .formParam("Action", "ModifyCapacityReservation")
+            .formParam("CapacityReservationId", capacityReservationId)
+            .formParam("InstanceCount", "-1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidParameterValue"));
+
+        given()
+            .formParam("Action", "DescribeCapacityReservations")
+            .formParam("CapacityReservationId.1", capacityReservationId)
             .header("Authorization", AUTH_HEADER)
         .when()
             .post("/")
         .then()
             .statusCode(200)
-            .body("CancelCapacityReservationResponse.return", equalTo("true"));
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.totalInstanceCount", equalTo("5"))
+            .body("DescribeCapacityReservationsResponse.capacityReservationSet.item.availableInstanceCount", equalTo("5"));
     }
 
     @Test
-    @Order(7)
+    @Order(8)
+    void createAcceptsAvailabilityZoneIdInsteadOfAvailabilityZone() {
+        given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("InstanceType", "t3.nano")
+            .formParam("InstancePlatform", "Linux/UNIX")
+            .formParam("AvailabilityZoneId", "use1-az2")
+            .formParam("InstanceCount", "1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("CreateCapacityReservationResponse.capacityReservation.availabilityZoneId", equalTo("use1-az2"))
+            .body("CreateCapacityReservationResponse.capacityReservation.totalInstanceCount", equalTo("1"))
+            .body("CreateCapacityReservationResponse.capacityReservation.instanceMatchCriteria", equalTo("open"));
+
+        given()
+            .formParam("Action", "CreateCapacityReservation")
+            .formParam("InstanceType", "t3.nano")
+            .formParam("InstancePlatform", "Linux/UNIX")
+            .formParam("InstanceCount", "1")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("MissingParameter"));
+    }
+
+    @Test
+    @Order(9)
     void missingRequiredParameterIsRejected() {
         given()
             .formParam("Action", "CreateCapacityReservation")
@@ -204,7 +264,7 @@ class Ec2CapacityReservationIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(10)
     void cancelMarksTheReservationCancelledRatherThanDeletingIt() {
         given()
             .formParam("Action", "CancelCapacityReservation")
@@ -229,7 +289,7 @@ class Ec2CapacityReservationIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(11)
     void describingAMissingReservationReturnsTheModelledError() {
         given()
             .formParam("Action", "DescribeCapacityReservations")
@@ -244,22 +304,12 @@ class Ec2CapacityReservationIntegrationTest {
     }
 
     /**
-     * lex00/floci#137: CreateCapacityReservation's own inline tag-specification parameter is the
-     * PLURAL "TagSpecifications.N.*", not the singular "TagSpecification.N.*" every other create
-     * action in this codebase uses - confirmed by capturing the real wire request a genuine
-     * hashicorp/terraform-provider-aws apply sends (TF_LOG=DEBUG), not by reading the docs alone.
-     * Order(1) above already exercises the singular spelling and would keep passing even if the
-     * plural one were never handled, which is exactly how this shipped unnoticed: the choudoufu
-     * corpus-autoscaling-complete/greenfield gauntlet unit caught it by reading
-     * DescribeCapacityReservations/DescribeTags directly against a real apply, with no terraform
-     * in the loop, and finding the tags simply absent right after create.
-     *
-     * <p>A separate, independent reservation and a follow-up Describe (not just the Create
-     * response's own echo) so this proves the tag is actually PERSISTED, not merely reflected in
-     * the same in-memory object the handler happens to still be holding.
+     * {@code parseTagsForResource} accepts both TagSpecification spellings for every action.
+     * Order(1) covers the singular form. This test covers the plural form and reads the tags
+     * back through Describe.
      */
     @Test
-    @Order(10)
+    @Order(12)
     void createHonoursThePluralTagSpecificationsParameter() {
         String id = given()
             .formParam("Action", "CreateCapacityReservation")


### PR DESCRIPTION
## Summary

Adds EC2 Capacity Reservation CRUD. None of the four operations existed, so aws_ec2_capacity_reservation failed on create with UnsupportedOperation.

Creation is synchronous and reports active on the create response. Cancel keeps the record as cancelled with zero available capacity rather than deleting it, matching AWS.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire shapes follow botocore's ec2/2016-11-15 service model. Create requires InstanceType and InstancePlatform and InstanceCount and rejects a non-positive count. Describe supports the documented filters plus the shared tag family.

## Checklist

- [ ] `./mvnw test` passes locally (capacity reservation and adjacent EC2 suites pass locally)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
