### PR TITLE
feat(dynamodb): resource policies and GSI-level OnDemandThroughput

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -66,6 +66,9 @@ public class DynamoDbJsonHandler {
             case "TagResource" -> handleTagResource(request, region);
             case "UntagResource" -> handleUntagResource(request, region);
             case "ListTagsOfResource" -> handleListTagsOfResource(request, region);
+            case "PutResourcePolicy" -> handlePutResourcePolicy(request, region);
+            case "GetResourcePolicy" -> handleGetResourcePolicy(request, region);
+            case "DeleteResourcePolicy" -> handleDeleteResourcePolicy(request, region);
             case "EnableKinesisStreamingDestination" -> handleEnableKinesisStreamingDestination(request, region);
             case "DisableKinesisStreamingDestination" -> handleDisableKinesisStreamingDestination(request, region);
             case "DescribeKinesisStreamingDestination" -> handleDescribeKinesisStreamingDestination(request, region);
@@ -131,6 +134,15 @@ public class DynamoDbJsonHandler {
                 if (!gsiPt.isMissingNode()) {
                     gsi.getProvisionedThroughput().setReadCapacityUnits(gsiPt.path("ReadCapacityUnits").asLong(0));
                     gsi.getProvisionedThroughput().setWriteCapacityUnits(gsiPt.path("WriteCapacityUnits").asLong(0));
+                }
+                JsonNode gsiOnDemand = gsiNode.path("OnDemandThroughput");
+                if (gsiOnDemand.isObject()) {
+                    if (gsiOnDemand.has("MaxReadRequestUnits")) {
+                        gsi.setOnDemandMaxReadRequestUnits(gsiOnDemand.get("MaxReadRequestUnits").asInt());
+                    }
+                    if (gsiOnDemand.has("MaxWriteRequestUnits")) {
+                        gsi.setOnDemandMaxWriteRequestUnits(gsiOnDemand.get("MaxWriteRequestUnits").asInt());
+                    }
                 }
                 gsis.add(gsi);
             }
@@ -1276,6 +1288,15 @@ public class DynamoDbJsonHandler {
                         newGsi.getProvisionedThroughput().setReadCapacityUnits(newGsiPt.path("ReadCapacityUnits").asLong(0));
                         newGsi.getProvisionedThroughput().setWriteCapacityUnits(newGsiPt.path("WriteCapacityUnits").asLong(0));
                     }
+                    JsonNode newGsiOnDemand = createNode.path("OnDemandThroughput");
+                    if (newGsiOnDemand.isObject()) {
+                        if (newGsiOnDemand.has("MaxReadRequestUnits")) {
+                            newGsi.setOnDemandMaxReadRequestUnits(newGsiOnDemand.get("MaxReadRequestUnits").asInt());
+                        }
+                        if (newGsiOnDemand.has("MaxWriteRequestUnits")) {
+                            newGsi.setOnDemandMaxWriteRequestUnits(newGsiOnDemand.get("MaxWriteRequestUnits").asInt());
+                        }
+                    }
                     gsiCreates.add(newGsi);
                 }
                 JsonNode deleteNode = update.path("Delete");
@@ -1671,6 +1692,58 @@ public class DynamoDbJsonHandler {
             tagsArray.add(tagNode);
         }
         response.set("Tags", tagsArray);
+        return Response.ok(response).build();
+    }
+
+    private Response handlePutResourcePolicy(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceArn").asText();
+        if (!isValidDynamoDbTableArn(resourceArn)) {
+            throw new AwsException("ValidationException",
+                    "Invalid ResourceArn: " + resourceArn, 400);
+        }
+        if (!request.hasNonNull("Policy")) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value null at 'policy' failed to satisfy constraint: "
+                    + "Member must not be null", 400);
+        }
+        String policy = request.path("Policy").asText();
+        String expectedRevisionId = request.has("ExpectedRevisionId")
+                ? request.get("ExpectedRevisionId").asText() : null;
+
+        String revisionId = dynamoDbService.putResourcePolicy(resourceArn, policy, expectedRevisionId, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("RevisionId", revisionId);
+        return Response.ok(response).build();
+    }
+
+    private Response handleGetResourcePolicy(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceArn").asText();
+        if (!isValidDynamoDbTableArn(resourceArn)) {
+            throw new AwsException("ValidationException",
+                    "Invalid ResourceArn: " + resourceArn, 400);
+        }
+        DynamoDbService.ResourcePolicyResult result = dynamoDbService.getResourcePolicy(resourceArn, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("Policy", result.policy());
+        response.put("RevisionId", result.revisionId());
+        return Response.ok(response).build();
+    }
+
+    private Response handleDeleteResourcePolicy(JsonNode request, String region) {
+        String resourceArn = request.path("ResourceArn").asText();
+        if (!isValidDynamoDbTableArn(resourceArn)) {
+            throw new AwsException("ValidationException",
+                    "Invalid ResourceArn: " + resourceArn, 400);
+        }
+        String expectedRevisionId = request.has("ExpectedRevisionId")
+                ? request.get("ExpectedRevisionId").asText() : null;
+
+        String revisionId = dynamoDbService.deleteResourcePolicy(resourceArn, expectedRevisionId, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("RevisionId", revisionId);
         return Response.ok(response).build();
     }
 
@@ -2090,6 +2163,18 @@ public class DynamoDbJsonHandler {
                 gsiNode.set("ProvisionedThroughput", gsiPt);
                 gsiNode.put("IndexSizeBytes", gsi.getIndexSizeBytes());
                 gsiNode.put("ItemCount", gsi.getItemCount());
+
+                if (gsi.getOnDemandMaxReadRequestUnits() != null
+                        || gsi.getOnDemandMaxWriteRequestUnits() != null) {
+                    ObjectNode gsiOdt = objectMapper.createObjectNode();
+                    if (gsi.getOnDemandMaxReadRequestUnits() != null) {
+                        gsiOdt.put("MaxReadRequestUnits", gsi.getOnDemandMaxReadRequestUnits());
+                    }
+                    if (gsi.getOnDemandMaxWriteRequestUnits() != null) {
+                        gsiOdt.put("MaxWriteRequestUnits", gsi.getOnDemandMaxWriteRequestUnits());
+                    }
+                    gsiNode.set("OnDemandThroughput", gsiOdt);
+                }
 
                 gsiArray.add(gsiNode);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1613,6 +1613,54 @@ public class DynamoDbService implements ResourceProvider {
         return table.getTags() != null ? table.getTags() : Map.of();
     }
 
+    /** Result of a successful GetResourcePolicy call: the raw policy document and its revision id. */
+    public record ResourcePolicyResult(String policy, String revisionId) {}
+
+    public String putResourcePolicy(String resourceArn, String policy, String expectedRevisionId, String region) {
+        TableDefinition table = findTableByArn(resourceArn, region);
+        if (expectedRevisionId != null
+                && !expectedRevisionId.equals(table.getResourcePolicyRevisionId())) {
+            throw new AwsException("PolicyNotFoundException",
+                    "Policy with revision id " + expectedRevisionId + " does not exist for: " + resourceArn, 400);
+        }
+        String revisionId = UUID.randomUUID().toString();
+        table.setResourcePolicy(policy);
+        table.setResourcePolicyRevisionId(revisionId);
+        String storageKey = regionKey(region, table.getTableName());
+        tableStore.put(storageKey, table);
+        LOG.debugv("Put resource policy: {0}", resourceArn);
+        return revisionId;
+    }
+
+    public ResourcePolicyResult getResourcePolicy(String resourceArn, String region) {
+        TableDefinition table = findTableByArn(resourceArn, region);
+        if (table.getResourcePolicy() == null) {
+            throw new AwsException("PolicyNotFoundException",
+                    "No resource policy found for: " + resourceArn, 400);
+        }
+        return new ResourcePolicyResult(table.getResourcePolicy(), table.getResourcePolicyRevisionId());
+    }
+
+    public String deleteResourcePolicy(String resourceArn, String expectedRevisionId, String region) {
+        TableDefinition table = findTableByArn(resourceArn, region);
+        if (table.getResourcePolicy() == null) {
+            throw new AwsException("PolicyNotFoundException",
+                    "No resource policy found for: " + resourceArn, 400);
+        }
+        if (expectedRevisionId != null
+                && !expectedRevisionId.equals(table.getResourcePolicyRevisionId())) {
+            throw new AwsException("PolicyNotFoundException",
+                    "Policy with revision id " + expectedRevisionId + " does not exist for: " + resourceArn, 400);
+        }
+        String revisionId = table.getResourcePolicyRevisionId();
+        table.setResourcePolicy(null);
+        table.setResourcePolicyRevisionId(null);
+        String storageKey = regionKey(region, table.getTableName());
+        tableStore.put(storageKey, table);
+        LOG.debugv("Deleted resource policy: {0}", resourceArn);
+        return revisionId;
+    }
+
     private TableDefinition findTableByArn(String arn, String region) {
         String prefix = region + "::";
         return tableStore.scan(k -> k.startsWith(prefix)).stream()

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/GlobalSecondaryIndex.java
@@ -19,6 +19,8 @@ public class GlobalSecondaryIndex {
     private long itemCount;
     private long indexSizeBytes;
     private List<String> nonKeyAttributes;
+    private Integer onDemandMaxReadRequestUnits;
+    private Integer onDemandMaxWriteRequestUnits;
 
     public GlobalSecondaryIndex() {
         this.provisionedThroughput = new ProvisionedThroughput(0, 0);
@@ -63,6 +65,12 @@ public class GlobalSecondaryIndex {
 
     public long getIndexSizeBytes() { return indexSizeBytes; }
     public void setIndexSizeBytes(long indexSizeBytes) { this.indexSizeBytes = indexSizeBytes; }
+
+    public Integer getOnDemandMaxReadRequestUnits() { return onDemandMaxReadRequestUnits; }
+    public void setOnDemandMaxReadRequestUnits(Integer v) { this.onDemandMaxReadRequestUnits = v; }
+
+    public Integer getOnDemandMaxWriteRequestUnits() { return onDemandMaxWriteRequestUnits; }
+    public void setOnDemandMaxWriteRequestUnits(Integer v) { this.onDemandMaxWriteRequestUnits = v; }
 
     @JsonIgnore
     public String getPartitionKeyName() {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/model/TableDefinition.java
@@ -51,6 +51,11 @@ public class TableDefinition {
     // Replica regions for a global table (single-process emulator backs them all with this table's
     // data; the list drives the DescribeTable Replicas/GlobalTableVersion projection).
     private List<String> replicaRegions;
+    // Resource-based policy attached via PutResourcePolicy (JSON policy document text), and the
+    // opaque revision id AWS hands back so callers can pass ExpectedRevisionId for optimistic
+    // concurrency on subsequent Put/DeleteResourcePolicy calls. Null when no policy is attached.
+    private String resourcePolicy;
+    private String resourcePolicyRevisionId;
 
     public TableDefinition() {
         this.keySchema = new ArrayList<>();
@@ -206,6 +211,12 @@ public class TableDefinition {
 
     public Integer getOnDemandMaxWriteRequestUnits() { return onDemandMaxWriteRequestUnits; }
     public void setOnDemandMaxWriteRequestUnits(Integer v) { this.onDemandMaxWriteRequestUnits = v; }
+
+    public String getResourcePolicy() { return resourcePolicy; }
+    public void setResourcePolicy(String resourcePolicy) { this.resourcePolicy = resourcePolicy; }
+
+    public String getResourcePolicyRevisionId() { return resourcePolicyRevisionId; }
+    public void setResourcePolicyRevisionId(String resourcePolicyRevisionId) { this.resourcePolicyRevisionId = resourcePolicyRevisionId; }
 
     @JsonIgnore
     public String getPartitionKeyName() {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
@@ -332,5 +333,136 @@ class DynamoDbJsonHandlerTest {
 
         assertEquals("None", reasons.get(0).get("Code").asText());
         assertNull(reasons.get(0).get("Message"), "non failed item must not have a Message field");
+    }
+
+    // PutResourcePolicy/GetResourcePolicy/DeleteResourcePolicy previously fell through to the
+    // default 400 UnknownOperationException branch, which blocks the Terraform provider's
+    // aws_dynamodb_resource_policy resource at apply time.
+    @Test
+    void putGetDeleteResourcePolicyRoundTrips() throws Exception {
+        TableDefinition table = createUsersTable("eu-west-1");
+        String tableArn = table.getTableArn();
+        String policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AllowDummyRoleAccess\","
+                + "\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::222222222222:role/DummyRole\"},"
+                + "\"Action\":\"dynamodb:GetItem\",\"Resource\":\"" + tableArn + "\"}]}";
+
+        ObjectNode putRequest = mapper.createObjectNode();
+        putRequest.put("ResourceArn", tableArn);
+        putRequest.put("Policy", policy);
+
+        Response putResponse = handler.handle("PutResourcePolicy", putRequest, "eu-west-1");
+        assertEquals(200, putResponse.getStatus());
+        JsonNode putBody = mapper.convertValue(putResponse.getEntity(), JsonNode.class);
+        assertTrue(putBody.has("RevisionId"), "PutResourcePolicy must return a RevisionId");
+        String revisionId = putBody.get("RevisionId").asText();
+        assertFalse(revisionId.isBlank());
+
+        ObjectNode getRequest = mapper.createObjectNode();
+        getRequest.put("ResourceArn", tableArn);
+
+        Response getResponse = handler.handle("GetResourcePolicy", getRequest, "eu-west-1");
+        assertEquals(200, getResponse.getStatus());
+        JsonNode getBody = mapper.convertValue(getResponse.getEntity(), JsonNode.class);
+        assertEquals(policy, getBody.get("Policy").asText());
+        assertEquals(revisionId, getBody.get("RevisionId").asText());
+
+        ObjectNode deleteRequest = mapper.createObjectNode();
+        deleteRequest.put("ResourceArn", tableArn);
+
+        Response deleteResponse = handler.handle("DeleteResourcePolicy", deleteRequest, "eu-west-1");
+        assertEquals(200, deleteResponse.getStatus());
+        JsonNode deleteBody = mapper.convertValue(deleteResponse.getEntity(), JsonNode.class);
+        assertEquals(revisionId, deleteBody.get("RevisionId").asText());
+
+        // Policy is gone: GetResourcePolicy must fail now
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("GetResourcePolicy", getRequest, "eu-west-1"));
+        assertEquals("PolicyNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void putResourcePolicyRejectsAStaleExpectedRevisionId() throws Exception {
+        TableDefinition table = createUsersTable("eu-west-1");
+        String tableArn = table.getTableArn();
+
+        ObjectNode putRequest = mapper.createObjectNode();
+        putRequest.put("ResourceArn", tableArn);
+        putRequest.put("Policy", "{}");
+        handler.handle("PutResourcePolicy", putRequest, "eu-west-1");
+
+        putRequest.put("ExpectedRevisionId", "not-the-current-revision");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("PutResourcePolicy", putRequest, "eu-west-1"));
+        assertEquals("PolicyNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void putResourcePolicyRejectsInvalidResourceArn() {
+        ObjectNode putRequest = mapper.createObjectNode();
+        putRequest.put("ResourceArn", "not-an-arn");
+        putRequest.put("Policy", "{}");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("PutResourcePolicy", putRequest, "eu-west-1"));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    // A GSI created with an explicit OnDemandThroughput never had the value stored, so
+    // DescribeTable could not report it back; the Terraform provider then proposes replacing
+    // the GSI on every plan even though nothing drifted.
+    @Test
+    void createTableWithGsiOnDemandThroughputRoundTripsThroughDescribeTable() throws Exception {
+        ObjectNode createRequest = mapper.createObjectNode();
+        createRequest.put("TableName", "gsi-odt-table");
+        createRequest.put("BillingMode", "PAY_PER_REQUEST");
+
+        ArrayNode attrDefs = mapper.createArrayNode();
+        attrDefs.add(mapper.createObjectNode().put("AttributeName", "id").put("AttributeType", "S"));
+        attrDefs.add(mapper.createObjectNode().put("AttributeName", "title").put("AttributeType", "S"));
+        attrDefs.add(mapper.createObjectNode().put("AttributeName", "age").put("AttributeType", "S"));
+        createRequest.set("AttributeDefinitions", attrDefs);
+
+        ArrayNode keySchema = mapper.createArrayNode();
+        keySchema.add(mapper.createObjectNode().put("AttributeName", "id").put("KeyType", "HASH"));
+        createRequest.set("KeySchema", keySchema);
+
+        ObjectNode gsi = mapper.createObjectNode();
+        gsi.put("IndexName", "TitleIndex");
+        ArrayNode gsiKeySchema = mapper.createArrayNode();
+        gsiKeySchema.add(mapper.createObjectNode().put("AttributeName", "title").put("KeyType", "HASH"));
+        gsiKeySchema.add(mapper.createObjectNode().put("AttributeName", "age").put("KeyType", "RANGE"));
+        gsi.set("KeySchema", gsiKeySchema);
+        ObjectNode projection = mapper.createObjectNode();
+        projection.put("ProjectionType", "INCLUDE");
+        projection.set("NonKeyAttributes", mapper.createArrayNode().add("id"));
+        gsi.set("Projection", projection);
+        ObjectNode gsiOnDemand = mapper.createObjectNode();
+        gsiOnDemand.put("MaxReadRequestUnits", 1);
+        gsiOnDemand.put("MaxWriteRequestUnits", 1);
+        gsi.set("OnDemandThroughput", gsiOnDemand);
+        createRequest.set("GlobalSecondaryIndexes", mapper.createArrayNode().add(gsi));
+
+        Response createResponse = handler.handle("CreateTable", createRequest, "eu-west-1");
+        assertEquals(200, createResponse.getStatus());
+        JsonNode createBody = mapper.convertValue(createResponse.getEntity(), JsonNode.class);
+        JsonNode createdGsi = createBody.get("TableDescription").get("GlobalSecondaryIndexes").get(0);
+        assertTrue(createdGsi.has("OnDemandThroughput"),
+                "CreateTable response must echo the GSI's OnDemandThroughput");
+        assertEquals(1, createdGsi.get("OnDemandThroughput").get("MaxReadRequestUnits").asInt());
+        assertEquals(1, createdGsi.get("OnDemandThroughput").get("MaxWriteRequestUnits").asInt());
+
+        ObjectNode describeRequest = mapper.createObjectNode();
+        describeRequest.put("TableName", "gsi-odt-table");
+
+        Response describeResponse = handler.handle("DescribeTable", describeRequest, "eu-west-1");
+        assertEquals(200, describeResponse.getStatus());
+        JsonNode describeBody = mapper.convertValue(describeResponse.getEntity(), JsonNode.class);
+        JsonNode describedGsi = describeBody.get("Table").get("GlobalSecondaryIndexes").get(0);
+
+        assertTrue(describedGsi.has("OnDemandThroughput"),
+                "DescribeTable must report the GSI's OnDemandThroughput");
+        JsonNode odt = describedGsi.get("OnDemandThroughput");
+        assertEquals(1, odt.get("MaxReadRequestUnits").asInt());
+        assertEquals(1, odt.get("MaxWriteRequestUnits").asInt());
     }
 }


### PR DESCRIPTION
DynamoDB rejected PutResourcePolicy/GetResourcePolicy/DeleteResourcePolicy
with UnknownOperationException, and a GSI created with OnDemandThroughput
never stored the value, so DescribeTable could not report it back. Both
break the Terraform provider: aws_dynamodb_resource_policy fails at apply,
and an on-demand GSI shows phantom drift on every plan.

Policies are stored on the table with an opaque RevisionId and honor
ExpectedRevisionId on Put/Delete, answering PolicyNotFoundException on a
mismatch or a missing policy, per the API reference. The GSI parse and
emit mirror the existing table-level OnDemandThroughput handling on
CreateTable, UpdateTable and DescribeTable.

Four new handler tests cover both round-trips plus the stale
ExpectedRevisionId and invalid-ARN rejections; the full local DynamoDb*
test family passes. Happy to adjust to conventions.
