### PR TITLE
docs(lambda): qualify which kubeconfig auth methods the Kubernetes executor supports

### DIFF
--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -313,7 +313,10 @@ environment as a Kubernetes pod instead of a Docker container. This is designed
 for CI/CD clusters where privileged containers and `docker.sock` access are not
 allowed. Floci talks to the cluster through the standard Kubernetes API: when
 running inside the cluster it uses its ServiceAccount, and when running outside
-it uses your local kubeconfig.
+it uses your local kubeconfig. Only an inline static bearer `token` or a
+client-certificate/client-key credential with a PKCS#8 private key is
+supported; `tokenFile`, exec, and auth-provider credential plugins
+(`aws eks get-token`, gcloud, etc.) are not, and fail with a named error.
 
 How an invocation works:
 


### PR DESCRIPTION
## Summary

Follow-up from #2919's approval review: the Kubernetes executor section of `docs/services/lambda.md` said Floci "uses your local kubeconfig" without qualifying which credential types that covers. Since #2919 swapped the Fabric8 client for a plain REST client, only a static bearer token or client-certificate/client-key credential works; exec and auth-provider plugins (`aws eks get-token`, gcloud) fail with a named error. Adds one sentence naming that split so an EKS/GKE user isn't surprised.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A, docs-only change, no code touched.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
