### PR TITLE
refactor(ses): extract the identity domain into SesIdentityService

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -355,7 +355,7 @@ public class SesController {
                 throw new AwsException("BadRequestException",
                         "EXTERNAL origin requires DomainSigningSelector and DomainSigningPrivateKey.", 400);
             }
-            SesService.DkimSigningResult result = sesService.putDkimSigningAttributes(
+            SesIdentityService.DkimSigningResult result = sesService.putDkimSigningAttributes(
                     emailIdentity, origin, selector, nextKeyLength, region);
             ObjectNode out = objectMapper.createObjectNode();
             out.put("DkimStatus", toV2Status(result.dkimStatus()));

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesIdentityService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesIdentityService.java
@@ -1,0 +1,645 @@
+package io.github.hectorvent.floci.services.ses;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.route53.Route53Service;
+import io.github.hectorvent.floci.services.route53.model.HostedZone;
+import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
+import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
+import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.Tag;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Email and domain identities, extracted from {@link SesService} as the last store of the
+ * store-based domain split: the store, key derivation and whitespace validation, verification
+ * (email and domain), listing, MAIL FROM and notification settings, the CVET pending registration,
+ * the ARN-dispatched identity tagging, and the DKIM state machine (token generation, signing
+ * attributes, the Route53-backed record detection with its lookup cache) live here.
+ *
+ * <p>The remaining boundary follows the cross-domain seams: the default-configuration-set
+ * association and the send-path reads stay in the facade and reach the store through
+ * {@link #find}/{@link #save}. The facade also keeps the tenant delete-guard and the policy
+ * cascade around {@link #delete}.
+ */
+@ApplicationScoped
+public class SesIdentityService {
+
+    private static final Logger LOG = Logger.getLogger(SesIdentityService.class);
+
+    private static final Duration DKIM_LOOKUP_CACHE_TTL = Duration.ofSeconds(5);
+
+    private final StorageBackend<String, Identity> identityStore;
+    // Null means DNS lookup disabled: DKIM records are then never detected and statuses stay Pending.
+    private final Route53Service route53Service;
+    private final Clock clock;
+    private final ConcurrentHashMap<String, DkimLookupCacheEntry> dkimLookupCache = new ConcurrentHashMap<>();
+
+    @Inject
+    public SesIdentityService(StorageFactory storageFactory, Route53Service route53Service, Clock clock) {
+        this(storageFactory.create("ses", "ses-identities.json",
+                new TypeReference<Map<String, Identity>>() {}), route53Service, clock);
+    }
+
+    SesIdentityService(StorageBackend<String, Identity> identityStore,
+                       Route53Service route53Service, Clock clock) {
+        this.identityStore = identityStore;
+        this.route53Service = route53Service;
+        this.clock = clock;
+    }
+
+    public Identity verifyEmailIdentity(String emailAddress, String region) {
+        validateIdentityWhitespace(emailAddress, "Email address");
+        if (emailAddress == null || emailAddress.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "Email address is required.", 400);
+        }
+        String key = identityKey(region, emailAddress);
+        Identity existing = identityStore.get(key).orElse(null);
+        if (existing != null) {
+            return existing;
+        }
+
+        Identity identity = new Identity(emailAddress, "EmailAddress");
+        identityStore.put(key, identity);
+        LOG.infov("Verified email identity: {0} in region {1}", emailAddress, region);
+        return identity;
+    }
+
+    public Identity verifyDomainIdentity(String domain, String region) {
+        validateIdentityWhitespace(domain, "Domain");
+        if (domain == null || domain.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "Domain is required.", 400);
+        }
+        String key = identityKey(region, domain);
+        Identity existing = identityStore.get(key).orElse(null);
+        if (existing != null) {
+            return existing;
+        }
+
+        Identity identity = new Identity(domain, "Domain");
+        regenerateDkimTokens(identity);
+        identity.setVerificationStatus("Pending");
+        identity.setDkimEnabled(true);
+        // The create response reports DKIM verification as NotStarted (SES hasn't begun tracking the
+        // CNAMEs yet); the first Get/List refresh transitions it to Pending. Matches AWS, where
+        // CreateEmailIdentity returns NOT_STARTED but a subsequent GetEmailIdentity returns PENDING.
+        identity.setDkimVerificationStatus("NotStarted");
+        identityStore.put(key, identity);
+        LOG.infov("Verified domain identity: {0} in region {1}", domain, region);
+        return identity;
+    }
+
+    public Identity getIdentityVerificationAttributes(String identityValue, String region) {
+        Identity identity = identityStore.get(identityKey(region, identityValue)).orElse(null);
+        return refreshIdentityState(identity, region);
+    }
+
+    /** True when the address itself or its parent domain is a verified identity. */
+    public boolean isVerifiedSender(String fromEmail, String region) {
+        if (fromEmail == null) {
+            return false;
+        }
+        if (isIdentityVerified(fromEmail, region)) {
+            return true;
+        }
+        int at = fromEmail.indexOf('@');
+        return at >= 0 && at < fromEmail.length() - 1
+                && isIdentityVerified(fromEmail.substring(at + 1), region);
+    }
+
+    private boolean isIdentityVerified(String identity, String region) {
+        Identity id = getIdentityVerificationAttributes(identity, region);
+        return id != null && "Success".equals(id.getVerificationStatus());
+    }
+
+    public List<Identity> listIdentities(String identityType, String region) {
+        List<Identity> all = identityStore.scan(k -> k.startsWith(keyPrefix(region)));
+        if (identityType == null || identityType.isBlank()) {
+            return all;
+        }
+        return all.stream()
+                .filter(i -> identityType.equals(i.getIdentityType()))
+                .toList();
+    }
+
+    public List<String> getVerifiedEmailAddresses(String region) {
+        List<Identity> all = identityStore.scan(k -> k.startsWith(keyPrefix(region)));
+        List<String> emails = new ArrayList<>();
+        for (Identity identity : all) {
+            if ("EmailAddress".equals(identity.getIdentityType())
+                    && "Success".equals(identity.getVerificationStatus())) {
+                emails.add(identity.getIdentity());
+            }
+        }
+        return emails;
+    }
+
+    /**
+     * Deletes the identity's record and any aliased records whose stored identity value matches,
+     * and invalidates the DKIM lookup cache. The facade wraps this with the tenant delete-guard
+     * and the sending-authorization policy cascade.
+     */
+    public void delete(String identityValue, String region) {
+        identityStore.delete(identityKey(region, identityValue));
+        invalidateDkimLookupCache(region, identityValue);
+
+        List<String> keys = new ArrayList<>(identityStore.keys().stream()
+                .filter(k -> k.startsWith(keyPrefix(region)))
+                .toList());
+        for (String storedKey : keys) {
+            Identity storedIdentity = identityStore.get(storedKey).orElse(null);
+            if (storedIdentity != null && identityValue.equals(storedIdentity.getIdentity())) {
+                identityStore.delete(storedKey);
+            }
+        }
+    }
+
+    public void setMailFromDomain(String identityValue, String mailFromDomain,
+                                  String behaviorOnMxFailure, String region) {
+        String normalizedBehavior = null;
+        if (behaviorOnMxFailure != null) {
+            if (!"UseDefaultValue".equals(behaviorOnMxFailure)
+                    && !"RejectMessage".equals(behaviorOnMxFailure)) {
+                throw new AwsException("ValidationError",
+                        "1 validation error detected: Value at 'behaviorOnMXFailure' failed to satisfy "
+                                + "constraint: Member must satisfy enum value set: [RejectMessage, UseDefaultValue]", 400);
+            }
+            normalizedBehavior = behaviorOnMxFailure;
+        }
+        boolean clearing = mailFromDomain == null || mailFromDomain.isEmpty();
+        if (!clearing && mailFromDomain.isBlank()) {
+            throw new AwsException("InvalidParameterValue",
+                    "MailFromDomain must be a domain or an empty string to clear; whitespace is not accepted.", 400);
+        }
+        String key = identityKey(region, identityValue);
+        Identity identity = identityStore.get(key)
+                .orElseThrow(() -> new AwsException("InvalidParameterValue",
+                        "Identity <" + identityValue + "> does not exist.", 400));
+        identity.setMailFromDomain(clearing ? null : mailFromDomain);
+        identity.setMailFromDomainStatus(clearing ? "Pending" : "Success");
+        if (clearing) {
+            identity.setBehaviorOnMxFailure("UseDefaultValue");
+        } else if (normalizedBehavior != null) {
+            identity.setBehaviorOnMxFailure(normalizedBehavior);
+        }
+        identityStore.put(key, identity);
+        LOG.infov("Updated MAIL FROM domain for {0}: domain={1}, behavior={2}",
+                identityValue, mailFromDomain, normalizedBehavior);
+    }
+
+    public Identity getMailFromAttributes(String identityValue, String region) {
+        return identityStore.get(identityKey(region, identityValue)).orElse(null);
+    }
+
+    /** Registers the CVET recipient as a pending email identity when it is not already known. */
+    public void markPendingEmailIdentity(String emailAddress, String region) {
+        String key = identityKey(region, emailAddress);
+        if (identityStore.get(key).isEmpty()) {
+            Identity identity = new Identity(emailAddress, "EmailAddress");
+            identity.setVerificationStatus("Pending");
+            identityStore.put(key, identity);
+            LOG.infov("SES custom verification email registered pending identity {0} in region {1}",
+                    emailAddress, region);
+        }
+    }
+
+    static final List<String> NOTIFICATION_TYPES = List.of("Bounce", "Complaint", "Delivery");
+
+    public void setIdentityNotificationTopic(String identityValue, String notificationType,
+                                             String snsTopic, String region) {
+        Identity identity = identityStore.get(identityKey(region, identityValue))
+                .orElseThrow(() -> new AwsException("InvalidParameterValue",
+                        "Identity does not exist: " + identityValue, 400));
+        if (snsTopic != null && !snsTopic.isBlank()) {
+            identity.getNotificationAttributes().put(notificationType + "Topic", snsTopic);
+        } else {
+            identity.getNotificationAttributes().remove(notificationType + "Topic");
+        }
+        save(identity, region);
+    }
+
+    public Identity getIdentityNotificationAttributes(String identityValue, String region) {
+        return identityStore.get(identityKey(region, identityValue)).orElse(null);
+    }
+
+    public void setFeedbackForwardingEnabled(String identityValue, boolean enabled, String region) {
+        Identity identity = identityStore.get(identityKey(region, identityValue))
+                .orElseThrow(() -> new AwsException("InvalidParameterValue",
+                        "Identity " + identityValue
+                                + " is invalid. Must be a verified email address or domain.", 400));
+        identity.setFeedbackForwardingEnabled(enabled);
+        save(identity, region);
+        LOG.infov("Updated feedback forwarding for {0}: enabled={1}", identityValue, enabled);
+    }
+
+    public void setHeadersInNotificationsEnabled(String identityValue, String notificationType,
+                                                 boolean enabled, String region) {
+        if (notificationType == null || notificationType.isBlank()) {
+            throw new AwsException("InvalidParameterValue",
+                    "NotificationType is required.", 400);
+        }
+        if (!NOTIFICATION_TYPES.contains(notificationType)) {
+            throw new AwsException("ValidationError",
+                    "1 validation error detected: Value at 'notificationType' failed to satisfy "
+                            + "constraint: Member must satisfy enum value set: "
+                            + NOTIFICATION_TYPES, 400);
+        }
+        Identity identity = identityStore.get(identityKey(region, identityValue))
+                .orElseThrow(() -> new AwsException("InvalidParameterValue",
+                        "Identity " + identityValue
+                                + " is invalid. It must be a verified email address or domain.", 400));
+        identity.getHeadersInNotificationsEnabled().put(notificationType, enabled);
+        save(identity, region);
+        LOG.infov("Updated headers-in-notifications for {0}: {1}={2}",
+                identityValue, notificationType, enabled);
+    }
+
+    public List<Tag> listTags(String identityValue, String region) {
+        return new ArrayList<>(requireForTags(identityValue, region).getTags());
+    }
+
+    public void tag(String identityValue, String region, List<Tag> newTags) {
+        Identity identity = requireForTags(identityValue, region);
+        identity.setTags(SesTags.merge(identity.getTags(), newTags));
+        identityStore.put(identityKey(region, identityValue), identity);
+        LOG.infov("Tagged SES identity: {0} (region {1}, +{2} tags)", identityValue, region, newTags.size());
+    }
+
+    public void untag(String identityValue, String region, List<String> tagKeys) {
+        Identity identity = requireForTags(identityValue, region);
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        // Copy-on-write: the stored list may be immutable, and unlocked readers iterate it.
+        List<Tag> remaining = new ArrayList<>(identity.getTags());
+        remaining.removeIf(t -> toRemove.contains(t.key()));
+        identity.setTags(remaining);
+        identityStore.put(identityKey(region, identityValue), identity);
+        LOG.infov("Untagged SES identity: {0} (region {1}, -{2} keys)", identityValue, region, tagKeys.size());
+    }
+
+    public void setTags(String identityValue, String region, List<Tag> tags) {
+        SesTags.validate(tags);
+        Identity identity = requireForTags(identityValue, region);
+        identity.setTags(tags);
+        identityStore.put(identityKey(region, identityValue), identity);
+    }
+
+    private Identity requireForTags(String identityValue, String region) {
+        return identityStore.get(identityKey(region, identityValue))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No EmailIdentity present with name: " + identityValue, 404));
+    }
+
+    // ──────────────────────── DKIM (second stage) ────────────────────────
+
+    public void setDkimAttributes(String identityValue, boolean signingEnabled, String region) {
+        if (identityValue == null || identityValue.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "Identity is required.", 400);
+        }
+        // DKIM is a domain concept and an email reports its parent domain's DKIM (via effectiveDkimSource),
+        // so toggling DKIM on an email whose parent domain is a registered identity is a no-op that leaves
+        // the domain untouched, matching real AWS, regardless of whether the email identity itself exists.
+        if (identityValue.contains("@")) {
+            String domain = identityValue.substring(identityValue.indexOf('@') + 1);
+            if (identityStore.get(identityKey(region, domain)).isPresent()) {
+                return;
+            }
+        }
+        Identity identity = identityStore.get(identityKey(region, identityValue)).orElse(null);
+        if (identity == null) {
+            String domain = identityValue.contains("@")
+                    ? identityValue.substring(identityValue.indexOf('@') + 1)
+                    : identityValue;
+            // v1-native code; the v2 controller remaps InvalidParameterValue -> BadRequestException.
+            throw new AwsException("InvalidParameterValue",
+                    "Domain " + domain + " is not verified for DKIM signing.", 400);
+        }
+
+        // Only toggle the signing flag. DkimVerificationStatus tracks DNS record detection (via the
+        // Route53 lookup in refreshIdentityState), not the enabled flag, matching real AWS, where
+        // SetIdentityDkimEnabled / PutEmailIdentityDkimAttributes leave the verification status alone.
+        identity.setDkimEnabled(signingEnabled);
+        save(identity, region);
+        LOG.infov("Updated DKIM attributes for {0}: signingEnabled={1}", identityValue, signingEnabled);
+    }
+
+    private List<String> generateDkimTokens() {
+        List<String> tokens = new ArrayList<>(3);
+        for (int i = 0; i < 3; i++) {
+            tokens.add(UUID.randomUUID().toString().replace("-", ""));
+        }
+        return tokens;
+    }
+
+    /**
+     * Generates a fresh Easy DKIM token set and records the key length / generation timestamp. New
+     * tokens mean the previously published CNAMEs no longer match, so the verification status resets
+     * to Pending (re-detected via the Route53 lookup) and the origin returns to AWS_SES. Only meaningful
+     * for domain identities; refreshIdentityState re-upgrades to Success once the new records exist.
+     */
+    private void regenerateDkimTokens(Identity identity) {
+        identity.setDkimTokens(generateDkimTokens());
+        identity.setDkimCurrentSigningKeyLength(identity.getDkimNextSigningKeyLength());
+        identity.setDkimLastKeyGenerationTimestamp(Instant.now(clock));
+        identity.setDkimSigningAttributesOrigin("AWS_SES");
+        // The new tokens' CNAMEs aren't detected yet, so DKIM verification resets to Pending. The
+        // identity's own verification is NOT revoked by a key rotation (matching AWS): keep Success
+        // when already verified; a not-yet-verified identity stays Pending.
+        identity.setDkimVerificationStatus("Pending");
+        if (!"Success".equals(identity.getVerificationStatus())) {
+            identity.setVerificationStatus("Pending");
+        }
+    }
+
+    /**
+     * v1 VerifyDomainDkim: returns the domain identity's DKIM tokens (3), generating them if needed.
+     * Tokens are stable across calls (AWS does not regenerate them). The domain is registered as a
+     * pending identity if it does not exist yet, matching AWS's lenient behavior (VerifyDomainDkim
+     * starts DKIM setup for any domain).
+     */
+    public List<String> verifyDomainDkim(String domain, String region) {
+        validateIdentityWhitespace(domain, "Domain");
+        if (domain == null || domain.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "Domain is required.", 400);
+        }
+        if (domain.contains("@")) {
+            // Domain-only action: an email-shaped value must not create an email-valued "Domain".
+            throw new AwsException("InvalidParameterValue", "Domain " + domain + " is invalid.", 400);
+        }
+        Identity identity = identityStore.get(identityKey(region, domain)).orElse(null);
+        if (identity == null) {
+            identity = new Identity(domain, "Domain");
+            identity.setVerificationStatus("Pending");
+            identity.setDkimEnabled(true);
+            identity.setDkimVerificationStatus("Pending");
+        }
+        if (!hasDkimTokens(identity)) {
+            regenerateDkimTokens(identity);
+        }
+        save(identity, region);
+        LOG.infov("VerifyDomainDkim: {0} (region {1})", domain, region);
+        return identity.getDkimTokens();
+    }
+
+    /**
+     * v2 PutEmailIdentityDkimSigningAttributes. AWS_SES (Easy DKIM): sets the next signing key length
+     * and regenerates tokens when the length changes. EXTERNAL (BYODKIM): switches the origin and
+     * clears the Easy DKIM tokens (the caller publishes its own selector, which Floci does not use for
+     * signing). Returns the resulting DKIM status and tokens.
+     */
+    public DkimSigningResult putDkimSigningAttributes(String identityValue, String origin,
+                                                      String signingSelector, String nextKeyLength,
+                                                      String region) {
+        // DKIM signing attributes are domain-level; AWS rejects a missing/blank value or an
+        // email-address identity here (verified: all return the same 400 "must be a valid domain")
+        // rather than mutating state that the email would just inherit back from its parent domain.
+        if (identityValue == null || identityValue.isBlank() || identityValue.contains("@")) {
+            throw new AwsException("BadRequestException",
+                    "The EmailIdentity value must be a valid domain.", 400);
+        }
+        Identity identity = identityStore.get(identityKey(region, identityValue))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "Email identity " + identityValue + " does not exist.", 404));
+        if ("EXTERNAL".equals(origin)) {
+            identity.setDkimSigningAttributesOrigin("EXTERNAL");
+            // Clear the Easy DKIM tokens and reset the status: Floci can't verify a BYODKIM selector,
+            // so leaving a prior Success/Pending with no tokens (and no Route53 detection path) would
+            // be inconsistent.
+            identity.setDkimTokens(new ArrayList<>());
+            identity.setDkimVerificationStatus("Pending");
+            LOG.infov("PutEmailIdentityDkimSigningAttributes(EXTERNAL): {0} selector={1}",
+                    identityValue, signingSelector);
+        } else {
+            identity.setDkimSigningAttributesOrigin("AWS_SES");
+            // DKIM tokens are a domain concept; only (re)generate them for a domain identity.
+            if ("Domain".equals(identity.getIdentityType())) {
+                if (nextKeyLength != null && !nextKeyLength.equals(identity.getDkimCurrentSigningKeyLength())) {
+                    identity.setDkimNextSigningKeyLength(nextKeyLength);
+                    regenerateDkimTokens(identity);
+                } else if (!hasDkimTokens(identity)) {
+                    regenerateDkimTokens(identity);
+                }
+            }
+            LOG.infov("PutEmailIdentityDkimSigningAttributes(AWS_SES): {0} keyLength={1}",
+                    identityValue, nextKeyLength);
+        }
+        save(refreshIdentityState(identity, region), region);
+        Identity src = effectiveDkimSource(identity, region);
+        return new DkimSigningResult(src.getDkimVerificationStatus(),
+                src.getDkimTokens() == null ? List.of() : src.getDkimTokens());
+    }
+
+    /** Carrier for the PutEmailIdentityDkimSigningAttributes response ({@code dkimStatus} is v1-native). */
+    public record DkimSigningResult(String dkimStatus, List<String> dkimTokens) {}
+
+    /**
+     * Resolves which identity's DKIM state should be reported for {@code identity}. A domain reports
+     * its own DKIM; an email address reports its parent domain's DKIM (SigningEnabled / Status /
+     * Tokens all inherit from the domain), matching AWS. Falls back to the identity itself when the
+     * parent domain is not a registered identity.
+     */
+    public Identity effectiveDkimSource(Identity identity, String region) {
+        if (identity == null || !"EmailAddress".equals(identity.getIdentityType())) {
+            return identity;
+        }
+        String addr = identity.getIdentity();
+        int at = addr == null ? -1 : addr.indexOf('@');
+        if (at < 0 || at == addr.length() - 1) {
+            return identity;
+        }
+        Identity domainIdentity = identityStore.get(identityKey(region, addr.substring(at + 1))).orElse(null);
+        return domainIdentity == null ? identity : refreshIdentityState(domainIdentity, region);
+    }
+
+    Identity refreshIdentityState(Identity identity, String region) {
+        if (identity == null) {
+            return null;
+        }
+
+        boolean changed = false;
+        if ("Domain".equals(identity.getIdentityType()) && identity.getDkimTokens() == null) {
+            regenerateDkimTokens(identity);
+            changed = true;
+        }
+
+        if ("Domain".equals(identity.getIdentityType()) && hasDkimTokens(identity)) {
+            changed |= normalizePendingDomainState(identity);
+            // Upgrade identity- and DKIM-verification independently so that, e.g., after a key rotation
+            // (which resets only DkimVerificationStatus while the identity stays verified), the DKIM
+            // status can still return to Success once the new records are detected.
+            // Only look up DNS when a status can still be upgraded: skip the (cached) Route53 check
+            // once both identity- and DKIM-verification are already Success. DKIM verification tracks
+            // DNS detection independently of the signing-enabled flag, so it can reach Success even
+            // when DKIM signing is disabled, and can re-pend/re-upgrade after a key rotation.
+            boolean needsUpgrade = !"Success".equals(identity.getVerificationStatus())
+                    || !"Success".equals(identity.getDkimVerificationStatus());
+            if (needsUpgrade && hasAllExpectedDkimRecords(identity, region)) {
+                if (!"Success".equals(identity.getVerificationStatus())) {
+                    identity.setVerificationStatus("Success");
+                    changed = true;
+                }
+                if (!"Success".equals(identity.getDkimVerificationStatus())) {
+                    identity.setDkimVerificationStatus("Success");
+                    changed = true;
+                }
+            }
+        }
+
+        if ("Success".equals(identity.getVerificationStatus())) {
+            invalidateDkimLookupCache(region, identity.getIdentity());
+        }
+
+        if (changed) {
+            save(identity, region);
+        }
+        return identity;
+    }
+
+    private boolean hasDkimTokens(Identity identity) {
+        return identity.getDkimTokens() != null && !identity.getDkimTokens().isEmpty();
+    }
+
+    private boolean normalizePendingDomainState(Identity identity) {
+        boolean changed = false;
+        if (!"Success".equals(identity.getVerificationStatus())
+                && !"Pending".equals(identity.getVerificationStatus())) {
+            identity.setVerificationStatus("Pending");
+            changed = true;
+        }
+        // DKIM verification tracks DNS detection, not the signing-enabled flag, so a domain that has
+        // begun tracking (NotStarted -> Pending) reports Pending on Get even while signing is disabled.
+        if (!"Success".equals(identity.getDkimVerificationStatus())
+                && !"Pending".equals(identity.getDkimVerificationStatus())) {
+            identity.setDkimVerificationStatus("Pending");
+            changed = true;
+        }
+        return changed;
+    }
+
+    private boolean hasAllExpectedDkimRecords(Identity identity, String region) {
+        if (route53Service == null) {
+            return false;
+        }
+        Instant now = Instant.now(clock);
+        String cacheKey = dkimLookupCacheKey(region, identity);
+        DkimLookupCacheEntry cached = dkimLookupCache.get(cacheKey);
+        if (cached != null) {
+            if (now.isBefore(cached.expiresAt())) {
+                return cached.present();
+            }
+            dkimLookupCache.remove(cacheKey, cached);
+        }
+
+        boolean present = true;
+        for (String token : identity.getDkimTokens()) {
+            if (!hasExpectedDkimRecord(identity.getIdentity(), token)) {
+                present = false;
+                break;
+            }
+        }
+        dkimLookupCache.put(cacheKey, new DkimLookupCacheEntry(present, now.plus(DKIM_LOOKUP_CACHE_TTL)));
+        return present;
+    }
+
+    private boolean hasExpectedDkimRecord(String domain, String token) {
+        String expectedName = normalizeDnsName(token + "._domainkey." + domain);
+        String expectedValue = normalizeDnsName(token + ".dkim.amazonses.com");
+        for (HostedZone zone : route53Service.listHostedZones(null, Integer.MAX_VALUE)) {
+            for (ResourceRecordSet recordSet : route53Service.listResourceRecordSets(zone.getId(), null, null,
+                    Integer.MAX_VALUE)) {
+                if (!"CNAME".equalsIgnoreCase(recordSet.getType())) {
+                    continue;
+                }
+                if (!expectedName.equals(normalizeDnsName(recordSet.getName()))) {
+                    continue;
+                }
+                List<ResourceRecord> records = recordSet.getRecords();
+                if (records == null) {
+                    continue;
+                }
+                for (ResourceRecord record : records) {
+                    if (record != null && expectedValue.equals(normalizeDnsName(record.getValue()))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private String normalizeDnsName(String value) {
+        if (value == null) {
+            return "";
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        while (normalized.endsWith(".")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized;
+    }
+
+    private void invalidateDkimLookupCache(String region, String identityValue) {
+        if (identityValue == null || identityValue.isBlank()) {
+            return;
+        }
+        String cachePrefix = region + "::" + normalizeDnsName(identityValue) + "::";
+        dkimLookupCache.keySet().removeIf(key -> key.startsWith(cachePrefix));
+    }
+
+    private String dkimLookupCacheKey(String region, Identity identity) {
+        List<String> normalizedTokens = identity.getDkimTokens().stream()
+                .map(this::normalizeDnsName)
+                .sorted()
+                .toList();
+        return region + "::" + normalizeDnsName(identity.getIdentity()) + "::" + String.join(",", normalizedTokens);
+    }
+
+    private record DkimLookupCacheEntry(boolean present, Instant expiresAt) {}
+
+    /**
+     * Reads an identity without throwing, so the facade's default-configuration-set association and
+     * send-path reads can keep their own error contracts.
+     */
+    public Optional<Identity> find(String identityValue, String region) {
+        return identityStore.get(identityKey(region, identityValue));
+    }
+
+    /** Persists an identity mutated by the facade's cross-domain flows. */
+    public void save(Identity identity, String region) {
+        identityStore.put(identityKey(region, identity.getIdentity()), identity);
+    }
+
+    private static String keyPrefix(String region) {
+        return "identity::" + region + "::";
+    }
+
+    static String identityKey(String region, String identity) {
+        validateIdentityWhitespace(identity, "Identity");
+        return "identity::" + region + "::" + identity;
+    }
+
+    static void validateIdentityWhitespace(String identity, String fieldName) {
+        if (identity == null || identity.isBlank()) {
+            return;
+        }
+        if (Character.isWhitespace(identity.charAt(0)) || Character.isWhitespace(identity.charAt(identity.length() - 1))) {
+            throw new AwsException("InvalidParameterValue", fieldName + " must not contain leading or trailing whitespace.", 400);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesIdentityService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesIdentityService.java
@@ -232,7 +232,7 @@ public class SesIdentityService {
         } else {
             identity.getNotificationAttributes().remove(notificationType + "Topic");
         }
-        save(identity, region);
+        identityStore.put(identityKey(region, identityValue), identity);
     }
 
     public Identity getIdentityNotificationAttributes(String identityValue, String region) {
@@ -245,7 +245,7 @@ public class SesIdentityService {
                         "Identity " + identityValue
                                 + " is invalid. Must be a verified email address or domain.", 400));
         identity.setFeedbackForwardingEnabled(enabled);
-        save(identity, region);
+        identityStore.put(identityKey(region, identityValue), identity);
         LOG.infov("Updated feedback forwarding for {0}: enabled={1}", identityValue, enabled);
     }
 
@@ -266,7 +266,7 @@ public class SesIdentityService {
                         "Identity " + identityValue
                                 + " is invalid. It must be a verified email address or domain.", 400));
         identity.getHeadersInNotificationsEnabled().put(notificationType, enabled);
-        save(identity, region);
+        identityStore.put(identityKey(region, identityValue), identity);
         LOG.infov("Updated headers-in-notifications for {0}: {1}={2}",
                 identityValue, notificationType, enabled);
     }
@@ -335,7 +335,7 @@ public class SesIdentityService {
         // Route53 lookup in refreshIdentityState), not the enabled flag, matching real AWS, where
         // SetIdentityDkimEnabled / PutEmailIdentityDkimAttributes leave the verification status alone.
         identity.setDkimEnabled(signingEnabled);
-        save(identity, region);
+        identityStore.put(identityKey(region, identityValue), identity);
         LOG.infov("Updated DKIM attributes for {0}: signingEnabled={1}", identityValue, signingEnabled);
     }
 
@@ -392,7 +392,7 @@ public class SesIdentityService {
         if (!hasDkimTokens(identity)) {
             regenerateDkimTokens(identity);
         }
-        save(identity, region);
+        identityStore.put(identityKey(region, domain), identity);
         LOG.infov("VerifyDomainDkim: {0} (region {1})", domain, region);
         return identity.getDkimTokens();
     }
@@ -439,7 +439,7 @@ public class SesIdentityService {
             LOG.infov("PutEmailIdentityDkimSigningAttributes(AWS_SES): {0} keyLength={1}",
                     identityValue, nextKeyLength);
         }
-        save(refreshIdentityState(identity, region), region);
+        identityStore.put(identityKey(region, identityValue), refreshIdentityState(identity, region));
         Identity src = effectiveDkimSource(identity, region);
         return new DkimSigningResult(src.getDkimVerificationStatus(),
                 src.getDkimTokens() == null ? List.of() : src.getDkimTokens());

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -4,12 +4,6 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
-import io.github.hectorvent.floci.core.storage.StorageFactory;
-import io.github.hectorvent.floci.services.route53.Route53Service;
-import io.github.hectorvent.floci.services.route53.model.HostedZone;
-import io.github.hectorvent.floci.services.route53.model.ResourceRecord;
-import io.github.hectorvent.floci.services.route53.model.ResourceRecordSet;
 import io.github.hectorvent.floci.services.ses.model.AccountSuppressionAttributes;
 import io.github.hectorvent.floci.services.ses.model.AccountDetails;
 import io.github.hectorvent.floci.services.ses.model.AccountVdmAttributes;
@@ -40,7 +34,6 @@ import io.github.hectorvent.floci.services.ses.model.TenantResourceAssociation;
 import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
 import io.github.hectorvent.floci.services.ses.model.Tag;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -51,8 +44,6 @@ import org.jboss.logging.Logger;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -70,7 +61,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -83,11 +73,12 @@ public class SesService {
 
     private static final int MAX_BULK_DESTINATIONS = 50;
     private static final int MAX_RECIPIENTS_PER_DESTINATION = 50;
-    private static final Duration DKIM_LOOKUP_CACHE_TTL = Duration.ofSeconds(5);
-
     private static final SecureRandom BOUNDARY_RANDOM = new SecureRandom();
 
-    private final StorageBackend<String, Identity> identityStore;
+    // Identities extracted to SesIdentityService (CRUD, verification, MAIL FROM, notifications,
+    // tags, and the DKIM state machine with its Route53 lookup). The facade keeps the cross-domain
+    // flows and send-path reads, reaching the store through its find/save.
+    private final SesIdentityService identityService;
     // Sent-email records extracted to SesSentEmailService. The send path records finished emails via
     // it; send-statistics and inspection read back through it.
     private final SesSentEmailService sentEmailService;
@@ -125,25 +116,21 @@ public class SesService {
     // Base URL used to build functional list-management unsubscribe links (the {{amazonSESUnsubscribeUrl}}
     // placeholder and the List-Unsubscribe header) that resolve to Floci's own unsubscribe endpoint.
     private final String baseUrl;
-    private final Route53Service route53Service;
     // Resolves the caller's account per request so send-event payloads report the sending account, not
-    // the fixed default. Null in the package-private test constructors (falls back to defaultAccountId).
+    // the fixed default. Null in the package-private test constructor (falls back to defaultAccountId).
     private final RegionResolver regionResolver;
-    private final Clock clock;
-    private final ConcurrentHashMap<String, DkimLookupCacheEntry> dkimLookupCache = new ConcurrentHashMap<>();
 
     @Inject
-    public SesService(StorageFactory storageFactory, SesReceiptRuleService receiptRuleService,
+    public SesService(SesIdentityService identityService, SesReceiptRuleService receiptRuleService,
                        SesAccountService accountService, SesCvetService cvetService,
                        SesPolicyService policyService, SesContactService contactService,
                        SesSuppressionService suppressionService, SesDedicatedIpService dedicatedIpService,
                        SesTemplateService templateService, SesSentEmailService sentEmailService,
                        SesTenantService tenantService, SesConfigurationSetService configSetService,
                        SmtpRelay smtpRelay, ObjectMapper objectMapper,
-                       SesEventPublisher eventPublisher, EmulatorConfig config, Route53Service route53Service,
-                       RegionResolver regionResolver, Clock clock) {
-        this.identityStore = storageFactory.create("ses", "ses-identities.json",
-                new TypeReference<Map<String, Identity>>() {});
+                       SesEventPublisher eventPublisher, EmulatorConfig config,
+                       RegionResolver regionResolver) {
+        this.identityService = identityService;
         this.sentEmailService = sentEmailService;
         this.accountService = accountService;
         this.templateService = templateService;
@@ -160,12 +147,10 @@ public class SesService {
         this.eventPublisher = eventPublisher;
         this.defaultAccountId = config.defaultAccountId();
         this.baseUrl = config.effectiveBaseUrl();
-        this.route53Service = route53Service;
         this.regionResolver = regionResolver;
-        this.clock = clock;
     }
 
-    SesService(StorageBackend<String, Identity> identityStore,
+    SesService(SesIdentityService identityService,
                SesSentEmailService sentEmailService,
                SesAccountService accountService,
                SesTemplateService templateService,
@@ -178,30 +163,8 @@ public class SesService {
                SesCvetService cvetService,
                SesTenantService tenantService,
                SmtpRelay smtpRelay,
-               ObjectMapper objectMapper,
-               Clock clock) {
-        this(identityStore, sentEmailService, accountService, templateService, configSetService, suppressionService,
-                dedicatedIpService, contactService, policyService,
-                receiptRuleService, cvetService, tenantService, smtpRelay, objectMapper, null, clock);
-    }
-
-    SesService(StorageBackend<String, Identity> identityStore,
-               SesSentEmailService sentEmailService,
-               SesAccountService accountService,
-               SesTemplateService templateService,
-               SesConfigurationSetService configSetService,
-               SesSuppressionService suppressionService,
-               SesDedicatedIpService dedicatedIpService,
-               SesContactService contactService,
-               SesPolicyService policyService,
-               SesReceiptRuleService receiptRuleService,
-               SesCvetService cvetService,
-               SesTenantService tenantService,
-               SmtpRelay smtpRelay,
-               ObjectMapper objectMapper,
-               Route53Service route53Service,
-               Clock clock) {
-        this.identityStore = identityStore;
+               ObjectMapper objectMapper) {
+        this.identityService = identityService;
         this.sentEmailService = sentEmailService;
         this.accountService = accountService;
         this.templateService = templateService;
@@ -218,46 +181,15 @@ public class SesService {
         this.eventPublisher = null;
         this.defaultAccountId = "000000000000";
         this.baseUrl = "http://localhost:4566";
-        this.route53Service = route53Service;
         this.regionResolver = null;
-        this.clock = clock;
     }
 
     public Identity verifyEmailIdentity(String emailAddress, String region) {
-        validateIdentityWhitespace(emailAddress, "Email address");
-        if (emailAddress == null || emailAddress.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "Email address is required.", 400);
-        }
-        String key = identityKey(region, emailAddress);
-        Identity existing = identityStore.get(key).orElse(null);
-        if (existing != null) return existing;
-
-        Identity identity = new Identity(emailAddress, "EmailAddress");
-        identityStore.put(key, identity);
-        LOG.infov("Verified email identity: {0} in region {1}", emailAddress, region);
-        return identity;
+        return identityService.verifyEmailIdentity(emailAddress, region);
     }
 
     public Identity verifyDomainIdentity(String domain, String region) {
-        validateIdentityWhitespace(domain, "Domain");
-        if (domain == null || domain.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "Domain is required.", 400);
-        }
-        String key = identityKey(region, domain);
-        Identity existing = identityStore.get(key).orElse(null);
-        if (existing != null) return existing;
-
-        Identity identity = new Identity(domain, "Domain");
-        regenerateDkimTokens(identity);
-        identity.setVerificationStatus("Pending");
-        identity.setDkimEnabled(true);
-        // The create response reports DKIM verification as NotStarted (SES hasn't begun tracking the
-        // CNAMEs yet); the first Get/List refresh transitions it to Pending. Matches AWS, where
-        // CreateEmailIdentity returns NOT_STARTED but a subsequent GetEmailIdentity returns PENDING.
-        identity.setDkimVerificationStatus("NotStarted");
-        identityStore.put(key, identity);
-        LOG.infov("Verified domain identity: {0} in region {1}", domain, region);
-        return identity;
+        return identityService.verifyDomainIdentity(domain, region);
     }
 
     public void deleteIdentity(String identityValue, String region) {
@@ -269,20 +201,7 @@ public class SesService {
     }
 
     private void doDeleteIdentity(String identityValue, String region) {
-        String key = identityKey(region, identityValue);
-        identityStore.delete(key);
-        invalidateDkimLookupCache(region, identityValue);
-
-        String prefix = "identity::" + region + "::";
-        List<String> keys = new ArrayList<>(identityStore.keys().stream()
-                .filter(k -> k.startsWith(prefix))
-                .toList());
-        for (String storedKey : keys) {
-            Identity storedIdentity = identityStore.get(storedKey).orElse(null);
-            if (storedIdentity != null && identityValue.equals(storedIdentity.getIdentity())) {
-                identityStore.delete(storedKey);
-            }
-        }
+        identityService.delete(identityValue, region);
 
         // Policies are sub-resources of the identity; drop them too so they can't resurrect into a
         // same-named identity recreated later (and so the per-identity count stays correct).
@@ -292,20 +211,11 @@ public class SesService {
     }
 
     public List<Identity> listIdentities(String identityType, String region) {
-        String prefix = "identity::" + region + "::";
-        List<Identity> all = identityStore.scan(k -> k.startsWith(prefix));
-        if (identityType == null || identityType.isBlank()) {
-            return all;
-        }
-        return all.stream()
-                .filter(i -> identityType.equals(i.getIdentityType()))
-                .toList();
+        return identityService.listIdentities(identityType, region);
     }
 
     public Identity getIdentityVerificationAttributes(String identityValue, String region) {
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key).orElse(null);
-        return refreshIdentityState(identity, region);
+        return identityService.getIdentityVerificationAttributes(identityValue, region);
     }
 
     public String sendEmail(String source, List<String> toAddresses, List<String> ccAddresses,
@@ -575,13 +485,13 @@ public class SesService {
         if (email.isBlank()) {
             return targets;
         }
-        Identity emailIdentity = identityStore.get(identityKey(region, email)).orElse(null);
+        Identity emailIdentity = identityService.find(email, region).orElse(null);
         Identity domainIdentity = null;
         int at = email.indexOf('@');
         if (at >= 0 && at < email.length() - 1) {
-            domainIdentity = identityStore.get(identityKey(region, email.substring(at + 1))).orElse(null);
+            domainIdentity = identityService.find(email.substring(at + 1), region).orElse(null);
         }
-        for (String type : NOTIFICATION_TYPES) {
+        for (String type : SesIdentityService.NOTIFICATION_TYPES) {
             String topic = notificationTopicFor(emailIdentity, type);
             Identity owner = emailIdentity;
             if (topic == null) {
@@ -652,345 +562,39 @@ public class SesService {
 
     public void setIdentityNotificationTopic(String identityValue, String notificationType,
                                               String snsTopic, String region) {
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("InvalidParameterValue",
-                        "Identity does not exist: " + identityValue, 400));
-        if (snsTopic != null && !snsTopic.isBlank()) {
-            identity.getNotificationAttributes().put(notificationType + "Topic", snsTopic);
-        } else {
-            identity.getNotificationAttributes().remove(notificationType + "Topic");
-        }
-        identityStore.put(key, identity);
+        identityService.setIdentityNotificationTopic(identityValue, notificationType, snsTopic, region);
     }
 
     public Identity getIdentityNotificationAttributes(String identityValue, String region) {
-        String key = identityKey(region, identityValue);
-        return identityStore.get(key).orElse(null);
+        return identityService.getIdentityNotificationAttributes(identityValue, region);
     }
 
     public void setDkimAttributes(String identityValue, boolean signingEnabled, String region) {
-        if (identityValue == null || identityValue.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "Identity is required.", 400);
-        }
-        // DKIM is a domain concept and an email reports its parent domain's DKIM (via effectiveDkimSource),
-        // so toggling DKIM on an email whose parent domain is a registered identity is a no-op that leaves
-        // the domain untouched — matching real AWS, regardless of whether the email identity itself exists.
-        if (identityValue.contains("@")) {
-            String domain = identityValue.substring(identityValue.indexOf('@') + 1);
-            if (identityStore.get(identityKey(region, domain)).isPresent()) {
-                return;
-            }
-        }
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key).orElse(null);
-        if (identity == null) {
-            String domain = identityValue.contains("@")
-                    ? identityValue.substring(identityValue.indexOf('@') + 1)
-                    : identityValue;
-            // v1-native code; the v2 controller remaps InvalidParameterValue -> BadRequestException.
-            throw new AwsException("InvalidParameterValue",
-                    "Domain " + domain + " is not verified for DKIM signing.", 400);
-        }
-
-        // Only toggle the signing flag. DkimVerificationStatus tracks DNS record detection (via the
-        // Route53 lookup in refreshIdentityState), not the enabled flag — matching real AWS, where
-        // SetIdentityDkimEnabled / PutEmailIdentityDkimAttributes leave the verification status alone.
-        identity.setDkimEnabled(signingEnabled);
-        identityStore.put(key, identity);
-        LOG.infov("Updated DKIM attributes for {0}: signingEnabled={1}", identityValue, signingEnabled);
+        identityService.setDkimAttributes(identityValue, signingEnabled, region);
     }
 
-    private List<String> generateDkimTokens() {
-        List<String> tokens = new ArrayList<>(3);
-        for (int i = 0; i < 3; i++) {
-            tokens.add(UUID.randomUUID().toString().replace("-", ""));
-        }
-        return tokens;
-    }
-
-    /**
-     * Generates a fresh Easy DKIM token set and records the key length / generation timestamp. New
-     * tokens mean the previously published CNAMEs no longer match, so the verification status resets
-     * to Pending (re-detected via the Route53 lookup) and the origin returns to AWS_SES. Only meaningful
-     * for domain identities; refreshIdentityState re-upgrades to Success once the new records exist.
-     */
-    private void regenerateDkimTokens(Identity identity) {
-        identity.setDkimTokens(generateDkimTokens());
-        identity.setDkimCurrentSigningKeyLength(identity.getDkimNextSigningKeyLength());
-        identity.setDkimLastKeyGenerationTimestamp(Instant.now(clock));
-        identity.setDkimSigningAttributesOrigin("AWS_SES");
-        // The new tokens' CNAMEs aren't detected yet, so DKIM verification resets to Pending. The
-        // identity's own verification is NOT revoked by a key rotation (matching AWS) — keep Success
-        // when already verified; a not-yet-verified identity stays Pending.
-        identity.setDkimVerificationStatus("Pending");
-        if (!"Success".equals(identity.getVerificationStatus())) {
-            identity.setVerificationStatus("Pending");
-        }
-    }
-
-    /**
-     * v1 VerifyDomainDkim: returns the domain identity's DKIM tokens (3), generating them if needed.
-     * Tokens are stable across calls (AWS does not regenerate them). The domain is registered as a
-     * pending identity if it does not exist yet, matching AWS's lenient behavior (VerifyDomainDkim
-     * starts DKIM setup for any domain).
-     */
     public List<String> verifyDomainDkim(String domain, String region) {
-        validateIdentityWhitespace(domain, "Domain");
-        if (domain == null || domain.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "Domain is required.", 400);
-        }
-        if (domain.contains("@")) {
-            // Domain-only action: an email-shaped value must not create an email-valued "Domain".
-            throw new AwsException("InvalidParameterValue", "Domain " + domain + " is invalid.", 400);
-        }
-        String key = identityKey(region, domain);
-        Identity identity = identityStore.get(key).orElse(null);
-        if (identity == null) {
-            identity = new Identity(domain, "Domain");
-            identity.setVerificationStatus("Pending");
-            identity.setDkimEnabled(true);
-            identity.setDkimVerificationStatus("Pending");
-        }
-        if (!hasDkimTokens(identity)) {
-            regenerateDkimTokens(identity);
-        }
-        identityStore.put(key, identity);
-        LOG.infov("VerifyDomainDkim: {0} (region {1})", domain, region);
-        return identity.getDkimTokens();
+        return identityService.verifyDomainDkim(domain, region);
     }
 
-    /**
-     * v2 PutEmailIdentityDkimSigningAttributes. AWS_SES (Easy DKIM): sets the next signing key length
-     * and regenerates tokens when the length changes. EXTERNAL (BYODKIM): switches the origin and
-     * clears the Easy DKIM tokens (the caller publishes its own selector, which Floci does not use for
-     * signing). Returns the resulting DKIM status and tokens.
-     */
-    public DkimSigningResult putDkimSigningAttributes(String identityValue, String origin,
-                                                      String signingSelector, String nextKeyLength,
-                                                      String region) {
-        // DKIM signing attributes are domain-level; AWS rejects a missing/blank value or an
-        // email-address identity here (verified: all return the same 400 "must be a valid domain")
-        // rather than mutating state that the email would just inherit back from its parent domain.
-        if (identityValue == null || identityValue.isBlank() || identityValue.contains("@")) {
-            throw new AwsException("BadRequestException",
-                    "The EmailIdentity value must be a valid domain.", 400);
-        }
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "Email identity " + identityValue + " does not exist.", 404));
-        if ("EXTERNAL".equals(origin)) {
-            identity.setDkimSigningAttributesOrigin("EXTERNAL");
-            // Clear the Easy DKIM tokens and reset the status: Floci can't verify a BYODKIM selector,
-            // so leaving a prior Success/Pending with no tokens (and no Route53 detection path) would
-            // be inconsistent.
-            identity.setDkimTokens(new ArrayList<>());
-            identity.setDkimVerificationStatus("Pending");
-            LOG.infov("PutEmailIdentityDkimSigningAttributes(EXTERNAL): {0} selector={1}",
-                    identityValue, signingSelector);
-        } else {
-            identity.setDkimSigningAttributesOrigin("AWS_SES");
-            // DKIM tokens are a domain concept; only (re)generate them for a domain identity.
-            if ("Domain".equals(identity.getIdentityType())) {
-                if (nextKeyLength != null && !nextKeyLength.equals(identity.getDkimCurrentSigningKeyLength())) {
-                    identity.setDkimNextSigningKeyLength(nextKeyLength);
-                    regenerateDkimTokens(identity);
-                } else if (!hasDkimTokens(identity)) {
-                    regenerateDkimTokens(identity);
-                }
-            }
-            LOG.infov("PutEmailIdentityDkimSigningAttributes(AWS_SES): {0} keyLength={1}",
-                    identityValue, nextKeyLength);
-        }
-        identityStore.put(key, refreshIdentityState(identity, region));
-        Identity src = effectiveDkimSource(identity, region);
-        return new DkimSigningResult(src.getDkimVerificationStatus(),
-                src.getDkimTokens() == null ? List.of() : src.getDkimTokens());
+    public SesIdentityService.DkimSigningResult putDkimSigningAttributes(String identityValue, String origin,
+                                                                         String signingSelector, String nextKeyLength,
+                                                                         String region) {
+        return identityService.putDkimSigningAttributes(identityValue, origin, signingSelector,
+                nextKeyLength, region);
     }
 
-    /** Carrier for the PutEmailIdentityDkimSigningAttributes response ({@code dkimStatus} is v1-native). */
-    public record DkimSigningResult(String dkimStatus, List<String> dkimTokens) {}
-
-    /**
-     * Resolves which identity's DKIM state should be reported for {@code identity}. A domain reports
-     * its own DKIM; an email address reports its parent domain's DKIM (SigningEnabled / Status /
-     * Tokens all inherit from the domain), matching AWS. Falls back to the identity itself when the
-     * parent domain is not a registered identity.
-     */
     public Identity effectiveDkimSource(Identity identity, String region) {
-        if (identity == null || !"EmailAddress".equals(identity.getIdentityType())) {
-            return identity;
-        }
-        String addr = identity.getIdentity();
-        int at = addr == null ? -1 : addr.indexOf('@');
-        if (at < 0 || at == addr.length() - 1) {
-            return identity;
-        }
-        Identity domainIdentity = identityStore.get(identityKey(region, addr.substring(at + 1))).orElse(null);
-        return domainIdentity == null ? identity : refreshIdentityState(domainIdentity, region);
+        return identityService.effectiveDkimSource(identity, region);
     }
-
-    private Identity refreshIdentityState(Identity identity, String region) {
-        if (identity == null) {
-            return null;
-        }
-
-        boolean changed = false;
-        if ("Domain".equals(identity.getIdentityType()) && identity.getDkimTokens() == null) {
-            regenerateDkimTokens(identity);
-            changed = true;
-        }
-
-        if ("Domain".equals(identity.getIdentityType()) && hasDkimTokens(identity)) {
-            changed |= normalizePendingDomainState(identity);
-            // Upgrade identity- and DKIM-verification independently so that, e.g., after a key rotation
-            // (which resets only DkimVerificationStatus while the identity stays verified), the DKIM
-            // status can still return to Success once the new records are detected.
-            // Only look up DNS when a status can still be upgraded — skip the (cached) Route53 check
-            // once both identity- and DKIM-verification are already Success. DKIM verification tracks
-            // DNS detection independently of the signing-enabled flag, so it can reach Success even
-            // when DKIM signing is disabled, and can re-pend/re-upgrade after a key rotation.
-            boolean needsUpgrade = !"Success".equals(identity.getVerificationStatus())
-                    || !"Success".equals(identity.getDkimVerificationStatus());
-            if (needsUpgrade && hasAllExpectedDkimRecords(identity, region)) {
-                if (!"Success".equals(identity.getVerificationStatus())) {
-                    identity.setVerificationStatus("Success");
-                    changed = true;
-                }
-                if (!"Success".equals(identity.getDkimVerificationStatus())) {
-                    identity.setDkimVerificationStatus("Success");
-                    changed = true;
-                }
-            }
-        }
-
-        if ("Success".equals(identity.getVerificationStatus())) {
-            invalidateDkimLookupCache(region, identity.getIdentity());
-        }
-
-        if (changed) {
-            identityStore.put(identityKey(region, identity.getIdentity()), identity);
-        }
-        return identity;
-    }
-
-    private boolean hasDkimTokens(Identity identity) {
-        return identity.getDkimTokens() != null && !identity.getDkimTokens().isEmpty();
-    }
-
-    private boolean normalizePendingDomainState(Identity identity) {
-        boolean changed = false;
-        if (!"Success".equals(identity.getVerificationStatus())
-                && !"Pending".equals(identity.getVerificationStatus())) {
-            identity.setVerificationStatus("Pending");
-            changed = true;
-        }
-        // DKIM verification tracks DNS detection, not the signing-enabled flag, so a domain that has
-        // begun tracking (NotStarted -> Pending) reports Pending on Get even while signing is disabled.
-        if (!"Success".equals(identity.getDkimVerificationStatus())
-                && !"Pending".equals(identity.getDkimVerificationStatus())) {
-            identity.setDkimVerificationStatus("Pending");
-            changed = true;
-        }
-        return changed;
-    }
-
-    private boolean hasAllExpectedDkimRecords(Identity identity, String region) {
-        if (route53Service == null) {
-            return false;
-        }
-        Instant now = Instant.now(clock);
-        String cacheKey = dkimLookupCacheKey(region, identity);
-        DkimLookupCacheEntry cached = dkimLookupCache.get(cacheKey);
-        if (cached != null) {
-            if (now.isBefore(cached.expiresAt())) {
-                return cached.present();
-            }
-            dkimLookupCache.remove(cacheKey, cached);
-        }
-
-        boolean present = true;
-        for (String token : identity.getDkimTokens()) {
-            if (!hasExpectedDkimRecord(identity.getIdentity(), token)) {
-                present = false;
-                break;
-            }
-        }
-        dkimLookupCache.put(cacheKey, new DkimLookupCacheEntry(present, now.plus(DKIM_LOOKUP_CACHE_TTL)));
-        return present;
-    }
-
-    private boolean hasExpectedDkimRecord(String domain, String token) {
-        String expectedName = normalizeDnsName(token + "._domainkey." + domain);
-        String expectedValue = normalizeDnsName(token + ".dkim.amazonses.com");
-        for (HostedZone zone : route53Service.listHostedZones(null, Integer.MAX_VALUE)) {
-            for (ResourceRecordSet recordSet : route53Service.listResourceRecordSets(zone.getId(), null, null,
-                    Integer.MAX_VALUE)) {
-                if (!"CNAME".equalsIgnoreCase(recordSet.getType())) {
-                    continue;
-                }
-                if (!expectedName.equals(normalizeDnsName(recordSet.getName()))) {
-                    continue;
-                }
-                List<ResourceRecord> records = recordSet.getRecords();
-                if (records == null) {
-                    continue;
-                }
-                for (ResourceRecord record : records) {
-                    if (record != null && expectedValue.equals(normalizeDnsName(record.getValue()))) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    }
-
-    private String normalizeDnsName(String value) {
-        if (value == null) {
-            return "";
-        }
-        String normalized = value.trim().toLowerCase(Locale.ROOT);
-        while (normalized.endsWith(".")) {
-            normalized = normalized.substring(0, normalized.length() - 1);
-        }
-        return normalized;
-    }
-
-    private void invalidateDkimLookupCache(String region, String identityValue) {
-        if (identityValue == null || identityValue.isBlank()) {
-            return;
-        }
-        String cachePrefix = region + "::" + normalizeDnsName(identityValue) + "::";
-        dkimLookupCache.keySet().removeIf(key -> key.startsWith(cachePrefix));
-    }
-
-    private String dkimLookupCacheKey(String region, Identity identity) {
-        List<String> normalizedTokens = identity.getDkimTokens().stream()
-                .map(this::normalizeDnsName)
-                .sorted()
-                .toList();
-        return region + "::" + normalizeDnsName(identity.getIdentity()) + "::" + String.join(",", normalizedTokens);
-    }
-
-    private record DkimLookupCacheEntry(boolean present, Instant expiresAt) {}
 
     public void setFeedbackForwardingEnabled(String identityValue, boolean enabled, String region) {
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("InvalidParameterValue",
-                        "Identity " + identityValue
-                                + " is invalid. Must be a verified email address or domain.", 400));
-        identity.setFeedbackForwardingEnabled(enabled);
-        identityStore.put(key, identity);
-        LOG.infov("Updated feedback forwarding for {0}: enabled={1}", identityValue, enabled);
+        identityService.setFeedbackForwardingEnabled(identityValue, enabled, region);
     }
 
     public void setEmailIdentityConfigurationSet(String identityValue, String configurationSetName,
                                                  String region) {
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
+        Identity identity = identityService.find(identityValue, region)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Identity <" + identityValue + "> does not exist.", 404));
         boolean clearing = configurationSetName == null || configurationSetName.isEmpty();
@@ -998,7 +602,7 @@ public class SesService {
             getConfigurationSet(configurationSetName, region);
         }
         identity.setConfigurationSetName(clearing ? null : configurationSetName);
-        identityStore.put(key, identity);
+        identityService.save(identity, region);
         LOG.infov("Updated default ConfigurationSet for {0}: {1}",
                 identityValue, clearing ? "<cleared>" : configurationSetName);
     }
@@ -1022,14 +626,14 @@ public class SesService {
         if (email.isBlank()) {
             return configurationSetName;
         }
-        String fromEmail = existingDefaultConfigSet(identityStore.get(identityKey(region, email)).orElse(null), region);
+        String fromEmail = existingDefaultConfigSet(identityService.find(email, region).orElse(null), region);
         if (fromEmail != null) {
             return fromEmail;
         }
         int at = email.indexOf('@');
         if (at >= 0 && at < email.length() - 1) {
             String fromDomain = existingDefaultConfigSet(
-                    identityStore.get(identityKey(region, email.substring(at + 1))).orElse(null), region);
+                    identityService.find(email.substring(at + 1), region).orElse(null), region);
             if (fromDomain != null) {
                 return fromDomain;
             }
@@ -1056,79 +660,20 @@ public class SesService {
 
     public void setMailFromDomain(String identityValue, String mailFromDomain,
                                    String behaviorOnMxFailure, String region) {
-        String normalizedBehavior = null;
-        if (behaviorOnMxFailure != null) {
-            if (!"UseDefaultValue".equals(behaviorOnMxFailure)
-                    && !"RejectMessage".equals(behaviorOnMxFailure)) {
-                throw new AwsException("ValidationError",
-                        "1 validation error detected: Value at 'behaviorOnMXFailure' failed to satisfy "
-                                + "constraint: Member must satisfy enum value set: [RejectMessage, UseDefaultValue]", 400);
-            }
-            normalizedBehavior = behaviorOnMxFailure;
-        }
-        boolean clearing = mailFromDomain == null || mailFromDomain.isEmpty();
-        if (!clearing && mailFromDomain.isBlank()) {
-            throw new AwsException("InvalidParameterValue",
-                    "MailFromDomain must be a domain or an empty string to clear; whitespace is not accepted.", 400);
-        }
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("InvalidParameterValue",
-                        "Identity <" + identityValue + "> does not exist.", 400));
-        identity.setMailFromDomain(clearing ? null : mailFromDomain);
-        identity.setMailFromDomainStatus(clearing ? "Pending" : "Success");
-        if (clearing) {
-            identity.setBehaviorOnMxFailure("UseDefaultValue");
-        } else if (normalizedBehavior != null) {
-            identity.setBehaviorOnMxFailure(normalizedBehavior);
-        }
-        identityStore.put(key, identity);
-        LOG.infov("Updated MAIL FROM domain for {0}: domain={1}, behavior={2}",
-                identityValue, mailFromDomain, normalizedBehavior);
+        identityService.setMailFromDomain(identityValue, mailFromDomain, behaviorOnMxFailure, region);
     }
 
     public Identity getMailFromAttributes(String identityValue, String region) {
-        String key = identityKey(region, identityValue);
-        return identityStore.get(key).orElse(null);
+        return identityService.getMailFromAttributes(identityValue, region);
     }
-
-    private static final java.util.List<String> NOTIFICATION_TYPES =
-            java.util.List.of("Bounce", "Complaint", "Delivery");
 
     public void setHeadersInNotificationsEnabled(String identityValue, String notificationType,
                                                    boolean enabled, String region) {
-        if (notificationType == null || notificationType.isBlank()) {
-            throw new AwsException("InvalidParameterValue",
-                    "NotificationType is required.", 400);
-        }
-        if (!NOTIFICATION_TYPES.contains(notificationType)) {
-            throw new AwsException("ValidationError",
-                    "1 validation error detected: Value at 'notificationType' failed to satisfy "
-                            + "constraint: Member must satisfy enum value set: "
-                            + NOTIFICATION_TYPES, 400);
-        }
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("InvalidParameterValue",
-                        "Identity " + identityValue
-                                + " is invalid. It must be a verified email address or domain.", 400));
-        identity.getHeadersInNotificationsEnabled().put(notificationType, enabled);
-        identityStore.put(key, identity);
-        LOG.infov("Updated headers-in-notifications for {0}: {1}={2}",
-                identityValue, notificationType, enabled);
+        identityService.setHeadersInNotificationsEnabled(identityValue, notificationType, enabled, region);
     }
 
     public List<String> getVerifiedEmailAddresses(String region) {
-        String prefix = "identity::" + region + "::";
-        List<Identity> all = identityStore.scan(k -> k.startsWith(prefix));
-        List<String> emails = new ArrayList<>();
-        for (Identity identity : all) {
-            if ("EmailAddress".equals(identity.getIdentityType())
-                    && "Success".equals(identity.getVerificationStatus())) {
-                emails.add(identity.getIdentity());
-            }
-        }
-        return emails;
+        return identityService.getVerifiedEmailAddresses(region);
     }
 
     public List<SentEmail> getEmails() {
@@ -1259,7 +804,7 @@ public class SesService {
         CustomVerificationEmailTemplate template = cvetService.find(templateName, region)
                 .orElseThrow(() -> new AwsException("CustomVerificationEmailTemplateDoesNotExist",
                         "Template <" + templateName + "> does not exist", 400));
-        if (!isVerifiedSender(template.getFromEmailAddress(), region)) {
+        if (!identityService.isVerifiedSender(template.getFromEmailAddress(), region)) {
             throw new AwsException("FromEmailAddressNotVerified",
                     "Email address is not verified. The following identities failed the check in region "
                             + region.toUpperCase(Locale.ROOT) + ": " + template.getFromEmailAddress(), 400);
@@ -1270,7 +815,7 @@ public class SesService {
 
         // AWS registers the recipient as a pending-verification identity as part of sending the
         // verification email, so ListIdentities / GetIdentityVerificationAttributes surface it.
-        markPendingEmailIdentity(emailAddress, region);
+        identityService.markPendingEmailIdentity(emailAddress, region);
 
         // AWS sends the template content verbatim and appends a fixed, non-removable disclaimer (SES
         // docs Q10). AWS also appends a unique verification link, which Floci does not reproduce
@@ -1314,17 +859,6 @@ public class SesService {
         return count;
     }
 
-    private void markPendingEmailIdentity(String emailAddress, String region) {
-        String key = identityKey(region, emailAddress);
-        if (identityStore.get(key).isEmpty()) {
-            Identity identity = new Identity(emailAddress, "EmailAddress");
-            identity.setVerificationStatus("Pending");
-            identityStore.put(key, identity);
-            LOG.infov("SES custom verification email registered pending identity {0} in region {1}",
-                    emailAddress, region);
-        }
-    }
-
     private void validateCustomVerificationTemplate(CustomVerificationEmailTemplate t, String region) {
         requireCvetField(t.getTemplateName(), "TemplateName");
         requireCvetField(t.getFromEmailAddress(), "FromEmailAddress");
@@ -1332,7 +866,7 @@ public class SesService {
         requireCvetField(t.getTemplateContent(), "TemplateContent");
         requireCvetField(t.getSuccessRedirectionURL(), "SuccessRedirectionURL");
         requireCvetField(t.getFailureRedirectionURL(), "FailureRedirectionURL");
-        if (!isVerifiedSender(t.getFromEmailAddress(), region)) {
+        if (!identityService.isVerifiedSender(t.getFromEmailAddress(), region)) {
             // v1-native code (verified: FromEmailAddressNotVerified / 400); remapV1Exception
             // translates it to NotFoundException / 404 for the v2 boundary.
             throw new AwsException("FromEmailAddressNotVerified",
@@ -1344,23 +878,6 @@ public class SesService {
         if (!isValidRedirectUrl(t.getFailureRedirectionURL())) {
             throw new AwsException("InvalidParameterValue", "The failure redirection URL is invalid", 400);
         }
-    }
-
-    private boolean isVerifiedSender(String fromEmail, String region) {
-        if (fromEmail == null) {
-            return false;
-        }
-        if (isIdentityVerified(fromEmail, region)) {
-            return true;
-        }
-        int at = fromEmail.indexOf('@');
-        return at >= 0 && at < fromEmail.length() - 1
-                && isIdentityVerified(fromEmail.substring(at + 1), region);
-    }
-
-    private boolean isIdentityVerified(String identity, String region) {
-        Identity id = getIdentityVerificationAttributes(identity, region);
-        return id != null && "Success".equals(id.getVerificationStatus());
     }
 
     private static boolean isValidRedirectUrl(String url) {
@@ -1725,13 +1242,13 @@ public class SesService {
         if (email.isBlank()) {
             return fromEmailAddress.trim();
         }
-        if (identityStore.get(identityKey(region, email)).isPresent()) {
+        if (identityService.find(email, region).isPresent()) {
             return email;
         }
         int at = email.lastIndexOf('@');
         if (at >= 0) {
             String domain = email.substring(at + 1);
-            if (identityStore.get(identityKey(region, domain)).isPresent()) {
+            if (identityService.find(domain, region).isPresent()) {
                 return domain;
             }
         }
@@ -1743,7 +1260,7 @@ public class SesService {
     private void requireTenantResourceExists(SesTenantService.AssociationResource ref, String region) {
         boolean exists = switch (ref.type()) {
             case SesTenantService.RESOURCE_TYPE_IDENTITY ->
-                    identityStore.get(identityKey(region, ref.name())).isPresent();
+                    identityService.find(ref.name(), region).isPresent();
             case SesTenantService.RESOURCE_TYPE_CONFIGURATION_SET ->
                     SesConfigurationSetService.isValidName(ref.name())
                             && configSetService.find(ref.name(), region).isPresent();
@@ -1924,7 +1441,7 @@ public class SesService {
     }
 
     private void requireIdentityExists(String identity, String region) {
-        if (identityStore.get(identityKey(region, identity)).isEmpty()) {
+        if (identityService.find(identity, region).isEmpty()) {
             throw new AwsException("NotFoundException",
                     "Email identity <" + identity + "> does not exist.", 404);
         }
@@ -1984,7 +1501,7 @@ public class SesService {
         List<Tag> tags = switch (ref.type()) {
             case "configuration-set" -> listConfigurationSetTags(ref.name(), region);
             case "template" -> listEmailTemplateTags(ref.name(), region);
-            case "identity" -> listIdentityTags(ref.name(), region);
+            case "identity" -> identityService.listTags(ref.name(), region);
             case "contact-list" -> contactService.listTags(ref.name(), region);
             case "custom-verification-email-template" -> cvetService.listTags(ref.name(), region);
             case "dedicated-ip-pool" -> dedicatedIpService.listTags(ref.name(), region);
@@ -2015,7 +1532,7 @@ public class SesService {
         switch (ref.type()) {
             case "configuration-set" -> tagConfigurationSet(ref.name(), region, tags);
             case "template" -> tagEmailTemplate(ref.name(), region, tags);
-            case "identity" -> tagIdentity(ref.name(), region, tags);
+            case "identity" -> identityService.tag(ref.name(), region, tags);
             case "contact-list" -> contactService.tag(ref.name(), region, tags);
             case "custom-verification-email-template" -> cvetService.tag(ref.name(), region, tags);
             case "dedicated-ip-pool" -> dedicatedIpService.tag(ref.name(), region, tags);
@@ -2042,7 +1559,7 @@ public class SesService {
         switch (ref.type()) {
             case "configuration-set" -> untagConfigurationSet(ref.name(), region, tagKeys);
             case "template" -> untagEmailTemplate(ref.name(), region, tagKeys);
-            case "identity" -> untagIdentity(ref.name(), region, tagKeys);
+            case "identity" -> identityService.untag(ref.name(), region, tagKeys);
             case "contact-list" -> contactService.untag(ref.name(), region, tagKeys);
             case "custom-verification-email-template" -> cvetService.untag(ref.name(), region, tagKeys);
             case "dedicated-ip-pool" -> dedicatedIpService.untag(ref.name(), region, tagKeys);
@@ -2126,45 +1643,8 @@ public class SesService {
         LOG.infov("Tagged SES template: {0} (region {1}, +{2} tags)", name, region, newTags.size());
     }
 
-    private List<Tag> listIdentityTags(String identityValue, String region) {
-        Identity identity = identityStore.get(identityKey(region, identityValue))
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No EmailIdentity present with name: " + identityValue, 404));
-        return new ArrayList<>(identity.getTags());
-    }
-
-    private void tagIdentity(String identityValue, String region, List<Tag> newTags) {
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No EmailIdentity present with name: " + identityValue, 404));
-        identity.setTags(SesTags.merge(identity.getTags(), newTags));
-        identityStore.put(key, identity);
-        LOG.infov("Tagged SES identity: {0} (region {1}, +{2} tags)", identityValue, region, newTags.size());
-    }
-
-    private void untagIdentity(String identityValue, String region, List<String> tagKeys) {
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No EmailIdentity present with name: " + identityValue, 404));
-        Set<String> toRemove = new HashSet<>(tagKeys);
-        // Copy-on-write: the stored list may be immutable, and unlocked readers iterate it.
-        List<Tag> remaining = new ArrayList<>(identity.getTags());
-        remaining.removeIf(t -> toRemove.contains(t.key()));
-        identity.setTags(remaining);
-        identityStore.put(key, identity);
-        LOG.infov("Untagged SES identity: {0} (region {1}, -{2} keys)", identityValue, region, tagKeys.size());
-    }
-
     public void setIdentityTags(String identityValue, String region, List<Tag> tags) {
-        SesTags.validate(tags);
-        String key = identityKey(region, identityValue);
-        Identity identity = identityStore.get(key)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No EmailIdentity present with name: " + identityValue, 404));
-        identity.setTags(tags);
-        identityStore.put(key, identity);
+        identityService.setTags(identityValue, region, tags);
     }
 
     private void untagEmailTemplate(String name, String region, List<String> tagKeys) {
@@ -2867,17 +2347,4 @@ public class SesService {
         return name;
     }
 
-    private static String identityKey(String region, String identity) {
-        validateIdentityWhitespace(identity, "Identity");
-        return "identity::" + region + "::" + identity;
-    }
-
-    private static void validateIdentityWhitespace(String identity, String fieldName) {
-        if (identity == null || identity.isBlank()) {
-            return;
-        }
-        if (Character.isWhitespace(identity.charAt(0)) || Character.isWhitespace(identity.charAt(identity.length() - 1))) {
-            throw new AwsException("InvalidParameterValue", fieldName + " must not contain leading or trailing whitespace.", 400);
-        }
-    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityServiceTest.java
@@ -1,0 +1,149 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ses.model.Identity;
+import io.github.hectorvent.floci.services.ses.model.Tag;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit test for the extracted identity domain: store ownership, key validation, verification
+ * (email and domain), listing, MAIL FROM, the CVET pending registration, identity tags, and the
+ * find/save escape hatches the facade's notification flows rely on. The DKIM state machine moved
+ * here too and keeps its behavioral coverage in the existing facade-level unit and integration
+ * tests, which now exercise it through the delegation; only its creation-time surface is pinned
+ * here.
+ */
+class SesIdentityServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private SesIdentityService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SesIdentityService(new InMemoryStorage<>(), null, Clock.systemUTC());
+    }
+
+    @Test
+    void verifyEmailIdentity_createsOnce_returnsExistingOnRepeat() {
+        Identity first = service.verifyEmailIdentity("alice@example.com", REGION);
+        assertEquals("EmailAddress", first.getIdentityType());
+        first.setVerificationStatus("Success");
+        service.save(first, REGION);
+        Identity second = service.verifyEmailIdentity("alice@example.com", REGION);
+        assertEquals("Success", second.getVerificationStatus());
+    }
+
+    @Test
+    void verifyEmailIdentity_rejectsBlankAndWhitespace() {
+        AwsException blank = assertThrows(AwsException.class,
+                () -> service.verifyEmailIdentity(" ", REGION));
+        assertEquals("Email address is required.", blank.getMessage());
+        AwsException padded = assertThrows(AwsException.class,
+                () -> service.verifyEmailIdentity(" alice@example.com", REGION));
+        assertEquals("Email address must not contain leading or trailing whitespace.",
+                padded.getMessage());
+    }
+
+    @Test
+    void verifyDomainIdentity_generatesDkimTokens_reportsNotStarted() {
+        Identity domain = service.verifyDomainIdentity("example.com", REGION);
+        assertEquals("Domain", domain.getIdentityType());
+        assertEquals("Pending", domain.getVerificationStatus());
+        assertEquals("NotStarted", domain.getDkimVerificationStatus());
+        assertEquals(3, domain.getDkimTokens().size());
+        // Tokens are stable across repeated calls.
+        assertEquals(domain.getDkimTokens(),
+                service.verifyDomainIdentity("example.com", REGION).getDkimTokens());
+        assertEquals(domain.getDkimTokens(), service.verifyDomainDkim("example.com", REGION));
+    }
+
+    @Test
+    void listIdentities_filtersByType_andRegion() {
+        service.verifyEmailIdentity("alice@example.com", REGION);
+        service.save(new Identity("example.com", "Domain"), REGION);
+        service.verifyEmailIdentity("other@example.com", "eu-west-1");
+        assertEquals(2, service.listIdentities(null, REGION).size());
+        assertEquals(List.of("example.com"),
+                service.listIdentities("Domain", REGION).stream().map(Identity::getIdentity).toList());
+    }
+
+    @Test
+    void getVerifiedEmailAddresses_onlySuccessfulEmails() {
+        Identity verified = service.verifyEmailIdentity("alice@example.com", REGION);
+        verified.setVerificationStatus("Success");
+        service.save(verified, REGION);
+        service.markPendingEmailIdentity("pending@example.com", REGION);
+        Identity domain = new Identity("example.com", "Domain");
+        domain.setVerificationStatus("Success");
+        service.save(domain, REGION);
+        assertEquals(List.of("alice@example.com"), service.getVerifiedEmailAddresses(REGION));
+    }
+
+    @Test
+    void delete_removesTheRecord() {
+        service.verifyEmailIdentity("alice@example.com", REGION);
+        service.delete("alice@example.com", REGION);
+        assertTrue(service.find("alice@example.com", REGION).isEmpty());
+    }
+
+    @Test
+    void setMailFromDomain_setClearAndValidate() {
+        service.verifyEmailIdentity("alice@example.com", REGION);
+        service.setMailFromDomain("alice@example.com", "mail.example.com", "RejectMessage", REGION);
+        Identity attrs = service.getMailFromAttributes("alice@example.com", REGION);
+        assertEquals("mail.example.com", attrs.getMailFromDomain());
+        assertEquals("Success", attrs.getMailFromDomainStatus());
+        assertEquals("RejectMessage", attrs.getBehaviorOnMxFailure());
+
+        service.setMailFromDomain("alice@example.com", "", null, REGION);
+        attrs = service.getMailFromAttributes("alice@example.com", REGION);
+        assertEquals(null, attrs.getMailFromDomain());
+        assertEquals("UseDefaultValue", attrs.getBehaviorOnMxFailure());
+
+        assertThrows(AwsException.class, () -> service.setMailFromDomain(
+                "alice@example.com", "mail.example.com", "BadEnum", REGION));
+        AwsException missing = assertThrows(AwsException.class, () -> service.setMailFromDomain(
+                "ghost@example.com", "mail.example.com", null, REGION));
+        assertEquals("Identity <ghost@example.com> does not exist.", missing.getMessage());
+    }
+
+    @Test
+    void markPendingEmailIdentity_registersOnce_neverDowngrades() {
+        Identity verified = service.verifyEmailIdentity("alice@example.com", REGION);
+        verified.setVerificationStatus("Success");
+        service.save(verified, REGION);
+        service.markPendingEmailIdentity("alice@example.com", REGION);
+        assertEquals("Success",
+                service.find("alice@example.com", REGION).orElseThrow().getVerificationStatus());
+
+        service.markPendingEmailIdentity("new@example.com", REGION);
+        assertEquals("Pending",
+                service.find("new@example.com", REGION).orElseThrow().getVerificationStatus());
+    }
+
+    @Test
+    void tags_lifecycle_andNotFoundMessage() {
+        service.verifyEmailIdentity("alice@example.com", REGION);
+        service.tag("alice@example.com", REGION, List.of(new Tag("team", "floci")));
+        assertEquals(1, service.listTags("alice@example.com", REGION).size());
+
+        service.setTags("alice@example.com", REGION,
+                List.of(new Tag("team", "floci"), new Tag("env", "dev")));
+        service.untag("alice@example.com", REGION, List.of("team"));
+        assertEquals(List.of("env"),
+                service.listTags("alice@example.com", REGION).stream().map(Tag::key).toList());
+
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.listTags("ghost@example.com", REGION));
+        assertEquals("No EmailIdentity present with name: ghost@example.com", e.getMessage());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
@@ -53,9 +53,9 @@ final class SesServiceTestBuilder {
             new InMemoryStorage<>();
 
     private SmtpRelay smtpRelay = mock(SmtpRelay.class);
-    // Default null, matching the production null-Route53 case: SesService treats a null Route53Service
-    // as "DNS lookup disabled" for DKIM record checks. Tests that exercise the lookup opt in via
-    // route53Service(...).
+    // Default null, matching the production null-Route53 case: SesIdentityService treats a null
+    // Route53Service as "DNS lookup disabled" for DKIM record checks. Tests that exercise the lookup
+    // opt in via route53Service(...).
     private Route53Service route53Service = null;
     private ObjectMapper objectMapper = new ObjectMapper();
     private Clock clock = Clock.systemUTC();
@@ -116,7 +116,7 @@ final class SesServiceTestBuilder {
 
     SesService build() {
         return new SesService(
-                identityStore,
+                new SesIdentityService(identityStore, route53Service, clock),
                 new SesSentEmailService(emailStore),
                 new SesAccountService(accountSettingsStore, accountVdmStore, accountDetailsStore),
                 new SesTemplateService(templateStore),
@@ -129,8 +129,6 @@ final class SesServiceTestBuilder {
                 new SesCvetService(cvetStore),
                 new SesTenantService(tenantStore, tenantAssociationStore, clock, new SecureRandom()),
                 smtpRelay,
-                objectMapper,
-                route53Service,
-                clock);
+                objectMapper);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #2356: extracts the second of the two stores the strangler refactor (#2357) deferred,
completing the store-based split after the configuration-set extraction (#2881). The last
facade-owned store, `identityStore`, moves into a dedicated `SesIdentityService`. The service owns
the store, key derivation and whitespace validation, verification (email and domain), listing,
MAIL FROM and notification settings, the CVET pending-identity registration, the ARN-dispatched
identity tagging, and the DKIM state machine (token generation, signing attributes, and the
Route53-backed record detection with its lookup cache), taking `Route53Service` (null still means
DNS lookup disabled) and `Clock` as constructor dependencies; the facade no longer needs either.

The facade keeps what is genuinely cross-domain: the default-configuration-set association (it
validates the configuration set), the `DeleteIdentity` wrapper (tenant delete-guard and the policy
cascade), and the send-path reads, all through the service's find/save escape hatches. With this,
`SesService` drops from 2851 to 2318 lines and holds no store of its own.

No behavior change: request/response shapes, error messages, and validation order are untouched.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Pure code motion behind the facade; no wire-visible change. The full SES test suite (1028 tests:
unit, integration, and the v1/v2 protocol tests) passes unchanged, pinning the existing
probe-confirmed shapes and messages, including the DKIM state transitions driven by the
MutableClock-based cache-TTL tests, which now exercise the moved code through the delegation.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (not applicable: behavior-preserving refactor, existing tests pin the behavior; a focused `SesIdentityServiceTest` with 9 tests pins the extracted surface)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
