### PR TITLE
fix(sqs): honour ReceiveMessageWaitTimeSeconds when ReceiveMessage omits WaitTimeSeconds

### DIFF
--- a/docs/services/sqs.md
+++ b/docs/services/sqs.md
@@ -82,7 +82,7 @@ curl -X DELETE "http://localhost:4566/_aws/sqs/messages?QueueUrl=$QUEUE_URL"
 
 ## Long Polling
 
-`ReceiveMessage` waits up to `WaitTimeSeconds` for a message to arrive and returns as soon as one is available. When the request omits `WaitTimeSeconds`, the queue's `ReceiveMessageWaitTimeSeconds` attribute applies (default `0`, short polling), matching AWS.
+`ReceiveMessage` waits up to `WaitTimeSeconds` (0 to 20) for a message to arrive and returns as soon as one is available. Values outside that range are rejected with `InvalidParameterValue`. When the request omits `WaitTimeSeconds`, the queue's `ReceiveMessageWaitTimeSeconds` attribute applies (default `0`, short polling), matching AWS.
 
 ```bash
 # Enable long polling for every consumer of the queue

--- a/docs/services/sqs.md
+++ b/docs/services/sqs.md
@@ -80,6 +80,18 @@ curl "http://localhost:4566/_aws/sqs/messages?QueueUrl=$QUEUE_URL"
 curl -X DELETE "http://localhost:4566/_aws/sqs/messages?QueueUrl=$QUEUE_URL"
 ```
 
+## Long Polling
+
+`ReceiveMessage` waits up to `WaitTimeSeconds` for a message to arrive and returns as soon as one is available. When the request omits `WaitTimeSeconds`, the queue's `ReceiveMessageWaitTimeSeconds` attribute applies (default `0`, short polling), matching AWS.
+
+```bash
+# Enable long polling for every consumer of the queue
+aws sqs set-queue-attributes \
+  --queue-url $QUEUE_URL \
+  --attributes ReceiveMessageWaitTimeSeconds=20 \
+  --endpoint-url $AWS_ENDPOINT_URL
+```
+
 ## Configuration
 
 | Variable | Default | Description |

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -243,7 +243,7 @@ public class SqsJsonHandler {
         String queueUrl = request.path("QueueUrl").asText(null);
         int maxMessages = request.path("MaxNumberOfMessages").asInt(1);
         int visibilityTimeout = request.path("VisibilityTimeout").asInt(-1);
-        int waitTimeSeconds = request.path("WaitTimeSeconds").asInt(0);
+        int waitTimeSeconds = request.path("WaitTimeSeconds").asInt(-1);
 
         java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
         requestedAttrs.addAll(jsonNodeToList(request.path("AttributeNames")));

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -244,7 +244,7 @@ public class SqsJsonHandler {
         if (node.isMissingNode() || node.isNull()) {
             return null;
         }
-        if (!node.canConvertToInt()) {
+        if (!node.isIntegralNumber() || !node.canConvertToInt()) {
             throw new AwsException("InvalidParameterValue",
                     "Value " + node.asText() + " for parameter " + field + " is invalid. Reason: Must be an integer.", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsJsonHandler.java
@@ -239,11 +239,23 @@ public class SqsJsonHandler {
         return Response.ok(response).build();
     }
 
+    private Integer getOptionalIntField(JsonNode request, String field) {
+        JsonNode node = request.path(field);
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (!node.canConvertToInt()) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value " + node.asText() + " for parameter " + field + " is invalid. Reason: Must be an integer.", 400);
+        }
+        return node.asInt();
+    }
+
     private Response handleReceiveMessage(JsonNode request, String region) {
         String queueUrl = request.path("QueueUrl").asText(null);
         int maxMessages = request.path("MaxNumberOfMessages").asInt(1);
         int visibilityTimeout = request.path("VisibilityTimeout").asInt(-1);
-        int waitTimeSeconds = request.path("WaitTimeSeconds").asInt(-1);
+        Integer waitTimeSeconds = getOptionalIntField(request, "WaitTimeSeconds");
 
         java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
         requestedAttrs.addAll(jsonNodeToList(request.path("AttributeNames")));

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -262,7 +262,7 @@ public class SqsQueryHandler {
         String queueUrl = getParam(params, "QueueUrl");
         int maxMessages = getIntParam(params, "MaxNumberOfMessages", 1);
         int visibilityTimeout = getIntParam(params, "VisibilityTimeout", -1);
-        int waitTimeSeconds = getIntParam(params, "WaitTimeSeconds", -1);
+        Integer waitTimeSeconds = getOptionalIntParam(params, "WaitTimeSeconds");
 
         java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
         requestedAttrs.addAll(collectIndexed(params, "AttributeName."));
@@ -562,6 +562,19 @@ public class SqsQueryHandler {
 
     private String getParam(MultivaluedMap<String, String> params, String name) {
         return params.getFirst(name);
+    }
+
+    private Integer getOptionalIntParam(MultivaluedMap<String, String> params, String name) {
+        String value = params.getFirst(name);
+        if (value == null) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value " + value + " for parameter " + name + " is invalid. Reason: Must be an integer.", 400);
+        }
     }
 
     private int getIntParam(MultivaluedMap<String, String> params, String name, int defaultValue) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsQueryHandler.java
@@ -262,7 +262,7 @@ public class SqsQueryHandler {
         String queueUrl = getParam(params, "QueueUrl");
         int maxMessages = getIntParam(params, "MaxNumberOfMessages", 1);
         int visibilityTimeout = getIntParam(params, "VisibilityTimeout", -1);
-        int waitTimeSeconds = getIntParam(params, "WaitTimeSeconds", 0);
+        int waitTimeSeconds = getIntParam(params, "WaitTimeSeconds", -1);
 
         java.util.Set<String> requestedAttrs = new java.util.LinkedHashSet<>();
         requestedAttrs.addAll(collectIndexed(params, "AttributeName."));

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -35,6 +35,7 @@ public class SqsService implements Resettable, ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(SqsService.class);
     private static final int DEDUP_WINDOW_SECONDS = 300; // 5 minutes
+    private static final int MAX_RECEIVE_WAIT_TIME_SECONDS = 20;
 
     private final StorageBackend<String, Queue> queueStore;
     private final StorageBackend<String, List<Message>> messageStore;
@@ -633,7 +634,7 @@ public class SqsService implements Resettable, ResourceProvider {
     }
 
     public List<Message> receiveMessage(String queueUrl, int maxMessages, int visibilityTimeout,
-                                        int waitTimeSeconds, String region) {
+                                        Integer waitTimeSeconds, String region) {
         String storageKey = regionKey(region, queueUrl);
         Queue queue = getQueueByUrl(storageKey, queueUrl)
                 .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
@@ -641,6 +642,11 @@ public class SqsService implements Resettable, ResourceProvider {
 
         if (maxMessages < 1 || maxMessages > 10) {
             maxMessages = 1;
+        }
+        if (waitTimeSeconds != null && (waitTimeSeconds < 0 || waitTimeSeconds > MAX_RECEIVE_WAIT_TIME_SECONDS)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Value " + waitTimeSeconds + " for parameter WaitTimeSeconds is invalid. "
+                            + "Reason: Must be >= 0 and <= " + MAX_RECEIVE_WAIT_TIME_SECONDS + ".", 400);
         }
 
         long start = System.currentTimeMillis();
@@ -685,11 +691,13 @@ public class SqsService implements Resettable, ResourceProvider {
         }
     }
 
-    private int resolveWaitTimeSeconds(Queue queue, int requestedWaitTimeSeconds) {
-        if (requestedWaitTimeSeconds >= 0) {
+    private int resolveWaitTimeSeconds(Queue queue, Integer requestedWaitTimeSeconds) {
+        if (requestedWaitTimeSeconds != null) {
             return requestedWaitTimeSeconds;
         }
-        return parseNonNegativeSecondsAttribute(queue.getAttributes().get("ReceiveMessageWaitTimeSeconds"));
+        int queueWaitTimeSeconds = parseNonNegativeSecondsAttribute(
+                queue.getAttributes().get("ReceiveMessageWaitTimeSeconds"));
+        return Math.min(queueWaitTimeSeconds, MAX_RECEIVE_WAIT_TIME_SECONDS);
     }
 
     private RedrivePolicy getOrParseRedrivePolicy(Queue queue, String storageKey) {

--- a/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sqs/SqsService.java
@@ -294,6 +294,7 @@ public class SqsService implements Resettable, ResourceProvider {
         queue.getAttributes().putIfAbsent("VisibilityTimeout", String.valueOf(defaultVisibilityTimeout));
         queue.getAttributes().putIfAbsent("MaximumMessageSize", String.valueOf(maxMessageSize));
         queue.getAttributes().putIfAbsent("DelaySeconds", "0");
+        queue.getAttributes().putIfAbsent("ReceiveMessageWaitTimeSeconds", "0");
         queue.getAttributes().putIfAbsent("MessageRetentionPeriod", "345600");
         if (queue.isFifo()) {
             if (attributes != null && attributes.containsKey("ContentBasedDeduplication") && "true".equals(attributes.get("ContentBasedDeduplication"))) {
@@ -426,7 +427,7 @@ public class SqsService implements Resettable, ResourceProvider {
                             "Reason: Message must be shorter than " + queueMaxMessageSize + " bytes.", 400);
         }
 
-        int queueDelaySeconds = parseDelaySecondsAttribute(queue.getAttributes().get("DelaySeconds"));
+        int queueDelaySeconds = parseNonNegativeSecondsAttribute(queue.getAttributes().get("DelaySeconds"));
 
         // Resolve the effective delay:
         //   - FIFO queues only support queue-level DelaySeconds per AWS SQS,
@@ -592,12 +593,7 @@ public class SqsService implements Resettable, ResourceProvider {
         return total;
     }
 
-    /**
-     * Parse the queue-level DelaySeconds attribute. Returns 0 when the
-     * attribute is null, empty, non-numeric, or negative -- the queue falls
-     * back to "no default delay" rather than failing the SendMessage call.
-     */
-    private int parseDelaySecondsAttribute(String value) {
+    private int parseNonNegativeSecondsAttribute(String value) {
         if (value == null || value.isEmpty()) {
             return 0;
         }
@@ -639,7 +635,7 @@ public class SqsService implements Resettable, ResourceProvider {
     public List<Message> receiveMessage(String queueUrl, int maxMessages, int visibilityTimeout,
                                         int waitTimeSeconds, String region) {
         String storageKey = regionKey(region, queueUrl);
-        getQueueByUrl(storageKey, queueUrl)
+        Queue queue = getQueueByUrl(storageKey, queueUrl)
                 .orElseThrow(() -> new AwsException("AWS.SimpleQueueService.NonExistentQueue",
                         "The specified queue does not exist.", 400));
 
@@ -648,7 +644,7 @@ public class SqsService implements Resettable, ResourceProvider {
         }
 
         long start = System.currentTimeMillis();
-        long maxWait = waitTimeSeconds * 1000L;
+        long maxWait = resolveWaitTimeSeconds(queue, waitTimeSeconds) * 1000L;
         Object lock = queueLocks.computeIfAbsent(storageKey, k -> new Object());
         // The queue incarnation this call polls against. DeleteQueue removes it
         // from messagesByQueue (and CreateQueue registers a fresh instance), so
@@ -687,6 +683,13 @@ public class SqsService implements Resettable, ResourceProvider {
                 return result;
             }
         }
+    }
+
+    private int resolveWaitTimeSeconds(Queue queue, int requestedWaitTimeSeconds) {
+        if (requestedWaitTimeSeconds >= 0) {
+            return requestedWaitTimeSeconds;
+        }
+        return parseNonNegativeSecondsAttribute(queue.getAttributes().get("ReceiveMessageWaitTimeSeconds"));
     }
 
     private RedrivePolicy getOrParseRedrivePolicy(Queue queue, String storageKey) {

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -724,4 +724,34 @@ class SqsIntegrationTest {
             .when().post("/");
         }
     }
+
+    @Test
+    void receiveMessageRejectsInvalidWaitTimeSeconds() {
+        String rangeQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "query-wait-time-range-queue")
+        .when().post("/").then().statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            for (String invalid : new String[]{"-1", "21", "abc"}) {
+                given()
+                    .contentType("application/x-www-form-urlencoded")
+                    .formParam("Action", "ReceiveMessage")
+                    .formParam("QueueUrl", rangeQueueUrl)
+                    .formParam("WaitTimeSeconds", invalid)
+                .when().post("/").then()
+                    .statusCode(400)
+                    .body(containsString("<Code>InvalidParameterValue</Code>"))
+                    .body(containsString("WaitTimeSeconds"));
+            }
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", rangeQueueUrl)
+            .when().post("/");
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -735,7 +735,7 @@ class SqsIntegrationTest {
             .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
 
         try {
-            for (String invalid : new String[]{"-1", "21", "abc"}) {
+            for (String invalid : new String[]{"-1", "21", "1.5", "abc"}) {
                 given()
                     .contentType("application/x-www-form-urlencoded")
                     .formParam("Action", "ReceiveMessage")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsIntegrationTest.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.*;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -676,6 +677,50 @@ class SqsIntegrationTest {
                 .contentType("application/x-www-form-urlencoded")
                 .formParam("Action", "DeleteQueue")
                 .formParam("QueueUrl", traceQueueUrl)
+            .when().post("/");
+        }
+    }
+
+
+    @Test
+    void receiveMessageWithoutWaitTimeSecondsHonoursQueueReceiveMessageWaitTimeSeconds() {
+        String longPollQueueUrl = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateQueue")
+            .formParam("QueueName", "query-long-poll-attr-queue")
+            .formParam("Attribute.1.Name", "ReceiveMessageWaitTimeSeconds")
+            .formParam("Attribute.1.Value", "1")
+        .when().post("/").then().statusCode(200)
+            .extract().xmlPath().getString("CreateQueueResponse.CreateQueueResult.QueueUrl");
+
+        try {
+            long start = System.nanoTime();
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", longPollQueueUrl)
+            .when().post("/").then().statusCode(200)
+                .body(not(containsString("<Message>")));
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs >= 900,
+                    "Omitting WaitTimeSeconds must long poll for the queue's ReceiveMessageWaitTimeSeconds, but returned after " + elapsedMs + "ms");
+
+            start = System.nanoTime();
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", longPollQueueUrl)
+                .formParam("WaitTimeSeconds", "0")
+            .when().post("/").then().statusCode(200)
+                .body(not(containsString("<Message>")));
+            elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs < 1000,
+                    "WaitTimeSeconds=0 must override the queue attribute, but returned after " + elapsedMs + "ms");
+        } finally {
+            given()
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "DeleteQueue")
+                .formParam("QueueUrl", longPollQueueUrl)
             .when().post("/");
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -585,4 +585,33 @@ class SqsJsonProtocolTest {
             .when().post("/");
         }
     }
+
+    @Test
+    void receiveMessageRejectsInvalidWaitTimeSeconds() {
+        String rangeQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body("{\"QueueName\":\"json-wait-time-range-queue\"}")
+        .when().post("/").then().statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        try {
+            for (String invalid : new String[]{"-1", "21", "\"abc\""}) {
+                given()
+                    .contentType(CONTENT_TYPE)
+                    .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                    .body("{\"QueueUrl\":\"" + rangeQueueUrl + "\",\"WaitTimeSeconds\":" + invalid + "}")
+                .when().post("/").then()
+                    .statusCode(400)
+                    .body("__type", equalTo("InvalidParameterValue"))
+                    .body("message", containsString("WaitTimeSeconds"));
+            }
+        } finally {
+            given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.DeleteQueue")
+                .body("{\"QueueUrl\":\"" + rangeQueueUrl + "\"}")
+            .when().post("/");
+        }
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -596,7 +596,7 @@ class SqsJsonProtocolTest {
             .extract().jsonPath().getString("QueueUrl");
 
         try {
-            for (String invalid : new String[]{"-1", "21", "\"abc\""}) {
+            for (String invalid : new String[]{"-1", "21", "1.5", "\"abc\""}) {
                 given()
                     .contentType(CONTENT_TYPE)
                     .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsJsonProtocolTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -540,5 +541,48 @@ class SqsJsonProtocolTest {
             .statusCode(200)
             .body("Messages", hasSize(1))
             .body("Messages[0].Body", equalTo("hello from signed json"));
+    }
+
+
+    @Test
+    void receiveMessageWithoutWaitTimeSecondsHonoursQueueReceiveMessageWaitTimeSeconds() {
+        String createBody = "{\"QueueName\":\"json-long-poll-attr-queue\","
+                + "\"Attributes\":{\"ReceiveMessageWaitTimeSeconds\":\"1\"}}";
+        String longPollQueueUrl = given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+            .body(createBody)
+        .when().post("/").then().statusCode(200)
+            .extract().jsonPath().getString("QueueUrl");
+
+        try {
+            long start = System.nanoTime();
+            given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .body("{\"QueueUrl\":\"" + longPollQueueUrl + "\"}")
+            .when().post("/").then().statusCode(200)
+                .body("$", not(hasKey("Messages")));
+            long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs >= 900,
+                    "Omitting WaitTimeSeconds must long poll for the queue's ReceiveMessageWaitTimeSeconds, but returned after " + elapsedMs + "ms");
+
+            start = System.nanoTime();
+            given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .body("{\"QueueUrl\":\"" + longPollQueueUrl + "\",\"WaitTimeSeconds\":0}")
+            .when().post("/").then().statusCode(200)
+                .body("$", not(hasKey("Messages")));
+            elapsedMs = (System.nanoTime() - start) / 1_000_000;
+            assertTrue(elapsedMs < 1000,
+                    "WaitTimeSeconds=0 must override the queue attribute, but returned after " + elapsedMs + "ms");
+        } finally {
+            given()
+                .contentType(CONTENT_TYPE)
+                .header("X-Amz-Target", "AmazonSQS.DeleteQueue")
+                .body("{\"QueueUrl\":\"" + longPollQueueUrl + "\"}")
+            .when().post("/");
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -1076,7 +1076,7 @@ class SqsServiceTest {
                 Map.of("ReceiveMessageWaitTimeSeconds", "1"), region);
 
         long start = System.nanoTime();
-        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, -1, region);
+        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, null, region);
         long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
         assertTrue(result.isEmpty());
@@ -1106,12 +1106,32 @@ class SqsServiceTest {
         assertEquals("0", queue.getAttributes().get("ReceiveMessageWaitTimeSeconds"));
 
         long start = System.nanoTime();
-        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, -1, region);
+        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, null, region);
         long elapsedMs = (System.nanoTime() - start) / 1_000_000;
 
         assertTrue(result.isEmpty());
         assertTrue(elapsedMs < 1000,
                 "A queue without ReceiveMessageWaitTimeSeconds must short poll, but returned after " + elapsedMs + "ms");
+    }
+
+    @Test
+    void receiveMessageRejectsWaitTimeOutsideAwsRange() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("queue-longpoll-range",
+                Map.of("ReceiveMessageWaitTimeSeconds", "20"), region);
+        String queueUrl = queue.getQueueUrl();
+
+        for (int invalid : new int[]{-1, 21}) {
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> sqsService.receiveMessage(queueUrl, 1, 30, invalid, region));
+            assertEquals("InvalidParameterValue", ex.getErrorCode());
+            assertTrue(ex.getMessage().contains("WaitTimeSeconds"),
+                    "The error must name the offending parameter, got: " + ex.getMessage());
+        }
+
+        sqsService.sendMessage(queueUrl, "in-range", 0, region);
+        List<Message> result = sqsService.receiveMessage(queueUrl, 1, 30, 20, region);
+        assertEquals(1, result.size(), "WaitTimeSeconds=20 is the AWS maximum and must be accepted");
     }
 
     @Test
@@ -1125,7 +1145,7 @@ class SqsServiceTest {
         final var result = new AtomicReference<List<Message>>();
         Thread poller = new Thread(() -> {
             pollerEntered.countDown();
-            result.set(sqsService.receiveMessage(queueUrl, 1, 30, -1, region));
+            result.set(sqsService.receiveMessage(queueUrl, 1, 30, null, region));
         });
         poller.start();
         assertTrue(pollerEntered.await(5, TimeUnit.SECONDS));

--- a/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sqs/SqsServiceTest.java
@@ -1065,4 +1065,78 @@ class SqsServiceTest {
         assertTrue(staleResult.get().isEmpty(),
                 "The pre-delete long poll must not consume the recreated queue's delivery");
     }
+
+
+    // --- ReceiveMessage falls back to the queue's ReceiveMessageWaitTimeSeconds ---
+
+    @Test
+    void receiveMessageWithoutWaitTimeUsesQueueReceiveMessageWaitTimeSeconds() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("queue-default-longpoll",
+                Map.of("ReceiveMessageWaitTimeSeconds", "1"), region);
+
+        long start = System.nanoTime();
+        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, -1, region);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(result.isEmpty());
+        assertTrue(elapsedMs >= 900,
+                "A receive that omits WaitTimeSeconds must long poll for the queue's ReceiveMessageWaitTimeSeconds, but returned after " + elapsedMs + "ms");
+    }
+
+    @Test
+    void explicitWaitTimeOverridesQueueReceiveMessageWaitTimeSeconds() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("queue-longpoll-override",
+                Map.of("ReceiveMessageWaitTimeSeconds", "20"), region);
+
+        long start = System.nanoTime();
+        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, 0, region);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(result.isEmpty());
+        assertTrue(elapsedMs < 1000,
+                "WaitTimeSeconds=0 in the request must override the queue attribute, but returned after " + elapsedMs + "ms");
+    }
+
+    @Test
+    void receiveMessageWithoutWaitTimeReturnsImmediatelyWhenQueueDoesNotLongPoll() {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("queue-no-longpoll", null, region);
+        assertEquals("0", queue.getAttributes().get("ReceiveMessageWaitTimeSeconds"));
+
+        long start = System.nanoTime();
+        List<Message> result = sqsService.receiveMessage(queue.getQueueUrl(), 1, 30, -1, region);
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        assertTrue(result.isEmpty());
+        assertTrue(elapsedMs < 1000,
+                "A queue without ReceiveMessageWaitTimeSeconds must short poll, but returned after " + elapsedMs + "ms");
+    }
+
+    @Test
+    void queueDefaultLongPollReturnsAsSoonAsAMessageArrives() throws InterruptedException {
+        String region = "eu-west-1";
+        Queue queue = sqsService.createQueue("queue-longpoll-wakeup", null, region);
+        String queueUrl = queue.getQueueUrl();
+        sqsService.setQueueAttributes(queueUrl, Map.of("ReceiveMessageWaitTimeSeconds", "20"), region);
+
+        final var pollerEntered = new CountDownLatch(1);
+        final var result = new AtomicReference<List<Message>>();
+        Thread poller = new Thread(() -> {
+            pollerEntered.countDown();
+            result.set(sqsService.receiveMessage(queueUrl, 1, 30, -1, region));
+        });
+        poller.start();
+        assertTrue(pollerEntered.await(5, TimeUnit.SECONDS));
+        Thread.sleep(300);
+
+        sqsService.sendMessage(queueUrl, "wake-up", 0, region);
+        poller.join(3000);
+
+        assertFalse(poller.isAlive(),
+                "A long poll driven by the queue attribute must return as soon as a message arrives");
+        assertEquals(1, result.get().size());
+        assertEquals("wake-up", result.get().get(0).getBody());
+    }
 }


### PR DESCRIPTION
## Summary

`ReceiveMessage` treated a missing `WaitTimeSeconds` as `0` and returned immediately, ignoring the queue's `ReceiveMessageWaitTimeSeconds` attribute. AWS applies that attribute as the default wait, and only an explicit `WaitTimeSeconds` in the request overrides it. Consumers that enable long polling on the queue (for example Terraform's `receive_wait_time_seconds = 20`) and omit the parameter on each receive were therefore short polling against Floci in a tight loop.

Changes:

- Both protocol handlers carry `WaitTimeSeconds` as a nullable value so only a genuinely absent parameter falls back to the queue attribute. Non-integer values are rejected with `InvalidParameterValue`.
- The service rejects explicit values outside 0 to 20 with `InvalidParameterValue` (`Value X for parameter WaitTimeSeconds is invalid. Reason: Must be >= 0 and <= 20.`), matching AWS, and caps the queue attribute fallback at 20.
- `SqsService.receiveMessage` resolves the wait from the queue's `ReceiveMessageWaitTimeSeconds` attribute when unspecified, mirroring the existing `VisibilityTimeout` fallback. The attribute is parsed defensively (null, empty, non-numeric or negative values mean `0`).
- `CreateQueue` stores the AWS default `ReceiveMessageWaitTimeSeconds=0`, so `GetQueueAttributes` reports it like AWS does.
- Docs: added a Long Polling section to `docs/services/sqs.md`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reproduced against `floci/floci:2.0.1` with AWS CLI 2.34.32 (JSON protocol) and curl (Query protocol) on an empty queue created with `ReceiveMessageWaitTimeSeconds=5`:

| Request | Time |
|---|---|
| JSON, explicit `WaitTimeSeconds=3` | 3.4s |
| JSON, `WaitTimeSeconds` omitted | 0.35s |
| Query, explicit `WaitTimeSeconds=2` | 2.0s |
| Query, `WaitTimeSeconds` omitted | 0.01s |

On AWS the omitted cases wait 5s. Explicit `WaitTimeSeconds` was already honoured and is unchanged. Callers inside Floci (Lambda ESM poller, Pipes poller) pass `0` explicitly and keep their short-poll behaviour.

## Checklist

- [x] SQS, SNS, Pipes, Lambda ESM and Step Functions test classes pass locally (48 classes, 649 tests); full `./mvnw test` is left to CI
- [x] New or updated integration test added (`SqsIntegrationTest` and `SqsJsonProtocolTest` cover Query and JSON; `SqsServiceTest` covers fallback, explicit override, short-poll default, range validation and wake-up on arrival)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
