### PR TITLE
fix(docdb): accept an existing security group on CreateDBCluster and ModifyDBCluster

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -233,6 +233,26 @@ teardown() {
     assert_output --partial 'DBClusterNotFoundFault'
 }
 
+@test "docdb: a security group that exists is accepted on create" {
+    CLUSTER_ID="bats-docdb-sg-$(unique_name)"
+    run aws_cmd ec2 create-vpc --cidr-block 10.42.0.0/16
+    assert_success
+    VPC_ID=$(json_get "$output" '.Vpc.VpcId')
+    run aws_cmd ec2 create-security-group --group-name "$CLUSTER_ID" --description d --vpc-id "$VPC_ID"
+    assert_success
+    SG_ID=$(json_get "$output" '.GroupId')
+
+    run aws_cmd docdb create-db-cluster --db-cluster-identifier "$CLUSTER_ID" --engine docdb \
+        --master-username docdbadmin --master-user-password "secret99password" \
+        --vpc-security-group-ids "$SG_ID"
+    assert_success
+    run aws_cmd docdb describe-db-clusters --db-cluster-identifier "$CLUSTER_ID"
+    assert_success
+    assert_output --partial "\"VpcSecurityGroupId\": \"$SG_ID\""
+
+    aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
+}
+
 @test "docdb: cluster settings given on create are returned by describe" {
     CLUSTER_ID="bats-docdb-settings-$(unique_name)"
     run aws_cmd kms create-key --description "$CLUSTER_ID"

--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -14,6 +14,12 @@ teardown() {
         aws_cmd secretsmanager delete-secret --secret-id "$MANAGED_SECRET_ARN" \
             --force-delete-without-recovery >/dev/null 2>&1 || true
     fi
+    # EC2 fixtures of the docdb security-group case, whether or not its assertions passed
+    if [ -n "${SG_ID:-}" ]; then
+        aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
+        aws_cmd ec2 delete-security-group --group-id "$SG_ID" >/dev/null 2>&1 || true
+        aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
+    fi
 }
 
 @test "RDS: create db instance returns resource identifiers" {
@@ -249,10 +255,6 @@ teardown() {
     run aws_cmd docdb describe-db-clusters --db-cluster-identifier "$CLUSTER_ID"
     assert_success
     assert_output --partial "\"VpcSecurityGroupId\": \"$SG_ID\""
-
-    aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
-    aws_cmd ec2 delete-security-group --group-id "$SG_ID" >/dev/null 2>&1 || true
-    aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
 }
 
 @test "docdb: cluster settings given on create are returned by describe" {

--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -251,6 +251,8 @@ teardown() {
     assert_output --partial "\"VpcSecurityGroupId\": \"$SG_ID\""
 
     aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
+    aws_cmd ec2 delete-security-group --group-id "$SG_ID" >/dev/null 2>&1 || true
+    aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
 }
 
 @test "docdb: cluster settings given on create are returned by describe" {

--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -18,6 +18,8 @@ teardown() {
     if [ -n "${SG_ID:-}" ]; then
         aws_cmd docdb delete-db-cluster --db-cluster-identifier "$CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
         aws_cmd ec2 delete-security-group --group-id "$SG_ID" >/dev/null 2>&1 || true
+    fi
+    if [ -n "${VPC_ID:-}" ]; then
         aws_cmd ec2 delete-vpc --vpc-id "$VPC_ID" >/dev/null 2>&1 || true
     fi
 }

--- a/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/docdb/DocDbService.java
@@ -325,7 +325,7 @@ public class DocDbService {
                 throw new IllegalStateException("DocDbService was built without an Ec2Service");
             }
             for (String groupId : securityGroups) {
-                boolean known = ec2Service.describeSecurityGroups(region, List.of(groupId), null, Map.of())
+                boolean known = ec2Service.describeSecurityGroups(region, List.of(groupId), List.of(), Map.of())
                         .stream().anyMatch(sg -> groupId.equals(sg.getGroupId()));
                 if (!known) {
                     throw new AwsException("InvalidParameterValue",

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbClusterSettingsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbClusterSettingsIntegrationTest.java
@@ -18,7 +18,7 @@ import static org.hamcrest.Matchers.containsString;
 
 /**
  * The settings a DocumentDB cluster is created with come back from DescribeDBClusters, as on a
- * live account — through the Query protocol, with a real KMS key from the KMS store and the
+ * live account: through the Query protocol, with a real KMS key from the KMS store and the
  * default subnet group, parameter group and security group.
  */
 @QuarkusTest
@@ -56,7 +56,7 @@ class DocDbClusterSettingsIntegrationTest {
     }
 
     /**
-     * A security group that exists is the case a live stack always sends — and the one a probe
+     * A security group that exists is the case a live stack always sends, and the one a probe
      * with a made-up id never reaches, because an unknown id is refused before its record is
      * consulted. 2.0.1 answered it with an internal error.
      */

--- a/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbClusterSettingsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/docdb/DocDbClusterSettingsIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.docdb;
 
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.kms.KmsService;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
@@ -35,6 +37,9 @@ class DocDbClusterSettingsIntegrationTest {
     @Inject
     KmsService kmsService;
 
+    @Inject
+    Ec2Service ec2Service;
+
     private static io.restassured.specification.RequestSpecification rds(String action) {
         return given().header("Authorization",
                         "AWS4-HMAC-SHA256 Credential=test/20260615/us-east-1/rds/aws4_request, "
@@ -48,6 +53,38 @@ class DocDbClusterSettingsIntegrationTest {
     void cleanUp() {
         rds("DeleteDBInstance").formParam("DBInstanceIdentifier", ID + "-1").when().post("/");
         rds("DeleteDBCluster").formParam("DBClusterIdentifier", ID).formParam("SkipFinalSnapshot", "true").when().post("/");
+    }
+
+    /**
+     * A security group that exists is the case a live stack always sends — and the one a probe
+     * with a made-up id never reaches, because an unknown id is refused before its record is
+     * consulted. 2.0.1 answered it with an internal error.
+     */
+    @Test
+    void anExistingSecurityGroupIsAcceptedOnCreateAndModify() {
+        String vpcId = ec2Service.createVpc("us-east-1", "10.9.0.0/16", false).getVpcId();
+        SecurityGroup first = ec2Service.createSecurityGroup("us-east-1", "docdb-first", "d", vpcId);
+        SecurityGroup second = ec2Service.createSecurityGroup("us-east-1", "docdb-second", "d", vpcId);
+
+        rds("CreateDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("Engine", "docdb")
+                .formParam("MasterUsername", "u")
+                .formParam("MasterUserPassword", "secret99password")
+                .formParam("VpcSecurityGroupIds.VpcSecurityGroupId.1", first.getGroupId())
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<VpcSecurityGroupId>" + first.getGroupId() + "</VpcSecurityGroupId>"));
+
+        rds("ModifyDBCluster")
+                .formParam("DBClusterIdentifier", ID)
+                .formParam("VpcSecurityGroupIds.VpcSecurityGroupId.1", first.getGroupId())
+                .formParam("VpcSecurityGroupIds.VpcSecurityGroupId.2", second.getGroupId())
+                .when().post("/").then().statusCode(200);
+
+        rds("DescribeDBClusters").formParam("DBClusterIdentifier", ID)
+                .when().post("/").then().statusCode(200)
+                .body(containsString("<VpcSecurityGroupId>" + first.getGroupId() + "</VpcSecurityGroupId>"))
+                .body(containsString("<VpcSecurityGroupId>" + second.getGroupId() + "</VpcSecurityGroupId>"));
     }
 
     @Test


### PR DESCRIPTION
Closes #2990

### What was wrong
`CreateDBCluster` / `ModifyDBCluster` with a security group that **exists** answered `InternalFailure`: the lookup added in #2651 passed `null` for group names and `Ec2Service.describeSecurityGroups` calls `isEmpty()` on it. A made-up id never reached that filter (the id filter rejects it first), which is why the live probe, the unit test (mocked `Ec2Service`) and the integration test (no group given) all passed. Terraform's `aws_docdb_cluster` retries the 500 for ever, so on 2.0.1 a cluster in a VPC never gets created.

### What changes
The lookup passes an empty list of names. One line.

### Tests
- `DocDbClusterSettingsIntegrationTest.anExistingSecurityGroupIsAcceptedOnCreateAndModify`: creates a VPC and two groups through the EC2 store, gives one on create and both on modify, reads them back. Fails with a 500 without the fix.
- bats `docdb: a security group that exists is accepted on create` — the same through the AWS CLI.
