### PR TITLE
fix(lambda): honor configured function architecture

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -132,6 +132,7 @@ floci:
       enabled: true
       ephemeral: false                        # true = remove container after each invocation
       ecr-base-uri: public.ecr.aws            # Registry for Lambda runtime images (legacy: floci.ecr-base-uri / FLOCI_ECR_BASE_URI)
+      honour-architectures: false             # true = select the declared Lambda Docker architecture
       default-memory-mb: 128
       default-timeout-seconds: 3
       runtime-api-base-port: 12000            # Port range for Lambda Runtime API
@@ -312,8 +313,14 @@ All keys in this table are declared on `EmulatorConfig` and accept environment v
 | `FLOCI_SERVICES_SES_SMTP_USER`                     | *(unset)*        | SMTP authentication username                                  |
 | `FLOCI_SERVICES_SES_SMTP_PASS`                     | *(unset)*        | SMTP authentication password                                  |
 | `FLOCI_SERVICES_SES_SMTP_STARTTLS`                 | `DISABLED`       | STARTTLS mode: `DISABLED`, `OPTIONAL`, or `REQUIRED`          |
+| `FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES`       | `false`          | Select the declared Lambda architecture for Docker image pulls and containers |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED`         | `false`          | Enable bind-mount hot-reload mode (`S3Bucket=hot-reload`)     |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ALLOWED_PATHS`   | *(unset)*        | Comma-separated list of host paths allowed as bind-mount roots; unset = any absolute path |
+
+Enable `FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES` only when the Docker host can run the
+function architecture. Foreign architectures require Docker Desktop support or host emulation
+such as `binfmt_misc` with QEMU. Floci does not fall back to the host architecture when this
+setting is enabled.
 
 Per-queue SQS redrive policy (`maxReceiveCount`) is configured at queue creation time via `SetQueueAttributes` / `CreateQueue`, not as a global default.
 

--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -211,10 +211,19 @@ These AWS Lambda operations have no handler in Floci. Calls will return `404` or
 
 ## Configuration
 
+!!! warning "Lambda container architecture"
+    Floci uses the Docker host architecture by default. Set
+    `FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES=true` to run each function with
+    its declared `arm64` or `x86_64` architecture. The Docker host must support
+    the selected architecture. Foreign architectures require Docker Desktop or
+    host emulation such as `binfmt_misc` with QEMU. Floci does not fall back to
+    the host architecture when this setting is enabled.
+
 | Variable | Default | Description |
 |---|---|---|
 | `FLOCI_SERVICES_LAMBDA_ENABLED` | `true` | Enable or disable the service |
 | `FLOCI_SERVICES_LAMBDA_EPHEMERAL` | `false` | Remove containers after each invocation |
+| `FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES` | `false` | Select each function's declared architecture for Docker image pulls and containers |
 | `FLOCI_SERVICES_LAMBDA_DEFAULT_MEMORY_MB` | `128` | Default function memory (MB) |
 | `FLOCI_SERVICES_LAMBDA_DEFAULT_TIMEOUT_SECONDS` | `3` | Default function timeout (seconds) |
 | `FLOCI_SERVICES_LAMBDA_RUNTIME_API_BASE_PORT` | `12000` | First port in the Lambda Runtime API range |

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1861,6 +1861,16 @@ public interface EmulatorConfig {
         @WithDefault("false")
         boolean ephemeral();
 
+        /**
+         * When true, Docker Lambda containers use the platform declared by the function's
+         * Architectures value. Disabled by default because foreign-platform containers require
+         * host support such as binfmt_misc or QEMU.
+         *
+         * Env var: FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES
+         */
+        @WithDefault("false")
+        boolean honourArchitectures();
+
         @WithDefault("300")
         int containerIdleTimeoutSeconds();
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -102,8 +102,8 @@ public class ContainerLifecycleManager {
      * @return the container ID
      */
     public String create(ContainerSpec spec) {
-        imageCacheService.ensureImageExists(spec.image());
-        return create(spec, spec.image(), null);
+        String resolvedImage = imageCacheService.ensureImageExists(spec.image());
+        return create(spec, resolvedImage, null);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -102,14 +102,33 @@ public class ContainerLifecycleManager {
      * @return the container ID
      */
     public String create(ContainerSpec spec) {
-        LOG.debugv("Creating container from spec: image={0}, name={1}", spec.image(), spec.name());
-
         imageCacheService.ensureImageExists(spec.image());
+        return create(spec, spec.image(), null);
+    }
+
+    /**
+     * Creates a container for a specific Docker platform.
+     *
+     * @param spec the container specification
+     * @param platform Docker platform, such as {@code linux/arm64}
+     * @return the container ID
+     */
+    public String create(ContainerSpec spec, String platform) {
+        String resolvedImage = imageCacheService.ensureImageExists(spec.image(), platform);
+        return create(spec, resolvedImage, platform);
+    }
+
+    private String create(ContainerSpec spec, String resolvedImage, String platform) {
+        LOG.debugv("Creating container from spec: image={0}, name={1}", spec.image(), spec.name());
 
         HostConfig hostConfig = buildHostConfig(spec);
 
-        CreateContainerCmd createCmd = dockerClient.createContainerCmd(spec.image())
+        CreateContainerCmd createCmd = dockerClient.createContainerCmd(resolvedImage)
                 .withHostConfig(hostConfig);
+
+        if (platform != null && !platform.isBlank()) {
+            createCmd.withPlatform(platform);
+        }
 
         if (spec.name() != null) {
             createCmd.withName(spec.name());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1506,8 +1506,14 @@ public class LambdaService implements ResourceProvider {
     }
 
     private static List<String> validateArchitectures(Object value) {
-        if (!(value instanceof List<?> architectures)) {
+        if (value == null) {
             return null;
+        }
+        if (!(value instanceof List<?> architectures)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "1 validation error detected: Value '" + value + "' at 'architectures' "
+                            + "failed to satisfy constraint: Member must be a list",
+                    400);
         }
         if (architectures.isEmpty()) {
             throw new AwsException("InvalidParameterValueException",

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -75,6 +75,7 @@ public class LambdaService implements ResourceProvider {
             "arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+");
     private static final Pattern HANDLER_PATTERN = Pattern.compile("\\S+");
     private static final int MAX_HANDLER_LENGTH = 128;
+    private static final List<String> FUNCTION_ARCHITECTURES = List.of("x86_64", "arm64");
 
     private final LambdaFunctionStore functionStore;
     private final LambdaExecutorService executorService;
@@ -338,6 +339,7 @@ public class LambdaService implements ResourceProvider {
             throw new AwsException("ResourceConflictException",
                     "Function already exist: " + functionName, 409);
         }
+        List<String> architectures = validateArchitectures(request.get("Architectures"));
 
         LambdaFunction fn = new LambdaFunction();
         fn.setAccountId(regionResolver.getAccountId());
@@ -368,10 +370,6 @@ public class LambdaService implements ResourceProvider {
         Map<String, String> tags = (Map<String, String>) request.get("Tags");
         if (tags != null) fn.setTags(tags);
 
-        // Architectures
-        @SuppressWarnings("unchecked")
-        List<String> architectures = request.get("Architectures") instanceof List
-                ? (List<String>) request.get("Architectures") : null;
         if (architectures != null && !architectures.isEmpty()) {
             fn.setArchitectures(new ArrayList<>(architectures));
         }
@@ -555,6 +553,7 @@ public class LambdaService implements ResourceProvider {
     public LambdaFunction updateFunctionCode(String region, String functionName, Map<String, Object> request) {
         LambdaFunction fn = getFunction(region, functionName);
         functionName = fn.getFunctionName();
+        List<String> architectures = validateArchitectures(request.get("Architectures"));
 
         String zipFileBase64 = (String) request.get("ZipFile");
         String imageUri = (String) request.get("ImageUri");
@@ -577,13 +576,8 @@ public class LambdaService implements ResourceProvider {
             }
         }
 
-        if (request.containsKey("Architectures")) {
-            @SuppressWarnings("unchecked")
-            List<String> archs = request.get("Architectures") instanceof List
-                    ? (List<String>) request.get("Architectures") : null;
-            if (archs != null && !archs.isEmpty()) {
-                fn.setArchitectures(new ArrayList<>(archs));
-            }
+        if (architectures != null) {
+            fn.setArchitectures(new ArrayList<>(architectures));
         }
 
         fn.setLastModified(System.currentTimeMillis());
@@ -602,6 +596,7 @@ public class LambdaService implements ResourceProvider {
 
     public LambdaFunction updateFunctionConfiguration(String region, String functionName, Map<String, Object> request) {
         LambdaFunction fn = getFunction(region, functionName);
+        List<String> architectures = validateArchitectures(request.get("Architectures"));
 
         // Validated before any field mutation below, not inline where Layers is applied further
         // down - fn is the live object backing this store entry (InMemoryStorage#get returns the
@@ -680,13 +675,8 @@ public class LambdaService implements ResourceProvider {
             }
         }
 
-        if (request.containsKey("Architectures")) {
-            @SuppressWarnings("unchecked")
-            List<String> archs = request.get("Architectures") instanceof List
-                    ? (List<String>) request.get("Architectures") : null;
-            if (archs != null && !archs.isEmpty()) {
-                fn.setArchitectures(new ArrayList<>(archs));
-            }
+        if (architectures != null) {
+            fn.setArchitectures(new ArrayList<>(architectures));
         }
 
         if (request.containsKey("EphemeralStorage")) {
@@ -1513,6 +1503,27 @@ public class LambdaService implements ResourceProvider {
             parsed.add(new LambdaFileSystemConfig(arn, localMountPath));
         }
         return parsed;
+    }
+
+    private static List<String> validateArchitectures(Object value) {
+        if (!(value instanceof List<?> architectures) || architectures.isEmpty()) {
+            return null;
+        }
+
+        List<String> validated = new ArrayList<>(architectures.size());
+        for (int index = 0; index < architectures.size(); index++) {
+            Object architecture = architectures.get(index);
+            if (!FUNCTION_ARCHITECTURES.contains(architecture)) {
+                throw new AwsException("InvalidParameterValueException",
+                        "1 validation error detected: Value '" + architecture
+                                + "' at 'architectures." + (index + 1) + ".member' "
+                                + "failed to satisfy constraint: Member must satisfy enum value set: "
+                                + FUNCTION_ARCHITECTURES,
+                        400);
+            }
+            validated.add((String) architecture);
+        }
+        return validated;
     }
 
     private static void validateFileSystemVpcConfig(List<LambdaFileSystemConfig> fileSystemConfigs,

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1506,24 +1506,32 @@ public class LambdaService implements ResourceProvider {
     }
 
     private static List<String> validateArchitectures(Object value) {
-        if (!(value instanceof List<?> architectures) || architectures.isEmpty()) {
+        if (!(value instanceof List<?> architectures)) {
             return null;
         }
-
-        List<String> validated = new ArrayList<>(architectures.size());
-        for (int index = 0; index < architectures.size(); index++) {
-            Object architecture = architectures.get(index);
-            if (!FUNCTION_ARCHITECTURES.contains(architecture)) {
-                throw new AwsException("InvalidParameterValueException",
-                        "1 validation error detected: Value '" + architecture
-                                + "' at 'architectures." + (index + 1) + ".member' "
-                                + "failed to satisfy constraint: Member must satisfy enum value set: "
-                                + FUNCTION_ARCHITECTURES,
-                        400);
-            }
-            validated.add((String) architecture);
+        if (architectures.isEmpty()) {
+            throw new AwsException("InvalidParameterValueException",
+                    "1 validation error detected: Value '[]' at 'architectures' "
+                            + "failed to satisfy constraint: Member must have length greater than or equal to 1",
+                    400);
         }
-        return validated;
+        if (architectures.size() > 1) {
+            throw new AwsException("InvalidParameterValueException",
+                    "1 validation error detected: Value '" + architectures + "' at 'architectures' "
+                            + "failed to satisfy constraint: Member must have length less than or equal to 1",
+                    400);
+        }
+
+        Object architecture = architectures.getFirst();
+        if (!FUNCTION_ARCHITECTURES.contains(architecture)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "1 validation error detected: Value '" + architecture
+                            + "' at 'architectures.1.member' "
+                            + "failed to satisfy constraint: Member must satisfy enum value set: "
+                            + FUNCTION_ARCHITECTURES,
+                    400);
+        }
+        return List.of((String) architecture);
     }
 
     private static void validateFileSystemVpcConfig(List<LambdaFileSystemConfig> fileSystemConfigs,

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -515,16 +515,18 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         }
     }
 
-    private static String dockerPlatform(LambdaFunction fn) {
+    private static Optional<String> dockerPlatform(LambdaFunction fn) {
         List<String> architectures = fn.getArchitectures();
-        String architecture = architectures == null || architectures.isEmpty()
-                ? "x86_64"
-                : architectures.getFirst();
-        return switch (architecture) {
-            case "arm64" -> "linux/arm64";
-            case "x86_64" -> "linux/amd64";
-            default -> throw new IllegalArgumentException(
-                    "Unsupported Lambda architecture: " + architecture);
+        if (architectures == null) {
+            return Optional.of("linux/amd64");
+        }
+        if (architectures.size() != 1) {
+            return Optional.empty();
+        }
+        return switch (architectures.getFirst()) {
+            case "arm64" -> Optional.of("linux/arm64");
+            case "x86_64" -> Optional.of("linux/amd64");
+            default -> Optional.empty();
         };
     }
 
@@ -532,7 +534,14 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         if (!config.services().lambda().honourArchitectures()) {
             return lifecycleManager.create(spec);
         }
-        return lifecycleManager.create(spec, dockerPlatform(fn));
+        Optional<String> platform = dockerPlatform(fn);
+        if (platform.isEmpty()) {
+            LOG.warnv("Ignoring invalid persisted architectures {0} for function {1}; "
+                            + "using Docker daemon default platform",
+                    fn.getArchitectures(), fn.getFunctionName());
+            return lifecycleManager.create(spec);
+        }
+        return lifecycleManager.create(spec, platform.get());
     }
 
     public void stop(ContainerHandle handle) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -372,7 +372,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
 
         // Create container without starting — provided.* runtimes exec
         // /var/runtime/bootstrap on start, so code must be copied first.
-        containerId = lifecycleManager.create(spec);
+        containerId = createContainer(spec, fn);
         LOG.infov("Created container {0} for function {1}", containerId, fn.getFunctionName());
         // Docker now holds the real container-to-volume reference, which removeVolume's own in-use
         // check protects from here on - release the in-flight marker that stood in for it before
@@ -513,6 +513,26 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
             }
             throw e;
         }
+    }
+
+    private static String dockerPlatform(LambdaFunction fn) {
+        List<String> architectures = fn.getArchitectures();
+        String architecture = architectures == null || architectures.isEmpty()
+                ? "x86_64"
+                : architectures.getFirst();
+        return switch (architecture) {
+            case "arm64" -> "linux/arm64";
+            case "x86_64" -> "linux/amd64";
+            default -> throw new IllegalArgumentException(
+                    "Unsupported Lambda architecture: " + architecture);
+        };
+    }
+
+    private String createContainer(ContainerSpec spec, LambdaFunction fn) {
+        if (!config.services().lambda().honourArchitectures()) {
+            return lifecycleManager.create(spec);
+        }
+        return lifecycleManager.create(spec, dockerPlatform(fn));
     }
 
     public void stop(ContainerHandle handle) {
@@ -876,19 +896,19 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         String shortId = java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 8);
         // A minimal helper container (sleep) with the volume mounted read-write at /var/task; we
         // tar-copy the code into it, then discard it — the data persists in the volume.
-        ContainerSpec helperSpec = containerBuilder.newContainer(image)
+        ContainerBuilder.Builder helperBuilder = containerBuilder.newContainer(image)
                 .withName(resolveContainerNamePrefix(config) + "-codevol-" + fn.getFunctionName() + "-" + shortId)
                 .withEnv(java.util.List.of())
                 .withEntrypoint(java.util.List.of("sleep"))
                 .withCmd(java.util.List.of("3600"))
-                .withNamedVolume(volName, TASK_DIR, false)
-                .build();
+                .withNamedVolume(volName, TASK_DIR, false);
+        ContainerSpec helperSpec = helperBuilder.build();
         // Gate the heavy work (helper create + ~90MB tar copy) so a burst of first-time populates
         // doesn't thrash the Docker daemon. Only populates are serialized — plain cold starts aren't.
         acquirePopulatePermit(fn.getFunctionName());
         String helperId = null;
         try {
-            helperId = lifecycleManager.create(helperSpec);
+            helperId = createContainer(helperSpec, fn);
             lifecycleManager.startCreated(helperId, helperSpec);
             copyDirToContainerStrict(lifecycleManager.getDockerClient(), helperId,
                     Path.of(fn.getCodeLocalPath()), TASK_DIR, fn.getFunctionName());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -536,10 +536,8 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         }
         Optional<String> platform = dockerPlatform(fn);
         if (platform.isEmpty()) {
-            LOG.warnv("Ignoring invalid persisted architectures {0} for function {1}; "
-                            + "using Docker daemon default platform",
-                    fn.getArchitectures(), fn.getFunctionName());
-            return lifecycleManager.create(spec);
+            throw new IllegalStateException("Invalid persisted architectures "
+                    + fn.getArchitectures() + " for function '" + fn.getFunctionName() + "'");
         }
         return lifecycleManager.create(spec, platform.get());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
@@ -7,12 +7,14 @@ import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.api.model.Info;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -33,6 +35,7 @@ public class ImageCacheService {
     private final List<EmulatorConfig.DockerConfig.RegistryCredential> registryCredentials;
     private final Map<ImageKey, String> resolvedImages = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Object> locks = new ConcurrentHashMap<>();
+    private volatile String daemonPlatform;
 
     @Inject
     public ImageCacheService(DockerClient dockerClient, EmulatorConfig config) {
@@ -40,20 +43,21 @@ public class ImageCacheService {
         this.registryCredentials = config.docker().registryCredentials();
     }
 
-    public void ensureImageExists(String imageUri) {
-        ensureImageExists(imageUri, null);
+    public String ensureImageExists(String imageUri) {
+        return ensureImageExists(imageUri, null);
     }
 
     public String ensureImageExists(String imageUri, String platform) {
-        String requestedPlatform = platform == null || platform.isBlank() ? null : platform.trim();
+        boolean explicitPlatform = platform != null && !platform.isBlank();
+        String requestedPlatform = explicitPlatform ? platform.trim() : daemonPlatform();
         ImageKey imageKey = new ImageKey(imageUri, requestedPlatform);
-        String resolvedImage = resolvedImages.get(imageKey);
+        String resolvedImage = validResolvedImage(imageKey);
         if (resolvedImage != null) {
             return resolvedImage;
         }
         Object lock = locks.computeIfAbsent(imageUri, k -> new Object());
         synchronized (lock) {
-            resolvedImage = resolvedImages.get(imageKey);
+            resolvedImage = validResolvedImage(imageKey);
             if (resolvedImage != null) {
                 return resolvedImage;
             }
@@ -69,16 +73,14 @@ public class ImageCacheService {
                 runWithRetry(imageUri, MAX_PULL_ATTEMPTS, INITIAL_BACKOFF_MS, () -> {
                     PullImageCmd pullImage = dockerClient.pullImageCmd(imageUri)
                             .withAuthConfig(resolveAuth(imageUri));
-                    if (requestedPlatform != null) {
+                    if (explicitPlatform) {
                         pullImage.withPlatform(requestedPlatform);
                     }
                     pullImage.exec(new PullImageResultCallback())
                             .awaitCompletion(5, TimeUnit.MINUTES);
                 });
-                resolvedImage = requestedPlatform == null
-                        ? imageUri
-                        : resolvedImageReference(imageUri, requestedPlatform,
-                                inspectLocalImage(imageUri));
+                resolvedImage = resolvedImageReference(imageUri, requestedPlatform,
+                        inspectLocalImage(imageUri));
                 resolvedImages.put(imageKey, resolvedImage);
                 LOG.infov("Image pulled successfully: {0}", imageUri);
                 return resolvedImage;
@@ -147,6 +149,42 @@ public class ImageCacheService {
         }
     }
 
+    private String validResolvedImage(ImageKey imageKey) {
+        String resolvedImage = resolvedImages.get(imageKey);
+        if (resolvedImage == null) {
+            return null;
+        }
+        if (inspectLocalImage(resolvedImage) != null) {
+            return resolvedImage;
+        }
+        resolvedImages.remove(imageKey, resolvedImage);
+        return null;
+    }
+
+    private String daemonPlatform() {
+        String resolvedPlatform = daemonPlatform;
+        if (resolvedPlatform != null) {
+            return resolvedPlatform;
+        }
+        Info info = dockerClient.infoCmd().exec();
+        String architecture = info.getArchitecture();
+        if (architecture == null || architecture.isBlank()) {
+            throw new DockerClientException("Docker did not report its architecture");
+        }
+        String os = info.getOsType();
+        if (os == null || os.isBlank()) {
+            os = "linux";
+        }
+        String normalizedArchitecture = switch (architecture.toLowerCase(Locale.ROOT)) {
+            case "aarch64" -> "arm64";
+            case "x86_64" -> "amd64";
+            default -> architecture.toLowerCase(Locale.ROOT);
+        };
+        resolvedPlatform = os.toLowerCase(Locale.ROOT) + "/" + normalizedArchitecture;
+        daemonPlatform = resolvedPlatform;
+        return resolvedPlatform;
+    }
+
     private static boolean matchesPlatform(InspectImageResponse image, String platform) {
         if (image == null) {
             return false;
@@ -165,9 +203,6 @@ public class ImageCacheService {
         if (!matchesPlatform(image, platform)) {
             throw new DockerClientException(
                     "Docker image does not match requested platform " + platform + ": " + imageUri);
-        }
-        if (platform == null) {
-            return imageUri;
         }
         String imageId = image.getId();
         if (imageId == null || imageId.isBlank()) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.lambda.launcher;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectImageResponse;
+import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
@@ -11,12 +13,12 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Ensures each Docker image is pulled only once.
+ * Ensures each Docker image is pulled only once per platform.
  * Thread-safe using ConcurrentHashMap for double-checked locking per image.
  */
 @ApplicationScoped
@@ -29,7 +31,7 @@ public class ImageCacheService {
 
     private final DockerClient dockerClient;
     private final List<EmulatorConfig.DockerConfig.RegistryCredential> registryCredentials;
-    private final Set<String> pulledImages = ConcurrentHashMap.newKeySet();
+    private final Map<ImageKey, String> resolvedImages = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Object> locks = new ConcurrentHashMap<>();
 
     @Inject
@@ -39,28 +41,47 @@ public class ImageCacheService {
     }
 
     public void ensureImageExists(String imageUri) {
-        if (pulledImages.contains(imageUri)) {
-            return;
+        ensureImageExists(imageUri, null);
+    }
+
+    public String ensureImageExists(String imageUri, String platform) {
+        String requestedPlatform = platform == null || platform.isBlank() ? null : platform.trim();
+        ImageKey imageKey = new ImageKey(imageUri, requestedPlatform);
+        String resolvedImage = resolvedImages.get(imageKey);
+        if (resolvedImage != null) {
+            return resolvedImage;
         }
         Object lock = locks.computeIfAbsent(imageUri, k -> new Object());
         synchronized (lock) {
-            if (pulledImages.contains(imageUri)) {
-                return;
+            resolvedImage = resolvedImages.get(imageKey);
+            if (resolvedImage != null) {
+                return resolvedImage;
             }
-            if (isLocalImagePresent(imageUri)) {
-                pulledImages.add(imageUri);
+            InspectImageResponse localImage = inspectLocalImage(imageUri);
+            if (matchesPlatform(localImage, requestedPlatform)) {
+                resolvedImage = resolvedImageReference(imageUri, requestedPlatform, localImage);
+                resolvedImages.put(imageKey, resolvedImage);
                 LOG.infov("Image already present locally, skipping pull: {0}", imageUri);
-                return;
+                return resolvedImage;
             }
             LOG.infov("Pulling image: {0}", imageUri);
             try {
-                runWithRetry(imageUri, MAX_PULL_ATTEMPTS, INITIAL_BACKOFF_MS,
-                        () -> dockerClient.pullImageCmd(imageUri)
-                                .withAuthConfig(resolveAuth(imageUri))
-                                .exec(new PullImageResultCallback())
-                                .awaitCompletion(5, TimeUnit.MINUTES));
-                pulledImages.add(imageUri);
+                runWithRetry(imageUri, MAX_PULL_ATTEMPTS, INITIAL_BACKOFF_MS, () -> {
+                    PullImageCmd pullImage = dockerClient.pullImageCmd(imageUri)
+                            .withAuthConfig(resolveAuth(imageUri));
+                    if (requestedPlatform != null) {
+                        pullImage.withPlatform(requestedPlatform);
+                    }
+                    pullImage.exec(new PullImageResultCallback())
+                            .awaitCompletion(5, TimeUnit.MINUTES);
+                });
+                resolvedImage = requestedPlatform == null
+                        ? imageUri
+                        : resolvedImageReference(imageUri, requestedPlatform,
+                                inspectLocalImage(imageUri));
+                resolvedImages.put(imageKey, resolvedImage);
                 LOG.infov("Image pulled successfully: {0}", imageUri);
+                return resolvedImage;
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new RuntimeException("Interrupted while pulling image: " + imageUri, e);
@@ -118,14 +139,44 @@ public class ImageCacheService {
         void run() throws InterruptedException;
     }
 
-    private boolean isLocalImagePresent(String imageUri) {
+    private InspectImageResponse inspectLocalImage(String imageUri) {
         try {
-            dockerClient.inspectImageCmd(imageUri).exec();
-            return true;
+            return dockerClient.inspectImageCmd(imageUri).exec();
         } catch (com.github.dockerjava.api.exception.NotFoundException e) {
-            return false;
+            return null;
         }
     }
+
+    private static boolean matchesPlatform(InspectImageResponse image, String platform) {
+        if (image == null) {
+            return false;
+        }
+        if (platform == null) {
+            return true;
+        }
+        String[] parts = platform.split("/", 2);
+        return parts.length == 2
+                && parts[0].equals(image.getOs())
+                && parts[1].equals(image.getArch());
+    }
+
+    private static String resolvedImageReference(String imageUri, String platform,
+                                                  InspectImageResponse image) {
+        if (!matchesPlatform(image, platform)) {
+            throw new DockerClientException(
+                    "Docker image does not match requested platform " + platform + ": " + imageUri);
+        }
+        if (platform == null) {
+            return imageUri;
+        }
+        String imageId = image.getId();
+        if (imageId == null || imageId.isBlank()) {
+            throw new DockerClientException("Docker did not report an image ID for: " + imageUri);
+        }
+        return imageId;
+    }
+
+    private record ImageKey(String imageUri, String platform) {}
 
     private AuthConfig resolveAuth(String imageUri) {
         String host = extractRegistryHost(imageUri);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -266,6 +266,7 @@ floci:
       enabled: true
       ephemeral: false
       ecr-base-uri: public.ecr.aws            # FLOCI_SERVICES_LAMBDA_ECR_BASE_URI — registry for Lambda runtime images (legacy: floci.ecr-base-uri / FLOCI_ECR_BASE_URI)
+      honour-architectures: false             # Select the Lambda architecture for Docker pull and create
       default-memory-mb: 128
       default-timeout-seconds: 3
       # 500 ports, not the former 100 (9200-9299): one port is held per running Lambda

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -77,6 +77,7 @@ class ContainerLifecycleManagerLabelsTest {
         assertEquals(
                 Map.of("floci", "true", "floci_emulator", "floci-aws"),
                 capturedLabels(createCmd));
+        verify(imageCacheService).ensureImageExists("busybox:stable");
     }
 
     @Test
@@ -101,6 +102,19 @@ class ContainerLifecycleManagerLabelsTest {
         assertEquals(
                 Map.of("floci", "true", "floci_emulator", "custom-value"),
                 capturedLabels(createCmd));
+    }
+
+    @Test
+    void createUsesRequestedDockerPlatform() {
+        when(imageCacheService.ensureImageExists("busybox:stable", "linux/arm64"))
+                .thenReturn("sha256:arm64");
+        CreateContainerCmd createCmd = stubCreateContainer("sha256:arm64");
+
+        manager().create(new ContainerSpec("busybox:stable"), "linux/arm64");
+
+        verify(imageCacheService).ensureImageExists("busybox:stable", "linux/arm64");
+        verify(dockerClient).createContainerCmd("sha256:arm64");
+        verify(createCmd).withPlatform("linux/arm64");
     }
 
     @Test
@@ -169,8 +183,12 @@ class ContainerLifecycleManagerLabelsTest {
     }
 
     private CreateContainerCmd stubCreateContainer() {
+        return stubCreateContainer("busybox:stable");
+    }
+
+    private CreateContainerCmd stubCreateContainer(String image) {
         CreateContainerCmd createCmd = mock(CreateContainerCmd.class, RETURNS_SELF);
-        when(dockerClient.createContainerCmd("busybox:stable")).thenReturn(createCmd);
+        when(dockerClient.createContainerCmd(image)).thenReturn(createCmd);
         CreateContainerResponse response = mock(CreateContainerResponse.class);
         when(response.getId()).thenReturn("container-id");
         when(createCmd.exec()).thenReturn(response);

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -31,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -66,6 +67,8 @@ class ContainerLifecycleManagerLabelsTest {
     void setUp() {
         lenient().when(config.docker()).thenReturn(dockerConfig);
         lenient().when(dockerConfig.resourceNamespace()).thenReturn(Optional.empty());
+        lenient().when(imageCacheService.ensureImageExists(any()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
     }
 
     @Test
@@ -115,6 +118,18 @@ class ContainerLifecycleManagerLabelsTest {
         verify(imageCacheService).ensureImageExists("busybox:stable", "linux/arm64");
         verify(dockerClient).createContainerCmd("sha256:arm64");
         verify(createCmd).withPlatform("linux/arm64");
+    }
+
+    @Test
+    void createUsesResolvedImageForDaemonDefaultPlatform() {
+        when(imageCacheService.ensureImageExists("busybox:stable"))
+                .thenReturn("sha256:native");
+        CreateContainerCmd createCmd = stubCreateContainer("sha256:native");
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        verify(dockerClient).createContainerCmd("sha256:native");
+        verify(createCmd, never()).withPlatform(any());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerPlatformDockerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerPlatformDockerIntegrationTest.java
@@ -1,0 +1,71 @@
+package io.github.hectorvent.floci.core.common.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+class ContainerPlatformDockerIntegrationTest {
+
+    private static final Logger LOG = Logger.getLogger(ContainerPlatformDockerIntegrationTest.class);
+    private static final String IMAGE = "public.ecr.aws/docker/library/busybox:1.36";
+
+    @Inject
+    DockerClient dockerClient;
+
+    @Inject
+    ContainerBuilder containerBuilder;
+
+    @Inject
+    ContainerLifecycleManager lifecycleManager;
+
+    @BeforeEach
+    void requireDocker() {
+        Assumptions.assumeTrue(isDockerAvailable(),
+                "Docker daemon must be available for container platform integration tests");
+    }
+
+    @Test
+    void createUsesRequestedForeignPlatformImage() {
+        String hostArchitecture = dockerClient.infoCmd().exec().getArchitecture()
+                .toLowerCase(Locale.ROOT);
+        boolean armHost = hostArchitecture.equals("arm64") || hostArchitecture.equals("aarch64");
+        String requestedArchitecture = armHost ? "amd64" : "arm64";
+        String platform = "linux/" + requestedArchitecture;
+        ContainerSpec spec = containerBuilder.newContainer(IMAGE)
+                .withName("floci-platform-test-" + UUID.randomUUID())
+                .build();
+
+        String containerId = null;
+        try {
+            containerId = lifecycleManager.create(spec, platform);
+            String imageId = dockerClient.inspectContainerCmd(containerId).exec().getImageId();
+
+            assertEquals(requestedArchitecture,
+                    dockerClient.inspectImageCmd(imageId).exec().getArch());
+        } finally {
+            if (containerId != null) {
+                dockerClient.removeContainerCmd(containerId).withForce(true).exec();
+            }
+        }
+    }
+
+    private boolean isDockerAvailable() {
+        try {
+            dockerClient.pingCmd().exec();
+            return true;
+        } catch (Exception e) {
+            LOG.warn("Docker daemon is not available for the container platform integration test", e);
+            return false;
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -636,6 +636,18 @@ class LambdaServiceTest {
     }
 
     @Test
+    void createFunctionRejectsScalarArchitecturesWithoutPersistingFunction() {
+        Map<String, Object> request = baseRequest("scalar-create-architectures");
+        request.put("Architectures", "arm64");
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.createFunction(REGION, request));
+
+        assertMalformedArchitectures(error, "arm64");
+        assertTrue(service.listFunctions(REGION).isEmpty());
+    }
+
+    @Test
     void updateFunctionCodeRejectsUnsupportedArchitectureBeforeMutation() {
         service.createFunction(REGION, baseRequest("unsupported-code-architecture"));
 
@@ -648,6 +660,24 @@ class LambdaServiceTest {
         LambdaFunction unchanged = service.getFunction(REGION, "unsupported-code-architecture");
         assertNull(unchanged.getImageUri());
         assertNull(unchanged.getArchitectures());
+    }
+
+    @Test
+    void updateFunctionCodeRejectsObjectArchitecturesBeforeMutation() {
+        service.createFunction(REGION, baseRequest("object-code-architectures"));
+        String revisionId = service.getFunction(REGION, "object-code-architectures").getRevisionId();
+        Map<String, String> malformedArchitectures = Map.of("Architecture", "arm64");
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateFunctionCode(REGION, "object-code-architectures",
+                        Map.of("ImageUri", "example.invalid/changed:latest",
+                                "Architectures", malformedArchitectures)));
+
+        assertMalformedArchitectures(error, malformedArchitectures);
+        LambdaFunction unchanged = service.getFunction(REGION, "object-code-architectures");
+        assertNull(unchanged.getImageUri());
+        assertNull(unchanged.getArchitectures());
+        assertEquals(revisionId, unchanged.getRevisionId());
     }
 
     @Test
@@ -665,6 +695,22 @@ class LambdaServiceTest {
     }
 
     @Test
+    void updateFunctionConfigurationRejectsScalarArchitecturesBeforeMutation() {
+        service.createFunction(REGION, baseRequest("scalar-config-architectures"));
+        String revisionId = service.getFunction(REGION, "scalar-config-architectures").getRevisionId();
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateFunctionConfiguration(REGION, "scalar-config-architectures",
+                        Map.of("Description", "changed", "Architectures", 64)));
+
+        assertMalformedArchitectures(error, 64);
+        LambdaFunction unchanged = service.getFunction(REGION, "scalar-config-architectures");
+        assertNull(unchanged.getDescription());
+        assertNull(unchanged.getArchitectures());
+        assertEquals(revisionId, unchanged.getRevisionId());
+    }
+
+    @Test
     void updateFunctionCodeWithoutArchitecturesKeepsExisting() {
         Map<String, Object> req = baseRequest("arch-keep-fn");
         req.put("Architectures", List.of("arm64"));
@@ -679,6 +725,14 @@ class LambdaServiceTest {
         assertEquals(400, error.getHttpStatus());
         assertEquals("1 validation error detected: Value 'sparc' at 'architectures.1.member' "
                 + "failed to satisfy constraint: Member must satisfy enum value set: [x86_64, arm64]",
+                error.getMessage());
+    }
+
+    private static void assertMalformedArchitectures(AwsException error, Object value) {
+        assertEquals("InvalidParameterValueException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals("1 validation error detected: Value '" + value + "' at 'architectures' "
+                + "failed to satisfy constraint: Member must be a list",
                 error.getMessage());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -592,6 +592,47 @@ class LambdaServiceTest {
     }
 
     @Test
+    void createFunctionRejectsUnsupportedArchitectureWithoutPersistingFunction() {
+        Map<String, Object> request = baseRequest("unsupported-create-architecture");
+        request.put("Architectures", List.of("sparc"));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.createFunction(REGION, request));
+
+        assertUnsupportedArchitecture(error);
+        assertTrue(service.listFunctions(REGION).isEmpty());
+    }
+
+    @Test
+    void updateFunctionCodeRejectsUnsupportedArchitectureBeforeMutation() {
+        service.createFunction(REGION, baseRequest("unsupported-code-architecture"));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateFunctionCode(REGION, "unsupported-code-architecture",
+                        Map.of("ImageUri", "example.invalid/changed:latest",
+                                "Architectures", List.of("sparc"))));
+
+        assertUnsupportedArchitecture(error);
+        LambdaFunction unchanged = service.getFunction(REGION, "unsupported-code-architecture");
+        assertNull(unchanged.getImageUri());
+        assertNull(unchanged.getArchitectures());
+    }
+
+    @Test
+    void updateFunctionConfigurationRejectsUnsupportedArchitectureBeforeMutation() {
+        service.createFunction(REGION, baseRequest("unsupported-config-architecture"));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateFunctionConfiguration(REGION, "unsupported-config-architecture",
+                        Map.of("Description", "changed", "Architectures", List.of("sparc"))));
+
+        assertUnsupportedArchitecture(error);
+        LambdaFunction unchanged = service.getFunction(REGION, "unsupported-config-architecture");
+        assertNull(unchanged.getDescription());
+        assertNull(unchanged.getArchitectures());
+    }
+
+    @Test
     void updateFunctionCodeWithoutArchitecturesKeepsExisting() {
         Map<String, Object> req = baseRequest("arch-keep-fn");
         req.put("Architectures", List.of("arm64"));
@@ -599,6 +640,14 @@ class LambdaServiceTest {
 
         LambdaFunction updated = service.updateFunctionCode(REGION, "arch-keep-fn", Map.of());
         assertEquals(List.of("arm64"), updated.getArchitectures());
+    }
+
+    private static void assertUnsupportedArchitecture(AwsException error) {
+        assertEquals("InvalidParameterValueException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals("1 validation error detected: Value 'sparc' at 'architectures.1.member' "
+                + "failed to satisfy constraint: Member must satisfy enum value set: [x86_64, arm64]",
+                error.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -604,6 +604,38 @@ class LambdaServiceTest {
     }
 
     @Test
+    void createFunctionRejectsMultipleArchitecturesWithoutPersistingFunction() {
+        Map<String, Object> request = baseRequest("multiple-create-architectures");
+        request.put("Architectures", List.of("arm64", "x86_64"));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.createFunction(REGION, request));
+
+        assertEquals("InvalidParameterValueException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals("1 validation error detected: Value '[arm64, x86_64]' at 'architectures' "
+                + "failed to satisfy constraint: Member must have length less than or equal to 1",
+                error.getMessage());
+        assertTrue(service.listFunctions(REGION).isEmpty());
+    }
+
+    @Test
+    void createFunctionRejectsEmptyArchitecturesWithoutPersistingFunction() {
+        Map<String, Object> request = baseRequest("empty-create-architectures");
+        request.put("Architectures", List.of());
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.createFunction(REGION, request));
+
+        assertEquals("InvalidParameterValueException", error.getErrorCode());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals("1 validation error detected: Value '[]' at 'architectures' "
+                + "failed to satisfy constraint: Member must have length greater than or equal to 1",
+                error.getMessage());
+        assertTrue(service.listFunctions(REGION).isEmpty());
+    }
+
+    @Test
     void updateFunctionCodeRejectsUnsupportedArchitectureBeforeMutation() {
         service.createFunction(REGION, baseRequest("unsupported-code-architecture"));
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -260,6 +260,23 @@ class ContainerLauncherTest {
     }
 
     @Test
+    void launchFunction_usesAmd64DockerPlatformWhenArchitectureIsOmitted() throws Exception {
+        EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
+        when(lambda.honourArchitectures()).thenReturn(true);
+        Path codePath = Files.createDirectory(tempDir.resolve("default-architecture-code"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("default-architecture-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+
+        launcher.launch(fn);
+
+        assertEquals("linux/amd64", captureRealContainerPlatform());
+    }
+
+    @Test
     void launchFunction_keepsDaemonDefaultPlatformWhenArchitectureHonouringIsDisabled() throws Exception {
         Path codePath = Files.createDirectory(tempDir.resolve("native-platform-code"));
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -299,7 +299,7 @@ class ContainerLauncherTest {
 
     @ParameterizedTest
     @MethodSource("invalidPersistedArchitectures")
-    void launchFunction_keepsDaemonDefaultPlatformForInvalidPersistedArchitectures(
+    void launchFunction_rejectsInvalidPersistedArchitecturesBeforeCreatingContainer(
             List<String> architectures) throws Exception {
         EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
         when(lambda.honourArchitectures()).thenReturn(true);
@@ -312,9 +312,12 @@ class ContainerLauncherTest {
         fn.setCodeLocalPath(codePath.toString());
         fn.setArchitectures(architectures);
 
-        launcher.launch(fn);
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                () -> launcher.launch(fn));
 
-        captureRealContainerSpec();
+        assertEquals("Invalid persisted architectures " + architectures
+                + " for function 'legacy-invalid-architecture-fn'", exception.getMessage());
+        verify(lifecycleManager, never()).create(any(ContainerSpec.class));
         verify(lifecycleManager, never()).create(any(ContainerSpec.class), anyString());
         assertSame(architectures, fn.getArchitectures());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
@@ -50,11 +52,13 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -291,6 +295,35 @@ class ContainerLauncherTest {
 
         captureRealContainerSpec();
         verify(lifecycleManager, never()).create(any(ContainerSpec.class), anyString());
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidPersistedArchitectures")
+    void launchFunction_keepsDaemonDefaultPlatformForInvalidPersistedArchitectures(
+            List<String> architectures) throws Exception {
+        EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
+        when(lambda.honourArchitectures()).thenReturn(true);
+        Path codePath = Files.createDirectory(tempDir.resolve("legacy-invalid-architecture-code"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("legacy-invalid-architecture-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setArchitectures(architectures);
+
+        launcher.launch(fn);
+
+        captureRealContainerSpec();
+        verify(lifecycleManager, never()).create(any(ContainerSpec.class), anyString());
+        assertSame(architectures, fn.getArchitectures());
+    }
+
+    private static Stream<List<String>> invalidPersistedArchitectures() {
+        return Stream.of(
+                List.of(),
+                List.of("riscv64"),
+                List.of("arm64", "x86_64"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherTest.java
@@ -146,6 +146,7 @@ class ContainerLauncherTest {
         // lenient: the failure-path test (populate fails before any container is created) never
         // reaches these, but every success-path test does — they must not trip strict-stubs.
         lenient().when(lifecycleManager.create(any())).thenReturn("container-123");
+        lenient().when(lifecycleManager.create(any(), anyString())).thenReturn("container-123");
         ContainerLifecycleManager.ContainerInfo info =
                 new ContainerLifecycleManager.ContainerInfo("container-123", Map.of());
         lenient().when(lifecycleManager.startCreated(eq("container-123"), any())).thenReturn(info);
@@ -204,6 +205,13 @@ class ContainerLauncherTest {
                 .orElseGet(() -> specs.get(specs.size() - 1));
     }
 
+    private String captureRealContainerPlatform() {
+        ArgumentCaptor<String> platformCaptor = ArgumentCaptor.forClass(String.class);
+        verify(lifecycleManager, atLeastOnce()).create(any(ContainerSpec.class), platformCaptor.capture());
+        List<String> platforms = platformCaptor.getAllValues();
+        return platforms.get(platforms.size() - 1);
+    }
+
     /** Returns the read-only {@code /var/task} volume mount on the spec, or null if absent. */
     private static Mount varTaskVolumeMount(ContainerSpec spec) {
         if (spec.mounts() == null) {
@@ -213,6 +221,88 @@ class ContainerLauncherTest {
                 .filter(m -> m.getType() == MountType.VOLUME && "/var/task".equals(m.getTarget()))
                 .findFirst()
                 .orElse(null);
+    }
+
+    @Test
+    void launchFunction_usesArm64DockerPlatformWhenArchitectureHonouringIsEnabled() throws Exception {
+        EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
+        when(lambda.honourArchitectures()).thenReturn(true);
+        Path codePath = Files.createDirectory(tempDir.resolve("arm64-code"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("arm64-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setArchitectures(List.of("arm64"));
+
+        launcher.launch(fn);
+
+        assertEquals("linux/arm64", captureRealContainerPlatform());
+    }
+
+    @Test
+    void launchFunction_usesAmd64DockerPlatformForX86Architecture() throws Exception {
+        EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
+        when(lambda.honourArchitectures()).thenReturn(true);
+        Path codePath = Files.createDirectory(tempDir.resolve("x86-code"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("x86-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setArchitectures(List.of("x86_64"));
+
+        launcher.launch(fn);
+
+        assertEquals("linux/amd64", captureRealContainerPlatform());
+    }
+
+    @Test
+    void launchFunction_keepsDaemonDefaultPlatformWhenArchitectureHonouringIsDisabled() throws Exception {
+        Path codePath = Files.createDirectory(tempDir.resolve("native-platform-code"));
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("native-platform-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setArchitectures(List.of("arm64"));
+
+        launcher.launch(fn);
+
+        captureRealContainerSpec();
+        verify(lifecycleManager, never()).create(any(ContainerSpec.class), anyString());
+    }
+
+    @Test
+    void launchFunction_usesArm64DockerPlatformForCodeVolumeHelper() throws Exception {
+        EmulatorConfig.LambdaServiceConfig lambda = config.services().lambda();
+        when(lambda.honourArchitectures()).thenReturn(true);
+        Path codePath = Files.createDirectory(tempDir.resolve("large-arm64-code"));
+        Files.write(codePath.resolve("bundle.bin"), new byte[8 * 1024]);
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("large-arm64-fn");
+        fn.setRuntime("nodejs20.x");
+        fn.setHandler("index.handler");
+        fn.setCodeLocalPath(codePath.toString());
+        fn.setCodeSha256("large-arm64-code-sha");
+        fn.setArchitectures(List.of("arm64"));
+
+        long originalThreshold = ContainerLauncher.CODE_VOLUME_MIN_BYTES;
+        try {
+            ContainerLauncher.CODE_VOLUME_MIN_BYTES = 4 * 1024;
+            launcher.launch(fn);
+        } finally {
+            ContainerLauncher.CODE_VOLUME_MIN_BYTES = originalThreshold;
+        }
+
+        ArgumentCaptor<String> platformCaptor = ArgumentCaptor.forClass(String.class);
+        verify(lifecycleManager, times(2)).create(any(ContainerSpec.class), platformCaptor.capture());
+        assertTrue(platformCaptor.getAllValues().stream()
+                .allMatch("linux/arm64"::equals));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.lambda.launcher;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectImageCmd;
 import com.github.dockerjava.api.command.InspectImageResponse;
+import com.github.dockerjava.api.command.InfoCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.DockerClientException;
@@ -10,6 +11,7 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.exception.UnauthorizedException;
+import com.github.dockerjava.api.model.Info;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +27,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +42,11 @@ class ImageCacheServiceTest {
         PullImageCmd pullImage = mock(PullImageCmd.class);
         PullImageResultCallback callback = mock(PullImageResultCallback.class);
         when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
-        when(inspectImage.exec()).thenThrow(new NotFoundException("image not found"));
+        when(inspectImage.exec()).thenThrow(new NotFoundException("image not found"))
+                .thenReturn(new InspectImageResponse()
+                        .withId("sha256:native")
+                        .withOs("linux")
+                        .withArch("amd64"));
         when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
         when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
         when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
@@ -132,6 +139,71 @@ class ImageCacheServiceTest {
         assertEquals("sha256:amd64", amdImage);
         verify(pullImage).withPlatform("linux/arm64");
         verify(pullImage).withPlatform("linux/amd64");
+    }
+
+    @Test
+    void restoresDaemonDefaultImageAfterPlatformSpecificPull() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(inspectImage.exec()).thenThrow(new NotFoundException("image not found"))
+                .thenReturn(new InspectImageResponse()
+                        .withId("sha256:arm64")
+                        .withOs("linux")
+                        .withArch("arm64"),
+                        new InspectImageResponse()
+                                .withId("sha256:arm64")
+                                .withOs("linux")
+                                .withArch("arm64"),
+                        new InspectImageResponse()
+                                .withId("sha256:amd64")
+                                .withOs("linux")
+                                .withArch("amd64"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/arm64")).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        ImageCacheService service = newService(dockerClient);
+        service.ensureImageExists(IMAGE, "linux/arm64");
+        service.ensureImageExists(IMAGE);
+
+        verify(pullImage, times(2)).exec(any(PullImageResultCallback.class));
+        verify(pullImage).withPlatform("linux/arm64");
+    }
+
+    @Test
+    void repullsPlatformImageWhenCachedImageWasRemoved() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        InspectImageCmd inspectCachedImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(dockerClient.inspectImageCmd("sha256:arm64-old")).thenReturn(inspectCachedImage);
+        when(inspectImage.exec()).thenReturn(
+                new InspectImageResponse()
+                        .withId("sha256:arm64-old")
+                        .withOs("linux")
+                        .withArch("arm64"),
+                new InspectImageResponse().withOs("linux").withArch("amd64"),
+                new InspectImageResponse()
+                        .withId("sha256:arm64-new")
+                        .withOs("linux")
+                        .withArch("arm64"));
+        when(inspectCachedImage.exec()).thenThrow(new NotFoundException("image was removed"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/arm64")).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        ImageCacheService service = newService(dockerClient);
+        assertEquals("sha256:arm64-old", service.ensureImageExists(IMAGE, "linux/arm64"));
+
+        assertEquals("sha256:arm64-new", service.ensureImageExists(IMAGE, "linux/arm64"));
+        verify(pullImage).exec(any(PullImageResultCallback.class));
     }
 
     @Test
@@ -234,6 +306,9 @@ class ImageCacheServiceTest {
     }
 
     private static ImageCacheService newService(DockerClient dockerClient) {
+        InfoCmd infoCmd = mock(InfoCmd.class);
+        when(dockerClient.infoCmd()).thenReturn(infoCmd);
+        when(infoCmd.exec()).thenReturn(new Info().withOsType("linux").withArchitecture("amd64"));
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.DockerConfig dockerConfig = mock(EmulatorConfig.DockerConfig.class);
         when(config.docker()).thenReturn(dockerConfig);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.lambda.launcher;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectImageCmd;
+import com.github.dockerjava.api.command.InspectImageResponse;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.exception.DockerClientException;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,6 +47,7 @@ class ImageCacheServiceTest {
         newService(dockerClient).ensureImageExists(IMAGE);
 
         verify(pullImage).exec(any(PullImageResultCallback.class));
+        verify(pullImage, never()).withPlatform(nullable(String.class));
         verify(callback).awaitCompletion(5, TimeUnit.MINUTES);
     }
 
@@ -61,6 +64,74 @@ class ImageCacheServiceTest {
 
         assertSame(failure, thrown);
         verify(dockerClient, never()).pullImageCmd(IMAGE);
+    }
+
+    @Test
+    void pullsRequestedPlatformWhenLocalImageArchitectureDoesNotMatch() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(inspectImage.exec()).thenReturn(
+                new InspectImageResponse().withOs("linux").withArch("amd64"),
+                new InspectImageResponse().withId("sha256:arm64").withOs("linux").withArch("arm64"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/arm64")).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        String resolvedImage = newService(dockerClient)
+                .ensureImageExists(IMAGE, "linux/arm64");
+
+        assertEquals("sha256:arm64", resolvedImage);
+        verify(pullImage).withPlatform("linux/arm64");
+        verify(callback).awaitCompletion(5, TimeUnit.MINUTES);
+    }
+
+    @Test
+    void skipsPullWhenLocalImageMatchesRequestedPlatform() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(inspectImage.exec()).thenReturn(new InspectImageResponse()
+                .withId("sha256:arm64")
+                .withOs("linux")
+                .withArch("arm64"));
+
+        String resolvedImage = newService(dockerClient)
+                .ensureImageExists(IMAGE, "linux/arm64");
+
+        assertEquals("sha256:arm64", resolvedImage);
+        verify(dockerClient, never()).pullImageCmd(IMAGE);
+    }
+
+    @Test
+    void keepsDifferentPlatformsAsSeparateCacheRequests() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(inspectImage.exec()).thenReturn(
+                new InspectImageResponse().withOs("linux").withArch("amd64"),
+                new InspectImageResponse().withId("sha256:arm64").withOs("linux").withArch("arm64"),
+                new InspectImageResponse().withOs("linux").withArch("arm64"),
+                new InspectImageResponse().withId("sha256:amd64").withOs("linux").withArch("amd64"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/arm64")).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/amd64")).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        ImageCacheService service = newService(dockerClient);
+        String armImage = service.ensureImageExists(IMAGE, "linux/arm64");
+        String amdImage = service.ensureImageExists(IMAGE, "linux/amd64");
+
+        assertEquals("sha256:arm64", armImage);
+        assertEquals("sha256:amd64", amdImage);
+        verify(pullImage).withPlatform("linux/arm64");
+        verify(pullImage).withPlatform("linux/amd64");
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -127,6 +127,7 @@ floci:
       enabled: true
     lambda:
       enabled: true
+      honour-architectures: false
       # aws-config-path:
       hot-reload:
         enabled: true


### PR DESCRIPTION
## Summary

  Allow Lambda containers to use the function's declared `arm64` or `x86_64` architecture when `FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES=true`.

  Apply the selected platform to Docker image pulls, Lambda container creation, and helper containers used for large function packages.

  This behavior is opt-in because foreign-architecture containers require Docker Desktop or host emulation. Enabling it by default could break existing installations. The default therefore remains host-native
  execution.

  Fixes #2840.

  ## Type of change

  - [x] Bug fix (`fix:`)
  - [ ] New feature (`feat:`)
  - [ ] Breaking change (`feat!:` or `fix!:`)
  - [ ] Docs / chore

  ## AWS Compatibility

  Floci previously stored and returned a Lambda function's declared architecture but did not use it when starting Docker containers. An `arm64` function could therefore run with an `amd64` image or fail with a
  misleading timeout.

  When architecture handling is enabled, Floci now selects `linux/arm64` or `linux/amd64` during image pulls and container creation.

  Verified with focused unit tests and a Docker integration test that creates a container with a foreign-platform image. All 66 focused tests passed.

  The full suite completed all 15,322 tests twice. Both runs reported an unrelated RDS Data isolation error. One run also reported an unrelated EC2 test flake. Each affected test passed when run alone. The Lambda
  architecture tests passed in both full runs.

  ## Checklist

  - [ ] `./mvnw test` passes locally
  - [x] New or updated integration test added
  - [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)