### PR TITLE
feat(s3): add Intelligent-Tiering configuration CRUD

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/s3.bats
+++ b/compatibility-tests/sdk-test-awscli/test/s3.bats
@@ -339,3 +339,58 @@ EOF
     assert_failure
     assert_output --partial "NoSuchConfiguration"
 }
+
+@test "S3: intelligent-tiering configurations round-trip and never touch the bucket" {
+    aws_cmd s3api create-bucket --bucket "$BUCKET" >/dev/null
+
+    run aws_cmd s3api put-bucket-intelligent-tiering-configuration \
+        --bucket "$BUCKET" --id EntireBucket \
+        --intelligent-tiering-configuration 'Id=EntireBucket,Status=Enabled,Tierings=[{AccessTier=ARCHIVE_ACCESS,Days=90}]'
+    assert_success
+
+    run aws_cmd s3api get-bucket-intelligent-tiering-configuration --bucket "$BUCKET" --id EntireBucket
+    assert_success
+    [ "$(json_get "$output" '.IntelligentTieringConfiguration.Id')" = "EntireBucket" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfiguration.Status')" = "Enabled" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfiguration.Tierings[0].AccessTier')" = "ARCHIVE_ACCESS" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfiguration.Tierings[0].Days')" = "90" ]
+
+    run aws_cmd s3api put-bucket-intelligent-tiering-configuration \
+        --bucket "$BUCKET" --id Filtered \
+        --intelligent-tiering-configuration 'Id=Filtered,Filter={And={Prefix=logs/,Tags=[{Key=env,Value=prod}]}},Status=Disabled,Tierings=[{AccessTier=ARCHIVE_ACCESS,Days=90},{AccessTier=DEEP_ARCHIVE_ACCESS,Days=180}]'
+    assert_success
+
+    run aws_cmd s3api list-bucket-intelligent-tiering-configurations --bucket "$BUCKET"
+    assert_success
+    [ "$(json_get "$output" '.IntelligentTieringConfigurationList | length')" = "2" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfigurationList[1].Filter.And.Prefix')" = "logs/" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfigurationList[1].Filter.And.Tags[0].Key')" = "env" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfigurationList[1].Status')" = "Disabled" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfigurationList[1].Tierings | length')" = "2" ]
+
+    # Putting the same id replaces rather than duplicates.
+    run aws_cmd s3api put-bucket-intelligent-tiering-configuration \
+        --bucket "$BUCKET" --id EntireBucket \
+        --intelligent-tiering-configuration 'Id=EntireBucket,Status=Disabled,Tierings=[{AccessTier=DEEP_ARCHIVE_ACCESS,Days=180}]'
+    assert_success
+
+    run aws_cmd s3api get-bucket-intelligent-tiering-configuration --bucket "$BUCKET" --id EntireBucket
+    assert_success
+    [ "$(json_get "$output" '.IntelligentTieringConfiguration.Status')" = "Disabled" ]
+    [ "$(json_get "$output" '.IntelligentTieringConfiguration.Tierings[0].AccessTier')" = "DEEP_ARCHIVE_ACCESS" ]
+
+    run aws_cmd s3api list-bucket-intelligent-tiering-configurations --bucket "$BUCKET"
+    assert_success
+    [ "$(json_get "$output" '.IntelligentTieringConfigurationList | length')" = "2" ]
+
+    # A sub-resource DELETE removes only that configuration; the bucket must survive it.
+    run aws_cmd s3api delete-bucket-intelligent-tiering-configuration --bucket "$BUCKET" --id EntireBucket
+    assert_success
+
+    run aws_cmd s3api head-bucket --bucket "$BUCKET"
+    assert_success
+
+    run aws_cmd s3api get-bucket-intelligent-tiering-configuration --bucket "$BUCKET" --id EntireBucket
+    assert_failure
+    assert_output --partial "NoSuchConfiguration"
+}

--- a/docs/services/s3.md
+++ b/docs/services/s3.md
@@ -25,6 +25,7 @@
 | **S3 Select** | SelectObjectContent |
 | **Public Access Block** | PutPublicAccessBlock, GetPublicAccessBlock, DeletePublicAccessBlock |
 | **Metrics** | PutBucketMetricsConfiguration, GetBucketMetricsConfiguration, ListBucketMetricsConfigurations, DeleteBucketMetricsConfiguration |
+| **Intelligent-Tiering** | PutBucketIntelligentTieringConfiguration, GetBucketIntelligentTieringConfiguration, ListBucketIntelligentTieringConfigurations, DeleteBucketIntelligentTieringConfiguration |
 | **Replication** | PutBucketReplication, GetBucketReplication, DeleteBucketReplication |
 
 **RestoreObject** is accepted but stubbed: Floci validates the request and returns `202 Accepted`, but no restore state machine runs.
@@ -173,7 +174,6 @@ These AWS S3 features have no handler in Floci. Calls will return an error (typi
 
 - Access logging (`PutBucketLogging`, `GetBucketLogging`)
 - Request payment (`PutBucketRequestPayment`, `GetBucketRequestPayment`)
-- Intelligent-Tiering configurations
 - Inventory configurations
 - Analytics configurations
 
@@ -262,9 +262,11 @@ Enable it in the SDK with `forcePathStyle` / `pathStyleAccessEnabled`:
 === "Python"
 
     ```python
-    s3 = boto3.client("s3",
+    s3 = boto3.client(
+        "s3",
         endpoint_url="http://localhost:4566",
-        config=Config(s3={"addressing_style": "path"}))
+        config=Config(s3={"addressing_style": "path"}),
+    )
     ```
 
 ### Virtual-Hosted Style
@@ -313,8 +315,7 @@ Configure the SDK endpoint to one of the base domains (no `forcePathStyle`):
 === "Python"
 
     ```python
-    s3 = boto3.client("s3",
-        endpoint_url="http://s3.localhost.floci.io:4566")
+    s3 = boto3.client("s3", endpoint_url="http://s3.localhost.floci.io:4566")
     # SDK sends requests to: my-bucket.s3.localhost.floci.io:4566
     ```
 

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -336,6 +336,9 @@ public class S3Controller {
             // Same fall-through hazard as metrics: an intelligent-tiering PUT must not become a
             // CreateBucket.
             if (hasQueryParam(uriInfo, "intelligent-tiering")) {
+                S3Service.RequestAuthorization authorization = S3RequestAuthorizationParser.parseIfRequired(
+                        s3Service.isAuthEnforced(), httpHeaders, uriInfo);
+                s3Service.authorizeBucketWrite(bucket, "s3:PutIntelligentTieringConfiguration", authorization);
                 return handlePutBucketIntelligentTieringConfiguration(bucket, uriInfo, body);
             }
 
@@ -380,7 +383,8 @@ public class S3Controller {
     @DELETE
     @Path("/{bucket}")
     public Response deleteBucket(@PathParam("bucket") String bucket,
-                                  @Context UriInfo uriInfo) {
+                                  @Context UriInfo uriInfo,
+                                  @Context HttpHeaders httpHeaders) {
         try {
             validateRawUri();
             if (hasQueryParam(uriInfo, "tagging")) {
@@ -426,6 +430,9 @@ public class S3Controller {
             }
             if (hasQueryParam(uriInfo, "intelligent-tiering")) {
                 // Likewise this must not fall through to deleting the bucket.
+                S3Service.RequestAuthorization authorization = S3RequestAuthorizationParser.parseIfRequired(
+                        s3Service.isAuthEnforced(), httpHeaders, uriInfo);
+                s3Service.authorizeBucketWrite(bucket, "s3:PutIntelligentTieringConfiguration", authorization);
                 s3Service.deleteBucketIntelligentTieringConfiguration(bucket,
                         requireIntelligentTieringId(uriInfo));
                 return Response.noContent().build();
@@ -1859,8 +1866,9 @@ public class S3Controller {
     private Response handlePutBucketIntelligentTieringConfiguration(String bucket, UriInfo uriInfo,
                                                                     byte[] body) {
         String id = requireIntelligentTieringId(uriInfo);
+        String xml = body == null ? null : new String(body, StandardCharsets.UTF_8);
         S3IntelligentTieringConfiguration configuration =
-                S3IntelligentTieringConfiguration.parse(new String(body, StandardCharsets.UTF_8));
+                S3IntelligentTieringConfiguration.parse(xml);
         // AWS rejects a body whose Id disagrees with the id in the query string.
         if (!id.equals(configuration.id())) {
             throw new AwsException("MalformedXML",

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -2532,6 +2532,18 @@ public class S3Controller {
         if (condition != null) {
             xmlBuilder.elem("Condition", condition);
         }
+        // S3 InvalidArgument responses carry ArgumentName and ArgumentValue so the SDK can
+        // surface which input was rejected. They travel through AwsException.extendedData.
+        if (e.getExtendedData() != null) {
+            Object argumentName = e.getExtendedData().get("ArgumentName");
+            Object argumentValue = e.getExtendedData().get("ArgumentValue");
+            if (argumentName != null) {
+                xmlBuilder.elem("ArgumentName", argumentName.toString());
+            }
+            if (argumentValue != null) {
+                xmlBuilder.elem("ArgumentValue", argumentValue.toString());
+            }
+        }
         String xml = xmlBuilder
                 .elem("RequestId", java.util.UUID.randomUUID().toString())
                 .end("Error")

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -333,6 +333,11 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "metrics")) {
                 return handlePutBucketMetricsConfiguration(bucket, uriInfo, body);
             }
+            // Same fall-through hazard as metrics: an intelligent-tiering PUT must not become a
+            // CreateBucket.
+            if (hasQueryParam(uriInfo, "intelligent-tiering")) {
+                return handlePutBucketIntelligentTieringConfiguration(bucket, uriInfo, body);
+            }
 
             String locationConstraint = null;
             if (body != null && body.length > 0) {
@@ -417,6 +422,12 @@ public class S3Controller {
             if (hasQueryParam(uriInfo, "metrics")) {
                 // Likewise this must not fall through to deleting the bucket.
                 s3Service.deleteBucketMetricsConfiguration(bucket, requireMetricsId(uriInfo));
+                return Response.noContent().build();
+            }
+            if (hasQueryParam(uriInfo, "intelligent-tiering")) {
+                // Likewise this must not fall through to deleting the bucket.
+                s3Service.deleteBucketIntelligentTieringConfiguration(bucket,
+                        requireIntelligentTieringId(uriInfo));
                 return Response.noContent().build();
             }
             if (hasQueryParam(uriInfo, "accelerate")) {
@@ -542,6 +553,17 @@ public class S3Controller {
                 String xml = id != null
                         ? s3Service.getBucketMetricsConfiguration(bucket, id)
                         : s3Service.listBucketMetricsConfigurations(bucket);
+                return Response.ok(xml).type("application/xml").build();
+            }
+            // GetBucketIntelligentTieringConfiguration and ListBucketIntelligentTieringConfigurations
+            // share ?intelligent-tiering and are told apart by the id, which only the
+            // single-configuration read carries.
+            if (hasQueryParam(uriInfo, "intelligent-tiering")) {
+                s3Service.authorizeBucketRead(bucket, "s3:GetIntelligentTieringConfiguration", authorization);
+                String id = uriInfo.getQueryParameters().getFirst("id");
+                String xml = id != null
+                        ? s3Service.getBucketIntelligentTieringConfiguration(bucket, id)
+                        : s3Service.listBucketIntelligentTieringConfigurations(bucket);
                 return Response.ok(xml).type("application/xml").build();
             }
 
@@ -1828,6 +1850,36 @@ public class S3Controller {
         String id = uriInfo.getQueryParameters().getFirst("id");
         if (id == null) {
             throw new AwsException("InvalidArgument", "The metrics id must be specified.", 400);
+        }
+        return id;
+    }
+
+    // --- Intelligent-Tiering Configurations ---
+
+    private Response handlePutBucketIntelligentTieringConfiguration(String bucket, UriInfo uriInfo,
+                                                                    byte[] body) {
+        String id = requireIntelligentTieringId(uriInfo);
+        S3IntelligentTieringConfiguration configuration =
+                S3IntelligentTieringConfiguration.parse(new String(body, StandardCharsets.UTF_8));
+        // AWS rejects a body whose Id disagrees with the id in the query string.
+        if (!id.equals(configuration.id())) {
+            throw new AwsException("MalformedXML",
+                    "The XML you provided was not well-formed or did not validate against our "
+                            + "published schema", 400);
+        }
+        s3Service.putBucketIntelligentTieringConfiguration(bucket, id, configuration.innerXml());
+        return Response.noContent().build();
+    }
+
+    /**
+     * The id identifies the configuration, so a request without one is refused rather than guessed
+     * at, mirroring the metrics subresource.
+     */
+    private String requireIntelligentTieringId(UriInfo uriInfo) {
+        String id = uriInfo.getQueryParameters().getFirst("id");
+        if (id == null) {
+            throw new AwsException("InvalidArgument",
+                    "The intelligent-tiering configuration id must be specified.", 400);
         }
         return id;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.core.common.XmlParser;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,6 +24,10 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
     private static final List<String> STATUSES = List.of("Enabled", "Disabled");
     private static final List<String> ACCESS_TIERS = List.of("ARCHIVE_ACCESS", "DEEP_ARCHIVE_ACCESS");
 
+    private static final int ARCHIVE_ACCESS_MIN_DAYS = 90;
+    private static final int DEEP_ARCHIVE_ACCESS_MIN_DAYS = 180;
+    private static final int MAX_DAYS = 730;
+
     /** AWS reports a body that does not match the published schema this way. */
     private static AwsException malformed() {
         return new AwsException("MalformedXML",
@@ -31,17 +36,17 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
 
     /**
      * AWS reports a {@code Days} value outside the tier-specific allowed range this way: the XML
-     * is well-formed, but the value is semantically invalid. Minimums are tier-specific (90 for
-     * ARCHIVE_ACCESS, 180 for DEEP_ARCHIVE_ACCESS) and both are capped at 730. The response
-     * carries {@code ArgumentName} and {@code ArgumentValue} so the SDK can surface which input
-     * was rejected, matching the real S3 error shape.
+     * is well-formed, but the value is semantically invalid. Minimums are tier-specific
+     * ({@link #ARCHIVE_ACCESS_MIN_DAYS} for ARCHIVE_ACCESS, {@link #DEEP_ARCHIVE_ACCESS_MIN_DAYS}
+     * for DEEP_ARCHIVE_ACCESS) and both are capped at {@link #MAX_DAYS}. The response carries
+     * {@code ArgumentName} and {@code ArgumentValue} so the SDK can surface which input was
+     * rejected, matching the real S3 error shape.
      */
-    private static AwsException daysOutOfRange(String accessTier, int days) {
-        int min = "DEEP_ARCHIVE_ACCESS".equals(accessTier) ? 180 : 90;
+    private static AwsException daysOutOfRange(String accessTier, int min, int days) {
         String message = days < min
                 ? "Days must be at least " + min + " for AccessTier " + accessTier + "."
-                : "Days must be at most 730 for AccessTier " + accessTier + ".";
-        Map<String, Object> detail = new java.util.LinkedHashMap<>();
+                : "Days must be at most " + MAX_DAYS + " for AccessTier " + accessTier + ".";
+        Map<String, Object> detail = new LinkedHashMap<>();
         detail.put("ArgumentName", "Tiering.Days");
         detail.put("ArgumentValue", String.valueOf(days));
         return new AwsException("InvalidArgument", message, 400, detail);
@@ -146,7 +151,8 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
     /**
      * Serializes the {@code index}-th {@code Tiering} entry. Each tiering is an access tier and a
      * positive day count, and both are required. Days must also fall in the tier-specific range
-     * AWS enforces: 90-730 for ARCHIVE_ACCESS and 180-730 for DEEP_ARCHIVE_ACCESS.
+     * AWS enforces: {@link #ARCHIVE_ACCESS_MIN_DAYS}-{@link #MAX_DAYS} for ARCHIVE_ACCESS and
+     * {@link #DEEP_ARCHIVE_ACCESS_MIN_DAYS}-{@link #MAX_DAYS} for DEEP_ARCHIVE_ACCESS.
      */
     private static String tieringXml(String xml, int index) {
         List<Map<String, String>> entries = XmlParser.extractGroups(xml, "Tiering");
@@ -174,9 +180,9 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
         }
         // Beyond well-formedness, AWS enforces a tier-specific range. A value outside it is
         // semantically invalid, not malformed, so AWS answers InvalidArgument.
-        int min = "DEEP_ARCHIVE_ACCESS".equals(accessTier) ? 180 : 90;
-        if (dayCount < min || dayCount > 730) {
-            throw daysOutOfRange(accessTier, dayCount);
+        int min = "DEEP_ARCHIVE_ACCESS".equals(accessTier) ? DEEP_ARCHIVE_ACCESS_MIN_DAYS : ARCHIVE_ACCESS_MIN_DAYS;
+        if (dayCount < min || dayCount > MAX_DAYS) {
+            throw daysOutOfRange(accessTier, min, dayCount);
         }
         return new XmlBuilder()
                 .elem("AccessTier", accessTier)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
@@ -29,6 +29,24 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
                 "The XML you provided was not well-formed or did not validate against our published schema", 400);
     }
 
+    /**
+     * AWS reports a {@code Days} value outside the tier-specific allowed range this way: the XML
+     * is well-formed, but the value is semantically invalid. Minimums are tier-specific (90 for
+     * ARCHIVE_ACCESS, 180 for DEEP_ARCHIVE_ACCESS) and both are capped at 730. The response
+     * carries {@code ArgumentName} and {@code ArgumentValue} so the SDK can surface which input
+     * was rejected, matching the real S3 error shape.
+     */
+    private static AwsException daysOutOfRange(String accessTier, int days) {
+        int min = "DEEP_ARCHIVE_ACCESS".equals(accessTier) ? 180 : 90;
+        String message = days < min
+                ? "Days must be at least " + min + " for AccessTier " + accessTier + "."
+                : "Days must be at most 730 for AccessTier " + accessTier + ".";
+        Map<String, Object> detail = new java.util.LinkedHashMap<>();
+        detail.put("ArgumentName", "Tiering.Days");
+        detail.put("ArgumentValue", String.valueOf(days));
+        return new AwsException("InvalidArgument", message, 400, detail);
+    }
+
     static S3IntelligentTieringConfiguration parse(String xml) {
         if (xml == null || xml.isBlank() || !ROOT.equals(XmlParser.rootElementName(xml))) {
             throw malformed();
@@ -127,7 +145,8 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
 
     /**
      * Serializes the {@code index}-th {@code Tiering} entry. Each tiering is an access tier and a
-     * positive day count, and both are required.
+     * positive day count, and both are required. Days must also fall in the tier-specific range
+     * AWS enforces: 90-730 for ARCHIVE_ACCESS and 180-730 for DEEP_ARCHIVE_ACCESS.
      */
     private static String tieringXml(String xml, int index) {
         List<Map<String, String>> entries = XmlParser.extractGroups(xml, "Tiering");
@@ -143,13 +162,21 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
         if (days == null || !days.matches("\\d+")) {
             throw malformed();
         }
+        int dayCount;
         try {
-            if (Integer.parseInt(days) < 1) {
-                throw malformed();
-            }
+            dayCount = Integer.parseInt(days);
         } catch (NumberFormatException e) {
             // Values above Integer.MAX_VALUE match the regex but overflow parseInt.
             throw malformed();
+        }
+        if (dayCount < 1) {
+            throw malformed();
+        }
+        // Beyond well-formedness, AWS enforces a tier-specific range. A value outside it is
+        // semantically invalid, not malformed, so AWS answers InvalidArgument.
+        int min = "DEEP_ARCHIVE_ACCESS".equals(accessTier) ? 180 : 90;
+        if (dayCount < min || dayCount > 730) {
+            throw daysOutOfRange(accessTier, dayCount);
         }
         return new XmlBuilder()
                 .elem("AccessTier", accessTier)

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
@@ -1,0 +1,159 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.XmlBuilder;
+import io.github.hectorvent.floci.core.common.XmlParser;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A parsed {@code IntelligentTieringConfiguration} request body, reduced to a canonical
+ * serialization of its contents.
+ *
+ * <p>The body is re-serialized rather than stored verbatim, so that what a later
+ * GetBucketIntelligentTieringConfiguration or ListBucketIntelligentTieringConfigurations returns
+ * is built by floci instead of being whatever XML the caller sent, and so that the same stored
+ * form can be wrapped in either response.
+ */
+record S3IntelligentTieringConfiguration(String id, String innerXml) {
+
+    private static final String ROOT = "IntelligentTieringConfiguration";
+
+    private static final List<String> STATUSES = List.of("Enabled", "Disabled");
+    private static final List<String> ACCESS_TIERS = List.of("ARCHIVE_ACCESS", "DEEP_ARCHIVE_ACCESS");
+
+    /** AWS reports a body that does not match the published schema this way. */
+    private static AwsException malformed() {
+        return new AwsException("MalformedXML",
+                "The XML you provided was not well-formed or did not validate against our published schema", 400);
+    }
+
+    static S3IntelligentTieringConfiguration parse(String xml) {
+        if (xml == null || xml.isBlank() || !ROOT.equals(XmlParser.rootElementName(xml))) {
+            throw malformed();
+        }
+
+        // The configuration is one Id, one Status, at most one Filter, and at least one Tiering,
+        // so anything else under the root is a body AWS would not have accepted.
+        List<String> children = XmlParser.childElementNames(xml, ROOT);
+        long ids = children.stream().filter("Id"::equals).count();
+        long statuses = children.stream().filter("Status"::equals).count();
+        long filters = children.stream().filter("Filter"::equals).count();
+        long tierings = children.stream().filter("Tiering"::equals).count();
+        if (ids != 1 || statuses != 1 || filters > 1 || tierings < 1
+                || children.size() != ids + statuses + filters + tierings) {
+            throw malformed();
+        }
+
+        String id = XmlParser.extractFirst(xml, "Id", null);
+        if (id == null || id.isBlank()) {
+            throw malformed();
+        }
+
+        String status = XmlParser.extractFirst(xml, "Status", null);
+        if (status == null || !STATUSES.contains(status)) {
+            throw malformed();
+        }
+
+        XmlBuilder inner = new XmlBuilder().elem("Id", id);
+        if (filters == 1) {
+            inner.start("Filter").raw(filterXml(xml)).end("Filter");
+        }
+        inner.elem("Status", status);
+        for (int i = 0; i < tierings; i++) {
+            inner.start("Tiering").raw(tieringXml(xml, i)).end("Tiering");
+        }
+        return new S3IntelligentTieringConfiguration(id, inner.build());
+    }
+
+    /**
+     * Serializes the filter. A filter is exactly one of a prefix, an object tag, or an And
+     * conjunction: AWS answers MalformedXML for a filter naming none of them or more than one,
+     * and for an And holding fewer than two predicates.
+     */
+    private static String filterXml(String xml) {
+        List<String> predicates = XmlParser.childElementNames(xml, "Filter");
+        if (predicates.size() != 1) {
+            throw malformed();
+        }
+
+        String predicate = predicates.getFirst();
+        return switch (predicate) {
+            case "Prefix" -> new XmlBuilder().elem("Prefix", requireText(xml, "Prefix")).build();
+            case "Tag" -> tagsXml(xml, 1);
+            case "And" -> {
+                List<String> conjuncts = XmlParser.childElementNames(xml, "And");
+                if (conjuncts.size() < 2) {
+                    throw malformed();
+                }
+                XmlBuilder and = new XmlBuilder().start("And");
+                if (conjuncts.contains("Prefix")) {
+                    and.elem("Prefix", requireText(xml, "Prefix"));
+                }
+                long tagCount = conjuncts.stream().filter("Tag"::equals).count();
+                if (tagCount > 0) {
+                    and.raw(tagsXml(xml, (int) tagCount));
+                }
+                // Every conjunct has to be one floci understands, or the filter it stores would
+                // not be the filter that was sent.
+                if (conjuncts.size() != tagCount + (conjuncts.contains("Prefix") ? 1 : 0)) {
+                    throw malformed();
+                }
+                yield and.end("And").build();
+            }
+            default -> throw malformed();
+        };
+    }
+
+    /**
+     * Serializes {@code expected} tags. A tag carries both a key and a value, so a pair short of
+     * the element count means one of them was missing.
+     */
+    private static String tagsXml(String xml, int expected) {
+        Map<String, String> tags = XmlParser.extractPairs(xml, "Tag", "Key", "Value");
+        if (tags.size() != expected) {
+            throw malformed();
+        }
+        XmlBuilder out = new XmlBuilder();
+        tags.forEach((key, value) -> {
+            if (key.isBlank() || value == null) {
+                throw malformed();
+            }
+            out.start("Tag").elem("Key", key).elem("Value", value).end("Tag");
+        });
+        return out.build();
+    }
+
+    /**
+     * Serializes the {@code index}-th {@code Tiering} entry. Each tiering is an access tier and a
+     * positive day count, and both are required.
+     */
+    private static String tieringXml(String xml, int index) {
+        List<Map<String, String>> entries = XmlParser.extractGroups(xml, "Tiering");
+        if (index >= entries.size()) {
+            throw malformed();
+        }
+        Map<String, String> tiering = entries.get(index);
+        String accessTier = tiering.get("AccessTier");
+        String days = tiering.get("Days");
+        if (accessTier == null || !ACCESS_TIERS.contains(accessTier)) {
+            throw malformed();
+        }
+        if (days == null || !days.matches("\\d+") || Integer.parseInt(days) < 1) {
+            throw malformed();
+        }
+        return new XmlBuilder()
+                .elem("AccessTier", accessTier)
+                .elem("Days", days)
+                .build();
+    }
+
+    private static String requireText(String xml, String element) {
+        String value = XmlParser.extractFirst(xml, element, null);
+        if (value == null) {
+            throw malformed();
+        }
+        return value;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfiguration.java
@@ -140,7 +140,15 @@ record S3IntelligentTieringConfiguration(String id, String innerXml) {
         if (accessTier == null || !ACCESS_TIERS.contains(accessTier)) {
             throw malformed();
         }
-        if (days == null || !days.matches("\\d+") || Integer.parseInt(days) < 1) {
+        if (days == null || !days.matches("\\d+")) {
+            throw malformed();
+        }
+        try {
+            if (Integer.parseInt(days) < 1) {
+                throw malformed();
+            }
+        } catch (NumberFormatException e) {
+            // Values above Integer.MAX_VALUE match the regex but overflow parseInt.
             throw malformed();
         }
         return new XmlBuilder()

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1813,6 +1813,88 @@ public class S3Service implements Resettable, ResourceProvider {
         return new AwsException("NoSuchConfiguration", "The specified configuration does not exist.", 404);
     }
 
+    // --- Intelligent-Tiering Configurations ---
+
+    /**
+     * Stores an Intelligent-Tiering configuration under {@code id}, replacing any configuration
+     * already stored under it. floci records the configuration and returns it; no objects are
+     * transitioned between tiers because of it.
+     */
+    public void putBucketIntelligentTieringConfiguration(String bucketName, String id, String innerXml) {
+        Bucket bucket = requireBucket(bucketName);
+        // Read-modify-write of the bucket record, so it takes the same monitor as the other
+        // bucket-scoped mutations: without it two concurrent puts of different ids both start from
+        // the same map and one of the configurations is lost.
+        synchronized (bucket) {
+            requireSameRecord(bucketName, bucket);
+            Map<String, String> configurations = bucket.getIntelligentTieringConfigurations() != null
+                    ? new java.util.LinkedHashMap<>(bucket.getIntelligentTieringConfigurations())
+                    : new java.util.LinkedHashMap<>();
+            configurations.put(id, innerXml);
+            bucket.setIntelligentTieringConfigurations(configurations);
+            bucketStore.put(bucketName, bucket);
+        }
+        LOG.debugv("Put intelligent-tiering configuration {0} on bucket: {1}", id, bucketName);
+    }
+
+    public String getBucketIntelligentTieringConfiguration(String bucketName, String id) {
+        Bucket bucket = requireBucket(bucketName);
+        String innerXml = bucket.getIntelligentTieringConfigurations() == null
+                ? null : bucket.getIntelligentTieringConfigurations().get(id);
+        if (innerXml == null) {
+            throw noSuchIntelligentTieringConfiguration();
+        }
+        return METRICS_XML_DECLARATION + new XmlBuilder()
+                .start("IntelligentTieringConfiguration", AwsNamespaces.S3)
+                .raw(innerXml)
+                .end("IntelligentTieringConfiguration")
+                .build();
+    }
+
+    /**
+     * Lists every Intelligent-Tiering configuration on the bucket. AWS pages these with a
+     * continuation token; floci returns them all in one unpaged response, ordered by id so that
+     * the listing is stable.
+     */
+    public String listBucketIntelligentTieringConfigurations(String bucketName) {
+        Bucket bucket = requireBucket(bucketName);
+        Map<String, String> configurations = bucket.getIntelligentTieringConfigurations() != null
+                ? bucket.getIntelligentTieringConfigurations() : Map.of();
+
+        XmlBuilder xml = new XmlBuilder().start("ListBucketIntelligentTieringConfigurationsResult",
+                AwsNamespaces.S3);
+        configurations.keySet().stream().sorted().forEach(id -> xml
+                .start("IntelligentTieringConfiguration")
+                .raw(configurations.get(id))
+                .end("IntelligentTieringConfiguration"));
+        return METRICS_XML_DECLARATION + xml
+                .elem("IsTruncated", false)
+                .end("ListBucketIntelligentTieringConfigurationsResult")
+                .build();
+    }
+
+    public void deleteBucketIntelligentTieringConfiguration(String bucketName, String id) {
+        Bucket bucket = requireBucket(bucketName);
+        // Same monitor as the put: the existence check and the write have to be one step, or a
+        // concurrent put of another id is dropped by the write that follows it.
+        synchronized (bucket) {
+            requireSameRecord(bucketName, bucket);
+            Map<String, String> configurations = bucket.getIntelligentTieringConfigurations();
+            if (configurations == null || !configurations.containsKey(id)) {
+                throw noSuchIntelligentTieringConfiguration();
+            }
+            Map<String, String> remaining = new java.util.LinkedHashMap<>(configurations);
+            remaining.remove(id);
+            bucket.setIntelligentTieringConfigurations(remaining);
+            bucketStore.put(bucketName, bucket);
+        }
+        LOG.debugv("Deleted intelligent-tiering configuration {0} from bucket: {1}", id, bucketName);
+    }
+
+    private static AwsException noSuchIntelligentTieringConfiguration() {
+        return new AwsException("NoSuchConfiguration", "The specified configuration does not exist.", 404);
+    }
+
     // --- Object Lock Configuration ---
 
     public void setBucketObjectLockEnabled(String bucketName) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1714,7 +1714,7 @@ public class S3Service implements Resettable, ResourceProvider {
 
     // --- Metrics Configurations ---
 
-    private static final String METRICS_XML_DECLARATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+    private static final String S3_XML_DECLARATION = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
 
     /**
      * Stores a CloudWatch request metrics configuration under {@code id}, replacing any
@@ -1745,7 +1745,7 @@ public class S3Service implements Resettable, ResourceProvider {
         if (innerXml == null) {
             throw noSuchMetricsConfiguration();
         }
-        return METRICS_XML_DECLARATION + new XmlBuilder()
+        return S3_XML_DECLARATION + new XmlBuilder()
                 .start("MetricsConfiguration", AwsNamespaces.S3)
                 .raw(innerXml)
                 .end("MetricsConfiguration")
@@ -1767,7 +1767,7 @@ public class S3Service implements Resettable, ResourceProvider {
                 .start("MetricsConfiguration")
                 .raw(configurations.get(id))
                 .end("MetricsConfiguration"));
-        return METRICS_XML_DECLARATION + xml
+        return S3_XML_DECLARATION + xml
                 .elem("IsTruncated", false)
                 .end("ListMetricsConfigurationsResult")
                 .build();
@@ -1844,7 +1844,7 @@ public class S3Service implements Resettable, ResourceProvider {
         if (innerXml == null) {
             throw noSuchIntelligentTieringConfiguration();
         }
-        return METRICS_XML_DECLARATION + new XmlBuilder()
+        return S3_XML_DECLARATION + new XmlBuilder()
                 .start("IntelligentTieringConfiguration", AwsNamespaces.S3)
                 .raw(innerXml)
                 .end("IntelligentTieringConfiguration")
@@ -1867,7 +1867,7 @@ public class S3Service implements Resettable, ResourceProvider {
                 .start("IntelligentTieringConfiguration")
                 .raw(configurations.get(id))
                 .end("IntelligentTieringConfiguration"));
-        return METRICS_XML_DECLARATION + xml
+        return S3_XML_DECLARATION + xml
                 .elem("IsTruncated", false)
                 .end("ListBucketIntelligentTieringConfigurationsResult")
                 .build();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -662,6 +662,35 @@ public class S3Service implements Resettable, ResourceProvider {
         authorizeS3Read(bucketName, null, null, action, bucketArn, authorization);
     }
 
+    void authorizeBucketWrite(String bucketName, String action, RequestAuthorization authorization) {
+        if (!enforceAuth) {
+            return;
+        }
+
+        authorizeSignedRequest(authorization);
+        RequestAuthorization requestAuthorization = authorization != null
+                ? authorization
+                : RequestAuthorization.unsigned();
+        if (requestAuthorization.signed()) {
+            return;
+        }
+
+        Bucket bucket = bucketStore.get(bucketName)
+                .orElseThrow(() -> new AwsException("NoSuchBucket", "The specified bucket does not exist.", 404));
+
+        String bucketArn = S3PublicAccessEvaluator.bucketArn(bucketName);
+        S3PublicAccessEvaluator.PublicAccessDecision policyDecision =
+                S3PublicAccessEvaluator.publicPolicyDecision(objectMapper, bucket.getPolicy(), action, bucketArn);
+        if (policyDecision == S3PublicAccessEvaluator.PublicAccessDecision.DENY) {
+            throw new AwsException("AccessDenied", "Access Denied", 403);
+        }
+        if (policyDecision == S3PublicAccessEvaluator.PublicAccessDecision.ALLOW) {
+            return;
+        }
+
+        throw new AwsException("AccessDenied", "Access Denied", 403);
+    }
+
     void authorizeObjectRead(String bucketName, String key, String versionId, String action, RequestAuthorization authorization) {
         String objectArn = S3PublicAccessEvaluator.objectArn(bucketName, key);
         authorizeS3Read(bucketName, key, versionId, action, objectArn, authorization);

--- a/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/model/Bucket.java
@@ -34,6 +34,8 @@ public class Bucket {
     private WebsiteConfiguration websiteConfiguration;
     /** CloudWatch request metrics configurations, keyed by the id they were stored under. */
     private Map<String, String> metricsConfigurations;
+    /** Intelligent-Tiering configurations, keyed by the id they were stored under. */
+    private Map<String, String> intelligentTieringConfigurations;
 
     public Bucket() {
         this.tags = new HashMap<>();
@@ -127,4 +129,9 @@ public class Bucket {
 
     public Map<String, String> getMetricsConfigurations() { return metricsConfigurations; }
     public void setMetricsConfigurations(Map<String, String> metricsConfigurations) { this.metricsConfigurations = metricsConfigurations; }
+
+    public Map<String, String> getIntelligentTieringConfigurations() { return intelligentTieringConfigurations; }
+    public void setIntelligentTieringConfigurations(Map<String, String> intelligentTieringConfigurations) {
+        this.intelligentTieringConfigurations = intelligentTieringConfigurations;
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationIntegrationTest.java
@@ -1,0 +1,323 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class S3IntelligentTieringConfigurationIntegrationTest {
+
+    private static final String BUCKET = "intelligent-tiering-int-test";
+
+    @Test
+    @Order(1)
+    void createBucket() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+    }
+
+    /**
+     * An unhandled {@code PUT /{bucket}?intelligent-tiering} would fall through to the
+     * unqualified {@code CreateBucket} and answer BucketAlreadyOwnedByYou. Real S3 stores the
+     * configuration and returns 204.
+     */
+    @Test
+    @Order(2)
+    void putIntelligentTieringConfigurationIsNotTreatedAsCreateBucket() {
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>EntireBucket</Id>
+                        <Status>Enabled</Status>
+                        <Tiering>
+                            <AccessTier>ARCHIVE_ACCESS</AccessTier>
+                            <Days>90</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=EntireBucket")
+        .then()
+            .statusCode(204)
+            .body(not(containsString("BucketAlreadyOwnedByYou")));
+    }
+
+    @Test
+    @Order(3)
+    void getIntelligentTieringConfigurationReturnsWhatWasStored() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=EntireBucket")
+        .then()
+            .statusCode(200)
+            .body(containsString("<IntelligentTieringConfiguration"))
+            .body(containsString("<Id>EntireBucket</Id>"))
+            .body(containsString("<Status>Enabled</Status>"))
+            .body(containsString("<AccessTier>ARCHIVE_ACCESS</AccessTier>"))
+            .body(containsString("<Days>90</Days>"));
+    }
+
+    @Test
+    @Order(4)
+    void putFilteredConfigurationKeepsTheFilterAndEveryTiering() {
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>Filtered</Id>
+                        <Filter>
+                            <And>
+                                <Prefix>logs/</Prefix>
+                                <Tag><Key>env</Key><Value>prod</Value></Tag>
+                                <Tag><Key>team</Key><Value>core</Value></Tag>
+                            </And>
+                        </Filter>
+                        <Status>Disabled</Status>
+                        <Tiering>
+                            <AccessTier>ARCHIVE_ACCESS</AccessTier>
+                            <Days>90</Days>
+                        </Tiering>
+                        <Tiering>
+                            <AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier>
+                            <Days>180</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(204);
+
+        // AWS repeats <Tag> inside <And> with no wrapping element.
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(200)
+            .body(containsString("<And><Prefix>logs/</Prefix>"
+                    + "<Tag><Key>env</Key><Value>prod</Value></Tag>"
+                    + "<Tag><Key>team</Key><Value>core</Value></Tag></And>"))
+            .body(containsString("<Status>Disabled</Status>"))
+            .body(containsString("<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier>"
+                    + "<Days>90</Days></Tiering>"
+                    + "<Tiering><AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier>"
+                    + "<Days>180</Days></Tiering>"));
+    }
+
+    @Test
+    @Order(5)
+    void listWithoutAnIdReturnsEveryConfiguration() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ListBucketIntelligentTieringConfigurationsResult"))
+            .body(containsString("<Id>EntireBucket</Id>"))
+            .body(containsString("<Id>Filtered</Id>"))
+            .body(containsString("<IsTruncated>false</IsTruncated>"));
+    }
+
+    @Test
+    @Order(6)
+    void puttingTheSameIdReplacesRatherThanDuplicates() {
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>EntireBucket</Id>
+                        <Status>Disabled</Status>
+                        <Tiering>
+                            <AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier>
+                            <Days>180</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=EntireBucket")
+        .then()
+            .statusCode(204);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=EntireBucket")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Status>Disabled</Status>"))
+            .body(containsString("<Days>180</Days>"));
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Id>EntireBucket</Id>"))
+            .body(containsString("<Id>Filtered</Id>"));
+    }
+
+    @Test
+    @Order(7)
+    void idInTheBodyMustMatchTheIdInTheQuery() {
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>Different</Id>
+                        <Status>Enabled</Status>
+                        <Tiering>
+                            <AccessTier>ARCHIVE_ACCESS</AccessTier>
+                            <Days>90</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=Mismatch")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"));
+    }
+
+    @Test
+    @Order(8)
+    void unknownIdIsNotFound() {
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=absent")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchConfiguration"));
+
+        // AWS does not treat deleting an absent configuration as a no-op.
+        given()
+        .when()
+            .delete("/" + BUCKET + "?intelligent-tiering&id=absent")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchConfiguration"));
+    }
+
+    /**
+     * An unhandled {@code DELETE /{bucket}?intelligent-tiering} would fall through to the
+     * unqualified {@code DeleteBucket} and silently remove the whole bucket, reporting success.
+     */
+    @Test
+    @Order(9)
+    void deleteIntelligentTieringConfigurationDoesNotDeleteBucket() {
+        given()
+        .when()
+            .delete("/" + BUCKET + "?intelligent-tiering&id=EntireBucket")
+        .then()
+            .statusCode(204);
+
+        // The bucket, and every other configuration on it, must survive.
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=EntireBucket")
+        .then()
+            .statusCode(404);
+    }
+
+    @Test
+    @Order(10)
+    void aRequestWithoutAnIdIsRefusedRatherThanGuessedAt() {
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>EntireBucket</Id>
+                        <Status>Enabled</Status>
+                        <Tiering>
+                            <AccessTier>ARCHIVE_ACCESS</AccessTier>
+                            <Days>90</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET + "?intelligent-tiering")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"));
+    }
+
+    @Test
+    @Order(11)
+    void malformedBodiesLeaveExistingConfigurationsUnchanged() {
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>Filtered</Id>
+                        <Status>Maybe</Status>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"));
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Status>Disabled</Status>"));
+    }
+
+    @Test
+    @Order(12)
+    void unqualifiedDeleteStillRemovesBucket() {
+        given()
+        .when()
+            .delete("/" + BUCKET)
+        .then()
+            .statusCode(204);
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchBucket"));
+    }
+
+    @Test
+    @Order(13)
+    void aRecreatedBucketDoesNotInheritTheOldConfigurations() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        given()
+        .when()
+            .get("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchConfiguration"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET)
+        .then()
+            .statusCode(204);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationIntegrationTest.java
@@ -284,6 +284,17 @@ class S3IntelligentTieringConfigurationIntegrationTest {
 
     @Test
     @Order(12)
+    void aPutWithoutABodyIsMalformedXml() {
+        given()
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=Filtered")
+        .then()
+            .statusCode(400)
+            .body(containsString("MalformedXML"));
+    }
+
+    @Test
+    @Order(13)
     void unqualifiedDeleteStillRemovesBucket() {
         given()
         .when()
@@ -299,7 +310,7 @@ class S3IntelligentTieringConfigurationIntegrationTest {
     }
 
     @Test
-    @Order(13)
+    @Order(14)
     void aRecreatedBucketDoesNotInheritTheOldConfigurations() {
         given()
         .when()

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationIntegrationTest.java
@@ -331,4 +331,81 @@ class S3IntelligentTieringConfigurationIntegrationTest {
         .then()
             .statusCode(204);
     }
+
+    @Test
+    @Order(15)
+    void outOfRangeDaysReturnsInvalidArgumentWithArgumentNameAndValue() {
+        given()
+        .when()
+            .put("/" + BUCKET)
+        .then()
+            .statusCode(200);
+
+        // ARCHIVE_ACCESS requires at least 90 days; AWS answers InvalidArgument with ArgumentName
+        // and ArgumentValue so the SDK can surface which input was rejected.
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>TooFewDays</Id>
+                        <Status>Enabled</Status>
+                        <Tiering>
+                            <AccessTier>ARCHIVE_ACCESS</AccessTier>
+                            <Days>1</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=TooFewDays")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("<ArgumentName>Tiering.Days</ArgumentName>"))
+            .body(containsString("<ArgumentValue>1</ArgumentValue>"));
+
+        // DEEP_ARCHIVE_ACCESS requires at least 180 days; 90 is valid for ARCHIVE_ACCESS but not here.
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>TooFewDays</Id>
+                        <Status>Enabled</Status>
+                        <Tiering>
+                            <AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier>
+                            <Days>90</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=TooFewDays")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("<ArgumentName>Tiering.Days</ArgumentName>"))
+            .body(containsString("<ArgumentValue>90</ArgumentValue>"));
+
+        // Both tiers are capped at 730 days.
+        given()
+            .body("""
+                    <IntelligentTieringConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                        <Id>TooManyDays</Id>
+                        <Status>Enabled</Status>
+                        <Tiering>
+                            <AccessTier>ARCHIVE_ACCESS</AccessTier>
+                            <Days>731</Days>
+                        </Tiering>
+                    </IntelligentTieringConfiguration>
+                    """)
+        .when()
+            .put("/" + BUCKET + "?intelligent-tiering&id=TooManyDays")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidArgument"))
+            .body(containsString("<ArgumentName>Tiering.Days</ArgumentName>"))
+            .body(containsString("<ArgumentValue>731</ArgumentValue>"));
+
+        given()
+        .when()
+            .delete("/" + BUCKET)
+        .then()
+            .statusCode(204);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationTest.java
@@ -1,0 +1,212 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class S3IntelligentTieringConfigurationTest {
+
+    private static final String NS = "http://s3.amazonaws.com/doc/2006-03-01/";
+
+    private static String body(String inner) {
+        return "<IntelligentTieringConfiguration xmlns=\"" + NS + "\">" + inner
+                + "</IntelligentTieringConfiguration>";
+    }
+
+    private static String tiering(String accessTier, int days) {
+        return "<Tiering><AccessTier>" + accessTier + "</AccessTier><Days>" + days + "</Days></Tiering>";
+    }
+
+    @Test
+    void parsesAMinimalConfiguration() {
+        S3IntelligentTieringConfiguration parsed = S3IntelligentTieringConfiguration.parse(
+                body("<Id>EntireBucket</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90)));
+
+        assertEquals("EntireBucket", parsed.id());
+        assertEquals("<Id>EntireBucket</Id><Status>Enabled</Status>"
+                + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>",
+                parsed.innerXml());
+    }
+
+    @Test
+    void parsesMultipleTieringsInOrder() {
+        String parsed = S3IntelligentTieringConfiguration.parse(body(
+                "<Id>a</Id><Status>Disabled</Status>"
+                        + tiering("ARCHIVE_ACCESS", 90)
+                        + tiering("DEEP_ARCHIVE_ACCESS", 180))).innerXml();
+
+        assertEquals("<Id>a</Id><Status>Disabled</Status>"
+                + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>"
+                + "<Tiering><AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier><Days>180</Days></Tiering>",
+                parsed);
+    }
+
+    @Test
+    void parsesEachSingleFilterPredicate() {
+        assertEquals("<Id>a</Id><Filter><Prefix>logs/</Prefix></Filter><Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body("<Id>a</Id>"
+                        + "<Filter><Prefix>logs/</Prefix></Filter><Status>Enabled</Status>"
+                        + tiering("ARCHIVE_ACCESS", 90))).innerXml());
+
+        assertEquals("<Id>a</Id><Filter><Tag><Key>env</Key><Value>prod</Value></Tag></Filter>"
+                        + "<Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body("<Id>a</Id>"
+                        + "<Filter><Tag><Key>env</Key><Value>prod</Value></Tag></Filter>"
+                        + "<Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90))).innerXml());
+    }
+
+    @Test
+    void parsesAnAndConjunctionKeepingEveryTag() {
+        // IntelligentTieringAndOperator.Tags is a flattened list named Tag, so the tags repeat
+        // with no wrapping element and all of them have to survive the round trip.
+        String parsed = S3IntelligentTieringConfiguration.parse(body("""
+                <Id>a</Id>
+                <Filter>
+                    <And>
+                        <Prefix>logs/</Prefix>
+                        <Tag><Key>env</Key><Value>prod</Value></Tag>
+                        <Tag><Key>team</Key><Value>core</Value></Tag>
+                    </And>
+                </Filter>
+                <Status>Enabled</Status>
+                """ + tiering("ARCHIVE_ACCESS", 90))).innerXml();
+
+        assertEquals("<Id>a</Id><Filter><And><Prefix>logs/</Prefix>"
+                + "<Tag><Key>env</Key><Value>prod</Value></Tag>"
+                + "<Tag><Key>team</Key><Value>core</Value></Tag></And></Filter>"
+                + "<Status>Enabled</Status>"
+                + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>", parsed);
+    }
+
+    @Test
+    void escapesValuesOnTheWayBackOut() {
+        String parsed = S3IntelligentTieringConfiguration.parse(body(
+                "<Id>a&amp;b</Id><Filter><Prefix>x&lt;y</Prefix></Filter><Status>Enabled</Status>"
+                        + tiering("ARCHIVE_ACCESS", 90))).innerXml();
+
+        assertEquals("<Id>a&amp;b</Id><Filter><Prefix>x&lt;y</Prefix></Filter>"
+                + "<Status>Enabled</Status>"
+                + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>", parsed);
+    }
+
+    @Test
+    void rejectsBodiesThatDoNotMatchTheSchema() {
+        // Missing id, missing status, missing tiering, wrong root element, empty and non-XML
+        // bodies are all MalformedXML on AWS.
+        for (String invalid : new String[]{
+                body(""),
+                body("<Id>   </Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90)),
+                body("<Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90)),
+                body("<Id>a</Id>" + tiering("ARCHIVE_ACCESS", 90)),
+                body("<Id>a</Id><Status>Enabled</Status>"),
+                "<SomethingElse><Id>a</Id></SomethingElse>",
+                "not xml at all",
+                ""}) {
+            AwsException e = assertThrows(AwsException.class,
+                    () -> S3IntelligentTieringConfiguration.parse(invalid),
+                    () -> "expected rejection of: " + invalid);
+            assertEquals("MalformedXML", e.getErrorCode());
+            assertEquals(400, e.getHttpStatus());
+        }
+    }
+
+    @Test
+    void rejectsStatusesOutsideTheEnum() {
+        for (String status : new String[]{"enabled", "ENABLED", "Suspended", ""}) {
+            AwsException e = assertThrows(AwsException.class,
+                    () -> S3IntelligentTieringConfiguration.parse(body(
+                            "<Id>a</Id><Status>" + status + "</Status>" + tiering("ARCHIVE_ACCESS", 90))),
+                    () -> "expected rejection of status: " + status);
+            assertEquals("MalformedXML", e.getErrorCode());
+        }
+    }
+
+    @Test
+    void rejectsTieringsOutsideTheSchema() {
+        String unknownAccessTier = "<Tiering><AccessTier>GLACIER</AccessTier><Days>90</Days></Tiering>";
+        String missingDays = "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier></Tiering>";
+        String missingAccessTier = "<Tiering><Days>90</Days></Tiering>";
+        String zeroDays = "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>0</Days></Tiering>";
+        String nonNumericDays = "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>soon</Days></Tiering>";
+
+        for (String invalid : new String[]{
+                unknownAccessTier, missingDays, missingAccessTier, zeroDays, nonNumericDays}) {
+            AwsException e = assertThrows(AwsException.class,
+                    () -> S3IntelligentTieringConfiguration.parse(body(
+                            "<Id>a</Id><Status>Enabled</Status>" + invalid)),
+                    () -> "expected rejection of: " + invalid);
+            assertEquals("MalformedXML", e.getErrorCode());
+        }
+    }
+
+    @Test
+    void rejectsFiltersThatAreNotExactlyOnePredicate() {
+        String suffix = "<Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90);
+        String bothPrefixAndTag = "<Id>a</Id><Filter><Prefix>logs/</Prefix>"
+                + "<Tag><Key>env</Key><Value>prod</Value></Tag></Filter>" + suffix;
+        String emptyFilter = "<Id>a</Id><Filter></Filter>" + suffix;
+        String andWithOnePredicate = "<Id>a</Id><Filter><And><Prefix>logs/</Prefix></And></Filter>" + suffix;
+        String andWithOneTag = "<Id>a</Id><Filter><And>"
+                + "<Tag><Key>env</Key><Value>prod</Value></Tag></And></Filter>" + suffix;
+        String tagWithoutAKey = "<Id>a</Id><Filter><Tag><Value>prod</Value></Tag></Filter>" + suffix;
+        String tagWithoutAValue = "<Id>a</Id><Filter><Tag><Key>env</Key></Tag></Filter>" + suffix;
+        String unknownPredicate = "<Id>a</Id><Filter><Something>x</Something></Filter>" + suffix;
+        String andWithAnUnknownConjunct = "<Id>a</Id><Filter><And><Prefix>logs/</Prefix>"
+                + "<Something>x</Something></And></Filter>" + suffix;
+
+        for (String invalid : new String[]{
+                bothPrefixAndTag, emptyFilter, andWithOnePredicate, andWithOneTag, tagWithoutAKey,
+                tagWithoutAValue, unknownPredicate, andWithAnUnknownConjunct}) {
+            AwsException e = assertThrows(AwsException.class,
+                    () -> S3IntelligentTieringConfiguration.parse(body(invalid)),
+                    () -> "expected rejection of: " + invalid);
+            assertEquals("MalformedXML", e.getErrorCode());
+        }
+    }
+
+    @Test
+    void rejectsDuplicateOrMisplacedElements() {
+        String valid = "<Id>a</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90);
+        // Normalizing these away would store a configuration that is not the one that was sent.
+        String twoIds = "<Id>a</Id><Id>b</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90);
+        String twoStatuses = "<Id>a</Id><Status>Enabled</Status><Status>Disabled</Status>"
+                + tiering("ARCHIVE_ACCESS", 90);
+        String twoFilters = "<Id>a</Id><Filter><Prefix>x</Prefix></Filter>"
+                + "<Filter><Prefix>y</Prefix></Filter><Status>Enabled</Status>"
+                + tiering("ARCHIVE_ACCESS", 90);
+        String strayElement = valid + "<Prefix>logs/</Prefix>";
+
+        for (String invalid : new String[]{twoIds, twoStatuses, twoFilters, strayElement}) {
+            AwsException e = assertThrows(AwsException.class,
+                    () -> S3IntelligentTieringConfiguration.parse(body(invalid)),
+                    () -> "expected rejection of: " + invalid);
+            assertEquals("MalformedXML", e.getErrorCode());
+        }
+    }
+
+    @Test
+    void acceptsElementsInAnyOrder() {
+        // Element order is not something to be strict about; the set of elements is.
+        assertEquals("<Id>a</Id><Filter><Prefix>logs/</Prefix></Filter><Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body(tiering("ARCHIVE_ACCESS", 90)
+                        + "<Status>Enabled</Status><Filter><Prefix>logs/</Prefix></Filter>"
+                        + "<Id>a</Id>")).innerXml());
+    }
+
+    @Test
+    void refusesToResolveExternalEntities() {
+        // The parser must not read local files on behalf of a request body.
+        String xxe = "<?xml version=\"1.0\"?>"
+                + "<!DOCTYPE foo [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]>"
+                + "<IntelligentTieringConfiguration><Id>&xxe;</Id></IntelligentTieringConfiguration>";
+
+        AwsException e = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(xxe));
+        assertEquals("MalformedXML", e.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationTest.java
@@ -144,6 +144,19 @@ class S3IntelligentTieringConfigurationTest {
     }
 
     @Test
+    void rejectsDaysThatOverflowIntegerRange() {
+        // A value above Integer.MAX_VALUE matches the \\d+ regex but overflows parseInt.
+        // AWS answers MalformedXML, not InternalError.
+        String overflowDays = "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier>"
+                + "<Days>99999999999999999999</Days></Tiering>";
+        AwsException e = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + overflowDays)));
+        assertEquals("MalformedXML", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+    }
+
+    @Test
     void rejectsFiltersThatAreNotExactlyOnePredicate() {
         String suffix = "<Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90);
         String bothPrefixAndTag = "<Id>a</Id><Filter><Prefix>logs/</Prefix>"

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3IntelligentTieringConfigurationTest.java
@@ -157,6 +157,83 @@ class S3IntelligentTieringConfigurationTest {
     }
 
     @Test
+    void rejectsArchiveAccessDaysBelowMinimum() {
+        // ARCHIVE_ACCESS requires at least 90 days; AWS answers InvalidArgument, not MalformedXML.
+        AwsException e = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 89))));
+        assertEquals("InvalidArgument", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+        assertEquals("Tiering.Days", e.getExtendedData().get("ArgumentName"));
+        assertEquals("89", e.getExtendedData().get("ArgumentValue"));
+    }
+
+    @Test
+    void rejectsDeepArchiveAccessDaysBelowMinimum() {
+        // DEEP_ARCHIVE_ACCESS requires at least 180 days; 90 is valid for ARCHIVE_ACCESS but not here.
+        AwsException e = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("DEEP_ARCHIVE_ACCESS", 90))));
+        assertEquals("InvalidArgument", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+        assertEquals("Tiering.Days", e.getExtendedData().get("ArgumentName"));
+        assertEquals("90", e.getExtendedData().get("ArgumentValue"));
+    }
+
+    @Test
+    void rejectsDaysAboveMaximum() {
+        // Both tiers are capped at 730 days.
+        AwsException archive = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 731))));
+        assertEquals("InvalidArgument", archive.getErrorCode());
+        assertEquals(400, archive.getHttpStatus());
+        assertEquals("Tiering.Days", archive.getExtendedData().get("ArgumentName"));
+        assertEquals("731", archive.getExtendedData().get("ArgumentValue"));
+
+        AwsException deep = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("DEEP_ARCHIVE_ACCESS", 731))));
+        assertEquals("InvalidArgument", deep.getErrorCode());
+        assertEquals(400, deep.getHttpStatus());
+        assertEquals("Tiering.Days", deep.getExtendedData().get("ArgumentName"));
+        assertEquals("731", deep.getExtendedData().get("ArgumentValue"));
+    }
+
+    @Test
+    void acceptsDaysAtTierBoundaries() {
+        // The minimum and maximum are inclusive.
+        assertEquals("<Id>a</Id><Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>90</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90))).innerXml());
+        assertEquals("<Id>a</Id><Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>ARCHIVE_ACCESS</AccessTier><Days>730</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 730))).innerXml());
+        assertEquals("<Id>a</Id><Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier><Days>180</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("DEEP_ARCHIVE_ACCESS", 180))).innerXml());
+        assertEquals("<Id>a</Id><Status>Enabled</Status>"
+                        + "<Tiering><AccessTier>DEEP_ARCHIVE_ACCESS</AccessTier><Days>730</Days></Tiering>",
+                S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>" + tiering("DEEP_ARCHIVE_ACCESS", 730))).innerXml());
+    }
+
+    @Test
+    void rejectsOutOfRangeDaysInOneOfSeveralTierings() {
+        // A valid tiering followed by an out-of-range one must still be rejected.
+        AwsException e = assertThrows(AwsException.class,
+                () -> S3IntelligentTieringConfiguration.parse(body(
+                        "<Id>a</Id><Status>Enabled</Status>"
+                                + tiering("ARCHIVE_ACCESS", 90)
+                                + tiering("DEEP_ARCHIVE_ACCESS", 179))));
+        assertEquals("InvalidArgument", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+    }
+
+    @Test
     void rejectsFiltersThatAreNotExactlyOnePredicate() {
         String suffix = "<Status>Enabled</Status>" + tiering("ARCHIVE_ACCESS", 90);
         String bothPrefixAndTag = "<Id>a</Id><Filter><Prefix>logs/</Prefix>"

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ServiceTest.java
@@ -976,4 +976,150 @@ class S3ServiceTest {
                     "configuration config-" + i + " was lost by a concurrent put");
         }
     }
+
+    @Test
+    void intelligentTieringConfigurationsOnABucketWithoutAnyBehaveAsEmpty() {
+        // A bucket persisted before this field existed deserializes with a null map, which is the
+        // same shape a freshly created bucket has, so neither may fault.
+        s3Service.createBucket("no-tiering", "us-east-1");
+
+        assertTrue(s3Service.listBucketIntelligentTieringConfigurations("no-tiering")
+                .contains("<IsTruncated>false</IsTruncated>"));
+        assertEquals("NoSuchConfiguration", assertThrows(AwsException.class,
+                () -> s3Service.getBucketIntelligentTieringConfiguration("no-tiering", "any")).getErrorCode());
+        assertEquals("NoSuchConfiguration", assertThrows(AwsException.class,
+                () -> s3Service.deleteBucketIntelligentTieringConfiguration("no-tiering", "any")).getErrorCode());
+
+        // And the first put still lands on it.
+        s3Service.putBucketIntelligentTieringConfiguration("no-tiering", "first", "<Id>first</Id>");
+        assertTrue(s3Service.getBucketIntelligentTieringConfiguration("no-tiering", "first")
+                .contains("<Id>first</Id>"));
+    }
+
+    @Test
+    void intelligentTieringPutReplacesTheConfigurationStoredUnderTheSameId() {
+        s3Service.createBucket("tiering-replace", "us-east-1");
+        s3Service.putBucketIntelligentTieringConfiguration("tiering-replace", "id",
+                "<Id>id</Id><Status>Enabled</Status>");
+        s3Service.putBucketIntelligentTieringConfiguration("tiering-replace", "id",
+                "<Id>id</Id><Status>Disabled</Status>");
+
+        String stored = s3Service.getBucketIntelligentTieringConfiguration("tiering-replace", "id");
+        assertTrue(stored.contains("<Status>Disabled</Status>"));
+        assertTrue(s3Service.listBucketIntelligentTieringConfigurations("tiering-replace")
+                .indexOf("<Id>id</Id>") == s3Service
+                        .listBucketIntelligentTieringConfigurations("tiering-replace")
+                        .lastIndexOf("<Id>id</Id>"));
+    }
+
+    @Test
+    void intelligentTieringConfigurationsAreIsolatedPerBucket() {
+        s3Service.createBucket("tiering-a", "us-east-1");
+        s3Service.createBucket("tiering-b", "us-east-1");
+        s3Service.putBucketIntelligentTieringConfiguration("tiering-a", "shared",
+                "<Id>shared</Id><Status>Enabled</Status>");
+        s3Service.putBucketIntelligentTieringConfiguration("tiering-b", "shared",
+                "<Id>shared</Id><Status>Disabled</Status>");
+
+        assertTrue(s3Service.getBucketIntelligentTieringConfiguration("tiering-a", "shared")
+                .contains("<Status>Enabled</Status>"));
+        assertTrue(s3Service.getBucketIntelligentTieringConfiguration("tiering-b", "shared")
+                .contains("<Status>Disabled</Status>"));
+
+        s3Service.deleteBucketIntelligentTieringConfiguration("tiering-a", "shared");
+
+        assertEquals("NoSuchConfiguration", assertThrows(AwsException.class,
+                () -> s3Service.getBucketIntelligentTieringConfiguration("tiering-a", "shared")).getErrorCode());
+        assertTrue(s3Service.getBucketIntelligentTieringConfiguration("tiering-b", "shared")
+                .contains("<Status>Disabled</Status>"));
+    }
+
+    @Test
+    void intelligentTieringConfigurationsDoNotOutliveTheirBucket() {
+        s3Service.createBucket("recycled-tiering", "us-east-1");
+        s3Service.putBucketIntelligentTieringConfiguration("recycled-tiering", "old", "<Id>old</Id>");
+        s3Service.deleteBucket("recycled-tiering");
+
+        s3Service.createBucket("recycled-tiering", "us-east-1");
+
+        assertEquals("NoSuchConfiguration", assertThrows(AwsException.class,
+                () -> s3Service.getBucketIntelligentTieringConfiguration("recycled-tiering", "old")).getErrorCode());
+    }
+
+    @Test
+    void intelligentTieringConfigurationsSurviveARestart() {
+        // Through the real storage layer rather than Jackson alone: written, flushed to disk, and
+        // read back by a second service over the same file, the way a restart does it.
+        Path bucketsFile = tempDir.resolve("s3-buckets-tiering.json");
+        var beforeRestart = new io.github.hectorvent.floci.core.storage.HybridStorage<String, Bucket>(
+                bucketsFile, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Bucket>>() {}, 60000);
+        S3Service before = new S3Service(beforeRestart, new InMemoryStorage<>(), tempDir.resolve("s3b"), false);
+        before.createBucket("persisted-tiering", "us-east-1");
+        before.putBucketIntelligentTieringConfiguration("persisted-tiering", "EntireBucket",
+                "<Id>EntireBucket</Id>");
+        beforeRestart.flush();
+        beforeRestart.shutdown();
+
+        var afterRestart = new io.github.hectorvent.floci.core.storage.HybridStorage<String, Bucket>(
+                bucketsFile, new com.fasterxml.jackson.core.type.TypeReference<Map<String, Bucket>>() {}, 60000);
+        afterRestart.load();
+        try {
+            S3Service after = new S3Service(afterRestart, new InMemoryStorage<>(), tempDir.resolve("s3b"), false);
+            assertTrue(after.getBucketIntelligentTieringConfiguration("persisted-tiering", "EntireBucket")
+                    .contains("<Id>EntireBucket</Id>"));
+        } finally {
+            afterRestart.shutdown();
+        }
+    }
+
+    @Test
+    void intelligentTieringConfigurationsSurviveAJacksonRoundTrip() throws Exception {
+        // Bucket records are persisted as JSON, so the configurations have to come back after a
+        // restart, and a record written before the field existed has to still load.
+        var mapper = new com.fasterxml.jackson.databind.ObjectMapper().findAndRegisterModules();
+        Bucket bucket = new Bucket("persisted");
+        bucket.setIntelligentTieringConfigurations(new java.util.LinkedHashMap<>(
+                Map.of("EntireBucket", "<Id>EntireBucket</Id>")));
+
+        Bucket reloaded = mapper.readValue(mapper.writeValueAsString(bucket), Bucket.class);
+        assertEquals("<Id>EntireBucket</Id>",
+                reloaded.getIntelligentTieringConfigurations().get("EntireBucket"));
+
+        Bucket legacy = mapper.readValue("{\"name\":\"legacy\"}", Bucket.class);
+        assertNull(legacy.getIntelligentTieringConfigurations());
+    }
+
+    @Test
+    void concurrentIntelligentTieringConfigurationPutsAllSurvive() throws Exception {
+        // Each put reads the configuration map, adds to it and writes it back, so without a shared
+        // monitor concurrent puts of different ids overwrite each other's work.
+        s3Service.createBucket("tiering-race", "us-east-1");
+        int count = 24;
+        var pool = java.util.concurrent.Executors.newFixedThreadPool(8);
+        var start = new java.util.concurrent.CountDownLatch(1);
+        try {
+            var submitted = new java.util.ArrayList<java.util.concurrent.Future<?>>();
+            for (int i = 0; i < count; i++) {
+                String id = "config-" + i;
+                submitted.add(pool.submit(() -> {
+                    start.await();
+                    s3Service.putBucketIntelligentTieringConfiguration("tiering-race", id,
+                            "<Id>" + id + "</Id>");
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (var future : submitted) {
+                future.get(30, java.util.concurrent.TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        String listed = s3Service.listBucketIntelligentTieringConfigurations("tiering-race");
+        for (int i = 0; i < count; i++) {
+            assertTrue(listed.contains("<Id>config-" + i + "</Id>"),
+                    "configuration config-" + i + " was lost by a concurrent put");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds AWS S3 Intelligent-Tiering configuration management (put, get, list, delete) through the real REST XML `?intelligent-tiering` subresource, mirroring the existing metrics configuration pattern.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

S3 Intelligent-Tiering is a REST XML service. The implementation follows the real AWS wire protocol:

- `PutBucketIntelligentTieringConfiguration` (PUT, 204)
- `GetBucketIntelligentTieringConfiguration` (GET by id)
- `ListBucketIntelligentTieringConfigurations` (GET without id)
- `DeleteBucketIntelligentTieringConfiguration` (DELETE, 204)

`Days` validation matches the AWS `Tiering` schema: minimum 90 for `ARCHIVE_ACCESS`, minimum 180 for `DEEP_ARCHIVE_ACCESS`, capped at 730 for both. Out-of-range values return `InvalidArgument` with `ArgumentName` and `ArgumentValue` in the XML error body, matching the real S3 error shape.

Verified with:
- `JAVA_HOME=/Users/chiara.forresi/Library/Java/JavaVirtualMachines/openjdk-25/Contents/Home ./mvnw -Dtest=S3IntelligentTieringConfigurationTest,S3IntelligentTieringConfigurationIntegrationTest test`
- 33 tests passed

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
