### PR TITLE
fix(codebuild): resolve project ARNs in batch lookup

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildJsonHandler.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @ApplicationScoped
 public class CodeBuildJsonHandler {
@@ -121,8 +122,10 @@ public class CodeBuildJsonHandler {
         List<String> names = new ArrayList<>();
         req.path("names").forEach(n -> names.add(n.asText()));
         List<Project> found = service.batchGetProjects(region, names);
-        List<String> foundNames = found.stream().map(Project::getName).toList();
-        List<String> notFound = names.stream().filter(n -> !foundNames.contains(n)).toList();
+        List<String> foundIdentifiers = found.stream()
+                .flatMap(project -> Stream.of(project.getName(), project.getArn()))
+                .toList();
+        List<String> notFound = names.stream().filter(n -> !foundIdentifiers.contains(n)).toList();
         return Response.ok(Map.of("projects", found, "projectsNotFound", notFound)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
@@ -227,7 +227,16 @@ public class CodeBuildService {
     public List<Project> batchGetProjects(String region, List<String> names) {
         Map<String, Project> store = projectsFor(region);
         return names.stream()
-                .map(store::get)
+                .map(identifier -> {
+                    Project project = store.get(identifier);
+                    if (project != null) {
+                        return project;
+                    }
+                    return store.values().stream()
+                            .filter(candidate -> identifier.equals(candidate.getArn()))
+                            .findFirst()
+                            .orElse(null);
+                })
                 .filter(p -> p != null)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildIntegrationTest.java
@@ -94,7 +94,10 @@ class CodeBuildIntegrationTest {
             .contentType(CONTENT_TYPE)
             .body("""
                 {
-                    "names": ["my-build-project", "nonexistent-project"]
+                    "names": [
+                        "arn:aws:codebuild:us-east-1:000000000000:project/my-build-project",
+                        "nonexistent-project"
+                    ]
                 }
                 """)
         .when()


### PR DESCRIPTION
## Summary

Resolve BatchGetProjects identifiers against both stored project names and exact project ARNs. Keep successfully resolved ARNs out of projectsNotFound.

Closes #2799

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

AWS CodeBuild accepts either names or ARNs in BatchGetProjects. Floci previously keyed its store only by bare name, so Terraform refreshes using an ARN returned an empty result. The JSON 1.1 integration test now looks up the created project by its full ARN and verifies only the genuinely missing identifier is returned in projectsNotFound.

## Checklist

- [x] ./mvnw test -Dtest=CodeBuildIntegrationTest passes locally: 13 tests
- [x] Updated integration test added
- [x] Commit messages follow Conventional Commits