### PR TITLE
fix(kms): validate KeyUsage against KeySpec on CreateKey (#2787)

### DIFF
--- a/compatibility-tests/sdk-test-python/tests/test_kms.py
+++ b/compatibility-tests/sdk-test-python/tests/test_kms.py
@@ -40,6 +40,15 @@ class TestKMSKey:
         response = kms_client.describe_key(KeyId=key_id)
         assert response["KeyMetadata"]["KeyState"] == "PendingDeletion"
 
+    def test_create_key_rejects_incompatible_key_usage(self, kms_client):
+        """CreateKey rejects a KeyUsage that AWS KMS does not allow for the KeySpec."""
+        with pytest.raises(ClientError) as excinfo:
+            kms_client.create_key(
+                KeySpec="ECC_NIST_EDWARDS25519",
+                KeyUsage="ENCRYPT_DECRYPT",
+            )
+        assert excinfo.value.response["Error"]["Code"] == "ValidationException"
+
 
 class TestKMSGrants:
     """Test KMS grant operations."""

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -248,16 +248,9 @@ public class KmsService implements ResourceProvider {
     }
 
     private static void validateKeyUsageForSpec(KmsKeyUsage keyUsage, KmsKeySpec spec) {
-        if (isHmac(spec) && KmsKeyUsage.GENERATE_VERIFY_MAC != keyUsage) {
+        if (!spec.allowedKeyUsages().contains(keyUsage)) {
             throw new AwsException("ValidationException",
-                    "KeyUsage " + keyUsage + " is not compatible with KeySpec " + spec
-                            + ". HMAC key specs require KeyUsage GENERATE_VERIFY_MAC.",
-                    400);
-        }
-        if (KmsKeyUsage.GENERATE_VERIFY_MAC == keyUsage && !isHmac(spec)) {
-            throw new AwsException("ValidationException",
-                    "KeyUsage GENERATE_VERIFY_MAC requires an HMAC KeySpec (HMAC_224, HMAC_256, HMAC_384, or HMAC_512).",
-                    400);
+                    "KeyUsage " + keyUsage + " is not compatible with KeySpec " + spec + ".", 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
@@ -6,6 +6,7 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 @RegisterForReflection
 public enum KmsKeySpec {
@@ -79,6 +80,28 @@ public enum KmsKeySpec {
     public String curveName() {
         return curveName;
     }
+
+    /**
+     * The KeyUsage values AWS KMS accepts for this key spec at CreateKey.
+     *
+     * <p>Source: CreateKey API reference, KeyUsage parameter. NIST-standard ECC
+     * pairs allow SIGN_VERIFY or KEY_AGREEMENT; ECC_SECG_P256K1 and Edwards25519
+     * are signing only; RSA allows ENCRYPT_DECRYPT or SIGN_VERIFY; symmetric is
+     * ENCRYPT_DECRYPT only; HMAC is GENERATE_VERIFY_MAC only.
+     */
+    public Set<KmsKeyUsage> allowedKeyUsages() {
+        return switch (keyType) {
+            case SYMMETRIC -> EnumSet.of(KmsKeyUsage.ENCRYPT_DECRYPT);
+            case HMAC -> EnumSet.of(KmsKeyUsage.GENERATE_VERIFY_MAC);
+            case RSA -> EnumSet.of(KmsKeyUsage.ENCRYPT_DECRYPT, KmsKeyUsage.SIGN_VERIFY);
+            case ED25519, ML_DSA -> EnumSet.of(KmsKeyUsage.SIGN_VERIFY);
+            case SM2 -> EnumSet.of(KmsKeyUsage.ENCRYPT_DECRYPT, KmsKeyUsage.SIGN_VERIFY, KmsKeyUsage.KEY_AGREEMENT);
+            case ECC -> this == ECC_SECG_P256K1
+                    ? EnumSet.of(KmsKeyUsage.SIGN_VERIFY)
+                    : EnumSet.of(KmsKeyUsage.SIGN_VERIFY, KmsKeyUsage.KEY_AGREEMENT);
+        };
+    }
+
     public enum KeyType {
         RSA, ECC, ED25519, SYMMETRIC, HMAC, ML_DSA, SM2
     }

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -1042,49 +1042,49 @@ class KmsIntegrationTest {
     @ParameterizedTest
     @CsvSource({
             "SYMMETRIC_DEFAULT, ENCRYPT_DECRYPT, 200",
-            "SYMMETRIC_DEFAULT, SIGN_VERIFY, 200",
+            "SYMMETRIC_DEFAULT, SIGN_VERIFY, 400",
             "SYMMETRIC_DEFAULT, GENERATE_VERIFY_MAC, 400",
-            "SYMMETRIC_DEFAULT, KEY_AGREEMENT, 200",
+            "SYMMETRIC_DEFAULT, KEY_AGREEMENT, 400",
 
             "RSA_2048, ENCRYPT_DECRYPT, 200",
             "RSA_2048, SIGN_VERIFY, 200",
             "RSA_2048, GENERATE_VERIFY_MAC, 400",
-            "RSA_2048, KEY_AGREEMENT, 200",
+            "RSA_2048, KEY_AGREEMENT, 400",
 
             "RSA_3072, ENCRYPT_DECRYPT, 200",
             "RSA_3072, SIGN_VERIFY, 200",
             "RSA_3072, GENERATE_VERIFY_MAC, 400",
-            "RSA_3072, KEY_AGREEMENT, 200",
+            "RSA_3072, KEY_AGREEMENT, 400",
 
             "RSA_4096, ENCRYPT_DECRYPT, 200",
             "RSA_4096, SIGN_VERIFY, 200",
             "RSA_4096, GENERATE_VERIFY_MAC, 400",
-            "RSA_4096, KEY_AGREEMENT, 200",
+            "RSA_4096, KEY_AGREEMENT, 400",
 
-            "ECC_NIST_P256, ENCRYPT_DECRYPT, 200",
+            "ECC_NIST_P256, ENCRYPT_DECRYPT, 400",
             "ECC_NIST_P256, SIGN_VERIFY, 200",
             "ECC_NIST_P256, GENERATE_VERIFY_MAC, 400",
             "ECC_NIST_P256, KEY_AGREEMENT, 200",
 
-            "ECC_NIST_P384, ENCRYPT_DECRYPT, 200",
+            "ECC_NIST_P384, ENCRYPT_DECRYPT, 400",
             "ECC_NIST_P384, SIGN_VERIFY, 200",
             "ECC_NIST_P384, GENERATE_VERIFY_MAC, 400",
             "ECC_NIST_P384, KEY_AGREEMENT, 200",
 
-            "ECC_NIST_P521, ENCRYPT_DECRYPT, 200",
+            "ECC_NIST_P521, ENCRYPT_DECRYPT, 400",
             "ECC_NIST_P521, SIGN_VERIFY, 200",
             "ECC_NIST_P521, GENERATE_VERIFY_MAC, 400",
             "ECC_NIST_P521, KEY_AGREEMENT, 200",
 
-            "ECC_NIST_EDWARDS25519, ENCRYPT_DECRYPT, 200",
+            "ECC_NIST_EDWARDS25519, ENCRYPT_DECRYPT, 400",
             "ECC_NIST_EDWARDS25519, SIGN_VERIFY, 200",
             "ECC_NIST_EDWARDS25519, GENERATE_VERIFY_MAC, 400",
-            "ECC_NIST_EDWARDS25519, KEY_AGREEMENT, 200",
+            "ECC_NIST_EDWARDS25519, KEY_AGREEMENT, 400",
 
-            "ECC_SECG_P256K1, ENCRYPT_DECRYPT, 200",
+            "ECC_SECG_P256K1, ENCRYPT_DECRYPT, 400",
             "ECC_SECG_P256K1, SIGN_VERIFY, 200",
             "ECC_SECG_P256K1, GENERATE_VERIFY_MAC, 400",
-            "ECC_SECG_P256K1, KEY_AGREEMENT, 200",
+            "ECC_SECG_P256K1, KEY_AGREEMENT, 400",
 
             "HMAC_224, ENCRYPT_DECRYPT, 400",
             "HMAC_224, SIGN_VERIFY, 400",
@@ -1141,6 +1141,46 @@ class KmsIntegrationTest {
                 .post("/")
                 .then()
                 .statusCode(expectedStatusCode);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "SYMMETRIC_DEFAULT, SIGN_VERIFY",
+            "RSA_2048, KEY_AGREEMENT",
+            "ECC_NIST_P256, ENCRYPT_DECRYPT",
+            "ECC_NIST_EDWARDS25519, ENCRYPT_DECRYPT",
+            "ECC_NIST_EDWARDS25519, KEY_AGREEMENT",
+            "ECC_SECG_P256K1, KEY_AGREEMENT"
+    })
+    void createKeyRejectsIncompatibleKeyUsage(String keySpec, String keyUsage) {
+        given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"%s\",\"KeySpec\":\"%s\"}".formatted(keyUsage, keySpec))
+                .when().post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", equalTo(
+                        "KeyUsage " + keyUsage + " is not compatible with KeySpec " + keySpec + "."));
+    }
+
+    /**
+     * AWS accepts KEY_AGREEMENT for NIST-standard ECC key specs at CreateKey, even though
+     * Floci has no DeriveSharedSecret operation yet. Matching AWS at the CreateKey boundary
+     * is deliberate; this guards against an over-broad tightening.
+     */
+    @Test
+    void createKeyAllowsKeyAgreementForNistEccSpecs() {
+        given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"KEY_AGREEMENT\",\"KeySpec\":\"ECC_NIST_P256\"}")
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("KeyMetadata.KeyUsage", equalTo("KEY_AGREEMENT"))
+                .body("KeyMetadata.KeySpec", equalTo("ECC_NIST_P256"));
     }
 
     // ── Issue #1528 — ListKeyPolicies ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Validates `KeyUsage` against `KeySpec` on KMS `CreateKey`, rejecting incompatible combinations with HTTP 400 (`ValidationException`).

Fixes the second defect in #2787 (the primary bug around Ed25519 key generation was previously resolved in #2930).

Closes #2787

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

### Incorrect Behavior
Previously, `KmsService.validateKeyUsageForSpec` only enforced the HMAC <-> `GENERATE_VERIFY_MAC` pairing; all other `KeySpec` and `KeyUsage` combinations returned HTTP 200. Real AWS KMS rejects incompatible combinations at `CreateKey`.

### Target AWS Matrix
Derived from the [AWS KMS CreateKey API reference](https://docs.aws.amazon.com/kms/latest/APIReference/API_CreateKey.html):

| KeySpec | Valid KeyUsage |
| --- | --- |
| `SYMMETRIC_DEFAULT` | `ENCRYPT_DECRYPT` only |
| `HMAC_224` / `HMAC_256` / `HMAC_384` / `HMAC_512` | `GENERATE_VERIFY_MAC` only |
| `RSA_2048` / `RSA_3072` / `RSA_4096` | `ENCRYPT_DECRYPT` or `SIGN_VERIFY` |
| `ECC_NIST_P256` / `ECC_NIST_P384` / `ECC_NIST_P521` | `SIGN_VERIFY` or `KEY_AGREEMENT` |
| `ECC_NIST_EDWARDS25519` | `SIGN_VERIFY` only |
| `ECC_SECG_P256K1` | `SIGN_VERIFY` only |
| `ML_DSA_44` / `ML_DSA_65` / `ML_DSA_87` | `SIGN_VERIFY` only |
| `SM2` | `ENCRYPT_DECRYPT` / `SIGN_VERIFY` / `KEY_AGREEMENT` |

### Key Points and Nuances
- **Validation logic:** Added `allowedKeyUsages()` to `KmsKeySpec` enum returning an `EnumSet` per key type (with `ECC_SECG_P256K1` restricted to `SIGN_VERIFY`). `KmsService.validateKeyUsageForSpec` delegates to this method.
- **NIST ECC with KEY_AGREEMENT:** `ECC_NIST_P256/P384/P521` + `KEY_AGREEMENT` deliberately keeps returning HTTP 200 to match real AWS `CreateKey` behavior (even though `DeriveSharedSecret` is not yet implemented in Floci).
- **Provisional error type:** Error `__type` is `ValidationException`, chosen for consistency with existing in-method validation. The exact exception type/message that live AWS KMS returns for this `CreateKey` path is not verified against a live AWS account. Happy to adjust if maintainers confirm via live testing.
- **SM2 / ML_DSA:** Unimplemented key specs remain rejected upfront before reaching `validateKeyUsageForSpec`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
