### PR TITLE
feat(eks): configure k3s runtimes per cluster

### DIFF
--- a/docs/services/eks.md
+++ b/docs/services/eks.md
@@ -77,6 +77,40 @@ services:
 !!! note "No port mapping needed for k3s ports"
     k3s containers bind their API server port (6500–6599) directly on the host via Docker — no `ports:` entry is required in `docker-compose.yml`. See [Ports Reference](../configuration/ports.md#ports-65006599-eks-real-mode) for the full explanation.
 
+#### Per-cluster k3s runtime
+
+`CreateCluster` recognizes the following `floci:` keys in its standard `tags` map as local
+emulator configuration. They are creation-only runtime inputs: Floci removes them from returned
+EKS tags and rejects them from `TagResource`, so `DescribeCluster` and `ListTagsForResource`
+remain AWS-shaped.
+
+| Tag | Runtime setting | Default |
+|---|---|---|
+| `floci:eks-image` | k3s container image | `FLOCI_SERVICES_EKS_DEFAULT_IMAGE` |
+| `floci:eks-node-ipv4-address` | Static IPv4 address on the configured user-defined Docker network | Docker-assigned address |
+| `floci:eks-pod-ipv4-cidr` | k3s Pod CIDR | `10.42.0.0/16` |
+
+The standard `kubernetesNetworkConfig.serviceIpv4Cidr` remains the Service CIDR and defaults to
+`10.100.0.0/16`. Floci starts k3s with `--node-ip`, `--cluster-cidr`, and `--service-cidr` from
+these values. The Pod and Service CIDRs must be canonical IPv4 networks that do not overlap, and
+a static node address must be outside both networks. A static address requires a user-defined
+Docker network with matching IPAM configuration; Docker's `bridge`, `host`, and `none` modes do
+not support it.
+
+```bash
+aws eks create-cluster \
+  --name example \
+  --role-arn arn:aws:iam::000000000000:role/eks-role \
+  --resources-vpc-config subnetIds=subnet-0123456789abcdef0 \
+  --kubernetes-network-config serviceIpv4Cidr=10.100.0.0/16 \
+  --tags floci:eks-image=rancher/k3s:v1.34.0-k3s1,floci:eks-node-ipv4-address=172.20.0.20,floci:eks-pod-ipv4-cidr=10.244.0.0/16
+```
+```
+
+Floci persists the resolved runtime settings in `eks-runtime-configs.json`, separate from the
+AWS-shaped cluster record. When a missing k3s container is recreated after restart, it receives
+the same image and network settings.
+
 #### Clusters survive a restart
 
 With a persistent [storage mode](../configuration/storage.md) (the default), clusters recorded in

--- a/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
@@ -13,6 +13,9 @@ public final class ReservedTags {
     public static final String OVERRIDE_ID_KEY = RESERVED_PREFIX + "override-id";
     public static final String OVERRIDE_COGNITO_CLIENT_ID_KEY = RESERVED_PREFIX + "override-cognito-client-id";
     public static final String OVERRIDE_COGNITO_CLIENT_SECRET_KEY = RESERVED_PREFIX + "override-cognito-client-secret";
+    public static final String EKS_IMAGE_KEY = RESERVED_PREFIX + "eks-image";
+    public static final String EKS_NODE_IPV4_ADDRESS_KEY = RESERVED_PREFIX + "eks-node-ipv4-address";
+    public static final String EKS_POD_IPV4_CIDR_KEY = RESERVED_PREFIX + "eks-pod-ipv4-cidr";
 
     /**
      * API Gateway accepted a custom id through this key before {@link #OVERRIDE_ID_KEY} existed. It is

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilder.java
@@ -117,6 +117,7 @@ public class ContainerBuilder {
         private final Map<Integer, Integer> portBindings = new HashMap<>();
         private final List<Integer> exposedPorts = new ArrayList<>();
         private String networkMode;
+        private String networkIpv4Address;
         private final List<Mount> mounts = new ArrayList<>();
         private final List<Bind> binds = new ArrayList<>();
         private final List<String> extraHosts = new ArrayList<>();
@@ -241,6 +242,16 @@ public class ContainerBuilder {
          */
         public Builder withNetworkMode(String networkMode) {
             this.networkMode = networkMode;
+            return this;
+        }
+
+        /**
+         * Requests this container's static IPv4 address on its resolved Docker network.
+         * The lifecycle manager attaches port-bound containers before start so Docker preserves
+         * host-port publishing on Docker Desktop.
+         */
+        public Builder withNetworkIpv4Address(String networkIpv4Address) {
+            this.networkIpv4Address = networkIpv4Address;
             return this;
         }
 
@@ -442,6 +453,7 @@ public class ContainerBuilder {
                     Map.copyOf(portBindings),
                     List.copyOf(exposedPorts),
                     networkMode,
+                    networkIpv4Address,
                     List.copyOf(mounts),
                     List.copyOf(binds),
                     List.copyOf(extraHosts),

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManager.java
@@ -151,24 +151,43 @@ public class ContainerLifecycleManager {
      * @return information about the running container including resolved endpoints
      */
     public ContainerInfo startCreated(String containerId, ContainerSpec spec) {
+        if (spec.hasNetworkIpv4Address()) {
+            connectToNetwork(containerId, spec, true);
+        }
         startContainer(containerId);
         LOG.infov("Started container {0}", containerId);
 
-        if (spec.networkMode() != null && !spec.networkMode().isBlank() && spec.hasPortBindings()) {
-            try {
-                dockerClient.connectToNetworkCmd()
-                        .withContainerId(containerId)
-                        .withNetworkId(spec.networkMode())
-                        .exec();
-                LOG.debugv("Connected container {0} to network {1}", containerId, spec.networkMode());
-            } catch (Exception e) {
-                LOG.warnv("Could not connect container {0} to network {1}: {2}",
-                        containerId, spec.networkMode(), e.getMessage());
-            }
+        if (!spec.hasNetworkIpv4Address() && spec.networkMode() != null && !spec.networkMode().isBlank()
+                && spec.hasPortBindings()) {
+            connectToNetwork(containerId, spec, false);
         }
 
         Map<Integer, EndpointInfo> endpoints = resolveEndpoints(containerId, spec);
         return new ContainerInfo(containerId, endpoints);
+    }
+
+    private void connectToNetwork(String containerId, ContainerSpec spec, boolean required) {
+        if (spec.networkMode() == null || spec.networkMode().isBlank()) {
+            throw new IllegalArgumentException("A static network IPv4 address requires a Docker network");
+        }
+        try {
+            var command = dockerClient.connectToNetworkCmd()
+                    .withContainerId(containerId)
+                    .withNetworkId(spec.networkMode());
+            if (spec.hasNetworkIpv4Address()) {
+                command.withContainerNetwork(new ContainerNetwork().withIpamConfig(
+                        new ContainerNetwork.Ipam().withIpv4Address(spec.networkIpv4Address())));
+            }
+            command.exec();
+            LOG.debugv("Connected container {0} to network {1}", containerId, spec.networkMode());
+        } catch (Exception e) {
+            if (required) {
+                throw new IllegalStateException("Could not assign static IPv4 address "
+                        + spec.networkIpv4Address() + " on Docker network " + spec.networkMode(), e);
+            }
+            LOG.warnv("Could not connect container {0} to network {1}: {2}",
+                    containerId, spec.networkMode(), e.getMessage());
+        }
     }
 
     /**
@@ -817,7 +836,8 @@ public class ContainerLifecycleManager {
         // withNetworkMode() + port bindings suppresses port publishing on macOS Docker Desktop,
         // so containers with port bindings (e.g. ECR registry) connect to the network
         // after start via connectToNetworkCmd() instead.
-        if (spec.networkMode() != null && !spec.networkMode().isBlank() && !spec.hasPortBindings()) {
+        if (spec.networkMode() != null && !spec.networkMode().isBlank() && !spec.hasPortBindings()
+                && !spec.hasNetworkIpv4Address()) {
             hostConfig.withNetworkMode(spec.networkMode());
         }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/docker/ContainerSpec.java
@@ -20,6 +20,7 @@ import java.util.Map;
  * @param portBindings Map of container port to host port (0 = dynamic allocation)
  * @param exposedPorts Ports to expose (required for port bindings)
  * @param networkMode Docker network name or mode (null = default bridge)
+ * @param networkIpv4Address Static IPv4 address on networkMode (null = Docker-assigned)
  * @param mounts Volume mounts (named volumes, bind mounts, tmpfs)
  * @param binds Legacy bind mounts (prefer mounts for new code)
  * @param extraHosts Extra /etc/hosts entries as "hostname:ip" strings
@@ -42,6 +43,7 @@ public record ContainerSpec(
         Map<Integer, Integer> portBindings,
         List<Integer> exposedPorts,
         String networkMode,
+        String networkIpv4Address,
         List<Mount> mounts,
         List<Bind> binds,
         List<String> extraHosts,
@@ -59,7 +61,7 @@ public record ContainerSpec(
      * All other fields will be null or empty lists.
      */
     public ContainerSpec(String image) {
-        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(), null, null, List.of());
+        this(image, null, List.of(), null, null, null, Map.of(), List.of(), null, null, List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(), null, null, List.of());
     }
 
     /**
@@ -67,6 +69,11 @@ public record ContainerSpec(
      */
     public boolean hasPortBindings() {
         return portBindings != null && !portBindings.isEmpty();
+    }
+
+    /** Returns true if the container must receive a static IPv4 address on its Docker network. */
+    public boolean hasNetworkIpv4Address() {
+        return networkIpv4Address != null && !networkIpv4Address.isBlank();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksClusterManager.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.eks;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsRegions;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
@@ -14,6 +15,7 @@ import io.github.hectorvent.floci.core.common.docker.PortAllocator;
 import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.eks.model.CertificateAuthority;
 import io.github.hectorvent.floci.services.eks.model.Cluster;
+import io.github.hectorvent.floci.services.eks.model.EksClusterRuntimeConfig;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.model.Frame;
@@ -88,7 +90,12 @@ public class EksClusterManager {
      * {@link #isReady(Cluster)} returns true and {@link #finalizeCluster(Cluster)} is called.
      */
     public void startCluster(Cluster cluster) {
-        String image = config.services().eks().defaultImage();
+        EksClusterRuntimeConfig runtimeConfig = cluster.getRuntimeConfig() != null
+                ? cluster.getRuntimeConfig()
+                : new EksClusterRuntimeConfig();
+        String image = runtimeConfig.getImage() != null
+                ? runtimeConfig.getImage()
+                : config.services().eks().defaultImage();
         if (cluster.getDockerName() == null) {
             cluster.setDockerName(accountQualifiedName(cluster));
         }
@@ -118,7 +125,12 @@ public class EksClusterManager {
         // filesystem, so chmod works correctly and data persists across container restarts.
         String volumeName = cluster.getDockerName();
 
-        List<String> serverArgs = buildServerArgs(config.services().eks().disableCni());
+        String serviceIpv4Cidr = cluster.getKubernetesNetworkConfig() != null
+                && cluster.getKubernetesNetworkConfig().getServiceIpv4Cidr() != null
+                ? cluster.getKubernetesNetworkConfig().getServiceIpv4Cidr()
+                : EksService.DEFAULT_SERVICE_IPV4_CIDR;
+        List<String> serverArgs = buildServerArgs(config.services().eks().disableCni(), runtimeConfig,
+                serviceIpv4Cidr);
 
         // The account label comes from the cluster record when set (restore runs with no request
         // context); regionResolver is the fallback for the create path.
@@ -135,6 +147,9 @@ public class EksClusterManager {
                 .withLogRotation()
                 .withLabels(ContainerStorageHelper.resourceIdentityLabels(
                         "eks", cluster.getName(), labelAccountId, regionResolver.getDefaultRegion()));
+        if (runtimeConfig.getNodeIpv4Address() != null) {
+            specBuilder.withNetworkIpv4Address(runtimeConfig.getNodeIpv4Address());
+        }
 
         // Wire a token-authentication webhook so `aws eks get-token` bearer tokens are validated by
         // Floci and mapped to cluster-admin. The k3s API server POSTs a TokenReview to Floci's
@@ -168,17 +183,26 @@ public class EksClusterManager {
             specBuilder.withCmd(serverArgs);
         }
         ContainerSpec spec = specBuilder.build();
+        if (runtimeConfig.getNodeIpv4Address() != null && !supportsStaticAddress(spec.networkMode())) {
+            throw new IllegalStateException(ReservedTags.EKS_NODE_IPV4_ADDRESS_KEY
+                    + " requires a user-defined Docker network");
+        }
 
         // create -> inject webhook kubeconfig -> start, so the file exists before the API server boots.
         String containerId = lifecycleManager.create(spec);
         cluster.setContainerId(containerId);
-        if (webhookLocalFile != null) {
-            copyWebhookIntoContainer(containerId, webhookLocalFile, cluster.getName());
-        }
-        injectEcrRegistryMirror(containerId, cluster.getName());
-        ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+        try {
+            if (webhookLocalFile != null) {
+                copyWebhookIntoContainer(containerId, webhookLocalFile, cluster.getName());
+            }
+            injectEcrRegistryMirror(containerId, cluster.getName());
+            ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
 
-        applyEndpoints(cluster, containerName, hostPort, info);
+            applyEndpoints(cluster, containerName, hostPort, info);
+        } catch (RuntimeException e) {
+            lifecycleManager.removeIfExists(containerId);
+            throw e;
+        }
 
         LOG.infov("k3s container {0} started for cluster {1} on port {2} (internal: {3})",
                 containerId, cluster.getName(), String.valueOf(hostPort), cluster.getInternalEndpoint());
@@ -446,6 +470,24 @@ public class EksClusterManager {
             serverArgs.add("--disable-kube-proxy");
         }
         return serverArgs;
+    }
+
+    static List<String> buildServerArgs(boolean disableCni, EksClusterRuntimeConfig runtimeConfig,
+                                        String serviceIpv4Cidr) {
+        List<String> serverArgs = buildServerArgs(disableCni);
+        serverArgs.add("--service-cidr=" + serviceIpv4Cidr);
+        serverArgs.add("--cluster-cidr=" + EksRuntimeConfig.podIpv4Cidr(runtimeConfig));
+        if (runtimeConfig.getNodeIpv4Address() != null) {
+            serverArgs.add("--node-ip=" + runtimeConfig.getNodeIpv4Address());
+        }
+        return serverArgs;
+    }
+
+    private static boolean supportsStaticAddress(String networkMode) {
+        return networkMode != null && !networkMode.isBlank()
+                && !"bridge".equals(networkMode)
+                && !"host".equals(networkMode)
+                && !"none".equals(networkMode);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksRuntimeConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksRuntimeConfig.java
@@ -1,0 +1,168 @@
+package io.github.hectorvent.floci.services.eks;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.ReservedTags;
+import io.github.hectorvent.floci.services.eks.model.EksClusterRuntimeConfig;
+import io.github.hectorvent.floci.services.eks.model.KubernetesNetworkConfig;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Resolves Floci's input-only EKS runtime tags and validates the k3s network contract.
+ * EksService consumes this at creation and EksClusterManager uses the persisted result at runtime.
+ */
+final class EksRuntimeConfig {
+
+    private static final String DEFAULT_POD_IPV4_CIDR = "10.42.0.0/16";
+
+    private static final Set<String> SUPPORTED_TAGS = Set.of(
+            ReservedTags.EKS_IMAGE_KEY,
+            ReservedTags.EKS_NODE_IPV4_ADDRESS_KEY,
+            ReservedTags.EKS_POD_IPV4_CIDR_KEY);
+
+    private EksRuntimeConfig() {
+    }
+
+    static EksClusterRuntimeConfig fromCreateTags(Map<String, String> tags) {
+        rejectUnknownReservedTags(tags);
+        return new EksClusterRuntimeConfig(
+                tagValue(tags, ReservedTags.EKS_IMAGE_KEY),
+                tagValue(tags, ReservedTags.EKS_NODE_IPV4_ADDRESS_KEY),
+                tagValue(tags, ReservedTags.EKS_POD_IPV4_CIDR_KEY));
+    }
+
+    static void validate(EksClusterRuntimeConfig runtime, KubernetesNetworkConfig networkConfig) {
+        if (networkConfig == null) {
+            throw invalid("kubernetesNetworkConfig is required");
+        }
+        if (networkConfig.getIpFamily() != null && !"ipv4".equals(networkConfig.getIpFamily())) {
+            throw invalid("kubernetesNetworkConfig.ipFamily must be ipv4");
+        }
+
+        String serviceCidr = networkConfig.getServiceIpv4Cidr();
+        Ipv4Cidr service = Ipv4Cidr.parse("kubernetesNetworkConfig.serviceIpv4Cidr", serviceCidr);
+        String podCidr = podIpv4Cidr(runtime);
+        Ipv4Cidr pod = Ipv4Cidr.parse(ReservedTags.EKS_POD_IPV4_CIDR_KEY, podCidr);
+        if (service.overlaps(pod)) {
+            throw invalid("kubernetesNetworkConfig.serviceIpv4Cidr must not overlap "
+                    + ReservedTags.EKS_POD_IPV4_CIDR_KEY);
+        }
+
+        if (runtime.getNodeIpv4Address() != null) {
+            long nodeAddress = parseIpv4Address(ReservedTags.EKS_NODE_IPV4_ADDRESS_KEY,
+                    runtime.getNodeIpv4Address());
+            if (service.contains(nodeAddress) || pod.contains(nodeAddress)) {
+                throw invalid(ReservedTags.EKS_NODE_IPV4_ADDRESS_KEY
+                        + " must not be in the service or pod CIDR");
+            }
+        }
+    }
+
+    private static void rejectUnknownReservedTags(Map<String, String> tags) {
+        if (tags == null) {
+            return;
+        }
+        for (String key : tags.keySet()) {
+            if (key != null && key.startsWith(ReservedTags.RESERVED_PREFIX)
+                    && !SUPPORTED_TAGS.contains(key)) {
+                throw invalid(key + " is an unknown Reserved Tag.");
+            }
+        }
+    }
+
+    static String podIpv4Cidr(EksClusterRuntimeConfig runtime) {
+        return runtime.getPodIpv4Cidr() != null
+                ? runtime.getPodIpv4Cidr()
+                : DEFAULT_POD_IPV4_CIDR;
+    }
+
+    private static String tagValue(Map<String, String> tags, String key) {
+        if (tags == null || !tags.containsKey(key)) {
+            return null;
+        }
+        String value = tags.get(key);
+        if (value == null || value.isBlank()) {
+            throw invalid(key + " must not be blank");
+        }
+        if (!value.equals(value.trim()) || value.chars().anyMatch(Character::isWhitespace)) {
+            throw invalid(key + " must not contain whitespace");
+        }
+        return value;
+    }
+
+    private static AwsException invalid(String message) {
+        return new AwsException("InvalidParameterException", message, 400);
+    }
+
+    private static long parseIpv4Address(String field, String value) {
+        if (value == null) {
+            throw invalid(field + " must be an IPv4 address");
+        }
+        String[] octets = value.split("\\.", -1);
+        if (octets.length != 4) {
+            throw invalid(field + " must be an IPv4 address");
+        }
+        long address = 0;
+        for (String octet : octets) {
+            if (octet.isEmpty() || !octet.chars().allMatch(Character::isDigit)) {
+                throw invalid(field + " must be an IPv4 address");
+            }
+            int number;
+            try {
+                number = Integer.parseInt(octet);
+            } catch (NumberFormatException e) {
+                throw invalid(field + " must be an IPv4 address");
+            }
+            if (number > 255) {
+                throw invalid(field + " must be an IPv4 address");
+            }
+            address = (address << 8) | number;
+        }
+        return address;
+    }
+
+    private record Ipv4Cidr(long networkAddress, int prefixLength) {
+
+        static Ipv4Cidr parse(String field, String value) {
+            if (value == null) {
+                throw invalid(field + " must be an IPv4 CIDR");
+            }
+            String[] parts = value.split("/", -1);
+            if (parts.length != 2) {
+                throw invalid(field + " must be an IPv4 CIDR");
+            }
+            long address = parseIpv4Address(field, parts[0]);
+            int prefixLength;
+            try {
+                prefixLength = Integer.parseInt(parts[1]);
+            } catch (NumberFormatException e) {
+                throw invalid(field + " must be an IPv4 CIDR");
+            }
+            if (prefixLength < 0 || prefixLength > 32) {
+                throw invalid(field + " must be an IPv4 CIDR");
+            }
+            long mask = mask(prefixLength);
+            if ((address & mask) != address) {
+                throw invalid(field + " must use its network address");
+            }
+            return new Ipv4Cidr(address, prefixLength);
+        }
+
+        boolean overlaps(Ipv4Cidr other) {
+            long sharedMask = mask(Math.min(prefixLength, other.prefixLength));
+            return (networkAddress & sharedMask) == (other.networkAddress & sharedMask);
+        }
+
+        boolean contains(long address) {
+            return (address & mask(prefixLength)) == networkAddress;
+        }
+
+        private static long mask(int prefixLength) {
+            if (prefixLength == 0) {
+                return 0;
+            }
+            return (0xffffffffL << (32 - prefixLength)) & 0xffffffffL;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/EksService.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.ReservedTags;
 import io.github.hectorvent.floci.core.common.TagHandler;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -17,6 +18,7 @@ import io.github.hectorvent.floci.services.eks.model.OidcIdentity;
 import io.github.hectorvent.floci.services.eks.model.CreateClusterRequest;
 import io.github.hectorvent.floci.services.eks.model.CreateFargateProfileRequest;
 import io.github.hectorvent.floci.services.eks.model.CreateNodeGroupRequest;
+import io.github.hectorvent.floci.services.eks.model.EksClusterRuntimeConfig;
 import io.github.hectorvent.floci.services.eks.model.FargateProfile;
 import io.github.hectorvent.floci.services.eks.model.FargateProfileStatus;
 import io.github.hectorvent.floci.services.eks.model.KubernetesNetworkConfig;
@@ -55,8 +57,10 @@ public class EksService implements TagHandler, ResourceProvider {
     /** The AWS charset for EKS cluster names. It admits no dot, which the Docker-name account
      *  qualifier relies on — see EksClusterManager#accountQualifiedName. */
     static final String CLUSTER_NAME_REGEX = "[0-9A-Za-z][A-Za-z0-9\\-_]*";
+    static final String DEFAULT_SERVICE_IPV4_CIDR = "10.100.0.0/16";
 
     private final StorageBackend<String, Cluster> storage;
+    private final StorageBackend<String, EksClusterRuntimeConfig> runtimeConfigStorage;
     private final StorageBackend<String, Nodegroup> nodeGroupStorage;
     private final StorageBackend<String, FargateProfile> fargateProfileStorage;
     private final EmulatorConfig config;
@@ -72,6 +76,9 @@ public class EksService implements TagHandler, ResourceProvider {
             EksOidcService oidcService) {
         this.storage = storageFactory.create("eks", "eks-clusters.json",
                 new TypeReference<Map<String, Cluster>>() {
+                });
+        this.runtimeConfigStorage = storageFactory.create("eks", "eks-runtime-configs.json",
+                new TypeReference<Map<String, EksClusterRuntimeConfig>>() {
                 });
         this.nodeGroupStorage = storageFactory.create("eks", "eks-nodegroups.json",
                 new TypeReference<Map<String, Nodegroup>>() {
@@ -119,6 +126,7 @@ public class EksService implements TagHandler, ResourceProvider {
             if (cluster.getAccountId() == null) {
                 cluster.setAccountId(entry.accountId());
             }
+            cluster.setRuntimeConfig(runtimeConfigForAccount(entry.accountId(), cluster.getName()));
             // A persisted name that predates create-time validation may violate the AWS charset —
             // in particular contain a dot, which could spell out another account's qualified
             // Docker name and cross-bind its container. Such a record is never restored; the
@@ -154,6 +162,13 @@ public class EksService implements TagHandler, ResourceProvider {
                         cluster.getAccountId() != null ? cluster.getAccountId() : regionResolver.getAccountId(),
                         cluster.getName(), cluster))
                 .toList();
+    }
+
+    private EksClusterRuntimeConfig runtimeConfigForAccount(String accountId, String clusterName) {
+        if (runtimeConfigStorage instanceof AccountAwareStorageBackend<EksClusterRuntimeConfig> aware) {
+            return aware.getForAccount(accountId, clusterName).orElseGet(EksClusterRuntimeConfig::new);
+        }
+        return runtimeConfigStorage.get(clusterName).orElseGet(EksClusterRuntimeConfig::new);
     }
 
     /**
@@ -242,7 +257,10 @@ public class EksService implements TagHandler, ResourceProvider {
         cluster.setResourcesVpcConfig(buildVpcConfigResponse(request.getResourcesVpcConfig(), resolvedVpcId));
         cluster.setKubernetesNetworkConfig(buildNetworkConfig(request.getKubernetesNetworkConfig()));
         cluster.setStatus(ClusterStatus.CREATING);
-        cluster.setTags(request.getTags() != null ? new HashMap<>(request.getTags()) : new HashMap<>());
+        EksClusterRuntimeConfig runtimeConfig = EksRuntimeConfig.fromCreateTags(request.getTags());
+        EksRuntimeConfig.validate(runtimeConfig, cluster.getKubernetesNetworkConfig());
+        cluster.setRuntimeConfig(runtimeConfig);
+        cluster.setTags(ReservedTags.stripReservedTags(request.getTags()));
         cluster.setPlatformVersion("eks.1");
         cluster.setCertificateAuthority(new CertificateAuthority(""));
 
@@ -263,6 +281,7 @@ public class EksService implements TagHandler, ResourceProvider {
         }
 
         storage.put(name, cluster);
+        runtimeConfigStorage.put(name, runtimeConfig);
         return cluster;
     }
 
@@ -288,6 +307,7 @@ public class EksService implements TagHandler, ResourceProvider {
             clusterManager.stopCluster(cluster);
         }
         storage.delete(name);
+        runtimeConfigStorage.delete(name);
         oidcService.deleteKey(name);
         return cluster;
     }
@@ -459,6 +479,7 @@ public class EksService implements TagHandler, ResourceProvider {
 
     @Override
     public void tagResource(String region, String resourceArn, Map<String, String> tags) {
+        ReservedTags.rejectReservedTagsOnUpdate(tags);
         String clusterName = extractClusterName(resourceArn);
         Cluster cluster = storage.get(clusterName)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
@@ -572,10 +593,12 @@ public class EksService implements TagHandler, ResourceProvider {
     private KubernetesNetworkConfig buildNetworkConfig(KubernetesNetworkConfig request) {
         KubernetesNetworkConfig config = new KubernetesNetworkConfig();
         if (request != null) {
-            config.setServiceIpv4Cidr(request.getServiceIpv4Cidr() != null ? request.getServiceIpv4Cidr() : "10.100.0.0/16");
+            config.setServiceIpv4Cidr(request.getServiceIpv4Cidr() != null
+                    ? request.getServiceIpv4Cidr()
+                    : DEFAULT_SERVICE_IPV4_CIDR);
             config.setIpFamily(request.getIpFamily() != null ? request.getIpFamily() : "ipv4");
         } else {
-            config.setServiceIpv4Cidr("10.100.0.0/16");
+            config.setServiceIpv4Cidr(DEFAULT_SERVICE_IPV4_CIDR);
             config.setIpFamily("ipv4");
         }
         return config;

--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/Cluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/Cluster.java
@@ -66,6 +66,13 @@ public class Cluster {
     private int hostPort;
 
     /**
+     * Floci-only runtime settings. Persisted by EksService's companion store rather than this
+     * AWS response model, which is serialized directly by DescribeCluster.
+     */
+    @JsonIgnore
+    private EksClusterRuntimeConfig runtimeConfig;
+
+    /**
      * Resolved Docker container/volume name for this cluster's k3s resources. In-memory only
      * (never part of the AWS response shape): assigned when the container is started, or
      * re-resolved deterministically from surviving Docker resources on restore.
@@ -125,6 +132,9 @@ public class Cluster {
 
     public int getHostPort() { return hostPort; }
     public void setHostPort(int hostPort) { this.hostPort = hostPort; }
+
+    public EksClusterRuntimeConfig getRuntimeConfig() { return runtimeConfig; }
+    public void setRuntimeConfig(EksClusterRuntimeConfig runtimeConfig) { this.runtimeConfig = runtimeConfig; }
 
     public String getDockerName() { return dockerName; }
     public void setDockerName(String dockerName) { this.dockerName = dockerName; }

--- a/src/main/java/io/github/hectorvent/floci/services/eks/model/EksClusterRuntimeConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eks/model/EksClusterRuntimeConfig.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.eks.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * Floci-only runtime settings for one EKS cluster, persisted separately from the AWS response
+ * model so a DescribeCluster response remains AWS-shaped.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class EksClusterRuntimeConfig {
+
+    @JsonProperty("image")
+    private String image;
+
+    @JsonProperty("nodeIpv4Address")
+    private String nodeIpv4Address;
+
+    @JsonProperty("podIpv4Cidr")
+    private String podIpv4Cidr;
+
+    public EksClusterRuntimeConfig() {
+    }
+
+    public EksClusterRuntimeConfig(String image, String nodeIpv4Address, String podIpv4Cidr) {
+        this.image = image;
+        this.nodeIpv4Address = nodeIpv4Address;
+        this.podIpv4Cidr = podIpv4Cidr;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getNodeIpv4Address() {
+        return nodeIpv4Address;
+    }
+
+    public void setNodeIpv4Address(String nodeIpv4Address) {
+        this.nodeIpv4Address = nodeIpv4Address;
+    }
+
+    public String getPodIpv4Cidr() {
+        return podIpv4Cidr;
+    }
+
+    public void setPodIpv4Cidr(String podIpv4Cidr) {
+        this.podIpv4Cidr = podIpv4Cidr;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerBuilderTest.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,6 +50,20 @@ class ContainerBuilderTest {
                 .build();
 
         assertEquals("avoxx-network", spec.networkMode());
+    }
+
+    @Test
+    void withNetworkIpv4AddressRecordsStaticDockerAddress() {
+        TestFixture fixture = new TestFixture();
+
+        ContainerSpec spec = fixture.builder.newContainer("alpine")
+                .withDockerNetwork(Optional.of("test-network"))
+                .withNetworkIpv4Address("172.20.0.20")
+                .build();
+
+        assertEquals("test-network", spec.networkMode());
+        assertEquals("172.20.0.20", spec.networkIpv4Address());
+        assertTrue(spec.hasNetworkIpv4Address());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerLabelsTest.java
@@ -164,7 +164,7 @@ class ContainerLifecycleManagerLabelsTest {
     private static ContainerSpec specWithLabels(Map<String, String> labels) {
         return new ContainerSpec(
                 "busybox:stable", null, List.of(), null, null, null, Map.of(), List.of(), null,
-                List.of(), List.of(), List.of(), labels, null, false, null, List.of(), null,
+                null, List.of(), List.of(), List.of(), labels, null, false, null, List.of(), null,
                 null, List.of());
     }
 

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerStartFailureTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerLifecycleManagerStartFailureTest.java
@@ -1,25 +1,31 @@
 package io.github.hectorvent.floci.core.common.docker;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ConnectToNetworkCmd;
 import com.github.dockerjava.api.command.RemoveContainerCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.model.ContainerNetwork;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.lambda.launcher.ImageCacheService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -120,5 +126,28 @@ class ContainerLifecycleManagerStartFailureTest {
                 () -> manager.startCreated("container-id", spec));
 
         assertSame(portConflict, thrown, "unrelated Docker errors must propagate unchanged");
+    }
+
+    @Test
+    void startCreatedAssignsTheStaticAddressBeforeStartingTheContainer() {
+        ContainerSpec staticNetworkSpec = new ContainerSpec(
+                "busybox:latest", null, List.of(), null, null, null, Map.of(), List.of(),
+                "test-network", "172.20.0.20", List.of(), List.of(), List.of(), Map.of(),
+                null, false, null, List.of(), null, null, List.of());
+        ConnectToNetworkCmd connectCmd = mock(ConnectToNetworkCmd.class, org.mockito.Mockito.RETURNS_SELF);
+        StartContainerCmd startCmd = mock(StartContainerCmd.class);
+        when(dockerClient.connectToNetworkCmd()).thenReturn(connectCmd);
+        when(dockerClient.startContainerCmd("container-id")).thenReturn(startCmd);
+
+        manager.startCreated("container-id", staticNetworkSpec);
+
+        ArgumentCaptor<ContainerNetwork> network = ArgumentCaptor.forClass(ContainerNetwork.class);
+        verify(connectCmd).withContainerId("container-id");
+        verify(connectCmd).withNetworkId("test-network");
+        verify(connectCmd).withContainerNetwork(network.capture());
+        assertEquals("172.20.0.20", network.getValue().getIpamConfig().getIpv4Address());
+        var order = inOrder(connectCmd, startCmd);
+        order.verify(connectCmd).exec();
+        order.verify(startCmd).exec();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksClusterManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksClusterManagerTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.common.docker.PortAllocator;
 import io.github.hectorvent.floci.services.ecr.registry.EcrRegistryManager;
 import io.github.hectorvent.floci.services.eks.model.Cluster;
+import io.github.hectorvent.floci.services.eks.model.EksClusterRuntimeConfig;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -141,6 +142,18 @@ class EksClusterManagerTest {
     }
 
     @Test
+    void serverArgsApplyThePerClusterRuntimeNetwork() {
+        EksClusterRuntimeConfig runtime = new EksClusterRuntimeConfig(
+                "registry.example.test/k3s:v1.34.0", "172.20.0.20", "10.244.0.0/16");
+
+        List<String> args = EksClusterManager.buildServerArgs(false, runtime, "10.100.0.0/16");
+
+        assertTrue(args.contains("--service-cidr=10.100.0.0/16"));
+        assertTrue(args.contains("--cluster-cidr=10.244.0.0/16"));
+        assertTrue(args.contains("--node-ip=172.20.0.20"));
+    }
+
+    @Test
     void rshareEntrypointIsPosixShCompatible() {
         String script = EksClusterManager.RSHARE_ENTRYPOINT.get(2);
 
@@ -171,7 +184,7 @@ class EksClusterManagerTest {
     }
 
     @Test
-    void startClusterLabelsContainerWithResourceIdentity() {
+    void startClusterAppliesRuntimeConfigAndResourceIdentityLabels() {
         EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig services = Mockito.mock(EmulatorConfig.ServicesConfig.class);
         EmulatorConfig.EksServiceConfig eks = Mockito.mock(EmulatorConfig.EksServiceConfig.class);
@@ -193,7 +206,9 @@ class EksClusterManagerTest {
         ContainerBuilder containerBuilder = Mockito.mock(ContainerBuilder.class);
         ContainerBuilder.Builder builder = Mockito.mock(ContainerBuilder.Builder.class, Mockito.RETURNS_SELF);
         when(containerBuilder.newContainer(anyString())).thenReturn(builder);
-        when(builder.build()).thenReturn(Mockito.mock(ContainerSpec.class));
+        ContainerSpec spec = Mockito.mock(ContainerSpec.class);
+        when(spec.networkMode()).thenReturn("test-network");
+        when(builder.build()).thenReturn(spec);
 
         RegionResolver regionResolver = Mockito.mock(RegionResolver.class);
         when(regionResolver.getAccountId()).thenReturn("000000000000");
@@ -206,9 +221,13 @@ class EksClusterManagerTest {
 
         Cluster cluster = new Cluster();
         cluster.setName("my-cluster");
+        cluster.setRuntimeConfig(new EksClusterRuntimeConfig(
+                "registry.example.test/k3s:v1.34.0", "172.20.0.20", "10.244.0.0/16"));
 
         manager.startCluster(cluster);
 
+        verify(containerBuilder).newContainer("registry.example.test/k3s:v1.34.0");
+        verify(builder).withNetworkIpv4Address("172.20.0.20");
         verify(builder).withLabels(Map.of(
                 "io.floci", "aws",
                 "io.floci.service", "eks",

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksRuntimeConfigTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksRuntimeConfigTest.java
@@ -1,0 +1,72 @@
+package io.github.hectorvent.floci.services.eks;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.ReservedTags;
+import io.github.hectorvent.floci.services.eks.model.EksClusterRuntimeConfig;
+import io.github.hectorvent.floci.services.eks.model.KubernetesNetworkConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EksRuntimeConfigTest {
+
+    @Test
+    void resolvesOnlyTheSupportedCreateTags() {
+        EksClusterRuntimeConfig runtime = EksRuntimeConfig.fromCreateTags(Map.of(
+                ReservedTags.EKS_IMAGE_KEY, "registry.example.test/k3s:v1.34.0",
+                ReservedTags.EKS_NODE_IPV4_ADDRESS_KEY, "172.20.0.20",
+                ReservedTags.EKS_POD_IPV4_CIDR_KEY, "10.244.0.0/16"));
+
+        assertEquals("registry.example.test/k3s:v1.34.0", runtime.getImage());
+        assertEquals("172.20.0.20", runtime.getNodeIpv4Address());
+        assertEquals("10.244.0.0/16", runtime.getPodIpv4Cidr());
+    }
+
+    @Test
+    void preservesGlobalDefaultsWhenNoRuntimeTagsAreSet() {
+        EksClusterRuntimeConfig runtime = EksRuntimeConfig.fromCreateTags(Map.of("team", "platform"));
+
+        assertNull(runtime.getImage());
+        assertNull(runtime.getNodeIpv4Address());
+        assertNull(runtime.getPodIpv4Cidr());
+    }
+
+    @Test
+    void rejectsReservedTagsOwnedByOtherServices() {
+        AwsException exception = assertThrows(AwsException.class,
+                () -> EksRuntimeConfig.fromCreateTags(Map.of(ReservedTags.OVERRIDE_ID_KEY, "not-eks")));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsOverlappingServiceAndPodNetworks() {
+        EksClusterRuntimeConfig runtime = new EksClusterRuntimeConfig(null, null, "10.100.1.0/24");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> EksRuntimeConfig.validate(runtime, network("10.100.0.0/16")));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    @Test
+    void rejectsAStaticNodeAddressInsideTheKubernetesNetworks() {
+        EksClusterRuntimeConfig runtime = new EksClusterRuntimeConfig(null, "10.244.0.20", "10.244.0.0/16");
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> EksRuntimeConfig.validate(runtime, network("10.100.0.0/16")));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+    }
+
+    private static KubernetesNetworkConfig network(String serviceIpv4Cidr) {
+        KubernetesNetworkConfig network = new KubernetesNetworkConfig();
+        network.setIpFamily("ipv4");
+        network.setServiceIpv4Cidr(serviceIpv4Cidr);
+        return network;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eks/EksServiceTest.java
@@ -24,6 +24,8 @@ import io.github.hectorvent.floci.services.eks.model.CreateNodeGroupRequest;
 import io.github.hectorvent.floci.services.eks.model.FargateProfile;
 import io.github.hectorvent.floci.services.eks.model.FargateProfileStatus;
 import io.github.hectorvent.floci.services.eks.model.Cluster;
+import io.github.hectorvent.floci.services.eks.model.EksClusterRuntimeConfig;
+import io.github.hectorvent.floci.services.eks.model.KubernetesNetworkConfig;
 import io.github.hectorvent.floci.services.eks.model.Nodegroup;
 import io.github.hectorvent.floci.services.eks.model.NodegroupScalingConfig;
 import io.github.hectorvent.floci.services.eks.model.NodegroupStatus;
@@ -430,15 +432,36 @@ class EksServiceTest {
 
     @SuppressWarnings("unchecked")
     private StorageFactory fixedStorageFactory(StorageBackend<String, ?> backend) {
+        AccountAwareStorageBackend<EksClusterRuntimeConfig> runtimeConfigs =
+                AccountAwareStorageBackend.inMemory("000000000000");
         return new StorageFactory(null, null) {
             @Override
             public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
+                if ("eks-runtime-configs.json".equals(fileName)) {
+                    return (AccountAwareStorageBackend<V>) runtimeConfigs;
+                }
                 if (backend instanceof AccountAwareStorageBackend<?> aware) {
                     return (AccountAwareStorageBackend<V>) aware;
                 }
                 return new AccountAwareStorageBackend<>(
                         (StorageBackend<String, V>) backend, null, "000000000000");
+            }
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private StorageFactory eksStorageFactory(AccountAwareStorageBackend<Cluster> clusters,
+            AccountAwareStorageBackend<EksClusterRuntimeConfig> runtimeConfigs) {
+        return new StorageFactory(null, null) {
+            @Override
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                return switch (fileName) {
+                    case "eks-clusters.json" -> (AccountAwareStorageBackend<V>) clusters;
+                    case "eks-runtime-configs.json" -> (AccountAwareStorageBackend<V>) runtimeConfigs;
+                    default -> AccountAwareStorageBackend.inMemory("000000000000");
+                };
             }
         };
     }
@@ -478,6 +501,88 @@ class EksServiceTest {
         createTestCluster("Valid-Name_123");
 
         assertTrue(eksService.listClusters().contains("Valid-Name_123"));
+    }
+
+    @Test
+    void createClusterConsumesRuntimeTagsWithoutExposingThemAsAwsTags() {
+        CreateClusterRequest request = new CreateClusterRequest();
+        request.setName("runtime-cluster");
+        request.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        request.setTags(Map.of(
+                "team", "platform",
+                "floci:eks-image", "registry.example.test/k3s:v1.34.0",
+                "floci:eks-node-ipv4-address", "172.20.0.20",
+                "floci:eks-pod-ipv4-cidr", "10.244.0.0/16"));
+        KubernetesNetworkConfig networkConfig = new KubernetesNetworkConfig();
+        networkConfig.setIpFamily("ipv4");
+        networkConfig.setServiceIpv4Cidr("10.100.0.0/16");
+        request.setKubernetesNetworkConfig(networkConfig);
+
+        Cluster cluster = eksService.createCluster(request);
+
+        assertEquals(Map.of("team", "platform"), cluster.getTags());
+        assertEquals("registry.example.test/k3s:v1.34.0", cluster.getRuntimeConfig().getImage());
+        assertEquals("172.20.0.20", cluster.getRuntimeConfig().getNodeIpv4Address());
+        assertEquals("10.244.0.0/16", cluster.getRuntimeConfig().getPodIpv4Cidr());
+        AwsException exception = assertThrows(AwsException.class,
+                () -> eksService.tagResource(cluster.getArn(), Map.of("floci:eks-image", "too-late")));
+        assertEquals("ValidationException", exception.getErrorCode());
+    }
+
+    @Test
+    void createClusterRejectsOverlappingRuntimeNetworks() {
+        CreateClusterRequest request = new CreateClusterRequest();
+        request.setName("overlapping-runtime-cluster");
+        request.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        request.setTags(Map.of("floci:eks-pod-ipv4-cidr", "10.100.1.0/24"));
+        KubernetesNetworkConfig networkConfig = new KubernetesNetworkConfig();
+        networkConfig.setIpFamily("ipv4");
+        networkConfig.setServiceIpv4Cidr("10.100.0.0/16");
+        request.setKubernetesNetworkConfig(networkConfig);
+
+        AwsException exception = assertThrows(AwsException.class,
+                () -> eksService.createCluster(request));
+
+        assertEquals("InvalidParameterException", exception.getErrorCode());
+        assertTrue(eksService.listClusters().isEmpty());
+    }
+
+    @Test
+    void initRestoresRuntimeConfigFromItsCompanionStore() {
+        AccountAwareStorageBackend<Cluster> clusters = AccountAwareStorageBackend.inMemory("000000000000");
+        AccountAwareStorageBackend<EksClusterRuntimeConfig> runtimeConfigs =
+                AccountAwareStorageBackend.inMemory("000000000000");
+        StorageFactory storageFactory = eksStorageFactory(clusters, runtimeConfigs);
+        EksOidcService oidcService = new EksOidcService(storageFactory, new ObjectMapper());
+        EksService created = new EksService(storageFactory, testConfig(),
+                new RegionResolver("us-east-1", "000000000000"), null, null, oidcService);
+        CreateClusterRequest request = new CreateClusterRequest();
+        request.setName("restored-runtime-cluster");
+        request.setRoleArn("arn:aws:iam::000000000000:role/eks-role");
+        request.setTags(Map.of(
+                "floci:eks-image", "registry.example.test/k3s:v1.34.0",
+                "floci:eks-node-ipv4-address", "172.20.0.20",
+                "floci:eks-pod-ipv4-cidr", "10.244.0.0/16"));
+
+        created.createCluster(request);
+        Cluster persisted = clusters.get("restored-runtime-cluster").orElseThrow();
+        persisted.setRuntimeConfig(null);
+        clusters.put("restored-runtime-cluster", persisted);
+
+        EksClusterManager clusterManager = mock(EksClusterManager.class);
+        EksService restarted = new EksService(storageFactory, testConfig(false),
+                new RegionResolver("us-east-1", "000000000000"), clusterManager, null, oidcService);
+        try {
+            restarted.init();
+
+            verify(clusterManager).restoreCluster(persisted);
+            assertEquals("registry.example.test/k3s:v1.34.0", persisted.getRuntimeConfig().getImage());
+            assertEquals("172.20.0.20", persisted.getRuntimeConfig().getNodeIpv4Address());
+            assertEquals("10.244.0.0/16", persisted.getRuntimeConfig().getPodIpv4Cidr());
+        } finally {
+            created.shutdown();
+            restarted.shutdown();
+        }
     }
 
     @Test


### PR DESCRIPTION
### Problem

Floci launches a k3s Docker container for each non-mock EKS cluster, but it uses global runtime settings and does not pass the requested Service CIDR to k3s. A local topology that needs a pinned image, static Docker address, or independent Pod network needs a cluster-specific runtime contract.

### Solution

Accept create-only `floci:` EKS tags through the standard `tags` map. Validate and persist the k3s image, static Docker-network IPv4 address, and Pod CIDR; configure k3s with `--node-ip`, `--cluster-cidr`, and the requested Service CIDR. Keep the inputs out of AWS-shaped cluster tags, restore them after restart, and preserve the global defaults for ordinary EKS callers.