### PR TITLE
fix(lambda): serialise the version snapshot against function updates

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -81,6 +81,15 @@ public class LambdaService implements ResourceProvider {
     private static final int MAX_HANDLER_LENGTH = 128;
     private static final List<String> FUNCTION_ARCHITECTURES = List.of("x86_64", "arm64");
 
+    /**
+     * Structure members {@code UpdateFunctionConfiguration} accepts. Shape-checked before the
+     * function lookup so a malformed member reports SerializationException rather than 404 (#3051),
+     * which is why the list is named here rather than left implicit in the extraction below.
+     */
+    private static final List<String> CONFIG_STRUCTURE_MEMBERS = List.of(
+            "Environment", "EphemeralStorage", "TracingConfig", "DeadLetterConfig",
+            "VpcConfig", "SnapStart", "LoggingConfig", "ImageConfig");
+
     private final LambdaFunctionStore functionStore;
     private final LambdaExecutorService executorService;
     private final LambdaConcurrencyLimiter concurrencyLimiter;
@@ -599,7 +608,20 @@ public class LambdaService implements ResourceProvider {
 
     public LambdaFunction updateFunctionCode(String region, String functionName, Map<String, Object> request) {
         LambdaFunction fn = getFunction(region, functionName);
-        functionName = fn.getFunctionName();
+        // publishVersion copies roughly thirty fields off this same live object. Without the
+        // updaters holding the lock it copies under, an update landing mid-copy yields a snapshot
+        // that is part old code and part new configuration, carrying a sourceRevisionId that
+        // identifies neither state (issue #3007). The monitor is reentrant and per function ARN, so
+        // the nested acquisitions further down, and publishVersion's own when Publish is set, are
+        // no-ops rather than a second lock.
+        synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
+            return updateFunctionCodeLocked(region, fn, request);
+        }
+    }
+
+    private LambdaFunction updateFunctionCodeLocked(String region, LambdaFunction fn,
+                                                    Map<String, Object> request) {
+        String functionName = fn.getFunctionName();
         List<String> architectures = validateArchitectures(request.get("Architectures"));
 
         String zipFileBase64 = (String) request.get("ZipFile");
@@ -642,6 +664,27 @@ public class LambdaService implements ResourceProvider {
     }
 
     public LambdaFunction updateFunctionConfiguration(String region, String functionName, Map<String, Object> request) {
+        // Shape-checked ahead of the lookup, which is where #3051 put these: a malformed member on
+        // a function that does not exist reports SerializationException, not 404. Splitting the
+        // mutation into a locked body below must not move them behind the lookup, so they stay
+        // here and the locked body re-reads them. structureMember is pure, so the second read
+        // cannot fail once these have passed.
+        for (String member : CONFIG_STRUCTURE_MEMBERS) {
+            structureMember(request, member);
+        }
+
+        LambdaFunction fn = getFunction(region, functionName);
+        // Same reason as updateFunctionCode: publishVersion's snapshot copy must not observe a
+        // half-applied configuration change (issue #3007).
+        synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
+            return updateFunctionConfigurationLocked(region, fn, request);
+        }
+    }
+
+    private LambdaFunction updateFunctionConfigurationLocked(String region, LambdaFunction fn,
+                                                             Map<String, Object> request) {
+        String functionName = fn.getFunctionName();
+        List<String> architectures = validateArchitectures(request.get("Architectures"));
         Map<String, Object> environment = structureMember(request, "Environment");
         Map<String, String> environmentVariables = environmentVariables(environment);
         Map<String, Object> ephemeralStorage = structureMember(request, "EphemeralStorage");
@@ -651,9 +694,6 @@ public class LambdaService implements ResourceProvider {
         Map<String, Object> snapStart = structureMember(request, "SnapStart");
         Map<String, Object> loggingConfig = structureMember(request, "LoggingConfig");
         Map<String, Object> imageConfig = structureMember(request, "ImageConfig");
-
-        LambdaFunction fn = getFunction(region, functionName);
-        List<String> architectures = validateArchitectures(request.get("Architectures"));
 
         // Validated before any field mutation below, not inline where Layers is applied further
         // down - fn is the live object backing this store entry (InMemoryStorage#get returns the
@@ -1948,9 +1988,10 @@ public class LambdaService implements ResourceProvider {
         // delete, persisting a snapshot.codeLocalPath (below) that names a directory about to
         // be removed as unreferenced.
         synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
-            // Inside the lock UpdateFunctionCode takes, so the hash cannot be checked against one
-            // version of $LATEST and the snapshot then taken from another. Checking it outside
-            // would let an overlapping deploy publish code the caller never authorised.
+            // Inside the lock UpdateFunctionCode and UpdateFunctionConfiguration now take, so the
+            // hash cannot be checked against one version of $LATEST and the snapshot then taken
+            // from another. Checking it outside would let an overlapping deploy publish code the
+            // caller never authorised.
             // No isBlank() exclusion here. A present but empty value was previously treated as
             // absent, so it skipped the comparison entirely and published without checking
             // anything, which is the failure this precondition exists to prevent. It is simply

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.HashSet;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1579,5 +1580,62 @@ class LambdaServiceTest {
             zos.closeEntry();
         }
         return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    @Test
+    void updateFunctionCodeWaitsForAConcurrentHolderOfTheFunctionsConcurrencyLock() throws Exception {
+        assertUpdaterWaitsForTheLock("update-code-lock-fn",
+                (service, name) -> service.updateFunctionCode(REGION, name,
+                        new HashMap<>(Map.of("ImageUri", "public.ecr.aws/x/y:1"))));
+    }
+
+    @Test
+    void updateFunctionConfigurationWaitsForAConcurrentHolderOfTheFunctionsConcurrencyLock() throws Exception {
+        assertUpdaterWaitsForTheLock("update-config-lock-fn",
+                (service, name) -> service.updateFunctionConfiguration(REGION, name,
+                        new HashMap<>(Map.of("Timeout", 42))));
+    }
+
+    /**
+     * publishVersion copies roughly thirty fields off the live function inside this lock. Neither
+     * updater used to take it, so nothing was serialised and a snapshot could be part old code and
+     * part new configuration (issue #3007). Proving each updater blocks on the lock closes that
+     * window regardless of the exact interleaving, rather than relying on timing to catch it.
+     */
+    private void assertUpdaterWaitsForTheLock(
+            String functionName,
+            java.util.function.BiFunction<LambdaService, String, LambdaFunction> updater) throws Exception {
+        LambdaFunction fn = service.createFunction(REGION, baseRequest(functionName));
+        Object lock = service.lockForConcurrencyOp(fn.getFunctionArn());
+
+        ExecutorService pool = Executors.newFixedThreadPool(1);
+        CountDownLatch acquired = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Thread holder = new Thread(() -> {
+            synchronized (lock) {
+                acquired.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        });
+        try {
+            holder.start();
+            assertTrue(acquired.await(2, java.util.concurrent.TimeUnit.SECONDS));
+
+            Future<LambdaFunction> updateFuture = pool.submit(() -> updater.apply(service, functionName));
+            assertThrows(java.util.concurrent.TimeoutException.class,
+                    () -> updateFuture.get(200, java.util.concurrent.TimeUnit.MILLISECONDS),
+                    "the updater must block while another operation holds this function's lock");
+
+            release.countDown();
+            holder.join();
+            assertNotNull(updateFuture.get(5, java.util.concurrent.TimeUnit.SECONDS));
+        } finally {
+            release.countDown();
+            pool.shutdownNow();
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaStructureSerializationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaStructureSerializationIntegrationTest.java
@@ -57,6 +57,24 @@ class LambdaStructureSerializationIntegrationTest {
     }
 
     @Test
+    void updateFunctionConfigurationRejectsScalarStructureMembersOnAnUnknownFunction() {
+        // The shape check runs ahead of the function lookup, so a malformed member reports
+        // SerializationException rather than the 404 the lookup would raise. Pinned because this is
+        // ordering rather than logic: it holds only while the checks stay in front of getFunction,
+        // and nothing else fails if a refactor moves them behind it.
+        for (String member : FUNCTION_STRUCTURE_MEMBERS) {
+            given()
+                .contentType("application/json")
+                .body(Map.of(member, 5))
+            .when()
+                .put(BASE_PATH + "/functions/structure-check-on-missing-function/configuration")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+        }
+    }
+
+    @Test
     void environmentVariablesRejectsScalarBeforeUpdateMutation() {
         Map<String, Object> createRequest = functionRequest("nested-environment-create");
         createRequest.put("Environment", Map.of("Variables", 5));


### PR DESCRIPTION
## Summary

Closes #3007. Raised by @pgermosen while reviewing #2941.

`publishVersion` copies roughly thirty fields off the live `LambdaFunction` inside
`synchronized (lockForConcurrencyOp(...))`, but neither updater took that lock, so nothing was
serialised:

```
updateFunctionConfiguration  -> lockForConcurrencyOp occurrences: 0   (21 fn.set* calls)
updateFunctionCode           -> lockForConcurrencyOp occurrences: 0
```

An update landing mid-copy produced a snapshot that was part old code and part new configuration,
carrying a `sourceRevisionId` that identified neither state.

## Scope, and my own error in it

#2939 made `extractZipCodeBytes` publish the code identity fields under the lock, which closed the
`CodeSha256` precondition hole specifically. I believed that closed the wider problem. It did not:
the rest of the snapshot copy stayed unprotected, and `updateFunctionConfiguration` never touched the
lock at all.

This PR also corrects a comment I wrote in #2939 claiming the hash check ran "inside the lock
UpdateFunctionCode takes". `UpdateFunctionCode` did not take a lock. That sentence is on `main` today
and is wrong, which is half the reason for fixing this at the source rather than leaving a note.

## AWS Compatibility

This is an internal locking change. No wire protocol, no request or response shape, no error code
and no status code changes, and it adds no action. What it restores is a documented guarantee of two
existing actions.

Real AWS treats `PublishVersion` as capturing one coherent point in time. The version it returns
describes a single state of `$LATEST`: its code and its configuration belong to the same revision,
and the `RevisionId` it reports identifies that state. `UpdateFunctionCode` and
`UpdateFunctionConfiguration` are separate mutations of `$LATEST` that a publish is either entirely
before or entirely after; there is no interleaving in which a version captures the code from one
revision and the configuration from another.

Floci diverged only under concurrency, which is why no single-threaded test caught it. The snapshot
copy held a lock that neither writer contended for, so an `UpdateFunctionConfiguration` landing
partway through the copy produced a version carrying the old code fields, the new configuration
fields, and a `sourceRevisionId` matching neither. Sequentially the result is correct, so the
divergence is invisible to the CLI and to a single SDK client, and appears only when a deploy
pipeline publishes while another call is in flight. There is no new SDK or CLI verification to
report because there is no new behaviour to verify: the fix is that the existing behaviour now holds
when calls overlap.

One further divergence closes as a side effect, and it is worth stating because it is the part with
teeth. `extractZipCodeBytes` calls `zipExtractor.extractTo(...)` **outside** the lock, taking it only
afterwards to publish the code identity fields:

```java
zipExtractor.extractTo(zipBytes, codePath, configuredZipMaxEntries());   // unlocked
...
synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {               // fields only
    fn.setCodeLocalPath(...);
    fn.setCodeSha256(newSha256);
```

Extraction replaces `$LATEST`'s code directory wholesale. Since #3041 landed, `publishVersion` copies
that directory into the version's own directory while holding the lock. On `main` today those two
can overlap: a deploy can be rewriting the directory while a publish reads from it, so a version can
capture a half-written build. Once `updateFunctionCode` takes the lock around its whole body,
extraction included, it cannot. #3041's description claims the copy "cannot interleave with a
concurrent `UpdateFunctionCode`"; that claim is mine, and it is only fully true once this PR lands.

## What changed

Both updaters take the same per-function lock. Their bodies move **unchanged** into private
`...Locked` methods behind a thin wrapper, so the diff is production lines rather than a few hundred
lines of reindentation:

```java
public LambdaFunction updateFunctionCode(String region, String functionName, Map<String, Object> request) {
    LambdaFunction fn = getFunction(region, functionName);
    synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
        return updateFunctionCodeLocked(region, fn, request);
    }
}
```

**On deadlock**, which I checked rather than assumed: the monitor comes from
`concurrencyOpLocks.computeIfAbsent(functionArn, ...)`, so it is one object per function ARN, and
`synchronized` is reentrant. Every existing acquisition in `LambdaService` is keyed to a single
function, so there is no cross-ARN ordering to invert. The nested acquisitions inside
`extractZipCodeBytes`, and `publishVersion`'s own when `updateFunctionCode` is called with `Publish`,
are therefore no-ops rather than a second lock.

**On lock duration**: zip extraction and the handler-existence walk now run inside the lock. That
serialises concurrent deploys of the same function, which seems right rather than merely acceptable:
two overlapping deploys of one function racing over its code directory is the situation this is
meant to prevent, and as of #3041 a publish copying that directory is racing them too. Different
functions are unaffected, since the monitor is per ARN.

## On the rebase

@pgermosen asked whether the conflict against `main` was a clean textual overlap or a real design
collision, given how much Lambda concurrency work has landed. Answer: textual, with one ordering
detail that had to be handled deliberately rather than by picking a side.

- `LambdaServiceTest.java` was two independent blocks of new tests landing at the same spot. Both
  kept.
- `LambdaService.java` had `validateArchitectures` added to both updaters by a later PR. In
  `updateFunctionCode` it already sat after the lookup, so it moved into the locked body unchanged.
- The one that needed care: #3051 extracts `UpdateFunctionConfiguration`'s structure members
  **above** the function lookup, so a malformed member on a function that does not exist reports
  `SerializationException` rather than `404`. Moving that block wholesale into the locked body, which
  is what the naive resolution does, would have put those checks behind the lookup and silently
  flipped that 400 to a 404. The shape check therefore stays in front of the lookup, over a named
  `CONFIG_STRUCTURE_MEMBERS` list, and the locked body re-reads the members. `structureMember` is
  pure, so the second read cannot fail once the first has passed.

That ordering was load-bearing and nothing pinned it, so
`updateFunctionConfigurationRejectsScalarStructureMembersOnAnUnknownFunction` now does. It is the one
test here not about locking, and it is in this PR because this PR is what put the ordering at risk.

Since the branch was cut, #3041 merged and closed #2958. That changes the interaction described in
AWS Compatibility above but not this change's design.

## How it was tested

The lock accessor is package-private with a comment saying it is "not private so tests can hold this
lock to prove a critical section waits for it", and `publishVersionWaitsForAConcurrentHolder...`
already uses that idiom. I followed it rather than inventing a pattern, factoring the shared
mechanism into one helper:

| Test | Covers |
|---|---|
| `updateFunctionCodeWaitsForAConcurrentHolderOfTheFunctionsConcurrencyLock` | The updater blocks while another operation holds the lock, and completes once released |
| `updateFunctionConfigurationWaitsForAConcurrentHolderOfTheFunctionsConcurrencyLock` | Same for the configuration path |
| `updateFunctionConfigurationRejectsScalarStructureMembersOnAnUnknownFunction` | The 400-before-404 ordering the rebase put at risk, pinned |

Both lock tests fail without the change:

```
the updater must block while another operation holds this function's lock
  ==> Expected java.util.concurrent.TimeoutException to be thrown, but nothing was thrown.
```

## Related

#3007 and #2958 were the two halves of a published version being a coherent frozen snapshot. #2958,
now fixed by #3041, keeps the snapshot's code from changing after it is taken. This one makes the
snapshot internally consistent at the moment it is taken, and closes the extraction race that #3041's
in-lock copy still faces on `main`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
