### PR TITLE
fix(iot): isolate topic rule actions and run the error action

### DIFF
--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -148,7 +148,7 @@ Supported rule behavior:
 - `sqs` action sends the original payload to an SQS queue through Floci's SQS service boundary.
 - `sns` action publishes the original payload to an SNS topic through Floci's SNS service boundary.
 - `s3` action writes the original payload to the configured bucket/key through Floci's S3 service boundary.
-- `dynamoDBv2` action writes JSON object payload fields as DynamoDB attribute values through Floci's DynamoDB service boundary.
+- `dynamoDBv2` action writes JSON object payload fields as DynamoDB attribute values through Floci's DynamoDB service boundary; nested objects and arrays become maps and lists.
 - `kinesis` action puts the original payload into a Kinesis stream through Floci's Kinesis service boundary.
 - `lambda` action invokes the configured function ARN through Floci's Lambda service boundary.
 - One failing action never fails the publish or the other actions of the rule. The failure is logged, and once every action ran the rule's `errorAction` receives the AWS failure document: `ruleName`, `topic`, `base64OriginalPayload` and `failures` with `failedAction`, `failedResource` and `errorMessage` per failed action.

--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -21,7 +21,7 @@ Current MVP 1 limitations:
 
 - Certificate CSR handling creates emulator-local certificates; it does not perform real CA signing.
 - MQTT auth remains permissive; certificate and policy resources are modeled for provisioning compatibility, not enforced as broker authorization yet.
-- Rules support basic topic filter extraction and action dispatch only; SQL projection, WHERE evaluation, substitutions, and error actions remain follow-up scope.
+- Rules support basic topic filter extraction and action dispatch only; SQL projection, WHERE evaluation, and substitutions remain follow-up scope.
 
 ## MVP 2 Coverage
 
@@ -151,10 +151,12 @@ Supported rule behavior:
 - `dynamoDBv2` action writes JSON object payload fields as DynamoDB attribute values through Floci's DynamoDB service boundary.
 - `kinesis` action puts the original payload into a Kinesis stream through Floci's Kinesis service boundary.
 - `lambda` action invokes the configured function ARN through Floci's Lambda service boundary.
+- One failing action never fails the publish or the other actions of the rule. The failure is logged, and once every action ran the rule's `errorAction` receives the AWS failure document: `ruleName`, `topic`, `base64OriginalPayload` and `failures` with `failedAction`, `failedResource` and `errorMessage` per failed action.
+- `GetTopicRule` returns `awsIotSqlVersion` and `errorAction` as they were given to `CreateTopicRule` or `ReplaceTopicRule`.
 
 Current limitations:
 
-- SQL projection, WHERE clauses, functions, substitutions, error actions, and less common AWS IoT rule action types are follow-up scope.
+- SQL projection, WHERE clauses, functions, substitutions, and less common AWS IoT rule action types are follow-up scope.
 
 Open follow-up scope for phase 7 unless explicitly deferred:
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotController.java
@@ -31,6 +31,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -42,6 +43,8 @@ import java.util.Map;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class IotController {
+
+    private static final Logger LOG = Logger.getLogger(IotController.class);
 
     private final IotService iotService;
     private final IotTagHandler iotTagHandler;
@@ -1118,6 +1121,16 @@ public class IotController {
             response.set("actions", objectMapper.readTree(rule.getActionsJson()));
         } catch (JsonProcessingException e) {
             response.putArray("actions");
+        }
+        if (rule.getAwsIotSqlVersion() != null) {
+            response.put("awsIotSqlVersion", rule.getAwsIotSqlVersion());
+        }
+        if (rule.getErrorActionJson() != null) {
+            try {
+                response.set("errorAction", objectMapper.readTree(rule.getErrorActionJson()));
+            } catch (JsonProcessingException e) {
+                LOG.warnv("Stored error action of topic rule {0} is not JSON: {1}", rule.getRuleName(), e.getMessage());
+            }
         }
         return response;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotController.java
@@ -1129,7 +1129,7 @@ public class IotController {
             try {
                 response.set("errorAction", objectMapper.readTree(rule.getErrorActionJson()));
             } catch (JsonProcessingException e) {
-                LOG.warnv("Stored error action of topic rule {0} is not JSON: {1}", rule.getRuleName(), e.getMessage());
+                LOG.warnv(e, "Stored error action of topic rule {0} is not JSON", rule.getRuleName());
             }
         }
         return response;

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -1019,11 +1019,16 @@ public class IotService {
         List<ObjectNode> failures = new ArrayList<>();
         for (JsonNode action : storedJson(rule.getRuleName(), rule.getActionsJson())) {
             String type = actionType(action);
+            if (type == null) {
+                LOG.warnv("Topic rule {0} has an action without a type, skipping it: {1}", rule.getRuleName(), action);
+                continue;
+            }
+            JsonNode config = action.get(type);
             try {
-                runAction(type, action.path(type), payload, ruleRegion);
+                runAction(type, config, payload, ruleRegion);
             } catch (RuntimeException e) {
-                LOG.warnv("Action {0} of topic rule {1} failed: {2}", type, rule.getRuleName(), e.getMessage());
-                failures.add(failure(type, action.path(type), e));
+                LOG.warnv(e, "Action {0} of topic rule {1} failed", type, rule.getRuleName());
+                failures.add(failure(type, config, e));
             }
         }
         if (failures.isEmpty() || rule.getErrorActionJson() == null) {
@@ -1031,10 +1036,14 @@ public class IotService {
         }
         JsonNode errorAction = storedJson(rule.getRuleName(), rule.getErrorActionJson());
         String type = actionType(errorAction);
+        if (type == null) {
+            LOG.warnv("Topic rule {0} has an error action without a type, skipping it", rule.getRuleName());
+            return;
+        }
         try {
-            runAction(type, errorAction.path(type), failureDocument(rule, topic, payload, failures), ruleRegion);
+            runAction(type, errorAction.get(type), failureDocument(rule, topic, payload, failures), ruleRegion);
         } catch (RuntimeException e) {
-            LOG.warnv("Error action {0} of topic rule {1} failed: {2}", type, rule.getRuleName(), e.getMessage());
+            LOG.warnv(e, "Error action {0} of topic rule {1} failed", type, rule.getRuleName());
         }
     }
 
@@ -1042,7 +1051,7 @@ public class IotService {
         try {
             return objectMapper.readTree(json);
         } catch (JsonProcessingException e) {
-            LOG.warnv("Stored actions of topic rule {0} are not JSON and were skipped: {1}", ruleName, e.getMessage());
+            LOG.warnv(e, "Stored actions of topic rule {0} are not JSON and were skipped", ruleName);
             return objectMapper.createArrayNode();
         }
     }
@@ -1063,9 +1072,6 @@ public class IotService {
     }
 
     private void runAction(String type, JsonNode action, byte[] payload, String region) {
-        if (type == null) {
-            return;
-        }
         switch (type) {
             case "republish" -> {
                 String targetTopic = action.path("topic").asText(null);

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -1167,6 +1167,7 @@ public class IotService {
         }
     }
 
+    /** A JSON value as a DynamoDB attribute value; objects and arrays become maps and lists, as on AWS. */
     private ObjectNode toDynamoDbAttribute(JsonNode value) {
         ObjectNode attribute = objectMapper.createObjectNode();
         if (value == null || value.isNull()) {
@@ -1175,6 +1176,12 @@ public class IotService {
             attribute.put("BOOL", value.asBoolean());
         } else if (value.isNumber()) {
             attribute.put("N", value.asText());
+        } else if (value.isObject()) {
+            ObjectNode map = attribute.putObject("M");
+            value.fields().forEachRemaining(entry -> map.set(entry.getKey(), toDynamoDbAttribute(entry.getValue())));
+        } else if (value.isArray()) {
+            ArrayNode list = attribute.putArray("L");
+            value.forEach(element -> list.add(toDynamoDbAttribute(element)));
         } else {
             attribute.put("S", value.asText());
         }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -1,8 +1,10 @@
 package io.github.hectorvent.floci.services.iot;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
@@ -29,13 +31,16 @@ import io.github.hectorvent.floci.services.sns.SnsService;
 import io.github.hectorvent.floci.services.sqs.SqsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -47,6 +52,8 @@ import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class IotService {
+
+    private static final Logger LOG = Logger.getLogger(IotService.class);
 
     static final String DEFAULT_ENDPOINT_TYPE = "iot:Data-ATS";
 
@@ -861,6 +868,9 @@ public class IotService {
         rule.setRuleDisabled(payload.path("ruleDisabled").asBoolean(false));
         JsonNode actions = payload.path("actions");
         rule.setActionsJson(actions.isArray() ? actions.toString() : "[]");
+        rule.setAwsIotSqlVersion(payload.path("awsIotSqlVersion").asText(null));
+        JsonNode errorAction = payload.path("errorAction");
+        rule.setErrorActionJson(errorAction.isObject() ? errorAction.toString() : null);
         rule.setCreatedAt(createdAt == null ? Instant.now() : createdAt);
         topicRuleStore.put(topicRuleKey(region, ruleName), rule);
         return rule;
@@ -897,7 +907,7 @@ public class IotService {
         }
         for (IotTopicRule rule : rulesForPublish(region)) {
             if (!rule.isRuleDisabled() && topicMatches(extractTopicPattern(rule.getSql()), topic)) {
-                executeTopicRule(rule, eventPayload);
+                executeTopicRule(rule, topic, eventPayload);
             }
         }
     }
@@ -999,73 +1009,146 @@ public class IotService {
         }
     }
 
-    private void executeTopicRule(IotTopicRule rule, byte[] payload) {
+    /**
+     * Runs the actions of a matching rule. One failing action never fails the publish or the actions
+     * after it, as on AWS: the failure is logged, and once every action ran the rule's error action,
+     * if it has one, receives the failure document listing every action that failed.
+     */
+    private void executeTopicRule(IotTopicRule rule, String topic, byte[] payload) {
         String ruleRegion = AwsArnUtils.regionOrDefault(rule.getRuleArn(), config.defaultRegion());
-        try {
-            JsonNode actions = objectMapper.readTree(rule.getActionsJson());
-            if (!actions.isArray()) {
-                return;
+        List<ObjectNode> failures = new ArrayList<>();
+        for (JsonNode action : storedJson(rule.getRuleName(), rule.getActionsJson())) {
+            String type = actionType(action);
+            try {
+                runAction(type, action.path(type), payload, ruleRegion);
+            } catch (RuntimeException e) {
+                LOG.warnv("Action {0} of topic rule {1} failed: {2}", type, rule.getRuleName(), e.getMessage());
+                failures.add(failure(type, action.path(type), e));
             }
-            for (JsonNode action : actions) {
-                JsonNode republish = action.path("republish");
-                if (republish.isObject()) {
-                    String targetTopic = republish.path("topic").asText(null);
-                    if (targetTopic != null && !targetTopic.isBlank()) {
-                        handlePublish(targetTopic, payload, false, ruleRegion);
-                        mqttBrokerService.publish(targetTopic, payload);
-                    }
-                }
-                JsonNode sqs = action.path("sqs");
-                if (sqs.isObject()) {
-                    String queueUrl = sqs.path("queueUrl").asText(null);
-                    if (queueUrl != null && !queueUrl.isBlank()) {
-                        String body = sqs.path("useBase64").asBoolean(false)
-                                ? Base64.getEncoder().encodeToString(payload)
-                                : new String(payload, StandardCharsets.UTF_8);
-                        sqsService.sendMessage(queueUrl, body, 0, ruleRegion);
-                    }
-                }
-                JsonNode sns = action.path("sns");
-                if (sns.isObject()) {
-                    String targetArn = sns.path("targetArn").asText(null);
-                    if (targetArn != null && !targetArn.isBlank()) {
-                        snsService.publish(targetArn, null, new String(payload, StandardCharsets.UTF_8), null, ruleRegion);
-                    }
-                }
-                JsonNode s3 = action.path("s3");
-                if (s3.isObject()) {
-                    String bucketName = s3.path("bucketName").asText(null);
-                    String key = s3.path("key").asText(null);
-                    if (bucketName != null && !bucketName.isBlank() && key != null && !key.isBlank()) {
-                        s3Service.putObject(bucketName, key, payload, "application/octet-stream", Map.of());
-                    }
-                }
-                JsonNode kinesis = action.path("kinesis");
-                if (kinesis.isObject()) {
-                    String streamName = kinesis.path("streamName").asText(null);
-                    String partitionKey = kinesis.path("partitionKey").asText("floci-iot");
-                    if (streamName != null && !streamName.isBlank()) {
-                        kinesisService.putRecord(streamName, payload, partitionKey, ruleRegion);
-                    }
-                }
-                JsonNode dynamoDBv2 = action.path("dynamoDBv2");
-                if (dynamoDBv2.isObject()) {
-                    String tableName = dynamoDBv2.path("putItem").path("tableName").asText(null);
-                    if (tableName != null && !tableName.isBlank()) {
-                        dynamoDbService.putItem(tableName, toDynamoDbItem(payload), ruleRegion);
-                    }
-                }
-                JsonNode lambda = action.path("lambda");
-                if (lambda.isObject()) {
-                    String functionArn = lambda.path("functionArn").asText(null);
-                    if (functionArn != null && !functionArn.isBlank()) {
-                        lambdaService.invoke(ruleRegion, functionArn, payload, InvocationType.Event);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            throw new AwsException("InvalidRequestException", "Invalid topic rule action for " + rule.getRuleName() + ": " + e.getMessage(), 400);
         }
+        if (failures.isEmpty() || rule.getErrorActionJson() == null) {
+            return;
+        }
+        JsonNode errorAction = storedJson(rule.getRuleName(), rule.getErrorActionJson());
+        String type = actionType(errorAction);
+        try {
+            runAction(type, errorAction.path(type), failureDocument(rule, topic, payload, failures), ruleRegion);
+        } catch (RuntimeException e) {
+            LOG.warnv("Error action {0} of topic rule {1} failed: {2}", type, rule.getRuleName(), e.getMessage());
+        }
+    }
+
+    private JsonNode storedJson(String ruleName, String json) {
+        try {
+            return objectMapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            LOG.warnv("Stored actions of topic rule {0} are not JSON and were skipped: {1}", ruleName, e.getMessage());
+            return objectMapper.createArrayNode();
+        }
+    }
+
+    /** The one member an action object carries, naming its kind, or null when it carries none. */
+    private static String actionType(JsonNode action) {
+        if (action == null || !action.isObject()) {
+            return null;
+        }
+        Iterator<Map.Entry<String, JsonNode>> fields = action.fields();
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field = fields.next();
+            if (field.getValue().isObject()) {
+                return field.getKey();
+            }
+        }
+        return null;
+    }
+
+    private void runAction(String type, JsonNode action, byte[] payload, String region) {
+        if (type == null) {
+            return;
+        }
+        switch (type) {
+            case "republish" -> {
+                String targetTopic = action.path("topic").asText(null);
+                if (targetTopic != null && !targetTopic.isBlank()) {
+                    handlePublish(targetTopic, payload, false, region);
+                    mqttBrokerService.publish(targetTopic, payload);
+                }
+            }
+            case "sqs" -> {
+                String queueUrl = action.path("queueUrl").asText(null);
+                if (queueUrl != null && !queueUrl.isBlank()) {
+                    String body = action.path("useBase64").asBoolean(false)
+                            ? Base64.getEncoder().encodeToString(payload)
+                            : new String(payload, StandardCharsets.UTF_8);
+                    sqsService.sendMessage(queueUrl, body, 0, region);
+                }
+            }
+            case "sns" -> {
+                String targetArn = action.path("targetArn").asText(null);
+                if (targetArn != null && !targetArn.isBlank()) {
+                    snsService.publish(targetArn, null, new String(payload, StandardCharsets.UTF_8), null, region);
+                }
+            }
+            case "s3" -> {
+                String bucketName = action.path("bucketName").asText(null);
+                String key = action.path("key").asText(null);
+                if (bucketName != null && !bucketName.isBlank() && key != null && !key.isBlank()) {
+                    s3Service.putObject(bucketName, key, payload, "application/octet-stream", Map.of());
+                }
+            }
+            case "kinesis" -> {
+                String streamName = action.path("streamName").asText(null);
+                String partitionKey = action.path("partitionKey").asText("floci-iot");
+                if (streamName != null && !streamName.isBlank()) {
+                    kinesisService.putRecord(streamName, payload, partitionKey, region);
+                }
+            }
+            case "dynamoDBv2" -> {
+                String tableName = action.path("putItem").path("tableName").asText(null);
+                if (tableName != null && !tableName.isBlank()) {
+                    dynamoDbService.putItem(tableName, toDynamoDbItem(payload), region);
+                }
+            }
+            case "lambda" -> {
+                String functionArn = action.path("functionArn").asText(null);
+                if (functionArn != null && !functionArn.isBlank()) {
+                    lambdaService.invoke(region, functionArn, payload, InvocationType.Event);
+                }
+            }
+            default -> LOG.debugv("Topic rule action {0} is not supported and was skipped", type);
+        }
+    }
+
+    /** One entry of the failure document: the action kind and target as AWS names them. */
+    private ObjectNode failure(String type, JsonNode action, RuntimeException e) {
+        ObjectNode failure = objectMapper.createObjectNode();
+        failure.put("failedAction", Character.toUpperCase(type.charAt(0)) + type.substring(1) + "Action");
+        failure.put("failedResource", targetOf(type, action));
+        failure.put("errorMessage", e.getMessage() == null ? e.toString() : e.getMessage());
+        return failure;
+    }
+
+    private static String targetOf(String type, JsonNode action) {
+        return switch (type) {
+            case "republish" -> action.path("topic").asText("");
+            case "sqs" -> action.path("queueUrl").asText("");
+            case "sns" -> action.path("targetArn").asText("");
+            case "s3" -> action.path("bucketName").asText("");
+            case "kinesis" -> action.path("streamName").asText("");
+            case "dynamoDBv2" -> action.path("putItem").path("tableName").asText("");
+            case "lambda" -> action.path("functionArn").asText("");
+            default -> "";
+        };
+    }
+
+    private byte[] failureDocument(IotTopicRule rule, String topic, byte[] payload, List<ObjectNode> failures) {
+        ObjectNode document = objectMapper.createObjectNode();
+        document.put("ruleName", rule.getRuleName());
+        document.put("topic", topic);
+        document.put("base64OriginalPayload", Base64.getEncoder().encodeToString(payload));
+        ArrayNode list = document.putArray("failures");
+        failures.forEach(list::add);
+        return document.toString().getBytes(StandardCharsets.UTF_8);
     }
 
     private ObjectNode toDynamoDbItem(byte[] payload) {

--- a/src/main/java/io/github/hectorvent/floci/services/iot/model/IotTopicRule.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/model/IotTopicRule.java
@@ -14,6 +14,8 @@ public class IotTopicRule {
     private String description;
     private boolean ruleDisabled;
     private String actionsJson = "[]";
+    private String awsIotSqlVersion;
+    private String errorActionJson;
     private Instant createdAt;
     private Map<String, String> tags = new TreeMap<>();
 
@@ -63,6 +65,22 @@ public class IotTopicRule {
 
     public void setActionsJson(String actionsJson) {
         this.actionsJson = actionsJson;
+    }
+
+    public String getAwsIotSqlVersion() {
+        return awsIotSqlVersion;
+    }
+
+    public void setAwsIotSqlVersion(String awsIotSqlVersion) {
+        this.awsIotSqlVersion = awsIotSqlVersion;
+    }
+
+    public String getErrorActionJson() {
+        return errorActionJson;
+    }
+
+    public void setErrorActionJson(String errorActionJson) {
+        this.errorActionJson = errorActionJson;
     }
 
     public Instant getCreatedAt() {

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
@@ -281,4 +281,22 @@ class IotServiceTest {
         assertEquals(QUEUE_URL, item.at("/failures/L/0/M/failedResource/S").asText());
         assertTrue(item.at("/failures/L/0/M/errorMessage/S").asText().contains("does not exist"));
     }
+
+    @Test
+    void anActionWithoutATypeOrOfAnUnsupportedTypeIsSkippedAndTheOthersStillRun() throws Exception {
+        createRule("metricsRule", """
+            {"sql": "SELECT * FROM 'devices/+/metrics'",
+             "actions": [
+               {"comment": "not an action"},
+               {"kafka": {"destinationArn": "arn:aws:iot:us-east-1:000000000000:ruledestination/kafka/x", "topic": "t"}},
+               {"lambda": {"functionArn": "%s"}}
+             ],
+             "errorAction": {"note": "no type either"}}
+            """.formatted(FUNCTION_ARN));
+
+        assertDoesNotThrow(() -> publish("{\"v\":1}"));
+
+        verify(lambda).invoke(eq(REGION), eq(FUNCTION_ARN), any(), eq(InvocationType.Event));
+        verify(lambda, never()).invoke(eq(REGION), eq(ERROR_FUNCTION_ARN), any(), any());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.iot;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
@@ -52,6 +53,7 @@ class IotServiceTest {
     private final ObjectMapper mapper = new ObjectMapper();
     private final SqsService sqs = mock(SqsService.class);
     private final LambdaService lambda = mock(LambdaService.class);
+    private final DynamoDbService dynamoDb = mock(DynamoDbService.class);
     private IotService service;
 
     @BeforeEach
@@ -81,7 +83,7 @@ class IotServiceTest {
                 mock(SnsService.class),
                 mock(S3Service.class),
                 mock(KinesisService.class),
-                mock(DynamoDbService.class),
+                dynamoDb,
                 lambda);
     }
 
@@ -236,5 +238,47 @@ class IotServiceTest {
         IotTopicRule rule = service.getTopicRule("versionedRule", REGION);
         assertNull(rule.getAwsIotSqlVersion());
         assertNull(rule.getErrorActionJson());
+    }
+
+    private JsonNode capturedDynamoDbItem(String tableName) {
+        ArgumentCaptor<ObjectNode> item = ArgumentCaptor.forClass(ObjectNode.class);
+        verify(dynamoDb).putItem(eq(tableName), item.capture(), eq(REGION));
+        return item.getValue();
+    }
+
+    @Test
+    void dynamoDBv2ActionMapsNestedValuesToDynamoDbMapsAndLists() throws Exception {
+        createRule("metricsRule", """
+            {"sql": "SELECT * FROM 'devices/+/metrics'",
+             "actions": [{"dynamoDBv2": {"putItem": {"tableName": "metrics"}, "roleArn": "arn:aws:iam::000000000000:role/rule"}}]}
+            """);
+
+        publish("{\"device\": {\"id\": \"d1\", \"ok\": true}, \"readings\": [1.5, \"x\", null]}");
+
+        JsonNode item = capturedDynamoDbItem("metrics");
+        assertEquals("d1", item.at("/device/M/id/S").asText());
+        assertTrue(item.at("/device/M/ok/BOOL").asBoolean());
+        assertEquals("1.5", item.at("/readings/L/0/N").asText());
+        assertEquals("x", item.at("/readings/L/1/S").asText());
+        assertTrue(item.at("/readings/L/2/NULL").asBoolean());
+    }
+
+    @Test
+    void aDynamoDbErrorActionKeepsEveryFailureInTheItem() throws Exception {
+        createRule("metricsRule", """
+            {"sql": "SELECT * FROM 'devices/+/metrics'",
+             "actions": [{"sqs": {"queueUrl": "%s", "roleArn": "arn:aws:iam::000000000000:role/rule"}}],
+             "errorAction": {"dynamoDBv2": {"putItem": {"tableName": "rule-errors"}, "roleArn": "arn:aws:iam::000000000000:role/rule"}}}
+            """.formatted(QUEUE_URL));
+        queueIsMissing();
+
+        publish("{\"v\":1}");
+
+        JsonNode item = capturedDynamoDbItem("rule-errors");
+        assertEquals("metricsRule", item.at("/ruleName/S").asText());
+        assertEquals(TOPIC, item.at("/topic/S").asText());
+        assertEquals("SqsAction", item.at("/failures/L/0/M/failedAction/S").asText());
+        assertEquals(QUEUE_URL, item.at("/failures/L/0/M/failedResource/S").asText());
+        assertTrue(item.at("/failures/L/0/M/errorMessage/S").asText().contains("does not exist"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
@@ -1,0 +1,240 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.iot.model.IotTopicRule;
+import io.github.hectorvent.floci.services.kinesis.KinesisService;
+import io.github.hectorvent.floci.services.lambda.LambdaService;
+import io.github.hectorvent.floci.services.lambda.model.InvocationType;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsService;
+import io.github.hectorvent.floci.services.sqs.SqsService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Rules engine behaviour of {@link IotService} with in-memory stores and mocked action targets:
+ * one failing action never fails the publish or the other actions, and the error action receives
+ * the failure document.
+ */
+class IotServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+    private static final String TOPIC = "devices/d1/metrics";
+    private static final String QUEUE_URL = "http://localhost:4566/000000000000/metrics";
+    private static final String FUNCTION_ARN = "arn:aws:lambda:us-east-1:000000000000:function:handler";
+    private static final String ERROR_FUNCTION_ARN = "arn:aws:lambda:us-east-1:000000000000:function:errors";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final SqsService sqs = mock(SqsService.class);
+    private final LambdaService lambda = mock(LambdaService.class);
+    private IotService service;
+
+    @BeforeEach
+    void setUp() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        when(config.defaultRegion()).thenReturn(REGION);
+        service = new IotService(
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                AccountAwareStorageBackend.inMemory(ACCOUNT),
+                config,
+                new RegionResolver(REGION, ACCOUNT),
+                mapper,
+                new IotPublishEventRecorder(),
+                mock(IotMqttBrokerService.class),
+                sqs,
+                mock(SnsService.class),
+                mock(S3Service.class),
+                mock(KinesisService.class),
+                mock(DynamoDbService.class),
+                lambda);
+    }
+
+    private IotTopicRule createRule(String name, String payloadJson) throws Exception {
+        return service.createTopicRule(name, mapper.readTree(payloadJson), REGION);
+    }
+
+    /** A rule whose SQS action targets a queue that does not exist and whose Lambda action works. */
+    private static String sqsThenLambdaRule(String errorActionJson) {
+        String errorAction = errorActionJson == null ? "" : ", \"errorAction\": " + errorActionJson;
+        return """
+            {
+              "sql": "SELECT * FROM 'devices/+/metrics'",
+              "actions": [
+                {"sqs": {"queueUrl": "%s", "roleArn": "arn:aws:iam::000000000000:role/rule"}},
+                {"lambda": {"functionArn": "%s"}}
+              ]%s
+            }
+            """.formatted(QUEUE_URL, FUNCTION_ARN, errorAction);
+    }
+
+    private static String lambdaErrorAction() {
+        return "{\"lambda\": {\"functionArn\": \"" + ERROR_FUNCTION_ARN + "\"}}";
+    }
+
+    private void queueIsMissing() {
+        when(sqs.sendMessage(eq(QUEUE_URL), anyString(), anyInt(), anyString()))
+                .thenThrow(new AwsException("AWS.SimpleQueueService.NonExistentQueue",
+                        "The specified queue does not exist for this wsdl version.", 400));
+    }
+
+    private void publish(String payload) {
+        service.handlePublish(TOPIC, payload.getBytes(StandardCharsets.UTF_8), true, REGION);
+    }
+
+    private JsonNode capturedInvocationPayload(String functionArn) throws Exception {
+        ArgumentCaptor<byte[]> payload = ArgumentCaptor.forClass(byte[].class);
+        verify(lambda).invoke(eq(REGION), eq(functionArn), payload.capture(), eq(InvocationType.Event));
+        return mapper.readTree(payload.getValue());
+    }
+
+    @Test
+    void aFailingActionDoesNotFailThePublishOrStopTheOtherActions() throws Exception {
+        createRule("metricsRule", sqsThenLambdaRule(null));
+        queueIsMissing();
+
+        assertDoesNotThrow(() -> publish("{\"v\":1}"));
+
+        assertEquals("{\"v\":1}", capturedInvocationPayload(FUNCTION_ARN).toString());
+    }
+
+    @Test
+    void theErrorActionReceivesTheFailureDocumentWhenAnActionFails() throws Exception {
+        createRule("metricsRule", sqsThenLambdaRule(lambdaErrorAction()));
+        queueIsMissing();
+
+        publish("{\"v\":1}");
+
+        JsonNode document = capturedInvocationPayload(ERROR_FUNCTION_ARN);
+        assertEquals("metricsRule", document.get("ruleName").asText());
+        assertEquals(TOPIC, document.get("topic").asText());
+        assertEquals(Base64.getEncoder().encodeToString("{\"v\":1}".getBytes(StandardCharsets.UTF_8)),
+                document.get("base64OriginalPayload").asText());
+        assertEquals(1, document.get("failures").size());
+        JsonNode failure = document.get("failures").get(0);
+        assertEquals("SqsAction", failure.get("failedAction").asText());
+        assertEquals(QUEUE_URL, failure.get("failedResource").asText());
+        assertTrue(failure.get("errorMessage").asText().contains("does not exist"), failure.toString());
+    }
+
+    @Test
+    void theErrorActionDoesNotRunWhenEveryActionSucceeds() throws Exception {
+        createRule("metricsRule", sqsThenLambdaRule(lambdaErrorAction()));
+
+        publish("{\"v\":1}");
+
+        verify(lambda).invoke(eq(REGION), eq(FUNCTION_ARN), any(), eq(InvocationType.Event));
+        verify(lambda, never()).invoke(eq(REGION), eq(ERROR_FUNCTION_ARN), any(), any());
+    }
+
+    @Test
+    void aFailingErrorActionIsLoggedNotThrown() throws Exception {
+        createRule("metricsRule", sqsThenLambdaRule(lambdaErrorAction()));
+        queueIsMissing();
+        when(lambda.invoke(eq(REGION), eq(ERROR_FUNCTION_ARN), any(), any()))
+                .thenThrow(new AwsException("ResourceNotFoundException", "Function not found: errors", 404));
+
+        assertDoesNotThrow(() -> publish("{\"v\":1}"));
+
+        verify(lambda, times(1)).invoke(eq(REGION), eq(ERROR_FUNCTION_ARN), any(), eq(InvocationType.Event));
+    }
+
+    @Test
+    void everyFailingActionIsListedInTheFailureDocument() throws Exception {
+        createRule("metricsRule", """
+            {
+              "sql": "SELECT * FROM 'devices/+/metrics'",
+              "actions": [
+                {"sqs": {"queueUrl": "%s", "roleArn": "arn:aws:iam::000000000000:role/rule"}},
+                {"dynamoDBv2": {"putItem": {"tableName": "metrics"}, "roleArn": "arn:aws:iam::000000000000:role/rule"}}
+              ],
+              "errorAction": %s
+            }
+            """.formatted(QUEUE_URL, lambdaErrorAction()));
+        queueIsMissing();
+
+        publish("not json");
+
+        JsonNode failures = capturedInvocationPayload(ERROR_FUNCTION_ARN).get("failures");
+        assertEquals(2, failures.size());
+        assertEquals("SqsAction", failures.get(0).get("failedAction").asText());
+        assertEquals("DynamoDBv2Action", failures.get(1).get("failedAction").asText());
+        assertEquals("metrics", failures.get(1).get("failedResource").asText());
+    }
+
+    @Test
+    void topicRuleKeepsTheSqlVersionAndTheErrorAction() throws Exception {
+        createRule("versionedRule", """
+            {
+              "sql": "SELECT * FROM 'devices/+/metrics'",
+              "awsIotSqlVersion": "2016-03-23",
+              "actions": [{"lambda": {"functionArn": "%s"}}],
+              "errorAction": {"sqs": {"queueUrl": "%s", "roleArn": "arn:aws:iam::000000000000:role/rule"}}
+            }
+            """.formatted(FUNCTION_ARN, QUEUE_URL));
+
+        IotTopicRule rule = service.getTopicRule("versionedRule", REGION);
+
+        assertEquals("2016-03-23", rule.getAwsIotSqlVersion());
+        assertEquals(QUEUE_URL, mapper.readTree(rule.getErrorActionJson()).at("/sqs/queueUrl").asText());
+    }
+
+    @Test
+    void topicRuleWithoutTheOptionalMembersStoresNothingForThem() throws Exception {
+        createRule("plainRule", sqsThenLambdaRule(null));
+
+        IotTopicRule rule = service.getTopicRule("plainRule", REGION);
+
+        assertNull(rule.getAwsIotSqlVersion());
+        assertNull(rule.getErrorActionJson());
+    }
+
+    @Test
+    void replacingATopicRuleReplacesTheOptionalMembersToo() throws Exception {
+        createRule("versionedRule", """
+            {"sql": "SELECT * FROM 'a'", "awsIotSqlVersion": "2016-03-23", "actions": [],
+             "errorAction": {"sqs": {"queueUrl": "http://dlq", "roleArn": "r"}}}
+            """);
+
+        service.replaceTopicRule("versionedRule", mapper.readTree("{\"sql\": \"SELECT * FROM 'b'\", \"actions\": []}"), REGION);
+
+        IotTopicRule rule = service.getTopicRule("versionedRule", REGION);
+        assertNull(rule.getAwsIotSqlVersion());
+        assertNull(rule.getErrorActionJson());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotTopicRuleIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotTopicRuleIntegrationTest.java
@@ -39,6 +39,7 @@ class IotTopicRuleIntegrationTest {
                   "topicRulePayload": {
                     "sql": "SELECT * FROM 'devices/phase8/crud'",
                     "description": "phase 8 metadata",
+                    "awsIotSqlVersion": "2016-03-23",
                     "ruleDisabled": false,
                     "actions": [
                       {
@@ -47,7 +48,13 @@ class IotTopicRuleIntegrationTest {
                           "topic": "devices/phase8/target"
                         }
                       }
-                    ]
+                    ],
+                    "errorAction": {
+                      "republish": {
+                        "roleArn": "arn:aws:iam::000000000000:role/iot-rule-role",
+                        "topic": "devices/phase8/errors"
+                      }
+                    }
                   }
                 }
                 """)
@@ -69,6 +76,8 @@ class IotTopicRuleIntegrationTest {
             .body("rule.description", equalTo("phase 8 metadata"))
             .body("rule.ruleDisabled", equalTo(false))
             .body("rule.actions[0].republish.topic", equalTo("devices/phase8/target"))
+            .body("rule.awsIotSqlVersion", equalTo("2016-03-23"))
+            .body("rule.errorAction.republish.topic", equalTo("devices/phase8/errors"))
             .body("rule.createdAt", notNullValue());
 
         given()
@@ -210,6 +219,44 @@ class IotTopicRuleIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("sqs-rule-payload"));
+    }
+
+    @Test
+    void aFailingActionDoesNotFailThePublishAndTheErrorActionReceivesTheFailure() {
+        String queueUrl = createQueue("phase8-iot-rule-isolation-queue", "us-east-1");
+        String errorQueueUrl = createQueue("phase8-iot-rule-error-queue", "us-east-1");
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "topicRulePayload": {
+                    "sql": "SELECT * FROM 'devices/phase8/isolation'",
+                    "actions": [
+                      {"sqs": {"roleArn": "arn:aws:iam::000000000000:role/iot-rule-role", "queueUrl": "http://localhost:4566/000000000000/phase8-missing-queue"}},
+                      {"sqs": {"roleArn": "arn:aws:iam::000000000000:role/iot-rule-role", "queueUrl": "%s"}}
+                    ],
+                    "errorAction": {"sqs": {"roleArn": "arn:aws:iam::000000000000:role/iot-rule-role", "queueUrl": "%s"}}
+                  }
+                }
+                """.formatted(queueUrl, errorQueueUrl))
+        .when()
+            .put("/rules/phase8IsolationRule")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("text/plain")
+            .body("isolation-rule-payload")
+        .when()
+            .post("/topics/devices/phase8/isolation")
+        .then()
+            .statusCode(200);
+
+        receiveMessage(queueUrl, "us-east-1").body(containsString("isolation-rule-payload"));
+        receiveMessage(errorQueueUrl, "us-east-1")
+            .body(containsString("phase8IsolationRule"))
+            .body(containsString("SqsAction"))
+            .body(containsString("phase8-missing-queue"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

A topic rule action that fails no longer fails the publish that triggered it, or the actions after it.

Before this change every action of a matching rule ran inside one try/catch that rethrew. A Lambda that was not ready, or a queue that did not exist, turned every device publish on that topic into an `InvalidRequestException`. AWS never fails a publish because of a rule: the action failure is logged, and the rule's error action, if it has one, is invoked with a failure document.

Now each action runs on its own. A failure is logged at WARN with the rule name and the action type, the remaining actions still run, and once every action ran the rule's `errorAction` receives the AWS failure document: `ruleName`, `topic`, `base64OriginalPayload` and `failures`, with `failedAction`, `failedResource` and `errorMessage` per failed action. A failing error action is logged, never thrown.

Two members of the rule payload are now kept. `awsIotSqlVersion` and `errorAction` were dropped by `CreateTopicRule` and `ReplaceTopicRule`, so `GetTopicRule` never returned them and no rule could have an error action.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| Rules engine | One failing action never fails the publish | ✅ | Logged at WARN with the rule name and the action type. |
| Rules engine | The remaining actions still run after a failure | ✅ | |
| Rules engine | `errorAction` runs after a failure | ✅ | Once per publish, after every action ran, with every failure listed. Any action type the dispatcher runs can be the error action. |
| Rules engine | Failure document | 🟡 | `ruleName`, `topic`, `base64OriginalPayload` and `failures` with `failedAction`, `failedResource` and `errorMessage`. AWS also sends `cloudwatchTraceId` and `clientId`; neither exists in the emulator. |
| Rules engine | A failing error action | ✅ | Logged, never thrown. |
| API | `CreateTopicRule` and `ReplaceTopicRule` keep `awsIotSqlVersion` and `errorAction` | ✅ | |
| API | `GetTopicRule` returns `awsIotSqlVersion` and `errorAction` | ✅ | Omitted when the rule has none, as on AWS. |

Behaviour change: a publish whose rule action failed used to get a 400. It now succeeds, as it does on AWS. The IoT docs page says so.

## Files

- `IotService`: `executeTopicRule` runs each action on its own, builds the failure document and runs the error action; `buildAndStoreTopicRule` keeps the two payload members.
- `IotTopicRule`: `awsIotSqlVersion` and `errorActionJson`.
- `IotController`: `GetTopicRule` returns both.
- Tests: `IotServiceTest` (new: in-memory stores and mocked action targets) and `IotTopicRuleIntegrationTest` (a rule with one action on a queue that does not exist and one on a real queue: the publish succeeds, the real queue gets the message, the error action's queue gets the failure document; `GetTopicRule` returns both members).
- `docs/services/iot.md`.

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Docs / chore

### Checklist

* [ ] `./mvnw test` passes locally. Ran per class instead: `IotServiceTest` and every test class under `iot`. `make docs-check` passes.
* [x] New or updated integration test added
* [x] Commit messages follow Conventional Commits
