### PR TITLE
feat(iot): provision AWS::IoT::Thing, Policy and TopicRule

### DIFF
--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -86,7 +86,7 @@ cross-resource references.
 | Pipes | `Pipe` |
 | Kinesis | `Stream` |
 | Kinesis Data Firehose | `DeliveryStream` |
-| IoT Core | `DomainConfiguration` (`ServerCertificates` resolves to a JSON string) |
+| IoT Core | `DomainConfiguration` (`ServerCertificates` resolves to a JSON string), `Policy`, `Thing`, `TopicRule` |
 | CloudFront | `Distribution` |
 | CloudWatch | `Alarm` |
 | CloudWatch Logs | `LogGroup` |

--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -86,7 +86,7 @@ cross-resource references.
 | Pipes | `Pipe` |
 | Kinesis | `Stream` |
 | Kinesis Data Firehose | `DeliveryStream` |
-| IoT Core | `DomainConfiguration` (`ServerCertificates` resolves to a JSON string), `Policy`, `Thing`, `TopicRule` |
+| IoT Core | `DomainConfiguration` (`ServerCertificates` resolves to a JSON string), `Policy` (deleted after detaching it from its principals; on AWS the delete fails with `DeleteConflictException` while the policy is attached), `Thing`, `TopicRule` |
 | CloudFront | `Distribution` |
 | CloudWatch | `Alarm` |
 | CloudWatch Logs | `LogGroup` |

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
@@ -1,0 +1,271 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.iot.IotService;
+import io.github.hectorvent.floci.services.iot.model.IotPolicy;
+import io.github.hectorvent.floci.services.iot.model.IotTopicRule;
+import io.github.hectorvent.floci.services.iot.model.Thing;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.logging.Logger;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Provisions the IoT Core registry and rules engine types: {@code AWS::IoT::Thing},
+ * {@code AWS::IoT::Policy} and {@code AWS::IoT::TopicRule}. The physical id is the resource name,
+ * as it is on AWS, so a rename is a replacement: the new entity is created first and the prior
+ * one removed afterwards, since there is no generic replacement flow.
+ */
+@ApplicationScoped
+public class IotCfnProvisioner implements CfnResourceProvisioner {
+
+    private static final Logger LOG = Logger.getLogger(IotCfnProvisioner.class);
+    private static final String NOT_FOUND = "ResourceNotFoundException";
+    private static final int NAME_MAX_LENGTH = 128;
+
+    private final IotService iotService;
+
+    public IotCfnProvisioner(IotService iotService) {
+        this.iotService = iotService;
+    }
+
+    @Override
+    public Set<String> resourceTypes() {
+        return Set.of("AWS::IoT::Thing", "AWS::IoT::Policy", "AWS::IoT::TopicRule");
+    }
+
+    @Override
+    public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+        switch (r.getResourceType()) {
+            case "AWS::IoT::Thing" -> provisionThing(r, props, ctx);
+            case "AWS::IoT::Policy" -> provisionPolicy(r, props, ctx);
+            case "AWS::IoT::TopicRule" -> provisionTopicRule(r, props, ctx);
+            default -> throw new IllegalStateException("IotCfnProvisioner cannot handle " + r.getResourceType());
+        }
+    }
+
+    @Override
+    public void delete(String resourceType, String physicalId, String region) {
+        switch (resourceType) {
+            case "AWS::IoT::Thing" -> CfnDeletes.safeDelete("thing", physicalId,
+                    () -> iotService.deleteThing(physicalId, region), NOT_FOUND);
+            case "AWS::IoT::Policy" -> CfnDeletes.safeDelete("policy", physicalId,
+                    () -> detachAndDeletePolicy(physicalId, region), NOT_FOUND);
+            case "AWS::IoT::TopicRule" -> CfnDeletes.safeDelete("topic rule", physicalId,
+                    () -> iotService.deleteTopicRule(physicalId, region), NOT_FOUND);
+            default -> throw new IllegalStateException("IotCfnProvisioner cannot handle " + resourceType);
+        }
+    }
+
+    /**
+     * {@code AttributePayload.Attributes} is the whole desired attribute set: an update replaces the
+     * stored attributes rather than merging into them, as the CloudFormation handler does.
+     */
+    private void provisionThing(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String name = ctx.stablePhysicalName(ctx.resolveOptional(props, "ThingName"),
+                r.getLogicalId(), NAME_MAX_LENGTH, false);
+        Map<String, String> attributes = thingAttributes(props, ctx);
+        String region = ctx.region();
+        boolean sameThing = ctx.reusesPriorEntity(name);
+        Thing thing = sameThing
+                ? iotService.updateThing(name, attributes, null, region)
+                : iotService.createThing(name, attributes, region);
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", thing.getThingArn());
+        r.getAttributes().put("Id", thing.getThingId());
+        if (!sameThing) {
+            deletePrior(r, ctx);
+        }
+    }
+
+    /**
+     * A changed document becomes a new default version, as the CloudFormation handler does; the
+     * document is compared as the string the policy stores, which is what this provisioner wrote
+     * on the previous execution. {@code Id} is the policy name, as on AWS.
+     */
+    private void provisionPolicy(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String name = ctx.stablePhysicalName(ctx.resolveOptional(props, "PolicyName"),
+                r.getLogicalId(), NAME_MAX_LENGTH, false);
+        String document = props == null ? null : ctx.engine().resolveJsonAttribute(props.path("PolicyDocument"));
+        if (document == null || document.isBlank()) {
+            throw new IllegalArgumentException("AWS::IoT::Policy requires PolicyDocument");
+        }
+        Map<String, String> tags = ctx.resolveTags(props, "Tags");
+        String region = ctx.region();
+        if (ctx.reusesPriorEntity(name)) {
+            IotPolicy policy = iotService.getPolicy(name, region);
+            if (!document.equals(policy.getPolicyDocument())) {
+                iotService.createPolicyVersion(name, document, true, region);
+            }
+            reconcileTags(policy.getPolicyArn(), tags);
+            recordPolicy(r, name, policy.getPolicyArn());
+            return;
+        }
+        IotPolicy policy = iotService.createPolicy(name, document, region);
+        recordPolicy(r, name, policy.getPolicyArn());
+        finishCreate(r, ctx, () -> applyTags(policy.getPolicyArn(), tags));
+        deletePrior(r, ctx);
+    }
+
+    /**
+     * The template payload is handed to the service in the IoT API's own shape: the same members
+     * with a lowercase first letter, all the way down into the actions. A generated name keeps only
+     * the characters a rule name allows, since AWS rejects the hyphens
+     * {@link ProvisionContext#generatePhysicalName} emits.
+     */
+    private void provisionTopicRule(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String name = ctx.resolveOptional(props, "RuleName");
+        if (name == null || name.isBlank()) {
+            name = ctx.stablePhysicalName(null, r.getLogicalId(), NAME_MAX_LENGTH, false)
+                    .replaceAll("[^A-Za-z0-9_]", "");
+        }
+        if (props == null || !props.hasNonNull("TopicRulePayload")) {
+            throw new IllegalArgumentException("AWS::IoT::TopicRule requires TopicRulePayload");
+        }
+        JsonNode payload = toApiShape(ctx.engine().resolveNode(props.get("TopicRulePayload")));
+        Map<String, String> tags = ctx.resolveTags(props, "Tags");
+        String region = ctx.region();
+        if (ctx.reusesPriorEntity(name)) {
+            IotTopicRule rule = iotService.replaceTopicRule(name, payload, region);
+            reconcileTags(rule.getRuleArn(), tags);
+            recordTopicRule(r, name, rule.getRuleArn());
+            return;
+        }
+        IotTopicRule rule = iotService.createTopicRule(name, payload, region);
+        recordTopicRule(r, name, rule.getRuleArn());
+        finishCreate(r, ctx, () -> applyTags(rule.getRuleArn(), tags));
+        deletePrior(r, ctx);
+    }
+
+    /**
+     * The service refuses to delete a policy that is still attached to a principal, and on AWS the
+     * stack would fail with a DeleteConflictException. Here the stack that created the policy also
+     * takes its attachments with it, so a local teardown never gets stuck on a device that was
+     * connected while the stack existed.
+     */
+    private void detachAndDeletePolicy(String policyName, String region) {
+        for (String target : iotService.listTargetsForPolicy(policyName, region)) {
+            iotService.detachPolicy(policyName, target, region);
+        }
+        iotService.deletePolicy(policyName, region);
+    }
+
+    private static void recordPolicy(StackResource r, String name, String arn) {
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", arn);
+        r.getAttributes().put("Id", name);
+    }
+
+    private static void recordTopicRule(StackResource r, String name, String arn) {
+        r.setPhysicalId(name);
+        r.getAttributes().put("Arn", arn);
+    }
+
+    private static Map<String, String> thingAttributes(JsonNode props, ProvisionContext ctx) {
+        Map<String, String> attributes = new LinkedHashMap<>();
+        if (props == null || !props.has("AttributePayload")) {
+            return attributes;
+        }
+        JsonNode resolved = ctx.engine().resolveNode(props.get("AttributePayload"));
+        JsonNode values = resolved == null ? null : resolved.path("Attributes");
+        if (values != null && values.isObject()) {
+            values.fields().forEachRemaining(field ->
+                    attributes.put(field.getKey(), ctx.engine().resolve(field.getValue())));
+        }
+        return attributes;
+    }
+
+    /** Recursively renames the members of a resolved node to the API's camelCase, dropping nulls. */
+    private static JsonNode toApiShape(JsonNode node) {
+        if (node.isObject()) {
+            ObjectNode out = JsonNodeFactory.instance.objectNode();
+            node.fields().forEachRemaining(field -> {
+                if (!field.getValue().isNull()) {
+                    out.set(decapitalize(field.getKey()), toApiShape(field.getValue()));
+                }
+            });
+            return out;
+        }
+        if (node.isArray()) {
+            ArrayNode out = JsonNodeFactory.instance.arrayNode();
+            node.forEach(item -> out.add(toApiShape(item)));
+            return out;
+        }
+        return node;
+    }
+
+    private static String decapitalize(String key) {
+        return key.isEmpty() ? key : Character.toLowerCase(key.charAt(0)) + key.substring(1);
+    }
+
+    /**
+     * Runs the calls that follow a create with the resource marked as owned by this stack, so a
+     * failure among them still lets the create rollback delete the entity that now exists. When the
+     * create was a replacement, the entity is removed here instead: CloudFormationService restores
+     * the prior StackResource and never learns the new name, so nothing else would.
+     */
+    private void finishCreate(StackResource r, ProvisionContext ctx, Runnable finish) {
+        r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
+        try {
+            finish.run();
+        } catch (RuntimeException failure) {
+            if (ctx.isUpdate()) {
+                unwindReplacement(r, ctx.region(), failure);
+            }
+            throw failure;
+        }
+        r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
+    }
+
+    private void unwindReplacement(StackResource r, String region, RuntimeException failure) {
+        try {
+            delete(r.getResourceType(), r.getPhysicalId(), region);
+            r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
+        } catch (RuntimeException cleanupFailure) {
+            failure.addSuppressed(cleanupFailure);
+            String reason = "Could not remove " + r.getPhysicalId() + ", the replacement created for "
+                    + r.getLogicalId() + " by a failed update: " + cleanupFailure.getMessage();
+            LOG.warn(reason);
+            r.getAttributes().put(CfnRollback.UPDATE_ROLLBACK_FAILURE_ATTR, reason);
+        }
+    }
+
+    /**
+     * Removes the entity a replacement supersedes. As in CloudFormation's update cleanup, a failure
+     * does not fail the update: the stack already points at the new entity, so the prior one is
+     * left behind, for instance a policy that is still attached to a certificate.
+     */
+    private void deletePrior(StackResource r, ProvisionContext ctx) {
+        if (!ctx.isUpdate()) {
+            return;
+        }
+        try {
+            delete(r.getResourceType(), ctx.priorPhysicalId(), ctx.region());
+        } catch (AwsException e) {
+            LOG.warnv("Could not delete {0} {1} replaced by {2}: {3}",
+                    r.getResourceType(), ctx.priorPhysicalId(), r.getPhysicalId(), e.getMessage());
+        }
+    }
+
+    private void applyTags(String arn, Map<String, String> tags) {
+        if (!tags.isEmpty()) {
+            iotService.tagResource(arn, tags);
+        }
+    }
+
+    private void reconcileTags(String arn, Map<String, String> desired) {
+        List<String> stale = ProvisionContext.staleTagKeys(iotService.listTagsForResource(arn), desired);
+        if (!stale.isEmpty()) {
+            iotService.untagResource(arn, stale);
+        }
+        applyTags(arn, desired);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
@@ -118,27 +118,36 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
 
     /**
      * A policy holds at most five versions. When the service refuses a sixth, this does what the
-     * AWS handler does: the oldest version is deleted and the new one is created again. A default
-     * version cannot be deleted, so when the oldest is still the default the newest becomes the
-     * default first.
+     * AWS handler does: the oldest version is deleted and the new one is created again. Unlike that
+     * handler it tries more than once, because a version created by another client between the
+     * delete and the retry would otherwise fail the stack update; it gives up after as many
+     * attempts as a policy has versions.
      */
     private void createDefaultVersion(String name, String document, String region) {
-        try {
-            iotService.createPolicyVersion(name, document, true, region);
-        } catch (AwsException e) {
-            if (!"VersionsLimitExceededException".equals(e.getErrorCode())) {
-                throw e;
+        for (int attempt = 1; ; attempt++) {
+            try {
+                iotService.createPolicyVersion(name, document, true, region);
+                return;
+            } catch (AwsException e) {
+                if (!"VersionsLimitExceededException".equals(e.getErrorCode())
+                        || attempt >= IotService.MAX_POLICY_VERSIONS) {
+                    throw e;
+                }
             }
-            List<IotPolicy.PolicyVersion> versions = iotService.listPolicyVersions(name, region).stream()
-                    .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
-                    .toList();
-            String oldest = versions.get(0).getVersionId();
-            if (oldest.equals(iotService.getPolicy(name, region).getDefaultVersionId())) {
-                iotService.setDefaultPolicyVersion(name, versions.get(versions.size() - 1).getVersionId(), region);
-            }
-            iotService.deletePolicyVersion(name, oldest, region);
-            iotService.createPolicyVersion(name, document, true, region);
+            deleteOldestVersion(name, region);
         }
+    }
+
+    /** A default version cannot be deleted, so when the oldest is the default the newest becomes the default first. */
+    private void deleteOldestVersion(String name, String region) {
+        List<IotPolicy.PolicyVersion> versions = iotService.listPolicyVersions(name, region).stream()
+                .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
+                .toList();
+        String oldest = versions.get(0).getVersionId();
+        if (oldest.equals(iotService.getPolicy(name, region).getDefaultVersionId())) {
+            iotService.setDefaultPolicyVersion(name, versions.get(versions.size() - 1).getVersionId(), region);
+        }
+        iotService.deletePolicyVersion(name, oldest, region);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
@@ -13,6 +13,7 @@ import io.github.hectorvent.floci.services.iot.model.Thing;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +104,7 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
         if (ctx.reusesPriorEntity(name)) {
             IotPolicy policy = iotService.getPolicy(name, region);
             if (!document.equals(policy.getPolicyDocument())) {
-                iotService.createPolicyVersion(name, document, true, region);
+                createDefaultVersion(name, document, region);
             }
             reconcileTags(policy.getPolicyArn(), tags);
             recordPolicy(r, name, policy.getPolicyArn());
@@ -113,6 +114,31 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
         recordPolicy(r, name, policy.getPolicyArn());
         finishCreate(r, ctx, () -> applyTags(policy.getPolicyArn(), tags));
         deletePrior(r, ctx);
+    }
+
+    /**
+     * A policy holds at most five versions. When the service refuses a sixth, this does what the
+     * AWS handler does: the oldest version is deleted and the new one is created again. A default
+     * version cannot be deleted, so when the oldest is still the default the newest becomes the
+     * default first.
+     */
+    private void createDefaultVersion(String name, String document, String region) {
+        try {
+            iotService.createPolicyVersion(name, document, true, region);
+        } catch (AwsException e) {
+            if (!"VersionsLimitExceededException".equals(e.getErrorCode())) {
+                throw e;
+            }
+            List<IotPolicy.PolicyVersion> versions = iotService.listPolicyVersions(name, region).stream()
+                    .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
+                    .toList();
+            String oldest = versions.get(0).getVersionId();
+            if (oldest.equals(iotService.getPolicy(name, region).getDefaultVersionId())) {
+                iotService.setDefaultPolicyVersion(name, versions.get(versions.size() - 1).getVersionId(), region);
+            }
+            iotService.deletePolicyVersion(name, oldest, region);
+            iotService.createPolicyVersion(name, document, true, region);
+        }
     }
 
     /**
@@ -241,7 +267,7 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
     /**
      * Removes the entity a replacement supersedes. As in CloudFormation's update cleanup, a failure
      * does not fail the update: the stack already points at the new entity, so the prior one is
-     * left behind, for instance a policy that is still attached to a certificate.
+     * left behind with a warning in the log.
      */
     private void deletePrior(StackResource r, ProvisionContext ctx) {
         if (!ctx.isUpdate()) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
@@ -13,7 +13,6 @@ import io.github.hectorvent.floci.services.iot.model.Thing;
 import jakarta.enterprise.context.ApplicationScoped;
 import org.jboss.logging.Logger;
 
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,10 +117,10 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
 
     /**
      * A policy holds at most five versions. When the service refuses a sixth, this does what the
-     * AWS handler does: the oldest version is deleted and the new one is created again. Unlike that
-     * handler it tries more than once, because a version created by another client between the
-     * delete and the retry would otherwise fail the stack update; it gives up after as many
-     * attempts as a policy has versions.
+     * AWS handler does: the oldest version is deleted, in one step on the service's side, and the
+     * new one is created again. Unlike that handler it tries more than once, because a version
+     * created by another client between the delete and the retry would otherwise fail the stack
+     * update; it gives up after as many attempts as a policy has versions.
      */
     private void createDefaultVersion(String name, String document, String region) {
         for (int attempt = 1; ; attempt++) {
@@ -134,20 +133,8 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
                     throw e;
                 }
             }
-            deleteOldestVersion(name, region);
+            iotService.deleteOldestPolicyVersion(name, region);
         }
-    }
-
-    /** A default version cannot be deleted, so when the oldest is the default the newest becomes the default first. */
-    private void deleteOldestVersion(String name, String region) {
-        List<IotPolicy.PolicyVersion> versions = iotService.listPolicyVersions(name, region).stream()
-                .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
-                .toList();
-        String oldest = versions.get(0).getVersionId();
-        if (oldest.equals(iotService.getPolicy(name, region).getDefaultVersionId())) {
-            iotService.setDefaultPolicyVersion(name, versions.get(versions.size() - 1).getVersionId(), region);
-        }
-        iotService.deletePolicyVersion(name, oldest, region);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisioner.java
@@ -117,10 +117,10 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
 
     /**
      * A policy holds at most five versions. When the service refuses a sixth, this does what the
-     * AWS handler does: the oldest version is deleted, in one step on the service's side, and the
-     * new one is created again. Unlike that handler it tries more than once, because a version
-     * created by another client between the delete and the retry would otherwise fail the stack
-     * update; it gives up after as many attempts as a policy has versions.
+     * AWS handler does: the oldest version goes, in one step on the service's side, and the new one
+     * is created again. Unlike that handler it tries more than once, because a version created by
+     * another client between the delete and the retry would otherwise fail the stack update; it
+     * gives up after as many attempts as a policy has versions.
      */
     private void createDefaultVersion(String name, String document, String region) {
         for (int attempt = 1; ; attempt++) {
@@ -132,8 +132,10 @@ public class IotCfnProvisioner implements CfnResourceProvisioner {
                         || attempt >= IotService.MAX_POLICY_VERSIONS) {
                     throw e;
                 }
+                LOG.debugv("Policy {0} is at its version limit, deleting the oldest version before the new default: {1}",
+                        name, e.getMessage());
             }
-            iotService.deleteOldestPolicyVersion(name, region);
+            iotService.makeRoomForPolicyVersion(name, region);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -67,8 +67,8 @@ public class IotService {
     private static final Pattern FIREHOSE_SEPARATOR = Pattern.compile("([\\n\\t])|(\\r\\n)|(,)");
     public static final int MAX_POLICY_VERSIONS = 5;
 
-    /** One lock for every policy version write, so the cap check and the append cannot interleave. */
-    private final Object policyVersionLock = new Object();
+    /** One lock for every policy version write and the policy delete, so a cap check, an append and a delete cannot interleave. */
+    private final Object policyWriteLock = new Object();
 
     private final StorageBackend<String, Thing> thingStore;
     private final StorageBackend<String, IotCertificate> certificateStore;
@@ -377,20 +377,22 @@ public class IotService {
     }
 
     public void deletePolicy(String policyName, String region) {
-        getPolicy(policyName, region);
-        if (!policyAttachmentStore.get(policyAttachmentKey(region, policyName)).orElse(Set.of()).isEmpty()) {
-            throw new AwsException("InvalidRequestException", "Cannot delete attached policy", 400);
+        synchronized (policyWriteLock) {
+            getPolicy(policyName, region);
+            if (!policyAttachmentStore.get(policyAttachmentKey(region, policyName)).orElse(Set.of()).isEmpty()) {
+                throw new AwsException("InvalidRequestException", "Cannot delete attached policy", 400);
+            }
+            policyStore.delete(policyKey(region, policyName));
+            policyAttachmentStore.delete(policyAttachmentKey(region, policyName));
         }
-        policyStore.delete(policyKey(region, policyName));
-        policyAttachmentStore.delete(policyAttachmentKey(region, policyName));
     }
 
     public IotPolicy.PolicyVersion createPolicyVersion(String policyName, String policyDocument, boolean setAsDefault, String region) {
-        synchronized (policyVersionLock) {
+        synchronized (policyWriteLock) {
             IotPolicy policy = getPolicy(policyName, region);
             if (policy.getVersions().size() >= MAX_POLICY_VERSIONS) {
-                throw new AwsException("VersionsLimitExceededException",
-                        "The number of policy versions exceeds the limit", 409);
+                throw new AwsException("VersionsLimitExceededException", "The policy " + policyName
+                        + " already has the maximum number of versions (" + MAX_POLICY_VERSIONS + ")", 409);
             }
             int next = policy.getVersions().stream()
                     .map(IotPolicy.PolicyVersion::getVersionId)
@@ -428,7 +430,7 @@ public class IotService {
     }
 
     public void setDefaultPolicyVersion(String policyName, String versionId, String region) {
-        synchronized (policyVersionLock) {
+        synchronized (policyWriteLock) {
             IotPolicy policy = getPolicy(policyName, region);
             IotPolicy.PolicyVersion version = getPolicyVersion(policyName, versionId, region);
             policy.setDefaultVersionId(versionId);
@@ -438,7 +440,7 @@ public class IotService {
     }
 
     public void deletePolicyVersion(String policyName, String versionId, String region) {
-        synchronized (policyVersionLock) {
+        synchronized (policyWriteLock) {
             IotPolicy policy = getPolicy(policyName, region);
             if (versionId.equals(policy.getDefaultVersionId())) {
                 throw new AwsException("InvalidRequestException", "Cannot delete default policy version", 400);
@@ -455,22 +457,27 @@ public class IotService {
     }
 
     /**
-     * Deletes the oldest version so a new one fits under the cap, as the AWS CloudFormation handler
-     * does once the service refuses a sixth. A default version cannot be deleted, so when the oldest
-     * is the default the newest becomes the default first. One step under the version lock, so
-     * nothing else can move the selection in between.
+     * Deletes the oldest versions until one more fits under the cap, which is what the AWS
+     * CloudFormation handler means to do once the service refuses a sixth (it sorts version ids as
+     * text, so past nine it picks another one). A policy persisted before the cap can hold more
+     * than five, so this deletes as many as it takes. A default version cannot be deleted, so when
+     * the oldest is the default the newest becomes the default first. One step under the policy
+     * write lock, so nothing else can move the selection in between.
      */
-    public void deleteOldestPolicyVersion(String policyName, String region) {
-        synchronized (policyVersionLock) {
+    public void makeRoomForPolicyVersion(String policyName, String region) {
+        synchronized (policyWriteLock) {
             IotPolicy policy = getPolicy(policyName, region);
-            List<IotPolicy.PolicyVersion> versions = policy.getVersions().stream()
-                    .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
-                    .toList();
-            String oldest = versions.get(0).getVersionId();
-            if (oldest.equals(policy.getDefaultVersionId())) {
-                setDefaultPolicyVersion(policyName, versions.get(versions.size() - 1).getVersionId(), region);
+            while (policy.getVersions().size() >= MAX_POLICY_VERSIONS) {
+                List<IotPolicy.PolicyVersion> versions = policy.getVersions().stream()
+                        .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
+                        .toList();
+                String oldest = versions.get(0).getVersionId();
+                if (oldest.equals(policy.getDefaultVersionId())) {
+                    setDefaultPolicyVersion(policyName, versions.get(versions.size() - 1).getVersionId(), region);
+                }
+                deletePolicyVersion(policyName, oldest, region);
+                policy = getPolicy(policyName, region);
             }
-            deletePolicyVersion(policyName, oldest, region);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -65,6 +65,10 @@ public class IotService {
     private static final Pattern THING_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9:_-]{1,128}");
     /** The {@code FirehoseSeparator} shape of the IoT API model. */
     private static final Pattern FIREHOSE_SEPARATOR = Pattern.compile("([\\n\\t])|(\\r\\n)|(,)");
+    static final int MAX_POLICY_VERSIONS = 5;
+
+    /** One lock for every policy version write, so the cap check and the append cannot interleave. */
+    private final Object policyVersionLock = new Object();
 
     private final StorageBackend<String, Thing> thingStore;
     private final StorageBackend<String, IotCertificate> certificateStore;
@@ -382,25 +386,31 @@ public class IotService {
     }
 
     public IotPolicy.PolicyVersion createPolicyVersion(String policyName, String policyDocument, boolean setAsDefault, String region) {
-        IotPolicy policy = getPolicy(policyName, region);
-        int next = policy.getVersions().stream()
-                .map(IotPolicy.PolicyVersion::getVersionId)
-                .mapToInt(Integer::parseInt)
-                .max()
-                .orElse(0) + 1;
-        IotPolicy.PolicyVersion version = new IotPolicy.PolicyVersion();
-        version.setVersionId(Integer.toString(next));
-        version.setDocument(policyDocument);
-        version.setCreateDate(Instant.now());
-        List<IotPolicy.PolicyVersion> versions = new java.util.ArrayList<>(policy.getVersions());
-        versions.add(version);
-        policy.setVersions(versions);
-        if (setAsDefault) {
-            policy.setDefaultVersionId(version.getVersionId());
-            policy.setPolicyDocument(policyDocument);
+        synchronized (policyVersionLock) {
+            IotPolicy policy = getPolicy(policyName, region);
+            if (policy.getVersions().size() >= MAX_POLICY_VERSIONS) {
+                throw new AwsException("VersionsLimitExceededException",
+                        "The number of policy versions exceeds the limit", 409);
+            }
+            int next = policy.getVersions().stream()
+                    .map(IotPolicy.PolicyVersion::getVersionId)
+                    .mapToInt(Integer::parseInt)
+                    .max()
+                    .orElse(0) + 1;
+            IotPolicy.PolicyVersion version = new IotPolicy.PolicyVersion();
+            version.setVersionId(Integer.toString(next));
+            version.setDocument(policyDocument);
+            version.setCreateDate(Instant.now());
+            List<IotPolicy.PolicyVersion> versions = new ArrayList<>(policy.getVersions());
+            versions.add(version);
+            policy.setVersions(versions);
+            if (setAsDefault) {
+                policy.setDefaultVersionId(version.getVersionId());
+                policy.setPolicyDocument(policyDocument);
+            }
+            policyStore.put(policyKey(region, policyName), policy);
+            return version;
         }
-        policyStore.put(policyKey(region, policyName), policy);
-        return version;
     }
 
     public IotPolicy.PolicyVersion getPolicyVersion(String policyName, String versionId, String region) {
@@ -418,26 +428,30 @@ public class IotService {
     }
 
     public void setDefaultPolicyVersion(String policyName, String versionId, String region) {
-        IotPolicy policy = getPolicy(policyName, region);
-        IotPolicy.PolicyVersion version = getPolicyVersion(policyName, versionId, region);
-        policy.setDefaultVersionId(versionId);
-        policy.setPolicyDocument(version.getDocument());
-        policyStore.put(policyKey(region, policyName), policy);
+        synchronized (policyVersionLock) {
+            IotPolicy policy = getPolicy(policyName, region);
+            IotPolicy.PolicyVersion version = getPolicyVersion(policyName, versionId, region);
+            policy.setDefaultVersionId(versionId);
+            policy.setPolicyDocument(version.getDocument());
+            policyStore.put(policyKey(region, policyName), policy);
+        }
     }
 
     public void deletePolicyVersion(String policyName, String versionId, String region) {
-        IotPolicy policy = getPolicy(policyName, region);
-        if (versionId.equals(policy.getDefaultVersionId())) {
-            throw new AwsException("InvalidRequestException", "Cannot delete default policy version", 400);
+        synchronized (policyVersionLock) {
+            IotPolicy policy = getPolicy(policyName, region);
+            if (versionId.equals(policy.getDefaultVersionId())) {
+                throw new AwsException("InvalidRequestException", "Cannot delete default policy version", 400);
+            }
+            List<IotPolicy.PolicyVersion> versions = policy.getVersions().stream()
+                    .filter(version -> !versionId.equals(version.getVersionId()))
+                    .toList();
+            if (versions.size() == policy.getVersions().size()) {
+                throw new AwsException("ResourceNotFoundException", "Policy version not found: " + versionId, 404);
+            }
+            policy.setVersions(versions);
+            policyStore.put(policyKey(region, policyName), policy);
         }
-        List<IotPolicy.PolicyVersion> versions = policy.getVersions().stream()
-                .filter(version -> !versionId.equals(version.getVersionId()))
-                .toList();
-        if (versions.size() == policy.getVersions().size()) {
-            throw new AwsException("ResourceNotFoundException", "Policy version not found: " + versionId, 404);
-        }
-        policy.setVersions(versions);
-        policyStore.put(policyKey(region, policyName), policy);
     }
 
     public void attachPolicy(String policyName, String target, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -65,7 +65,7 @@ public class IotService {
     private static final Pattern THING_NAME_PATTERN = Pattern.compile("[a-zA-Z0-9:_-]{1,128}");
     /** The {@code FirehoseSeparator} shape of the IoT API model. */
     private static final Pattern FIREHOSE_SEPARATOR = Pattern.compile("([\\n\\t])|(\\r\\n)|(,)");
-    static final int MAX_POLICY_VERSIONS = 5;
+    public static final int MAX_POLICY_VERSIONS = 5;
 
     /** One lock for every policy version write, so the cap check and the append cannot interleave. */
     private final Object policyVersionLock = new Object();

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -454,6 +454,26 @@ public class IotService {
         }
     }
 
+    /**
+     * Deletes the oldest version so a new one fits under the cap, as the AWS CloudFormation handler
+     * does once the service refuses a sixth. A default version cannot be deleted, so when the oldest
+     * is the default the newest becomes the default first. One step under the version lock, so
+     * nothing else can move the selection in between.
+     */
+    public void deleteOldestPolicyVersion(String policyName, String region) {
+        synchronized (policyVersionLock) {
+            IotPolicy policy = getPolicy(policyName, region);
+            List<IotPolicy.PolicyVersion> versions = policy.getVersions().stream()
+                    .sorted(Comparator.comparingInt(version -> Integer.parseInt(version.getVersionId())))
+                    .toList();
+            String oldest = versions.get(0).getVersionId();
+            if (oldest.equals(policy.getDefaultVersionId())) {
+                setDefaultPolicyVersion(policyName, versions.get(versions.size() - 1).getVersionId(), region);
+            }
+            deletePolicyVersion(policyName, oldest, region);
+        }
+    }
+
     public void attachPolicy(String policyName, String target, String region) {
         getPolicy(policyName, region);
         Set<String> targets = new HashSet<>(policyAttachmentStore.get(policyAttachmentKey(region, policyName)).orElse(Set.of()));

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
@@ -38,6 +38,7 @@ import io.github.hectorvent.floci.services.cloudformation.provisioners.EcrCfnPro
 import io.github.hectorvent.floci.services.cloudformation.provisioners.EcsCapacityCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.FirehoseCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.IamRoleCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.IotDomainConfigurationCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.KinesisCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.KmsCfnProvisioner;
@@ -68,6 +69,7 @@ import io.github.hectorvent.floci.services.eventbridge.EventBridgeService;
 import io.github.hectorvent.floci.services.firehose.FirehoseService;
 import io.github.hectorvent.floci.services.iam.IamService;
 import io.github.hectorvent.floci.services.iot.IotDomainConfigurationService;
+import io.github.hectorvent.floci.services.iot.IotService;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
 import io.github.hectorvent.floci.services.kms.KmsService;
 import io.github.hectorvent.floci.services.lambda.LambdaLayerService;
@@ -150,6 +152,7 @@ final class CfnProvisionerFixture {
         // dispatcher. They exist only so inferredProvisioners() can wire their provisioner.
         private FlowLogService flowLogService;
         private IotDomainConfigurationService iotDomainConfigurationService;
+        private IotService iotService;
         private LambdaMicrovmsService lambdaMicrovmsService;
         private AwsConfigService awsConfigService;
         private OrganizationsService organizationsService;
@@ -253,6 +256,9 @@ final class CfnProvisionerFixture {
             }
             if (iotDomainConfigurationService != null) {
                 discovered.add(new IotDomainConfigurationCfnProvisioner(iotDomainConfigurationService));
+            }
+            if (iotService != null) {
+                discovered.add(new IotCfnProvisioner(iotService));
             }
             if (lambdaMicrovmsService != null) {
                 discovered.add(new LambdaMicrovmsCfnProvisioner(lambdaMicrovmsService));
@@ -468,6 +474,11 @@ final class CfnProvisionerFixture {
 
         public Builder iotDomainConfiguration(IotDomainConfigurationService v) {
             this.iotDomainConfigurationService = v;
+            return this;
+        }
+
+        public Builder iot(IotService v) {
+            this.iotService = v;
             return this;
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/IotCfnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/IotCfnIntegrationTest.java
@@ -1,0 +1,261 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.core.common.XmlParser;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Provisions an {@code AWS::IoT::Thing}, an {@code AWS::IoT::Policy} and an
+ * {@code AWS::IoT::TopicRule} through one CloudFormation stack and asserts that {@code Ref} and every
+ * {@code Fn::GetAtt} attribute carry what the IoT API reports, rather than the literal
+ * {@code Logical.Attr} the stub arm would leave behind. The rule's action targets a queue from the
+ * same template, so a publish through the rule proves the payload reached the service in the API's
+ * shape; a second action on a queue that does not exist proves that one failing action neither
+ * fails the publish nor the other action, and that the error action receives the failure. Also
+ * covers the in-place update of all three and that deleting the stack removes them.
+ */
+@QuarkusTest
+class IotCfnIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260903/us-east-1/cloudformation/aws4_request";
+    private static final String STACK = "iot-cfn-it";
+    private static final String THING = "iot-cfn-it-sensor";
+    private static final String POLICY = "iot-cfn-it-policy";
+    private static final String RULE = "iotCfnItRule";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/iot-cfn-it";
+
+    private static String template(String serialNumber, String policyAction, String topicFilter, String tagValue) {
+        return """
+            {
+              "Resources": {
+                "Queue": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "iot-cfn-it-queue"}},
+                "ErrorQueue": {"Type": "AWS::SQS::Queue", "Properties": {"QueueName": "iot-cfn-it-error-queue"}},
+                "Sensor": {
+                  "Type": "AWS::IoT::Thing",
+                  "Properties": {
+                    "ThingName": "%s",
+                    "AttributePayload": {"Attributes": {"SerialNumber": "%s"}}
+                  }
+                },
+                "Policy": {
+                  "Type": "AWS::IoT::Policy",
+                  "Properties": {
+                    "PolicyName": "%s",
+                    "PolicyDocument": {
+                      "Version": "2012-10-17",
+                      "Statement": [{"Effect": "Allow", "Action": "%s", "Resource": "*"}]
+                    },
+                    "Tags": [{"Key": "stack", "Value": "%s"}]
+                  }
+                },
+                "Rule": {
+                  "Type": "AWS::IoT::TopicRule",
+                  "Properties": {
+                    "RuleName": "%s",
+                    "TopicRulePayload": {
+                      "Sql": "SELECT * FROM '%s'",
+                      "AwsIotSqlVersion": "2016-03-23",
+                      "RuleDisabled": false,
+                      "Actions": [
+                        {"Sqs": {"QueueUrl": {"Ref": "Queue"}, "RoleArn": "%s", "UseBase64": false}},
+                        {"Sqs": {"QueueUrl": "http://localhost:4566/000000000000/iot-cfn-it-missing-queue", "RoleArn": "%s"}}
+                      ],
+                      "ErrorAction": {"Sqs": {"QueueUrl": {"Ref": "ErrorQueue"}, "RoleArn": "%s"}}
+                    },
+                    "Tags": [{"Key": "stack", "Value": "%s"}]
+                  }
+                }
+              },
+              "Outputs": {
+                "QueueUrl": {"Value": {"Ref": "Queue"}},
+                "ErrorQueueUrl": {"Value": {"Ref": "ErrorQueue"}},
+                "SensorRef": {"Value": {"Ref": "Sensor"}},
+                "SensorArn": {"Value": {"Fn::GetAtt": ["Sensor", "Arn"]}},
+                "SensorId": {"Value": {"Fn::GetAtt": ["Sensor", "Id"]}},
+                "PolicyRef": {"Value": {"Ref": "Policy"}},
+                "PolicyArn": {"Value": {"Fn::GetAtt": ["Policy", "Arn"]}},
+                "PolicyId": {"Value": {"Fn::GetAtt": ["Policy", "Id"]}},
+                "RuleRef": {"Value": {"Ref": "Rule"}},
+                "RuleArn": {"Value": {"Fn::GetAtt": ["Rule", "Arn"]}}
+              }
+            }
+            """.formatted(THING, serialNumber, POLICY, policyAction, tagValue, RULE, topicFilter,
+                ROLE_ARN, ROLE_ARN, ROLE_ARN, tagValue);
+    }
+
+    @Test
+    void iotStackExposesRealIdentifiersUpdatesInPlaceAndDeletesTheResources() throws Exception {
+        cloudFormation("CreateStack", template("SN-1", "iot:Connect", "iot-cfn-it/+/telemetry", "v1"));
+
+        String stacks = describeStacks("CREATE_COMPLETE");
+        String queueUrl = outputValue(stacks, "QueueUrl");
+        String errorQueueUrl = outputValue(stacks, "ErrorQueueUrl");
+        String thingArn = outputValue(stacks, "SensorArn");
+        String thingId = outputValue(stacks, "SensorId");
+        String policyArn = outputValue(stacks, "PolicyArn");
+        String ruleArn = outputValue(stacks, "RuleArn");
+        assertEquals(THING, outputValue(stacks, "SensorRef"));
+        assertEquals("arn:aws:iot:us-east-1:000000000000:thing/" + THING, thingArn);
+        assertEquals(POLICY, outputValue(stacks, "PolicyRef"));
+        assertEquals(POLICY, outputValue(stacks, "PolicyId"));
+        assertEquals("arn:aws:iot:us-east-1:000000000000:policy/" + POLICY, policyArn);
+        assertEquals(RULE, outputValue(stacks, "RuleRef"));
+        assertEquals("arn:aws:iot:us-east-1:000000000000:rule/" + RULE, ruleArn);
+
+        given()
+        .when()
+            .get("/things/" + THING)
+        .then()
+            .statusCode(200)
+            .body("thingArn", equalTo(thingArn))
+            .body("thingId", equalTo(thingId))
+            .body("attributes.SerialNumber", equalTo("SN-1"));
+        given()
+        .when()
+            .get("/policies/" + POLICY)
+        .then()
+            .statusCode(200)
+            .body("policyArn", equalTo(policyArn))
+            .body("defaultVersionId", equalTo("1"))
+            .body("policyDocument", containsString("iot:Connect"));
+        assertTagValue(policyArn, "v1");
+        given()
+        .when()
+            .get("/rules/" + RULE)
+        .then()
+            .statusCode(200)
+            .body("ruleArn", equalTo(ruleArn))
+            .body("rule.sql", equalTo("SELECT * FROM 'iot-cfn-it/+/telemetry'"))
+            .body("rule.awsIotSqlVersion", equalTo("2016-03-23"))
+            .body("rule.ruleDisabled", equalTo(false))
+            .body("rule.actions[0].sqs.queueUrl", equalTo(queueUrl))
+            .body("rule.errorAction.sqs.queueUrl", equalTo(errorQueueUrl));
+        assertTagValue(ruleArn, "v1");
+
+        given()
+            .contentType("text/plain")
+            .body("iot-cfn-it-payload")
+        .when()
+            .post("/topics/iot-cfn-it/d1/telemetry")
+        .then()
+            .statusCode(200);
+        receiveMessage(queueUrl).body(containsString("iot-cfn-it-payload"));
+        receiveMessage(errorQueueUrl)
+            .body(containsString(RULE))
+            .body(containsString("SqsAction"))
+            .body(containsString("iot-cfn-it-missing-queue"));
+
+        cloudFormation("UpdateStack", template("SN-2", "iot:Publish", "iot-cfn-it/+/telemetry/v2", "v2"));
+
+        String updated = describeStacks("UPDATE_COMPLETE");
+        assertEquals(thingId, outputValue(updated, "SensorId"));
+        given()
+        .when()
+            .get("/things/" + THING)
+        .then()
+            .statusCode(200)
+            .body("thingId", equalTo(thingId))
+            .body("attributes.SerialNumber", equalTo("SN-2"));
+        given()
+        .when()
+            .get("/policies/" + POLICY)
+        .then()
+            .statusCode(200)
+            .body("defaultVersionId", equalTo("2"))
+            .body("policyDocument", containsString("iot:Publish"));
+        assertTagValue(policyArn, "v2");
+        given()
+        .when()
+            .get("/rules/" + RULE)
+        .then()
+            .statusCode(200)
+            .body("ruleArn", equalTo(ruleArn))
+            .body("rule.sql", equalTo("SELECT * FROM 'iot-cfn-it/+/telemetry/v2'"));
+        assertTagValue(ruleArn, "v2");
+
+        cloudFormation("DeleteStack", null);
+        awaitStackDeleted();
+
+        given().when().get("/things/" + THING).then().statusCode(404);
+        given().when().get("/policies/" + POLICY).then().statusCode(404);
+        given().when().get("/rules/" + RULE).then().statusCode(404);
+    }
+
+    private static ValidatableResponse receiveMessage(String queueUrl) {
+        return given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ReceiveMessage")
+            .formParam("QueueUrl", queueUrl)
+            .formParam("MaxNumberOfMessages", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    private static void assertTagValue(String arn, String expected) {
+        given()
+            .queryParam("resourceArn", arn)
+        .when()
+            .get("/tags")
+        .then()
+            .statusCode(200)
+            .body("tags.find { it.Key == 'stack' }.Value", equalTo(expected));
+    }
+
+    private static void cloudFormation(String action, String templateBody) {
+        RequestSpecification request = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", action)
+            .formParam("StackName", STACK);
+        if (templateBody != null) {
+            request.formParam("TemplateBody", templateBody);
+        }
+        request.when().post("/").then().statusCode(200);
+    }
+
+    private static String describeStacks(String expectedStatus) {
+        return given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", STACK)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<StackStatus>" + expectedStatus + "</StackStatus>"))
+            .extract().asString();
+    }
+
+    /** DeleteStack runs asynchronously; a successful delete removes the stack entirely. */
+    private static void awaitStackDeleted() throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            String body = given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", CFN_AUTH)
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", STACK)
+            .when().post("/").then().extract().asString();
+            if (body.contains("does not exist")) {
+                return;
+            }
+            if (body.contains("<StackStatus>DELETE_FAILED</StackStatus>")) {
+                fail("stack delete failed: " + body);
+            }
+            Thread.sleep(50);
+        }
+        fail("stack " + STACK + " was not deleted within the timeout");
+    }
+
+    private static String outputValue(String xml, String key) {
+        return XmlParser.extractPairs(xml, "Outputs", "OutputKey", "OutputValue").get(key);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/IotCfnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/IotCfnIntegrationTest.java
@@ -52,7 +52,7 @@ class IotCfnIntegrationTest {
                     "PolicyName": "%s",
                     "PolicyDocument": {
                       "Version": "2012-10-17",
-                      "Statement": [{"Effect": "Allow", "Action": "%s", "Resource": "*"}]
+                      "Statement": [{"Effect": "Allow", "Action": "%s", "Resource": "arn:aws:iot:us-east-1:000000000000:client/${iot:Connection.Thing.ThingName}"}]
                     },
                     "Tags": [{"Key": "stack", "Value": "%s"}]
                   }
@@ -126,7 +126,8 @@ class IotCfnIntegrationTest {
             .statusCode(200)
             .body("policyArn", equalTo(policyArn))
             .body("defaultVersionId", equalTo("1"))
-            .body("policyDocument", containsString("iot:Connect"));
+            .body("policyDocument", containsString("iot:Connect"))
+            .body("policyDocument", containsString("${iot:Connection.Thing.ThingName}"));
         assertTagValue(policyArn, "v1");
         given()
         .when()

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/IotCfnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/IotCfnIntegrationTest.java
@@ -6,7 +6,10 @@ import io.restassured.response.ValidatableResponse;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -182,6 +185,27 @@ class IotCfnIntegrationTest {
             .body("ruleArn", equalTo(ruleArn))
             .body("rule.sql", equalTo("SELECT * FROM 'iot-cfn-it/+/telemetry/v2'"));
         assertTagValue(ruleArn, "v2");
+
+        // Four more document changes. The service refuses a sixth version, so the stack deletes
+        // the oldest one first, as the AWS handler does, and the policy keeps five versions.
+        for (String action : List.of("iot:Subscribe", "iot:Receive", "iot:GetThingShadow", "iot:UpdateThingShadow")) {
+            cloudFormation("UpdateStack", template("SN-2", action, "iot-cfn-it/+/telemetry/v2", "v2"));
+            describeStacks("UPDATE_COMPLETE");
+        }
+        given()
+        .when()
+            .get("/policies/" + POLICY + "/version")
+        .then()
+            .statusCode(200)
+            .body("policyVersions.versionId", contains("2", "3", "4", "5", "6"))
+            .body("policyVersions.find { it.isDefaultVersion }.versionId", equalTo("6"));
+        given()
+        .when()
+            .get("/policies/" + POLICY)
+        .then()
+            .statusCode(200)
+            .body("defaultVersionId", equalTo("6"))
+            .body("policyDocument", containsString("iot:UpdateThingShadow"));
 
         cloudFormation("DeleteStack", null);
         awaitStackDeleted();

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisionerTestSupport.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotCfnProvisionerTestSupport.java
@@ -1,0 +1,89 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationTemplateEngine;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * What the three {@link IotCfnProvisioner} unit tests share: a mocked template engine that behaves
+ * like the real one for the shapes these templates use, and the resource and error factories.
+ */
+final class IotCfnProvisionerTestSupport {
+
+    static final String REGION = "us-east-1";
+    static final String ACCOUNT = "000000000000";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private IotCfnProvisionerTestSupport() {
+    }
+
+    static ProvisionContext ctx() {
+        return ctx(null);
+    }
+
+    /**
+     * Scalars resolve to their text, an intrinsic collapses to a {@code resolved:} marker and
+     * everything else is walked in place, so a nested payload keeps its shape and scalar types.
+     */
+    static ProvisionContext ctx(String priorPhysicalId) {
+        CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+        when(engine.resolve(any())).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            return node == null || node.isMissingNode() || node.isNull() ? null : node.asText();
+        });
+        when(engine.resolveNode(any())).thenAnswer(inv -> resolveIntrinsics(inv.getArgument(0)));
+        when(engine.resolveJsonAttribute(any())).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            if (node == null || node.isMissingNode() || node.isNull()) {
+                return null;
+            }
+            return node.isTextual() ? node.asText() : node.toString();
+        });
+        return new ProvisionContext(engine, REGION, ACCOUNT, "my-stack", priorPhysicalId);
+    }
+
+    static JsonNode resolveIntrinsics(JsonNode node) {
+        if (node == null || !node.isContainerNode()) {
+            return node;
+        }
+        if (node.isArray()) {
+            ArrayNode out = MAPPER.createArrayNode();
+            node.forEach(item -> out.add(resolveIntrinsics(item)));
+            return out;
+        }
+        if (node.has("Fn::GetAtt")) {
+            JsonNode target = node.get("Fn::GetAtt");
+            return TextNode.valueOf("resolved:" + target.get(0).asText() + "." + target.get(1).asText());
+        }
+        if (node.has("Ref")) {
+            return TextNode.valueOf("resolved:" + node.get("Ref").asText());
+        }
+        ObjectNode out = MAPPER.createObjectNode();
+        node.fields().forEachRemaining(field -> out.set(field.getKey(), resolveIntrinsics(field.getValue())));
+        return out;
+    }
+
+    static StackResource resource(String type, String logicalId) {
+        StackResource r = new StackResource();
+        r.setLogicalId(logicalId);
+        r.setResourceType(type);
+        r.setAttributes(new HashMap<>());
+        return r;
+    }
+
+    static AwsException notFound(String what) {
+        return new AwsException("ResourceNotFoundException", what + " not found", 404);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
@@ -310,9 +310,9 @@ class IotPolicyCfnProvisionerTest {
 
         InOrder inOrder = inOrder(iot);
         inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
-        inOrder.verify(iot).deleteOldestPolicyVersion("device-policy", REGION);
+        inOrder.verify(iot).makeRoomForPolicyVersion("device-policy", REGION);
         inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
-        verify(iot, times(1)).deleteOldestPolicyVersion(anyString(), anyString());
+        verify(iot, times(1)).makeRoomForPolicyVersion(anyString(), anyString());
         verify(iot, never()).deletePolicyVersion(anyString(), anyString(), anyString());
         assertEquals(ARN, r.getAttributes().get("Arn"));
         assertEquals("device-policy", r.getAttributes().get("Id"));
@@ -330,7 +330,7 @@ class IotPolicyCfnProvisionerTest {
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
 
         assertEquals("InternalFailureException", e.getErrorCode());
-        verify(iot, never()).deleteOldestPolicyVersion(anyString(), anyString());
+        verify(iot, never()).makeRoomForPolicyVersion(anyString(), anyString());
     }
 
     @Test
@@ -346,7 +346,7 @@ class IotPolicyCfnProvisionerTest {
 
         provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
 
-        verify(iot, times(2)).deleteOldestPolicyVersion("device-policy", REGION);
+        verify(iot, times(2)).makeRoomForPolicyVersion("device-policy", REGION);
         verify(iot, times(3)).createPolicyVersion("device-policy", changed, true, REGION);
         assertEquals(ARN, r.getAttributes().get("Arn"));
     }
@@ -363,7 +363,7 @@ class IotPolicyCfnProvisionerTest {
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
 
         assertEquals("VersionsLimitExceededException", e.getErrorCode());
-        verify(iot, times(IotService.MAX_POLICY_VERSIONS - 1)).deleteOldestPolicyVersion("device-policy", REGION);
+        verify(iot, times(IotService.MAX_POLICY_VERSIONS - 1)).makeRoomForPolicyVersion("device-policy", REGION);
         verify(iot, times(IotService.MAX_POLICY_VERSIONS)).createPolicyVersion("device-policy", changed, true, REGION);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
@@ -28,10 +28,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.calls;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -283,5 +285,94 @@ class IotPolicyCfnProvisionerTest {
         verify(iot, never()).deletePolicy("gone", REGION);
         AwsException e = assertThrows(AwsException.class, () -> provisioner.delete(TYPE, "stuck", REGION));
         assertEquals("InternalFailureException", e.getErrorCode());
+    }
+
+    private static IotPolicy.PolicyVersion version(String id) {
+        IotPolicy.PolicyVersion version = new IotPolicy.PolicyVersion();
+        version.setVersionId(id);
+        return version;
+    }
+
+    private static AwsException versionsLimit() {
+        return new AwsException("VersionsLimitExceededException", "The number of policy versions exceeds the limit", 409);
+    }
+
+    @Test
+    void policyUpdateDeletesTheOldestVersionWhenTheServiceRefusesASixthAndCreatesAgain() throws Exception {
+        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        IotPolicy policy = policy("device-policy", DOCUMENT);
+        policy.setDefaultVersionId("10");
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy);
+        // Sorted as text, "10" would come first; the oldest version is the numerically smallest id.
+        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
+                version("10"), version("6"), version("7"), version("8"), version("9")));
+        when(iot.createPolicyVersion("device-policy", changed, true, REGION))
+                .thenThrow(versionsLimit())
+                .thenReturn(version("11"));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
+
+        InOrder inOrder = inOrder(iot);
+        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+        inOrder.verify(iot).deletePolicyVersion("device-policy", "6", REGION);
+        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+        verify(iot, never()).setDefaultPolicyVersion(anyString(), anyString(), anyString());
+        verify(iot, times(1)).deletePolicyVersion(anyString(), anyString(), anyString());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void policyUpdateMakesTheNewestVersionTheDefaultBeforeDeletingAnOldestDefault() throws Exception {
+        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
+                version("1"), version("2"), version("3"), version("4"), version("5")));
+        when(iot.createPolicyVersion("device-policy", changed, true, REGION))
+                .thenThrow(versionsLimit())
+                .thenReturn(version("6"));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
+
+        InOrder inOrder = inOrder(iot);
+        inOrder.verify(iot).setDefaultPolicyVersion("device-policy", "5", REGION);
+        inOrder.verify(iot).deletePolicyVersion("device-policy", "1", REGION);
+        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+    }
+
+    @Test
+    void policyUpdatePassesOtherVersionErrorsThroughWithoutPruning() throws Exception {
+        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        when(iot.createPolicyVersion("device-policy", changed, true, REGION))
+                .thenThrow(new AwsException("InternalFailureException", "storage", 500));
+        StackResource r = resource(TYPE, "Policy");
+        ObjectNode props = props("device-policy", mapper.readTree(changed), null);
+
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
+
+        assertEquals("InternalFailureException", e.getErrorCode());
+        verify(iot, never()).listPolicyVersions(anyString(), anyString());
+        verify(iot, never()).deletePolicyVersion(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void policyUpdateGivesUpWhenTheServiceStillRefusesAfterOneVersionWasDeleted() throws Exception {
+        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
+                version("1"), version("2"), version("3"), version("4"), version("5"), version("6")));
+        when(iot.createPolicyVersion("device-policy", changed, true, REGION))
+                .thenThrow(versionsLimit())
+                .thenThrow(versionsLimit());
+        StackResource r = resource(TYPE, "Policy");
+        ObjectNode props = props("device-policy", mapper.readTree(changed), null);
+
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
+
+        assertEquals("VersionsLimitExceededException", e.getErrorCode());
+        verify(iot, times(1)).deletePolicyVersion(anyString(), anyString(), anyString());
+        verify(iot, times(2)).createPolicyVersion("device-policy", changed, true, REGION);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
@@ -300,34 +300,7 @@ class IotPolicyCfnProvisionerTest {
     @Test
     void policyUpdateDeletesTheOldestVersionWhenTheServiceRefusesASixthAndCreatesAgain() throws Exception {
         String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
-        IotPolicy policy = policy("device-policy", DOCUMENT);
-        policy.setDefaultVersionId("10");
-        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy);
-        // Sorted as text, "10" would come first; the oldest version is the numerically smallest id.
-        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
-                version("10"), version("6"), version("7"), version("8"), version("9")));
-        when(iot.createPolicyVersion("device-policy", changed, true, REGION))
-                .thenThrow(versionsLimit())
-                .thenReturn(version("11"));
-        StackResource r = resource(TYPE, "Policy");
-
-        provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
-
-        InOrder inOrder = inOrder(iot);
-        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
-        inOrder.verify(iot).deletePolicyVersion("device-policy", "6", REGION);
-        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
-        verify(iot, never()).setDefaultPolicyVersion(anyString(), anyString(), anyString());
-        verify(iot, times(1)).deletePolicyVersion(anyString(), anyString(), anyString());
-        assertEquals(ARN, r.getAttributes().get("Arn"));
-    }
-
-    @Test
-    void policyUpdateMakesTheNewestVersionTheDefaultBeforeDeletingAnOldestDefault() throws Exception {
-        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
         when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
-        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
-                version("1"), version("2"), version("3"), version("4"), version("5")));
         when(iot.createPolicyVersion("device-policy", changed, true, REGION))
                 .thenThrow(versionsLimit())
                 .thenReturn(version("6"));
@@ -336,9 +309,13 @@ class IotPolicyCfnProvisionerTest {
         provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
 
         InOrder inOrder = inOrder(iot);
-        inOrder.verify(iot).setDefaultPolicyVersion("device-policy", "5", REGION);
-        inOrder.verify(iot).deletePolicyVersion("device-policy", "1", REGION);
         inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+        inOrder.verify(iot).deleteOldestPolicyVersion("device-policy", REGION);
+        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+        verify(iot, times(1)).deleteOldestPolicyVersion(anyString(), anyString());
+        verify(iot, never()).deletePolicyVersion(anyString(), anyString(), anyString());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+        assertEquals("device-policy", r.getAttributes().get("Id"));
     }
 
     @Test
@@ -353,20 +330,14 @@ class IotPolicyCfnProvisionerTest {
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
 
         assertEquals("InternalFailureException", e.getErrorCode());
-        verify(iot, never()).listPolicyVersions(anyString(), anyString());
-        verify(iot, never()).deletePolicyVersion(anyString(), anyString(), anyString());
+        verify(iot, never()).deleteOldestPolicyVersion(anyString(), anyString());
     }
 
     @Test
     void policyUpdatePrunesAgainWhenAnotherVersionRefilledTheSlotBeforeTheRetry() throws Exception {
-        // Another client created version 6 between the delete of version 1 and the retry.
+        // Another client created a version between the prune and the retry.
         String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
-        IotPolicy policy = policy("device-policy", DOCUMENT);
-        policy.setDefaultVersionId("5");
-        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy);
-        when(iot.listPolicyVersions("device-policy", REGION))
-                .thenReturn(List.of(version("1"), version("2"), version("3"), version("4"), version("5")))
-                .thenReturn(List.of(version("2"), version("3"), version("4"), version("5"), version("6")));
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
         when(iot.createPolicyVersion("device-policy", changed, true, REGION))
                 .thenThrow(versionsLimit())
                 .thenThrow(versionsLimit())
@@ -375,10 +346,7 @@ class IotPolicyCfnProvisionerTest {
 
         provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
 
-        InOrder inOrder = inOrder(iot);
-        inOrder.verify(iot).deletePolicyVersion("device-policy", "1", REGION);
-        inOrder.verify(iot).deletePolicyVersion("device-policy", "2", REGION);
-        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+        verify(iot, times(2)).deleteOldestPolicyVersion("device-policy", REGION);
         verify(iot, times(3)).createPolicyVersion("device-policy", changed, true, REGION);
         assertEquals(ARN, r.getAttributes().get("Arn"));
     }
@@ -386,11 +354,7 @@ class IotPolicyCfnProvisionerTest {
     @Test
     void policyUpdateGivesUpAfterAsManyPrunesAsAPolicyHasVersions() throws Exception {
         String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
-        IotPolicy policy = policy("device-policy", DOCUMENT);
-        policy.setDefaultVersionId("5");
-        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy);
-        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
-                version("1"), version("2"), version("3"), version("4"), version("5")));
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
         when(iot.createPolicyVersion("device-policy", changed, true, REGION))
                 .thenAnswer(inv -> { throw versionsLimit(); });
         StackResource r = resource(TYPE, "Policy");
@@ -399,7 +363,7 @@ class IotPolicyCfnProvisionerTest {
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
 
         assertEquals("VersionsLimitExceededException", e.getErrorCode());
-        verify(iot, times(IotService.MAX_POLICY_VERSIONS - 1)).deletePolicyVersion(anyString(), anyString(), anyString());
+        verify(iot, times(IotService.MAX_POLICY_VERSIONS - 1)).deleteOldestPolicyVersion("device-policy", REGION);
         verify(iot, times(IotService.MAX_POLICY_VERSIONS)).createPolicyVersion("device-policy", changed, true, REGION);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
@@ -358,21 +358,48 @@ class IotPolicyCfnProvisionerTest {
     }
 
     @Test
-    void policyUpdateGivesUpWhenTheServiceStillRefusesAfterOneVersionWasDeleted() throws Exception {
+    void policyUpdatePrunesAgainWhenAnotherVersionRefilledTheSlotBeforeTheRetry() throws Exception {
+        // Another client created version 6 between the delete of version 1 and the retry.
         String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
-        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
-        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
-                version("1"), version("2"), version("3"), version("4"), version("5"), version("6")));
+        IotPolicy policy = policy("device-policy", DOCUMENT);
+        policy.setDefaultVersionId("5");
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy);
+        when(iot.listPolicyVersions("device-policy", REGION))
+                .thenReturn(List.of(version("1"), version("2"), version("3"), version("4"), version("5")))
+                .thenReturn(List.of(version("2"), version("3"), version("4"), version("5"), version("6")));
         when(iot.createPolicyVersion("device-policy", changed, true, REGION))
                 .thenThrow(versionsLimit())
-                .thenThrow(versionsLimit());
+                .thenThrow(versionsLimit())
+                .thenReturn(version("7"));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
+
+        InOrder inOrder = inOrder(iot);
+        inOrder.verify(iot).deletePolicyVersion("device-policy", "1", REGION);
+        inOrder.verify(iot).deletePolicyVersion("device-policy", "2", REGION);
+        inOrder.verify(iot, calls(1)).createPolicyVersion("device-policy", changed, true, REGION);
+        verify(iot, times(3)).createPolicyVersion("device-policy", changed, true, REGION);
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void policyUpdateGivesUpAfterAsManyPrunesAsAPolicyHasVersions() throws Exception {
+        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        IotPolicy policy = policy("device-policy", DOCUMENT);
+        policy.setDefaultVersionId("5");
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy);
+        when(iot.listPolicyVersions("device-policy", REGION)).thenReturn(List.of(
+                version("1"), version("2"), version("3"), version("4"), version("5")));
+        when(iot.createPolicyVersion("device-policy", changed, true, REGION))
+                .thenAnswer(inv -> { throw versionsLimit(); });
         StackResource r = resource(TYPE, "Policy");
         ObjectNode props = props("device-policy", mapper.readTree(changed), null);
 
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
 
         assertEquals("VersionsLimitExceededException", e.getErrorCode());
-        verify(iot, times(1)).deletePolicyVersion(anyString(), anyString(), anyString());
-        verify(iot, times(2)).createPolicyVersion("device-policy", changed, true, REGION);
+        verify(iot, times(IotService.MAX_POLICY_VERSIONS - 1)).deletePolicyVersion(anyString(), anyString(), anyString());
+        verify(iot, times(IotService.MAX_POLICY_VERSIONS)).createPolicyVersion("device-policy", changed, true, REGION);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotPolicyCfnProvisionerTest.java
@@ -1,0 +1,287 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.iot.IotService;
+import io.github.hectorvent.floci.services.iot.model.IotPolicy;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.REGION;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.ctx;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.notFound;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.resource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code AWS::IoT::Policy} through the IoT CFN provisioner in isolation: one mocked service. Every
+ * case asserts the exact physical id and the exact {@code Fn::GetAtt} attribute keys, because an
+ * unmapped type still reports CREATE_COMPLETE through the dispatcher's stub arm.
+ */
+class IotPolicyCfnProvisionerTest {
+
+    private static final String TYPE = "AWS::IoT::Policy";
+    private static final String ARN = "arn:aws:iot:us-east-1:000000000000:policy/device-policy";
+    private static final String RENAMED_ARN = "arn:aws:iot:us-east-1:000000000000:policy/renamed";
+    private static final String DOCUMENT =
+            "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":\"iot:Connect\",\"Resource\":\"*\"}]}";
+
+    private final IotService iot = mock(IotService.class);
+    private final IotCfnProvisioner provisioner = new IotCfnProvisioner(iot);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static IotPolicy policy(String name, String document) {
+        IotPolicy policy = new IotPolicy();
+        policy.setPolicyName(name);
+        policy.setPolicyArn("arn:aws:iot:us-east-1:000000000000:policy/" + name);
+        policy.setPolicyDocument(document);
+        policy.setDefaultVersionId("1");
+        return policy;
+    }
+
+    private ObjectNode props(String name, JsonNode document, Map<String, String> tags) {
+        ObjectNode props = mapper.createObjectNode();
+        if (name != null) {
+            props.put("PolicyName", name);
+        }
+        if (document != null) {
+            props.set("PolicyDocument", document);
+        }
+        if (tags != null) {
+            tags.forEach((key, value) -> props.withArray("Tags").addObject().put("Key", key).put("Value", value));
+        }
+        return props;
+    }
+
+    private JsonNode document() throws Exception {
+        return mapper.readTree(DOCUMENT);
+    }
+
+    @Test
+    void policyWithAnObjectDocumentSerialisesItAndSetsNameAsPhysicalIdWithArnAndId() throws Exception {
+        when(iot.createPolicy("device-policy", DOCUMENT, REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", document(), null), ctx());
+
+        assertEquals("device-policy", r.getPhysicalId());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+        assertEquals("device-policy", r.getAttributes().get("Id"));
+        verify(iot, never()).tagResource(anyString(), any());
+    }
+
+    @Test
+    void policyWithAStringDocumentPassesItThroughUnchanged() {
+        String document = "{\"Version\": \"2012-10-17\", \"Statement\": []}";
+        when(iot.createPolicy("device-policy", document, REGION)).thenReturn(policy("device-policy", document));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", mapper.getNodeFactory().textNode(document), null), ctx());
+
+        verify(iot).createPolicy("device-policy", document, REGION);
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void policyRequiresADocument() {
+        StackResource r = resource(TYPE, "Policy");
+        ObjectNode props = props("device-policy", null, null);
+
+        assertThrows(IllegalArgumentException.class, () -> provisioner.provision(r, props, ctx()));
+        verify(iot, never()).createPolicy(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void policyWithoutNameGetsAGeneratedName() throws Exception {
+        when(iot.createPolicy(anyString(), eq(DOCUMENT), eq(REGION))).thenAnswer(inv -> policy(inv.getArgument(0), DOCUMENT));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props(null, document(), null), ctx());
+
+        assertTrue(r.getPhysicalId().matches("my-stack-Policy-[0-9a-f]{12}"), "generated policy name: " + r.getPhysicalId());
+        assertEquals(r.getPhysicalId(), r.getAttributes().get("Id"));
+    }
+
+    @Test
+    void policyCreateAppliesTheTemplateTags() throws Exception {
+        when(iot.createPolicy("device-policy", DOCUMENT, REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", document(), Map.of("env", "test")), ctx());
+
+        verify(iot).tagResource(ARN, Map.of("env", "test"));
+        assertFalse(r.getAttributes().containsKey(CfnRollback.ROLLBACK_OWNED_ATTR));
+    }
+
+    @Test
+    void policyCreateLeavesTheResourceOwnedWhenTaggingFailsSoTheRollbackDeletesIt() throws Exception {
+        when(iot.createPolicy("device-policy", DOCUMENT, REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        doThrow(new AwsException("InternalFailureException", "tagging failed", 500)).when(iot).tagResource(eq(ARN), any());
+        StackResource r = resource(TYPE, "Policy");
+        ObjectNode props = props("device-policy", document(), Map.of("env", "test"));
+
+        assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx()));
+
+        assertEquals("device-policy", r.getPhysicalId());
+        assertEquals("true", r.getAttributes().get(CfnRollback.ROLLBACK_OWNED_ATTR));
+        verify(iot, never()).deletePolicy(anyString(), anyString());
+    }
+
+    @Test
+    void policyUpdateWithAChangedDocumentCreatesANewDefaultVersion() throws Exception {
+        String changed = "{\"Version\":\"2012-10-17\",\"Statement\":[]}";
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", mapper.readTree(changed), null), ctx("device-policy"));
+
+        verify(iot).createPolicyVersion("device-policy", changed, true, REGION);
+        verify(iot, never()).createPolicy(anyString(), anyString(), anyString());
+        verify(iot, never()).deletePolicy(anyString(), anyString());
+        assertEquals("device-policy", r.getPhysicalId());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+        assertEquals("device-policy", r.getAttributes().get("Id"));
+    }
+
+    @Test
+    void policyUpdateWithTheSameDocumentDoesNotCreateAVersion() throws Exception {
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", document(), null), ctx("device-policy"));
+
+        verify(iot, never()).createPolicyVersion(anyString(), anyString(), anyBoolean(), anyString());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void policyUpdateDrivesTheTagsToTheTemplate() throws Exception {
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        when(iot.listTagsForResource(ARN)).thenReturn(Map.of("stale", "1", "env", "old"));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", document(), Map.of("env", "test")), ctx("device-policy"));
+
+        verify(iot).untagResource(ARN, List.of("stale"));
+        verify(iot).tagResource(ARN, Map.of("env", "test"));
+    }
+
+    @Test
+    void policyUpdateWithoutTagsRemovesEveryStoredTag() throws Exception {
+        when(iot.getPolicy("device-policy", REGION)).thenReturn(policy("device-policy", DOCUMENT));
+        when(iot.listTagsForResource(ARN)).thenReturn(Map.of("stale", "1"));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("device-policy", document(), null), ctx("device-policy"));
+
+        verify(iot).untagResource(ARN, List.of("stale"));
+        verify(iot, never()).tagResource(anyString(), any());
+    }
+
+    @Test
+    void policyRenameCreatesTheReplacementThenDetachesAndDeletesThePriorPolicy() throws Exception {
+        when(iot.createPolicy("renamed", DOCUMENT, REGION)).thenReturn(policy("renamed", DOCUMENT));
+        when(iot.listTargetsForPolicy("device-policy", REGION)).thenReturn(Set.of("arn:aws:iot:us-east-1:000000000000:cert/abc"));
+        StackResource r = resource(TYPE, "Policy");
+
+        provisioner.provision(r, props("renamed", document(), null), ctx("device-policy"));
+
+        InOrder inOrder = inOrder(iot);
+        inOrder.verify(iot).createPolicy("renamed", DOCUMENT, REGION);
+        inOrder.verify(iot).detachPolicy("device-policy", "arn:aws:iot:us-east-1:000000000000:cert/abc", REGION);
+        inOrder.verify(iot).deletePolicy("device-policy", REGION);
+        verify(iot, never()).createPolicyVersion(anyString(), anyString(), anyBoolean(), anyString());
+        assertEquals("renamed", r.getPhysicalId());
+        assertEquals(RENAMED_ARN, r.getAttributes().get("Arn"));
+        assertEquals("renamed", r.getAttributes().get("Id"));
+    }
+
+    @Test
+    void policyRenameKeepsTheUpdateWhenThePriorPolicyCannotBeDeleted() throws Exception {
+        // As in CloudFormation's cleanup phase: the new policy exists and the stack points at it,
+        // so a failed removal of the old one is logged and the update completes.
+        when(iot.createPolicy("renamed", DOCUMENT, REGION)).thenReturn(policy("renamed", DOCUMENT));
+        doThrow(new AwsException("InternalFailureException", "storage", 500)).when(iot).deletePolicy("device-policy", REGION);
+        StackResource r = resource(TYPE, "Policy");
+
+        assertDoesNotThrow(() -> provisioner.provision(r, props("renamed", document(), null), ctx("device-policy")));
+
+        assertEquals("renamed", r.getPhysicalId());
+        verify(iot, never()).deletePolicy("renamed", REGION);
+    }
+
+    @Test
+    void policyReplacementRemovesTheNewPolicyWhenTaggingItFails() throws Exception {
+        when(iot.createPolicy("renamed", DOCUMENT, REGION)).thenReturn(policy("renamed", DOCUMENT));
+        doThrow(new AwsException("InternalFailureException", "tagging failed", 500)).when(iot).tagResource(eq(RENAMED_ARN), any());
+        StackResource r = resource(TYPE, "Policy");
+        ObjectNode props = props("renamed", document(), Map.of("env", "test"));
+
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
+
+        assertEquals("InternalFailureException", e.getErrorCode());
+        verify(iot).deletePolicy("renamed", REGION);
+        verify(iot, never()).deletePolicy("device-policy", REGION);
+    }
+
+    @Test
+    void policyReplacementReportsARollbackFailureWhenTheNewPolicyCannotBeRemoved() throws Exception {
+        when(iot.createPolicy("renamed", DOCUMENT, REGION)).thenReturn(policy("renamed", DOCUMENT));
+        doThrow(new AwsException("InternalFailureException", "tagging failed", 500)).when(iot).tagResource(eq(RENAMED_ARN), any());
+        doThrow(new AwsException("InternalFailureException", "storage", 500)).when(iot).deletePolicy("renamed", REGION);
+        StackResource r = resource(TYPE, "Policy");
+        ObjectNode props = props("renamed", document(), Map.of("env", "test"));
+
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("device-policy")));
+
+        assertEquals("InternalFailureException", e.getErrorCode());
+        assertEquals(1, e.getSuppressed().length);
+        assertTrue(r.getAttributes().get(CfnRollback.UPDATE_ROLLBACK_FAILURE_ATTR).contains("renamed"));
+    }
+
+    @Test
+    void deletePolicyDetachesEveryTargetBeforeDeleting() {
+        when(iot.listTargetsForPolicy("device-policy", REGION)).thenReturn(new TreeSet<>(List.of(
+                "arn:aws:iot:us-east-1:000000000000:cert/abc", "arn:aws:iot:us-east-1:000000000000:cert/def")));
+
+        provisioner.delete(TYPE, "device-policy", REGION);
+
+        InOrder inOrder = inOrder(iot);
+        inOrder.verify(iot).detachPolicy("device-policy", "arn:aws:iot:us-east-1:000000000000:cert/abc", REGION);
+        inOrder.verify(iot).detachPolicy("device-policy", "arn:aws:iot:us-east-1:000000000000:cert/def", REGION);
+        inOrder.verify(iot).deletePolicy("device-policy", REGION);
+    }
+
+    @Test
+    void deletePolicyToleratesOnlyNotFound() {
+        doThrow(notFound("Policy")).when(iot).listTargetsForPolicy("gone", REGION);
+        doThrow(new AwsException("InternalFailureException", "storage", 500)).when(iot).deletePolicy("stuck", REGION);
+
+        assertDoesNotThrow(() -> provisioner.delete(TYPE, "gone", REGION));
+        verify(iot, never()).deletePolicy("gone", REGION);
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.delete(TYPE, "stuck", REGION));
+        assertEquals("InternalFailureException", e.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotThingCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotThingCfnProvisionerTest.java
@@ -1,0 +1,198 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.iot.IotService;
+import io.github.hectorvent.floci.services.iot.model.Thing;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.Set;
+
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.REGION;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.ctx;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.notFound;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.resource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code AWS::IoT::Thing} through the IoT CFN provisioner in isolation: one mocked service. Every
+ * case asserts the exact physical id and the exact {@code Fn::GetAtt} attribute keys, because an
+ * unmapped type still reports CREATE_COMPLETE through the dispatcher's stub arm.
+ */
+class IotThingCfnProvisionerTest {
+
+    private static final String TYPE = "AWS::IoT::Thing";
+    private static final String ARN = "arn:aws:iot:us-east-1:000000000000:thing/sensor-1";
+    private static final String THING_ID = "11111111-2222-3333-4444-555555555555";
+
+    private final IotService iot = mock(IotService.class);
+    private final IotCfnProvisioner provisioner = new IotCfnProvisioner(iot);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static Thing thing(String name, Map<String, String> attributes) {
+        Thing thing = new Thing();
+        thing.setThingName(name);
+        thing.setThingArn("arn:aws:iot:us-east-1:000000000000:thing/" + name);
+        thing.setThingId(THING_ID);
+        thing.setAttributes(attributes);
+        return thing;
+    }
+
+    private ObjectNode props(String name, Map<String, String> attributes) {
+        ObjectNode props = mapper.createObjectNode();
+        if (name != null) {
+            props.put("ThingName", name);
+        }
+        if (attributes != null) {
+            ObjectNode attrs = props.putObject("AttributePayload").putObject("Attributes");
+            attributes.forEach(attrs::put);
+        }
+        return props;
+    }
+
+    private Map<String, String> capturedAttributes(String thingName) {
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+        verify(iot).createThing(eq(thingName), captor.capture(), eq(REGION));
+        return captor.getValue();
+    }
+
+    @Test
+    void resourceTypesCoverThingPolicyAndTopicRule() {
+        assertEquals(Set.of(TYPE, "AWS::IoT::Policy", "AWS::IoT::TopicRule"), provisioner.resourceTypes());
+    }
+
+    @Test
+    void thingSetsNameAsPhysicalIdAndArnAndIdAttributes() {
+        Map<String, String> attributes = Map.of("SerialNumber", "SN-1", "Model", "M2");
+        when(iot.createThing(eq("sensor-1"), any(), eq(REGION))).thenReturn(thing("sensor-1", attributes));
+        StackResource r = resource(TYPE, "Sensor");
+
+        provisioner.provision(r, props("sensor-1", attributes), ctx());
+
+        assertEquals("sensor-1", r.getPhysicalId());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+        assertEquals(THING_ID, r.getAttributes().get("Id"));
+        assertEquals(attributes, capturedAttributes("sensor-1"));
+    }
+
+    @Test
+    void thingWithoutAttributePayloadIsCreatedWithNoAttributes() {
+        when(iot.createThing(eq("sensor-1"), any(), eq(REGION))).thenReturn(thing("sensor-1", Map.of()));
+        StackResource r = resource(TYPE, "Sensor");
+
+        provisioner.provision(r, props("sensor-1", null), ctx());
+
+        assertEquals(Map.of(), capturedAttributes("sensor-1"));
+    }
+
+    @Test
+    void thingWithoutNameGetsAGeneratedNameWithinTheLimit() {
+        when(iot.createThing(anyString(), any(), eq(REGION))).thenAnswer(inv -> thing(inv.getArgument(0), Map.of()));
+        StackResource r = resource(TYPE, "Sensor");
+
+        provisioner.provision(r, mapper.createObjectNode(), ctx());
+
+        String name = r.getPhysicalId();
+        assertTrue(name.matches("my-stack-Sensor-[0-9a-f]{12}"), "generated thing name: " + name);
+        assertTrue(name.length() <= 128);
+        assertEquals("arn:aws:iot:us-east-1:000000000000:thing/" + name, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void thingUpdateWithTheSameNameReplacesTheAttributesInPlace() {
+        Map<String, String> attributes = Map.of("Model", "M3");
+        when(iot.updateThing(eq("sensor-1"), any(), isNull(), eq(REGION))).thenReturn(thing("sensor-1", attributes));
+        StackResource r = resource(TYPE, "Sensor");
+
+        provisioner.provision(r, props("sensor-1", attributes), ctx("sensor-1"));
+
+        verify(iot, never()).createThing(anyString(), any(), anyString());
+        verify(iot, never()).deleteThing(anyString(), anyString());
+        assertEquals("sensor-1", r.getPhysicalId());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+        assertEquals(THING_ID, r.getAttributes().get("Id"));
+    }
+
+    @Test
+    void thingUpdateWithoutAnExplicitNameKeepsThePriorGeneratedName() {
+        when(iot.updateThing(eq("my-stack-Sensor-0123456789ab"), any(), isNull(), eq(REGION)))
+                .thenReturn(thing("my-stack-Sensor-0123456789ab", Map.of()));
+        StackResource r = resource(TYPE, "Sensor");
+
+        provisioner.provision(r, mapper.createObjectNode(), ctx("my-stack-Sensor-0123456789ab"));
+
+        verify(iot, never()).createThing(anyString(), any(), anyString());
+        assertEquals("my-stack-Sensor-0123456789ab", r.getPhysicalId());
+    }
+
+    @Test
+    void thingRenameCreatesTheReplacementThenDeletesThePriorThing() {
+        when(iot.createThing(eq("sensor-2"), any(), eq(REGION))).thenReturn(thing("sensor-2", Map.of()));
+        StackResource r = resource(TYPE, "Sensor");
+
+        provisioner.provision(r, props("sensor-2", null), ctx("sensor-1"));
+
+        verify(iot).deleteThing("sensor-1", REGION);
+        verify(iot, never()).updateThing(anyString(), any(), any(), anyString());
+        assertEquals("sensor-2", r.getPhysicalId());
+        assertEquals("arn:aws:iot:us-east-1:000000000000:thing/sensor-2", r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void thingRenameToleratesAPriorThingThatIsAlreadyGone() {
+        when(iot.createThing(eq("sensor-2"), any(), eq(REGION))).thenReturn(thing("sensor-2", Map.of()));
+        doThrow(notFound("Thing")).when(iot).deleteThing("sensor-1", REGION);
+        StackResource r = resource(TYPE, "Sensor");
+
+        assertDoesNotThrow(() -> provisioner.provision(r, props("sensor-2", null), ctx("sensor-1")));
+
+        assertEquals("sensor-2", r.getPhysicalId());
+    }
+
+    @Test
+    void thingRenameKeepsTheUpdateWhenThePriorThingCannotBeDeleted() {
+        // As in CloudFormation's cleanup phase: the new thing exists and the stack points at it,
+        // so a failed removal of the old one is logged and the update completes.
+        when(iot.createThing(eq("sensor-2"), any(), eq(REGION))).thenReturn(thing("sensor-2", Map.of()));
+        doThrow(new AwsException("InvalidRequestException", "Cannot delete", 400)).when(iot).deleteThing("sensor-1", REGION);
+        StackResource r = resource(TYPE, "Sensor");
+
+        assertDoesNotThrow(() -> provisioner.provision(r, props("sensor-2", null), ctx("sensor-1")));
+
+        assertEquals("sensor-2", r.getPhysicalId());
+    }
+
+    @Test
+    void deleteThingDelegatesToTheService() {
+        provisioner.delete(TYPE, "sensor-1", REGION);
+
+        verify(iot).deleteThing("sensor-1", REGION);
+    }
+
+    @Test
+    void deleteThingToleratesOnlyNotFound() {
+        doThrow(notFound("Thing")).when(iot).deleteThing("gone", REGION);
+        doThrow(new AwsException("InvalidRequestException", "Cannot delete", 400)).when(iot).deleteThing("held", REGION);
+
+        assertDoesNotThrow(() -> provisioner.delete(TYPE, "gone", REGION));
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.delete(TYPE, "held", REGION));
+        assertEquals("InvalidRequestException", e.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotTopicRuleCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IotTopicRuleCfnProvisionerTest.java
@@ -1,0 +1,248 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.iot.IotService;
+import io.github.hectorvent.floci.services.iot.model.IotTopicRule;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.REGION;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.ctx;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.notFound;
+import static io.github.hectorvent.floci.services.cloudformation.provisioners.IotCfnProvisionerTestSupport.resource;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@code AWS::IoT::TopicRule} through the IoT CFN provisioner in isolation: one mocked service.
+ * Every case asserts the exact physical id and the exact {@code Fn::GetAtt} attribute key, because
+ * an unmapped type still reports CREATE_COMPLETE through the dispatcher's stub arm.
+ */
+class IotTopicRuleCfnProvisionerTest {
+
+    private static final String TYPE = "AWS::IoT::TopicRule";
+    private static final String ARN = "arn:aws:iot:us-east-1:000000000000:rule/telemetryRule";
+    private static final String RENAMED_ARN = "arn:aws:iot:us-east-1:000000000000:rule/renamedRule";
+
+    private final IotService iot = mock(IotService.class);
+    private final IotCfnProvisioner provisioner = new IotCfnProvisioner(iot);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static IotTopicRule rule(String name) {
+        IotTopicRule rule = new IotTopicRule();
+        rule.setRuleName(name);
+        rule.setRuleArn("arn:aws:iot:us-east-1:000000000000:rule/" + name);
+        return rule;
+    }
+
+    /** The payload as CloudFormation spells it, with an intrinsic where CDK puts one. */
+    private ObjectNode templatePayload() {
+        ObjectNode payload = mapper.createObjectNode()
+                .put("Sql", "SELECT * FROM 'devices/+/telemetry'")
+                .put("AwsIotSqlVersion", "2016-03-23")
+                .put("RuleDisabled", false)
+                .put("Description", "telemetry fan-out");
+        ObjectNode functionArn = mapper.createObjectNode();
+        functionArn.set("Fn::GetAtt", mapper.createArrayNode().add("Handler").add("Arn"));
+        payload.withArray("Actions").addObject().putObject("Lambda").set("FunctionArn", functionArn);
+        ObjectNode sqs = payload.withArray("Actions").addObject().putObject("Sqs");
+        sqs.put("RoleArn", "arn:aws:iam::000000000000:role/rule").put("UseBase64", false);
+        sqs.set("QueueUrl", mapper.createObjectNode().put("Ref", "Queue"));
+        payload.putObject("ErrorAction").putObject("Sqs")
+                .put("QueueUrl", "http://localhost:4566/000000000000/dlq")
+                .put("RoleArn", "arn:aws:iam::000000000000:role/rule");
+        return payload;
+    }
+
+    private ObjectNode props(String name, ObjectNode payload, Map<String, String> tags) {
+        ObjectNode props = mapper.createObjectNode();
+        if (name != null) {
+            props.put("RuleName", name);
+        }
+        if (payload != null) {
+            props.set("TopicRulePayload", payload);
+        }
+        if (tags != null) {
+            tags.forEach((key, value) -> props.withArray("Tags").addObject().put("Key", key).put("Value", value));
+        }
+        return props;
+    }
+
+    private JsonNode capturedPayload(String ruleName) {
+        ArgumentCaptor<JsonNode> captor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(iot).createTopicRule(eq(ruleName), captor.capture(), eq(REGION));
+        return captor.getValue();
+    }
+
+    @Test
+    void topicRuleHandsTheServiceThePayloadInTheApiShapeAndSetsArn() {
+        when(iot.createTopicRule(eq("telemetryRule"), any(), eq(REGION))).thenReturn(rule("telemetryRule"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("telemetryRule", templatePayload(), null), ctx());
+
+        assertEquals("telemetryRule", r.getPhysicalId());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+        JsonNode payload = capturedPayload("telemetryRule");
+        assertEquals("SELECT * FROM 'devices/+/telemetry'", payload.get("sql").asText());
+        assertEquals("2016-03-23", payload.get("awsIotSqlVersion").asText());
+        assertEquals("telemetry fan-out", payload.get("description").asText());
+        assertTrue(payload.get("ruleDisabled").isBoolean());
+        assertFalse(payload.get("ruleDisabled").asBoolean());
+        assertEquals("resolved:Handler.Arn", payload.at("/actions/0/lambda/functionArn").asText());
+        assertEquals("resolved:Queue", payload.at("/actions/1/sqs/queueUrl").asText());
+        assertTrue(payload.at("/actions/1/sqs/useBase64").isBoolean());
+        assertEquals("http://localhost:4566/000000000000/dlq", payload.at("/errorAction/sqs/queueUrl").asText());
+        assertFalse(payload.has("Sql") || payload.has("Actions") || payload.has("ErrorAction"),
+                "no PascalCase keys may reach the service: " + payload);
+    }
+
+    @Test
+    void topicRuleDropsNullPayloadMembers() {
+        when(iot.createTopicRule(eq("telemetryRule"), any(), eq(REGION))).thenReturn(rule("telemetryRule"));
+        ObjectNode payload = mapper.createObjectNode().put("Sql", "SELECT * FROM 'a'");
+        payload.putNull("Description");
+        payload.withArray("Actions").addObject().putObject("Lambda").put("FunctionArn", "arn:fn");
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("telemetryRule", payload, null), ctx());
+
+        assertFalse(capturedPayload("telemetryRule").has("description"));
+    }
+
+    @Test
+    void topicRuleRequiresAPayload() {
+        StackResource r = resource(TYPE, "Rule");
+        ObjectNode props = props("telemetryRule", null, null);
+
+        assertThrows(IllegalArgumentException.class, () -> provisioner.provision(r, props, ctx()));
+        verify(iot, never()).createTopicRule(anyString(), any(), anyString());
+    }
+
+    @Test
+    void topicRuleWithoutNameGetsAGeneratedNameWithoutHyphens() {
+        when(iot.createTopicRule(anyString(), any(), eq(REGION))).thenAnswer(inv -> rule(inv.getArgument(0)));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props(null, templatePayload(), null), ctx());
+
+        assertTrue(r.getPhysicalId().matches("mystackRule[0-9a-f]{12}"), "generated rule name: " + r.getPhysicalId());
+        assertEquals("arn:aws:iot:us-east-1:000000000000:rule/" + r.getPhysicalId(), r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void topicRuleHandsAnExplicitNameToTheServiceUnchanged() {
+        // Only generated names are trimmed to the characters a rule name allows; validating an
+        // explicit name is the service's job, so it must not be altered on the way there.
+        when(iot.createTopicRule(eq("telemetry-rule"), any(), eq(REGION))).thenReturn(rule("telemetry-rule"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("telemetry-rule", templatePayload(), null), ctx());
+
+        assertEquals("telemetry-rule", r.getPhysicalId());
+        verify(iot).createTopicRule(eq("telemetry-rule"), any(), eq(REGION));
+    }
+
+    @Test
+    void topicRuleCreateAppliesTheTemplateTags() {
+        when(iot.createTopicRule(eq("telemetryRule"), any(), eq(REGION))).thenReturn(rule("telemetryRule"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("telemetryRule", templatePayload(), Map.of("env", "test")), ctx());
+
+        verify(iot).tagResource(ARN, Map.of("env", "test"));
+        assertFalse(r.getAttributes().containsKey(CfnRollback.ROLLBACK_OWNED_ATTR));
+    }
+
+    @Test
+    void topicRuleUpdateWithTheSameNameReplacesTheRule() {
+        when(iot.replaceTopicRule(eq("telemetryRule"), any(), eq(REGION))).thenReturn(rule("telemetryRule"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("telemetryRule", templatePayload(), null), ctx("telemetryRule"));
+
+        ArgumentCaptor<JsonNode> captor = ArgumentCaptor.forClass(JsonNode.class);
+        verify(iot).replaceTopicRule(eq("telemetryRule"), captor.capture(), eq(REGION));
+        assertEquals("SELECT * FROM 'devices/+/telemetry'", captor.getValue().get("sql").asText());
+        verify(iot, never()).createTopicRule(anyString(), any(), anyString());
+        verify(iot, never()).deleteTopicRule(anyString(), anyString());
+        assertEquals("telemetryRule", r.getPhysicalId());
+        assertEquals(ARN, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void topicRuleUpdateWithoutAnExplicitNameKeepsThePriorGeneratedName() {
+        when(iot.replaceTopicRule(eq("mystackRule0123456789ab"), any(), eq(REGION))).thenReturn(rule("mystackRule0123456789ab"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props(null, templatePayload(), null), ctx("mystackRule0123456789ab"));
+
+        verify(iot, never()).createTopicRule(anyString(), any(), anyString());
+        assertEquals("mystackRule0123456789ab", r.getPhysicalId());
+    }
+
+    @Test
+    void topicRuleUpdateDrivesTheTagsToTheTemplate() {
+        when(iot.replaceTopicRule(eq("telemetryRule"), any(), eq(REGION))).thenReturn(rule("telemetryRule"));
+        when(iot.listTagsForResource(ARN)).thenReturn(Map.of("stale", "1"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("telemetryRule", templatePayload(), Map.of("env", "test")), ctx("telemetryRule"));
+
+        verify(iot).untagResource(ARN, List.of("stale"));
+        verify(iot).tagResource(ARN, Map.of("env", "test"));
+    }
+
+    @Test
+    void topicRuleRenameCreatesTheReplacementThenDeletesThePriorRule() {
+        when(iot.createTopicRule(eq("renamedRule"), any(), eq(REGION))).thenReturn(rule("renamedRule"));
+        StackResource r = resource(TYPE, "Rule");
+
+        provisioner.provision(r, props("renamedRule", templatePayload(), null), ctx("telemetryRule"));
+
+        verify(iot).deleteTopicRule("telemetryRule", REGION);
+        verify(iot, never()).replaceTopicRule(anyString(), any(), anyString());
+        assertEquals("renamedRule", r.getPhysicalId());
+        assertEquals(RENAMED_ARN, r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void topicRuleReplacementRemovesTheNewRuleWhenTaggingItFails() {
+        when(iot.createTopicRule(eq("renamedRule"), any(), eq(REGION))).thenReturn(rule("renamedRule"));
+        doThrow(new AwsException("InternalFailureException", "tagging failed", 500)).when(iot).tagResource(eq(RENAMED_ARN), any());
+        StackResource r = resource(TYPE, "Rule");
+        ObjectNode props = props("renamedRule", templatePayload(), Map.of("env", "test"));
+
+        assertThrows(AwsException.class, () -> provisioner.provision(r, props, ctx("telemetryRule")));
+
+        verify(iot).deleteTopicRule("renamedRule", REGION);
+        verify(iot, never()).deleteTopicRule("telemetryRule", REGION);
+    }
+
+    @Test
+    void deleteTopicRuleToleratesOnlyNotFound() {
+        doThrow(notFound("Topic rule")).when(iot).deleteTopicRule("gone", REGION);
+        doThrow(new AwsException("InternalFailureException", "storage", 500)).when(iot).deleteTopicRule("stuck", REGION);
+
+        assertDoesNotThrow(() -> provisioner.delete(TYPE, "gone", REGION));
+        assertThrows(AwsException.class, () -> provisioner.delete(TYPE, "stuck", REGION));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotIntegrationTest.java
@@ -748,6 +748,52 @@ class IotIntegrationTest {
             .body("__type", equalTo("ResourceNotFoundException"));
     }
 
+    @Test
+    @Order(20)
+    void aSixthPolicyVersionIsRefusedUntilOneIsDeleted() {
+        String document = "{\"policyDocument\":\"{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[]}\"}";
+        given()
+            .contentType("application/json")
+            .body(document)
+        .when()
+            .post("/policies/five-versions")
+        .then()
+            .statusCode(200);
+        for (int version = 2; version <= 5; version++) {
+            given()
+                .contentType("application/json")
+                .body(document)
+            .when()
+                .post("/policies/five-versions/version")
+            .then()
+                .statusCode(200)
+                .body("policyVersionId", equalTo(Integer.toString(version)));
+        }
+
+        given()
+            .contentType("application/json")
+            .body(document)
+        .when()
+            .post("/policies/five-versions/version")
+        .then()
+            .statusCode(409)
+            .body("__type", equalTo("VersionsLimitExceededException"));
+
+        given()
+        .when()
+            .delete("/policies/five-versions/version/3")
+        .then()
+            .statusCode(200);
+        given()
+            .contentType("application/json")
+            .body(document)
+        .when()
+            .post("/policies/five-versions/version")
+        .then()
+            .statusCode(200)
+            .body("policyVersionId", equalTo("6"));
+    }
+
     private String createThingAndReturnArn(String thingName) {
         return given()
             .contentType("application/json")

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
@@ -558,4 +558,44 @@ class IotServiceTest {
         }
         assertEquals(5, service.listPolicyVersions("raced", REGION).size());
     }
+
+    @Test
+    void deletingTheOldestVersionRemovesTheNumericallySmallestIdAndKeepsTheDefault() {
+        service.createPolicy("pruned", "{\"v\":1}", REGION);
+        for (int v = 2; v <= 10; v++) {
+            if (service.listPolicyVersions("pruned", REGION).size() == IotService.MAX_POLICY_VERSIONS) {
+                service.deleteOldestPolicyVersion("pruned", REGION);
+            }
+            service.createPolicyVersion("pruned", "{\"v\":" + v + "}", true, REGION);
+        }
+        assertEquals(List.of(6, 7, 8, 9, 10), versionIds("pruned"));
+
+        // Sorted as text, "10" would come before "6"; the oldest version is the numerically smallest id.
+        service.deleteOldestPolicyVersion("pruned", REGION);
+
+        assertEquals(List.of(7, 8, 9, 10), versionIds("pruned"));
+        assertEquals("10", service.getPolicy("pruned", REGION).getDefaultVersionId());
+    }
+
+    @Test
+    void deletingTheOldestVersionMovesTheDefaultToTheNewestWhenTheOldestIsTheDefault() {
+        service.createPolicy("pinned", "{\"v\":1}", REGION);
+        for (int v = 2; v <= 5; v++) {
+            service.createPolicyVersion("pinned", "{\"v\":" + v + "}", false, REGION);
+        }
+        assertEquals("1", service.getPolicy("pinned", REGION).getDefaultVersionId());
+
+        service.deleteOldestPolicyVersion("pinned", REGION);
+
+        assertEquals(List.of(2, 3, 4, 5), versionIds("pinned"));
+        assertEquals("5", service.getPolicy("pinned", REGION).getDefaultVersionId());
+        assertEquals("{\"v\":5}", service.getPolicy("pinned", REGION).getPolicyDocument());
+    }
+
+    private List<Integer> versionIds(String policyName) {
+        return service.listPolicyVersions(policyName, REGION).stream()
+                .map(version -> Integer.parseInt(version.getVersionId()))
+                .sorted()
+                .toList();
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.cloudwatch.logs.CloudWatchLogsService
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.firehose.FirehoseService;
 import io.github.hectorvent.floci.services.firehose.model.Record;
+import io.github.hectorvent.floci.services.iot.model.IotPolicy;
 import io.github.hectorvent.floci.services.iot.model.IotTopicRule;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
 import io.github.hectorvent.floci.services.lambda.LambdaService;
@@ -564,14 +565,14 @@ class IotServiceTest {
         service.createPolicy("pruned", "{\"v\":1}", REGION);
         for (int v = 2; v <= 10; v++) {
             if (service.listPolicyVersions("pruned", REGION).size() == IotService.MAX_POLICY_VERSIONS) {
-                service.deleteOldestPolicyVersion("pruned", REGION);
+                service.makeRoomForPolicyVersion("pruned", REGION);
             }
             service.createPolicyVersion("pruned", "{\"v\":" + v + "}", true, REGION);
         }
         assertEquals(List.of(6, 7, 8, 9, 10), versionIds("pruned"));
 
         // Sorted as text, "10" would come before "6"; the oldest version is the numerically smallest id.
-        service.deleteOldestPolicyVersion("pruned", REGION);
+        service.makeRoomForPolicyVersion("pruned", REGION);
 
         assertEquals(List.of(7, 8, 9, 10), versionIds("pruned"));
         assertEquals("10", service.getPolicy("pruned", REGION).getDefaultVersionId());
@@ -585,11 +586,74 @@ class IotServiceTest {
         }
         assertEquals("1", service.getPolicy("pinned", REGION).getDefaultVersionId());
 
-        service.deleteOldestPolicyVersion("pinned", REGION);
+        service.makeRoomForPolicyVersion("pinned", REGION);
 
         assertEquals(List.of(2, 3, 4, 5), versionIds("pinned"));
         assertEquals("5", service.getPolicy("pinned", REGION).getDefaultVersionId());
         assertEquals("{\"v\":5}", service.getPolicy("pinned", REGION).getPolicyDocument());
+    }
+
+    @Test
+    void makingRoomOnAPolicyStoredWithMoreThanFiveVersionsDeletesDownToFourInOneStep() {
+        // A policy persisted before the cap existed can hold more than five versions; the stores
+        // hand out the live object, so adding to it is the same as having persisted it that way.
+        service.createPolicy("legacy", "{\"v\":1}", REGION);
+        for (int v = 2; v <= 5; v++) {
+            service.createPolicyVersion("legacy", "{\"v\":" + v + "}", true, REGION);
+        }
+        IotPolicy stored = service.getPolicy("legacy", REGION);
+        List<IotPolicy.PolicyVersion> versions = new ArrayList<>(stored.getVersions());
+        for (int v = 6; v <= 8; v++) {
+            IotPolicy.PolicyVersion version = new IotPolicy.PolicyVersion();
+            version.setVersionId(Integer.toString(v));
+            version.setDocument("{\"v\":" + v + "}");
+            versions.add(version);
+        }
+        stored.setVersions(versions);
+        assertEquals(List.of(1, 2, 3, 4, 5, 6, 7, 8), versionIds("legacy"));
+
+        service.makeRoomForPolicyVersion("legacy", REGION);
+
+        assertEquals(List.of(5, 6, 7, 8), versionIds("legacy"));
+        assertEquals("5", service.getPolicy("legacy", REGION).getDefaultVersionId());
+        assertEquals("9", service.createPolicyVersion("legacy", "{\"v\":9}", true, REGION).getVersionId());
+    }
+
+    @Test
+    void aPolicyDeletedWhileVersionsAreBeingCreatedStaysDeleted() throws Exception {
+        for (int round = 0; round < 20; round++) {
+            String name = "vanishing-" + round;
+            service.createPolicy(name, "{\"v\":1}", REGION);
+            CountDownLatch start = new CountDownLatch(1);
+            ExecutorService pool = Executors.newFixedThreadPool(4);
+            List<Future<?>> outcomes = new ArrayList<>();
+            try {
+                for (int i = 0; i < 3; i++) {
+                    outcomes.add(pool.submit(() -> {
+                        start.await();
+                        try {
+                            service.createPolicyVersion(name, "{\"v\":2}", false, REGION);
+                        } catch (AwsException e) {
+                            assertEquals("ResourceNotFoundException", e.getErrorCode());
+                        }
+                        return null;
+                    }));
+                }
+                outcomes.add(pool.submit(() -> {
+                    start.await();
+                    service.deletePolicy(name, REGION);
+                    return null;
+                }));
+                start.countDown();
+                for (Future<?> outcome : outcomes) {
+                    outcome.get();
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+            AwsException e = assertThrows(AwsException.class, () -> service.getPolicy(name, REGION));
+            assertEquals("ResourceNotFoundException", e.getErrorCode(), "round " + round + " brought the policy back");
+        }
     }
 
     private List<Integer> versionIds(String policyName) {

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotServiceTest.java
@@ -23,9 +23,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +52,7 @@ import static org.mockito.Mockito.when;
  * Rules engine behaviour of {@link IotService} with in-memory stores and mocked action targets:
  * one failing action never fails the publish or the other actions, the error action receives the
  * failure document, and the {@code firehose} and {@code cloudwatchLogs} actions deliver the payload.
+ * Also the five-version cap on a policy, including under racing creates.
  */
 class IotServiceTest {
 
@@ -497,5 +503,59 @@ class IotServiceTest {
 
         verify(lambda).invoke(eq(REGION), eq(FUNCTION_ARN), any(), eq(InvocationType.Event));
         verify(lambda, never()).invoke(eq(REGION), eq(ERROR_FUNCTION_ARN), any(), any());
+    }
+
+    @Test
+    void aPolicyHoldsAtMostFiveVersionsUntilOneIsDeleted() {
+        service.createPolicy("capped", "{\"v\":1}", REGION);
+        for (int v = 2; v <= 5; v++) {
+            assertEquals(Integer.toString(v),
+                    service.createPolicyVersion("capped", "{\"v\":" + v + "}", true, REGION).getVersionId());
+        }
+
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.createPolicyVersion("capped", "{\"v\":6}", true, REGION));
+
+        assertEquals("VersionsLimitExceededException", e.getErrorCode());
+        assertEquals(409, e.getHttpStatus());
+        assertEquals(5, service.listPolicyVersions("capped", REGION).size());
+        assertEquals("5", service.getPolicy("capped", REGION).getDefaultVersionId());
+        service.deletePolicyVersion("capped", "2", REGION);
+        assertEquals("6", service.createPolicyVersion("capped", "{\"v\":6}", true, REGION).getVersionId());
+        assertEquals("6", service.getPolicy("capped", REGION).getDefaultVersionId());
+    }
+
+    @Test
+    void racingVersionCreatesNeverPushAPolicyPastFiveVersions() throws Exception {
+        service.createPolicy("raced", "{\"v\":1}", REGION);
+        int writers = 8;
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(writers);
+        List<Future<Boolean>> outcomes = new ArrayList<>();
+        try {
+            for (int i = 0; i < writers; i++) {
+                outcomes.add(pool.submit(() -> {
+                    start.await();
+                    try {
+                        service.createPolicyVersion("raced", "{\"v\":true}", false, REGION);
+                        return true;
+                    } catch (AwsException e) {
+                        assertEquals("VersionsLimitExceededException", e.getErrorCode());
+                        return false;
+                    }
+                }));
+            }
+            start.countDown();
+            int created = 0;
+            for (Future<Boolean> outcome : outcomes) {
+                if (outcome.get()) {
+                    created++;
+                }
+            }
+            assertEquals(4, created, "exactly four of eight racing creates fit under the cap");
+        } finally {
+            pool.shutdownNow();
+        }
+        assertEquals(5, service.listPolicyVersions("raced", REGION).size());
     }
 }

--- a/src/test/resources/cloudformation/supported-resource-types.tsv
+++ b/src/test/resources/cloudformation/supported-resource-types.tsv
@@ -75,6 +75,9 @@ AWS::IAM::Policy	LEGACY_SWITCH
 AWS::IAM::Role	IamRoleCfnProvisioner
 AWS::IAM::User	LEGACY_SWITCH
 AWS::IoT::DomainConfiguration	IotDomainConfigurationCfnProvisioner
+AWS::IoT::Policy	IotCfnProvisioner
+AWS::IoT::Thing	IotCfnProvisioner
+AWS::IoT::TopicRule	IotCfnProvisioner
 AWS::KMS::Alias	KmsCfnProvisioner
 AWS::KMS::Key	KmsCfnProvisioner
 AWS::Kinesis::Stream	KinesisCfnProvisioner


### PR DESCRIPTION
> **Maintainers:** #3013 has merged and this branch is rebased onto `main`; it is no longer stacked on anything.

## Summary

CloudFormation can now create, update and delete `AWS::IoT::Thing`, `AWS::IoT::Policy` and `AWS::IoT::TopicRule`.

Before this change the three types were stubs. The stack turned green, but nothing was created: `Ref` and `Fn::GetAtt` returned the text `LogicalId.Arn`, and a topic rule from a stack never fired.

Now the provisioner calls the existing IoT operations (`CreateThing`, `CreatePolicy`, `CreateTopicRule` and their update and delete counterparts). `Ref` returns the name, and `Fn::GetAtt` returns what `DescribeThing`, `GetPolicy` and `GetTopicRule` report.

Stacked on #3012 and #3013: the first two commits belong to those pull requests, and the diff shrinks to the last commit once they merge. A rule created by a stack needs them: its payload carries `AwsIotSqlVersion` and `ErrorAction` (kept by #3012), and an action of a stack's rule may target something that is not there yet (a logged failure since #3012, not a failed publish).

Independent of #3008, which serves `AWS::IoT::DomainConfiguration` from its own class. Both touch the same registration files, with identical or adjacent hunks.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| `AWS::IoT::Thing` | Create | ✅ | |
| `AWS::IoT::Thing` | Update | ✅ | `AttributePayload` is replaced in place. A changed `ThingName` replaces the thing, as on AWS. |
| `AWS::IoT::Thing` | Delete | ✅ | An already deleted thing is fine. |
| `AWS::IoT::Thing` | `ThingName` | ✅ | Generated when absent and kept across updates. |
| `AWS::IoT::Thing` | `AttributePayload` | ✅ | |
| `AWS::IoT::Thing` | `Ref`, `Fn::GetAtt Arn`, `Fn::GetAtt Id` | ✅ | The name, the thing ARN and the thing id. `Arn` and `Id` are the only attributes in the AWS schema. |
| `AWS::IoT::Policy` | Create | ✅ | |
| `AWS::IoT::Policy` | Update | ✅ | A changed `PolicyDocument` becomes a new default version, as on AWS. Once five versions exist, the oldest is deleted first, as the AWS handler does. Tags are kept in sync with the template. A changed `PolicyName` replaces the policy. |
| `AWS::IoT::Policy` | Delete | 🟡 | An already deleted policy is fine. A policy still attached to a principal is detached first, then deleted. On AWS the delete fails instead; see below. |
| `AWS::IoT::Policy` | `PolicyName` | ✅ | Generated when absent and kept across updates. |
| `AWS::IoT::Policy` | `PolicyDocument` | ✅ | Required. An object or a string. |
| `AWS::IoT::Policy` | `Tags` | ✅ | |
| `AWS::IoT::Policy` | `Ref`, `Fn::GetAtt Arn`, `Fn::GetAtt Id` | ✅ | The name, the policy ARN and the name again: on AWS `Id` is the policy name. |
| `AWS::IoT::TopicRule` | Create | ✅ | |
| `AWS::IoT::TopicRule` | Update | ✅ | `ReplaceTopicRule` in place. Tags are kept in sync with the template. A changed `RuleName` replaces the rule. |
| `AWS::IoT::TopicRule` | Delete | ✅ | An already deleted rule is fine. |
| `AWS::IoT::TopicRule` | `RuleName` | ✅ | Generated when absent, without the hyphens AWS rejects in a rule name, and kept across updates. An explicit name is passed on as given. |
| `AWS::IoT::TopicRule` | `TopicRulePayload` | 🟡 | Required. Handed to the service in the API's own shape, with intrinsic functions inside it resolved. `Sql`, `Actions`, `RuleDisabled`, `Description`, `AwsIotSqlVersion` and `ErrorAction` are stored and returned by `GetTopicRule`. What runs on a publish is what the rules engine runs today; SQL beyond the topic filter is out of scope here. |
| `AWS::IoT::TopicRule` | `Tags` | ✅ | |
| `AWS::IoT::TopicRule` | `Ref`, `Fn::GetAtt Arn` | ✅ | The name and the rule ARN. `Arn` is the only attribute in the AWS schema. |

Two details, both on purpose:

- Replacements: as in CloudFormation's own cleanup phase, the replaced thing, policy or rule is removed after its replacement exists. If that removal fails, the update still completes and the old entity is left behind with a warning in the log.
- Policy delete: on AWS a policy that is still attached fails the stack with a `DeleteConflictException`. Here the stack detaches the policy from its principals and deletes it, because devices that connected while the stack existed would otherwise keep a local teardown from ever finishing. A `AWS::Lambda::Permission` with principal `iot.amazonaws.com` and the rule ARN as `SourceArn` works without a change: `AddPermission` stores it, and a rule's invoke does not check it.

## Files

- `IotCfnProvisioner` (new), its three rows in `supported-resource-types.tsv`, the `CfnProvisionerFixture` wiring and the `IoT Core` label in `tools/docs/cfn_resource_types.yaml`.
- `CfnRollback.UPDATE_ROLLBACK_FAILURE_ATTR`: the rollback failure marker now lives next to the restored marker, so provisioners in that package can set it. The legacy class aliases it. Same two lines as in #3008.
- Tests: `IotThingCfnProvisionerTest`, `IotPolicyCfnProvisionerTest` and `IotTopicRuleCfnProvisionerTest` (unit, one mocked service, exact attribute keys, shared `IotCfnProvisionerTestSupport`), and `IotCfnIntegrationTest`: a stack with all three types, a queue the rule targets, a second action on a queue that does not exist and an error queue. The outputs are real ids, a publish through the rule reaches the queue and the error queue gets the failure document, the update is in place, and everything is gone after `DeleteStack`.
- `docs/services/cloudformation.md` table regenerated with `make docs-sync`.

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Docs / chore

### Checklist

* [ ] `./mvnw test` passes locally. Ran per class instead: `CfnResourceInventoryTest`, `CfnProvisionerFixtureTest`, `CfnSchemaCoverageTest`, the three `Iot*CfnProvisionerTest` classes, `IotCfnIntegrationTest`, and every test class under `cloudformation` and `iot`. `make docs-check` passes.
* [x] New or updated integration test added
* [x] Commit messages follow Conventional Commits


