### PR TITLE
fix(cloudfront): echo TrustedSigners in cache behaviors so the AWS provider does not segfault

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
@@ -1968,6 +1968,7 @@ public class CloudFrontController {
                 .elem("ResponseHeadersPolicyId", dcb.getResponseHeadersPolicyId())
                 .elem("Compress", dcb.isCompress());
 
+        xml.raw(xmlTrustedSigners());
         xml.raw(xmlTrustedKeyGroups(
                 dcb.isTrustedKeyGroupsEnabled(), dcb.getTrustedKeyGroups()));
 
@@ -1997,6 +1998,7 @@ public class CloudFrontController {
                 .elem("ResponseHeadersPolicyId", cb.getResponseHeadersPolicyId())
                 .elem("Compress", cb.isCompress());
 
+        xml.raw(xmlTrustedSigners());
         xml.raw(xmlTrustedKeyGroups(
                 cb.isTrustedKeyGroupsEnabled(), cb.getTrustedKeyGroups()));
 
@@ -2066,6 +2068,18 @@ public class CloudFrontController {
             xml.end("Items");
         }
         return xml.end("TrustedKeyGroups").build();
+    }
+
+    // AWS always echoes a (usually empty) TrustedSigners object in every cache behavior. Floci models
+    // only the modern TrustedKeyGroups, but the Terraform AWS provider reads TrustedSigners.Items with
+    // no nil guard, so an omitted object segfaults it on read-back. Emit the disabled form AWS returns.
+    private String xmlTrustedSigners() {
+        return new XmlBuilder()
+                .start("TrustedSigners")
+                .elem("Enabled", false)
+                .elem("Quantity", 0)
+                .end("TrustedSigners")
+                .build();
     }
 
     private String xmlActiveTrustedKeyGroups(DistributionConfig config) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
@@ -159,6 +159,39 @@ class CloudFrontControllerTest {
     }
 
     @Test
+    void defaultCacheBehaviorEchoesTrustedSignersSoTheAwsProviderDoesNotSegfault() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-ts");
+            d.setEtag("etag-ts");
+            return d;
+        });
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+
+        when(service.getDistribution("dist-ts")).thenReturn(captor.getValue());
+
+        // The Terraform AWS provider reads DefaultCacheBehavior.TrustedSigners.Items with no nil
+        // guard, so an omitted object segfaults it on read-back. AWS always echoes the disabled form.
+        try (Response dist = controller.getDistribution("dist-ts")) {
+            String xml = (String) dist.getEntity();
+            int ts = xml.indexOf("<TrustedSigners>");
+            assertTrue(ts >= 0, "DefaultCacheBehavior must echo a TrustedSigners object");
+            String block = xml.substring(ts, xml.indexOf("</TrustedSigners>", ts));
+            assertTrue(block.contains("<Enabled>false</Enabled>"), "TrustedSigners.Enabled=false");
+            assertTrue(block.contains("<Quantity>0</Quantity>"), "TrustedSigners.Quantity=0");
+        }
+    }
+
+    @Test
     void orderedCacheBehaviorRoundTripsLambdaFunctionAssociations() {
         CloudFrontService service = mock(CloudFrontService.class);
         CloudFrontController controller = new CloudFrontController(service);


### PR DESCRIPTION
## What

Creating an `aws_cloudfront_distribution` against floci crashes the Terraform/pulumi AWS provider on read-back. `DefaultCacheBehavior` (and `CacheBehavior`) omit the `TrustedSigners` object, but the provider does `len(dcb.TrustedSigners.Items)` with **no nil guard** (`flattenDefaultCacheBehavior`), so an omitted object is a nil pointer dereference:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV ...]
terraform-provider-aws/internal/service/cloudfront.flattenDefaultCacheBehavior(...)
  distribution_configuration_structure.go
...resourceDistributionRead -> resourceDistributionCreate
```

The create succeeds, then the read-back panics and kills the whole apply, orphaning the distribution.

## Fix

Floci models only the modern `TrustedKeyGroups`, but real AWS **always** echoes a `TrustedSigners` object even when unused (`{Enabled:false, Quantity:0}`). Emit that disabled form in both cache-behavior writers (`xmlDefaultCacheBehavior`, `xmlCacheBehavior`), right next to `TrustedKeyGroups`. One small helper, two call sites.

## Test

`defaultCacheBehaviorEchoesTrustedSignersSoTheAwsProviderDoesNotSegfault` creates a distribution and asserts `getDistribution`'s `DefaultCacheBehavior` echoes a disabled `TrustedSigners`. It fails (object absent) before the fix and passes after. All 174 CloudFront tests stay green.

## Scope

Refs #2767. That issue lists three read-back gaps in the same object; this PR fixes the one that **crashes** the provider (TrustedSigners). The other two are fidelity/perpetual-diff issues, not crashes, and are left as follow-ups:
- `ForwardedValues`, `MinTTL`, `DefaultTTL`, `MaxTTL` dropped on read-back
- `AllowedMethods.Items` returns cached methods merged in as duplicates, with `CachedMethods` missing

(A sibling gap from #2767, LambdaFunctionAssociations/FunctionAssociations, was already fixed by #2915.)