### PR TITLE
ci(compat): record the native build size in the job summary and keep the stats JSON

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -149,6 +149,38 @@ jobs:
       - name: Build native executable (quick build)
         run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob"
 
+      # Quarkus always writes GraalVM's build-output JSON next to the native source jar. Surfacing
+      # it here gives every PR a size record for both architectures: code area, image heap, total
+      # image size and reachable type/method counts, plus the gzip size of the binary, which tracks
+      # the compressed layer Docker Hub will report. No extra build flags, a few seconds.
+      - name: Record native build size
+        run: |
+          python3 - "$GITHUB_STEP_SUMMARY" "${{ matrix.arch }}" <<'PY'
+          import glob, json, subprocess, sys
+          summary, arch = sys.argv[1], sys.argv[2]
+          stats = json.load(open(glob.glob("target/*-native-image-source-jar/*-build-output-stats.json")[0]))
+          d, a = stats["image_details"], stats["analysis_results"]
+          runner = glob.glob("target/*-runner")[0]
+          gz = int(subprocess.run(f"gzip -c '{runner}' | wc -c", shell=True, capture_output=True, text=True).stdout)
+          mib = lambda b: f"{b / 2**20:.1f} MiB"
+          rows = [("total image", mib(d["total_bytes"])), ("code area", mib(d["code_area"]["bytes"])),
+                  ("image heap", mib(d["image_heap"]["bytes"])),
+                  ("resources in heap", f"{mib(d['image_heap']['resources']['bytes'])} ({d['image_heap']['resources']['count']} files)"),
+                  ("binary gzip (Hub layer estimate)", f"{gz / 1e6:.2f} MB"),
+                  ("reachable types / methods", f"{a['types']['reachable']} / {a['methods']['reachable']}")]
+          with open(summary, "a") as f:
+              f.write(f"### Native build size ({arch}, quick build)\n\n| metric | value |\n|---|---|\n")
+              f.writelines(f"| {k} | {v} |\n" for k, v in rows)
+          print("\n".join(f"{k}: {v}" for k, v in rows))
+          PY
+
+      - name: Upload native build stats
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: native-build-stats-${{ matrix.arch }}
+          path: target/*-native-image-source-jar/*-build-output-stats.json
+          retention-days: 30
+
       - name: Stage native binary for packaging
         run: |
           mkdir -p native/${{ matrix.arch }}


### PR DESCRIPTION
## Summary

Quarkus passes `-H:BuildOutputJSONFile` to every native build, so GraalVM's build-output stats (code area, image heap, resources, total image size, reachable types and methods) already exist next to the native source jar in the `Build native floci image` job and were thrown away.

This adds one step after the quick build that reads the JSON, appends a small table to the job summary for each architecture (plus the gzip size of the binary, which tracks the compressed layer Docker Hub reports), and uploads the JSON as a 30-day artifact. No new build flags, a few seconds per job.

Why: the image grew 19 MB between 1.7.0 and 2.0.0 with nothing recording it (see `local` batman IMG-3 and #2919, #2940 which reversed it). Every dependency-removal PR that follows needs the amd64 numbers, and amd64 cannot be built on an Apple Silicon machine. Nothing fails yet; this only makes the size visible per PR. A threshold gate can come later once a few PRs have numbers.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Not applicable, CI only.

## Checklist

- [ ] `./mvnw test` passes locally (not run: no Java changes)
- [ ] New or updated integration test added (not applicable: workflow step; the step runs on this PR's own compatibility workflow, so its output is visible in the job summary here)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)