### PR TITLE
feat(neptune): support the Terraform aws_neptune_cluster read-back contract

### DIFF
--- a/compatibility-tests/compat-terraform/test/neptune-cluster-instance-tf/main.tf
+++ b/compatibility-tests/compat-terraform/test/neptune-cluster-instance-tf/main.tf
@@ -1,0 +1,69 @@
+resource "aws_neptune_cluster" "cluster" {
+  cluster_identifier  = "floci-tf-neptune-instances"
+  engine              = "neptune"
+  port                = 8183
+  skip_final_snapshot = true
+  apply_immediately   = true
+}
+
+resource "aws_neptune_cluster_instance" "writer" {
+  identifier         = "floci-tf-neptune-writer"
+  cluster_identifier = aws_neptune_cluster.cluster.id
+  instance_class     = "db.r5.large"
+  engine             = "neptune"
+  port               = 8183
+  apply_immediately  = true
+
+  tags = {
+    Name = "floci-tf-neptune-writer"
+  }
+}
+
+resource "aws_neptune_cluster_instance" "reader" {
+  identifier                 = "floci-tf-neptune-reader"
+  cluster_identifier         = aws_neptune_cluster.cluster.id
+  instance_class             = "db.r5.large"
+  engine                     = "neptune"
+  port                       = 8183
+  promotion_tier             = 2
+  auto_minor_version_upgrade = false
+  apply_immediately          = true
+
+  depends_on = [aws_neptune_cluster_instance.writer]
+}
+
+output "writer_arn" {
+  value = aws_neptune_cluster_instance.writer.arn
+}
+
+output "writer_endpoint" {
+  value = aws_neptune_cluster_instance.writer.endpoint
+}
+
+output "writer_port" {
+  value = aws_neptune_cluster_instance.writer.port
+}
+
+output "writer_is_writer" {
+  value = aws_neptune_cluster_instance.writer.writer
+}
+
+output "writer_storage_encrypted" {
+  value = aws_neptune_cluster_instance.writer.storage_encrypted
+}
+
+output "writer_parameter_group_name" {
+  value = aws_neptune_cluster_instance.writer.neptune_parameter_group_name
+}
+
+output "writer_auto_minor_version_upgrade" {
+  value = aws_neptune_cluster_instance.writer.auto_minor_version_upgrade
+}
+
+output "reader_is_writer" {
+  value = aws_neptune_cluster_instance.reader.writer
+}
+
+output "reader_promotion_tier" {
+  value = aws_neptune_cluster_instance.reader.promotion_tier
+}

--- a/compatibility-tests/compat-terraform/test/neptune-cluster-instance-tf/provider.tf
+++ b/compatibility-tests/compat-terraform/test/neptune-cluster-instance-tf/provider.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+variable "endpoint" {
+  type    = string
+  default = "http://localhost:4566"
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "test"
+  secret_key = "test"
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+
+  endpoints {
+    neptune = var.endpoint
+  }
+}

--- a/compatibility-tests/compat-terraform/test/neptune-cluster-tf/main.tf
+++ b/compatibility-tests/compat-terraform/test/neptune-cluster-tf/main.tf
@@ -1,0 +1,38 @@
+resource "aws_neptune_cluster" "cluster" {
+  cluster_identifier                  = "floci-tf-neptune"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  iam_database_authentication_enabled = true
+  deletion_protection                 = false
+  skip_final_snapshot                 = true
+  apply_immediately                   = true
+
+  tags = {
+    Name = "floci-tf-neptune"
+  }
+}
+
+output "cluster_arn" {
+  value = aws_neptune_cluster.cluster.arn
+}
+
+output "cluster_resource_id" {
+  value = aws_neptune_cluster.cluster.cluster_resource_id
+}
+
+output "endpoint" {
+  value = aws_neptune_cluster.cluster.endpoint
+}
+
+output "port" {
+  value = aws_neptune_cluster.cluster.port
+}
+
+output "storage_encrypted" {
+  value = aws_neptune_cluster.cluster.storage_encrypted
+}
+
+output "parameter_group_name" {
+  value = aws_neptune_cluster.cluster.neptune_cluster_parameter_group_name
+}

--- a/compatibility-tests/compat-terraform/test/neptune-cluster-tf/provider.tf
+++ b/compatibility-tests/compat-terraform/test/neptune-cluster-tf/provider.tf
@@ -1,0 +1,28 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+variable "endpoint" {
+  type    = string
+  default = "http://localhost:4566"
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "test"
+  secret_key = "test"
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+  s3_use_path_style           = true
+
+  endpoints {
+    neptune = var.endpoint
+  }
+}

--- a/compatibility-tests/compat-terraform/test/neptune_cluster.bats
+++ b/compatibility-tests/compat-terraform/test/neptune_cluster.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+# Neptune Cluster Compatibility Test
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    NEPTUNE_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/neptune-cluster-tf" && pwd)"
+    cd "$NEPTUNE_TF_DIR"
+
+    echo "# === Neptune Cluster Test ===" >&3
+    echo "# Endpoint: $FLOCI_ENDPOINT" >&3
+    echo "# Config: $NEPTUNE_TF_DIR" >&3
+
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+
+    echo "# --- terraform init ---" >&3
+    run terraform init -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform init failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform apply ---" >&3
+    run terraform apply -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform apply failed: $output" >&3
+        return 1
+    fi
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+
+    NEPTUNE_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/neptune-cluster-tf" && pwd)"
+    cd "$NEPTUNE_TF_DIR"
+
+    terraform destroy -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color || true
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    NEPTUNE_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/neptune-cluster-tf" && pwd)"
+}
+
+@test "Neptune cluster: terraform reads back the attributes it manages" {
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw storage_encrypted
+    assert_success
+    assert_output "false"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw parameter_group_name
+    assert_success
+    assert_output "default.neptune1.3"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw port
+    assert_success
+    assert_output "8182"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw cluster_arn
+    assert_success
+    assert_output --partial ":cluster:floci-tf-neptune"
+}
+
+@test "Neptune cluster: describe reports the configured settings" {
+    run aws_cmd neptune describe-db-clusters --db-cluster-identifier floci-tf-neptune
+    assert_success
+    [ "$(json_get "$output" '.DBClusters[0].Engine')" = "neptune" ]
+    [ "$(json_get "$output" '.DBClusters[0].Status')" = "available" ]
+    [ "$(json_get "$output" '.DBClusters[0].BackupRetentionPeriod')" = "5" ]
+    [ "$(json_get "$output" '.DBClusters[0].PreferredBackupWindow')" = "07:00-09:00" ]
+    [ "$(json_get "$output" '.DBClusters[0].StorageEncrypted')" = "false" ]
+    [ "$(json_get "$output" '.DBClusters[0].DeletionProtection')" = "false" ]
+    [ "$(json_get "$output" '.DBClusters[0].IAMDatabaseAuthenticationEnabled')" = "true" ]
+    [ "$(json_get "$output" '.DBClusters[0].DBClusterParameterGroup')" = "default.neptune1.3" ]
+    [ "$(json_get "$output" '.DBClusters[0].AvailabilityZones | length')" = "1" ]
+}
+
+@test "Neptune cluster: tags round-trip through ListTagsForResource" {
+    arn=$(terraform -chdir="$NEPTUNE_TF_DIR" output -raw cluster_arn)
+    run aws_cmd neptune list-tags-for-resource --resource-name "$arn"
+    assert_success
+    [ "$(json_get "$output" '.TagList[] | select(.Key == "Name") | .Value')" = "floci-tf-neptune" ]
+}
+
+@test "Neptune cluster: re-plan after apply is clean" {
+    cd "$NEPTUNE_TF_DIR"
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode
+    assert_success
+    assert_output --partial "No changes"
+}

--- a/compatibility-tests/compat-terraform/test/neptune_cluster_instance.bats
+++ b/compatibility-tests/compat-terraform/test/neptune_cluster_instance.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# Neptune Cluster Instance Compatibility Test
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    NEPTUNE_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/neptune-cluster-instance-tf" && pwd)"
+    cd "$NEPTUNE_TF_DIR"
+
+    echo "# === Neptune Cluster Instance Test ===" >&3
+    echo "# Endpoint: $FLOCI_ENDPOINT" >&3
+    echo "# Config: $NEPTUNE_TF_DIR" >&3
+
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+
+    echo "# --- terraform init ---" >&3
+    run terraform init -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform init failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform apply ---" >&3
+    run terraform apply -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform apply failed: $output" >&3
+        return 1
+    fi
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+
+    NEPTUNE_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/neptune-cluster-instance-tf" && pwd)"
+    cd "$NEPTUNE_TF_DIR"
+
+    terraform destroy -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color || true
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    NEPTUNE_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/neptune-cluster-instance-tf" && pwd)"
+}
+
+@test "Neptune cluster instance: terraform reads back the attributes it manages" {
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_is_writer
+    assert_success
+    assert_output "true"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw reader_is_writer
+    assert_success
+    assert_output "false"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_storage_encrypted
+    assert_success
+    assert_output "false"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_parameter_group_name
+    assert_success
+    assert_output "default.neptune1.3"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_port
+    assert_success
+    assert_output "8183"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_auto_minor_version_upgrade
+    assert_success
+    assert_output "true"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw reader_promotion_tier
+    assert_success
+    assert_output "2"
+
+    run terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_endpoint
+    assert_success
+    assert_output --partial ":8183"
+}
+
+@test "Neptune cluster instance: describe reports the configured settings" {
+    run aws_cmd neptune describe-db-instances --db-instance-identifier floci-tf-neptune-reader
+    assert_success
+    [ "$(json_get "$output" '.DBInstances[0].DBClusterIdentifier')" = "floci-tf-neptune-instances" ]
+    [ "$(json_get "$output" '.DBInstances[0].DBInstanceClass')" = "db.r5.large" ]
+    [ "$(json_get "$output" '.DBInstances[0].DBInstanceStatus')" = "available" ]
+    [ "$(json_get "$output" '.DBInstances[0].Endpoint.Port')" = "8183" ]
+    [ "$(json_get "$output" '.DBInstances[0].PromotionTier')" = "2" ]
+    [ "$(json_get "$output" '.DBInstances[0].AutoMinorVersionUpgrade')" = "false" ]
+    [ "$(json_get "$output" '.DBInstances[0].PubliclyAccessible')" = "false" ]
+    [ "$(json_get "$output" '.DBInstances[0].StorageEncrypted')" = "false" ]
+    [ "$(json_get "$output" '.DBInstances[0].DBSubnetGroup.DBSubnetGroupName')" = "default" ]
+    [ "$(json_get "$output" '.DBInstances[0].DBParameterGroups[0].DBParameterGroupName')" = "default.neptune1.3" ]
+}
+
+@test "Neptune cluster instance: tags round-trip through ListTagsForResource" {
+    arn=$(terraform -chdir="$NEPTUNE_TF_DIR" output -raw writer_arn)
+    run aws_cmd neptune list-tags-for-resource --resource-name "$arn"
+    assert_success
+    [ "$(json_get "$output" '.TagList[] | select(.Key == "Name") | .Value')" = "floci-tf-neptune-writer" ]
+}
+
+@test "Neptune cluster instance: the cluster reports exactly one writer" {
+    run aws_cmd neptune describe-db-clusters --db-cluster-identifier floci-tf-neptune-instances
+    assert_success
+    [ "$(json_get "$output" '.DBClusters[0].DBClusterMembers | length')" = "2" ]
+    [ "$(json_get "$output" '[.DBClusters[0].DBClusterMembers[] | select(.IsClusterWriter)] | length')" = "1" ]
+    [ "$(json_get "$output" '.DBClusters[0].DBClusterMembers[] | select(.IsClusterWriter) | .DBInstanceIdentifier')" = "floci-tf-neptune-writer" ]
+}
+
+@test "Neptune cluster instance: re-plan after apply is clean" {
+    cd "$NEPTUNE_TF_DIR"
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode
+    assert_success
+    assert_output --partial "No changes"
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/NeptuneTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/NeptuneTest.java
@@ -8,16 +8,20 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
-import software.amazon.awssdk.services.neptune.model.CreateDbClusterRequest;
+import software.amazon.awssdk.services.neptune.model.AddRoleToDbClusterRequest;
+import software.amazon.awssdk.services.neptune.model.AddTagsToResourceRequest;import software.amazon.awssdk.services.neptune.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.neptune.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.neptune.model.DeleteDbClusterRequest;
 import software.amazon.awssdk.services.neptune.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.neptune.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.neptune.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.neptune.model.InvalidDbClusterStateException;
-import software.amazon.awssdk.services.neptune.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.neptune.model.ListTagsForResourceRequest;import software.amazon.awssdk.services.neptune.model.ModifyDbClusterRequest;
 import software.amazon.awssdk.services.neptune.model.ModifyDbInstanceRequest;
-
+import software.amazon.awssdk.services.neptune.model.NeptuneException;
+import software.amazon.awssdk.services.neptune.model.RemoveRoleFromDbClusterRequest;
+import software.amazon.awssdk.services.neptune.model.RemoveTagsFromResourceRequest;
+import software.amazon.awssdk.services.neptune.model.Tag;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -58,6 +62,7 @@ class NeptuneTest {
         var response = neptune.createDBCluster(CreateDbClusterRequest.builder()
                 .dbClusterIdentifier(CLUSTER_ID)
                 .engine("neptune")
+                .tags(Tag.builder().key("Name").value(CLUSTER_ID).build())
                 .build());
 
         var cluster = response.dbCluster();
@@ -66,6 +71,14 @@ class NeptuneTest {
         assertThat(cluster.status()).isEqualTo("available");
         assertThat(cluster.dbClusterArn()).startsWith("arn:aws:neptune:");
         assertThat(cluster.port()).isGreaterThan(0);
+        assertThat(cluster.storageEncrypted()).isFalse();
+        assertThat(cluster.backupRetentionPeriod()).isEqualTo(1);
+        assertThat(cluster.availabilityZones()).hasSize(1);
+        assertThat(cluster.dbClusterParameterGroup()).isEqualTo("default.neptune1.3");
+        assertThat(cluster.dbSubnetGroup()).isEqualTo("default");
+        assertThat(cluster.deletionProtection()).isFalse();
+        assertThat(cluster.preferredBackupWindow()).isNotBlank();
+        assertThat(cluster.preferredMaintenanceWindow()).isNotBlank();
     }
 
     @Test
@@ -106,6 +119,77 @@ class NeptuneTest {
 
     @Test
     @Order(5)
+    @DisplayName("Tags round-trip through ListTagsForResource, AddTagsToResource and RemoveTagsFromResource")
+    void tagsRoundTrip() {
+        String arn = neptune.describeDBClusters(DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).build()).dbClusters().get(0).dbClusterArn();
+
+        var created = neptune.listTagsForResource(ListTagsForResourceRequest.builder().resourceName(arn).build());
+        assertThat(created.tagList()).containsExactly(Tag.builder().key("Name").value(CLUSTER_ID).build());
+
+        neptune.addTagsToResource(AddTagsToResourceRequest.builder()
+                .resourceName(arn)
+                .tags(Tag.builder().key("team").value("graph").build())
+                .build());
+        neptune.removeTagsFromResource(RemoveTagsFromResourceRequest.builder()
+                .resourceName(arn)
+                .tagKeys("Name")
+                .build());
+
+        var updated = neptune.listTagsForResource(ListTagsForResourceRequest.builder().resourceName(arn).build());
+        assertThat(updated.tagList()).containsExactly(Tag.builder().key("team").value("graph").build());
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("AddRoleToDBCluster and RemoveRoleFromDBCluster maintain AssociatedRoles")
+    void rolesRoundTrip() {
+        String roleArn = "arn:aws:iam::000000000000:role/" + CLUSTER_ID;
+
+        neptune.addRoleToDBCluster(AddRoleToDbClusterRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).roleArn(roleArn).build());
+        var withRole = neptune.describeDBClusters(DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).build()).dbClusters().get(0);
+        assertThat(withRole.associatedRoles()).hasSize(1);
+        assertThat(withRole.associatedRoles().get(0).roleArn()).isEqualTo(roleArn);
+        assertThat(withRole.associatedRoles().get(0).status()).isEqualTo("ACTIVE");
+
+        neptune.removeRoleFromDBCluster(RemoveRoleFromDbClusterRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).roleArn(roleArn).build());
+        var withoutRole = neptune.describeDBClusters(DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).build()).dbClusters().get(0);
+        assertThat(withoutRole.associatedRoles()).isEmpty();
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("ModifyDBCluster applies backup and protection settings and protection blocks delete")
+    void modifySettingsAndDeletionProtection() {
+        var modified = neptune.modifyDBCluster(ModifyDbClusterRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID)
+                .backupRetentionPeriod(7)
+                .deletionProtection(true)
+                .build()).dbCluster();
+        assertThat(modified.backupRetentionPeriod()).isEqualTo(7);
+        assertThat(modified.deletionProtection()).isTrue();
+
+        assertThatThrownBy(() -> neptune.deleteDBCluster(DeleteDbClusterRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID)
+                .skipFinalSnapshot(true)
+                .build()))
+                .isInstanceOf(NeptuneException.class)
+                .hasMessageContaining("deletion protection");
+
+        var unprotected = neptune.modifyDBCluster(ModifyDbClusterRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID)
+                .deletionProtection(false)
+                .build()).dbCluster();
+        assertThat(unprotected.deletionProtection()).isFalse();
+        assertThat(unprotected.backupRetentionPeriod()).isEqualTo(7);
+    }
+
+    @Test
+    @Order(15)
     @DisplayName("CreateDBInstance returns valid instance descriptor")
     void createInstance() {
         var response = neptune.createDBInstance(CreateDbInstanceRequest.builder()
@@ -123,7 +207,7 @@ class NeptuneTest {
     }
 
     @Test
-    @Order(6)
+    @Order(16)
     @DisplayName("DescribeDBInstances returns created instance")
     void describeInstances() {
         var response = neptune.describeDBInstances(DescribeDbInstancesRequest.builder()
@@ -132,10 +216,15 @@ class NeptuneTest {
 
         assertThat(response.dbInstances()).hasSize(1);
         assertThat(response.dbInstances().get(0).dbInstanceIdentifier()).isEqualTo(INSTANCE_ID);
+
+        var cluster = neptune.describeDBClusters(DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).build()).dbClusters().get(0);
+        assertThat(cluster.dbClusterMembers()).hasSize(1);
+        assertThat(cluster.dbClusterMembers().get(0).dbInstanceIdentifier()).isEqualTo(INSTANCE_ID);
     }
 
     @Test
-    @Order(7)
+    @Order(17)
     @DisplayName("ModifyDBInstance updates instance class")
     void modifyInstance() {
         var response = neptune.modifyDBInstance(ModifyDbInstanceRequest.builder()
@@ -147,7 +236,7 @@ class NeptuneTest {
     }
 
     @Test
-    @Order(8)
+    @Order(18)
     @DisplayName("DeleteDBCluster fails when instances still exist")
     void deleteClusterWithInstancesFails() {
         assertThatThrownBy(() ->
@@ -159,7 +248,7 @@ class NeptuneTest {
     }
 
     @Test
-    @Order(9)
+    @Order(19)
     @DisplayName("DeleteDBInstance removes instance")
     void deleteInstance() {
         neptune.deleteDBInstance(DeleteDbInstanceRequest.builder()
@@ -168,7 +257,7 @@ class NeptuneTest {
     }
 
     @Test
-    @Order(10)
+    @Order(20)
     @DisplayName("DeleteDBCluster removes cluster after instances are gone")
     void deleteCluster() {
         neptune.deleteDBCluster(DeleteDbClusterRequest.builder()

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/NeptuneTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/NeptuneTest.java
@@ -9,14 +9,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.neptune.model.AddRoleToDbClusterRequest;
-import software.amazon.awssdk.services.neptune.model.AddTagsToResourceRequest;import software.amazon.awssdk.services.neptune.model.CreateDbClusterRequest;
+import software.amazon.awssdk.services.neptune.model.AddTagsToResourceRequest;
+import software.amazon.awssdk.services.neptune.model.CreateDbClusterRequest;
 import software.amazon.awssdk.services.neptune.model.CreateDbInstanceRequest;
 import software.amazon.awssdk.services.neptune.model.DeleteDbClusterRequest;
 import software.amazon.awssdk.services.neptune.model.DeleteDbInstanceRequest;
 import software.amazon.awssdk.services.neptune.model.DescribeDbClustersRequest;
 import software.amazon.awssdk.services.neptune.model.DescribeDbInstancesRequest;
 import software.amazon.awssdk.services.neptune.model.InvalidDbClusterStateException;
-import software.amazon.awssdk.services.neptune.model.ListTagsForResourceRequest;import software.amazon.awssdk.services.neptune.model.ModifyDbClusterRequest;
+import software.amazon.awssdk.services.neptune.model.ListTagsForResourceRequest;
+import software.amazon.awssdk.services.neptune.model.ModifyDbClusterRequest;
 import software.amazon.awssdk.services.neptune.model.ModifyDbInstanceRequest;
 import software.amazon.awssdk.services.neptune.model.NeptuneException;
 import software.amazon.awssdk.services.neptune.model.RemoveRoleFromDbClusterRequest;
@@ -24,6 +26,7 @@ import software.amazon.awssdk.services.neptune.model.RemoveTagsFromResourceReque
 import software.amazon.awssdk.services.neptune.model.Tag;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
 
 @DisplayName("Neptune Cluster and Instance Management")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -190,13 +193,17 @@ class NeptuneTest {
 
     @Test
     @Order(15)
-    @DisplayName("CreateDBInstance returns valid instance descriptor")
+    @DisplayName("CreateDBInstance returns the descriptor Terraform's aws_neptune_cluster_instance reads back")
     void createInstance() {
         var response = neptune.createDBInstance(CreateDbInstanceRequest.builder()
                 .dbInstanceIdentifier(INSTANCE_ID)
                 .dbClusterIdentifier(CLUSTER_ID)
                 .dbInstanceClass("db.r5.large")
                 .engine("neptune")
+                .autoMinorVersionUpgrade(true)
+                .promotionTier(0)
+                .publiclyAccessible(false)
+                .tags(Tag.builder().key("Name").value(INSTANCE_ID).build())
                 .build());
 
         var instance = response.dbInstance();
@@ -204,6 +211,19 @@ class NeptuneTest {
         assertThat(instance.dbClusterIdentifier()).isEqualTo(CLUSTER_ID);
         assertThat(instance.dbInstanceStatus()).isEqualTo("available");
         assertThat(instance.dbInstanceArn()).startsWith("arn:aws:neptune:");
+        assertThat(instance.autoMinorVersionUpgrade()).isTrue();
+        assertThat(instance.promotionTier()).isZero();
+        assertThat(instance.publiclyAccessible()).isFalse();
+        assertThat(instance.storageEncrypted()).isFalse();
+        assertThat(instance.availabilityZone()).isNotBlank();
+        assertThat(instance.preferredBackupWindow()).isNotBlank();
+        assertThat(instance.preferredMaintenanceWindow()).isNotBlank();
+        assertThat(instance.instanceCreateTime()).isNotNull();
+        assertThat(instance.dbSubnetGroup().dbSubnetGroupName()).isEqualTo("default");
+        assertThat(instance.dbParameterGroups()).hasSize(1);
+        assertThat(instance.dbParameterGroups().get(0).dbParameterGroupName()).startsWith("default.neptune");
+        assertThat(instance.endpoint().port()).isEqualTo(neptune.describeDBClusters(DescribeDbClustersRequest.builder()
+                .dbClusterIdentifier(CLUSTER_ID).build()).dbClusters().get(0).port());
     }
 
     @Test
@@ -216,23 +236,43 @@ class NeptuneTest {
 
         assertThat(response.dbInstances()).hasSize(1);
         assertThat(response.dbInstances().get(0).dbInstanceIdentifier()).isEqualTo(INSTANCE_ID);
+        assertThat(response.dbInstances().get(0).promotionTier()).isZero();
 
         var cluster = neptune.describeDBClusters(DescribeDbClustersRequest.builder()
                 .dbClusterIdentifier(CLUSTER_ID).build()).dbClusters().get(0);
         assertThat(cluster.dbClusterMembers()).hasSize(1);
         assertThat(cluster.dbClusterMembers().get(0).dbInstanceIdentifier()).isEqualTo(INSTANCE_ID);
+        assertThat(cluster.dbClusterMembers().get(0).isClusterWriter()).isTrue();
+
+        var tags = neptune.listTagsForResource(ListTagsForResourceRequest.builder()
+                .resourceName(response.dbInstances().get(0).dbInstanceArn()).build()).tagList();
+        assertThat(tags).extracting(Tag::key, Tag::value).containsExactly(tuple("Name", INSTANCE_ID));
     }
 
     @Test
     @Order(17)
-    @DisplayName("ModifyDBInstance updates instance class")
+    @DisplayName("ModifyDBInstance updates the settings Terraform changes in place")
     void modifyInstance() {
         var response = neptune.modifyDBInstance(ModifyDbInstanceRequest.builder()
                 .dbInstanceIdentifier(INSTANCE_ID)
                 .dbInstanceClass("db.r5.xlarge")
+                .autoMinorVersionUpgrade(false)
+                .promotionTier(3)
+                .preferredMaintenanceWindow("sun:05:00-sun:06:00")
+                .applyImmediately(true)
                 .build());
 
-        assertThat(response.dbInstance().dbInstanceClass()).isEqualTo("db.r5.xlarge");
+        var instance = response.dbInstance();
+        assertThat(instance.dbInstanceClass()).isEqualTo("db.r5.xlarge");
+        assertThat(instance.autoMinorVersionUpgrade()).isFalse();
+        assertThat(instance.promotionTier()).isEqualTo(3);
+        assertThat(instance.preferredMaintenanceWindow()).isEqualTo("sun:05:00-sun:06:00");
+        assertThat(instance.publiclyAccessible()).isFalse();
+
+        var described = neptune.describeDBInstances(DescribeDbInstancesRequest.builder()
+                .dbInstanceIdentifier(INSTANCE_ID).build()).dbInstances().get(0);
+        assertThat(described.promotionTier()).isEqualTo(3);
+        assertThat(described.autoMinorVersionUpgrade()).isFalse();
     }
 
     @Test

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -54,7 +54,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Athena](athena.md) | `POST /` + `X-Amz-Target: AmazonAthena.*` | JSON 1.1 | 4 |
 | [Glue](glue.md) | `POST /` + `X-Amz-Target: AWSGlue.*` | JSON 1.1 | 38 |
 | [Lake Formation](lakeformation.md) | `POST /<Action>` | REST JSON | 16 |
-| [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 8 |
+| [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 14 |
 | [DocumentDB](docdb.md) | `POST /` with `Action=` param + MongoDB container | Query + MongoDB wire | 8 |
 | [Redshift](redshift.md) | `POST /` with `Action=` param + PostgreSQL container | Query + PostgreSQL wire | 21 |
 | [EMR](emr.md) | `POST /` + `X-Amz-Target: ElasticMapReduce.*` | JSON 1.1 | 24 |

--- a/docs/services/neptune.md
+++ b/docs/services/neptune.md
@@ -51,6 +51,17 @@ The proxy is a transparent byte relay, so the host-facing proxy port range is un
 - Tags given on create are readable through `ListTagsForResource`, and the provider's tag updates go through `AddTagsToResource` and `RemoveTagsFromResource`.
 - `DescribeGlobalClusters` answers with an empty list, which is what the provider's read needs when the cluster is not part of a global cluster.
 
+### The `aws_neptune_cluster_instance` resource
+
+`DescribeDBInstances` reads back the fields the provider's `aws_neptune_cluster_instance` resource manages, so an instance plan is clean after apply too:
+
+- `AutoMinorVersionUpgrade` (default `true`), `PromotionTier` (default `1`), `PubliclyAccessible` (default `false`), `AvailabilityZone`, `DBParameterGroups` (default `default.neptune<major>.<minor>`), `DBSubnetGroup` (default `default`), `PreferredBackupWindow` and `PreferredMaintenanceWindow` are stored on create, updated by `ModifyDBInstance` and read back.
+- `StorageEncrypted`, `KmsKeyId` and `StorageType` are the cluster's values.
+- The first instance created in a cluster is the writer in `DBClusterMembers`; later instances are readers, and deleting the writer promotes the next member.
+- Instance tags are readable through `ListTagsForResource` with the instance ARN.
+
+An instance answers on its cluster's port. Terraform's instance `port` attribute defaults to `8182`, so set it to the cluster's port when the cluster does not use `8182`.
+
 ### Port
 
 A requested `Port` is honoured when it is free and inside the proxy port range (`8182`-`8282` by default); otherwise the cluster gets the next free port in the range and `DescribeDBClusters` reports that port. Terraform's `port` attribute defaults to `8182`, so the first cluster is a clean match. For a second cluster set `port` explicitly (for example `port = 8183`) so the plan stays clean, because two clusters cannot share one host port.

--- a/docs/services/neptune.md
+++ b/docs/services/neptune.md
@@ -24,15 +24,36 @@ The proxy is a transparent byte relay, so the host-facing proxy port range is un
 <!-- floci:actions:start -->
 | Action | Description |
 | --- | --- |
-| `CreateDBCluster` | Create a Neptune cluster and start a Gremlin Server container |
+| `CreateDBCluster` | Create a Neptune cluster (tags, placement, backup, protection and log-export settings included) and start a graph database container |
 | `DescribeDBClusters` | List clusters and their connection details |
 | `DeleteDBCluster` | Stop and remove a cluster |
-| `ModifyDBCluster` | Update cluster settings |
+| `ModifyDBCluster` | Update cluster settings, including deletion protection, backup retention, log exports and security groups |
+| `AddRoleToDBCluster` | Associate an IAM role with a cluster (listed under `AssociatedRoles`) |
+| `RemoveRoleFromDBCluster` | Disassociate an IAM role from a cluster |
+| `DescribeGlobalClusters` | Always an empty list; global clusters are not modelled |
 | `CreateDBInstance` | Add an instance to a cluster |
 | `DescribeDBInstances` | List instances |
 | `DeleteDBInstance` | Remove an instance from a cluster |
 | `ModifyDBInstance` | Update instance settings |
+| `ListTagsForResource` | List the tags on a cluster or instance by ARN |
+| `AddTagsToResource` | Add or overwrite tags on a cluster or instance |
+| `RemoveTagsFromResource` | Remove tags from a cluster or instance by key |
 <!-- floci:actions:end -->
+
+## Terraform and the `aws_neptune_cluster` resource
+
+`DescribeDBClusters` returns every field the Terraform AWS provider's `aws_neptune_cluster` resource reads back, with the values the request set and the AWS defaults otherwise, so a `terraform plan` straight after `terraform apply` reports no changes:
+
+- `StorageEncrypted` defaults to `false`, as on AWS; pass `StorageEncrypted=true` (and optionally `KmsKeyId`) to encrypt.
+- `AvailabilityZones` echoes the requested zones and otherwise contains the emulator's default zone.
+- `BackupRetentionPeriod` (default 1), `PreferredBackupWindow`, `PreferredMaintenanceWindow`, `DBSubnetGroup` (default `default`), `DBClusterParameterGroup` (default `default.neptune<major>.<minor>` for the engine version), `DeletionProtection`, `CopyTagsToSnapshot`, `StorageType`, `EnabledCloudwatchLogsExports`, `VpcSecurityGroups`, `ServerlessV2ScalingConfiguration` and `AssociatedRoles` are all stored and read back.
+- Deleting a cluster with `DeletionProtection` enabled fails with `InvalidParameterCombination`, as on AWS.
+- Tags given on create are readable through `ListTagsForResource`, and the provider's tag updates go through `AddTagsToResource` and `RemoveTagsFromResource`.
+- `DescribeGlobalClusters` answers with an empty list, which is what the provider's read needs when the cluster is not part of a global cluster.
+
+### Port
+
+A requested `Port` is honoured when it is free and inside the proxy port range (`8182`-`8282` by default); otherwise the cluster gets the next free port in the range and `DescribeDBClusters` reports that port. Terraform's `port` attribute defaults to `8182`, so the first cluster is a clean match. For a second cluster set `port` explicitly (for example `port = 8183`) so the plan stays clean, because two clusters cannot share one host port.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -300,8 +300,9 @@ public class AwsQueryController {
             case "elasticache" -> elastiCacheQueryHandler.handle(action, formParams, region);
             case "rds" -> {
                 // Neptune signs requests with "rds" credential scope (same wire protocol).
-                // Route to Neptune when Engine=neptune (create ops) or when the cluster/instance
-                // already exists in Neptune storage (describe/modify/delete ops).
+                // Route to Neptune when Engine=neptune (create ops), when the cluster/instance
+                // already exists in Neptune storage (describe/modify/delete ops), or when a
+                // tagging ResourceName is a Neptune ARN.
                 String engine = formParams.getFirst("Engine");
                 String clusterId = formParams.getFirst("DBClusterIdentifier");
                 String instanceId = formParams.getFirst("DBInstanceIdentifier");
@@ -313,7 +314,8 @@ public class AwsQueryController {
 
                 if ("neptune".equalsIgnoreCase(engine)
                         || neptuneService.hasCluster(clusterId)
-                        || neptuneService.hasInstance(instanceId)) {
+                        || neptuneService.hasInstance(instanceId)
+                        || neptuneService.hasResourceWithArn(formParams.getFirst("ResourceName"))) {
                     yield neptuneQueryHandler.handle(action, formParams);
                 }
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -518,6 +518,7 @@ public class AwsQueryController {
             "CreateDBSubnetGroup", "DescribeDBSubnetGroups", "ModifyDBSubnetGroup", "DeleteDBSubnetGroup",
             "AddTagsToResource", "ListTagsForResource", "RemoveTagsFromResource",
             "CreateDBCluster", "DescribeDBClusters", "DeleteDBCluster", "ModifyDBCluster",
+            "AddRoleToDBCluster", "RemoveRoleFromDBCluster",
             "DescribeGlobalClusters",
             "CreateDBParameterGroup", "DescribeDBParameterGroups",
             "DeleteDBParameterGroup", "ModifyDBParameterGroup", "DescribeDBParameters",

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -4,8 +4,10 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
+import io.github.hectorvent.floci.core.common.BackupWindows;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneClusterSettings;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -13,8 +15,15 @@ import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @ApplicationScoped
 public class NeptuneQueryHandler {
@@ -38,10 +47,16 @@ public class NeptuneQueryHandler {
                 case "DescribeDBClusters" -> handleDescribeDbClusters(params);
                 case "DeleteDBCluster"    -> handleDeleteDbCluster(params);
                 case "ModifyDBCluster"    -> handleModifyDbCluster(params);
+                case "AddRoleToDBCluster" -> handleAddRoleToDbCluster(params);
+                case "RemoveRoleFromDBCluster" -> handleRemoveRoleFromDbCluster(params);
+                case "DescribeGlobalClusters" -> handleDescribeGlobalClusters(params);
                 case "CreateDBInstance"   -> handleCreateDbInstance(params);
                 case "DescribeDBInstances"-> handleDescribeDbInstances(params);
                 case "DeleteDBInstance"   -> handleDeleteDbInstance(params);
                 case "ModifyDBInstance"   -> handleModifyDbInstance(params);
+                case "ListTagsForResource" -> handleListTagsForResource(params);
+                case "AddTagsToResource"   -> handleAddTagsToResource(params);
+                case "RemoveTagsFromResource" -> handleRemoveTagsFromResource(params);
                 default -> AwsQueryResponse.error("UnsupportedOperation",
                         "Operation " + action + " is not supported by Neptune.", AwsNamespaces.RDS, 400);
             };
@@ -64,7 +79,8 @@ public class NeptuneQueryHandler {
         String engineVersion = params.getFirst("EngineVersion");
         boolean iamEnabled = "true".equalsIgnoreCase(params.getFirst("EnableIAMDatabaseAuthentication"));
 
-        NeptuneCluster cluster = service.createDbCluster(id, engineVersion, iamEnabled);
+        NeptuneCluster cluster = service.createDbCluster(id, engineVersion, iamEnabled,
+                clusterSettings(params, true), parseTags(params));
         return Response.ok(AwsQueryResponse.envelope("CreateDBCluster", AwsNamespaces.RDS,
                 clusterXml(cluster))).build();
     }
@@ -143,9 +159,57 @@ public class NeptuneQueryHandler {
         String iamStr = params.getFirst("EnableIAMDatabaseAuthentication");
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
 
-        NeptuneCluster cluster = service.modifyDbCluster(id, engineVersion, iamEnabled);
+        NeptuneCluster cluster = service.modifyDbCluster(id, engineVersion, iamEnabled,
+                clusterSettings(params, false));
         return Response.ok(AwsQueryResponse.envelope("ModifyDBCluster", AwsNamespaces.RDS,
                 clusterXml(cluster))).build();
+    }
+
+    private Response handleAddRoleToDbCluster(MultivaluedMap<String, String> params) {
+        String id = params.getFirst("DBClusterIdentifier");
+        if (id == null || id.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "DBClusterIdentifier is required.", AwsNamespaces.RDS, 400);
+        }
+        service.addRoleToDbCluster(id, params.getFirst("RoleArn"));
+        return Response.ok(AwsQueryResponse.envelopeNoResult("AddRoleToDBCluster", AwsNamespaces.RDS)).build();
+    }
+
+    private Response handleRemoveRoleFromDbCluster(MultivaluedMap<String, String> params) {
+        String id = params.getFirst("DBClusterIdentifier");
+        if (id == null || id.isBlank()) {
+            return AwsQueryResponse.error("InvalidParameterValue",
+                    "DBClusterIdentifier is required.", AwsNamespaces.RDS, 400);
+        }
+        service.removeRoleFromDbCluster(id, params.getFirst("RoleArn"));
+        return Response.ok(AwsQueryResponse.envelopeNoResult("RemoveRoleFromDBCluster", AwsNamespaces.RDS)).build();
+    }
+
+    private Response handleDescribeGlobalClusters(MultivaluedMap<String, String> params) {
+        String maxRecords = params.getFirst("MaxRecords");
+        if (maxRecords != null && !maxRecords.isBlank()) {
+            int max = -1;
+            try {
+                max = Integer.parseInt(maxRecords.trim());
+            } catch (NumberFormatException e) {
+                LOG.debugv("Non-numeric MaxRecords {0} on DescribeGlobalClusters", maxRecords);
+            }
+            if (max < 20 || max > 100) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid value " + maxRecords + " for MaxRecords. Must be between 20 and 100", 400);
+            }
+        }
+        String identifier = params.getFirst("GlobalClusterIdentifier");
+        if (identifier != null && !identifier.isBlank()) {
+            throw new AwsException("GlobalClusterNotFoundFault",
+                    "Global cluster '" + identifier + "' not found", 404);
+        }
+        String marker = params.getFirst("Marker");
+        if (marker != null && !marker.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "The request token is invalid.", 400);
+        }
+        XmlBuilder xml = new XmlBuilder().start("GlobalClusters").end("GlobalClusters");
+        return Response.ok(AwsQueryResponse.envelope("DescribeGlobalClusters", AwsNamespaces.RDS, xml.build())).build();
     }
 
     // ── Instances ─────────────────────────────────────────────────────────────
@@ -166,7 +230,7 @@ public class NeptuneQueryHandler {
         boolean iamEnabled = "true".equalsIgnoreCase(params.getFirst("EnableIAMDatabaseAuthentication"));
 
         NeptuneInstance instance = service.createDbInstance(id, dbClusterIdentifier,
-                dbInstanceClass, engineVersion, iamEnabled);
+                dbInstanceClass, engineVersion, iamEnabled, parseTags(params));
         return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS,
                 instanceXml(instance))).build();
     }
@@ -222,6 +286,126 @@ public class NeptuneQueryHandler {
                 instanceXml(instance))).build();
     }
 
+    // ── Tags ──────────────────────────────────────────────────────────────────
+
+    private Response handleListTagsForResource(MultivaluedMap<String, String> params) {
+        Map<String, String> tags = service.listTagsForResource(params.getFirst("ResourceName"));
+        XmlBuilder xml = new XmlBuilder().start("TagList");
+        tags.forEach((key, value) -> xml.start("Tag").elem("Key", key).elem("Value", value).end("Tag"));
+        xml.end("TagList");
+        return Response.ok(AwsQueryResponse.envelope("ListTagsForResource", AwsNamespaces.RDS, xml.build())).build();
+    }
+
+    private Response handleAddTagsToResource(MultivaluedMap<String, String> params) {
+        service.addTagsToResource(params.getFirst("ResourceName"), parseTags(params));
+        return Response.ok(AwsQueryResponse.envelopeNoResult("AddTagsToResource", AwsNamespaces.RDS)).build();
+    }
+
+    private Response handleRemoveTagsFromResource(MultivaluedMap<String, String> params) {
+        service.removeTagsFromResource(params.getFirst("ResourceName"), tagKeys(params));
+        return Response.ok(AwsQueryResponse.envelopeNoResult("RemoveTagsFromResource", AwsNamespaces.RDS)).build();
+    }
+
+    // ── Request parsing ───────────────────────────────────────────────────────
+
+    private static NeptuneClusterSettings clusterSettings(MultivaluedMap<String, String> params, boolean create) {
+        return new NeptuneClusterSettings(
+                create ? listParam(params, "AvailabilityZones", "AvailabilityZone") : null,
+                create ? optionalInt(params.getFirst("Port")) : null,
+                optionalInt(params.getFirst("BackupRetentionPeriod")),
+                params.getFirst("PreferredBackupWindow"),
+                params.getFirst("PreferredMaintenanceWindow"),
+                create ? params.getFirst("DBSubnetGroupName") : null,
+                params.getFirst("DBClusterParameterGroupName"),
+                listParam(params, "VpcSecurityGroupIds", "VpcSecurityGroupId"),
+                create ? optionalBoolean(params.getFirst("StorageEncrypted")) : null,
+                create ? params.getFirst("KmsKeyId") : null,
+                params.getFirst("StorageType"),
+                optionalBoolean(params.getFirst("DeletionProtection")),
+                optionalBoolean(params.getFirst("CopyTagsToSnapshot")),
+                create ? listParam(params, "EnableCloudwatchLogsExports", "member")
+                       : listParam(params, "CloudwatchLogsExportConfiguration.EnableLogTypes", "member"),
+                create ? null : listParam(params, "CloudwatchLogsExportConfiguration.DisableLogTypes", "member"),
+                create ? params.getFirst("ReplicationSourceIdentifier") : null,
+                optionalDouble(params.getFirst("ServerlessV2ScalingConfiguration.MinCapacity")),
+                optionalDouble(params.getFirst("ServerlessV2ScalingConfiguration.MaxCapacity")));
+    }
+
+    private static List<String> listParam(MultivaluedMap<String, String> params, String name, String memberName) {
+        Set<String> prefixes = new LinkedHashSet<>(List.of(name + "." + memberName + ".", name + ".member."));
+        for (String prefix : prefixes) {
+            List<String> values = new ArrayList<>();
+            for (int i = 1; ; i++) {
+                String value = params.getFirst(prefix + i);
+                if (value == null) {
+                    break;
+                }
+                if (!value.isBlank()) {
+                    values.add(value);
+                }
+            }
+            if (!values.isEmpty()) {
+                return values;
+            }
+        }
+        return params.containsKey(name) ? new ArrayList<>() : null;
+    }
+
+    private static Map<String, String> parseTags(MultivaluedMap<String, String> params) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        for (String prefix : List.of("Tags.Tag", "Tags.member", "Tag")) {
+            for (int i = 1; ; i++) {
+                String key = params.getFirst(prefix + "." + i + ".Key");
+                if (key == null) {
+                    break;
+                }
+                String value = params.getFirst(prefix + "." + i + ".Value");
+                tags.put(key, value == null ? "" : value);
+            }
+        }
+        return tags;
+    }
+
+    private static List<String> tagKeys(MultivaluedMap<String, String> params) {
+        List<String> keys = new ArrayList<>();
+        for (String prefix : List.of("TagKeys.member", "TagKeys.TagKey", "TagKeys")) {
+            for (int i = 1; ; i++) {
+                String key = params.getFirst(prefix + "." + i);
+                if (key == null) {
+                    break;
+                }
+                keys.add(key);
+            }
+        }
+        return keys;
+    }
+
+    private static Boolean optionalBoolean(String value) {
+        return value == null ? null : !"false".equalsIgnoreCase(value.trim());
+    }
+
+    private static Integer optionalInt(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidParameterValue", "Value " + value + " is not a valid integer.", 400);
+        }
+    }
+
+    private static Double optionalDouble(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidParameterValue", "Value " + value + " is not a valid number.", 400);
+        }
+    }
+
     // ── XML builders ──────────────────────────────────────────────────────────
 
     private String clusterXml(NeptuneCluster c) {
@@ -239,17 +423,71 @@ public class NeptuneQueryHandler {
                 .elem("Port", c.getPort())
                 .elem("IAMDatabaseAuthenticationEnabled", c.isIamDatabaseAuthenticationEnabled())
                 .elem("MultiAZ", false)
-                .elem("StorageEncrypted", true)
-                .elem("AvailabilityZone", config.defaultAvailabilityZone())
+                .elem("StorageEncrypted", c.isStorageEncrypted())
+                .elem("KmsKeyId", c.getKmsKeyId())
+                .elem("StorageType", c.getStorageType())
+                .elem("DBSubnetGroup", c.getDbSubnetGroupName() != null ? c.getDbSubnetGroupName() : "default")
+                .elem("DBClusterParameterGroup", c.getDbClusterParameterGroupName() != null
+                        ? c.getDbClusterParameterGroupName()
+                        : "default." + NeptuneService.parameterGroupFamily(c.getEngineVersion()))
+                .elem("BackupRetentionPeriod", c.getBackupRetentionPeriod())
+                .elem("PreferredBackupWindow", c.getPreferredBackupWindow() != null
+                        ? c.getPreferredBackupWindow() : BackupWindows.DEFAULT_BACKUP_WINDOW)
+                .elem("PreferredMaintenanceWindow", c.getPreferredMaintenanceWindow() != null
+                        ? c.getPreferredMaintenanceWindow() : BackupWindows.DEFAULT_MAINTENANCE_WINDOW)
+                .elem("DeletionProtection", c.isDeletionProtection())
+                .elem("CopyTagsToSnapshot", c.isCopyTagsToSnapshot())
+                .elem("ReplicationSourceIdentifier", c.getReplicationSourceIdentifier())
                 .elem("DbClusterResourceId", c.getDbClusterResourceId())
-                .elem("DBClusterArn", c.getDbClusterArn())
-                .start("DBClusterMembers");
+                .elem("DBClusterArn", c.getDbClusterArn());
+        if (c.getCreatedAt() != null) {
+            xml.elem("ClusterCreateTime",
+                    DateTimeFormatter.ISO_INSTANT.format(c.getCreatedAt().truncatedTo(ChronoUnit.MILLIS)));
+        }
+        xml.start("AvailabilityZones");
+        List<String> zones = c.getAvailabilityZones();
+        if (zones.isEmpty()) {
+            xml.elem("AvailabilityZone", config.defaultAvailabilityZone());
+        } else {
+            zones.forEach(zone -> xml.elem("AvailabilityZone", zone));
+        }
+        xml.end("AvailabilityZones")
+           .start("EnabledCloudwatchLogsExports");
+        c.getEnabledCloudwatchLogsExports().forEach(logType -> xml.elem("member", logType));
+        xml.end("EnabledCloudwatchLogsExports")
+           .start("AssociatedRoles");
+        for (String roleArn : c.getAssociatedRoleArns()) {
+            xml.start("DBClusterRole")
+               .elem("RoleArn", roleArn)
+               .elem("Status", "ACTIVE")
+               .end("DBClusterRole");
+        }
+        xml.end("AssociatedRoles")
+           .start("VpcSecurityGroups");
+        for (String groupId : c.getVpcSecurityGroupIds()) {
+            xml.start("VpcSecurityGroupMembership")
+               .elem("VpcSecurityGroupId", groupId)
+               .elem("Status", "active")
+               .end("VpcSecurityGroupMembership");
+        }
+        xml.end("VpcSecurityGroups");
+        if (c.getServerlessV2MinCapacity() != null || c.getServerlessV2MaxCapacity() != null) {
+            xml.start("ServerlessV2ScalingConfiguration");
+            if (c.getServerlessV2MinCapacity() != null) {
+                xml.elem("MinCapacity", String.valueOf(c.getServerlessV2MinCapacity()));
+            }
+            if (c.getServerlessV2MaxCapacity() != null) {
+                xml.elem("MaxCapacity", String.valueOf(c.getServerlessV2MaxCapacity()));
+            }
+            xml.end("ServerlessV2ScalingConfiguration");
+        }
+        xml.start("DBClusterMembers");
         if (c.getDbClusterMembers() != null) {
             for (String memberId : c.getDbClusterMembers()) {
-                xml.start("member")
+                xml.start("DBClusterMember")
                    .elem("DBInstanceIdentifier", memberId)
                    .elem("IsClusterWriter", true)
-                   .end("member");
+                   .end("DBClusterMember");
             }
         }
         xml.end("DBClusterMembers");

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneClusterSettings;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneInstanceSettings;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MultivaluedMap;
@@ -230,7 +231,7 @@ public class NeptuneQueryHandler {
         boolean iamEnabled = "true".equalsIgnoreCase(params.getFirst("EnableIAMDatabaseAuthentication"));
 
         NeptuneInstance instance = service.createDbInstance(id, dbClusterIdentifier,
-                dbInstanceClass, engineVersion, iamEnabled, parseTags(params));
+                dbInstanceClass, engineVersion, iamEnabled, instanceSettings(params, true), parseTags(params));
         return Response.ok(AwsQueryResponse.envelope("CreateDBInstance", AwsNamespaces.RDS,
                 instanceXml(instance))).build();
     }
@@ -281,7 +282,8 @@ public class NeptuneQueryHandler {
         String iamStr = params.getFirst("EnableIAMDatabaseAuthentication");
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
 
-        NeptuneInstance instance = service.modifyDbInstance(id, dbInstanceClass, iamEnabled);
+        NeptuneInstance instance = service.modifyDbInstance(id, dbInstanceClass, iamEnabled,
+                instanceSettings(params, false));
         return Response.ok(AwsQueryResponse.envelope("ModifyDBInstance", AwsNamespaces.RDS,
                 instanceXml(instance))).build();
     }
@@ -329,6 +331,18 @@ public class NeptuneQueryHandler {
                 create ? params.getFirst("ReplicationSourceIdentifier") : null,
                 optionalDouble(params.getFirst("ServerlessV2ScalingConfiguration.MinCapacity")),
                 optionalDouble(params.getFirst("ServerlessV2ScalingConfiguration.MaxCapacity")));
+    }
+
+    private static NeptuneInstanceSettings instanceSettings(MultivaluedMap<String, String> params, boolean create) {
+        return new NeptuneInstanceSettings(
+                create ? params.getFirst("AvailabilityZone") : null,
+                optionalBoolean(params.getFirst("AutoMinorVersionUpgrade")),
+                optionalInt(params.getFirst("PromotionTier")),
+                create ? optionalBoolean(params.getFirst("PubliclyAccessible")) : null,
+                params.getFirst("DBParameterGroupName"),
+                create ? params.getFirst("DBSubnetGroupName") : null,
+                params.getFirst("PreferredBackupWindow"),
+                params.getFirst("PreferredMaintenanceWindow"));
     }
 
     private static List<String> listParam(MultivaluedMap<String, String> params, String name, String memberName) {
@@ -482,11 +496,12 @@ public class NeptuneQueryHandler {
             xml.end("ServerlessV2ScalingConfiguration");
         }
         xml.start("DBClusterMembers");
-        if (c.getDbClusterMembers() != null) {
-            for (String memberId : c.getDbClusterMembers()) {
+        List<String> members = c.getDbClusterMembers();
+        if (members != null) {
+            for (String memberId : members) {
                 xml.start("DBClusterMember")
                    .elem("DBInstanceIdentifier", memberId)
-                   .elem("IsClusterWriter", true)
+                   .elem("IsClusterWriter", memberId.equals(members.get(0)))
                    .end("DBClusterMember");
             }
         }
@@ -499,7 +514,16 @@ public class NeptuneQueryHandler {
     }
 
     private String instanceInnerXml(NeptuneInstance i) {
-        return new XmlBuilder()
+        NeptuneCluster cluster = service.findDbCluster(i.getDbClusterIdentifier()).orElse(null);
+        String backupWindow = i.getPreferredBackupWindow() != null ? i.getPreferredBackupWindow()
+                : cluster != null && cluster.getPreferredBackupWindow() != null ? cluster.getPreferredBackupWindow()
+                : BackupWindows.DEFAULT_BACKUP_WINDOW;
+        String subnetGroup = i.getDbSubnetGroupName() != null ? i.getDbSubnetGroupName()
+                : cluster != null && cluster.getDbSubnetGroupName() != null ? cluster.getDbSubnetGroupName()
+                : "default";
+        String parameterGroup = i.getDbParameterGroupName() != null ? i.getDbParameterGroupName()
+                : "default." + NeptuneService.parameterGroupFamily(i.getEngineVersion());
+        XmlBuilder xml = new XmlBuilder()
                 .elem("DBInstanceIdentifier", i.getDbInstanceIdentifier())
                 .elem("DBClusterIdentifier", i.getDbClusterIdentifier())
                 .elem("DBInstanceClass", i.getDbInstanceClass())
@@ -512,11 +536,34 @@ public class NeptuneQueryHandler {
                 .end("Endpoint")
                 .elem("IAMDatabaseAuthenticationEnabled", i.isIamDatabaseAuthenticationEnabled())
                 .elem("MultiAZ", false)
-                .elem("StorageEncrypted", true)
-                .elem("AvailabilityZone", config.defaultAvailabilityZone())
+                .elem("AutoMinorVersionUpgrade", i.isAutoMinorVersionUpgrade())
+                .elem("PromotionTier", i.getPromotionTier())
+                .elem("PubliclyAccessible", i.isPubliclyAccessible())
+                .elem("StorageEncrypted", cluster != null && cluster.isStorageEncrypted())
+                .elem("KmsKeyId", cluster != null ? cluster.getKmsKeyId() : null)
+                .elem("StorageType", cluster != null ? cluster.getStorageType() : null)
+                .elem("AvailabilityZone", i.getAvailabilityZone() != null
+                        ? i.getAvailabilityZone() : config.defaultAvailabilityZone())
+                .elem("PreferredBackupWindow", backupWindow)
+                .elem("PreferredMaintenanceWindow", i.getPreferredMaintenanceWindow() != null
+                        ? i.getPreferredMaintenanceWindow() : BackupWindows.DEFAULT_MAINTENANCE_WINDOW)
                 .elem("DbiResourceId", i.getDbiResourceId())
-                .elem("DBInstanceArn", i.getDbInstanceArn())
-                .build();
+                .elem("DBInstanceArn", i.getDbInstanceArn());
+        if (i.getCreatedAt() != null) {
+            xml.elem("InstanceCreateTime",
+                    DateTimeFormatter.ISO_INSTANT.format(i.getCreatedAt().truncatedTo(ChronoUnit.MILLIS)));
+        }
+        xml.start("DBSubnetGroup")
+           .elem("DBSubnetGroupName", subnetGroup)
+           .elem("SubnetGroupStatus", "Complete")
+           .end("DBSubnetGroup")
+           .start("DBParameterGroups")
+           .start("DBParameterGroup")
+           .elem("DBParameterGroupName", parameterGroup)
+           .elem("ParameterApplyStatus", "in-sync")
+           .end("DBParameterGroup")
+           .end("DBParameterGroups");
+        return xml.build();
     }
 
     private static String extractFilterValue(MultivaluedMap<String, String> params, String filterName) {

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.neptune;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -9,6 +10,7 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerHandle;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneClusterSettings;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneDbType;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
@@ -19,10 +21,13 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 @ApplicationScoped
 public class NeptuneService {
@@ -57,13 +62,19 @@ public class NeptuneService {
     // ── Clusters ──────────────────────────────────────────────────────────────
 
     public NeptuneCluster createDbCluster(String id, String engineVersion, boolean iamEnabled) {
+        return createDbCluster(id, engineVersion, iamEnabled, NeptuneClusterSettings.defaults(), Map.of());
+    }
+
+    public NeptuneCluster createDbCluster(String id, String engineVersion, boolean iamEnabled,
+                                          NeptuneClusterSettings settings, Map<String, String> tags) {
+        settings.validate();
         if (clusters.get(id).isPresent()) {
             throw new AwsException("DBClusterAlreadyExistsFault",
                     "Neptune cluster " + id + " already exists.", 400);
         }
 
         // Open the try immediately after reserving the port so config reads below can't leak it.
-        int proxyPort = allocateProxyPort();
+        int proxyPort = allocateProxyPort(settings.port());
         NeptuneContainerHandle handle = null;
         boolean provisioned = false;
         try {
@@ -104,6 +115,10 @@ public class NeptuneService {
             cluster.setCreatedAt(Instant.now());
             cluster.setDbClusterMembers(new ArrayList<>());
             cluster.setProxyPort(proxyPort);
+            settings.applyTo(cluster);
+            if (tags != null && !tags.isEmpty()) {
+                cluster.setTags(tags);
+            }
 
             if (handle != null) {
                 cluster.setContainerId(handle.getContainerId());
@@ -182,6 +197,16 @@ public class NeptuneService {
         return instances.get(id).isPresent();
     }
 
+    public boolean hasResourceWithArn(String arn) {
+        if (arn == null || !arn.startsWith("arn:")) {
+            return false;
+        }
+        return clusters.scan(k -> true).stream()
+                        .anyMatch(c -> arn.equalsIgnoreCase(c.getDbClusterArn()))
+                || instances.scan(k -> true).stream()
+                        .anyMatch(i -> arn.equalsIgnoreCase(i.getDbInstanceArn()));
+    }
+
     public Collection<NeptuneCluster> listDbClusters(String filterId) {
         if (filterId != null && !filterId.isBlank()) {
             // The db-cluster-id filter accepts ARNs as well as identifiers. Match the
@@ -199,6 +224,12 @@ public class NeptuneService {
     }
 
     public NeptuneCluster modifyDbCluster(String id, String engineVersion, Boolean iamEnabled) {
+        return modifyDbCluster(id, engineVersion, iamEnabled, NeptuneClusterSettings.unchanged());
+    }
+
+    public NeptuneCluster modifyDbCluster(String id, String engineVersion, Boolean iamEnabled,
+                                          NeptuneClusterSettings settings) {
+        settings.validate();
         NeptuneCluster cluster = getDbCluster(id);
         if (engineVersion != null && !engineVersion.isBlank()) {
             cluster.setEngineVersion(engineVersion);
@@ -206,6 +237,7 @@ public class NeptuneService {
         if (iamEnabled != null) {
             cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
         }
+        settings.applyTo(cluster);
         clusters.put(id, cluster);
         LOG.infov("Neptune cluster {0} modified", id);
         return cluster;
@@ -216,6 +248,10 @@ public class NeptuneService {
                 new AwsException("DBClusterNotFoundFault",
                         "Neptune cluster " + id + " not found.", 404));
 
+        if (cluster.isDeletionProtection()) {
+            throw new AwsException("InvalidParameterCombination",
+                    "Cannot delete protected Cluster, please disable deletion protection and try again.", 400);
+        }
         if (cluster.getDbClusterMembers() != null && !cluster.getDbClusterMembers().isEmpty()) {
             throw new AwsException("InvalidDBClusterStateFault",
                     "Cannot delete Neptune cluster " + id + " — it still has DB instances.", 400);
@@ -237,11 +273,60 @@ public class NeptuneService {
         LOG.infov("Neptune cluster {0} deleted", id);
     }
 
+    public NeptuneCluster addRoleToDbCluster(String id, String roleArn) {
+        if (roleArn == null || roleArn.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "RoleArn is required.", 400);
+        }
+        NeptuneCluster cluster = getDbCluster(id);
+        if (cluster.getAssociatedRoleArns().contains(roleArn)) {
+            throw new AwsException("DBClusterRoleAlreadyExists",
+                    "Role ARN " + roleArn + " is already associated with Neptune cluster " + id + ".", 400);
+        }
+        cluster.getAssociatedRoleArns().add(roleArn);
+        clusters.put(id, cluster);
+        LOG.infov("Role {0} added to Neptune cluster {1}", roleArn, id);
+        return cluster;
+    }
+
+    public NeptuneCluster removeRoleFromDbCluster(String id, String roleArn) {
+        NeptuneCluster cluster = getDbCluster(id);
+        if (roleArn == null || !cluster.getAssociatedRoleArns().remove(roleArn)) {
+            throw new AwsException("DBClusterRoleNotFound",
+                    "Role ARN " + roleArn + " is not associated with Neptune cluster " + id + ".", 404);
+        }
+        clusters.put(id, cluster);
+        LOG.infov("Role {0} removed from Neptune cluster {1}", roleArn, id);
+        return cluster;
+    }
+
+    public static String parameterGroupFamily(String engineVersion) {
+        String version = engineVersion == null || engineVersion.isBlank() ? ENGINE_VERSION_DEFAULT : engineVersion.trim();
+        String[] parts = version.split("\\.");
+        int major;
+        int minor;
+        try {
+            major = Integer.parseInt(parts[0]);
+            minor = parts.length > 1 ? Integer.parseInt(parts[1]) : 0;
+        } catch (NumberFormatException e) {
+            return parameterGroupFamily(ENGINE_VERSION_DEFAULT);
+        }
+        if (major == 1 && minor < 2) {
+            return "neptune1";
+        }
+        return "neptune" + major + "." + minor;
+    }
+
     // ── Instances ─────────────────────────────────────────────────────────────
 
     public NeptuneInstance createDbInstance(String id, String dbClusterIdentifier,
                                             String dbInstanceClass, String engineVersion,
                                             boolean iamEnabled) {
+        return createDbInstance(id, dbClusterIdentifier, dbInstanceClass, engineVersion, iamEnabled, Map.of());
+    }
+
+    public NeptuneInstance createDbInstance(String id, String dbClusterIdentifier,
+                                            String dbInstanceClass, String engineVersion,
+                                            boolean iamEnabled, Map<String, String> tags) {
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "Neptune instance " + id + " already exists.", 400);
@@ -263,6 +348,9 @@ public class NeptuneService {
         instance.setDbiResourceId("db-" + UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase());
         instance.setCreatedAt(Instant.now());
+        if (tags != null && !tags.isEmpty()) {
+            instance.setTags(tags);
+        }
 
         cluster.getDbClusterMembers().add(id);
         clusters.put(dbClusterIdentifier, cluster);
@@ -321,15 +409,91 @@ public class NeptuneService {
         LOG.infov("Neptune instance {0} deleted", id);
     }
 
+    // ── Tags ──────────────────────────────────────────────────────────────────
+
+    private record TagTarget(Map<String, String> tags, Consumer<Map<String, String>> save) {}
+
+    public Map<String, String> listTagsForResource(String resourceName) {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(resolveTagTarget(resourceName).tags()));
+    }
+
+    public synchronized void addTagsToResource(String resourceName, Map<String, String> tags) {
+        updateTags(resourceName, current -> current.putAll(tags));
+    }
+
+    public synchronized void removeTagsFromResource(String resourceName, Collection<String> tagKeys) {
+        updateTags(resourceName, current -> tagKeys.forEach(current::remove));
+    }
+
+    private void updateTags(String resourceName, Consumer<Map<String, String>> change) {
+        TagTarget target = resolveTagTarget(resourceName);
+        Map<String, String> updated = new LinkedHashMap<>(target.tags());
+        change.accept(updated);
+        target.save().accept(updated);
+    }
+
+    private TagTarget resolveTagTarget(String resourceName) {
+        if (resourceName == null || resourceName.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "ResourceName is required.", 400);
+        }
+        AwsArnUtils.Arn arn;
+        try {
+            arn = AwsArnUtils.parse(resourceName);
+        } catch (IllegalArgumentException malformed) {
+            throw new AwsException("InvalidParameterValue", "Invalid resource name: " + resourceName, 400);
+        }
+        String resource = arn.resource();
+        int separator = resource.indexOf(':');
+        if (separator < 0) {
+            throw new AwsException("InvalidParameterValue", "Invalid resource name: " + resourceName, 400);
+        }
+        String type = resource.substring(0, separator);
+        String id = resource.substring(separator + 1);
+        return switch (type) {
+            case "cluster" -> {
+                NeptuneCluster cluster = clusters.scan(k -> true).stream()
+                        .filter(c -> resourceName.equalsIgnoreCase(c.getDbClusterArn()))
+                        .findFirst()
+                        .orElseThrow(() -> new AwsException("DBClusterNotFoundFault",
+                                "Neptune cluster " + id + " not found.", 404));
+                yield new TagTarget(cluster.getTags(), updated -> {
+                    cluster.setTags(updated);
+                    clusters.put(cluster.getDbClusterIdentifier(), cluster);
+                });
+            }
+            case "db" -> {
+                NeptuneInstance instance = instances.scan(k -> true).stream()
+                        .filter(i -> resourceName.equalsIgnoreCase(i.getDbInstanceArn()))
+                        .findFirst()
+                        .orElseThrow(() -> new AwsException("DBInstanceNotFound",
+                                "Neptune instance " + id + " not found.", 404));
+                yield new TagTarget(instance.getTags(), updated -> {
+                    instance.setTags(updated);
+                    instances.put(instance.getDbInstanceIdentifier(), instance);
+                });
+            }
+            default -> throw new AwsException("InvalidParameterValue",
+                    "Tagging for resource type '" + type + "' is not supported by Neptune in Floci: " + resourceName, 400);
+        };
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private String resolveEndpointHost() {
         return config.hostname().orElse("localhost");
     }
 
-    private int allocateProxyPort() {
+    private int allocateProxyPort(Integer requested) {
         int base = config.services().neptune().proxyBasePort();
         int max = config.services().neptune().proxyMaxPort();
+        if (requested != null && requested >= base && requested <= max && usedPorts.add(requested)) {
+            return requested;
+        }
+        if (requested != null) {
+            LOG.infov("Requested Neptune port {0} is outside the proxy range {1}-{2} or already in use; "
+                    + "allocating the next free proxy port instead",
+                    String.valueOf(requested), String.valueOf(base), String.valueOf(max));
+        }
         for (int port = base; port <= max; port++) {
             if (usedPorts.add(port)) {
                 return port;

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -13,6 +13,7 @@ import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneClusterSettings;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneDbType;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneInstanceSettings;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -24,6 +25,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -327,6 +329,15 @@ public class NeptuneService {
     public NeptuneInstance createDbInstance(String id, String dbClusterIdentifier,
                                             String dbInstanceClass, String engineVersion,
                                             boolean iamEnabled, Map<String, String> tags) {
+        return createDbInstance(id, dbClusterIdentifier, dbInstanceClass, engineVersion, iamEnabled,
+                NeptuneInstanceSettings.defaults(), tags);
+    }
+
+    public NeptuneInstance createDbInstance(String id, String dbClusterIdentifier,
+                                            String dbInstanceClass, String engineVersion,
+                                            boolean iamEnabled, NeptuneInstanceSettings settings,
+                                            Map<String, String> tags) {
+        settings.validate();
         if (instances.get(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "Neptune instance " + id + " already exists.", 400);
@@ -348,6 +359,7 @@ public class NeptuneService {
         instance.setDbiResourceId("db-" + UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase());
         instance.setCreatedAt(Instant.now());
+        settings.applyTo(instance);
         if (tags != null && !tags.isEmpty()) {
             instance.setTags(tags);
         }
@@ -358,6 +370,10 @@ public class NeptuneService {
         instances.put(id, instance);
         LOG.infov("Neptune instance {0} created in cluster {1}", id, dbClusterIdentifier);
         return instance;
+    }
+
+    public Optional<NeptuneCluster> findDbCluster(String id) {
+        return id == null ? Optional.empty() : clusters.get(id);
     }
 
     public NeptuneInstance getDbInstance(String id) {
@@ -381,6 +397,12 @@ public class NeptuneService {
     }
 
     public NeptuneInstance modifyDbInstance(String id, String dbInstanceClass, Boolean iamEnabled) {
+        return modifyDbInstance(id, dbInstanceClass, iamEnabled, NeptuneInstanceSettings.unchanged());
+    }
+
+    public NeptuneInstance modifyDbInstance(String id, String dbInstanceClass, Boolean iamEnabled,
+                                            NeptuneInstanceSettings settings) {
+        settings.validate();
         NeptuneInstance instance = getDbInstance(id);
         if (dbInstanceClass != null && !dbInstanceClass.isBlank()) {
             instance.setDbInstanceClass(dbInstanceClass);
@@ -388,6 +410,7 @@ public class NeptuneService {
         if (iamEnabled != null) {
             instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
         }
+        settings.applyTo(instance);
         instances.put(id, instance);
         LOG.infov("Neptune instance {0} modified", id);
         return instance;

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneCluster.java
@@ -4,7 +4,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 @RegisterForReflection
 public class NeptuneCluster {
@@ -19,6 +21,24 @@ public class NeptuneCluster {
     private String dbClusterArn;
     private String dbClusterResourceId;
     private List<String> dbClusterMembers = new ArrayList<>();
+    private List<String> availabilityZones = new ArrayList<>();
+    private int backupRetentionPeriod = 1;
+    private String preferredBackupWindow;
+    private String preferredMaintenanceWindow;
+    private String dbSubnetGroupName;
+    private String dbClusterParameterGroupName;
+    private List<String> vpcSecurityGroupIds = new ArrayList<>();
+    private boolean storageEncrypted;
+    private String kmsKeyId;
+    private String storageType;
+    private boolean deletionProtection;
+    private boolean copyTagsToSnapshot;
+    private List<String> enabledCloudwatchLogsExports = new ArrayList<>();
+    private List<String> associatedRoleArns = new ArrayList<>();
+    private String replicationSourceIdentifier;
+    private Double serverlessV2MinCapacity;
+    private Double serverlessV2MaxCapacity;
+    private Map<String, String> tags = new LinkedHashMap<>();
     private Instant createdAt;
 
     // Docker / proxy runtime fields — persisted so cleanup works across restarts
@@ -61,6 +81,77 @@ public class NeptuneCluster {
     public List<String> getDbClusterMembers() { return dbClusterMembers; }
     public void setDbClusterMembers(List<String> dbClusterMembers) {
         this.dbClusterMembers = dbClusterMembers != null ? new ArrayList<>(dbClusterMembers) : new ArrayList<>();
+    }
+
+    public List<String> getAvailabilityZones() { return availabilityZones; }
+    public void setAvailabilityZones(List<String> availabilityZones) {
+        this.availabilityZones = availabilityZones != null ? new ArrayList<>(availabilityZones) : new ArrayList<>();
+    }
+
+    public int getBackupRetentionPeriod() { return backupRetentionPeriod; }
+    public void setBackupRetentionPeriod(int backupRetentionPeriod) { this.backupRetentionPeriod = backupRetentionPeriod; }
+
+    public String getPreferredBackupWindow() { return preferredBackupWindow; }
+    public void setPreferredBackupWindow(String preferredBackupWindow) { this.preferredBackupWindow = preferredBackupWindow; }
+
+    public String getPreferredMaintenanceWindow() { return preferredMaintenanceWindow; }
+    public void setPreferredMaintenanceWindow(String preferredMaintenanceWindow) {
+        this.preferredMaintenanceWindow = preferredMaintenanceWindow;
+    }
+
+    public String getDbSubnetGroupName() { return dbSubnetGroupName; }
+    public void setDbSubnetGroupName(String dbSubnetGroupName) { this.dbSubnetGroupName = dbSubnetGroupName; }
+
+    public String getDbClusterParameterGroupName() { return dbClusterParameterGroupName; }
+    public void setDbClusterParameterGroupName(String dbClusterParameterGroupName) {
+        this.dbClusterParameterGroupName = dbClusterParameterGroupName;
+    }
+
+    public List<String> getVpcSecurityGroupIds() { return vpcSecurityGroupIds; }
+    public void setVpcSecurityGroupIds(List<String> vpcSecurityGroupIds) {
+        this.vpcSecurityGroupIds = vpcSecurityGroupIds != null ? new ArrayList<>(vpcSecurityGroupIds) : new ArrayList<>();
+    }
+
+    public boolean isStorageEncrypted() { return storageEncrypted; }
+    public void setStorageEncrypted(boolean storageEncrypted) { this.storageEncrypted = storageEncrypted; }
+
+    public String getKmsKeyId() { return kmsKeyId; }
+    public void setKmsKeyId(String kmsKeyId) { this.kmsKeyId = kmsKeyId; }
+
+    public String getStorageType() { return storageType; }
+    public void setStorageType(String storageType) { this.storageType = storageType; }
+
+    public boolean isDeletionProtection() { return deletionProtection; }
+    public void setDeletionProtection(boolean deletionProtection) { this.deletionProtection = deletionProtection; }
+
+    public boolean isCopyTagsToSnapshot() { return copyTagsToSnapshot; }
+    public void setCopyTagsToSnapshot(boolean copyTagsToSnapshot) { this.copyTagsToSnapshot = copyTagsToSnapshot; }
+
+    public List<String> getEnabledCloudwatchLogsExports() { return enabledCloudwatchLogsExports; }
+    public void setEnabledCloudwatchLogsExports(List<String> enabledCloudwatchLogsExports) {
+        this.enabledCloudwatchLogsExports = enabledCloudwatchLogsExports != null
+                ? new ArrayList<>(enabledCloudwatchLogsExports) : new ArrayList<>();
+    }
+
+    public List<String> getAssociatedRoleArns() { return associatedRoleArns; }
+    public void setAssociatedRoleArns(List<String> associatedRoleArns) {
+        this.associatedRoleArns = associatedRoleArns != null ? new ArrayList<>(associatedRoleArns) : new ArrayList<>();
+    }
+
+    public String getReplicationSourceIdentifier() { return replicationSourceIdentifier; }
+    public void setReplicationSourceIdentifier(String replicationSourceIdentifier) {
+        this.replicationSourceIdentifier = replicationSourceIdentifier;
+    }
+
+    public Double getServerlessV2MinCapacity() { return serverlessV2MinCapacity; }
+    public void setServerlessV2MinCapacity(Double serverlessV2MinCapacity) { this.serverlessV2MinCapacity = serverlessV2MinCapacity; }
+
+    public Double getServerlessV2MaxCapacity() { return serverlessV2MaxCapacity; }
+    public void setServerlessV2MaxCapacity(Double serverlessV2MaxCapacity) { this.serverlessV2MaxCapacity = serverlessV2MaxCapacity; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>();
     }
 
     public Instant getCreatedAt() { return createdAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneClusterSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneClusterSettings.java
@@ -1,0 +1,149 @@
+package io.github.hectorvent.floci.services.neptune.model;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.BackupWindows;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The settings of a Neptune cluster as a request carries them: a null member is one the request
+ * left out, which means the AWS default on create and no change on modify.
+ */
+@RegisterForReflection
+public record NeptuneClusterSettings(List<String> availabilityZones,
+                                     Integer port,
+                                     Integer backupRetentionPeriod,
+                                     String preferredBackupWindow,
+                                     String preferredMaintenanceWindow,
+                                     String dbSubnetGroupName,
+                                     String dbClusterParameterGroupName,
+                                     List<String> vpcSecurityGroupIds,
+                                     Boolean storageEncrypted,
+                                     String kmsKeyId,
+                                     String storageType,
+                                     Boolean deletionProtection,
+                                     Boolean copyTagsToSnapshot,
+                                     List<String> enableLogTypes,
+                                     List<String> disableLogTypes,
+                                     String replicationSourceIdentifier,
+                                     Double serverlessV2MinCapacity,
+                                     Double serverlessV2MaxCapacity) {
+
+    public static final Set<String> STORAGE_TYPES = Set.of("standard", "iopt1");
+    public static final Set<String> LOG_TYPES = Set.of("audit", "slowquery");
+
+    public static NeptuneClusterSettings defaults() {
+        return new NeptuneClusterSettings(null, null, null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, null);
+    }
+
+    public static NeptuneClusterSettings unchanged() {
+        return defaults();
+    }
+
+    public void validate() {
+        if (kmsKeyId != null && !kmsKeyId.isBlank() && !Boolean.TRUE.equals(storageEncrypted)) {
+            throw new AwsException("InvalidParameterCombination",
+                    "You cannot specify KMS key for unencrypted clusters.", 400);
+        }
+        if (port != null && (port < 1150 || port > 65535)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid port: " + port + ". Port must be between 1150 and 65535.", 400);
+        }
+        if (backupRetentionPeriod != null && (backupRetentionPeriod < 1 || backupRetentionPeriod > 35)) {
+            throw new AwsException("InvalidParameterValue", "Invalid backup retention period: "
+                    + backupRetentionPeriod + ". Retention period must be between 1 and 35.", 400);
+        }
+        if (preferredBackupWindow != null) {
+            BackupWindows.parseBackupWindow(preferredBackupWindow);
+        }
+        if (preferredMaintenanceWindow != null) {
+            BackupWindows.parseMaintenanceWindow(preferredMaintenanceWindow);
+        }
+        if (storageType != null && !storageType.isBlank() && !STORAGE_TYPES.contains(storageType)) {
+            throw new AwsException("InvalidParameterValue",
+                    "Invalid storage type: " + storageType + ". Valid values are standard and iopt1.", 400);
+        }
+        if (serverlessV2MinCapacity != null && serverlessV2MaxCapacity != null
+                && serverlessV2MinCapacity > serverlessV2MaxCapacity) {
+            throw new AwsException("InvalidParameterCombination",
+                    "ServerlessV2ScalingConfiguration MinCapacity must not exceed MaxCapacity.", 400);
+        }
+        requireKnownLogTypes(enableLogTypes);
+        requireKnownLogTypes(disableLogTypes);
+    }
+
+    private static void requireKnownLogTypes(List<String> logTypes) {
+        if (logTypes == null) {
+            return;
+        }
+        for (String logType : logTypes) {
+            if (!LOG_TYPES.contains(logType)) {
+                throw new AwsException("InvalidParameterValue",
+                        "Invalid log type: " + logType + ". Valid values are audit and slowquery.", 400);
+            }
+        }
+    }
+
+    public void applyTo(NeptuneCluster cluster) {
+        if (availabilityZones != null && !availabilityZones.isEmpty()) {
+            cluster.setAvailabilityZones(availabilityZones);
+        }
+        if (backupRetentionPeriod != null) {
+            cluster.setBackupRetentionPeriod(backupRetentionPeriod);
+        }
+        if (preferredBackupWindow != null && !preferredBackupWindow.isBlank()) {
+            cluster.setPreferredBackupWindow(preferredBackupWindow);
+        }
+        if (preferredMaintenanceWindow != null && !preferredMaintenanceWindow.isBlank()) {
+            cluster.setPreferredMaintenanceWindow(BackupWindows.lowerCase(preferredMaintenanceWindow));
+        }
+        if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
+            cluster.setDbSubnetGroupName(dbSubnetGroupName);
+        }
+        if (dbClusterParameterGroupName != null && !dbClusterParameterGroupName.isBlank()) {
+            cluster.setDbClusterParameterGroupName(dbClusterParameterGroupName);
+        }
+        if (vpcSecurityGroupIds != null) {
+            cluster.setVpcSecurityGroupIds(vpcSecurityGroupIds);
+        }
+        if (storageEncrypted != null) {
+            cluster.setStorageEncrypted(storageEncrypted);
+        }
+        if (kmsKeyId != null && !kmsKeyId.isBlank()) {
+            cluster.setKmsKeyId(kmsKeyId);
+        }
+        if (storageType != null && !storageType.isBlank()) {
+            cluster.setStorageType(storageType);
+        }
+        if (deletionProtection != null) {
+            cluster.setDeletionProtection(deletionProtection);
+        }
+        if (copyTagsToSnapshot != null) {
+            cluster.setCopyTagsToSnapshot(copyTagsToSnapshot);
+        }
+        if (enableLogTypes != null || disableLogTypes != null) {
+            Set<String> logTypes = new LinkedHashSet<>(cluster.getEnabledCloudwatchLogsExports());
+            if (disableLogTypes != null) {
+                logTypes.removeAll(disableLogTypes);
+            }
+            if (enableLogTypes != null) {
+                logTypes.addAll(enableLogTypes);
+            }
+            cluster.setEnabledCloudwatchLogsExports(new ArrayList<>(logTypes));
+        }
+        if (replicationSourceIdentifier != null && !replicationSourceIdentifier.isBlank()) {
+            cluster.setReplicationSourceIdentifier(replicationSourceIdentifier);
+        }
+        if (serverlessV2MinCapacity != null) {
+            cluster.setServerlessV2MinCapacity(serverlessV2MinCapacity);
+        }
+        if (serverlessV2MaxCapacity != null) {
+            cluster.setServerlessV2MaxCapacity(serverlessV2MaxCapacity);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneInstance.java
@@ -3,6 +3,8 @@ package io.github.hectorvent.floci.services.neptune.model;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 @RegisterForReflection
 public class NeptuneInstance {
@@ -17,6 +19,7 @@ public class NeptuneInstance {
     private boolean iamDatabaseAuthenticationEnabled;
     private String dbInstanceArn;
     private String dbiResourceId;
+    private Map<String, String> tags = new LinkedHashMap<>();
     private Instant createdAt;
 
     public NeptuneInstance() {}
@@ -52,6 +55,11 @@ public class NeptuneInstance {
 
     public String getDbiResourceId() { return dbiResourceId; }
     public void setDbiResourceId(String dbiResourceId) { this.dbiResourceId = dbiResourceId; }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>();
+    }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneInstance.java
@@ -19,6 +19,14 @@ public class NeptuneInstance {
     private boolean iamDatabaseAuthenticationEnabled;
     private String dbInstanceArn;
     private String dbiResourceId;
+    private String availabilityZone;
+    private boolean autoMinorVersionUpgrade = true;
+    private int promotionTier = 1;
+    private boolean publiclyAccessible;
+    private String dbParameterGroupName;
+    private String dbSubnetGroupName;
+    private String preferredBackupWindow;
+    private String preferredMaintenanceWindow;
     private Map<String, String> tags = new LinkedHashMap<>();
     private Instant createdAt;
 
@@ -63,4 +71,32 @@ public class NeptuneInstance {
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public String getAvailabilityZone() { return availabilityZone; }
+    public void setAvailabilityZone(String availabilityZone) { this.availabilityZone = availabilityZone; }
+
+    public boolean isAutoMinorVersionUpgrade() { return autoMinorVersionUpgrade; }
+    public void setAutoMinorVersionUpgrade(boolean autoMinorVersionUpgrade) {
+        this.autoMinorVersionUpgrade = autoMinorVersionUpgrade;
+    }
+
+    public int getPromotionTier() { return promotionTier; }
+    public void setPromotionTier(int promotionTier) { this.promotionTier = promotionTier; }
+
+    public boolean isPubliclyAccessible() { return publiclyAccessible; }
+    public void setPubliclyAccessible(boolean publiclyAccessible) { this.publiclyAccessible = publiclyAccessible; }
+
+    public String getDbParameterGroupName() { return dbParameterGroupName; }
+    public void setDbParameterGroupName(String dbParameterGroupName) { this.dbParameterGroupName = dbParameterGroupName; }
+
+    public String getDbSubnetGroupName() { return dbSubnetGroupName; }
+    public void setDbSubnetGroupName(String dbSubnetGroupName) { this.dbSubnetGroupName = dbSubnetGroupName; }
+
+    public String getPreferredBackupWindow() { return preferredBackupWindow; }
+    public void setPreferredBackupWindow(String preferredBackupWindow) { this.preferredBackupWindow = preferredBackupWindow; }
+
+    public String getPreferredMaintenanceWindow() { return preferredMaintenanceWindow; }
+    public void setPreferredMaintenanceWindow(String preferredMaintenanceWindow) {
+        this.preferredMaintenanceWindow = preferredMaintenanceWindow;
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneInstanceSettings.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/model/NeptuneInstanceSettings.java
@@ -1,0 +1,64 @@
+package io.github.hectorvent.floci.services.neptune.model;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.BackupWindows;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record NeptuneInstanceSettings(String availabilityZone,
+                                      Boolean autoMinorVersionUpgrade,
+                                      Integer promotionTier,
+                                      Boolean publiclyAccessible,
+                                      String dbParameterGroupName,
+                                      String dbSubnetGroupName,
+                                      String preferredBackupWindow,
+                                      String preferredMaintenanceWindow) {
+
+    public static NeptuneInstanceSettings defaults() {
+        return new NeptuneInstanceSettings(null, null, null, null, null, null, null, null);
+    }
+
+    public static NeptuneInstanceSettings unchanged() {
+        return defaults();
+    }
+
+    public void validate() {
+        if (promotionTier != null && (promotionTier < 0 || promotionTier > 15)) {
+            throw new AwsException("InvalidParameterValue", "Invalid promotion tier: " + promotionTier
+                    + ". Promotion tier must be between 0 and 15.", 400);
+        }
+        if (preferredBackupWindow != null && !preferredBackupWindow.isBlank()) {
+            BackupWindows.parseBackupWindow(preferredBackupWindow);
+        }
+        if (preferredMaintenanceWindow != null && !preferredMaintenanceWindow.isBlank()) {
+            BackupWindows.parseMaintenanceWindow(preferredMaintenanceWindow);
+        }
+    }
+
+    public void applyTo(NeptuneInstance instance) {
+        if (availabilityZone != null && !availabilityZone.isBlank()) {
+            instance.setAvailabilityZone(availabilityZone);
+        }
+        if (autoMinorVersionUpgrade != null) {
+            instance.setAutoMinorVersionUpgrade(autoMinorVersionUpgrade);
+        }
+        if (promotionTier != null) {
+            instance.setPromotionTier(promotionTier);
+        }
+        if (publiclyAccessible != null) {
+            instance.setPubliclyAccessible(publiclyAccessible);
+        }
+        if (dbParameterGroupName != null && !dbParameterGroupName.isBlank()) {
+            instance.setDbParameterGroupName(dbParameterGroupName);
+        }
+        if (dbSubnetGroupName != null && !dbSubnetGroupName.isBlank()) {
+            instance.setDbSubnetGroupName(dbSubnetGroupName);
+        }
+        if (preferredBackupWindow != null && !preferredBackupWindow.isBlank()) {
+            instance.setPreferredBackupWindow(preferredBackupWindow);
+        }
+        if (preferredMaintenanceWindow != null && !preferredMaintenanceWindow.isBlank()) {
+            instance.setPreferredMaintenanceWindow(BackupWindows.lowerCase(preferredMaintenanceWindow));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneClusterSettingsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneClusterSettingsIntegrationTest.java
@@ -1,0 +1,280 @@
+package io.github.hectorvent.floci.services.neptune;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class NeptuneClusterSettingsIntegrationTest {
+
+    private static final String FORM = "application/x-www-form-urlencoded";
+    private static final String ID = "tf-neptune-settings";
+    private static final String INSTANCE_ID = "tf-neptune-settings-db";
+    private static final String ARN = "arn:aws:neptune:us-east-1:000000000000:cluster:" + ID;
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/neptune-load";
+
+    private static RequestSpecification signedAs(String service, String action) {
+        return given()
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260903/us-east-1/" + service
+                        + "/aws4_request, SignedHeaders=content-type;host, Signature=test")
+                .contentType(FORM)
+                .formParam("Action", action);
+    }
+
+    private static RequestSpecification rds(String action) {
+        return signedAs("rds", action);
+    }
+
+    @Test
+    @Order(1)
+    void createEchoesEverySettingTerraformSends() {
+        rds("CreateDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("Engine", "neptune")
+            .formParam("Port", "8200")
+            .formParam("StorageEncrypted", "false")
+            .formParam("DeletionProtection", "true")
+            .formParam("CopyTagsToSnapshot", "false")
+            .formParam("BackupRetentionPeriod", "7")
+            .formParam("AvailabilityZones.AvailabilityZone.1", "us-east-1a")
+            .formParam("AvailabilityZones.AvailabilityZone.2", "us-east-1b")
+            .formParam("EnableCloudwatchLogsExports.member.1", "audit")
+            .formParam("VpcSecurityGroupIds.VpcSecurityGroupId.1", "sg-11111111")
+            .formParam("PreferredBackupWindow", "03:00-04:00")
+            .formParam("PreferredMaintenanceWindow", "Sun:05:00-Sun:06:00")
+            .formParam("ServerlessV2ScalingConfiguration.MinCapacity", "2.5")
+            .formParam("ServerlessV2ScalingConfiguration.MaxCapacity", "16")
+            .formParam("Tags.Tag.1.Key", "Name")
+            .formParam("Tags.Tag.1.Value", ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Port>8200</Port>"))
+            .body(containsString("<StorageEncrypted>false</StorageEncrypted>"))
+            .body(containsString("<DeletionProtection>true</DeletionProtection>"))
+            .body(containsString("<CopyTagsToSnapshot>false</CopyTagsToSnapshot>"))
+            .body(containsString("<BackupRetentionPeriod>7</BackupRetentionPeriod>"))
+            .body(containsString("<AvailabilityZones><AvailabilityZone>us-east-1a</AvailabilityZone>"
+                    + "<AvailabilityZone>us-east-1b</AvailabilityZone></AvailabilityZones>"))
+            .body(containsString("<EnabledCloudwatchLogsExports><member>audit</member></EnabledCloudwatchLogsExports>"))
+            .body(containsString("<VpcSecurityGroupMembership><VpcSecurityGroupId>sg-11111111</VpcSecurityGroupId>"))
+            .body(containsString("<PreferredBackupWindow>03:00-04:00</PreferredBackupWindow>"))
+            .body(containsString("<PreferredMaintenanceWindow>sun:05:00-sun:06:00</PreferredMaintenanceWindow>"))
+            .body(containsString("<ServerlessV2ScalingConfiguration><MinCapacity>2.5</MinCapacity>"
+                    + "<MaxCapacity>16.0</MaxCapacity></ServerlessV2ScalingConfiguration>"))
+            .body(containsString("<DBClusterParameterGroup>default.neptune1.3</DBClusterParameterGroup>"))
+            .body(containsString("<DBSubnetGroup>default</DBSubnetGroup>"))
+            .body(containsString("<ClusterCreateTime>"))
+            .body(containsString("<DBClusterArn>" + ARN + "</DBClusterArn>"));
+    }
+
+    @Test
+    @Order(2)
+    void describeOnTheRdsScopeReadsTheSameSettingsBack() {
+        rds("DescribeDBClusters")
+            .formParam("DBClusterIdentifier", ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Port>8200</Port>"))
+            .body(containsString("<StorageEncrypted>false</StorageEncrypted>"))
+            .body(containsString("<DeletionProtection>true</DeletionProtection>"))
+            .body(containsString("<BackupRetentionPeriod>7</BackupRetentionPeriod>"))
+            .body(containsString("<AvailabilityZone>us-east-1b</AvailabilityZone>"))
+            .body(containsString("<AssociatedRoles></AssociatedRoles>"));
+    }
+
+    @Test
+    @Order(3)
+    void tagsRoundTripThroughTheRdsScopeByNeptuneArn() {
+        rds("ListTagsForResource")
+            .formParam("ResourceName", ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<TagList><Tag><Key>Name</Key><Value>" + ID + "</Value></Tag></TagList>"));
+
+        rds("AddTagsToResource")
+            .formParam("ResourceName", ARN)
+            .formParam("Tags.Tag.1.Key", "team")
+            .formParam("Tags.Tag.1.Value", "graph")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AddTagsToResourceResponse"));
+
+        rds("RemoveTagsFromResource")
+            .formParam("ResourceName", ARN)
+            .formParam("TagKeys.member.1", "Name")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("ListTagsForResource")
+            .formParam("ResourceName", ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Tag><Key>team</Key><Value>graph</Value></Tag>"))
+            .body(not(containsString("<Key>Name</Key>")));
+    }
+
+    @Test
+    @Order(4)
+    void tagsForAForeignArnAreNotFound() {
+        signedAs("neptune", "ListTagsForResource")
+            .formParam("ResourceName", ARN.replace("us-east-1", "eu-west-1"))
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("DBClusterNotFoundFault"));
+    }
+
+    @Test
+    @Order(5)
+    void rolesAreAssociatedAndListedOnTheCluster() {
+        rds("AddRoleToDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("RoleArn", ROLE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AddRoleToDBClusterResponse"));
+
+        rds("AddRoleToDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("RoleArn", ROLE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("DBClusterRoleAlreadyExists"));
+
+        rds("DescribeDBClusters")
+            .formParam("DBClusterIdentifier", ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AssociatedRoles><DBClusterRole><RoleArn>" + ROLE_ARN
+                    + "</RoleArn><Status>ACTIVE</Status></DBClusterRole></AssociatedRoles>"));
+
+        rds("RemoveRoleFromDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("RoleArn", ROLE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("RemoveRoleFromDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("RoleArn", ROLE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("DBClusterRoleNotFound"));
+    }
+
+    @Test
+    @Order(6)
+    void describeGlobalClustersIsEmptyOnBothScopes() {
+        signedAs("neptune", "DescribeGlobalClusters")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<GlobalClusters></GlobalClusters>"));
+
+        rds("DescribeGlobalClusters")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<GlobalClusters>"));
+    }
+
+    @Test
+    @Order(7)
+    void deleteIsRefusedWhileDeletionProtectionIsOn() {
+        rds("DeleteDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("SkipFinalSnapshot", "true")
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("InvalidParameterCombination"));
+    }
+
+    @Test
+    @Order(8)
+    void modifyAppliesTheChangedSettingsOnly() {
+        rds("ModifyDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("ApplyImmediately", "true")
+            .formParam("AllowMajorVersionUpgrade", "false")
+            .formParam("DeletionProtection", "false")
+            .formParam("BackupRetentionPeriod", "3")
+            .formParam("CloudwatchLogsExportConfiguration.EnableLogTypes.member.1", "slowquery")
+            .formParam("CloudwatchLogsExportConfiguration.DisableLogTypes.member.1", "audit")
+            .formParam("VpcSecurityGroupIds", "")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DeletionProtection>false</DeletionProtection>"))
+            .body(containsString("<BackupRetentionPeriod>3</BackupRetentionPeriod>"))
+            .body(containsString("<EnabledCloudwatchLogsExports><member>slowquery</member></EnabledCloudwatchLogsExports>"))
+            .body(containsString("<VpcSecurityGroups></VpcSecurityGroups>"))
+            .body(containsString("<Port>8200</Port>"))
+            .body(containsString("<PreferredBackupWindow>03:00-04:00</PreferredBackupWindow>"));
+    }
+
+    @Test
+    @Order(9)
+    void clusterMembersUseTheDbClusterMemberElement() {
+        rds("CreateDBInstance")
+            .formParam("DBInstanceIdentifier", INSTANCE_ID)
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("DBInstanceClass", "db.r5.large")
+            .formParam("Engine", "neptune")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("DescribeDBClusters")
+            .formParam("DBClusterIdentifier", ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusterMembers><DBClusterMember><DBInstanceIdentifier>" + INSTANCE_ID
+                    + "</DBInstanceIdentifier><IsClusterWriter>true</IsClusterWriter></DBClusterMember></DBClusterMembers>"));
+
+        rds("DeleteDBInstance")
+            .formParam("DBInstanceIdentifier", INSTANCE_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(10)
+    void deleteSucceedsOnceDeletionProtectionIsOff() {
+        rds("DeleteDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("SkipFinalSnapshot", "true")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString(ID));
+
+        rds("DescribeDBClusters")
+            .formParam("DBClusterIdentifier", ID)
+        .when().post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("DBClusterNotFoundFault"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneClusterSettingsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneClusterSettingsIntegrationTest.java
@@ -183,6 +183,32 @@ class NeptuneClusterSettingsIntegrationTest {
 
     @Test
     @Order(6)
+    void unsignedRoleActionsRouteToNeptune() {
+        given().contentType(FORM).formParam("Action", "AddRoleToDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("RoleArn", ROLE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AddRoleToDBClusterResponse"));
+
+        given().contentType(FORM).formParam("Action", "DescribeDBClusters")
+            .formParam("DBClusterIdentifier", ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<RoleArn>" + ROLE_ARN + "</RoleArn>"));
+
+        given().contentType(FORM).formParam("Action", "RemoveRoleFromDBCluster")
+            .formParam("DBClusterIdentifier", ID)
+            .formParam("RoleArn", ROLE_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(7)
     void describeGlobalClustersIsEmptyOnBothScopes() {
         signedAs("neptune", "DescribeGlobalClusters")
         .when().post("/")
@@ -198,7 +224,7 @@ class NeptuneClusterSettingsIntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void deleteIsRefusedWhileDeletionProtectionIsOn() {
         rds("DeleteDBCluster")
             .formParam("DBClusterIdentifier", ID)
@@ -210,7 +236,7 @@ class NeptuneClusterSettingsIntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void modifyAppliesTheChangedSettingsOnly() {
         rds("ModifyDBCluster")
             .formParam("DBClusterIdentifier", ID)
@@ -233,7 +259,7 @@ class NeptuneClusterSettingsIntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(10)
     void clusterMembersUseTheDbClusterMemberElement() {
         rds("CreateDBInstance")
             .formParam("DBInstanceIdentifier", INSTANCE_ID)
@@ -260,7 +286,7 @@ class NeptuneClusterSettingsIntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(11)
     void deleteSucceedsOnceDeletionProtectionIsOff() {
         rds("DeleteDBCluster")
             .formParam("DBClusterIdentifier", ID)

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneInstanceSettingsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneInstanceSettingsIntegrationTest.java
@@ -1,0 +1,196 @@
+package io.github.hectorvent.floci.services.neptune;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class NeptuneInstanceSettingsIntegrationTest {
+
+    private static final String FORM = "application/x-www-form-urlencoded";
+    private static final String CLUSTER_ID = "tf-neptune-instances";
+    private static final String WRITER_ID = "tf-neptune-instances-writer";
+    private static final String READER_ID = "tf-neptune-instances-reader";
+    private static final String WRITER_ARN = "arn:aws:neptune:us-east-1:000000000000:db:" + WRITER_ID;
+
+    private static RequestSpecification rds(String action) {
+        return given()
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260904/us-east-1/rds"
+                        + "/aws4_request, SignedHeaders=content-type;host, Signature=test")
+                .contentType(FORM)
+                .formParam("Action", action);
+    }
+
+    @Test
+    @Order(1)
+    void createEchoesEverySettingTerraformSends() {
+        rds("CreateDBCluster")
+            .formParam("DBClusterIdentifier", CLUSTER_ID)
+            .formParam("Engine", "neptune")
+            .formParam("Port", "8211")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("CreateDBInstance")
+            .formParam("DBInstanceIdentifier", WRITER_ID)
+            .formParam("DBClusterIdentifier", CLUSTER_ID)
+            .formParam("DBInstanceClass", "db.r5.large")
+            .formParam("Engine", "neptune")
+            .formParam("AutoMinorVersionUpgrade", "true")
+            .formParam("PromotionTier", "0")
+            .formParam("PubliclyAccessible", "false")
+            .formParam("Tags.Tag.1.Key", "Name")
+            .formParam("Tags.Tag.1.Value", WRITER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBInstanceClass>db.r5.large</DBInstanceClass>"))
+            .body(containsString("<Port>8211</Port>"))
+            .body(containsString("<AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>"))
+            .body(containsString("<PromotionTier>0</PromotionTier>"))
+            .body(containsString("<PubliclyAccessible>false</PubliclyAccessible>"))
+            .body(containsString("<StorageEncrypted>false</StorageEncrypted>"))
+            .body(containsString("<DBSubnetGroup><DBSubnetGroupName>default</DBSubnetGroupName>"))
+            .body(containsString("<DBParameterGroupName>default.neptune1.3</DBParameterGroupName>"))
+            .body(containsString("<PreferredBackupWindow>04:00-06:00</PreferredBackupWindow>"))
+            .body(containsString("<PreferredMaintenanceWindow>mon:00:00-mon:03:00</PreferredMaintenanceWindow>"))
+            .body(containsString("<InstanceCreateTime>"));
+    }
+
+    @Test
+    @Order(2)
+    void describeReadsTheSameSettingsBack() {
+        rds("DescribeDBInstances")
+            .formParam("DBInstanceIdentifier", WRITER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AutoMinorVersionUpgrade>true</AutoMinorVersionUpgrade>"))
+            .body(containsString("<PromotionTier>0</PromotionTier>"))
+            .body(containsString("<PubliclyAccessible>false</PubliclyAccessible>"))
+            .body(containsString("<StorageEncrypted>false</StorageEncrypted>"))
+            .body(containsString("<DBParameterGroupName>default.neptune1.3</DBParameterGroupName>"))
+            .body(containsString("<AvailabilityZone>"));
+    }
+
+    @Test
+    @Order(3)
+    void modifyAppliesTheChangedSettingsOnly() {
+        rds("ModifyDBInstance")
+            .formParam("DBInstanceIdentifier", WRITER_ID)
+            .formParam("AutoMinorVersionUpgrade", "false")
+            .formParam("PromotionTier", "5")
+            .formParam("DBParameterGroupName", "tuned")
+            .formParam("PreferredMaintenanceWindow", "Sun:05:00-Sun:06:00")
+            .formParam("ApplyImmediately", "true")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<AutoMinorVersionUpgrade>false</AutoMinorVersionUpgrade>"))
+            .body(containsString("<PromotionTier>5</PromotionTier>"))
+            .body(containsString("<DBParameterGroupName>tuned</DBParameterGroupName>"))
+            .body(containsString("<PreferredMaintenanceWindow>sun:05:00-sun:06:00</PreferredMaintenanceWindow>"))
+            .body(containsString("<DBInstanceClass>db.r5.large</DBInstanceClass>"))
+            .body(containsString("<PubliclyAccessible>false</PubliclyAccessible>"));
+    }
+
+    @Test
+    @Order(4)
+    void tagsRoundTripThroughTheInstanceArn() {
+        rds("AddTagsToResource")
+            .formParam("ResourceName", WRITER_ARN)
+            .formParam("Tags.Tag.1.Key", "env")
+            .formParam("Tags.Tag.1.Value", "test")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("ListTagsForResource")
+            .formParam("ResourceName", WRITER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Key>Name</Key><Value>" + WRITER_ID + "</Value>"))
+            .body(containsString("<Key>env</Key><Value>test</Value>"));
+
+        rds("RemoveTagsFromResource")
+            .formParam("ResourceName", WRITER_ARN)
+            .formParam("TagKeys.member.1", "env")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("ListTagsForResource")
+            .formParam("ResourceName", WRITER_ARN)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Key>env</Key>")));
+    }
+
+    @Test
+    @Order(5)
+    void onlyTheFirstMemberIsTheClusterWriter() {
+        rds("CreateDBInstance")
+            .formParam("DBInstanceIdentifier", READER_ID)
+            .formParam("DBClusterIdentifier", CLUSTER_ID)
+            .formParam("DBInstanceClass", "db.r5.large")
+            .formParam("Engine", "neptune")
+            .formParam("PromotionTier", "2")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<PromotionTier>2</PromotionTier>"));
+
+        rds("DescribeDBClusters")
+            .formParam("DBClusterIdentifier", CLUSTER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusterMember><DBInstanceIdentifier>" + WRITER_ID
+                    + "</DBInstanceIdentifier><IsClusterWriter>true</IsClusterWriter></DBClusterMember>"))
+            .body(containsString("<DBClusterMember><DBInstanceIdentifier>" + READER_ID
+                    + "</DBInstanceIdentifier><IsClusterWriter>false</IsClusterWriter></DBClusterMember>"));
+    }
+
+    @Test
+    @Order(6)
+    void deletingTheWriterPromotesTheNextMember() {
+        rds("DeleteDBInstance")
+            .formParam("DBInstanceIdentifier", WRITER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("DescribeDBClusters")
+            .formParam("DBClusterIdentifier", CLUSTER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<DBClusterMember><DBInstanceIdentifier>" + READER_ID
+                    + "</DBInstanceIdentifier><IsClusterWriter>true</IsClusterWriter></DBClusterMember>"))
+            .body(not(containsString(WRITER_ID)));
+
+        rds("DeleteDBInstance")
+            .formParam("DBInstanceIdentifier", READER_ID)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        rds("DeleteDBCluster")
+            .formParam("DBClusterIdentifier", CLUSTER_ID)
+            .formParam("SkipFinalSnapshot", "true")
+        .when().post("/")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneClusterSettings;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneDbType;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneInstanceSettings;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -351,5 +353,63 @@ class NeptuneServiceTest {
         assertEquals("neptune1.4", NeptuneService.parameterGroupFamily("1.4.5.1"));
         assertEquals("neptune1.3", NeptuneService.parameterGroupFamily(null));
         assertEquals("neptune1.3", NeptuneService.parameterGroupFamily("latest"));
+    }
+
+    // --- Instance settings the Terraform aws_neptune_cluster_instance resource reads back ---
+
+    @Test
+    void createDbInstanceStoresTheRequestedSettingsAndAwsDefaultsOtherwise() {
+        service.createDbCluster("instance-settings", "1.3.2.1", false);
+
+        NeptuneInstance requested = service.createDbInstance("with-settings", "instance-settings",
+                "db.r5.large", null, false,
+                new NeptuneInstanceSettings("us-east-1b", false, 0, true, "custom-params", "custom-subnets",
+                        "07:00-08:00", "Sun:05:00-Sun:06:00"),
+                Map.of("Name", "with-settings"));
+        assertEquals("us-east-1b", requested.getAvailabilityZone());
+        assertFalse(requested.isAutoMinorVersionUpgrade());
+        assertEquals(0, requested.getPromotionTier());
+        assertTrue(requested.isPubliclyAccessible());
+        assertEquals("custom-params", requested.getDbParameterGroupName());
+        assertEquals("custom-subnets", requested.getDbSubnetGroupName());
+        assertEquals("07:00-08:00", requested.getPreferredBackupWindow());
+        assertEquals("sun:05:00-sun:06:00", requested.getPreferredMaintenanceWindow());
+        assertEquals("with-settings", requested.getTags().get("Name"));
+
+        NeptuneInstance defaults = service.createDbInstance("bare", "instance-settings", "db.r5.large", null, false);
+        assertTrue(defaults.isAutoMinorVersionUpgrade());
+        assertEquals(1, defaults.getPromotionTier());
+        assertFalse(defaults.isPubliclyAccessible());
+        assertNull(defaults.getAvailabilityZone());
+        assertNull(defaults.getDbParameterGroupName());
+        assertNull(defaults.getPreferredMaintenanceWindow());
+    }
+
+    @Test
+    void modifyDbInstanceAppliesOnlyTheSettingsTheRequestCarries() {
+        service.createDbCluster("instance-modify", "1.3.2.1", false);
+        service.createDbInstance("to-modify", "instance-modify", "db.r5.large", null, false,
+                new NeptuneInstanceSettings(null, true, 2, null, null, null, null, null), Map.of());
+
+        NeptuneInstance modified = service.modifyDbInstance("to-modify", null, null,
+                new NeptuneInstanceSettings(null, false, null, null, "tuned", null, null, "Mon:02:00-Mon:03:00"));
+
+        assertFalse(modified.isAutoMinorVersionUpgrade());
+        assertEquals(2, modified.getPromotionTier(), "An omitted PromotionTier must keep its value");
+        assertEquals("tuned", modified.getDbParameterGroupName());
+        assertEquals("mon:02:00-mon:03:00", modified.getPreferredMaintenanceWindow());
+        assertEquals("db.r5.large", modified.getDbInstanceClass(), "An omitted DBInstanceClass must keep its value");
+    }
+
+    @Test
+    void instanceSettingsRejectAPromotionTierOutsideTheAwsRange() {
+        service.createDbCluster("instance-invalid", "1.3.2.1", false);
+
+        AwsException ex = assertThrows(AwsException.class, () -> service.createDbInstance("bad-tier",
+                "instance-invalid", "db.r5.large", null, false,
+                new NeptuneInstanceSettings(null, null, 16, null, null, null, null, null), Map.of()));
+
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+        assertFalse(service.hasInstance("bad-tier"), "A rejected create must not leave an instance behind");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -8,15 +8,19 @@ import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerHandle;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerManager;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneCluster;
+import io.github.hectorvent.floci.services.neptune.model.NeptuneClusterSettings;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneDbType;
 import io.github.hectorvent.floci.services.neptune.model.NeptuneInstance;
 import io.github.hectorvent.floci.services.neptune.proxy.NeptuneProxyManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -200,5 +204,152 @@ class NeptuneServiceTest {
         // Delete must not reach for a container that was never created.
         service.deleteDbCluster("no-docker-cluster");
         verify(containerManager, never()).stop(any());
+    }
+
+    private static NeptuneClusterSettings settings(Integer port, Integer backupRetentionPeriod,
+                                                   Boolean deletionProtection, List<String> vpcSecurityGroupIds,
+                                                   List<String> enableLogTypes, List<String> disableLogTypes) {
+        return new NeptuneClusterSettings(null, port, backupRetentionPeriod, null, null, null, null,
+                vpcSecurityGroupIds, null, null, null, deletionProtection, null, enableLogTypes, disableLogTypes,
+                null, null, null);
+    }
+
+    @Test
+    void createDbClusterStoresEverySettingAndTheTags() {
+        NeptuneClusterSettings requested = new NeptuneClusterSettings(
+                List.of("us-east-1a", "us-east-1b"), null, 7, "03:00-04:00", "Sun:05:00-Sun:06:00",
+                "my-subnets", "my-params", List.of("sg-1"), false, null, "iopt1", true, true,
+                List.of("audit"), null, null, 2.5, 8.0);
+
+        NeptuneCluster c = service.createDbCluster("settings", "1.3.2.1", false, requested, Map.of("Name", "settings"));
+
+        assertEquals(List.of("us-east-1a", "us-east-1b"), c.getAvailabilityZones());
+        assertEquals(7, c.getBackupRetentionPeriod());
+        assertEquals("03:00-04:00", c.getPreferredBackupWindow());
+        assertEquals("sun:05:00-sun:06:00", c.getPreferredMaintenanceWindow());
+        assertEquals("my-subnets", c.getDbSubnetGroupName());
+        assertEquals("my-params", c.getDbClusterParameterGroupName());
+        assertEquals(List.of("sg-1"), c.getVpcSecurityGroupIds());
+        assertFalse(c.isStorageEncrypted());
+        assertEquals("iopt1", c.getStorageType());
+        assertTrue(c.isDeletionProtection());
+        assertTrue(c.isCopyTagsToSnapshot());
+        assertEquals(List.of("audit"), c.getEnabledCloudwatchLogsExports());
+        assertEquals(Double.valueOf(2.5), c.getServerlessV2MinCapacity());
+        assertEquals(Double.valueOf(8.0), c.getServerlessV2MaxCapacity());
+        assertEquals(Map.of("Name", "settings"), c.getTags());
+    }
+
+    @Test
+    void storageEncryptedDefaultsToFalseLikeAws() {
+        NeptuneCluster c = service.createDbCluster("plain", "1.3.2.1", false);
+        assertFalse(c.isStorageEncrypted());
+        assertEquals(1, c.getBackupRetentionPeriod());
+        assertTrue(c.getAvailabilityZones().isEmpty());
+        assertTrue(c.getTags().isEmpty());
+    }
+
+    @Test
+    void requestedPortIsHonouredWhenFreeInTheProxyRangeAndFallsBackOtherwise() {
+        assertEquals(18190, service.createDbCluster("p1", "1.3.2.1", false,
+                settings(18190, null, null, null, null, null), Map.of()).getPort());
+        assertEquals(18182, service.createDbCluster("p2", "1.3.2.1", false,
+                settings(18190, null, null, null, null, null), Map.of()).getPort());
+        assertEquals(18183, service.createDbCluster("p3", "1.3.2.1", false,
+                settings(9999, null, null, null, null, null), Map.of()).getPort());
+
+        service.deleteDbCluster("p1");
+        assertEquals(18190, service.createDbCluster("p4", "1.3.2.1", false,
+                settings(18190, null, null, null, null, null), Map.of()).getPort());
+    }
+
+    @Test
+    void invalidSettingsAreRejectedBeforeAPortIsReserved() {
+        AwsException e = assertThrows(AwsException.class, () -> service.createDbCluster("bad", "1.3.2.1", false,
+                settings(null, 99, null, null, null, null), Map.of()));
+        assertEquals("InvalidParameterValue", e.getErrorCode());
+        assertEquals(18182, service.createDbCluster("good", "1.3.2.1", false).getPort());
+    }
+
+    @Test
+    void deleteIsRefusedWhileDeletionProtectionIsOn() {
+        service.createDbCluster("protected", "1.3.2.1", false,
+                settings(null, null, true, null, null, null), Map.of());
+
+        AwsException e = assertThrows(AwsException.class, () -> service.deleteDbCluster("protected"));
+        assertEquals("InvalidParameterCombination", e.getErrorCode());
+        assertTrue(service.hasCluster("protected"));
+
+        service.modifyDbCluster("protected", null, null, settings(null, null, false, null, null, null));
+        service.deleteDbCluster("protected");
+        assertFalse(service.hasCluster("protected"));
+    }
+
+    @Test
+    void modifyMergesLogExportsAndClearsSecurityGroupsWithAnEmptyList() {
+        service.createDbCluster("logs", "1.3.2.1", false,
+                settings(null, null, null, List.of("sg-1"), List.of("audit"), null), Map.of());
+
+        NeptuneCluster c = service.modifyDbCluster("logs", null, null,
+                settings(null, 3, null, List.of(), List.of("slowquery"), List.of("audit")));
+
+        assertEquals(List.of("slowquery"), c.getEnabledCloudwatchLogsExports());
+        assertTrue(c.getVpcSecurityGroupIds().isEmpty());
+        assertEquals(3, c.getBackupRetentionPeriod());
+
+        NeptuneCluster unchanged = service.modifyDbCluster("logs", null, null, NeptuneClusterSettings.unchanged());
+        assertEquals(List.of("slowquery"), unchanged.getEnabledCloudwatchLogsExports());
+        assertEquals(3, unchanged.getBackupRetentionPeriod());
+    }
+
+    @Test
+    void rolesAreAssociatedOnceAndRemovedByArn() {
+        service.createDbCluster("roles", "1.3.2.1", false);
+        String roleArn = "arn:aws:iam::000000000000:role/neptune-load";
+
+        assertEquals(List.of(roleArn), service.addRoleToDbCluster("roles", roleArn).getAssociatedRoleArns());
+        assertEquals("DBClusterRoleAlreadyExists",
+                assertThrows(AwsException.class, () -> service.addRoleToDbCluster("roles", roleArn)).getErrorCode());
+
+        assertTrue(service.removeRoleFromDbCluster("roles", roleArn).getAssociatedRoleArns().isEmpty());
+        assertEquals("DBClusterRoleNotFound",
+                assertThrows(AwsException.class, () -> service.removeRoleFromDbCluster("roles", roleArn)).getErrorCode());
+    }
+
+    @Test
+    void tagsAreResolvedByTheExactArnOnly() {
+        NeptuneCluster c = service.createDbCluster("tagged", "1.3.2.1", false,
+                NeptuneClusterSettings.defaults(), Map.of("env", "test"));
+        String arn = c.getDbClusterArn();
+
+        assertTrue(service.hasResourceWithArn(arn));
+        assertEquals(Map.of("env", "test"), service.listTagsForResource(arn));
+
+        service.addTagsToResource(arn, Map.of("team", "graph"));
+        service.removeTagsFromResource(arn, List.of("env", "absent"));
+        assertEquals(Map.of("team", "graph"), service.listTagsForResource(arn));
+
+        String foreign = arn.replace("us-east-1", "eu-west-1");
+        assertFalse(service.hasResourceWithArn(foreign));
+        assertEquals("DBClusterNotFoundFault",
+                assertThrows(AwsException.class, () -> service.listTagsForResource(foreign)).getErrorCode());
+        assertEquals("InvalidParameterValue",
+                assertThrows(AwsException.class, () -> service.listTagsForResource("tagged")).getErrorCode());
+
+        NeptuneInstance instance = service.createDbInstance("tagged-db", "tagged", null, null, false,
+                Map.of("role", "writer"));
+        assertTrue(service.hasResourceWithArn(instance.getDbInstanceArn()));
+        assertEquals(Map.of("role", "writer"), service.listTagsForResource(instance.getDbInstanceArn()));
+    }
+
+    @Test
+    void parameterGroupFamilyFollowsTheEngineMajorAndMinor() {
+        assertEquals("neptune1", NeptuneService.parameterGroupFamily("1.0.5.1"));
+        assertEquals("neptune1", NeptuneService.parameterGroupFamily("1.1.1.0"));
+        assertEquals("neptune1.2", NeptuneService.parameterGroupFamily("1.2.1.0"));
+        assertEquals("neptune1.3", NeptuneService.parameterGroupFamily("1.3.2.1"));
+        assertEquals("neptune1.4", NeptuneService.parameterGroupFamily("1.4.5.1"));
+        assertEquals("neptune1.3", NeptuneService.parameterGroupFamily(null));
+        assertEquals("neptune1.3", NeptuneService.parameterGroupFamily("latest"));
     }
 }


### PR DESCRIPTION
## Summary

The Terraform AWS provider's `aws_neptune_cluster` resource reads back every `DBCluster` field after create and update, and treats a mismatch on a `ForceNew` attribute as a replacement. Against Floci the resource could not converge:

- `StorageEncrypted` was hardcoded to `true`; the provider's default is `false` and the attribute is `ForceNew`, so every plan wanted a replacement.
- `AvailabilityZones` was emitted as a singular `AvailabilityZone` element, which SDK parsers drop; a configured `availability_zones` therefore never matched.
- `BackupRetentionPeriod` (provider default 1), `DeletionProtection`, `CopyTagsToSnapshot`, windows, groups, security groups, log exports and the other settings were never stored, so each apply issued a `ModifyDBCluster`.
- `ListTagsForResource`, `AddTagsToResource` and `RemoveTagsFromResource` on a Neptune ARN fell through to the RDS handler, and `Tags` on `CreateDBCluster` were ignored.
- `AddRoleToDBCluster` / `RemoveRoleFromDBCluster` (the `iam_roles` attribute) were unsupported.

### What changed

- `NeptuneClusterSettings` (modelled on `DocDbClusterSettings`) carries the settings a `CreateDBCluster` / `ModifyDBCluster` request sets; `NeptuneCluster` stores them and `DescribeDBClusters` reads them back with the AWS defaults otherwise: `AvailabilityZones`, `BackupRetentionPeriod`, `PreferredBackupWindow`, `PreferredMaintenanceWindow`, `DBSubnetGroup` (`default`), `DBClusterParameterGroup` (`default.neptune<major>.<minor>`), `VpcSecurityGroups`, `StorageEncrypted`, `KmsKeyId`, `StorageType`, `DeletionProtection`, `CopyTagsToSnapshot`, `EnabledCloudwatchLogsExports`, `ReplicationSourceIdentifier`, `ServerlessV2ScalingConfiguration`, `AssociatedRoles`, `ClusterCreateTime`.
- A requested `Port` is honoured when it is free and inside the proxy range; otherwise the next free proxy port is allocated as before. Terraform's default `port = 8182` therefore matches the first cluster.
- `DeleteDBCluster` refuses a cluster with `DeletionProtection` enabled with `InvalidParameterCombination`, as on AWS (and as DocDB already does in Floci).
- `DBClusterMembers` uses the `DBClusterMember` element the Neptune API model declares (the previous `member` element was dropped by SDK parsers, so `cluster_members` was always empty).
- New actions on the Neptune handler: `AddRoleToDBCluster`, `RemoveRoleFromDBCluster`, `DescribeGlobalClusters` (empty list, mirroring DocDB), `ListTagsForResource`, `AddTagsToResource`, `RemoveTagsFromResource`. `Tags` are accepted on `CreateDBCluster` and `CreateDBInstance`.
- `AwsQueryController` routes a tagging `ResourceName` that is a Neptune ARN to the Neptune handler on the `rds` credential scope (the scope the Neptune SDKs sign with), mirroring the existing DocDB routing.
- Docs: action table regenerated (`make docs-sync`), a "Terraform and the `aws_neptune_cluster` resource" section, Service Matrix count.
- `aws_neptune_cluster_instance`: `NeptuneInstanceSettings` (modelled on the cluster settings) stores `AutoMinorVersionUpgrade` (default `true`), `PromotionTier` (default `1`), `PubliclyAccessible` (default `false`), `AvailabilityZone`, `DBParameterGroupName`, `DBSubnetGroupName`, `PreferredBackupWindow` and `PreferredMaintenanceWindow` on `CreateDBInstance`, applies them on `ModifyDBInstance`, and `DescribeDBInstances` reads them back with `DBParameterGroups`, `DBSubnetGroup`, `InstanceCreateTime` and the cluster's `StorageEncrypted`, `KmsKeyId` and `StorageType`. `DBClusterMembers` reports the first member as the writer and deleting it promotes the next.
- Unsigned Query requests: `AddRoleToDBCluster` and `RemoveRoleFromDBCluster` are in the RDS action set used for service inference, so they reach the Neptune handler without a SigV4 header.
- Compatibility tests: `compat-terraform/test/neptune-cluster-tf` with `neptune_cluster.bats`, `compat-terraform/test/neptune-cluster-instance-tf` with `neptune_cluster_instance.bats` (a cluster on port 8183 with a writer and a reader instance), and the Java SDK `NeptuneTest` extended with tags, roles, modify settings, deletion protection, cluster members and the instance fields above.

### Behaviour changes to call out

- `StorageEncrypted` now reads `false` unless `StorageEncrypted=true` was requested. Previously every cluster read `true`. Records persisted before this change will read `false` after upgrade.
- `DeleteDBCluster` on a cluster with `DeletionProtection=true` now fails; previously the flag was ignored.
- `DBClusterMembers` members are now parsed by SDKs (element renamed from `member` to `DBClusterMember`), and only the first member of a cluster reports `IsClusterWriter=true`; previously every member did.
- `DescribeDBInstances` now reports the cluster's `StorageEncrypted` (so `false` by default) instead of a hardcoded `true`, and `PromotionTier` defaults to `1` when a request omits it, as on AWS.

### Notes

- Neptune cluster ARNs keep Floci's existing `arn:aws:neptune:...` form (real Neptune uses `arn:aws:rds:...`). Terraform treats the ARN opaquely, and the Java compat test asserts the existing prefix, so this PR does not change it.
- Two clusters cannot share a host port. For a second cluster set `port` explicitly in Terraform (for example `port = 8183`) or the provider's default of 8182 will show a diff against the allocated port. Documented in `docs/services/neptune.md`.
- `hosted_zone_id` reads as empty; the provider marks it Computed, so this does not affect plans.
- An instance answers on its cluster's port, and the provider's instance `port` defaults to `8182`, so set `port` on `aws_neptune_cluster_instance` when the cluster does not use `8182` (the fixture does this with `8183`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- `./mvnw test -Dtest='Neptune*'`: all Neptune unit and integration tests pass (66 tests), including the new `NeptuneClusterSettingsIntegrationTest`, `NeptuneInstanceSettingsIntegrationTest` and the new `NeptuneServiceTest` cases.
- Java SDK compat suite `NeptuneTest` against a running Floci: 13 tests pass (`software.amazon.awssdk:neptune` parses the new `DBCluster` and `DBInstance` fields, tags, roles and members).
- Terraform compat `neptune_cluster.bats` and `neptune_cluster_instance.bats` against a running Floci jar with Terraform 1.15.0 and `hashicorp/aws` 6.x: all 9 checks pass, including a clean re-plan with a writer and a reader `aws_neptune_cluster_instance`.
- Terraform end to end against a running Floci jar with `hashicorp/aws` 6.62.0 and Terraform 1.14.3 (Docker disabled so clusters take the metadata-only path):
  1. `terraform apply` of the new fixture: created in 31s (the provider's 30s waiter delay); outputs `storage_encrypted = false`, `port = 8182`, `parameter_group_name = "default.neptune1.3"`.
  2. `terraform plan -detailed-exitcode` straight after: `No changes` (exit 0).
  3. Update to `backup_retention_period = 10`, `deletion_protection = true`, `enable_cloudwatch_logs_exports = ["audit"]`, `iam_roles = [...]`, `vpc_security_group_ids = ["sg-11111111"]`, `preferred_maintenance_window = "sun:05:00-sun:06:00"`, an extra tag: `1 changed`, then `No changes` on re-plan; state shows every value as configured.
  4. `terraform destroy` while protected: fails with `InvalidParameterCombination: Cannot delete protected Cluster, please disable deletion protection and try again.`
  5. Revert apply (`1 changed`, re-plan clean), then `terraform destroy`: `1 destroyed`; `aws neptune describe-db-clusters` then returns `DBClusterNotFoundFault`.
  6. `aws neptune describe-db-clusters` and `list-tags-for-resource` (AWS CLI 2.36.37) parse the new XML, including `AvailabilityZones`, `ClusterCreateTime`, `AssociatedRoles` and `TagList`.
- `make docs-check` passes on the committed tree.

## Checklist

- [x] Neptune test classes (66 tests, including the new `NeptuneClusterSettingsIntegrationTest` and `NeptuneServiceTest` cases) and the DocDB, RDS and tagging classes touched by the shared Query routing change (26 classes, 653 tests) pass locally on current `main`; full `./mvnw test` is left to CI
- [x] New or updated integration test added (`NeptuneClusterSettingsIntegrationTest`, `NeptuneInstanceSettingsIntegrationTest`, Java SDK compat `NeptuneTest`, Terraform compat `neptune_cluster.bats` and `neptune_cluster_instance.bats`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
