### PR TITLE
fix(ssm): set the Arn attribute on AWS::SSM::Parameter

### DIFF
--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -231,7 +231,7 @@ before provisioning:
 - `AWS::SSM::Parameter::Value<List<String>>` and `AWS::SSM::Parameter::Name` typed parameters are
   **not yet** resolved — they are passed through as their literal input.
 
-The `AWS::SSM::Parameter` **resource** type exposes `Value`, `Type`, and `Name` attributes through
+The `AWS::SSM::Parameter` **resource** type exposes `Value`, `Type`, `Name`, and `Arn` attributes through
 `Ref` / `Fn::GetAtt` so downstream resources can consume a parameter the same stack creates.
 
 ## AWS::Include (`Fn::Transform`)

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SsmCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SsmCfnProvisioner.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.cloudformation.provisioners;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.ssm.SsmService;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -41,6 +42,13 @@ public class SsmCfnProvisioner implements CfnResourceProvisioner {
         r.getAttributes().put("Name", name);
         r.getAttributes().put("Type", type);
         r.getAttributes().put("Value", value);
+        r.getAttributes().put("Arn", parameterArn(name, ctx));
+    }
+
+    /** AWS's form is {@code parameter/<name>} whether or not the name starts with a slash. */
+    private static String parameterArn(String name, ProvisionContext ctx) {
+        String path = name.startsWith("/") ? name : "/" + name;
+        return AwsArnUtils.Arn.of("ssm", ctx.region(), ctx.accountId(), "parameter" + path).toString();
     }
 
     @Override

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LeafCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LeafCfnProvisionerTest.java
@@ -166,7 +166,20 @@ class LeafCfnProvisionerTest {
 
             verify(ssm).putParameter("/app/db", "secret", "String", null, true, REGION);
             assertEquals("/app/db", r.getPhysicalId());
-            assertEquals(Map.of("Name", "/app/db", "Type", "String", "Value", "secret"), r.getAttributes());
+            assertEquals(Map.of("Name", "/app/db", "Type", "String", "Value", "secret",
+                    "Arn", "arn:aws:ssm:us-east-1:000000000000:parameter/app/db"), r.getAttributes());
+        }
+
+        @Test
+        void arnOfANameWithoutALeadingSlashStillHasTheParameterPrefix() {
+            // AWS ARNs are always arn:...:parameter/<name>; a name without a leading slash gets the
+            // slash inserted, a name with one is not doubled.
+            StackResource r = resource("Param", "AWS::SSM::Parameter");
+            provisioner.provision(r, props("""
+                    {"Name": "db-host", "Value": "localhost"}
+                    """), ctx);
+
+            assertEquals("arn:aws:ssm:us-east-1:000000000000:parameter/db-host", r.getAttributes().get("Arn"));
         }
 
         @Test


### PR DESCRIPTION
## Summary

`AWS::SSM::Parameter` now returns its `Arn` through `Fn::GetAtt`.

The current AWS registry schema for this type lists `Arn` as its only read-only property. `SsmCfnProvisioner` did not set it, so `Fn::GetAtt [Param, Arn]` resolved to the text `Param.Arn`, and `CfnSchemaCoverageTest` fails on `main` as soon as the schema corpus is present in `local/aws/cfn-resource-schemas/us-east-1/`.

The ARN follows the AWS form `arn:aws:ssm:<region>:<account>:parameter/<name>`. A name without a leading slash gets one inserted, a name with one is not doubled.

| Item | Status | Note |
| --- | --- | --- |
| `Fn::GetAtt Arn` | ✅ | New |
| `Ref`, `Fn::GetAtt Name`, `Type`, `Value` | ✅ | Unchanged |

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Docs / chore

### Checklist

* [ ] `./mvnw test` passes locally. Ran per class: `LeafCfnProvisionerTest`, `CfnSchemaCoverageTest` (with the schema corpus), `CfnResourceInventoryTest`, `CloudFormationSsmParameterIntegrationTest`. `make docs-check` passes.
* [x] New or updated integration test added. Unit tests in `LeafCfnProvisionerTest` assert the exact attribute set and the leading-slash rule. The existing integration test already covers the resource; no protocol change.
* [x] Commit messages follow Conventional Commits
