### PR TITLE
refactor(ses): move template rendering and the ObjectMapper into SesTemplateService

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -35,7 +35,6 @@ import io.github.hectorvent.floci.services.ses.model.SuppressedDestination;
 import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
 import io.github.hectorvent.floci.services.ses.model.Tag;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -43,16 +42,11 @@ import org.jboss.logging.Logger;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HexFormat;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -61,20 +55,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class SesService {
 
     private static final Logger LOG = Logger.getLogger(SesService.class);
 
-    private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\{\\{\\s*([\\w-]+)\\s*\\}\\}");
-
     private static final int MAX_BULK_DESTINATIONS = 50;
     private static final int MAX_RECIPIENTS_PER_DESTINATION = 50;
-    private static final SecureRandom BOUNDARY_RANDOM = new SecureRandom();
-
     // Identities extracted to SesIdentityService (CRUD, verification, MAIL FROM, notifications,
     // tags, and the DKIM state machine with its Route53 lookup). The facade keeps the cross-domain
     // flows and send-path reads, reaching the store through its find/save.
@@ -110,7 +98,6 @@ public class SesService {
     // Tenants (multi-tenancy) live in SesTenantService. The facade delegates.
     private final SesTenantService tenantService;
     private final SmtpRelay smtpRelay;
-    private final ObjectMapper objectMapper;
     private final SesEventPublisher eventPublisher;
     private final String defaultAccountId;
     // Base URL used to build functional list-management unsubscribe links (the {{amazonSESUnsubscribeUrl}}
@@ -127,7 +114,7 @@ public class SesService {
                        SesSuppressionService suppressionService, SesDedicatedIpService dedicatedIpService,
                        SesTemplateService templateService, SesSentEmailService sentEmailService,
                        SesTenantService tenantService, SesConfigurationSetService configSetService,
-                       SmtpRelay smtpRelay, ObjectMapper objectMapper,
+                       SmtpRelay smtpRelay,
                        SesEventPublisher eventPublisher, EmulatorConfig config,
                        RegionResolver regionResolver) {
         this.identityService = identityService;
@@ -143,7 +130,6 @@ public class SesService {
         this.cvetService = cvetService;
         this.tenantService = tenantService;
         this.smtpRelay = smtpRelay;
-        this.objectMapper = objectMapper;
         this.eventPublisher = eventPublisher;
         this.defaultAccountId = config.defaultAccountId();
         this.baseUrl = config.effectiveBaseUrl();
@@ -162,8 +148,7 @@ public class SesService {
                SesReceiptRuleService receiptRuleService,
                SesCvetService cvetService,
                SesTenantService tenantService,
-               SmtpRelay smtpRelay,
-               ObjectMapper objectMapper) {
+               SmtpRelay smtpRelay) {
         this.identityService = identityService;
         this.sentEmailService = sentEmailService;
         this.accountService = accountService;
@@ -177,7 +162,6 @@ public class SesService {
         this.cvetService = cvetService;
         this.tenantService = tenantService;
         this.smtpRelay = smtpRelay;
-        this.objectMapper = objectMapper;
         this.eventPublisher = null;
         this.defaultAccountId = "000000000000";
         this.baseUrl = "http://localhost:4566";
@@ -2008,84 +1992,7 @@ public class SesService {
     }
 
     public String renderTestTemplate(String templateName, String templateDataRaw, String region) {
-        EmailTemplate template = getTemplate(templateName, region);
-        JsonNode templateData = parseRenderingData(objectMapper, templateDataRaw);
-        String subject = applyTemplateData(template.getSubject(), templateData);
-        String text = applyTemplateData(template.getTextPart(), templateData);
-        String html = applyTemplateData(template.getHtmlPart(), templateData);
-        return buildTestRenderMime(subject, text, html, ZonedDateTime.now(ZoneOffset.UTC), nextBoundary());
-    }
-
-    static JsonNode parseRenderingData(ObjectMapper mapper, String raw) {
-        if (raw == null || raw.isBlank()) {
-            throw new AwsException("InvalidRenderingParameter",
-                    "Template rendering data is required.", 400);
-        }
-        JsonNode node;
-        try {
-            node = mapper.readTree(raw);
-        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
-            throw new AwsException("InvalidRenderingParameter",
-                    "Template rendering data is invalid: " + e.getOriginalMessage(), 400);
-        }
-        if (!node.isObject()) {
-            throw new AwsException("InvalidRenderingParameter",
-                    "Template rendering data must be a JSON object.", 400);
-        }
-        return node;
-    }
-
-    static String buildTestRenderMime(String subject, String text, String html,
-                                       ZonedDateTime date, String boundary) {
-        String safeSubject = sanitizeSubject(subject);
-        String safeText = text == null ? "" : text;
-        String safeHtml = html == null ? "" : html;
-        String dateHeader = DateTimeFormatter.RFC_1123_DATE_TIME.format(date);
-        StringBuilder out = new StringBuilder();
-        out.append("Date: ").append(dateHeader).append("\r\n");
-        out.append("Subject: ").append(safeSubject).append("\r\n");
-        out.append("MIME-Version: 1.0\r\n");
-        out.append("Content-Type: multipart/alternative; boundary=\"").append(boundary).append("\"\r\n");
-        out.append("\r\n");
-        appendMimePart(out, boundary, "text/plain", safeText);
-        appendMimePart(out, boundary, "text/html", safeHtml);
-        out.append("--").append(boundary).append("--\r\n");
-        return out.toString();
-    }
-
-    private static void appendMimePart(StringBuilder out, String boundary, String mimeType, String body) {
-        out.append("--").append(boundary).append("\r\n");
-        out.append("Content-Type: ").append(mimeType).append("; charset=UTF-8\r\n");
-        out.append("Content-Transfer-Encoding: ").append(pickTransferEncoding(body)).append("\r\n");
-        out.append("\r\n");
-        String normalized = normalizeToCrlf(body);
-        out.append(normalized);
-        if (!normalized.endsWith("\r\n")) {
-            out.append("\r\n");
-        }
-    }
-
-    static String normalizeToCrlf(String body) {
-        return body.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n");
-    }
-
-    static String pickTransferEncoding(String body) {
-        return body.codePoints().allMatch(c -> c < 128) ? "7bit" : "8bit";
-    }
-
-    static String sanitizeSubject(String subject) {
-        if (subject == null) {
-            return "";
-        }
-        // Strip C0 control characters (U+0000-U+001F) and DEL (U+007F): RFC 5322
-        // forbids them in unstructured header field bodies. Replace with spaces so
-        // visible content is preserved when template data accidentally injects them.
-        StringBuilder out = new StringBuilder(subject.length());
-        for (int i = 0; i < subject.length(); i++) {
-            char c = subject.charAt(i);
-            out.append((c < 0x20 || c == 0x7F) ? ' ' : c);
-        }
-        return out.toString();
+        return templateService.renderTestTemplate(templateName, templateDataRaw, region);
     }
 
     static String stripXml10InvalidChars(String s) {
@@ -2114,12 +2021,6 @@ public class SesService {
                 || (cp >= 0x10000 && cp <= 0x10FFFF);
     }
 
-    private static String nextBoundary() {
-        byte[] bytes = new byte[6];
-        BOUNDARY_RANDOM.nextBytes(bytes);
-        return "===_floci_" + HexFormat.of().formatHex(bytes) + "_===";
-    }
-
     /**
      * Also called by the controller ahead of the tenant send gate: AWS reports an empty inline
      * template before it looks the tenant up (probe-confirmed), so the check must not stay behind
@@ -2144,9 +2045,9 @@ public class SesService {
                                             ListManagementOptions listManagement, String region) {
         requireInlineTemplateContent(subject, textPart, htmlPart);
         return sendEmail(source, toAddresses, ccAddresses, bccAddresses, replyToAddresses,
-                applyTemplateData(subject, templateData),
-                applyTemplateData(textPart, templateData),
-                applyTemplateData(htmlPart, templateData),
+                SesTemplateService.applyTemplateData(subject, templateData),
+                SesTemplateService.applyTemplateData(textPart, templateData),
+                SesTemplateService.applyTemplateData(htmlPart, templateData),
                 configurationSetName, emailTags, additionalHeaders, listManagement, region);
     }
 
@@ -2195,9 +2096,9 @@ public class SesService {
                 String messageId = sendEmail(source,
                         entry.toAddresses(), entry.ccAddresses(), entry.bccAddresses(),
                         replyToAddresses,
-                        applyTemplateData(subject, merged),
-                        applyTemplateData(textPart, merged),
-                        applyTemplateData(htmlPart, merged),
+                        SesTemplateService.applyTemplateData(subject, merged),
+                        SesTemplateService.applyTemplateData(textPart, merged),
+                        SesTemplateService.applyTemplateData(htmlPart, merged),
                         configurationSetName, mergedTags, mergedHeaders, null, region);
                 results.add(BulkEmailEntryResult.success(messageId));
             } catch (AwsException e) {
@@ -2295,33 +2196,6 @@ public class SesService {
         ObjectNode merged = ((ObjectNode) defaults).deepCopy();
         replacement.fields().forEachRemaining(e -> merged.set(e.getKey(), e.getValue()));
         return merged;
-    }
-
-    static String applyTemplateData(String text, JsonNode data) {
-        if (text == null || text.isEmpty()) {
-            return text;
-        }
-        Matcher matcher = TEMPLATE_VARIABLE.matcher(text);
-        StringBuilder out = new StringBuilder();
-        while (matcher.find()) {
-            String key = matcher.group(1);
-            if ("amazonSESUnsubscribeUrl".equals(key)) {
-                // Reserved list-management placeholder: leave it intact for post-render replacement
-                // in the send path, so a templated body can carry {{amazonSESUnsubscribeUrl}} without
-                // failing as a missing rendering attribute.
-                matcher.appendReplacement(out, Matcher.quoteReplacement(matcher.group(0)));
-                continue;
-            }
-            if (data == null || !data.hasNonNull(key)) {
-                throw new AwsException("MissingRenderingAttribute",
-                        "Attribute '" + key + "' is not present in the rendering data.", 400);
-            }
-            JsonNode value = data.get(key);
-            String replacement = value.isValueNode() ? value.asText() : value.toString();
-            matcher.appendReplacement(out, Matcher.quoteReplacement(replacement));
-        }
-        matcher.appendTail(out);
-        return out.toString();
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.ses;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -9,18 +11,30 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.security.SecureRandom;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Email templates (the {@code templateStore}), extracted from {@link SesService} as part of the
  * store-based domain split. Reached through the {@code SesService} facade, which delegates the CRUD
  * here; the facade's templated-send path reads templates back through {@link #getTemplate}, and its
  * ARN-dispatched tagging reads/writes through {@link #find} / {@link #save}.
+ *
+ * <p>Template rendering is domain logic too: {@code TestRenderTemplate} (data parsing, variable
+ * substitution, and the MIME assembly) lives here, and the facade's templated-send paths call the
+ * shared {@link #applyTemplateData}. The boundary MIME separator uses a constructor-passed
+ * {@link SecureRandom} (no static instance, so no native-image run-time-init registration).
  *
  * <p>Tag validation is a shared cross-resource concern, so {@code createTemplate} calls
  * {@link SesTags#validate} rather than depending back on the facade. The template ARN parser
@@ -32,16 +46,27 @@ public class SesTemplateService {
 
     private static final Logger LOG = Logger.getLogger(SesTemplateService.class);
 
+    private static final Pattern TEMPLATE_VARIABLE = Pattern.compile("\\{\\{\\s*([\\w-]+)\\s*\\}\\}");
+
     private final StorageBackend<String, EmailTemplate> templateStore;
+    private final ObjectMapper objectMapper;
+    private final SecureRandom boundaryRandom;
 
     @Inject
-    public SesTemplateService(StorageFactory storageFactory) {
-        this.templateStore = storageFactory.create("ses", "ses-templates.json",
-                new TypeReference<Map<String, EmailTemplate>>() {});
+    public SesTemplateService(StorageFactory storageFactory, ObjectMapper objectMapper) {
+        this(storageFactory.create("ses", "ses-templates.json",
+                new TypeReference<Map<String, EmailTemplate>>() {}), objectMapper, new SecureRandom());
     }
 
     SesTemplateService(StorageBackend<String, EmailTemplate> templateStore) {
+        this(templateStore, new ObjectMapper(), new SecureRandom());
+    }
+
+    SesTemplateService(StorageBackend<String, EmailTemplate> templateStore,
+                       ObjectMapper objectMapper, SecureRandom boundaryRandom) {
         this.templateStore = templateStore;
+        this.objectMapper = objectMapper;
+        this.boundaryRandom = boundaryRandom;
     }
 
     public EmailTemplate createTemplate(EmailTemplate template, String region) {
@@ -146,5 +171,121 @@ public class SesTemplateService {
     private static String templateKey(String region, String templateName) {
         validateTemplateName(templateName);
         return "template::" + region + "::" + templateName;
+    }
+
+    // ──────────────────────── Rendering (TestRenderTemplate + send-path substitution) ────────────────────────
+
+    public String renderTestTemplate(String templateName, String templateDataRaw, String region) {
+        EmailTemplate template = getTemplate(templateName, region);
+        JsonNode templateData = parseRenderingData(objectMapper, templateDataRaw);
+        String subject = applyTemplateData(template.getSubject(), templateData);
+        String text = applyTemplateData(template.getTextPart(), templateData);
+        String html = applyTemplateData(template.getHtmlPart(), templateData);
+        return buildTestRenderMime(subject, text, html, ZonedDateTime.now(ZoneOffset.UTC), nextBoundary());
+    }
+
+    static JsonNode parseRenderingData(ObjectMapper mapper, String raw) {
+        if (raw == null || raw.isBlank()) {
+            throw new AwsException("InvalidRenderingParameter",
+                    "Template rendering data is required.", 400);
+        }
+        JsonNode node;
+        try {
+            node = mapper.readTree(raw);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            throw new AwsException("InvalidRenderingParameter",
+                    "Template rendering data is invalid: " + e.getOriginalMessage(), 400);
+        }
+        if (!node.isObject()) {
+            throw new AwsException("InvalidRenderingParameter",
+                    "Template rendering data must be a JSON object.", 400);
+        }
+        return node;
+    }
+
+    static String applyTemplateData(String text, JsonNode data) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        Matcher matcher = TEMPLATE_VARIABLE.matcher(text);
+        StringBuilder out = new StringBuilder();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            if ("amazonSESUnsubscribeUrl".equals(key)) {
+                // Reserved list-management placeholder: leave it intact for post-render replacement
+                // in the send path, so a templated body can carry {{amazonSESUnsubscribeUrl}} without
+                // failing as a missing rendering attribute.
+                matcher.appendReplacement(out, Matcher.quoteReplacement(matcher.group(0)));
+                continue;
+            }
+            if (data == null || !data.hasNonNull(key)) {
+                throw new AwsException("MissingRenderingAttribute",
+                        "Attribute '" + key + "' is not present in the rendering data.", 400);
+            }
+            JsonNode value = data.get(key);
+            String replacement = value.isValueNode() ? value.asText() : value.toString();
+            matcher.appendReplacement(out, Matcher.quoteReplacement(replacement));
+        }
+        matcher.appendTail(out);
+        return out.toString();
+    }
+
+    static String buildTestRenderMime(String subject, String text, String html,
+                                       ZonedDateTime date, String boundary) {
+        String safeSubject = sanitizeSubject(subject);
+        String safeText = text == null ? "" : text;
+        String safeHtml = html == null ? "" : html;
+        String dateHeader = DateTimeFormatter.RFC_1123_DATE_TIME.format(date);
+        StringBuilder out = new StringBuilder();
+        out.append("Date: ").append(dateHeader).append("\r\n");
+        out.append("Subject: ").append(safeSubject).append("\r\n");
+        out.append("MIME-Version: 1.0\r\n");
+        out.append("Content-Type: multipart/alternative; boundary=\"").append(boundary).append("\"\r\n");
+        out.append("\r\n");
+        appendMimePart(out, boundary, "text/plain", safeText);
+        appendMimePart(out, boundary, "text/html", safeHtml);
+        out.append("--").append(boundary).append("--\r\n");
+        return out.toString();
+    }
+
+    private static void appendMimePart(StringBuilder out, String boundary, String mimeType, String body) {
+        out.append("--").append(boundary).append("\r\n");
+        out.append("Content-Type: ").append(mimeType).append("; charset=UTF-8\r\n");
+        out.append("Content-Transfer-Encoding: ").append(pickTransferEncoding(body)).append("\r\n");
+        out.append("\r\n");
+        String normalized = normalizeToCrlf(body);
+        out.append(normalized);
+        if (!normalized.endsWith("\r\n")) {
+            out.append("\r\n");
+        }
+    }
+
+    static String normalizeToCrlf(String body) {
+        return body.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\r\n");
+    }
+
+    static String pickTransferEncoding(String body) {
+        return body.codePoints().allMatch(c -> c < 128) ? "7bit" : "8bit";
+    }
+
+    static String sanitizeSubject(String subject) {
+        if (subject == null) {
+            return "";
+        }
+        // Strip C0 control characters (U+0000-U+001F) and DEL (U+007F): RFC 5322
+        // forbids them in unstructured header field bodies. Replace with spaces so
+        // visible content is preserved when template data accidentally injects them.
+        StringBuilder out = new StringBuilder(subject.length());
+        for (int i = 0; i < subject.length(); i++) {
+            char c = subject.charAt(i);
+            out.append((c < 0x20 || c == 0x7F) ? ' ' : c);
+        }
+        return out.toString();
+    }
+
+    private String nextBoundary() {
+        byte[] bytes = new byte[6];
+        boundaryRandom.nextBytes(bytes);
+        return "===_floci_" + HexFormat.of().formatHex(bytes) + "_===";
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
@@ -58,10 +58,6 @@ public class SesTemplateService {
                 new TypeReference<Map<String, EmailTemplate>>() {}), objectMapper, new SecureRandom());
     }
 
-    SesTemplateService(StorageBackend<String, EmailTemplate> templateStore) {
-        this(templateStore, new ObjectMapper(), new SecureRandom());
-    }
-
     SesTemplateService(StorageBackend<String, EmailTemplate> templateStore,
                        ObjectMapper objectMapper, SecureRandom boundaryRandom) {
         this.templateStore = templateStore;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,7 +77,6 @@ quarkus:
       - --initialize-at-run-time=io.github.hectorvent.floci.services.acm.CertificateGenerator
       - --initialize-at-run-time=io.github.hectorvent.floci.config.TlsConfigSource
       - --initialize-at-run-time=io.github.hectorvent.floci.services.cognito.CognitoSrpHelper
-      - --initialize-at-run-time=io.github.hectorvent.floci.services.ses.SesService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.route53.Route53Service
       - --initialize-at-run-time=io.github.hectorvent.floci.services.kms.KmsService
       - --initialize-at-run-time=io.github.hectorvent.floci.services.cloudfront.CloudFrontService

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceListManagementTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceListManagementTest.java
@@ -238,7 +238,7 @@ class SesServiceListManagementTest {
 
     @Test
     void applyTemplateData_leavesUnsubscribePlaceholderIntact() {
-        String rendered = SesService.applyTemplateData("<p>{{amazonSESUnsubscribeUrl}} {{name}}</p>",
+        String rendered = SesTemplateService.applyTemplateData("<p>{{amazonSESUnsubscribeUrl}} {{name}}</p>",
                 new ObjectMapper().createObjectNode().put("name", "Bob"));
         assertEquals("<p>{{amazonSESUnsubscribeUrl}} Bob</p>", rendered);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
@@ -30,28 +30,28 @@ class SesServiceTemplateTest {
     void undefinedVariable_throwsMissingRenderingAttribute() {
         JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.applyTemplateData("Hello {{name}}, team {{team}}", data));
+                () -> SesTemplateService.applyTemplateData("Hello {{name}}, team {{team}}", data));
         assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
     void spacedVariable_matchesCorrectly() {
         JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
-        String result = SesService.applyTemplateData("Hello {{ name }}", data);
+        String result = SesTemplateService.applyTemplateData("Hello {{ name }}", data);
         assertEquals("Hello Alice", result);
     }
 
     @Test
     void hyphenatedVariableName() {
         JsonNode data = MAPPER.createObjectNode().put("first-name", "Alice");
-        String result = SesService.applyTemplateData("Hello {{first-name}}", data);
+        String result = SesTemplateService.applyTemplateData("Hello {{first-name}}", data);
         assertEquals("Hello Alice", result);
     }
 
     @Test
     void unclosedBraces_leftAsIs() {
         JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
-        String result = SesService.applyTemplateData("Hello {{name}} and {{foo", data);
+        String result = SesTemplateService.applyTemplateData("Hello {{name}} and {{foo", data);
         assertEquals("Hello Alice and {{foo", result);
     }
 
@@ -62,80 +62,80 @@ class SesServiceTemplateTest {
         data.put("active", true);
         data.set("nested", MAPPER.readTree("{\"key\":\"val\"}"));
 
-        assertEquals("Items: 42", SesService.applyTemplateData("Items: {{count}}", data));
-        assertEquals("Active: true", SesService.applyTemplateData("Active: {{active}}", data));
-        assertEquals("Data: {\"key\":\"val\"}", SesService.applyTemplateData("Data: {{nested}}", data));
+        assertEquals("Items: 42", SesTemplateService.applyTemplateData("Items: {{count}}", data));
+        assertEquals("Active: true", SesTemplateService.applyTemplateData("Active: {{active}}", data));
+        assertEquals("Data: {\"key\":\"val\"}", SesTemplateService.applyTemplateData("Data: {{nested}}", data));
     }
 
     @Test
     void emptyTemplateData_throwsMissingRenderingAttribute() {
         JsonNode data = MAPPER.createObjectNode();
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.applyTemplateData("Hello {{name}}, {{team}}", data));
+                () -> SesTemplateService.applyTemplateData("Hello {{name}}, {{team}}", data));
         assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
     void nullTemplateData_throwsMissingRenderingAttribute() {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.applyTemplateData("Hello {{name}}", null));
+                () -> SesTemplateService.applyTemplateData("Hello {{name}}", null));
         assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
     void nullText_returnsNull() {
-        assertNull(SesService.applyTemplateData(null, MAPPER.createObjectNode()));
+        assertNull(SesTemplateService.applyTemplateData(null, MAPPER.createObjectNode()));
     }
 
     @Test
     void emptyText_returnsEmpty() {
-        assertEquals("", SesService.applyTemplateData("", MAPPER.createObjectNode()));
+        assertEquals("", SesTemplateService.applyTemplateData("", MAPPER.createObjectNode()));
     }
 
     @Test
     void noVariables_textUnchanged() {
         JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
-        assertEquals("Hello world", SesService.applyTemplateData("Hello world", data));
+        assertEquals("Hello world", SesTemplateService.applyTemplateData("Hello world", data));
     }
 
     @Test
     void duplicateVariables_allReplaced() {
         JsonNode data = MAPPER.createObjectNode().put("name", "Alice");
-        String result = SesService.applyTemplateData("{{name}} and {{name}}", data);
+        String result = SesTemplateService.applyTemplateData("{{name}} and {{name}}", data);
         assertEquals("Alice and Alice", result);
     }
 
     @Test
     void replacementWithRegexMetacharacters() {
         JsonNode data = MAPPER.createObjectNode().put("val", "price is $100 (50% off)");
-        String result = SesService.applyTemplateData("The {{val}}", data);
+        String result = SesTemplateService.applyTemplateData("The {{val}}", data);
         assertEquals("The price is $100 (50% off)", result);
     }
 
     @Test
     void variableNameCaseSensitive_matchesExact() {
         JsonNode data = MAPPER.createObjectNode().put("Name", "Alice");
-        assertEquals("Hello Alice", SesService.applyTemplateData("Hello {{Name}}", data));
+        assertEquals("Hello Alice", SesTemplateService.applyTemplateData("Hello {{Name}}", data));
     }
 
     @Test
     void variableNameCaseSensitive_throwsForCaseMismatch() {
         JsonNode data = MAPPER.createObjectNode().put("Name", "Alice");
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.applyTemplateData("Hello {{name}}", data));
+                () -> SesTemplateService.applyTemplateData("Hello {{name}}", data));
         assertEquals("MissingRenderingAttribute", ex.getErrorCode());
     }
 
     @Test
     void emptyStringValue() {
         JsonNode data = MAPPER.createObjectNode().put("name", "");
-        assertEquals("Hello ", SesService.applyTemplateData("Hello {{name}}", data));
+        assertEquals("Hello ", SesTemplateService.applyTemplateData("Hello {{name}}", data));
     }
 
     @Test
     void buildTestRenderMime_asciiBody_uses7bit() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime("Hello", "Hi there", "<p>Hi</p>", date, "BOUND");
+        String mime = SesTemplateService.buildTestRenderMime("Hello", "Hi there", "<p>Hi</p>", date, "BOUND");
         assertTrue(mime.contains("Subject: Hello\r\n"));
         assertTrue(mime.contains("Content-Type: multipart/alternative; boundary=\"BOUND\""));
         assertTrue(mime.contains("Content-Transfer-Encoding: 7bit"));
@@ -146,7 +146,7 @@ class SesServiceTemplateTest {
     @Test
     void buildTestRenderMime_utf8Body_uses8bit() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime("件名", "こんにちは", "<p>こんにちは</p>", date, "BOUND");
+        String mime = SesTemplateService.buildTestRenderMime("件名", "こんにちは", "<p>こんにちは</p>", date, "BOUND");
         assertTrue(mime.contains("Subject: 件名\r\n"));
         assertTrue(mime.contains("Content-Transfer-Encoding: 8bit"));
         assertTrue(mime.contains("こんにちは"));
@@ -155,7 +155,7 @@ class SesServiceTemplateTest {
     @Test
     void buildTestRenderMime_subjectStripsCRLF() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime("Multi\r\nLine", "x", "x", date, "BOUND");
+        String mime = SesTemplateService.buildTestRenderMime("Multi\r\nLine", "x", "x", date, "BOUND");
         // CR and LF are both C0 controls and are replaced with spaces.
         assertTrue(mime.contains("Subject: Multi  Line\r\n"));
     }
@@ -163,7 +163,7 @@ class SesServiceTemplateTest {
     @ParameterizedTest(name = "{0} -> {1}")
     @MethodSource("pickTransferEncodingCases")
     void pickTransferEncoding_returnsExpected(String body, String expected) {
-        assertEquals(expected, SesService.pickTransferEncoding(body));
+        assertEquals(expected, SesTemplateService.pickTransferEncoding(body));
     }
 
     static Stream<Arguments> pickTransferEncodingCases() {
@@ -179,7 +179,7 @@ class SesServiceTemplateTest {
     @MethodSource("parseRenderingDataInvalidCases")
     void parseRenderingData_invalid_throwsInvalidRenderingParameter(String label, String raw) {
         AwsException ex = assertThrows(AwsException.class,
-                () -> SesService.parseRenderingData(MAPPER, raw));
+                () -> SesTemplateService.parseRenderingData(MAPPER, raw));
         assertEquals("InvalidRenderingParameter", ex.getErrorCode());
     }
 
@@ -195,13 +195,13 @@ class SesServiceTemplateTest {
 
     @Test
     void parseRenderingData_emptyObject_accepted() {
-        assertTrue(SesService.parseRenderingData(MAPPER, "{}").isObject());
+        assertTrue(SesTemplateService.parseRenderingData(MAPPER, "{}").isObject());
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("normalizeToCrlfCases")
     void normalizeToCrlf_normalizesAllVariants(String label, String input, String expected) {
-        assertEquals(expected, SesService.normalizeToCrlf(input));
+        assertEquals(expected, SesTemplateService.normalizeToCrlf(input));
     }
 
     static Stream<Arguments> normalizeToCrlfCases() {
@@ -216,7 +216,7 @@ class SesServiceTemplateTest {
     @Test
     void buildTestRenderMime_bodyWithBareLf_normalizedToCrlf() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime("S", "line1\nline2", "<p>x\ny</p>", date, "BOUND");
+        String mime = SesTemplateService.buildTestRenderMime("S", "line1\nline2", "<p>x\ny</p>", date, "BOUND");
         assertTrue(mime.contains("line1\r\nline2"));
         assertTrue(mime.contains("x\r\ny"));
         assertFalse(mime.contains("line1\nline2"));
@@ -225,7 +225,7 @@ class SesServiceTemplateTest {
     @Test
     void buildTestRenderMime_bodyEndingWithNewline_noExtraBlankLine() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime("S", "hello\n", "<p>hi</p>\n", date, "BOUND");
+        String mime = SesTemplateService.buildTestRenderMime("S", "hello\n", "<p>hi</p>\n", date, "BOUND");
         assertFalse(mime.contains("hello\r\n\r\n--BOUND"));
         assertTrue(mime.contains("hello\r\n--BOUND"));
         assertFalse(mime.contains("</p>\r\n\r\n--BOUND"));
@@ -235,7 +235,7 @@ class SesServiceTemplateTest {
     @Test
     void buildTestRenderMime_bodyWithoutTrailingNewline_addsCrlfBeforeBoundary() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime("S", "hello", "<p>hi</p>", date, "BOUND");
+        String mime = SesTemplateService.buildTestRenderMime("S", "hello", "<p>hi</p>", date, "BOUND");
         assertTrue(mime.contains("hello\r\n--BOUND"));
         assertTrue(mime.contains("</p>\r\n--BOUND"));
     }
@@ -257,13 +257,13 @@ class SesServiceTemplateTest {
 
     @Test
     void sanitizeSubject_nullReturnsEmpty() {
-        assertEquals("", SesService.sanitizeSubject(null));
+        assertEquals("", SesTemplateService.sanitizeSubject(null));
     }
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("sanitizeSubjectCases")
     void sanitizeSubject_returnsExpected(String label, String input, String expected) {
-        assertEquals(expected, SesService.sanitizeSubject(input));
+        assertEquals(expected, SesTemplateService.sanitizeSubject(input));
     }
 
     static Stream<Arguments> sanitizeSubjectCases() {
@@ -304,7 +304,7 @@ class SesServiceTemplateTest {
     @Test
     void buildTestRenderMime_subjectWithControlChars_replacedWithSpace() {
         java.time.ZonedDateTime date = java.time.ZonedDateTime.parse("2026-05-02T12:00:00Z");
-        String mime = SesService.buildTestRenderMime(
+        String mime = SesTemplateService.buildTestRenderMime(
                 "Hello\u0001World", "x", "x", date, "BOUND");
         assertTrue(mime.contains("Subject: Hello World\r\n"));
         assertFalse(mime.contains("\u0001"));

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTestBuilder.java
@@ -119,7 +119,7 @@ final class SesServiceTestBuilder {
                 new SesIdentityService(identityStore, route53Service, clock),
                 new SesSentEmailService(emailStore),
                 new SesAccountService(accountSettingsStore, accountVdmStore, accountDetailsStore),
-                new SesTemplateService(templateStore),
+                new SesTemplateService(templateStore, objectMapper, new SecureRandom()),
                 new SesConfigurationSetService(configSetStore),
                 new SesSuppressionService(suppressionStore, accountSuppressionStore, new InMemoryStorage<>()),
                 new SesDedicatedIpService(dedicatedIpPoolStore),
@@ -128,7 +128,6 @@ final class SesServiceTestBuilder {
                 new SesReceiptRuleService(receiptRuleStore, clock),
                 new SesCvetService(cvetStore),
                 new SesTenantService(tenantStore, tenantAssociationStore, clock, new SecureRandom()),
-                smtpRelay,
-                objectMapper);
+                smtpRelay);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateServiceTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ses;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
@@ -7,6 +8,7 @@ import io.github.hectorvent.floci.services.ses.model.Tag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.security.SecureRandom;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -26,7 +28,7 @@ class SesTemplateServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new SesTemplateService(new InMemoryStorage<>());
+        service = new SesTemplateService(new InMemoryStorage<>(), new ObjectMapper(), new SecureRandom());
     }
 
     private static EmailTemplate template(String name) {


### PR DESCRIPTION
## Summary

Follow-up to #2356: with the store split complete (#2881, #2984), this moves the remaining
template-domain logic out of the `SesService` facade into `SesTemplateService`: `TestRenderTemplate`
(data parsing, variable substitution, and the MIME assembly with its helpers), plus the
`applyTemplateData` substitution shared with the templated-send paths, which the facade now calls
on the service. The service takes `ObjectMapper` and a constructor-passed `SecureRandom` (for the
MIME boundary) as dependencies.

Two facade-side cleanups fall out of this: the `objectMapper` field and constructor parameter are
removed (rendering was its only remaining use), and the static `BOUNDARY_RANDOM` disappears, so the
`--initialize-at-run-time` entry for `SesService` in `application.yml` is removed as well (the
constructor-passed instance needs no native-image registration; the guard test confirms).

No behavior change: request/response shapes, error messages, and rendering semantics are untouched.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Pure code motion behind the facade; no wire-visible change. The full SES test suite (1037 tests)
plus the native-image runtime-initialization guard passes unchanged, pinning the existing rendering
behavior (variable substitution edge cases, MIME structure, transfer-encoding selection, and the
`InvalidRenderingParameter` / `MissingRenderingAttribute` wordings).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (not applicable: behavior-preserving refactor; the existing rendering unit tests now target the moved statics directly)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
