### PR TITLE
fix(dynamodb): apply GSI throughput updates

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1334,6 +1334,10 @@ public class DynamoDbJsonHandler {
             TableDefinition currentTable = dynamoDbService.describeTable(tableName, region);
             for (JsonNode updateNode : gsiUpdatesToApply) {
                 String indexName = updateNode.path("IndexName").asText();
+                if (gsiDeletes.contains(indexName)) {
+                    throw new AwsException("ValidationException",
+                            "Cannot delete and update the same index: " + indexName, 400);
+                }
                 if (currentTable.findGsi(indexName).isEmpty()) {
                     throw new AwsException("ValidationException",
                             "The table does not have the specified index: " + indexName, 400);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1282,6 +1282,7 @@ public class DynamoDbJsonHandler {
 
         List<GlobalSecondaryIndex> gsiCreates = new ArrayList<>();
         List<String> gsiDeletes = new ArrayList<>();
+        List<JsonNode> gsiUpdatesToApply = new ArrayList<>();
         JsonNode gsiUpdates = request.path("GlobalSecondaryIndexUpdates");
         if (!gsiUpdates.isMissingNode() && gsiUpdates.isArray()) {
             for (JsonNode update : gsiUpdates) {
@@ -1322,6 +1323,21 @@ public class DynamoDbJsonHandler {
                 if (!deleteNode.isMissingNode()) {
                     gsiDeletes.add(deleteNode.path("IndexName").asText());
                 }
+                JsonNode updateNode = update.path("Update");
+                if (updateNode.isObject()) {
+                    gsiUpdatesToApply.add(updateNode);
+                }
+            }
+        }
+
+        if (!gsiUpdatesToApply.isEmpty()) {
+            TableDefinition currentTable = dynamoDbService.describeTable(tableName, region);
+            for (JsonNode updateNode : gsiUpdatesToApply) {
+                String indexName = updateNode.path("IndexName").asText();
+                if (currentTable.findGsi(indexName).isEmpty()) {
+                    throw new AwsException("ValidationException",
+                            "The table does not have the specified index: " + indexName, 400);
+                }
             }
         }
 
@@ -1342,6 +1358,28 @@ public class DynamoDbJsonHandler {
 
         TableDefinition table = dynamoDbService.updateTable(tableName, readCapacity, writeCapacity,
                 gsiCreates, gsiDeletes, newAttrDefs, region);
+
+        for (JsonNode updateNode : gsiUpdatesToApply) {
+            GlobalSecondaryIndex gsi = table.findGsi(updateNode.path("IndexName").asText()).orElseThrow();
+            JsonNode gsiPt = updateNode.path("ProvisionedThroughput");
+            if (gsiPt.isObject()) {
+                if (gsiPt.has("ReadCapacityUnits")) {
+                    gsi.getProvisionedThroughput().setReadCapacityUnits(gsiPt.get("ReadCapacityUnits").asLong());
+                }
+                if (gsiPt.has("WriteCapacityUnits")) {
+                    gsi.getProvisionedThroughput().setWriteCapacityUnits(gsiPt.get("WriteCapacityUnits").asLong());
+                }
+            }
+            JsonNode gsiOnDemand = updateNode.path("OnDemandThroughput");
+            if (gsiOnDemand.isObject()) {
+                if (gsiOnDemand.has("MaxReadRequestUnits")) {
+                    gsi.setOnDemandMaxReadRequestUnits(gsiOnDemand.get("MaxReadRequestUnits").asInt());
+                }
+                if (gsiOnDemand.has("MaxWriteRequestUnits")) {
+                    gsi.setOnDemandMaxWriteRequestUnits(gsiOnDemand.get("MaxWriteRequestUnits").asInt());
+                }
+            }
+        }
 
         JsonNode deletionProtectionNode = request.path("DeletionProtectionEnabled");
         if (!deletionProtectionNode.isMissingNode()) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.dynamodb.model.AttributeDefinition;
+import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
 import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
 import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
 import jakarta.ws.rs.core.Response;
@@ -411,7 +412,7 @@ class DynamoDbJsonHandlerTest {
     // DescribeTable could not report it back; the Terraform provider then proposes replacing
     // the GSI on every plan even though nothing drifted.
     @Test
-    void createTableWithGsiOnDemandThroughputRoundTripsThroughDescribeTable() throws Exception {
+    void createAndUpdateTableWithGsiOnDemandThroughputRoundTripsThroughDescribeTable() throws Exception {
         ObjectNode createRequest = mapper.createObjectNode();
         createRequest.put("TableName", "gsi-odt-table");
         createRequest.put("BillingMode", "PAY_PER_REQUEST");
@@ -464,5 +465,70 @@ class DynamoDbJsonHandlerTest {
         JsonNode odt = describedGsi.get("OnDemandThroughput");
         assertEquals(1, odt.get("MaxReadRequestUnits").asInt());
         assertEquals(1, odt.get("MaxWriteRequestUnits").asInt());
+
+        ObjectNode updateAction = mapper.createObjectNode();
+        updateAction.put("IndexName", "TitleIndex");
+        updateAction.set("OnDemandThroughput", mapper.createObjectNode()
+                .put("MaxReadRequestUnits", 20)
+                .put("MaxWriteRequestUnits", 30));
+        ObjectNode updateRequest = mapper.createObjectNode();
+        updateRequest.put("TableName", "gsi-odt-table");
+        updateRequest.set("GlobalSecondaryIndexUpdates", mapper.createArrayNode().add(
+                mapper.createObjectNode().set("Update", updateAction)));
+
+        Response updateResponse = handler.handle("UpdateTable", updateRequest, "eu-west-1");
+        assertEquals(200, updateResponse.getStatus());
+        JsonNode updateBody = mapper.convertValue(updateResponse.getEntity(), JsonNode.class);
+        JsonNode updatedGsi = updateBody.get("TableDescription").get("GlobalSecondaryIndexes").get(0);
+        assertEquals(20, updatedGsi.get("OnDemandThroughput").get("MaxReadRequestUnits").asInt());
+        assertEquals(30, updatedGsi.get("OnDemandThroughput").get("MaxWriteRequestUnits").asInt());
+
+        describeResponse = handler.handle("DescribeTable", describeRequest, "eu-west-1");
+        describeBody = mapper.convertValue(describeResponse.getEntity(), JsonNode.class);
+        describedGsi = describeBody.get("Table").get("GlobalSecondaryIndexes").get(0);
+        assertEquals(20, describedGsi.get("OnDemandThroughput").get("MaxReadRequestUnits").asInt());
+        assertEquals(30, describedGsi.get("OnDemandThroughput").get("MaxWriteRequestUnits").asInt());
+    }
+
+    @Test
+    void updateTableChangesGsiProvisionedThroughput() throws Exception {
+        GlobalSecondaryIndex gsi = new GlobalSecondaryIndex(
+                "TitleIndex",
+                List.of(new KeySchemaElement("title", "HASH")),
+                null, "ALL", null);
+        gsi.getProvisionedThroughput().setReadCapacityUnits(5);
+        gsi.getProvisionedThroughput().setWriteCapacityUnits(5);
+        service.createTable(
+                "gsi-provisioned-table",
+                List.of(new KeySchemaElement("id", "HASH")),
+                List.of(
+                        new AttributeDefinition("id", "S"),
+                        new AttributeDefinition("title", "S")),
+                5L, 5L, List.of(gsi), "eu-west-1");
+
+        ObjectNode updateAction = mapper.createObjectNode();
+        updateAction.put("IndexName", "TitleIndex");
+        updateAction.set("ProvisionedThroughput", mapper.createObjectNode()
+                .put("ReadCapacityUnits", 20)
+                .put("WriteCapacityUnits", 30));
+        ObjectNode updateRequest = mapper.createObjectNode();
+        updateRequest.put("TableName", "gsi-provisioned-table");
+        updateRequest.set("GlobalSecondaryIndexUpdates", mapper.createArrayNode().add(
+                mapper.createObjectNode().set("Update", updateAction)));
+
+        Response updateResponse = handler.handle("UpdateTable", updateRequest, "eu-west-1");
+        assertEquals(200, updateResponse.getStatus());
+        JsonNode updateBody = mapper.convertValue(updateResponse.getEntity(), JsonNode.class);
+        JsonNode updatedGsi = updateBody.get("TableDescription").get("GlobalSecondaryIndexes").get(0);
+        assertEquals(20, updatedGsi.get("ProvisionedThroughput").get("ReadCapacityUnits").asInt());
+        assertEquals(30, updatedGsi.get("ProvisionedThroughput").get("WriteCapacityUnits").asInt());
+
+        ObjectNode describeRequest = mapper.createObjectNode();
+        describeRequest.put("TableName", "gsi-provisioned-table");
+        Response describeResponse = handler.handle("DescribeTable", describeRequest, "eu-west-1");
+        JsonNode describeBody = mapper.convertValue(describeResponse.getEntity(), JsonNode.class);
+        JsonNode describedGsi = describeBody.get("Table").get("GlobalSecondaryIndexes").get(0);
+        assertEquals(20, describedGsi.get("ProvisionedThroughput").get("ReadCapacityUnits").asInt());
+        assertEquals(30, describedGsi.get("ProvisionedThroughput").get("WriteCapacityUnits").asInt());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandlerTest.java
@@ -38,6 +38,22 @@ class DynamoDbJsonHandlerTest {
                 5L, 5L, region);
     }
 
+    private void createProvisionedTableWithGsi(String tableName, String region) {
+        GlobalSecondaryIndex gsi = new GlobalSecondaryIndex(
+                "TitleIndex",
+                List.of(new KeySchemaElement("title", "HASH")),
+                null, "ALL", null);
+        gsi.getProvisionedThroughput().setReadCapacityUnits(5);
+        gsi.getProvisionedThroughput().setWriteCapacityUnits(5);
+        service.createTable(
+                tableName,
+                List.of(new KeySchemaElement("id", "HASH")),
+                List.of(
+                        new AttributeDefinition("id", "S"),
+                        new AttributeDefinition("title", "S")),
+                5L, 5L, List.of(gsi), region);
+    }
+
     private ObjectNode attributeValue(String type, String value) {
         ObjectNode attrValue = mapper.createObjectNode();
         attrValue.put(type, value);
@@ -492,19 +508,7 @@ class DynamoDbJsonHandlerTest {
 
     @Test
     void updateTableChangesGsiProvisionedThroughput() throws Exception {
-        GlobalSecondaryIndex gsi = new GlobalSecondaryIndex(
-                "TitleIndex",
-                List.of(new KeySchemaElement("title", "HASH")),
-                null, "ALL", null);
-        gsi.getProvisionedThroughput().setReadCapacityUnits(5);
-        gsi.getProvisionedThroughput().setWriteCapacityUnits(5);
-        service.createTable(
-                "gsi-provisioned-table",
-                List.of(new KeySchemaElement("id", "HASH")),
-                List.of(
-                        new AttributeDefinition("id", "S"),
-                        new AttributeDefinition("title", "S")),
-                5L, 5L, List.of(gsi), "eu-west-1");
+        createProvisionedTableWithGsi("gsi-provisioned-table", "eu-west-1");
 
         ObjectNode updateAction = mapper.createObjectNode();
         updateAction.put("IndexName", "TitleIndex");
@@ -530,5 +534,34 @@ class DynamoDbJsonHandlerTest {
         JsonNode describedGsi = describeBody.get("Table").get("GlobalSecondaryIndexes").get(0);
         assertEquals(20, describedGsi.get("ProvisionedThroughput").get("ReadCapacityUnits").asInt());
         assertEquals(30, describedGsi.get("ProvisionedThroughput").get("WriteCapacityUnits").asInt());
+    }
+
+    @Test
+    void updateTableRejectsConflictingDeleteAndUpdateWithoutRemovingGsi() throws Exception {
+        createProvisionedTableWithGsi("gsi-conflicting-update-table", "eu-west-1");
+
+        ObjectNode updateRequest = mapper.createObjectNode();
+        updateRequest.put("TableName", "gsi-conflicting-update-table");
+        updateRequest.set("GlobalSecondaryIndexUpdates", mapper.createArrayNode()
+                .add(mapper.createObjectNode().set("Delete",
+                        mapper.createObjectNode().put("IndexName", "TitleIndex")))
+                .add(mapper.createObjectNode().set("Update", mapper.createObjectNode()
+                        .put("IndexName", "TitleIndex")
+                        .set("ProvisionedThroughput", mapper.createObjectNode()
+                                .put("ReadCapacityUnits", 20)
+                                .put("WriteCapacityUnits", 30)))));
+
+        RuntimeException error = assertThrows(RuntimeException.class,
+                () -> handler.handle("UpdateTable", updateRequest, "eu-west-1"));
+
+        ObjectNode describeRequest = mapper.createObjectNode();
+        describeRequest.put("TableName", "gsi-conflicting-update-table");
+        Response describeResponse = handler.handle("DescribeTable", describeRequest, "eu-west-1");
+        JsonNode describeBody = mapper.convertValue(describeResponse.getEntity(), JsonNode.class);
+        JsonNode describedIndexes = describeBody.get("Table").path("GlobalSecondaryIndexes");
+        assertAll(
+                () -> assertTrue(error instanceof AwsException awsError
+                        && "ValidationException".equals(awsError.getErrorCode())),
+                () -> assertEquals(1, describedIndexes.size()));
     }
 }


### PR DESCRIPTION
## Summary

- apply `GlobalSecondaryIndexUpdates[].Update` actions to the existing GSI
- support both provisioned capacity and on-demand throughput limits
- validate every target index before mutating the table, then reuse the existing persistence path

Fixes #3028.

## Root cause

The shared DynamoDB JSON handler parsed GSI `Create` and `Delete` actions but silently ignored `Update`, so `UpdateTable` returned success while later `DescribeTable` responses retained stale throughput values.

## Testing

- TDD red: on-demand regression expected `20` but observed `1`
- TDD red: provisioned regression expected `20` but observed `5`
- `DynamoDbJsonHandlerTest,DynamoDbServiceTest`: 149 passed
- `DynamoDb*Test`: 492 passed
- conflicting Delete+Update regression: rejects with `ValidationException`, preserves the GSI, and brings `DynamoDb*Test` to 493 passed
- full CI-equivalent suite: 15,394 run, 15,385 passed, 9 skipped, 0 failures/errors across 1,143 test classes
- `make docs-check`
- Java 25 clean test compilation and Quarkus package build
- boto3 smoke test: provisioned `20/30` and on-demand `40/50` round-tripped through both `UpdateTable` and `DescribeTable`

No documentation change is needed because this fixes existing `UpdateTable` behavior without adding an action or configuration surface.
