### PR TITLE
fix(cloudformation): keep unchanged VPCs and security groups on stack update

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -706,7 +706,8 @@ public class CloudFormationResourceProvisioner {
         // provision() re-runs for every resource on every update. Re-creating an unchanged group
         // would mint a new group id (and collide on the name whenever the VPC id is stable), so
         // reuse the group this resource already points at.
-        var sg = existingSecurityGroupToReconcile(r.getPhysicalId(), groupName, region);
+        var sg = existingSecurityGroupToReconcile(r.getPhysicalId(), groupName, description, vpcId, region);
+        boolean reused = sg != null;
         if (sg == null) {
             sg = ec2Service.createSecurityGroup(region, groupName, description, vpcId);
         }
@@ -720,13 +721,23 @@ public class CloudFormationResourceProvisioner {
         // Inline rule properties — previously dropped, leaving the group empty. The mapping is
         // shared with the standalone SecurityGroupIngress/Egress resource types, which live in
         // Ec2SecurityGroupRuleCfnProvisioner; this arm joins them when it is extracted.
+        // Authorize appends without a duplicate check, so re-running this on a reused group would
+        // stack another copy of every inline rule on each update. Clear the sets the template
+        // declares first, which also drops rules the template no longer lists. A set the template
+        // does not declare is left alone, so the group keeps its default egress.
         if (props != null && props.has("SecurityGroupIngress")) {
+            if (reused && !sg.getIpPermissions().isEmpty()) {
+                ec2Service.revokeSecurityGroupIngress(region, sg.getGroupId(), List.copyOf(sg.getIpPermissions()));
+            }
             for (JsonNode rule : props.get("SecurityGroupIngress")) {
                 ec2Service.authorizeSecurityGroupIngress(region, sg.getGroupId(),
                         List.of(Ec2SecurityGroupRuleCfnProvisioner.toIpPermission(rule, engine)));
             }
         }
         if (props != null && props.has("SecurityGroupEgress")) {
+            if (reused && !sg.getIpPermissionsEgress().isEmpty()) {
+                ec2Service.revokeSecurityGroupEgress(region, sg.getGroupId(), List.copyOf(sg.getIpPermissionsEgress()));
+            }
             for (JsonNode rule : props.get("SecurityGroupEgress")) {
                 ec2Service.authorizeSecurityGroupEgress(region, sg.getGroupId(),
                         List.of(Ec2SecurityGroupRuleCfnProvisioner.toIpPermission(rule, engine)));
@@ -1219,10 +1230,13 @@ public class CloudFormationResourceProvisioner {
      * left it unchanged. Unlike most resources the physical id here is the group <em>id</em>, not
      * the name, so the rename check compares the stored group's name against the template's.
      *
-     * <p>Returns {@code null} for a fresh create, a rename (a replacement on AWS), or a group
-     * deleted out of band - the caller then creates.
+     * <p>Returns {@code null} for a fresh create, a group deleted out of band, or any change AWS
+     * treats as a replacement: GroupName, GroupDescription and VpcId are all immutable on a
+     * security group, so a template that changes one wants a new group, not an edit to this one.
+     * The caller then creates.
      */
-    private SecurityGroup existingSecurityGroupToReconcile(String priorPhysicalId, String groupName, String region) {
+    private SecurityGroup existingSecurityGroupToReconcile(String priorPhysicalId, String groupName,
+                                                           String description, String vpcId, String region) {
         if (priorPhysicalId == null || priorPhysicalId.isBlank()) {
             return null;
         }
@@ -1230,6 +1244,9 @@ public class CloudFormationResourceProvisioner {
             return ec2Service.describeSecurityGroups(region, List.of(priorPhysicalId), List.of(), Map.of())
                     .stream()
                     .filter(existing -> groupName == null || groupName.equals(existing.getGroupName()))
+                    .filter(existing -> description == null || description.equals(existing.getDescription()))
+                    // A template that omits VpcId is not asking to move the group out of its VPC.
+                    .filter(existing -> vpcId == null || vpcId.equals(existing.getVpcId()))
                     .findFirst()
                     .orElse(null);
         } catch (AwsException notFound) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -41,6 +41,7 @@ import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.MetricAlarm;
+import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisStream;
@@ -702,7 +703,13 @@ public class CloudFormationResourceProvisioner {
             description = "Managed by CloudFormation";
         }
         String vpcId = resolveOptional(props, "VpcId", engine);
-        var sg = ec2Service.createSecurityGroup(region, groupName, description, vpcId);
+        // provision() re-runs for every resource on every update. Re-creating an unchanged group
+        // would mint a new group id (and collide on the name whenever the VPC id is stable), so
+        // reuse the group this resource already points at.
+        var sg = existingSecurityGroupToReconcile(r.getPhysicalId(), groupName, region);
+        if (sg == null) {
+            sg = ec2Service.createSecurityGroup(region, groupName, description, vpcId);
+        }
         // Ref on AWS::EC2::SecurityGroup returns the group id for VPC security groups.
         r.setPhysicalId(sg.getGroupId());
         r.getAttributes().put("GroupId", sg.getGroupId());
@@ -1205,6 +1212,32 @@ public class CloudFormationResourceProvisioner {
         }
         r.setPhysicalId(group.getDbClusterParameterGroupName());
         r.getAttributes().put("DBClusterParameterGroupName", group.getDbClusterParameterGroupName());
+    }
+
+    /**
+     * The security group this stack resource already points at, when an UpdateStack re-invocation
+     * left it unchanged. Unlike most resources the physical id here is the group <em>id</em>, not
+     * the name, so the rename check compares the stored group's name against the template's.
+     *
+     * <p>Returns {@code null} for a fresh create, a rename (a replacement on AWS), or a group
+     * deleted out of band - the caller then creates.
+     */
+    private SecurityGroup existingSecurityGroupToReconcile(String priorPhysicalId, String groupName, String region) {
+        if (priorPhysicalId == null || priorPhysicalId.isBlank()) {
+            return null;
+        }
+        try {
+            return ec2Service.describeSecurityGroups(region, List.of(priorPhysicalId), List.of(), Map.of())
+                    .stream()
+                    .filter(existing -> groupName == null || groupName.equals(existing.getGroupName()))
+                    .findFirst()
+                    .orElse(null);
+        } catch (AwsException notFound) {
+            // Expected when the group was deleted out of band since the prior update.
+            LOG.debugv(notFound, "No existing security group {0} found on file, falling back to create",
+                    priorPhysicalId);
+            return null;
+        }
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -50,6 +50,7 @@ import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
 import io.github.hectorvent.floci.services.kinesis.model.KinesisStream;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
+import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
 import io.github.hectorvent.floci.services.firehose.FirehoseService;
 import io.github.hectorvent.floci.services.firehose.model.DeliveryStreamDescription;
 import io.github.hectorvent.floci.services.rds.RdsService;
@@ -734,12 +735,13 @@ public class CloudFormationResourceProvisioner {
         // resources, and clearing them on an unrelated update would close ports another stack
         // resource is responsible for. Removing a rule the template no longer declares needs the
         // provisioner to record what it authorized; noted as a follow-up.
+        var peerGroupId = peerGroupIdResolver(region, sg.getVpcId());
         if (props != null && props.has("SecurityGroupIngress")) {
-            authorizeMissing(props.get("SecurityGroupIngress"), sg.getIpPermissions(), engine,
+            authorizeMissing(props.get("SecurityGroupIngress"), sg.getIpPermissions(), engine, peerGroupId,
                     perms -> ec2Service.authorizeSecurityGroupIngress(region, sg.getGroupId(), perms));
         }
         if (props != null && props.has("SecurityGroupEgress")) {
-            authorizeMissing(props.get("SecurityGroupEgress"), sg.getIpPermissionsEgress(), engine,
+            authorizeMissing(props.get("SecurityGroupEgress"), sg.getIpPermissionsEgress(), engine, peerGroupId,
                     perms -> ec2Service.authorizeSecurityGroupEgress(region, sg.getGroupId(), perms));
         }
     }
@@ -1235,16 +1237,33 @@ public class CloudFormationResourceProvisioner {
      */
     private void authorizeMissing(JsonNode declared, List<IpPermission> existing,
                                   CloudFormationTemplateEngine engine,
+                                  java.util.function.UnaryOperator<String> peerGroupId,
                                   java.util.function.Consumer<List<IpPermission>> authorize) {
         Set<String> present = existing.stream()
-                .map(CloudFormationResourceProvisioner::permissionKey)
+                .map(p -> permissionKey(p, peerGroupId))
                 .collect(java.util.stream.Collectors.toSet());
         for (JsonNode rule : declared) {
             IpPermission perm = Ec2SecurityGroupRuleCfnProvisioner.toIpPermission(rule, engine);
-            if (present.add(permissionKey(perm))) {
+            if (present.add(permissionKey(perm, peerGroupId))) {
                 authorize.accept(List.of(perm));
             }
         }
+    }
+
+    /**
+     * Resolves a peer group's name to its id, the same lookup {@code Ec2Service} performs when it
+     * stores an authorized rule. Group names are unique per VPC rather than per region, so the
+     * search is confined to the group being authorized. A name matching nothing there stays a
+     * name, which is also what the service does.
+     */
+    private java.util.function.UnaryOperator<String> peerGroupIdResolver(String region, String vpcId) {
+        return groupName -> ec2Service.describeSecurityGroups(region, List.of(), List.of(groupName), Map.of())
+                .stream()
+                .filter(peer -> Objects.equals(vpcId, peer.getVpcId()))
+                .map(SecurityGroup::getGroupId)
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(groupName);
     }
 
     /**
@@ -1252,7 +1271,7 @@ public class CloudFormationResourceProvisioner {
      * it holds define no {@code equals}, so compare a canonical rendering instead. Descriptions
      * are left out: AWS treats a rule differing only by description as the same rule.
      */
-    private static String permissionKey(IpPermission p) {
+    private static String permissionKey(IpPermission p, java.util.function.UnaryOperator<String> peerGroupId) {
         return String.join("|",
                 String.valueOf(p.getIpProtocol()),
                 String.valueOf(p.getFromPort()),
@@ -1262,12 +1281,27 @@ public class CloudFormationResourceProvisioner {
                 p.getIpv6Ranges().stream().map(Ipv6Range::getCidrIpv6).filter(Objects::nonNull).sorted()
                         .collect(java.util.stream.Collectors.joining(",")),
                 p.getUserIdGroupPairs().stream()
-                        .map(g -> g.getGroupId() != null ? g.getGroupId() : g.getGroupName())
+                        .map(g -> peerIdentity(g, peerGroupId))
                         .filter(Objects::nonNull).sorted()
                         .collect(java.util.stream.Collectors.joining(",")),
                 p.getPrefixListIds().stream().map(PrefixListId::getPrefixListId)
                         .filter(Objects::nonNull).sorted()
                         .collect(java.util.stream.Collectors.joining(",")));
+    }
+
+    /**
+     * How a peer group is identified when two permissions are compared: its id whenever one can be
+     * had. A stored pair already carries one, because authorize resolves the name as it records the
+     * rule, while a pair straight from the template carries only the name it was declared with.
+     * Keying a resolved id against an unresolved name never matches, which re-authorized a rule
+     * naming its peer through {@code SourceSecurityGroupName} on every single update.
+     */
+    private static String peerIdentity(UserIdGroupPair pair,
+                                       java.util.function.UnaryOperator<String> peerGroupId) {
+        if (pair.getGroupId() != null) {
+            return pair.getGroupId();
+        }
+        return pair.getGroupName() == null ? null : peerGroupId.apply(pair.getGroupName());
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -41,6 +41,10 @@ import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.cloudwatch.metrics.model.MetricAlarm;
+import io.github.hectorvent.floci.services.ec2.model.IpPermission;
+import io.github.hectorvent.floci.services.ec2.model.IpRange;
+import io.github.hectorvent.floci.services.ec2.model.Ipv6Range;
+import io.github.hectorvent.floci.services.ec2.model.PrefixListId;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.kinesis.KinesisService;
@@ -706,11 +710,10 @@ public class CloudFormationResourceProvisioner {
         // provision() re-runs for every resource on every update. Re-creating an unchanged group
         // would mint a new group id (and collide on the name whenever the VPC id is stable), so
         // reuse the group this resource already points at.
-        var sg = existingSecurityGroupToReconcile(r.getPhysicalId(), groupName, description, vpcId, region);
-        boolean reused = sg != null;
-        if (sg == null) {
-            sg = ec2Service.createSecurityGroup(region, groupName, description, vpcId);
-        }
+        var reconciled = existingSecurityGroupToReconcile(r.getPhysicalId(), groupName, description, vpcId, region);
+        final SecurityGroup sg = reconciled != null
+                ? reconciled
+                : ec2Service.createSecurityGroup(region, groupName, description, vpcId);
         // Ref on AWS::EC2::SecurityGroup returns the group id for VPC security groups.
         r.setPhysicalId(sg.getGroupId());
         r.getAttributes().put("GroupId", sg.getGroupId());
@@ -722,26 +725,22 @@ public class CloudFormationResourceProvisioner {
         // shared with the standalone SecurityGroupIngress/Egress resource types, which live in
         // Ec2SecurityGroupRuleCfnProvisioner; this arm joins them when it is extracted.
         // Authorize appends without a duplicate check, so re-running this on a reused group would
-        // stack another copy of every inline rule on each update. Clear the sets the template
-        // declares first, which also drops rules the template no longer lists. A set the template
-        // does not declare is left alone, so the group keeps its default egress.
+        // stack another copy of every inline rule on each update. Only authorize what the group
+        // does not already carry.
+        //
+        // Deliberately additive: a rule dropped from the template is not revoked here. Revoking
+        // the difference would mean revoking permissions this resource cannot prove it owns - a
+        // group can also carry rules from standalone AWS::EC2::SecurityGroupIngress/Egress
+        // resources, and clearing them on an unrelated update would close ports another stack
+        // resource is responsible for. Removing a rule the template no longer declares needs the
+        // provisioner to record what it authorized; noted as a follow-up.
         if (props != null && props.has("SecurityGroupIngress")) {
-            if (reused && !sg.getIpPermissions().isEmpty()) {
-                ec2Service.revokeSecurityGroupIngress(region, sg.getGroupId(), List.copyOf(sg.getIpPermissions()));
-            }
-            for (JsonNode rule : props.get("SecurityGroupIngress")) {
-                ec2Service.authorizeSecurityGroupIngress(region, sg.getGroupId(),
-                        List.of(Ec2SecurityGroupRuleCfnProvisioner.toIpPermission(rule, engine)));
-            }
+            authorizeMissing(props.get("SecurityGroupIngress"), sg.getIpPermissions(), engine,
+                    perms -> ec2Service.authorizeSecurityGroupIngress(region, sg.getGroupId(), perms));
         }
         if (props != null && props.has("SecurityGroupEgress")) {
-            if (reused && !sg.getIpPermissionsEgress().isEmpty()) {
-                ec2Service.revokeSecurityGroupEgress(region, sg.getGroupId(), List.copyOf(sg.getIpPermissionsEgress()));
-            }
-            for (JsonNode rule : props.get("SecurityGroupEgress")) {
-                ec2Service.authorizeSecurityGroupEgress(region, sg.getGroupId(),
-                        List.of(Ec2SecurityGroupRuleCfnProvisioner.toIpPermission(rule, engine)));
-            }
+            authorizeMissing(props.get("SecurityGroupEgress"), sg.getIpPermissionsEgress(), engine,
+                    perms -> ec2Service.authorizeSecurityGroupEgress(region, sg.getGroupId(), perms));
         }
     }
 
@@ -1225,6 +1224,52 @@ public class CloudFormationResourceProvisioner {
         r.getAttributes().put("DBClusterParameterGroupName", group.getDbClusterParameterGroupName());
     }
 
+    /** The VPC a security group would land in for this template value: the default when omitted. */
+    private String effectiveVpcId(String vpcId, String region) {
+        return vpcId != null && !vpcId.isEmpty() ? vpcId : String.valueOf(ec2Service.resolveDefaultVpcId(region));
+    }
+
+    /**
+     * Authorizes each declared rule that the group does not already carry, one call per rule so a
+     * rejected rule cannot take its siblings down with it.
+     */
+    private void authorizeMissing(JsonNode declared, List<IpPermission> existing,
+                                  CloudFormationTemplateEngine engine,
+                                  java.util.function.Consumer<List<IpPermission>> authorize) {
+        Set<String> present = existing.stream()
+                .map(CloudFormationResourceProvisioner::permissionKey)
+                .collect(java.util.stream.Collectors.toSet());
+        for (JsonNode rule : declared) {
+            IpPermission perm = Ec2SecurityGroupRuleCfnProvisioner.toIpPermission(rule, engine);
+            if (present.add(permissionKey(perm))) {
+                authorize.accept(List.of(perm));
+            }
+        }
+    }
+
+    /**
+     * Identity of a permission for duplicate detection. {@link IpPermission} and the range types
+     * it holds define no {@code equals}, so compare a canonical rendering instead. Descriptions
+     * are left out: AWS treats a rule differing only by description as the same rule.
+     */
+    private static String permissionKey(IpPermission p) {
+        return String.join("|",
+                String.valueOf(p.getIpProtocol()),
+                String.valueOf(p.getFromPort()),
+                String.valueOf(p.getToPort()),
+                p.getIpRanges().stream().map(IpRange::getCidrIp).filter(Objects::nonNull).sorted()
+                        .collect(java.util.stream.Collectors.joining(",")),
+                p.getIpv6Ranges().stream().map(Ipv6Range::getCidrIpv6).filter(Objects::nonNull).sorted()
+                        .collect(java.util.stream.Collectors.joining(",")),
+                p.getUserIdGroupPairs().stream()
+                        .map(g -> g.getGroupId() != null ? g.getGroupId() : g.getGroupName())
+                        .filter(Objects::nonNull).sorted()
+                        .collect(java.util.stream.Collectors.joining(",")),
+                p.getPrefixListIds().stream().map(PrefixListId::getPrefixListId)
+                        .filter(Objects::nonNull).sorted()
+                        .collect(java.util.stream.Collectors.joining(",")));
+    }
+
     /**
      * The security group this stack resource already points at, when an UpdateStack re-invocation
      * left it unchanged. Unlike most resources the physical id here is the group <em>id</em>, not
@@ -1245,8 +1290,12 @@ public class CloudFormationResourceProvisioner {
                     .stream()
                     .filter(existing -> groupName == null || groupName.equals(existing.getGroupName()))
                     .filter(existing -> description == null || description.equals(existing.getDescription()))
-                    // A template that omits VpcId is not asking to move the group out of its VPC.
-                    .filter(existing -> vpcId == null || vpcId.equals(existing.getVpcId()))
+                    // Compare the VpcId the template would actually get, not the raw property.
+                    // createSecurityGroup resolves an omitted VpcId to the region's default VPC,
+                    // so the stored group always has one: comparing against a null property would
+                    // either force a replacement on every update, or - the bug - let a template
+                    // that drops VpcId keep a group sitting in the explicit VPC it named before.
+                    .filter(existing -> effectiveVpcId(vpcId, region).equals(existing.getVpcId()))
                     .findFirst()
                     .orElse(null);
         } catch (AwsException notFound) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisioner.java
@@ -1,10 +1,13 @@
 package io.github.hectorvent.floci.services.cloudformation.provisioners;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -16,6 +19,8 @@ import java.util.Set;
  */
 @ApplicationScoped
 public class Ec2VpcCfnProvisioner implements CfnResourceProvisioner {
+
+    private static final Logger LOG = Logger.getLogger(Ec2VpcCfnProvisioner.class);
 
     private final Ec2Service ec2Service;
 
@@ -32,7 +37,8 @@ public class Ec2VpcCfnProvisioner implements CfnResourceProvisioner {
     @Override
     public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
         String cidr = ctx.resolveOptional(props, "CidrBlock");
-        var vpc = ec2Service.createVpc(ctx.region(), cidr, false);
+        Vpc reconciled = existingVpcToReconcile(r.getPhysicalId(), cidr, ctx.region());
+        final Vpc vpc = reconciled != null ? reconciled : ec2Service.createVpc(ctx.region(), cidr, false);
         r.setPhysicalId(vpc.getVpcId());
         r.getAttributes().put("VpcId", vpc.getVpcId());
         if (vpc.getCidrBlock() != null) {
@@ -44,6 +50,38 @@ public class Ec2VpcCfnProvisioner implements CfnResourceProvisioner {
                 .filter(sg -> vpc.getVpcId().equals(sg.getVpcId()))
                 .findFirst()
                 .ifPresent(sg -> r.getAttributes().put("DefaultSecurityGroup", sg.getGroupId()));
+    }
+
+    /**
+     * The VPC this stack resource already points at, when an UpdateStack re-invocation left it
+     * unchanged. {@code provision()} re-runs for every resource on every update, so creating
+     * unconditionally would mint a fresh VPC id and silently orphan every subnet, route table and
+     * security group that referenced the old one.
+     *
+     * <p>Returns {@code null} for a fresh create, for a CidrBlock change (which AWS treats as a
+     * replacement), or when the VPC is gone from the backend - the caller then creates.
+     */
+    private Vpc existingVpcToReconcile(String priorPhysicalId, String cidr, String region) {
+        if (priorPhysicalId == null || priorPhysicalId.isBlank()) {
+            return null;
+        }
+        Vpc existing;
+        try {
+            existing = ec2Service.describeVpcs(region, List.of(priorPhysicalId), Map.of())
+                    .stream().findFirst().orElse(null);
+        } catch (AwsException notFound) {
+            // Expected when the VPC was deleted out of band since the prior update.
+            LOG.debugv(notFound, "No existing VPC {0} found on file, falling back to create", priorPhysicalId);
+            return null;
+        }
+        if (existing == null) {
+            return null;
+        }
+        // A changed CidrBlock is a replacement on AWS, so let the caller create a new VPC.
+        if (cidr != null && !cidr.isBlank() && !cidr.equals(existing.getCidrBlock())) {
+            return null;
+        }
+        return existing;
     }
 
     // No delete override: the switch this replaces had no AWS::EC2::VPC delete arm,

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisioner.java
@@ -37,7 +37,7 @@ public class Ec2VpcCfnProvisioner implements CfnResourceProvisioner {
     @Override
     public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
         String cidr = ctx.resolveOptional(props, "CidrBlock");
-        Vpc reconciled = existingVpcToReconcile(r.getPhysicalId(), cidr, ctx.region());
+        Vpc reconciled = existingVpcToReconcile(ctx.isUpdate() ? ctx.priorPhysicalId() : null, cidr, ctx.region());
         final Vpc vpc = reconciled != null ? reconciled : ec2Service.createVpc(ctx.region(), cidr, false);
         r.setPhysicalId(vpc.getVpcId());
         r.getAttributes().put("VpcId", vpc.getVpcId());
@@ -60,6 +60,10 @@ public class Ec2VpcCfnProvisioner implements CfnResourceProvisioner {
      *
      * <p>Returns {@code null} for a fresh create, for a CidrBlock change (which AWS treats as a
      * replacement), or when the VPC is gone from the backend - the caller then creates.
+     *
+     * <p>The prior id is the one the context captured, not the one on the {@link StackResource}:
+     * {@code provision} assigns the new id onto that resource as it runs, so a resource-derived
+     * check flips from create to update mid-method.
      */
     private Vpc existingVpcToReconcile(String priorPhysicalId, String cidr, String region) {
         if (priorPhysicalId == null || priorPhysicalId.isBlank()) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
@@ -153,12 +153,6 @@ class CfnUnchangedResourceUpdateIntegrationTest {
             }""";
 
     /**
-     * AuthorizeSecurityGroupIngress appends without a duplicate check, so re-running provision on a
-     * reused group stacks another copy of every inline rule on each update. Retaining the group id
-     * is not enough on its own: the group has to still describe the rules the template declares,
-     * once each.
-     */
-    /**
      * A group can carry rules from standalone AWS::EC2::SecurityGroupIngress resources as well as
      * its own inline ones. Reconciling the inline set by clearing the group first would revoke
      * those too, so a stack update unrelated to them would silently close their ports.
@@ -201,6 +195,12 @@ class CfnUnchangedResourceUpdateIntegrationTest {
                 "the standalone resource's rule was revoked by the inline reconciliation");
     }
 
+    /**
+     * AuthorizeSecurityGroupIngress appends without a duplicate check, so re-running provision on a
+     * reused group stacks another copy of every inline rule on each update. Retaining the group id
+     * is not enough on its own: the group has to still describe the rules the template declares,
+     * once each.
+     */
     @Test
     void securityGroupInlineRulesAreNotDuplicatedByAnUpdate() {
         String body = SG_WITH_INGRESS.replace("DESCRIPTION", "stable");
@@ -217,6 +217,52 @@ class CfnUnchangedResourceUpdateIntegrationTest {
         assertEquals(1, occurrences,
                 "inline ingress rule appears " + occurrences + " times after one update; "
                         + "provision re-authorized it on the reused group");
+    }
+
+    /**
+     * A rule naming its peer through SourceSecurityGroupName is the case the CidrIp rules above
+     * cannot reach. Ec2Service resolves the name to a group id as it records the rule, while the
+     * declaration the template hands back on the next update still carries only the name, so
+     * comparing the two forms directly finds no match and re-authorizes the rule every time.
+     *
+     * <p>DependsOn is load-bearing: the peer has to exist when the rule is first authorized, or
+     * the stored pair keeps the unresolved name and both sides agree for the wrong reason.
+     */
+    @Test
+    void aRuleNamingItsPeerByNameIsNotDuplicatedByAnUpdate() {
+        String body = """
+                "Peer": {
+                  "Type": "AWS::EC2::SecurityGroup",
+                  "Properties": {
+                    "GroupName": "probe-sg-peer-SUFFIX",
+                    "GroupDescription": "probe peer"
+                  }
+                },
+                "Named": {
+                  "Type": "AWS::EC2::SecurityGroup",
+                  "DependsOn": "Peer",
+                  "Properties": {
+                    "GroupName": "probe-sg-byname-SUFFIX",
+                    "GroupDescription": "probe by name",
+                    "SecurityGroupIngress": [
+                      {"IpProtocol": "tcp", "FromPort": 5432, "ToPort": 5432,
+                       "SourceSecurityGroupName": "probe-sg-peer-SUFFIX"}
+                    ]
+                  }
+                }""";
+        String[] ids = createThenUpdate("sg-byname", body, body);
+        assertEquals(ids[0], ids[1], "unchanged security group was re-created under a new physical id");
+
+        String described = given()
+                .contentType("application/x-www-form-urlencoded").header("Authorization", EC2_AUTH)
+                .formParam("Action", "DescribeSecurityGroups").formParam("GroupId.1", ids[1])
+            .when().post("/").then().statusCode(200)
+            .extract().body().asString();
+
+        int occurrences = described.split("<fromPort>5432</fromPort>", -1).length - 1;
+        assertEquals(1, occurrences,
+                "name-based ingress rule appears " + occurrences + " times after one update; "
+                        + "the stored peer is keyed by id and the declared one by name");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
@@ -110,6 +110,72 @@ class CfnUnchangedResourceUpdateIntegrationTest {
                 label + ": unchanged resource was re-created under a new physical id");
     }
 
+    private static final String EC2_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260808/us-west-2/ec2/aws4_request";
+
+    /** Runs create-then-update and hands back the Named physical id before and after. */
+    private String[] createThenUpdate(String label, String createBody, String updateBody) {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "probe-" + label + "-" + suffix;
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack").formParam("StackName", stackName)
+            .formParam("TemplateBody", stackWith(createBody.replace("SUFFIX", suffix), "probe-q-a-" + suffix))
+        .when().post("/").then().statusCode(200);
+
+        String before = namedPhysicalId(stackName);
+        assertNotNull(before, "no PhysicalResourceId for Named after create");
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "UpdateStack").formParam("StackName", stackName)
+            .formParam("TemplateBody", stackWith(updateBody.replace("SUFFIX", suffix), "probe-q-b-" + suffix))
+        .when().post("/").then().statusCode(200);
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks").formParam("StackName", stackName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"))
+            .body(not(containsString("ROLLBACK")));
+
+        return new String[] {before, namedPhysicalId(stackName)};
+    }
+
+    private static final String SG_WITH_INGRESS = """
+            "Named": {
+              "Type": "AWS::EC2::SecurityGroup",
+              "Properties": {
+                "GroupName": "probe-sg-SUFFIX",
+                "GroupDescription": "probe DESCRIPTION",
+                "SecurityGroupIngress": [
+                  {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIp": "10.0.0.0/8"}
+                ]
+              }
+            }""";
+
+    /**
+     * AuthorizeSecurityGroupIngress appends without a duplicate check, so re-running provision on a
+     * reused group stacks another copy of every inline rule on each update. Retaining the group id
+     * is not enough on its own: the group has to still describe the rules the template declares,
+     * once each.
+     */
+    @Test
+    void securityGroupInlineRulesAreNotDuplicatedByAnUpdate() {
+        String body = SG_WITH_INGRESS.replace("DESCRIPTION", "stable");
+        String[] ids = createThenUpdate("sg-rules", body, body);
+        assertEquals(ids[0], ids[1], "unchanged security group was re-created under a new physical id");
+
+        String described = given()
+                .contentType("application/x-www-form-urlencoded").header("Authorization", EC2_AUTH)
+                .formParam("Action", "DescribeSecurityGroups").formParam("GroupId.1", ids[1])
+            .when().post("/").then().statusCode(200)
+            .extract().body().asString();
+
+        int occurrences = described.split("<fromPort>22</fromPort>", -1).length - 1;
+        assertEquals(1, occurrences,
+                "inline ingress rule appears " + occurrences + " times after one update; "
+                        + "provision re-authorized it on the reused group");
+    }
+
     @Test
     void logGroup() {
         assertUnchangedResourceSurvivesUpdate("loggroup", """

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
@@ -158,6 +158,49 @@ class CfnUnchangedResourceUpdateIntegrationTest {
      * is not enough on its own: the group has to still describe the rules the template declares,
      * once each.
      */
+    /**
+     * A group can carry rules from standalone AWS::EC2::SecurityGroupIngress resources as well as
+     * its own inline ones. Reconciling the inline set by clearing the group first would revoke
+     * those too, so a stack update unrelated to them would silently close their ports.
+     */
+    @Test
+    void anUpdateLeavesRulesOwnedByStandaloneResourcesAlone() {
+        String body = """
+                "Named": {
+                  "Type": "AWS::EC2::SecurityGroup",
+                  "Properties": {
+                    "GroupName": "probe-sg-mixed-SUFFIX",
+                    "GroupDescription": "probe mixed",
+                    "SecurityGroupIngress": [
+                      {"IpProtocol": "tcp", "FromPort": 22, "ToPort": 22, "CidrIp": "10.0.0.0/8"}
+                    ]
+                  }
+                },
+                "ExtraRule": {
+                  "Type": "AWS::EC2::SecurityGroupIngress",
+                  "Properties": {
+                    "GroupId": {"Ref": "Named"},
+                    "IpProtocol": "tcp",
+                    "FromPort": 8080,
+                    "ToPort": 8080,
+                    "CidrIp": "10.9.0.0/16"
+                  }
+                }""";
+        String[] ids = createThenUpdate("sg-mixed", body, body);
+        assertEquals(ids[0], ids[1], "unchanged security group was re-created under a new physical id");
+
+        String described = given()
+                .contentType("application/x-www-form-urlencoded").header("Authorization", EC2_AUTH)
+                .formParam("Action", "DescribeSecurityGroups").formParam("GroupId.1", ids[1])
+            .when().post("/").then().statusCode(200)
+            .extract().body().asString();
+
+        assertEquals(1, described.split("<fromPort>22</fromPort>", -1).length - 1,
+                "inline rule should appear exactly once after an update");
+        assertEquals(1, described.split("<fromPort>8080</fromPort>", -1).length - 1,
+                "the standalone resource's rule was revoked by the inline reconciliation");
+    }
+
     @Test
     void securityGroupInlineRulesAreNotDuplicatedByAnUpdate() {
         String body = SG_WITH_INGRESS.replace("DESCRIPTION", "stable");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
@@ -1,0 +1,202 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * UpdateStack must leave an unchanged resource alone, whatever its type.
+ *
+ * <p>{@code provision()} re-runs for every resource on every update, changed or not, so a
+ * provisioner that calls create unconditionally either collides with itself (rolling the stack
+ * back) or quietly mints a new physical id, orphaning everything that referenced the old one.
+ * Each case here builds a stack holding one resource plus a throwaway queue, updates only the
+ * queue, and asserts both that the stack reached UPDATE_COMPLETE and that the untouched resource
+ * kept its physical id.
+ *
+ * <p>Regression cover for "CloudFormation update recreates unchanged named resources"
+ * (floci-io/floci#2134).
+ */
+@QuarkusTest
+class CfnUnchangedResourceUpdateIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260808/us-west-2/cloudformation/aws4_request";
+
+    private static String stackWith(String namedResourceJson, String queueName) {
+        return """
+                {
+                  "Resources": {
+                    %s,
+                    "ChurnQueue": {
+                      "Type": "AWS::SQS::Queue",
+                      "Properties": {"QueueName": "%s"}
+                    }
+                  }
+                }
+                """.formatted(namedResourceJson, queueName);
+    }
+
+    /**
+     * Pulls the PhysicalResourceId of one logical resource out of a DescribeStackResources body.
+     * The member ordering is not guaranteed, so match the pair rather than a fixed offset.
+     */
+    private static String physicalIdOf(String describeBody, String logicalId) {
+        Matcher m = Pattern.compile(
+                "<member>(?:(?!</member>).)*?<LogicalResourceId>" + Pattern.quote(logicalId)
+                        + "</LogicalResourceId>(?:(?!</member>).)*?</member>", Pattern.DOTALL)
+                .matcher(describeBody);
+        if (!m.find()) {
+            return null;
+        }
+        Matcher pid = Pattern.compile("<PhysicalResourceId>(.*?)</PhysicalResourceId>", Pattern.DOTALL)
+                .matcher(m.group());
+        return pid.find() ? pid.group(1) : null;
+    }
+
+    private String namedPhysicalId(String stackName) {
+        String body = given()
+                .contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+                .formParam("Action", "DescribeStackResources").formParam("StackName", stackName)
+            .when().post("/").then().statusCode(200)
+            .extract().body().asString();
+        return physicalIdOf(body, "Named");
+    }
+
+    /**
+     * Creates the stack, updates it with only the churn queue renamed, then asserts both that the
+     * update completed and that the untouched resource kept its physical id. The second assertion
+     * is the load-bearing one: a provisioner that re-creates the resource under a fresh id can
+     * still report UPDATE_COMPLETE while silently orphaning whatever referenced the old id.
+     */
+    private void assertUnchangedResourceSurvivesUpdate(String label, String namedResourceJson) {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "probe-" + label + "-" + suffix;
+        String body = namedResourceJson.replace("SUFFIX", suffix);
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "CreateStack").formParam("StackName", stackName)
+            .formParam("TemplateBody", stackWith(body, "probe-q-a-" + suffix))
+        .when().post("/").then().statusCode(200);
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks").formParam("StackName", stackName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        String before = namedPhysicalId(stackName);
+        assertNotNull(before, "no PhysicalResourceId for Named after create");
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "UpdateStack").formParam("StackName", stackName)
+            .formParam("TemplateBody", stackWith(body, "probe-q-b-" + suffix))
+        .when().post("/").then().statusCode(200);
+
+        given().contentType("application/x-www-form-urlencoded").header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks").formParam("StackName", stackName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<StackStatus>UPDATE_COMPLETE</StackStatus>"))
+            .body(not(containsString("ROLLBACK")));
+
+        assertEquals(before, namedPhysicalId(stackName),
+                label + ": unchanged resource was re-created under a new physical id");
+    }
+
+    @Test
+    void logGroup() {
+        assertUnchangedResourceSurvivesUpdate("loggroup", """
+                "Named": {
+                  "Type": "AWS::Logs::LogGroup",
+                  "Properties": {"LogGroupName": "/probe/log-SUFFIX"}
+                }""");
+    }
+
+    @Test
+    void snsTopic() {
+        assertUnchangedResourceSurvivesUpdate("sns", """
+                "Named": {
+                  "Type": "AWS::SNS::Topic",
+                  "Properties": {"TopicName": "probe-topic-SUFFIX"}
+                }""");
+    }
+
+    @Test
+    void sqsQueue() {
+        assertUnchangedResourceSurvivesUpdate("sqs", """
+                "Named": {
+                  "Type": "AWS::SQS::Queue",
+                  "Properties": {"QueueName": "probe-queue-SUFFIX"}
+                }""");
+    }
+
+    @Test
+    void ecrRepository() {
+        assertUnchangedResourceSurvivesUpdate("ecr", """
+                "Named": {
+                  "Type": "AWS::ECR::Repository",
+                  "Properties": {"RepositoryName": "probe-repo-SUFFIX"}
+                }""");
+    }
+
+    @Test
+    void kmsAlias() {
+        assertUnchangedResourceSurvivesUpdate("kms", """
+                "Key": {"Type": "AWS::KMS::Key", "Properties": {}},
+                "Named": {
+                  "Type": "AWS::KMS::Alias",
+                  "Properties": {"AliasName": "alias/probe-SUFFIX", "TargetKeyId": {"Ref": "Key"}}
+                }""");
+    }
+
+    @Test
+    void kinesisStream() {
+        assertUnchangedResourceSurvivesUpdate("kinesis", """
+                "Named": {
+                  "Type": "AWS::Kinesis::Stream",
+                  "Properties": {"Name": "probe-stream-SUFFIX", "ShardCount": 1}
+                }""");
+    }
+
+    @Test
+    void securityGroup() {
+        assertUnchangedResourceSurvivesUpdate("sg", """
+                "Vpc": {
+                  "Type": "AWS::EC2::VPC",
+                  "Properties": {"CidrBlock": "10.99.0.0/16"}
+                },
+                "Named": {
+                  "Type": "AWS::EC2::SecurityGroup",
+                  "Properties": {
+                    "GroupName": "probe-sg-SUFFIX",
+                    "GroupDescription": "probe",
+                    "VpcId": {"Ref": "Vpc"}
+                  }
+                }""");
+    }
+
+    @Test
+    void vpc() {
+        assertUnchangedResourceSurvivesUpdate("vpc", """
+                "Named": {
+                  "Type": "AWS::EC2::VPC",
+                  "Properties": {"CidrBlock": "10.98.0.0/16"}
+                }""");
+    }
+
+    @Test
+    void s3Bucket() {
+        assertUnchangedResourceSurvivesUpdate("s3", """
+                "Named": {
+                  "Type": "AWS::S3::Bucket",
+                  "Properties": {"BucketName": "probe-bucket-SUFFIX"}
+                }""");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnUnchangedResourceUpdateIntegrationTest.java
@@ -1,10 +1,8 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
+import io.github.hectorvent.floci.core.common.XmlParser;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -47,19 +45,15 @@ class CfnUnchangedResourceUpdateIntegrationTest {
 
     /**
      * Pulls the PhysicalResourceId of one logical resource out of a DescribeStackResources body.
-     * The member ordering is not guaranteed, so match the pair rather than a fixed offset.
+     * The member ordering is not guaranteed, so pick the member by its LogicalResourceId rather
+     * than by position.
      */
     private static String physicalIdOf(String describeBody, String logicalId) {
-        Matcher m = Pattern.compile(
-                "<member>(?:(?!</member>).)*?<LogicalResourceId>" + Pattern.quote(logicalId)
-                        + "</LogicalResourceId>(?:(?!</member>).)*?</member>", Pattern.DOTALL)
-                .matcher(describeBody);
-        if (!m.find()) {
-            return null;
-        }
-        Matcher pid = Pattern.compile("<PhysicalResourceId>(.*?)</PhysicalResourceId>", Pattern.DOTALL)
-                .matcher(m.group());
-        return pid.find() ? pid.group(1) : null;
+        return XmlParser.extractGroups(describeBody, "member").stream()
+                .filter(member -> logicalId.equals(member.get("LogicalResourceId")))
+                .map(member -> member.get("PhysicalResourceId"))
+                .findFirst()
+                .orElse(null);
     }
 
     private String namedPhysicalId(String stackName) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisionerTest.java
@@ -31,19 +31,18 @@ class Ec2VpcCfnProvisionerTest {
 
     private Ec2Service ec2;
     private Ec2VpcCfnProvisioner provisioner;
-    private ProvisionContext ctx;
+    private CloudFormationTemplateEngine engine;
 
     @BeforeEach
     void setUp() {
         ec2 = mock(Ec2Service.class);
         provisioner = new Ec2VpcCfnProvisioner(ec2);
-        CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+        engine = mock(CloudFormationTemplateEngine.class);
         when(engine.resolve(any())).thenAnswer(i -> {
             JsonNode node = i.getArgument(0);
             return node == null || node.isMissingNode() || node.isNull() ? null : node.asText();
         });
         when(engine.resolveNode(any())).thenAnswer(i -> i.getArgument(0));
-        ctx = new ProvisionContext(engine, REGION, "000000000000", "my-stack");
         when(ec2.describeSecurityGroups(anyString(), any(), any(), any())).thenReturn(List.of());
     }
 
@@ -62,11 +61,22 @@ class Ec2VpcCfnProvisionerTest {
         return v;
     }
 
+    /**
+     * Provisions the way the engine does: an update arrives with the prior id on both the context
+     * and the resource, so a provisioner reading the wrong one still looks correct here. The
+     * create-path cases below are what separate them.
+     */
     private StackResource provision(String priorPhysicalId, String json) {
+        return provision(priorPhysicalId, priorPhysicalId, json);
+    }
+
+    private StackResource provision(String contextPriorId, String resourcePhysicalId, String json) {
         StackResource r = new StackResource();
         r.setLogicalId("Vpc");
         r.setResourceType("AWS::EC2::VPC");
-        r.setPhysicalId(priorPhysicalId);
+        r.setPhysicalId(resourcePhysicalId);
+        ProvisionContext ctx =
+                new ProvisionContext(engine, REGION, "000000000000", "my-stack", contextPriorId);
         provisioner.provision(r, props(json), ctx);
         return r;
     }
@@ -113,6 +123,21 @@ class Ec2VpcCfnProvisionerTest {
 
         verify(ec2).createVpc(REGION, "10.1.0.0/16", false);
         assertEquals("vpc-replaced", r.getPhysicalId());
+    }
+
+    @Test
+    void anIdOnTheResourceAloneDoesNotCountAsAnUpdate() {
+        when(ec2.createVpc(anyString(), anyString(), anyBoolean())).thenReturn(vpc("vpc-new", "10.0.0.0/16"));
+
+        // A resource carrying a physical id under a create context: what provision() itself
+        // produces the moment it assigns the new id. Reading create-vs-update off the resource
+        // makes that state indistinguishable from a real update.
+        StackResource r = provision(null, "vpc-assigned-mid-method", """
+                {"CidrBlock": "10.0.0.0/16"}""");
+
+        verify(ec2, never()).describeVpcs(anyString(), any(), any());
+        verify(ec2).createVpc(REGION, "10.0.0.0/16", false);
+        assertEquals("vpc-new", r.getPhysicalId());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2VpcCfnProvisionerTest.java
@@ -1,0 +1,130 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationTemplateEngine;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ec2.model.SecurityGroup;
+import io.github.hectorvent.floci.services.ec2.model.Vpc;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** {@code AWS::EC2::VPC}. */
+class Ec2VpcCfnProvisionerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String REGION = "us-east-1";
+
+    private Ec2Service ec2;
+    private Ec2VpcCfnProvisioner provisioner;
+    private ProvisionContext ctx;
+
+    @BeforeEach
+    void setUp() {
+        ec2 = mock(Ec2Service.class);
+        provisioner = new Ec2VpcCfnProvisioner(ec2);
+        CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+        when(engine.resolve(any())).thenAnswer(i -> {
+            JsonNode node = i.getArgument(0);
+            return node == null || node.isMissingNode() || node.isNull() ? null : node.asText();
+        });
+        when(engine.resolveNode(any())).thenAnswer(i -> i.getArgument(0));
+        ctx = new ProvisionContext(engine, REGION, "000000000000", "my-stack");
+        when(ec2.describeSecurityGroups(anyString(), any(), any(), any())).thenReturn(List.of());
+    }
+
+    private static JsonNode props(String json) {
+        try {
+            return MAPPER.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static Vpc vpc(String id, String cidr) {
+        Vpc v = new Vpc();
+        v.setVpcId(id);
+        v.setCidrBlock(cidr);
+        return v;
+    }
+
+    private StackResource provision(String priorPhysicalId, String json) {
+        StackResource r = new StackResource();
+        r.setLogicalId("Vpc");
+        r.setResourceType("AWS::EC2::VPC");
+        r.setPhysicalId(priorPhysicalId);
+        provisioner.provision(r, props(json), ctx);
+        return r;
+    }
+
+    @Test
+    void refIsTheVpcIdAndGetAttExposesTheDocumentedAttributes() {
+        when(ec2.createVpc(anyString(), anyString(), anyBoolean())).thenReturn(vpc("vpc-new", "10.0.0.0/16"));
+        SecurityGroup def = new SecurityGroup();
+        def.setGroupId("sg-default");
+        def.setVpcId("vpc-new");
+        when(ec2.describeSecurityGroups(REGION, List.of(), List.of("default"), Map.of()))
+                .thenReturn(List.of(def));
+
+        StackResource r = provision(null, """
+                {"CidrBlock": "10.0.0.0/16"}""");
+
+        assertEquals("vpc-new", r.getPhysicalId());
+        assertEquals("vpc-new", r.getAttributes().get("VpcId"));
+        assertEquals("10.0.0.0/16", r.getAttributes().get("CidrBlock"));
+        assertEquals("sg-default", r.getAttributes().get("DefaultSecurityGroup"));
+    }
+
+    @Test
+    void anUnchangedVpcIsReusedInsteadOfCreatedAgain() {
+        when(ec2.describeVpcs(REGION, List.of("vpc-existing"), Map.of()))
+                .thenReturn(List.of(vpc("vpc-existing", "10.0.0.0/16")));
+
+        StackResource r = provision("vpc-existing", """
+                {"CidrBlock": "10.0.0.0/16"}""");
+
+        verify(ec2, never()).createVpc(anyString(), anyString(), anyBoolean());
+        assertEquals("vpc-existing", r.getPhysicalId(),
+                "reusing must keep the id every subnet and route table already references");
+    }
+
+    @Test
+    void aChangedCidrBlockCreatesAReplacement() {
+        when(ec2.describeVpcs(REGION, List.of("vpc-existing"), Map.of()))
+                .thenReturn(List.of(vpc("vpc-existing", "10.0.0.0/16")));
+        when(ec2.createVpc(anyString(), anyString(), anyBoolean())).thenReturn(vpc("vpc-replaced", "10.1.0.0/16"));
+
+        StackResource r = provision("vpc-existing", """
+                {"CidrBlock": "10.1.0.0/16"}""");
+
+        verify(ec2).createVpc(REGION, "10.1.0.0/16", false);
+        assertEquals("vpc-replaced", r.getPhysicalId());
+    }
+
+    @Test
+    void aVpcDeletedOutOfBandFallsBackToCreate() {
+        when(ec2.describeVpcs(REGION, List.of("vpc-gone"), Map.of()))
+                .thenThrow(new AwsException("InvalidVpcID.NotFound", "not found", 400));
+        when(ec2.createVpc(anyString(), anyString(), anyBoolean())).thenReturn(vpc("vpc-fresh", "10.0.0.0/16"));
+
+        StackResource r = provision("vpc-gone", """
+                {"CidrBlock": "10.0.0.0/16"}""");
+
+        verify(ec2).createVpc(REGION, "10.0.0.0/16", false);
+        assertEquals("vpc-fresh", r.getPhysicalId());
+    }
+}


### PR DESCRIPTION
## Summary

`provision()` re-runs for every resource on every `UpdateStack`, changed or not. Two provisioners still called create unconditionally.

- `AWS::EC2::VPC`: re-created on every update, silently orphaning every subnet, route table and security group that referenced the old id.
- `AWS::EC2::SecurityGroup`: hid behind the VPC case. Because the VPC id changed too, the `(name, vpcId)` duplicate check never fired, so the stack reported `UPDATE_COMPLETE` while leaking a second group.

Both now reconcile the resource the stack already points at. A changed `CidrBlock`, `GroupName`, `GroupDescription` or `VpcId` is still a replacement, and a resource deleted out of band still falls back to create.

Part of #2134. The `AWS::S3::Bucket` half this PR originally carried is dropped: #2788's `stablePhysicalName`/`reusesPriorEntity` landed the same fix generically, and covers the generated-name case too.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

### Incorrect Behavior

On a second deploy with no template change, a stack holding a VPC or security group returned `UPDATE_COMPLETE` while replacing resources AWS leaves untouched. On AWS an update that changes no properties is a no-op and the physical id is retained.

### Key Points and Nuances

- **Inline rules on a reused group:** `authorizeSecurityGroupIngress`/`Egress` append without a duplicate check, so reusing the group made the inline sets accumulate another copy on every update. Reconciliation is additive: a declared rule is authorized only when the group does not already carry it, compared on a canonical key since `IpPermission` defines no `equals`. Nothing is revoked, because a group can also hold rules from standalone `SecurityGroupIngress`/`Egress` resources and clearing them on an unrelated update would close ports another resource owns. **Trade-off:** a rule dropped from the template is not revoked either; doing that safely needs the provisioner to record what it authorized, which this arm cannot do inside the monolith.
- **`CloudFormationResourceProvisioner` is touched.** No resource type is added; this fixes the existing security-group path in place. Happy to extract an `Ec2SecurityGroupCfnProvisioner` instead if you would prefer that.
- **Test asserts physical-id retention**, not terminal status. An earlier version asserting `UPDATE_COMPLETE` alone passed against all nine types while VPCs and security groups were still being re-created.
- **No focused unit test for the security-group arm.** It lives in the legacy monolith rather than a `*CfnProvisioner`, so there is no class to mock a single service against. `Ec2VpcCfnProvisionerTest` follows `S3CfnProvisionerTest` for the half that does have one.

## Checklist

- [x] `./mvnw test -Dtest=CfnUnchangedResourceUpdateIntegrationTest,Ec2VpcCfnProvisionerTest` passes locally: 17 tests
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
