### PR TITLE
perf(docker): drop the gosu layer and two no-op native-image inputs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,8 @@ ENV AWS_ACCESS_KEY_ID=test
 ENV AWS_SECRET_ACCESS_KEY=test
 ENV AWS_CONFIG_FILE=/etc/floci/aws/config
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+# Privilege drop happens in the entrypoint through coreutils chroot, so no gosu
+# download; wget stays for the HEALTHCHECK below.
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends ca-certificates passwd python3 python3-pip wget; \
@@ -34,16 +33,7 @@ RUN set -eux; \
     mv "$aws_bin" /usr/bin/aws.real; \
     printf '#!/bin/sh\nexec /usr/bin/aws.real --endpoint-url=http://localhost:4566 "$@"\n' > /usr/bin/aws; \
     chmod +x /usr/bin/aws; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(dpkg --print-architecture)"; \
-    case "$arch" in \
-        amd64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        arm64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
 
 WORKDIR /app
 

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -7,25 +7,12 @@ ARG TARGETARCH
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
-RUN set -eux; \
-    microdnf install -y --nodocs shadow-utils; \
-    microdnf clean all; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
-        -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu; \
-    gosu --version; \
-    gosu nobody true
+# ubi9-minimal already ships shadow-utils (useradd) and coreutils (chroot), so no package is
+# installed and no binary is downloaded: the entrypoint drops privileges with
+# `chroot --userspec`, which replaces gosu, and adds the Docker socket's group with
+# `chroot --groups`, which replaces the runtime usermod. Measured on 2.0.1 the layer this
+# replaces was 3.66 MB compressed and 19 MB on disk.
+RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
 
 WORKDIR /app
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-# Starts as root, normalizes the bind-mounted Docker socket's group
-# ownership so the unprivileged `floci` user can reach it on any host,
-# then re-executes this script as `floci` via gosu. The second invocation
-# falls through to exec the user's command.
+# Starts as root, reads the bind-mounted Docker socket's group so the
+# unprivileged `floci` user can reach it on any host, then re-executes this
+# script as `floci` via coreutils `chroot --userspec`, which also grants that
+# group as a supplementary group. The second invocation falls through to exec
+# the user's command. No gosu, no usermod: both would cost a package layer the
+# base image does not otherwise need.
 #
 # Why: on native Linux Docker, /var/run/docker.sock is owned by
 # root:docker with mode 660 and the docker GID varies by distro. On
@@ -15,15 +17,11 @@
 set -eu
 
 if [ "$(id -u)" = '0' ]; then
+    groups='0'
     if [ -S /var/run/docker.sock ]; then
         sock_gid="$(stat -c '%g' /var/run/docker.sock)"
         if [ "$sock_gid" != '0' ]; then
-            group_name="$(getent group "$sock_gid" | cut -d: -f1)" || group_name=''
-            if [ -z "$group_name" ]; then
-                groupadd -g "$sock_gid" docker-host
-                group_name='docker-host'
-            fi
-            usermod -aG "$group_name" floci
+            groups="0,$sock_gid"
         fi
     fi
 
@@ -34,7 +32,11 @@ if [ "$(id -u)" = '0' ]; then
         chown -R floci:root /app/data 2>/dev/null || true
     fi
 
-    exec gosu floci "$0" "$@"
+    # `chroot /` changes nothing but the identity: uid 1001, primary gid 0, plus the socket's
+    # group. Supplementary groups are set by number, so the group needs no /etc/group entry.
+    # --skip-chdir keeps the working directory (/app, where relative data paths resolve); GNU
+    # chroot would otherwise chdir to the new root.
+    exec chroot --userspec=1001:0 --groups="$groups" --skip-chdir / "$0" "$@"
 fi
 
 if [ "${LOCALSTACK_PARITY:-true}" != "false" ]; then

--- a/docker/test-entrypoint.sh
+++ b/docker/test-entrypoint.sh
@@ -4,9 +4,9 @@
 # Exit 0 on success, non-zero on first failure summary.
 #
 # These tests run the entrypoint as an unprivileged user with
-# LOCALSTACK_PARITY=false, so the root-only gosu block and the parity
+# LOCALSTACK_PARITY=false, so the root-only chroot block and the parity
 # script (installed at an absolute path inside the image) stay out of
-# the way. The root/gosu path is covered by the Docker image tests.
+# the way. The root/chroot path is covered by the Docker image tests.
 
 set -eu
 
@@ -26,7 +26,7 @@ assert_eq() {
 }
 
 if [ "$(id -u)" = '0' ]; then
-    echo "These tests must run as an unprivileged user (the root path re-execs via gosu)." >&2
+    echo "These tests must run as an unprivileged user (the root path re-execs via chroot)." >&2
     exit 1
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,31 @@
         <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-rest-jackson</artifactId>
+          <!-- brotli4j resolves a JNI jar for the build host's platform (native-osx-aarch64 on a
+               Mac, native-linux-* in CI); Floci never enables Brotli HTTP compression. Maven
+               wildcards match a whole artifactId only, hence the explicit list. -->
+          <exclusions>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-osx-aarch64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-osx-x86_64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-linux-aarch64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-linux-x86_64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-windows-x86_64</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <!-- YAML config support -->
         <dependency>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -59,9 +59,10 @@ quarkus:
         - org/xerial/snappy/native/Linux/s390x/**
         - org/xerial/snappy/native/Linux/x86/**
         - org/xerial/snappy/native/Linux/x86_64-musl/**
+    # No --allow-incomplete-classpath and no --report-unsupported-elements-at-runtime: both have
+    # been no-ops since GraalVM 22.1 (incomplete classpaths are the default, and Quarkus passes
+    # --link-at-build-time itself, so a reachable class missing from the classpath fails the build).
     additional-build-args:
-      - --report-unsupported-elements-at-runtime
-      - --allow-incomplete-classpath
       - --enable-url-protocols=http,https
       - --initialize-at-run-time=io.vertx.ext.mail.impl.sasl.NTLMEngineImpl
       - --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32


### PR DESCRIPTION
## Summary

The native image's tools layer installed shadow-utils, which ubi9-minimal 9.7 already
ships, and downloaded a gosu binary: 19 MB on disk, 3.66 MB compressed, byte-identical on
every release since 1.5.34. The entrypoint still starts as root and still grants the
bind-mounted Docker socket's group to the floci user, but through coreutils, which the
base image has: `chroot --userspec=1001:0 --groups=0,<socket gid> --skip-chdir /` drops to
uid 1001 with the socket's gid as a supplementary group. The layer is now 24.6 kB (one
`useradd`). The JVM Dockerfile drops its gosu download too: the entrypoint is shared, so once it execs `chroot` nothing there calls gosu, and the binary plus the wget-and-checksum block on every build were dead weight. Floci's release and nightly pipelines never publish that image; `build-images.yml` is a reusable `workflow_call` a fork invokes to publish its own copy to its own registry, so it deserves the same trim. Its base (`eclipse-temurin:25-jre-noble`, coreutils 9.4) supports `--userspec`, `--groups` and `--skip-chdir`, verified on the built image.

Two native-build inputs go with it, neither changing a byte of the binary:
`--allow-incomplete-classpath` and `--report-unsupported-elements-at-runtime` have been
no-ops since GraalVM 22.1 (Quarkus passes `--link-at-build-time` itself), and the brotli4j
platform JNI jars are excluded from `quarkus-rest-jackson` because Floci never enables
Brotli compression and the jar was never embedded. A native build without them produces
the same 232.25 MB image and the same reachable set.

Part of the image-size work that started with #3016; this PR's job summary is the first
amd64 measurement of that baseline.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No emulated surface changes. Verified on the arm64 native image: `id` inside the container
is uid=1001 gid=0; a Docker socket owned by gid 999 yields groups=0,999 end to end; `/app/data`
is writable; the `sdk-test-java` compat suite passes 1,667/1,667 against the image with the
socket mounted. `--skip-chdir` is required: without it the first run failed 58 Lambda and
Docker-backed cases with "Failed to extract deployment package: /data".

## Checklist

- [ ] `./mvnw test` passes locally (no Java changed; the three native config guards
      `ApplicationDefaultsTest`, `NativeImageRuntimeInitializationTest` and
      `ServiceConfigYamlCoverageTest` pass on this tree)
- [ ] New or updated integration test added (Dockerfile and build-config change; the
      compat CLI job and the native suite legs in `compatibility.yml` exercise it)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

