### PR TITLE
fix(lambda): give each published version its own copy of the code

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -850,7 +850,8 @@ public class LambdaService implements ResourceProvider {
         synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
             warmPool.drainEnvironment(version.get());
             functionStore.deleteVersion(region, name, qualifier);
-            // The snapshot shares $LATEST's code directory, so this only reclaims once no
+            reclaimVersionCodeDirectory(fn, qualifier, version.get());
+            // The snapshot may still share $LATEST's code directory, so this only reclaims once no
             // remaining version references it.
             reclaimLegacyCodeDirectoryIfUnused(name);
         }
@@ -894,6 +895,28 @@ public class LambdaService implements ResourceProvider {
             }
         }
         LOG.infov("Deleted Lambda function: {0}", functionName);
+    }
+
+    /**
+     * Drops the code directory a deleted version owned. Without this the only thing that ever
+     * reclaimed version code was deleting the whole function, so a repeated publish/delete cycle
+     * left one package on disk per version ever published.
+     *
+     * <p>Guarded on the version actually owning that directory rather than deleting it outright.
+     * A version whose copy could not be made fell back to {@code $LATEST}'s path, and image-backed
+     * and hot-reload versions never had a copy at all: for those the recorded path is the live
+     * function's own directory, and removing it would delete the code {@code $LATEST} still runs.
+     */
+    private void reclaimVersionCodeDirectory(LambdaFunction fn, String version, LambdaFunction snapshot) {
+        String recorded = snapshot.getCodeLocalPath();
+        if (recorded == null) {
+            return;
+        }
+        String owned = codeStore.getVersionCodePath(ownerAccount(fn), fn.getFunctionName(), version)
+                .toAbsolutePath().normalize().toString();
+        if (owned.equals(Path.of(recorded).toAbsolutePath().normalize().toString())) {
+            codeStore.deleteVersion(ownerAccount(fn), fn.getFunctionName(), version);
+        }
     }
 
     /**
@@ -1792,6 +1815,31 @@ public class LambdaService implements ResourceProvider {
                 .max(java.util.Comparator.comparingLong(v -> Long.parseLong(v.getVersion())));
     }
 
+    /**
+     * Copies the function's current code into a directory belonging to this version, falling back
+     * to {@code $LATEST}'s path if there is nothing to copy or the copy fails.
+     *
+     * <p>A copy failure must not fail the publish: the version is still a correct snapshot of the
+     * configuration, and falling back leaves it exactly as good as every version published before
+     * this existed, rather than turning a working call into an error.
+     */
+    private String versionCodePath(LambdaFunction fn, String version) {
+        String current = fn.getCodeLocalPath();
+        if (current == null || fn.getHotReloadHostPath() != null) {
+            return current;
+        }
+        try {
+            Path copied = codeStore.copyForVersion(
+                    ownerAccount(fn), fn.getFunctionName(), version, Path.of(current));
+            return copied == null ? current : copied.toAbsolutePath().normalize().toString();
+        } catch (IOException e) {
+            LOG.warnv("Could not give version {0} of {1} its own code directory, "
+                            + "falling back to the shared one: {2}",
+                    version, fn.getFunctionName(), e.getMessage());
+            return current;
+        }
+    }
+
     private int nextVersionNumber(String counterKey, String legacyCounterKey) {
         synchronized (versionCounterLocks.computeIfAbsent(counterKey, k -> new Object())) {
             Integer current = versionCounters.get(counterKey);
@@ -1908,7 +1956,13 @@ public class LambdaService implements ResourceProvider {
             // with nothing in it, and hangs to the function timeout instead of failing (#1987). A
             // published version is an immutable snapshot of code plus configuration, so it carries the
             // code location for every package type, not only Zip.
-            snapshot.setCodeLocalPath(fn.getCodeLocalPath());
+            // A version's own copy of the code, not a reference to $LATEST's directory. Sharing that
+            // directory meant a later UpdateFunctionCode rewrote what an already-published version
+            // ran, so the version advertised one CodeSha256 over a different build (issue #2958).
+            // Nothing to copy for image-backed or hot-reload functions, which keep the reference
+            // they had: an image is already immutable by digest, and a hot-reload function's whole
+            // point is that its bind-mounted directory tracks the developer's working tree.
+            snapshot.setCodeLocalPath(versionCodePath(fn, String.valueOf(version)));
             snapshot.setCodeSha256(fn.getCodeSha256());
             snapshot.setS3Bucket(fn.getS3Bucket());
             snapshot.setS3Key(fn.getS3Key());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
@@ -21,6 +22,12 @@ import java.util.Comparator;
 public class CodeStore {
 
     private static final Logger LOG = Logger.getLogger(CodeStore.class);
+
+    /**
+     * Separates a function's versions directory from any function's own code directory. Deliberately
+     * outside {@link #sanitizeName}'s output character set, so the two namespaces cannot overlap.
+     */
+    private static final String VERSIONS_DIR_SUFFIX = "@versions";
 
     private final Path baseDir;
 
@@ -46,8 +53,75 @@ public class CodeStore {
         return baseDir.resolve(sanitizeName(functionName));
     }
 
+    /**
+     * Where a function's published-version code lives: one directory, holding a subdirectory per
+     * published version.
+     *
+     * <p>A sibling of the {@code $LATEST} directory rather than a child of it. Extraction replaces
+     * {@link #getCodePath}'s directory wholesale, so anything nested inside would be deleted on the
+     * next deploy, which is the very thing a version's copy exists to survive.
+     *
+     * <p>The {@link #VERSIONS_DIR_SUFFIX} is what keeps that sibling from colliding with a real
+     * function. {@link #sanitizeName} maps every name into {@code [a-zA-Z0-9_.-]}, so no function
+     * can produce a directory name containing {@code @}, whatever it is called. Floci does not
+     * restrict the character set of {@code FunctionName} today, only that it is non-blank, so a
+     * plainer {@code <name>.v<n>} sibling carried no such guarantee: a function genuinely named
+     * {@code foo.v1} owns the exact directory {@code foo}'s version 1 would otherwise claim, and
+     * deleting either one silently corrupts the other.
+     */
+    public Path getVersionsPath(String accountId, String functionName) {
+        return baseDir.resolve(sanitizeName(accountId))
+                .resolve(sanitizeName(functionName) + VERSIONS_DIR_SUFFIX);
+    }
+
+    /** Where one published version's own copy of the code lives. */
+    public Path getVersionCodePath(String accountId, String functionName, String version) {
+        return getVersionsPath(accountId, functionName).resolve(sanitizeName(version));
+    }
+
+    /**
+     * Copies a function's current code into its own directory for {@code version}, replacing any
+     * directory already there. Returns null when there is nothing to copy, which is the case for
+     * image-backed and hot-reload functions.
+     */
+    public Path copyForVersion(String accountId, String functionName, String version, Path source)
+            throws IOException {
+        if (source == null || !Files.isDirectory(source)) {
+            return null;
+        }
+        Path target = getVersionCodePath(accountId, functionName, version);
+        deleteDirectory(target, functionName);
+        try (var walk = Files.walk(source)) {
+            for (Path from : walk.toList()) {
+                Path to = target.resolve(source.relativize(from).toString());
+                if (Files.isDirectory(from)) {
+                    Files.createDirectories(to);
+                } else {
+                    Files.createDirectories(to.getParent());
+                    Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING);
+                }
+            }
+        }
+        return target;
+    }
+
+    /** Removes every published version's code for a function. */
+    public void deleteVersions(String accountId, String functionName) {
+        deleteDirectory(getVersionsPath(accountId, functionName), functionName);
+    }
+
+    /**
+     * Removes one published version's code, leaving the function's other versions and
+     * {@code $LATEST} in place. Deleting a single version otherwise left its package on disk for
+     * as long as the data directory lived, so a repeated publish/delete cycle grew without bound.
+     */
+    public void deleteVersion(String accountId, String functionName, String version) {
+        deleteDirectory(getVersionCodePath(accountId, functionName, version), functionName);
+    }
+
     public void delete(String accountId, String functionName) {
         deleteDirectory(getCodePath(accountId, functionName), functionName);
+        deleteVersions(accountId, functionName);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaAccountScopedCodeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaAccountScopedCodeTest.java
@@ -110,14 +110,18 @@ class LambdaAccountScopedCodeTest {
     }
 
     @Test
-    void updateFunctionCodeDoesNotDeleteALegacyDirectoryStillReferencedByAPublishedVersion(
+    void aPublishedVersionsCodeSurvivesLatestMigratingOffTheLegacyPath(
             @TempDir Path baseDir) throws Exception {
-        // publishVersion snapshots codeLocalPath verbatim (it must, or a version-qualified
-        // invoke launches a container with no code - see #1987). If $LATEST was still on the
-        // legacy path at publish time, that version's snapshot is now the ONLY thing keeping
-        // the legacy directory alive once $LATEST itself migrates. The unused-check only scanned
-        // $LATEST records, so it missed this and reclaimed the directory out from under the
-        // published version's own future invokes.
+        // publishVersion used to snapshot codeLocalPath verbatim (it had to, or a
+        // version-qualified invoke launched a container with no code - see #1987). If $LATEST was
+        // still on the legacy path at publish time, that version's snapshot became the ONLY thing
+        // keeping the legacy directory alive once $LATEST itself migrated, and the unused-check
+        // reclaimed it out from under the version's own future invokes.
+        //
+        // A version now copies the code into a directory of its own (#2958), so it no longer
+        // depends on the legacy directory surviving. The guarantee this test protects is unchanged
+        // and now stronger: whatever happens to the directory $LATEST was using, the version keeps
+        // the code it was published from.
         CodeStore codeStore = new CodeStore(baseDir);
         LambdaService svc = serviceFor(ACCOUNT_A, codeStore);
         svc.createFunction(REGION, zipRequest("legacy-version-fn", "v1"));
@@ -129,13 +133,17 @@ class LambdaAccountScopedCodeTest {
         latest.setCodeLocalPath(legacyPath.toAbsolutePath().normalize().toString());
 
         LambdaFunction version = svc.publishVersion(REGION, "legacy-version-fn", null);
-        assertEquals(legacyPath.toAbsolutePath().normalize().toString(), version.getCodeLocalPath(),
-                "the published version must have snapshotted the legacy path");
+        Path versionPath = Path.of(version.getCodeLocalPath());
+        assertNotEquals(legacyPath.toAbsolutePath().normalize().toString(), version.getCodeLocalPath(),
+                "the published version must own its code rather than reference the legacy directory");
+        assertEquals("v1", Files.readString(versionPath.resolve("index.js")).trim());
 
         svc.updateFunctionCode(REGION, "legacy-version-fn", Map.of("ZipFile", zipBase64("index.js", "v2")));
 
-        assertTrue(Files.exists(legacyPath),
-                "a legacy directory a published version still references must survive this update");
+        assertTrue(Files.isDirectory(versionPath),
+                "the published version's own code must survive $LATEST migrating off the legacy path");
+        assertEquals("v1", Files.readString(versionPath.resolve("index.js")).trim(),
+                "the version must still hold the code it was published from");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -15,6 +15,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Base64;
 import java.util.HashSet;
@@ -1466,5 +1468,95 @@ class LambdaServiceTest {
         assertThrows(AwsException.class, () -> service.updateEventSourceMapping(esm.getUuid(), Map.of(
                 "FunctionName", "arn:aws:lambda:us-west-2:000000000000:function:other-region-fn"
         )));
+    }
+
+    /**
+     * Issue #2958: a published version stored a reference to {@code $LATEST}'s code directory
+     * rather than a copy of the code, and extraction replaces that directory wholesale on every
+     * deploy. A later UpdateFunctionCode therefore rewrote what an already-published version would
+     * run, leaving the version advertising one CodeSha256 over a different build.
+     */
+    @Test
+    void aPublishedVersionKeepsItsOwnCodeWhenLatestIsRedeployed() throws Exception {
+        Map<String, Object> request = baseRequest("version-code-isolation-fn");
+        request.put("Code", Map.of("ZipFile", zipWithBody("v1")));
+        service.createFunction(REGION, request);
+
+        LambdaFunction v1 = service.publishVersion(REGION, "version-code-isolation-fn", null);
+        Path v1Path = Path.of(v1.getCodeLocalPath());
+        String v1Sha = v1.getCodeSha256();
+
+        assertTrue(Files.isDirectory(v1Path), "a published version must have its own code directory");
+        assertEquals("v1", Files.readString(v1Path.resolve("index.js")).trim());
+
+        // Redeploy $LATEST. Extraction replaces its directory wholesale, which is what used to take
+        // the published version's code with it.
+        service.updateFunctionCode(REGION, "version-code-isolation-fn",
+                Map.of("ZipFile", zipWithBody("v2")));
+
+        LambdaFunction latest = service.getFunction(REGION, "version-code-isolation-fn");
+        assertNotEquals(v1Path.toString(), latest.getCodeLocalPath(),
+                "a version must not share $LATEST's directory");
+        assertEquals("v2",
+                Files.readString(Path.of(latest.getCodeLocalPath()).resolve("index.js")).trim());
+
+        // The version still holds the bytes it was published from, and they still match the hash it
+        // advertises, which is the guarantee that was broken.
+        assertTrue(Files.isDirectory(v1Path), "the version's code must survive a redeploy of $LATEST");
+        assertEquals("v1", Files.readString(v1Path.resolve("index.js")).trim());
+        assertEquals(v1Sha, v1.getCodeSha256());
+    }
+
+    @Test
+    void deletingAFunctionRemovesItsPublishedVersionsCode() throws Exception {
+        Map<String, Object> request = baseRequest("version-code-delete-fn");
+        request.put("Code", Map.of("ZipFile", zipWithBody("v1")));
+        service.createFunction(REGION, request);
+
+        LambdaFunction v1 = service.publishVersion(REGION, "version-code-delete-fn", null);
+        Path v1Path = Path.of(v1.getCodeLocalPath());
+        assertTrue(Files.isDirectory(v1Path));
+
+        service.deleteFunction(REGION, "version-code-delete-fn");
+
+        assertFalse(Files.exists(v1Path),
+                "a version's code must not outlive the function it belongs to");
+    }
+
+    @Test
+    void deletingOnePublishedVersionReclaimsOnlyThatVersionsCode() throws Exception {
+        Map<String, Object> request = baseRequest("version-code-reclaim-fn");
+        request.put("Code", Map.of("ZipFile", zipWithBody("v1")));
+        service.createFunction(REGION, request);
+
+        LambdaFunction v1 = service.publishVersion(REGION, "version-code-reclaim-fn", null);
+        service.updateFunctionCode(REGION, "version-code-reclaim-fn",
+                Map.of("ZipFile", zipWithBody("v2")));
+        LambdaFunction v2 = service.publishVersion(REGION, "version-code-reclaim-fn", null);
+
+        Path v1Path = Path.of(v1.getCodeLocalPath());
+        Path v2Path = Path.of(v2.getCodeLocalPath());
+        Path latestPath = Path.of(
+                service.getFunction(REGION, "version-code-reclaim-fn").getCodeLocalPath());
+        assertNotEquals(v1Path, v2Path, "two versions must not share one code directory");
+
+        service.deleteFunction(REGION, "version-code-reclaim-fn", v1.getVersion());
+
+        // Only whole-function delete reclaimed any of this before, so every version ever published
+        // stayed on disk for as long as the data directory lived.
+        assertFalse(Files.exists(v1Path), "the deleted version's code must be reclaimed");
+        assertTrue(Files.isDirectory(v2Path), "a surviving version's code must be left alone");
+        assertEquals("v2", Files.readString(v2Path.resolve("index.js")).trim());
+        assertTrue(Files.isDirectory(latestPath), "$LATEST's code must be left alone");
+    }
+
+    private static String zipWithBody(String body) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write((body + "\n").getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
@@ -103,6 +103,60 @@ class CodeStoreTest {
         assertFalse(Files.exists(legacyPath));
     }
 
+    @Test
+    void aVersionDirectoryCannotCollideWithAnotherFunctionsOwnDirectory(@TempDir Path baseDir)
+            throws IOException {
+        // Floci does not restrict the character set of FunctionName today, only that it is
+        // non-blank, so "foo.v1" is a function a user can genuinely create. A "<name>.v<n>" sibling
+        // naming scheme handed it the exact directory version 1 of "foo" would claim, so deleting
+        // either function silently corrupted the other. The suffix used instead is outside the
+        // character set sanitizeName can emit, which makes the two namespaces disjoint by
+        // construction rather than by a prefix match that has to guess where the name ends.
+        CodeStore store = new CodeStore(baseDir);
+        writeHandler(store.getVersionCodePath(ACCOUNT_A, "foo", "1"), "foo-v1");
+        writeHandler(store.getCodePath(ACCOUNT_A, "foo.v1"), "other-function");
+        writeHandler(store.getVersionCodePath(ACCOUNT_A, "foo.v1", "1"), "other-function-v1");
+
+        store.delete(ACCOUNT_A, "foo");
+
+        assertTrue(store.exists(ACCOUNT_A, "foo.v1"),
+                "deleting foo must not remove a function literally named foo.v1");
+        assertEquals("other-function",
+                Files.readString(store.getCodePath(ACCOUNT_A, "foo.v1").resolve("index.js")));
+        assertEquals("other-function-v1",
+                Files.readString(store.getVersionCodePath(ACCOUNT_A, "foo.v1", "1").resolve("index.js")),
+                "another function's published version code must survive too");
+        assertFalse(Files.exists(store.getVersionCodePath(ACCOUNT_A, "foo", "1")),
+                "foo's own version code must still be reclaimed");
+    }
+
+    @Test
+    void deleteVersionRemovesOneVersionAndLeavesTheRestInPlace(@TempDir Path baseDir) throws IOException {
+        CodeStore store = new CodeStore(baseDir);
+        writeHandler(store.getCodePath(ACCOUNT_A, "fn"), "latest");
+        writeHandler(store.getVersionCodePath(ACCOUNT_A, "fn", "1"), "one");
+        writeHandler(store.getVersionCodePath(ACCOUNT_A, "fn", "2"), "two");
+
+        store.deleteVersion(ACCOUNT_A, "fn", "1");
+
+        assertFalse(Files.exists(store.getVersionCodePath(ACCOUNT_A, "fn", "1")));
+        assertEquals("two",
+                Files.readString(store.getVersionCodePath(ACCOUNT_A, "fn", "2").resolve("index.js")));
+        assertTrue(store.exists(ACCOUNT_A, "fn"), "$LATEST's code must be untouched");
+    }
+
+    @Test
+    void versionCodeLivesOutsideTheDirectoryExtractionReplaces(@TempDir Path baseDir) {
+        CodeStore store = new CodeStore(baseDir);
+
+        Path latest = store.getCodePath(ACCOUNT_A, "fn");
+        Path version = store.getVersionCodePath(ACCOUNT_A, "fn", "1");
+
+        assertFalse(version.normalize().startsWith(latest.normalize()),
+                "extraction replaces $LATEST's directory wholesale, taking any nested version with it");
+        assertTrue(version.normalize().startsWith(baseDir.normalize()));
+    }
+
     private void writeHandler(Path codePath, String content) throws IOException {
         Files.createDirectories(codePath);
         Files.writeString(codePath.resolve("index.js"), content);


### PR DESCRIPTION
## Summary

Closes #2958.

A published Lambda version's metadata was immutable, but the directory that metadata named was not.
`CodeStore.getCodePath` has no version component, so every version shared one directory with
`$LATEST`, and `publishVersion` copied only the `codeLocalPath` pointer. A later
`UpdateFunctionCode` replaces that directory wholesale, so it silently rewrote what an
already-published version ran: the version kept advertising the `CodeSha256` it was published with
while the bytes behind it were a different build, and `ContainerLauncher` tar-copies that directory
at launch, so a qualified invoke executed `$LATEST`'s code. That defeats the point of pinning to a
version at all: an alias held at version 1 for a canary, a rollback to a known-good build, or a
stack referencing `:1` all quietly started running the newest deploy.

`publishVersion` now copies the code into a directory belonging to that version, so the version owns
the bytes it was published from. Image-backed and hot-reload functions are carved out and keep the
reference they had: an image is already immutable by digest, and a hot-reload function's whole point
is that its bind-mounted directory tracks the developer's working tree. A copy failure falls back to
the old shared path rather than failing the publish, which leaves the version exactly as good as
every version published before this existed instead of turning a working call into an error.

```bash
# handler.py returns the string it was built with.
$ zip -j v1.zip handler.py            # returns "v1"
$ aws --endpoint-url=http://localhost:4566 lambda create-function \
      --function-name greeter --runtime python3.12 --handler handler.handler \
      --role arn:aws:iam::000000000000:role/r --zip-file fileb://v1.zip

$ aws --endpoint-url=http://localhost:4566 lambda publish-version --function-name greeter
{ "Version": "1", "CodeSha256": "8Xw...=" }

$ zip -j v2.zip handler.py            # rebuilt, now returns "v2"
$ aws --endpoint-url=http://localhost:4566 lambda update-function-code \
      --function-name greeter --zip-file fileb://v2.zip

# Invoke the PINNED version, which nothing should have changed.
$ aws --endpoint-url=http://localhost:4566 lambda invoke \
      --function-name greeter:1 out.json && cat out.json
```

```
BEFORE:  "v2"     wrong. Version 1 runs the build that replaced it, while still
                  reporting CodeSha256 8Xw...= for the build it no longer has.

AFTER:   "v1"     correct. Version 1 runs the bytes it was published from, and
                  those bytes still hash to 8Xw...=.
```

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real AWS treats a published version as an immutable snapshot of code plus configuration.
`UpdateFunctionCode` only ever moves `$LATEST`; it cannot alter a version that has already been
published, and `GetFunction` on a qualified name returns the code and the `CodeSha256` that version
was created with for the life of that version.

Floci diverged on the code, not on the metadata. The version record was correct and frozen, and
every existing version test asserts those fields and still passes. What was wrong was that the
`codeLocalPath` on that frozen record pointed at a directory the next deploy would overwrite, so the
`CodeSha256` a qualified `GetFunction` returned stopped describing the code a qualified `Invoke`
would run. There is no new wire protocol here and no new action: this restores an existing action's
documented behaviour, so the correction is verified against `LambdaVersionIntegrationTest` and the
unit coverage listed below rather than against a new SDK call.

Two secondary divergences are also fixed, both raised in review of the first cut of this PR:

- **`DeleteFunction` could destroy an unrelated function.** Version directories were named
  `<function>.v<n>` as siblings, and whole-function delete swept them with a bare
  `startsWith(name + ".v")`. Real AWS restricts `FunctionName` to `[a-zA-Z0-9-_]` so `foo.v1` cannot
  exist there, but Floci's `CreateFunction` validates only that the name is non-blank, making the
  collision reachable through Floci itself. Deleting `foo` wiped the code of a function genuinely
  named `foo.v1`, whose next invoke then launched an empty container and hung to the function
  timeout (the #1987 failure mode) with nothing recorded against the delete that caused it.
- **`DeleteFunction --qualifier` leaked storage.** Deleting a single published version removed the
  record but never its code, so only whole-function delete reclaimed anything and a repeated
  publish/delete cycle grew on disk without bound.

## What changed

- **`CodeStore`**: new `getVersionsPath` returning `<codePath>/<account>/<function>@versions`, a
  container holding one subdirectory per version. `deleteVersions` now deletes that one directory
  and the prefix scan is gone. New `deleteVersion` removes a single version's code.
- **`LambdaService`**: `deleteFunctionVersion` reclaims the deleted version's directory, inside the
  per-function lock it already held, and only when that version actually owned one. A version that
  fell back to `$LATEST`'s path, and every image-backed or hot-reload version, is left alone;
  deleting the path those record would take the live function's code with it.
- `versionCodePath` is called from inside `publishVersion`'s `lockForConcurrencyOp` block, so the
  copy cannot interleave with a concurrent `UpdateFunctionCode`.
- Rebased onto current `main`. `main` added `latestPublishedFrom` and `newestVersion` at the same
  point this branch inserted `versionCodePath`; the conflict is resolved by keeping all three, and
  `main`'s newer locking around the `PublishVersion` `CodeSha256` precondition is preserved intact.

### Why this shape rather than a delimiter-safe prefix match

Review asked for a delimiter-safe match instead of the bare `startsWith`. Tightening it to
`<name>.v<digits>` fixes `foo.v` but not `foo.v1`, which is the same collision one character over:
the real problem is that version directories and function directories shared one namespace, so no
matching rule over that layout can be correct. `@versions` is chosen deliberately, not
decoratively: `sanitizeName` maps every name into `[a-zA-Z0-9_.-]`, so no function, whatever a user
calls it, can produce a directory name containing `@`. The namespaces are disjoint by construction,
the prefix scan and its failure handling are deleted rather than patched, and the fix does not
depend on version qualifiers happening to be numeric.

## How it was tested

Baseline before this revision, on the rebased branch: **337 run, 0 failures, 0 errors, 0 skipped**.
After: **341 run, 0 failures, 0 errors, 0 skipped** (`Lambda*Test`, `CodeStore*Test`,
`ZipExtractor*Test`, integration excluded). Net +4 is two tests relocated and six added.

| Test | Covers |
|---|---|
| `LambdaServiceTest.aPublishedVersionKeepsItsOwnCodeWhenLatestIsRedeployed` | The reported bug: publish v1, redeploy `$LATEST`, assert the version still holds v1's bytes, that `$LATEST` extracted elsewhere, and that the version's `CodeSha256` still describes what is on disk |
| `LambdaServiceTest.deletingAFunctionRemovesItsPublishedVersionsCode` | A version's code does not outlive its function |
| `LambdaServiceTest.deletingOnePublishedVersionReclaimsOnlyThatVersionsCode` | Deleting version 1 of a two-version function reclaims only version 1, leaving version 2 and `$LATEST` intact and readable |
| `CodeStoreTest.aVersionDirectoryCannotCollideWithAnotherFunctionsOwnDirectory` | A function named `foo.v1` survives `delete("foo")` with both its `$LATEST` and its version code, while `foo`'s version code is still reclaimed |
| `CodeStoreTest.deleteVersionRemovesOneVersionAndLeavesTheRestInPlace` | `deleteVersion` is scoped to one version |
| `CodeStoreTest.versionCodeLivesOutsideTheDirectoryExtractionReplaces` | The layout invariant: a version directory is never under the directory extraction replaces (#2672) |

Both new regression tests were confirmed to fail against the pre-fix behaviour, by restoring the
flat `.v<n>` naming and removing the reclaim call:

```
CodeStoreTest.aVersionDirectoryCannotCollideWithAnotherFunctionsOwnDirectory:122
  deleting foo must not remove a function literally named foo.v1 ==> expected: <true> but was: <false>
LambdaServiceTest.deletingOnePublishedVersionReclaimsOnlyThatVersionsCode:1547
  the deleted version's code must be reclaimed ==> expected: <false> but was: <true>
```

The three service-level tests now live in `LambdaServiceTest` and the separate
`LambdaVersionCodeIsolationTest` class is deleted, resolving the naming point from review:
`AGENTS.md` documents `*ServiceTest.java` and `*IntegrationTest.java`, and that class was neither.

## Risk and rollback

Low. No public API signature change, no wire-protocol change, no configuration change. Behaviour
changes are confined to the on-disk layout under `floci.services.lambda.code-path` and to what
`DeleteFunction --qualifier` cleans up. No migration is needed: the `.v<n>` layout only ever existed
on this unmerged branch, so there is no released on-disk format to move off. Functions created
before this change keep working, including versions published while `$LATEST` was still on the
pre-account-scoped legacy path, which
`LambdaAccountScopedCodeTest.aPublishedVersionsCodeSurvivesLatestMigratingOffTheLegacyPath` covers.
Rollback is reverting the commit; the only residue would be orphaned `<function>@versions`
directories, which are inert and go when the function is deleted.

Disk use is now one extracted package per live published version, released when the version is
deleted. `copyForVersion` runs once per publish inside the per-function lock, so a very large
deployment package briefly serializes other operations on that one function. That is the price of
doing the copy where it cannot race a concurrent deploy.

## Note on the overlap with #3136

#3136 fixes the same issue with content addressing. It is the more elegant design and its storage
dedup is real, and I would be glad to see it land eventually. The case for this PR going first is
blast radius: it changes nothing on the deploy path, whereas content addressing changes the
extraction path for every function and needs a reclaim pass over historical builds whose filter has
to avoid deleting in-flight extractions. Review of #3136 found a null `codeLocalPath` crash and a
race from extracting outside the per-function lock in exactly that machinery, and greptile's own
citation there points at a prior rollback of a Lambda code-volume cleanup attempt. Happy to defer if
maintainers would rather take that approach; flagging it so two PRs do not sit on one issue.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Out of scope, worth its own issue

`CreateFunction` does not validate the `FunctionName` charset (only that it is non-blank), which is
why the `foo.v1` collision above was reachable at all and is itself a divergence from AWS. That is a
separate behaviour change with its own compatibility question, so it is deliberately not bundled
here. This PR is correct with or without it.
