### PR TITLE
docs(cloudformation): note that a stack detaches an IoT policy before deleting it

### DIFF
--- a/tools/docs/cfn_resource_types.yaml
+++ b/tools/docs/cfn_resource_types.yaml
@@ -148,6 +148,7 @@ notes:
   AWS::RDS::DBCluster: starts a real container
   AWS::CDK::Metadata: accepted; no-op
   AWS::IoT::DomainConfiguration: '`ServerCertificates` resolves to a JSON string'
+  AWS::IoT::Policy: 'deleted after detaching it from its principals; on AWS the delete fails with `DeleteConflictException` while the policy is attached'
   Custom::DynamoDBReplica: applied natively against DynamoDB, not via a provider Lambda
 
 # Trailing prose appended to a row after its type list, for behaviour that belongs to the service


### PR DESCRIPTION
## Summary

Follow-up to #3014, asked for there. The generated resource-type table in `docs/services/cloudformation.md` will tell users that a stack deletes an `AWS::IoT::Policy` after detaching it from its principals, and that on AWS the delete fails with `DeleteConflictException` while the policy is attached.

The behaviour itself comes with #3014 and does not change here. Floci detaches first so that a local teardown never gets stuck on a device that connected while the stack existed. On AWS, the CloudFormation handler for the type deletes the non-default policy versions and then calls `DeletePolicy` without detaching anything, and `DeletePolicy` refuses an attached policy with `DeleteConflictException` (HTTP 409). The stack delete fails there.

This PR is one line in `tools/docs/cfn_resource_types.yaml`. The table generator renders a note only for a type that has a row in `supported-resource-types.tsv`, and that row for `AWS::IoT::Policy` arrives with #3014, so on `main` today the line is inert and the generated table does not change. It can merge in any order: whichever of #3014 and this PR lands second picks the note up through `make docs-sync`, and if #3014 lands first I rebase this branch and push the regenerated row. Once both are in, the IoT Core row reads:

> `Policy` (deleted after detaching it from its principals; on AWS the delete fails with `DeleteConflictException` while the policy is attached)

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| `AWS::IoT::Policy` | Delete of a policy that is not attached | ✅ | Same as AWS. Comes with #3014; unchanged here. |
| `AWS::IoT::Policy` | Delete of a policy that is still attached | 🟡 | Floci detaches it from its principals and deletes it. AWS fails the stack delete with `DeleteConflictException`. This PR documents that difference in the table. |
| Docs | Resource-type table note | ✅ | One `notes:` entry; the row is generated by `make docs-sync` once the type has an inventory row. |

## Files

- `tools/docs/cfn_resource_types.yaml`: one `notes:` entry for `AWS::IoT::Policy`, next to the `AWS::IoT::DomainConfiguration` note.

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Docs / chore

### Checklist

* [ ] `./mvnw test` passes locally. Not run: no Java file changes. Ran `make docs-test` (53 tests) and `make docs-check` instead; both pass.
* [ ] New or updated integration test added. No tests: documentation only, no behaviour changes.
* [x] Commit messages follow Conventional Commits
