### PR TITLE
fix(kms): support SM2 signing in China regions

### DIFF
--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -614,9 +614,13 @@ public final class TestFixtures {
     }
 
     public static KmsClient kmsClient() {
+        return kmsClient(REGION);
+    }
+
+    public static KmsClient kmsClient(Region region) {
         return KmsClient.builder()
                 .endpointOverride(ENDPOINT)
-                .region(REGION)
+                .region(region)
                 .credentialsProvider(CREDENTIALS)
                 .build();
     }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KmsSm2Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KmsSm2Test.java
@@ -1,0 +1,51 @@
+package com.floci.test;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.KeySpec;
+import software.amazon.awssdk.services.kms.model.KeyUsageType;
+import software.amazon.awssdk.services.kms.model.MessageType;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KmsSm2Test {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"cn-north-1", "cn-northwest-1"})
+    void signAndVerifyUseSm2dsaWireAlgorithm(String region) {
+        try (KmsClient kms = TestFixtures.kmsClient(Region.of(region))) {
+            var key = kms.createKey(b -> b.keySpec(KeySpec.SM2).keyUsage(KeyUsageType.SIGN_VERIFY));
+            String keyId = key.keyMetadata().keyId();
+            try {
+                assertThat(key.keyMetadata().signingAlgorithms()).containsExactly(SigningAlgorithmSpec.SM2_DSA);
+                var publicKey = kms.getPublicKey(b -> b.keyId(keyId));
+                assertThat(publicKey.signingAlgorithms()).containsExactly(SigningAlgorithmSpec.SM2_DSA);
+                assertThat(publicKey.publicKey().asByteArray()).isNotEmpty();
+
+                var message = SdkBytes.fromUtf8String("SM2 SDK wire compatibility");
+                var signed = kms.sign(b -> b.keyId(keyId)
+                        .message(message)
+                        .messageType(MessageType.RAW)
+                        .signingAlgorithm(SigningAlgorithmSpec.SM2_DSA));
+                assertThat(signed.signingAlgorithm()).isEqualTo(SigningAlgorithmSpec.SM2_DSA);
+                assertThat(signed.signingAlgorithmAsString()).isEqualTo("SM2DSA");
+                assertThat(signed.signature().asByteArray()).isNotEmpty();
+
+                var verified = kms.verify(b -> b.keyId(keyId)
+                        .message(message)
+                        .messageType(MessageType.RAW)
+                        .signature(signed.signature())
+                        .signingAlgorithm(SigningAlgorithmSpec.SM2_DSA));
+                assertThat(verified.signingAlgorithm()).isEqualTo(SigningAlgorithmSpec.SM2_DSA);
+                assertThat(verified.signingAlgorithmAsString()).isEqualTo("SM2DSA");
+                assertThat(verified.signatureValid()).isTrue();
+            } finally {
+                kms.scheduleKeyDeletion(b -> b.keyId(keyId).pendingWindowInDays(7));
+            }
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KmsSm2Test.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KmsSm2Test.java
@@ -1,16 +1,19 @@
 package com.floci.test;
 
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.KeySpec;
 import software.amazon.awssdk.services.kms.model.KeyUsageType;
+import software.amazon.awssdk.services.kms.model.KmsException;
 import software.amazon.awssdk.services.kms.model.MessageType;
 import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class KmsSm2Test {
 
@@ -43,6 +46,45 @@ class KmsSm2Test {
                 assertThat(verified.signingAlgorithm()).isEqualTo(SigningAlgorithmSpec.SM2_DSA);
                 assertThat(verified.signingAlgorithmAsString()).isEqualTo("SM2DSA");
                 assertThat(verified.signatureValid()).isTrue();
+            } finally {
+                kms.scheduleKeyDeletion(b -> b.keyId(keyId).pendingWindowInDays(7));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "cn-north-1, ECDSA_SHA_256, RAW, InvalidKeyUsageException",
+            "cn-northwest-1, ECDSA_SHA_256, RAW, InvalidKeyUsageException",
+            "cn-north-1, SM2DSA, DIGEST, ValidationException",
+            "cn-northwest-1, SM2DSA, DIGEST, ValidationException"
+    })
+    void signAndVerifyRejectInvalidSm2Parameters(String region, String algorithm,
+                                               MessageType messageType, String errorCode) {
+        try (KmsClient kms = TestFixtures.kmsClient(Region.of(region))) {
+            var key = kms.createKey(b -> b.keySpec(KeySpec.SM2).keyUsage(KeyUsageType.SIGN_VERIFY));
+            String keyId = key.keyMetadata().keyId();
+            try {
+                var message = SdkBytes.fromByteArray(new byte[32]);
+                var signature = kms.sign(b -> b.keyId(keyId)
+                        .message(message)
+                        .messageType(MessageType.RAW)
+                        .signingAlgorithm(SigningAlgorithmSpec.SM2_DSA)).signature();
+
+                var signError = assertThrows(KmsException.class, () -> kms.sign(b -> b.keyId(keyId)
+                        .message(message)
+                        .messageType(messageType)
+                        .signingAlgorithm(algorithm)));
+                assertThat(signError.statusCode()).isEqualTo(400);
+                assertThat(signError.awsErrorDetails().errorCode()).isEqualTo(errorCode);
+
+                var verifyError = assertThrows(KmsException.class, () -> kms.verify(b -> b.keyId(keyId)
+                        .message(message)
+                        .messageType(messageType)
+                        .signature(signature)
+                        .signingAlgorithm(algorithm)));
+                assertThat(verifyError.statusCode()).isEqualTo(400);
+                assertThat(verifyError.awsErrorDetails().errorCode()).isEqualTo(errorCode);
             } finally {
                 kms.scheduleKeyDeletion(b -> b.keyId(keyId).pendingWindowInDays(7));
             }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -44,6 +44,7 @@ import org.bouncycastle.crypto.params.ParametersWithRandom;
 import org.bouncycastle.crypto.signers.ECDSASigner;
 import org.bouncycastle.crypto.signers.Ed25519phSigner;
 import org.bouncycastle.crypto.signers.PSSSigner;
+import org.bouncycastle.crypto.signers.SM2Signer;
 import org.bouncycastle.crypto.util.PrivateKeyFactory;
 import org.bouncycastle.crypto.util.PublicKeyFactory;
 import org.bouncycastle.jcajce.provider.asymmetric.ec.BCECPrivateKey;
@@ -1455,17 +1456,24 @@ public class KmsService implements ResourceProvider {
         }
 
         var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
+        var sm2 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.SM2;
         if (ed25519) {
             validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType, message);
         }
         if (kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ML_DSA) {
             validateMlDsaRequest(kmsKey.getKeySpec(), algorithm, messageType);
         }
+        if (sm2) {
+            validateSm2Request(kmsKey.getKeySpec(), algorithm, messageType);
+        }
 
         try {
             PrivateKey privateKey = loadPrivateKey(kmsKey.getPrivateKeyEncoded(), kmsKey.getKeySpec());
             if (ed25519) {
                 return signEd25519(privateKey, message, algorithm);
+            }
+            if (sm2) {
+                return signSm2(privateKey, message);
             }
             if (messageType == DIGEST && isRsaPssRequest(kmsKey.getKeySpec(), algorithm)) {
                 return signRsaPssDigest(privateKey, message, algorithm);
@@ -1506,17 +1514,24 @@ public class KmsService implements ResourceProvider {
         }
 
         var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
+        var sm2 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.SM2;
         if (ed25519) {
             validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType, message);
         }
         if (kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ML_DSA) {
             validateMlDsaRequest(kmsKey.getKeySpec(), algorithm, messageType);
         }
+        if (sm2) {
+            validateSm2Request(kmsKey.getKeySpec(), algorithm, messageType);
+        }
 
         try {
             PublicKey publicKey = loadPublicKey(kmsKey.getPublicKeyEncoded(), kmsKey.getKeySpec());
             if (ed25519) {
                 return verifyEd25519(publicKey, message, signature, algorithm);
+            }
+            if (sm2) {
+                return verifySm2(publicKey, message, signature);
             }
             String jcaAlgo = KmsKeySpec.getSignVerifyAlgorithm(algorithm).getJavaName();
 
@@ -1637,7 +1652,7 @@ public class KmsService implements ResourceProvider {
 
     private PrivateKey loadPrivateKey(String encoded, KmsKeySpec spec) throws Exception {
         byte[] decoded = Base64.getDecoder().decode(encoded);
-        if (isSecgP256k1(spec)) {
+        if (isSecgP256k1(spec) || isSm2(spec)) {
             // For secp256k1, use BC's KeyFactorySpi.EC directly as AsymmetricKeyInfoConverter.
             // This bypasses JCA and ClassLoader.loadClass; the allocation is live (generatePrivate
             // is called), so GraalVM's escape analysis keeps the class in the native image.
@@ -1649,7 +1664,7 @@ public class KmsService implements ResourceProvider {
 
     private PublicKey loadPublicKey(String encoded, KmsKeySpec spec) throws Exception {
         byte[] decoded = Base64.getDecoder().decode(encoded);
-        if (isSecgP256k1(spec)) {
+        if (isSecgP256k1(spec) || isSm2(spec)) {
             AsymmetricKeyInfoConverter converter = new KeyFactorySpi.EC();
             return converter.generatePublic(SubjectPublicKeyInfo.getInstance(decoded));
         }
@@ -1719,6 +1734,43 @@ public class KmsService implements ResourceProvider {
 
     private static boolean isSecgP256k1(KmsKeySpec spec) {
         return KmsKeySpec.ECC_SECG_P256K1 == spec;
+    }
+
+    private static boolean isSm2(KmsKeySpec spec) {
+        return KmsKeySpec.SM2 == spec;
+    }
+
+    private static void validateSm2Request(KmsKeySpec spec, String algorithm, KmsMessageType messageType) {
+        if (KmsKeySpec.getSignVerifyAlgorithm(algorithm) != KmsKeySpec.Algorithm.SM2_DSA) {
+            throw new AwsException("InvalidKeyUsageException",
+                    "Algorithm " + algorithm + " is incompatible with key spec " + spec.name() + ".", 400);
+        }
+        if (messageType != RAW) {
+            throw new AwsException("ValidationException",
+                    "Message type " + messageType + " is incompatible with key spec " + spec.name() + ".", 400);
+        }
+    }
+
+    private static byte[] signSm2(PrivateKey privateKey, byte[] message) throws Exception {
+        ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec("sm2p256v1");
+        ECDomainParameters domain = new ECDomainParameters(spec.getCurve(), spec.getG(), spec.getN(), spec.getH());
+        ECPrivateKeyParameters parameters = new ECPrivateKeyParameters(((BCECPrivateKey) privateKey).getD(), domain);
+
+        var signer = new SM2Signer();
+        signer.init(true, new ParametersWithRandom(parameters, SECURE_RANDOM));
+        signer.update(message, 0, message.length);
+        return signer.generateSignature();
+    }
+
+    private static boolean verifySm2(PublicKey publicKey, byte[] message, byte[] signature) {
+        ECNamedCurveParameterSpec spec = ECNamedCurveTable.getParameterSpec("sm2p256v1");
+        ECDomainParameters domain = new ECDomainParameters(spec.getCurve(), spec.getG(), spec.getN(), spec.getH());
+        ECPublicKeyParameters parameters = new ECPublicKeyParameters(((BCECPublicKey) publicKey).getQ(), domain);
+
+        var verifier = new SM2Signer();
+        verifier.init(false, parameters);
+        verifier.update(message, 0, message.length);
+        return verifier.verifySignature(signature);
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -264,7 +264,7 @@ public class KmsService implements ResourceProvider {
                     key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
                 }
                 case SM2 -> {
-                    if (!region.startsWith("cn-")) {
+                    if (!region.equals("cn-north-1") && !region.equals("cn-northwest-1")) {
                         throw new AwsException("UnsupportedOperationException",
                                 "KeySpec SM2 is not supported in this Region", 400);
                     }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -191,7 +191,7 @@ public class KmsService implements ResourceProvider {
             key.setKeyState(PENDING_IMPORT);
             key.setEnabled(false);
         } else {
-            generateKeyMaterial(key);
+            generateKeyMaterial(key, region);
         }
 
         keyStore.put(region + "::" + keyId, key);
@@ -216,7 +216,7 @@ public class KmsService implements ResourceProvider {
         return normalized;
     }
 
-    private void generateKeyMaterial(KmsKey key) {
+    private void generateKeyMaterial(KmsKey key, String region) {
         KmsKeySpec spec = key.getKeySpec();
         try {
             switch (spec.getKeyType()) {
@@ -262,9 +262,17 @@ public class KmsService implements ResourceProvider {
                     key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
                     key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
                 }
-                case SM2 ->
+                case SM2 -> {
+                    if (!region.startsWith("cn-")) {
                         throw new AwsException("UnsupportedOperationException",
                                 "KeySpec SM2 is not supported in this Region", 400);
+                    }
+                    KeyPairGenerator generator = new KeyPairGeneratorSpi.EC();
+                    generator.initialize(new ECGenParameterSpec("sm2p256v1"));
+                    KeyPair pair = generator.generateKeyPair();
+                    key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
+                    key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
+                }
                 default ->
                         throw new AwsException("InvalidCustomerMasterKeySpecException", "Unsupported key spec: " + spec, 400);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -1741,7 +1741,7 @@ public class KmsService implements ResourceProvider {
     }
 
     private static void validateSm2Request(KmsKeySpec spec, String algorithm, KmsMessageType messageType) {
-        if (KmsKeySpec.getSignVerifyAlgorithm(algorithm) != KmsKeySpec.Algorithm.SM2_DSA) {
+        if (KmsKeySpec.getSignVerifyAlgorithm(algorithm) != KmsKeySpec.Algorithm.SM2DSA) {
             throw new AwsException("InvalidKeyUsageException",
                     "Algorithm " + algorithm + " is incompatible with key spec " + spec.name() + ".", 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -262,6 +262,9 @@ public class KmsService implements ResourceProvider {
                     key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
                     key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
                 }
+                case SM2 ->
+                        throw new AwsException("UnsupportedOperationException",
+                                "KeySpec SM2 is not supported in this Region", 400);
                 default ->
                         throw new AwsException("InvalidCustomerMasterKeySpecException", "Unsupported key spec: " + spec, 400);
             }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
@@ -27,7 +27,7 @@ public enum KmsKeySpec {
     HMAC_384(KeyType.HMAC, Algorithm.HMAC_SHA_384),
     HMAC_512(KeyType.HMAC, Algorithm.HMAC_SHA_512),
 
-    SM2(KeyType.SM2, Algorithm.SM2_DSA),
+    SM2(KeyType.SM2, Algorithm.SM2DSA),
 
     ML_DSA_44(KeyType.ML_DSA, Algorithm.ML_DSA_SHAKE_256),
     ML_DSA_65(KeyType.ML_DSA, Algorithm.ML_DSA_SHAKE_256),
@@ -152,7 +152,7 @@ public enum KmsKeySpec {
         ECDSA_SHA_512("ECDSA_SHA_512", "SHA512withECDSA", KmsKeyUsage.SIGN_VERIFY),
         ED25519_SHA_512("ED25519_SHA_512","Ed25519", KmsKeyUsage.SIGN_VERIFY),
         ED25519_PH_SHA_512("ED25519_PH_SHA_512", "Ed25519", KmsKeyUsage.SIGN_VERIFY),
-        SM2_DSA("SM2DSA","", KmsKeyUsage.SIGN_VERIFY),
+        SM2DSA("SM2DSA","", KmsKeyUsage.SIGN_VERIFY),
         ML_DSA_SHAKE_256("ML_DSA_SHAKE_256", "ML-DSA", KmsKeyUsage.SIGN_VERIFY),
         HMAC_SHA_224("HMAC_SHA_224",""),
         HMAC_SHA_256("HMAC_SHA_256",""),

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -1195,6 +1195,19 @@ class KmsIntegrationTest {
                 .body("KeyMetadata.KeySpec", equalTo("ECC_NIST_P256"));
     }
 
+    @Test
+    void createSm2KeyReportsRegionUnsupportedOperation() {
+        given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"SIGN_VERIFY\",\"KeySpec\":\"SM2\"}")
+                .when().post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("UnsupportedOperationException"))
+                .body("message", equalTo("KeySpec SM2 is not supported in this Region"));
+    }
+
     // ── Issue #1528 — ListKeyPolicies ────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -92,11 +92,14 @@ class KmsServiceTest {
     @ValueSource(strings = {"cn-north-1", "cn-northwest-1"})
     void createSm2KeySucceedsInChinaRegions(String region) {
         KmsKey key = kmsService.createKey(null, "SIGN_VERIFY", "SM2", null, Map.of(), region);
+        byte[] message = "SM2 regional signing".getBytes(StandardCharsets.UTF_8);
+        byte[] signature = kmsService.sign(key.getKeyId(), message, "SM2_DSA", region);
 
         assertEquals(KmsKeySpec.SM2, key.getKeySpec());
         assertEquals(KmsKeyUsage.SIGN_VERIFY, key.getKeyUsage());
         assertNotNull(key.getPrivateKeyEncoded());
         assertNotNull(key.getPublicKeyEncoded());
+        assertTrue(kmsService.verify(key.getKeyId(), message, signature, "SM2_DSA", region));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -78,10 +78,11 @@ class KmsServiceTest {
         assertEquals("Enabled", key.getKeyState());
     }
 
-    @Test
-    void createSm2KeyReportsRegionUnsupportedOperation() {
+    @ParameterizedTest
+    @ValueSource(strings = {"us-east-1", "cn-fake-1"})
+    void createSm2KeyReportsRegionUnsupportedOperation(String region) {
         AwsException exception = assertThrows(AwsException.class, () ->
-                kmsService.createKey(null, "SIGN_VERIFY", "SM2", null, Map.of(), REGION));
+                kmsService.createKey(null, "SIGN_VERIFY", "SM2", null, Map.of(), region));
 
         assertEquals("UnsupportedOperationException", exception.getErrorCode());
         assertEquals("KeySpec SM2 is not supported in this Region", exception.getMessage());

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -88,6 +88,17 @@ class KmsServiceTest {
         assertEquals(400, exception.getHttpStatus());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {"cn-north-1", "cn-northwest-1"})
+    void createSm2KeySucceedsInChinaRegions(String region) {
+        KmsKey key = kmsService.createKey(null, "SIGN_VERIFY", "SM2", null, Map.of(), region);
+
+        assertEquals(KmsKeySpec.SM2, key.getKeySpec());
+        assertEquals(KmsKeyUsage.SIGN_VERIFY, key.getKeyUsage());
+        assertNotNull(key.getPrivateKeyEncoded());
+        assertNotNull(key.getPublicKeyEncoded());
+    }
+
     @Test
     void updateKeyDescriptionPersistsDescription() {
         KmsKey key = kmsService.createKey("old description", REGION);

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -94,13 +94,13 @@ class KmsServiceTest {
     void createSm2KeySucceedsInChinaRegions(String region) {
         KmsKey key = kmsService.createKey(null, "SIGN_VERIFY", "SM2", null, Map.of(), region);
         byte[] message = "SM2 regional signing".getBytes(StandardCharsets.UTF_8);
-        byte[] signature = kmsService.sign(key.getKeyId(), message, "SM2_DSA", region);
+        byte[] signature = kmsService.sign(key.getKeyId(), message, "SM2DSA", region);
 
         assertEquals(KmsKeySpec.SM2, key.getKeySpec());
         assertEquals(KmsKeyUsage.SIGN_VERIFY, key.getKeyUsage());
         assertNotNull(key.getPrivateKeyEncoded());
         assertNotNull(key.getPublicKeyEncoded());
-        assertTrue(kmsService.verify(key.getKeyId(), message, signature, "SM2_DSA", region));
+        assertTrue(kmsService.verify(key.getKeyId(), message, signature, "SM2DSA", region));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsServiceTest.java
@@ -79,6 +79,16 @@ class KmsServiceTest {
     }
 
     @Test
+    void createSm2KeyReportsRegionUnsupportedOperation() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                kmsService.createKey(null, "SIGN_VERIFY", "SM2", null, Map.of(), REGION));
+
+        assertEquals("UnsupportedOperationException", exception.getErrorCode());
+        assertEquals("KeySpec SM2 is not supported in this Region", exception.getMessage());
+        assertEquals(400, exception.getHttpStatus());
+    }
+
+    @Test
     void updateKeyDescriptionPersistsDescription() {
         KmsKey key = kmsService.createKey("old description", REGION);
 


### PR DESCRIPTION
## Summary

SM2 keys now return `UnsupportedOperationException` outside `cn-north-1` and `cn-northwest-1`. In those two regions, Floci generates SM2 key material and supports RAW Sign/Verify requests using the AWS wire algorithm name `SM2DSA`.

The signing and verification paths use Bouncy Castle's lightweight SM2 implementation. The Java enum now matches the wire value, so SDK requests are accepted instead of failing with `InvalidSigningAlgorithmException`.

Closes #3026

## Type of change

- [x] Bug fix

## AWS compatibility

- Preserve the exact error code, message, and HTTP status for unsupported regions.
- Advertise and accept `SM2DSA`, as documented in the [KMS Sign API](https://docs.aws.amazon.com/kms/latest/APIReference/API_Sign.html).
- Validate CreateKey, GetPublicKey, Sign, and Verify through the AWS Java SDK in both supported China regions.

## Testing

- KMS service and integration suites: 374 tests pass.
- `KmsSm2Test`: 6 SDK cases pass in both China regions, covering successful `SM2DSA` signing and verification, metadata deserialization, and exact error codes plus HTTP 400 responses for mismatched algorithms and non-RAW message types on both Sign and Verify.
- `KmsFeaturesTest`: 24 SDK regression cases pass, including the ML-DSA behavior merged into main.
- Application packaging and `git diff --check` pass.

## Checklist

- [x] Regression coverage added.
- [x] Conventional commits.
