### PR TITLE
fix(kms): support ML-DSA keys

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KmsFeaturesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/KmsFeaturesTest.java
@@ -1,6 +1,8 @@
 package com.floci.test;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.AlgorithmSpec;
@@ -17,6 +19,7 @@ import software.amazon.awssdk.services.kms.model.ExpirationModelType;
 import software.amazon.awssdk.services.kms.model.KeyState;
 import software.amazon.awssdk.services.kms.model.ListResourceTagsResponse;
 import software.amazon.awssdk.services.kms.model.OriginType;
+import software.amazon.awssdk.services.kms.model.SigningAlgorithmSpec;
 import software.amazon.awssdk.services.kms.model.WrappingKeySpec;
 
 import javax.crypto.Cipher;
@@ -225,6 +228,43 @@ class KmsFeaturesTest {
         assertThat(resp.keyMetadata().encryptionAlgorithms()).isEmpty();
 
         kms.scheduleKeyDeletion(b -> b.keyId(keyId).pendingWindowInDays(7));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = KeySpec.class, names = {"ML_DSA_44", "ML_DSA_65", "ML_DSA_87"})
+    @Order(43)
+    void mlDsaCreateGetPublicKeySignAndVerifyThroughSdk(KeySpec keySpec) {
+        String keyId = kms.createKey(b -> b
+                .description("ml-dsa-sdk-" + keySpec)
+                .keyUsage(KeyUsageType.SIGN_VERIFY)
+                .keySpec(keySpec))
+                .keyMetadata().keyId();
+
+        try {
+            var publicKey = kms.getPublicKey(b -> b.keyId(keyId));
+            assertThat(publicKey.publicKey()).isNotNull();
+            assertThat(publicKey.keySpec()).isEqualTo(keySpec);
+            assertThat(publicKey.keyUsage()).isEqualTo(KeyUsageType.SIGN_VERIFY);
+            assertThat(publicKey.signingAlgorithms()).containsExactly(SigningAlgorithmSpec.ML_DSA_SHAKE_256);
+
+            SdkBytes message = SdkBytes.fromUtf8String("ml-dsa SDK compatibility");
+            var signed = kms.sign(b -> b
+                    .keyId(keyId)
+                    .message(message)
+                    .signingAlgorithm(SigningAlgorithmSpec.ML_DSA_SHAKE_256));
+            assertThat(signed.signature()).isNotNull();
+            assertThat(signed.signingAlgorithm()).isEqualTo(SigningAlgorithmSpec.ML_DSA_SHAKE_256);
+
+            var verified = kms.verify(b -> b
+                    .keyId(keyId)
+                    .message(message)
+                    .signature(signed.signature())
+                    .signingAlgorithm(SigningAlgorithmSpec.ML_DSA_SHAKE_256));
+            assertThat(verified.signatureValid()).isTrue();
+            assertThat(verified.signingAlgorithm()).isEqualTo(SigningAlgorithmSpec.ML_DSA_SHAKE_256);
+        } finally {
+            kms.scheduleKeyDeletion(b -> b.keyId(keyId).pendingWindowInDays(7));
+        }
     }
 
     // ── Issue #1844: Decrypt enforces KeyId against the wrapping key ────────

--- a/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/KmsService.java
@@ -241,6 +241,12 @@ public class KmsService implements ResourceProvider {
                     key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
                     key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
                 }
+                case ML_DSA -> {
+                    String algorithm = spec.name().replace('_', '-');
+                    var pair = KeyPairGenerator.getInstance(algorithm).generateKeyPair();
+                    key.setPrivateKeyEncoded(Base64.getEncoder().encodeToString(pair.getPrivate().getEncoded()));
+                    key.setPublicKeyEncoded(Base64.getEncoder().encodeToString(pair.getPublic().getEncoded()));
+                }
                 case ECC -> {
                     String curveName = spec.curveName();
 
@@ -1441,6 +1447,9 @@ public class KmsService implements ResourceProvider {
         if (ed25519) {
             validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType, message);
         }
+        if (kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ML_DSA) {
+            validateMlDsaRequest(kmsKey.getKeySpec(), algorithm, messageType);
+        }
 
         try {
             PrivateKey privateKey = loadPrivateKey(kmsKey.getPrivateKeyEncoded(), kmsKey.getKeySpec());
@@ -1488,6 +1497,9 @@ public class KmsService implements ResourceProvider {
         var ed25519 = kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ED25519;
         if (ed25519) {
             validateEd25519Request(kmsKey.getKeySpec(), algorithm, messageType, message);
+        }
+        if (kmsKey.getKeySpec().getKeyType() == KmsKeySpec.KeyType.ML_DSA) {
+            validateMlDsaRequest(kmsKey.getKeySpec(), algorithm, messageType);
         }
 
         try {
@@ -1725,6 +1737,18 @@ public class KmsService implements ResourceProvider {
         }
     }
 
+    private static void validateMlDsaRequest(KmsKeySpec spec, String algorithm, KmsMessageType messageType) {
+        var signingAlgorithm = KmsKeySpec.getSignVerifyAlgorithm(algorithm);
+        if (signingAlgorithm != KmsKeySpec.Algorithm.ML_DSA_SHAKE_256) {
+            throw new AwsException("InvalidKeyUsageException",
+                    "Algorithm " + algorithm + " is incompatible with key spec " + spec.name() + ".", 400);
+        }
+        if (messageType != RAW) {
+            throw new AwsException("ValidationException",
+                    "Message type " + messageType + " is incompatible with key spec " + spec.name() + ".", 400);
+        }
+    }
+
     /**
      * Signs with an Ed25519 key.
      *
@@ -1907,6 +1931,7 @@ public class KmsService implements ResourceProvider {
         return KeyFactory.getInstance(switch (spec.getKeyType()) {
             case RSA -> "RSA";
             case ED25519 -> "Ed25519";
+            case ML_DSA -> "ML-DSA";
             default -> "EC";
         });
     }

--- a/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kms/model/KmsKeySpec.java
@@ -153,7 +153,7 @@ public enum KmsKeySpec {
         ED25519_SHA_512("ED25519_SHA_512","Ed25519", KmsKeyUsage.SIGN_VERIFY),
         ED25519_PH_SHA_512("ED25519_PH_SHA_512", "Ed25519", KmsKeyUsage.SIGN_VERIFY),
         SM2_DSA("SM2DSA","", KmsKeyUsage.SIGN_VERIFY),
-        ML_DSA_SHAKE_256("ML_DSA_SHAKE_256","", KmsKeyUsage.SIGN_VERIFY),
+        ML_DSA_SHAKE_256("ML_DSA_SHAKE_256", "ML-DSA", KmsKeyUsage.SIGN_VERIFY),
         HMAC_SHA_224("HMAC_SHA_224",""),
         HMAC_SHA_256("HMAC_SHA_256",""),
         HMAC_SHA_384("HMAC_SHA_384",""),

--- a/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kms/KmsIntegrationTest.java
@@ -1024,6 +1024,9 @@ class KmsIntegrationTest {
             "ECC_NIST_P384, SIGN_VERIFY, SigningAlgorithms, ECDSA_SHA_384",
             "ECC_NIST_P521, SIGN_VERIFY, SigningAlgorithms, ECDSA_SHA_512",
             "ECC_SECG_P256K1, SIGN_VERIFY, SigningAlgorithms, ECDSA_SHA_256",
+            "ML_DSA_44, SIGN_VERIFY, SigningAlgorithms, ML_DSA_SHAKE_256",
+            "ML_DSA_65, SIGN_VERIFY, SigningAlgorithms, ML_DSA_SHAKE_256",
+            "ML_DSA_87, SIGN_VERIFY, SigningAlgorithms, ML_DSA_SHAKE_256",
             "HMAC_224, GENERATE_VERIFY_MAC, MacAlgorithms, HMAC_SHA_224",
             "HMAC_256, GENERATE_VERIFY_MAC, MacAlgorithms, HMAC_SHA_256",
             "HMAC_384, GENERATE_VERIFY_MAC, MacAlgorithms, HMAC_SHA_384",
@@ -1121,17 +1124,17 @@ class KmsIntegrationTest {
             "SM2, KEY_AGREEMENT, 400",
 
             "ML_DSA_44, ENCRYPT_DECRYPT, 400", // Not implemented
-            "ML_DSA_44, SIGN_VERIFY, 400",
+            "ML_DSA_44, SIGN_VERIFY, 200",
             "ML_DSA_44, GENERATE_VERIFY_MAC, 400",
             "ML_DSA_44, KEY_AGREEMENT, 400",
 
             "ML_DSA_65, ENCRYPT_DECRYPT, 400",
-            "ML_DSA_65, SIGN_VERIFY, 400",
+            "ML_DSA_65, SIGN_VERIFY, 200",
             "ML_DSA_65, GENERATE_VERIFY_MAC, 400",
             "ML_DSA_65, KEY_AGREEMENT, 400",
 
             "ML_DSA_87, ENCRYPT_DECRYPT, 400",
-            "ML_DSA_87, SIGN_VERIFY, 400",
+            "ML_DSA_87, SIGN_VERIFY, 200",
             "ML_DSA_87, GENERATE_VERIFY_MAC, 400",
             "ML_DSA_87, KEY_AGREEMENT, 400"
     })
@@ -1506,6 +1509,78 @@ class KmsIntegrationTest {
                     .then().statusCode(200)
                     .body("SignatureValid", equalTo(true));
         }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "ML_DSA_44, 1334, 2420",
+            "ML_DSA_65, 1974, 3309",
+            "ML_DSA_87, 2614, 4627"
+    })
+    void mlDsaKeysCreateSignAndVerify(String keySpec, int publicKeyBytes, int signatureBytes) {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"SIGN_VERIFY\",\"KeySpec\":\"%s\"}".formatted(keySpec))
+                .when().post("/")
+                .then()
+                .statusCode(200)
+                .body("KeyMetadata.KeySpec", equalTo(keySpec))
+                .body("KeyMetadata.SigningAlgorithms", equalTo(List.of("ML_DSA_SHAKE_256")))
+                .extract().path("KeyMetadata.KeyId");
+
+        String publicKey = given()
+                .header("X-Amz-Target", "TrentService.GetPublicKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"" + keyId + "\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("KeySpec", equalTo(keySpec))
+                .body("SigningAlgorithms", equalTo(List.of("ML_DSA_SHAKE_256")))
+                .extract().path("PublicKey");
+        assertEquals(publicKeyBytes, Base64.getDecoder().decode(publicKey).length);
+
+        String message = Base64.getEncoder().encodeToString("message".getBytes(StandardCharsets.UTF_8));
+        String signature = given()
+                .header("X-Amz-Target", "TrentService.Sign")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"SigningAlgorithm\":\"ML_DSA_SHAKE_256\"}"
+                        .formatted(keyId, message))
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("Signature");
+        assertEquals(signatureBytes, Base64.getDecoder().decode(signature).length);
+
+        given()
+                .header("X-Amz-Target", "TrentService.Verify")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"%s\",\"Message\":\"%s\",\"Signature\":\"%s\",\"SigningAlgorithm\":\"ML_DSA_SHAKE_256\"}"
+                        .formatted(keyId, message, signature))
+                .when().post("/")
+                .then().statusCode(200)
+                .body("SignatureValid", equalTo(true));
+    }
+
+    @Test
+    void mlDsaRejectsDigestMessageType() {
+        String keyId = given()
+                .header("X-Amz-Target", "TrentService.CreateKey")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyUsage\":\"SIGN_VERIFY\",\"KeySpec\":\"ML_DSA_44\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .extract().path("KeyMetadata.KeyId");
+
+        given()
+                .header("X-Amz-Target", "TrentService.Sign")
+                .contentType(KMS_CONTENT_TYPE)
+                .body("{\"KeyId\":\"%s\",\"Message\":\"bWVzc2FnZQ==\",\"MessageType\":\"DIGEST\",\"SigningAlgorithm\":\"ML_DSA_SHAKE_256\"}"
+                        .formatted(keyId))
+                .when().post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("ValidationException"))
+                .body("message", equalTo("Message type DIGEST is incompatible with key spec ML_DSA_44."));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Summary

- create ML_DSA_44, ML_DSA_65, and ML_DSA_87 key pairs through the JDK 25 ML-DSA provider
- support GetPublicKey, Sign, and Verify with ML_DSA_SHAKE_256
- reject DIGEST messages and incompatible signing algorithms with KMS-compatible errors

Closes #3025

## Type of change

- [x] Bug fix

## AWS compatibility

The generated SubjectPublicKeyInfo and signature sizes match the values observed against AWS for all three ML-DSA key specs. ML-DSA operations expose ML_DSA_SHAKE_256 and accept RAW messages only.

## Testing

- KmsServiceTest: 159 tests passed
- KmsIntegrationTest: 144 tests passed
- git diff --check passed

## Checklist

- [x] Focused tests pass locally with JDK 25
- [x] Regression coverage added for all three key specs
- [x] Commit follows Conventional Commits