### PR TITLE
fix(s3): verify virtual-hosted presigned URLs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/PreSignedUrlFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/PreSignedUrlFilter.java
@@ -13,6 +13,7 @@ import org.jboss.logging.Logger;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -163,9 +164,10 @@ public class PreSignedUrlFilter implements ContainerRequestFilter {
             String credentialScope = date + "/" + region + "/" + service + "/aws4_request";
 
             // Build canonical headers from signed headers
-            String host = requestContext.getUriInfo().getRequestUri().getHost();
-            int port = requestContext.getUriInfo().getRequestUri().getPort();
-            String authority = (port > 0 && port != 80 && port != 443) ? host + ":" + port : host;
+            URI requestUri = requestContext.getProperty(S3VirtualHostFilter.ORIGINAL_REQUEST_URI_PROPERTY) instanceof URI uri
+                    ? uri
+                    : requestContext.getUriInfo().getRequestUri();
+            String authority = S3VirtualHostFilter.resolveHost(requestContext.getHeaderString("Host"), requestUri);
 
             StringBuilder canonicalHeaders = new StringBuilder();
             for (String header : signedHeaders.split(";")) {
@@ -178,7 +180,7 @@ public class PreSignedUrlFilter implements ContainerRequestFilter {
             }
 
             // Canonical request
-            String path = requestContext.getUriInfo().getRequestUri().getRawPath();
+            String path = requestUri.getRawPath();
             String canonicalQueryString = buildCanonicalQueryString(queryParams);
             String payloadHash = requestContext.getHeaderString("x-amz-content-sha256");
             if (payloadHash == null) {

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3VirtualHostFilter.java
@@ -25,6 +25,8 @@ import java.util.Set;
 @ApplicationScoped
 public class S3VirtualHostFilter implements ContainerRequestFilter {
 
+    static final String ORIGINAL_REQUEST_URI_PROPERTY = S3VirtualHostFilter.class.getName() + ".originalRequestUri";
+
     private final String baseHostname;
 
     /**
@@ -141,6 +143,7 @@ public class S3VirtualHostFilter implements ContainerRequestFilter {
                 .replacePath(newPath)
                 .build();
 
+        requestContext.setProperty(ORIGINAL_REQUEST_URI_PROPERTY, uri);
         requestContext.setRequestUri(newUri);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AuthEnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AuthEnforcementIntegrationTest.java
@@ -601,7 +601,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(23)
+    @Order(24)
     void presignedRequestWithMismatchedContentSha256IsRejected() throws Exception {
         String path = "/" + PRIVATE_BUCKET + "/" + PRIVATE_KEY;
         String contentHash = sha256Hex("private body");
@@ -623,7 +623,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(24)
+    @Order(25)
     void presignedRequestWithTamperedSignatureIsRejected() {
         String path = "/" + PRIVATE_BUCKET + "/" + PRIVATE_KEY;
         String signature = presignedSignature("GET", path, "test", "test", "3600");
@@ -644,7 +644,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(25)
+    @Order(26)
     void presignedRequestWithExpiresExceedingMaxIsRejected() {
         given()
             .queryParam("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
@@ -661,7 +661,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(26)
+    @Order(27)
     void presignedRequestWithExpiresZeroIsRejected() {
         given()
             .queryParam("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
@@ -678,7 +678,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(27)
+    @Order(28)
     void presignedRequestWithUnsupportedAlgorithmIsRejected() {
         given()
             .queryParam("X-Amz-Algorithm", "BOGUS-ALGORITHM")
@@ -695,7 +695,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(28)
+    @Order(29)
     void unsignedRequestCannotPutObject() {
         given().when().put("/" + WRITE_BUCKET).then().statusCode(200);
 
@@ -724,7 +724,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(29)
+    @Order(30)
     void unsignedRequestCannotDeleteObject() {
         given()
         .when()
@@ -750,7 +750,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(30)
+    @Order(31)
     void signedRequestWithBadAccessKeyCannotWriteObject() {
         given()
             .header("Authorization", BAD_AUTH_HEADER)
@@ -771,7 +771,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(31)
+    @Order(32)
     void bucketPolicyCanExplicitlyAllowAnonymousWrite() {
         given().when().put("/" + PUBLIC_WRITE_BUCKET).then().statusCode(200);
 
@@ -806,7 +806,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(32)
+    @Order(33)
     void unsignedRequestCannotWriteObjectSubresources() {
         given()
             .header("Authorization", LOCAL_AUTH_HEADER)
@@ -861,7 +861,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(33)
+    @Order(34)
     void unsignedRequestCannotWriteViaMultipartOrRestore() {
         given()
         .when()
@@ -931,7 +931,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(34)
+    @Order(35)
     void unsignedRequestCannotCopyObject() {
         given()
             .header("Authorization", LOCAL_AUTH_HEADER)
@@ -959,7 +959,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(35)
+    @Order(36)
     void batchDeleteObjectsDeniesUnauthorizedKeysButAllowsAuthorized() {
         given()
             .header("Authorization", LOCAL_AUTH_HEADER)
@@ -1017,7 +1017,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(36)
+    @Order(37)
     void batchDeleteObjectsWithUnknownAccessKeyFailsWholeRequest() {
         given()
             .header("Authorization", LOCAL_AUTH_HEADER)
@@ -1053,7 +1053,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(37)
+    @Order(38)
     void bucketAclPublicReadWriteAllowsAnonymousCreateButNotOverwriteOrDelete() {
         // Per AWS's ACL docs, a bucket-ACL WRITE grant to a non-owner (like AllUsers) "denies
         // non-owners the ability to overwrite or delete existing objects" -- it only lets them
@@ -1100,7 +1100,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(38)
+    @Order(39)
     void explicitPolicyDenyOverridesPublicWriteAcl() {
         given().when().put("/" + DENY_WRITE_ACL_BUCKET).then().statusCode(200);
 
@@ -1144,7 +1144,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(39)
+    @Order(40)
     void publicWriteAclDoesNotAuthorizeObjectSubresources() {
         given()
             .header("Authorization", LOCAL_AUTH_HEADER)
@@ -1174,7 +1174,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(40)
+    @Order(41)
     void deleteObjectPolicyGrantDoesNotAuthorizeVersionedDelete() {
         given().when().put("/" + DELETE_VERSION_BUCKET).then().statusCode(200);
 
@@ -1218,7 +1218,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(41)
+    @Order(42)
     void deleteObjectDoesNotBypassGovernanceRetentionWithoutDistinctPermission() {
         given().when().put("/" + BYPASS_BUCKET).then().statusCode(200);
 
@@ -1277,7 +1277,7 @@ class S3AuthEnforcementIntegrationTest {
     }
 
     @Test
-    @Order(42)
+    @Order(43)
     void conditionalPolicyDenyFailsClosedOverridingPublicWriteAcl() {
         // Floci has no request context to evaluate a Condition against, so a conditional Deny
         // is treated as applying (fail closed) -- consistent with S3PublicAccessEvaluatorTest's

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3AuthEnforcementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3AuthEnforcementIntegrationTest.java
@@ -579,6 +579,29 @@ class S3AuthEnforcementIntegrationTest {
 
     @Test
     @Order(23)
+    void virtualHostedPresignedRequestUsesOriginalHostAndPath() throws Exception {
+        String path = "/" + PRIVATE_KEY;
+        String authority = PRIVATE_BUCKET + ".localhost:" + io.restassured.RestAssured.port;
+        String signature = presignedSignature(
+                "GET", path, "test", "test", "3600", "UNSIGNED-PAYLOAD", authority);
+
+        given()
+            .header("Host", authority)
+            .queryParam("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+            .queryParam("X-Amz-Credential", credential("test"))
+            .queryParam("X-Amz-Date", SIGNING_TIMESTAMP)
+            .queryParam("X-Amz-Expires", "3600")
+            .queryParam("X-Amz-SignedHeaders", "host")
+            .queryParam("X-Amz-Signature", signature)
+        .when()
+            .get(path)
+        .then()
+            .statusCode(200)
+            .body(equalTo("private body"));
+    }
+
+    @Test
+    @Order(23)
     void presignedRequestWithMismatchedContentSha256IsRejected() throws Exception {
         String path = "/" + PRIVATE_BUCKET + "/" + PRIVATE_KEY;
         String contentHash = sha256Hex("private body");
@@ -1355,6 +1378,13 @@ class S3AuthEnforcementIntegrationTest {
     private static String presignedSignature(String method, String path,
                                               String accessKeyId, String secretKey,
                                               String expires, String payloadHash) {
+        return presignedSignature(method, path, accessKeyId, secretKey, expires, payloadHash,
+                "localhost:" + io.restassured.RestAssured.port);
+    }
+
+    private static String presignedSignature(String method, String path,
+                                              String accessKeyId, String secretKey,
+                                              String expires, String payloadHash, String authority) {
         try {
             String credentialScope = SIGNING_DATE + "/us-east-1/s3/aws4_request";
             String encodedCredential = URLEncoder.encode(
@@ -1373,7 +1403,7 @@ class S3AuthEnforcementIntegrationTest {
             String canonicalRequest = method + "\n"
                     + path + "\n"
                     + canonicalQueryString + "\n"
-                    + "host:localhost:" + io.restassured.RestAssured.port + "\n\n"
+                    + "host:" + authority + "\n\n"
                     + "host\n"
                     + payloadHash;
 


### PR DESCRIPTION
## Summary

- preserve the original request URI before virtual-hosted S3 routing rewrites the path
- canonicalize SigV4 with the Host header and path that the client actually signed
- retain the existing behavior for path-style and HTTP/2 requests

Closes #3045

## Type of change

- [x] Bug fix

## AWS compatibility

Presigned GetObject URLs now verify in both virtual-hosted and path addressing styles when S3 auth enforcement is enabled.

## Testing

- S3AuthEnforcementIntegrationTest: 43 tests passed
- PreSignedUrlFilterTest: 9 tests passed
- S3VirtualHostFilterTest: 167 tests passed
- git diff --check passed

## Checklist

- [x] Focused tests pass locally with JDK 25
- [x] Virtual-hosted regression test added
- [x] Commit follows Conventional Commits