### PR TITLE
fix(codebuild): persist build numbers across restarts

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildJsonHandler.java
@@ -49,10 +49,10 @@ public class CodeBuildJsonHandler {
             case "DeleteSourceCredentials" -> deleteSourceCredentials(request, region);
             case "ListCuratedEnvironmentImages" -> listCuratedEnvironmentImages();
             case "StartBuild" -> startBuild(request, region, account);
-            case "BatchGetBuilds" -> batchGetBuilds(request, region);
-            case "ListBuilds" -> listBuilds(region);
-            case "ListBuildsForProject" -> listBuildsForProject(request, region);
-            case "StopBuild" -> stopBuild(request, region);
+            case "BatchGetBuilds" -> batchGetBuilds(request, region, account);
+            case "ListBuilds" -> listBuilds(region, account);
+            case "ListBuildsForProject" -> listBuildsForProject(request, region, account);
+            case "StopBuild" -> stopBuild(request, region, account);
             case "RetryBuild" -> retryBuild(request, region, account);
             default -> throw new AwsException("InvalidAction", "Action " + action + " is not supported", 400);
         };
@@ -239,28 +239,28 @@ public class CodeBuildJsonHandler {
         return env;
     }
 
-    private Response batchGetBuilds(JsonNode req, String region) {
+    private Response batchGetBuilds(JsonNode req, String region, String account) {
         List<String> ids = new ArrayList<>();
         req.path("ids").forEach(n -> ids.add(n.asText()));
-        List<Build> found = service.batchGetBuilds(region, ids);
+        List<Build> found = service.batchGetBuilds(region, account, ids);
         List<String> foundIds = found.stream().map(Build::getId).toList();
         List<String> notFound = ids.stream().filter(id -> !foundIds.contains(id)).toList();
         return Response.ok(Map.of("builds", found, "buildsNotFound", notFound)).build();
     }
 
-    private Response listBuilds(String region) {
-        return Response.ok(Map.of("ids", service.listBuilds(region))).build();
+    private Response listBuilds(String region, String account) {
+        return Response.ok(Map.of("ids", service.listBuilds(region, account))).build();
     }
 
-    private Response listBuildsForProject(JsonNode req, String region) {
+    private Response listBuildsForProject(JsonNode req, String region, String account) {
         String projectName = req.path("projectName").asText(null);
-        return Response.ok(Map.of("ids", service.listBuildsForProject(region, projectName))).build();
+        return Response.ok(Map.of("ids", service.listBuildsForProject(region, account, projectName))).build();
     }
 
-    private Response stopBuild(JsonNode req, String region) {
+    private Response stopBuild(JsonNode req, String region, String account) {
         String id = req.path("id").asText(null);
-        service.stopBuild(region, id);
-        Build build = service.getBuild(region, id);
+        service.stopBuild(region, account, id);
+        Build build = service.getBuild(region, account, id);
         return Response.ok(Map.of("build", build)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildRunner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildRunner.java
@@ -117,17 +117,18 @@ public class CodeBuildRunner implements ContainerTeardown {
     }
 
     public void startBuild(String region, Build build, Project project, String buildspecOverride) {
+        String executionId = build.getArn();
         AtomicBoolean stopFlag = new AtomicBoolean(false);
-        stopFlags.put(build.getId(), stopFlag);
-        Thread.ofVirtual().start(() -> runBuild(region, build, project, buildspecOverride, stopFlag));
+        stopFlags.put(executionId, stopFlag);
+        Thread.ofVirtual().start(() -> runBuild(region, build, project, buildspecOverride, stopFlag, executionId));
     }
 
-    public void stopBuild(String buildId) {
-        AtomicBoolean flag = stopFlags.get(buildId);
+    public void stopBuild(String executionId) {
+        AtomicBoolean flag = stopFlags.get(executionId);
         if (flag != null) {
             flag.set(true);
         }
-        String containerId = runningContainers.get(buildId);
+        String containerId = runningContainers.get(executionId);
         if (containerId != null) {
             try {
                 dockerClient.stopContainerCmd(containerId).withTimeout(5).exec();
@@ -138,7 +139,7 @@ public class CodeBuildRunner implements ContainerTeardown {
     }
 
     private void runBuild(String region, Build build, Project project,
-                          String buildspecOverride, AtomicBoolean stopFlag) {
+                          String buildspecOverride, AtomicBoolean stopFlag, String executionId) {
         String buildId = build.getId();
         Path workspace = null;
         String containerId = null;
@@ -227,7 +228,7 @@ public class CodeBuildRunner implements ContainerTeardown {
 
             ContainerLifecycleManager.ContainerInfo info = lifecycleManager.createAndStart(spec);
             containerId = info.containerId();
-            runningContainers.put(buildId, containerId);
+            runningContainers.put(executionId, containerId);
 
             logHandle = logStreamer.attach(containerId, logGroup, logStream, region, "codebuild:" + buildId);
 
@@ -371,8 +372,8 @@ public class CodeBuildRunner implements ContainerTeardown {
                 build.getPhases().add(completedPhase);
             }
         } finally {
-            stopFlags.remove(buildId);
-            if (containerId != null && runningContainers.remove(buildId, containerId)) {
+            stopFlags.remove(executionId);
+            if (containerId != null && runningContainers.remove(executionId, containerId)) {
                 lifecycleManager.stopAndRemove(containerId, logHandle);
             } else if (logHandle != null) {
                 try { logHandle.close(); } catch (Exception ignored) {}

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
@@ -41,9 +41,9 @@ public class CodeBuildService {
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Build>> builds = new ConcurrentHashMap<>();
     // key: region -> buildId -> request buildspec override (transient: builds are runtime state)
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> buildspecOverrides = new ConcurrentHashMap<>();
-    // key: region:projectName -> last allocated build number (durable across restarts)
+    // key: account:region:projectName -> last allocated build number (durable across restarts)
     private Map<String, Long> persistedBuildCounters = new ConcurrentHashMap<>();
-    // key: region:projectName -> build counter (runtime synchronization wrapper)
+    // key: account:region:projectName -> build counter (runtime synchronization wrapper)
     private final ConcurrentHashMap<String, AtomicLong> buildCounters = new ConcurrentHashMap<>();
 
     private final CodeBuildRunner runner;
@@ -427,7 +427,7 @@ public class CodeBuildService {
             throw new AwsException("ResourceNotFoundException", "Project not found: " + projectName, 400);
         }
 
-        String counterKey = region + ":" + projectName;
+        String counterKey = account + ":" + region + ":" + projectName;
         AtomicLong counter = buildCounters.computeIfAbsent(counterKey,
                 key -> new AtomicLong(persistedBuildCounters.getOrDefault(key, 0L)));
         long buildNumber;

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
@@ -37,9 +37,9 @@ public class CodeBuildService {
     private Map<String, Map<String, ReportGroup>> reportGroups = new ConcurrentHashMap<>();
     // key: region -> arn -> source credential (token is stored but never returned)
     private Map<String, Map<String, SourceCredential>> sourceCredentials = new ConcurrentHashMap<>();
-    // key: region -> buildId -> build (transient: builds are runtime state)
+    // key: account:region -> buildId -> build (transient: builds are runtime state)
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Build>> builds = new ConcurrentHashMap<>();
-    // key: region -> buildId -> request buildspec override (transient: builds are runtime state)
+    // key: account:region -> buildId -> request buildspec override (transient: builds are runtime state)
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> buildspecOverrides = new ConcurrentHashMap<>();
     // key: account:region:projectName -> last allocated build number (durable across restarts)
     private Map<String, Long> persistedBuildCounters = new ConcurrentHashMap<>();
@@ -110,12 +110,12 @@ public class CodeBuildService {
         return sourceCredentials.computeIfAbsent(region, r -> new ConcurrentHashMap<>());
     }
 
-    private Map<String, Build> buildsFor(String region) {
-        return builds.computeIfAbsent(region, r -> new ConcurrentHashMap<>());
+    private Map<String, Build> buildsFor(String account, String region) {
+        return builds.computeIfAbsent(account + ":" + region, ignored -> new ConcurrentHashMap<>());
     }
 
-    private Map<String, String> buildspecOverridesFor(String region) {
-        return buildspecOverrides.computeIfAbsent(region, r -> new ConcurrentHashMap<>());
+    private Map<String, String> buildspecOverridesFor(String account, String region) {
+        return buildspecOverrides.computeIfAbsent(account + ":" + region, ignored -> new ConcurrentHashMap<>());
     }
 
     // ---- Projects ----
@@ -470,9 +470,9 @@ public class CodeBuildService {
 
         build.setPhases(new CopyOnWriteArrayList<>());
 
-        buildsFor(region).put(buildId, build);
+        buildsFor(account, region).put(buildId, build);
         if (buildspecOverride != null && !buildspecOverride.isBlank()) {
-            buildspecOverridesFor(region).put(buildId, buildspecOverride);
+            buildspecOverridesFor(account, region).put(buildId, buildspecOverride);
         }
         Build responseBuild = copyBuild(build);
 
@@ -481,24 +481,24 @@ public class CodeBuildService {
         return responseBuild;
     }
 
-    public Build getBuild(String region, String buildId) {
-        Build build = buildsFor(region).get(buildId);
+    public Build getBuild(String region, String account, String buildId) {
+        Build build = buildsFor(account, region).get(buildId);
         if (build == null) {
             throw new AwsException("ResourceNotFoundException", "Build not found: " + buildId, 400);
         }
         return build;
     }
 
-    public List<Build> batchGetBuilds(String region, List<String> buildIds) {
-        Map<String, Build> store = buildsFor(region);
+    public List<Build> batchGetBuilds(String region, String account, List<String> buildIds) {
+        Map<String, Build> store = buildsFor(account, region);
         return buildIds.stream()
                 .map(store::get)
                 .filter(b -> b != null)
                 .collect(Collectors.toList());
     }
 
-    public List<String> listBuilds(String region) {
-        return buildsFor(region).values().stream()
+    public List<String> listBuilds(String region, String account) {
+        return buildsFor(account, region).values().stream()
                 .sorted((a, b) -> Double.compare(
                         b.getStartTime() != null ? b.getStartTime() : 0,
                         a.getStartTime() != null ? a.getStartTime() : 0))
@@ -506,8 +506,8 @@ public class CodeBuildService {
                 .collect(Collectors.toList());
     }
 
-    public List<String> listBuildsForProject(String region, String projectName) {
-        return buildsFor(region).values().stream()
+    public List<String> listBuildsForProject(String region, String account, String projectName) {
+        return buildsFor(account, region).values().stream()
                 .filter(b -> projectName.equals(b.getProjectName()))
                 .sorted((a, b) -> Double.compare(
                         b.getStartTime() != null ? b.getStartTime() : 0,
@@ -516,17 +516,17 @@ public class CodeBuildService {
                 .collect(Collectors.toList());
     }
 
-    public void stopBuild(String region, String buildId) {
-        Build build = buildsFor(region).get(buildId);
+    public void stopBuild(String region, String account, String buildId) {
+        Build build = buildsFor(account, region).get(buildId);
         if (build == null) {
             throw new AwsException("ResourceNotFoundException", "Build not found: " + buildId, 400);
         }
-        runner.stopBuild(buildId);
+        runner.stopBuild(build.getArn());
     }
 
     public Build retryBuild(String region, String account, String buildId) {
-        Build original = getBuild(region, buildId);
-        String buildspecOverride = buildspecOverridesFor(region).get(original.getId());
+        Build original = getBuild(region, account, buildId);
+        String buildspecOverride = buildspecOverridesFor(account, region).get(original.getId());
         return startBuild(region, account, original.getProjectName(),
                 buildspecOverride, original.getEnvironment(), original.getArtifacts(),
                 null, original.getTimeoutInMinutes(), null, null);

--- a/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codebuild/CodeBuildService.java
@@ -41,7 +41,9 @@ public class CodeBuildService {
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, Build>> builds = new ConcurrentHashMap<>();
     // key: region -> buildId -> request buildspec override (transient: builds are runtime state)
     private final ConcurrentHashMap<String, ConcurrentHashMap<String, String>> buildspecOverrides = new ConcurrentHashMap<>();
-    // key: region:projectName -> build counter (transient)
+    // key: region:projectName -> last allocated build number (durable across restarts)
+    private Map<String, Long> persistedBuildCounters = new ConcurrentHashMap<>();
+    // key: region:projectName -> build counter (runtime synchronization wrapper)
     private final ConcurrentHashMap<String, AtomicLong> buildCounters = new ConcurrentHashMap<>();
 
     private final CodeBuildRunner runner;
@@ -66,6 +68,8 @@ public class CodeBuildService {
                 new TypeReference<Map<String, Map<String, ReportGroup>>>() {});
         this.sourceCredentials = storageBacked("codebuild-source-credentials.json",
                 new TypeReference<Map<String, Map<String, SourceCredential>>>() {});
+        this.persistedBuildCounters = storageBacked("codebuild-build-counters.json",
+                new TypeReference<Map<String, Long>>() {});
         normalizeRegionMaps(projects);
         normalizeRegionMaps(reportGroups);
         normalizeRegionMaps(sourceCredentials);
@@ -424,9 +428,13 @@ public class CodeBuildService {
         }
 
         String counterKey = region + ":" + projectName;
-        long buildNumber = buildCounters
-                .computeIfAbsent(counterKey, k -> new AtomicLong(0))
-                .incrementAndGet();
+        AtomicLong counter = buildCounters.computeIfAbsent(counterKey,
+                key -> new AtomicLong(persistedBuildCounters.getOrDefault(key, 0L)));
+        long buildNumber;
+        synchronized (counter) {
+            buildNumber = counter.incrementAndGet();
+            persistedBuildCounters.put(counterKey, buildNumber);
+        }
 
         String buildId = projectName + ":" + buildNumber;
         String arn = AwsArnUtils.Arn.of("codebuild", region, account, "build/" + buildId).toString();

--- a/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/codepipeline/CodePipelineService.java
@@ -895,11 +895,11 @@ public class CodePipelineService {
         state.setExternalExecutionId(build.getId());
         while (!Boolean.TRUE.equals(build.getBuildComplete())) {
             if (execution.isStopRequested()) {
-                codeBuildService.stopBuild(execution.getRegion(), build.getId());
+                codeBuildService.stopBuild(execution.getRegion(), execution.getAccountId(), build.getId());
                 break;
             }
             TimeUnit.MILLISECONDS.sleep(POLL_INTERVAL_MS);
-            build = codeBuildService.getBuild(execution.getRegion(), build.getId());
+            build = codeBuildService.getBuild(execution.getRegion(), execution.getAccountId(), build.getId());
         }
         if (!"SUCCEEDED".equals(build.getBuildStatus())) {
             throw new AwsException("ActionExecutionFailed",

--- a/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
@@ -120,10 +120,17 @@ class CodeBuildServicePersistenceTest {
                 new ProjectEnvironment(), "arn:aws:iam::" + ACCOUNT + ":role/cb",
                 null, null, null, null, null, null, null);
 
-        assertEquals(1, first.startBuild(REGION, ACCOUNT, "p1", null,
-                null, null, null, null, null, null).getBuildNumber());
-        assertEquals(1, first.startBuild(REGION, OTHER_ACCOUNT, "p1", null,
-                null, null, null, null, null, null).getBuildNumber());
+        Build accountBuild = first.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null);
+        Build otherAccountBuild = first.startBuild(REGION, OTHER_ACCOUNT, "p1", null,
+                null, null, null, null, null, null);
+
+        assertEquals(1, accountBuild.getBuildNumber());
+        assertEquals(1, otherAccountBuild.getBuildNumber());
+        assertEquals(accountBuild.getId(), otherAccountBuild.getId());
+        assertEquals(accountBuild.getArn(), first.getBuild(REGION, ACCOUNT, accountBuild.getId()).getArn());
+        assertEquals(otherAccountBuild.getArn(),
+                first.getBuild(REGION, OTHER_ACCOUNT, otherAccountBuild.getId()).getArn());
 
         CodeBuildService reloaded = serviceWithStorage(storage);
 
@@ -155,14 +162,14 @@ class CodeBuildServicePersistenceTest {
         assertEquals("IN_PROGRESS", startResponse.getBuildStatus());
         assertEquals(false, startResponse.getBuildComplete());
         assertEquals("SUBMITTED", startResponse.getCurrentPhase());
-        assertEquals("FAILED", service.getBuild(REGION, startResponse.getId()).getBuildStatus());
+        assertEquals("FAILED", service.getBuild(REGION, ACCOUNT, startResponse.getId()).getBuildStatus());
 
         Build retryResponse = service.retryBuild(REGION, ACCOUNT, startResponse.getId());
         assertEquals("IN_PROGRESS", retryResponse.getBuildStatus());
         assertEquals(false, retryResponse.getBuildComplete());
         assertEquals("SUBMITTED", retryResponse.getCurrentPhase());
         assertTrue(retryResponse.getBuildNumber() > startResponse.getBuildNumber());
-        assertEquals("FAILED", service.getBuild(REGION, retryResponse.getId()).getBuildStatus());
+        assertEquals("FAILED", service.getBuild(REGION, ACCOUNT, retryResponse.getId()).getBuildStatus());
     }
 
     private static ProjectSource source(String type) {

--- a/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
@@ -34,6 +34,7 @@ class CodeBuildServicePersistenceTest {
 
     private static final String REGION = "us-east-1";
     private static final String ACCOUNT = "000000000000";
+    private static final String OTHER_ACCOUNT = "111111111111";
 
     @Test
     void durableResourcesSurviveRestart() {
@@ -107,6 +108,29 @@ class CodeBuildServicePersistenceTest {
         assertEquals(2, second.getBuildNumber());
         assertEquals(3, third.getBuildNumber());
         assertEquals("p1:3", third.getId());
+    }
+
+    @Test
+    void buildNumbersAreIsolatedByAccountAcrossRestart() {
+        SharedStorageFactory storage = new SharedStorageFactory();
+
+        CodeBuildService first = serviceWithStorage(storage);
+        first.createProject(REGION, ACCOUNT, "p1", "demo",
+                source("NO_SOURCE"), null, null, artifacts("NO_ARTIFACTS"), null,
+                new ProjectEnvironment(), "arn:aws:iam::" + ACCOUNT + ":role/cb",
+                null, null, null, null, null, null, null);
+
+        assertEquals(1, first.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null).getBuildNumber());
+        assertEquals(1, first.startBuild(REGION, OTHER_ACCOUNT, "p1", null,
+                null, null, null, null, null, null).getBuildNumber());
+
+        CodeBuildService reloaded = serviceWithStorage(storage);
+
+        assertEquals(2, reloaded.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null).getBuildNumber());
+        assertEquals(2, reloaded.startBuild(REGION, OTHER_ACCOUNT, "p1", null,
+                null, null, null, null, null, null).getBuildNumber());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/codebuild/CodeBuildServicePersistenceTest.java
@@ -87,6 +87,29 @@ class CodeBuildServicePersistenceTest {
     }
 
     @Test
+    void buildNumbersContinueAfterRestart() {
+        SharedStorageFactory storage = new SharedStorageFactory();
+
+        CodeBuildService first = serviceWithStorage(storage);
+        first.createProject(REGION, ACCOUNT, "p1", "demo",
+                source("NO_SOURCE"), null, null, artifacts("NO_ARTIFACTS"), null,
+                new ProjectEnvironment(), "arn:aws:iam::" + ACCOUNT + ":role/cb",
+                null, null, null, null, null, null, null);
+        first.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null);
+        Build second = first.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null);
+
+        CodeBuildService reloaded = serviceWithStorage(storage);
+        Build third = reloaded.startBuild(REGION, ACCOUNT, "p1", null,
+                null, null, null, null, null, null);
+
+        assertEquals(2, second.getBuildNumber());
+        assertEquals(3, third.getBuildNumber());
+        assertEquals("p1:3", third.getId());
+    }
+
+    @Test
     void startAndRetryBuildResponsesUseAcceptedBuildSnapshot() {
         CodeBuildRunner runner = mock(CodeBuildRunner.class);
         doAnswer(invocation -> {


### PR DESCRIPTION
## Summary
- persist the last allocated build number for each region and CodeBuild project
- initialize runtime counters from durable storage after a restart
- serialize counter increments with persistence to prevent stale values under concurrent builds
- add a restart regression test that verifies numbering continues monotonically

## Testing
- ./mvnw -Dtest=CodeBuildServiceTest,CodeBuildServicePersistenceTest test

Fixes #2247