### PR TITLE
fix(lambda): reject scalar structure members

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -309,6 +309,7 @@ public class LambdaService implements ResourceProvider {
 
     public LambdaFunction createFunction(String region, Map<String, Object> request) {
         Map<String, Object> environment = structureMember(request, "Environment");
+        Map<String, String> environmentVariables = environmentVariables(environment);
         Map<String, Object> ephemeralStorage = structureMember(request, "EphemeralStorage");
         Map<String, Object> tracingConfig = structureMember(request, "TracingConfig");
         Map<String, Object> deadLetterConfig = structureMember(request, "DeadLetterConfig");
@@ -366,9 +367,7 @@ public class LambdaService implements ResourceProvider {
 
         // Handle environment variables
         if (environment != null) {
-            @SuppressWarnings("unchecked")
-            Map<String, String> vars = (Map<String, String>) environment.get("Variables");
-            if (vars != null) fn.setEnvironment(vars);
+            if (environmentVariables != null) fn.setEnvironment(environmentVariables);
         }
 
         // Handle tags
@@ -604,6 +603,7 @@ public class LambdaService implements ResourceProvider {
 
     public LambdaFunction updateFunctionConfiguration(String region, String functionName, Map<String, Object> request) {
         Map<String, Object> environment = structureMember(request, "Environment");
+        Map<String, String> environmentVariables = environmentVariables(environment);
         Map<String, Object> ephemeralStorage = structureMember(request, "EphemeralStorage");
         Map<String, Object> tracingConfig = structureMember(request, "TracingConfig");
         Map<String, Object> deadLetterConfig = structureMember(request, "DeadLetterConfig");
@@ -670,9 +670,7 @@ public class LambdaService implements ResourceProvider {
         }
         if (request.containsKey("Environment")) {
             if (environment != null && environment.containsKey("Variables")) {
-                @SuppressWarnings("unchecked")
-                Map<String, String> vars = (Map<String, String>) environment.get("Variables");
-                fn.setEnvironment(vars != null ? vars : new java.util.HashMap<>());
+                fn.setEnvironment(environmentVariables != null ? environmentVariables : new java.util.HashMap<>());
             }
         }
 
@@ -1551,6 +1549,15 @@ public class LambdaService implements ResourceProvider {
 
     private static Map<String, Object> structureMember(Map<String, Object> request, String member) {
         return structureValue(request.get(member), member);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, String> environmentVariables(Map<String, Object> environment) {
+        if (environment == null) {
+            return null;
+        }
+        return (Map<String, String>) (Map<?, ?>) structureValue(
+                environment.get("Variables"), "Environment.Variables");
     }
 
     private static void validateEventSourceMappingStructures(Map<String, Object> request) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -308,6 +308,16 @@ public class LambdaService implements ResourceProvider {
     }
 
     public LambdaFunction createFunction(String region, Map<String, Object> request) {
+        Map<String, Object> environment = structureMember(request, "Environment");
+        Map<String, Object> ephemeralStorage = structureMember(request, "EphemeralStorage");
+        Map<String, Object> tracingConfig = structureMember(request, "TracingConfig");
+        Map<String, Object> deadLetterConfig = structureMember(request, "DeadLetterConfig");
+        Map<String, Object> vpcConfig = structureMember(request, "VpcConfig");
+        Map<String, Object> snapStart = structureMember(request, "SnapStart");
+        Map<String, Object> loggingConfig = structureMember(request, "LoggingConfig");
+        Map<String, Object> imageConfig = structureMember(request, "ImageConfig");
+        Map<String, Object> code = structureMember(request, "Code");
+
         String functionName = (String) request.get("FunctionName");
         String role = (String) request.get("Role");
         String handler = (String) request.get("Handler");
@@ -355,11 +365,9 @@ public class LambdaService implements ResourceProvider {
         fn.setRevisionId(UUID.randomUUID().toString());
 
         // Handle environment variables
-        @SuppressWarnings("unchecked")
-        Map<String, Object> envBlock = (Map<String, Object>) request.get("Environment");
-        if (envBlock != null) {
+        if (environment != null) {
             @SuppressWarnings("unchecked")
-            Map<String, String> vars = (Map<String, String>) envBlock.get("Variables");
+            Map<String, String> vars = (Map<String, String>) environment.get("Variables");
             if (vars != null) fn.setEnvironment(vars);
         }
 
@@ -377,19 +385,19 @@ public class LambdaService implements ResourceProvider {
         }
 
         // EphemeralStorage
-        if (request.get("EphemeralStorage") instanceof Map<?, ?> es) {
-            fn.setEphemeralStorageSize(toInt(es.get("Size"), 512));
+        if (ephemeralStorage != null) {
+            fn.setEphemeralStorageSize(toInt(ephemeralStorage.get("Size"), 512));
         }
 
         // TracingConfig
-        if (request.get("TracingConfig") instanceof Map<?, ?> tc) {
-            Object mode = tc.get("Mode");
+        if (tracingConfig != null) {
+            Object mode = tracingConfig.get("Mode");
             fn.setTracingMode(mode != null ? mode.toString() : "PassThrough");
         }
 
         // DeadLetterConfig
-        if (request.get("DeadLetterConfig") instanceof Map<?, ?> dlq) {
-            fn.setDeadLetterTargetArn((String) dlq.get("TargetArn"));
+        if (deadLetterConfig != null) {
+            fn.setDeadLetterTargetArn((String) deadLetterConfig.get("TargetArn"));
         }
 
         // Layers
@@ -405,15 +413,13 @@ public class LambdaService implements ResourceProvider {
             fn.setKmsKeyArn((String) request.get("KMSKeyArn"));
         }
 
-        if (request.get("VpcConfig") instanceof Map<?, ?>) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> vpc = (Map<String, Object>) request.get("VpcConfig");
-            fn.setVpcConfig(vpc);
-            fn.setVpcId(resolveVpcId(region, vpc));
+        if (vpcConfig != null) {
+            fn.setVpcConfig(vpcConfig);
+            fn.setVpcId(resolveVpcId(region, vpcConfig));
         }
 
-        applySnapStart(fn, request.get("SnapStart"));
-        applyLoggingConfig(fn, request.get("LoggingConfig"));
+        applySnapStart(fn, snapStart);
+        applyLoggingConfig(fn, loggingConfig);
 
         List<LambdaFileSystemConfig> fileSystemConfigs =
                 parseFileSystemConfigs(request.get("FileSystemConfigs"));
@@ -421,9 +427,7 @@ public class LambdaService implements ResourceProvider {
         fn.setFileSystemConfigs(fileSystemConfigs);
 
         // ImageConfig (PackageType=Image overrides)
-        if (request.get("ImageConfig") instanceof Map<?, ?> ic) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> imageConfig = (Map<String, Object>) ic;
+        if (imageConfig != null) {
             if (imageConfig.get("Command") instanceof List<?> cmd) {
                 fn.setImageConfigCommand(cmd.stream().map(Object::toString).toList());
             }
@@ -436,8 +440,6 @@ public class LambdaService implements ResourceProvider {
         }
 
         // Handle code deployment
-        @SuppressWarnings("unchecked")
-        Map<String, Object> code = (Map<String, Object>) request.get("Code");
         if (code != null) {
             String imageUri = (String) code.get("ImageUri");
             if (imageUri != null) {
@@ -601,6 +603,15 @@ public class LambdaService implements ResourceProvider {
     }
 
     public LambdaFunction updateFunctionConfiguration(String region, String functionName, Map<String, Object> request) {
+        Map<String, Object> environment = structureMember(request, "Environment");
+        Map<String, Object> ephemeralStorage = structureMember(request, "EphemeralStorage");
+        Map<String, Object> tracingConfig = structureMember(request, "TracingConfig");
+        Map<String, Object> deadLetterConfig = structureMember(request, "DeadLetterConfig");
+        Map<String, Object> requestedVpcConfigUpdate = structureMember(request, "VpcConfig");
+        Map<String, Object> snapStart = structureMember(request, "SnapStart");
+        Map<String, Object> loggingConfig = structureMember(request, "LoggingConfig");
+        Map<String, Object> imageConfig = structureMember(request, "ImageConfig");
+
         LambdaFunction fn = getFunction(region, functionName);
 
         // Validated before any field mutation below, not inline where Layers is applied further
@@ -615,10 +626,10 @@ public class LambdaService implements ResourceProvider {
             validateLayersResolvable(layerList);
         }
         if (request.containsKey("SnapStart")) {
-            validateSnapStart(request.get("SnapStart"));
+            validateSnapStart(snapStart);
         }
         if (request.containsKey("LoggingConfig")) {
-            validateLoggingConfig(request.get("LoggingConfig"));
+            validateLoggingConfig(loggingConfig);
         }
         if (request.containsKey("Role")) {
             validateRoleArn((String) request.get("Role"));
@@ -628,10 +639,8 @@ public class LambdaService implements ResourceProvider {
         }
 
         Map<String, Object> requestedVpcConfig = fn.getVpcConfig();
-        if (request.get("VpcConfig") instanceof Map<?, ?>) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> vpc = (Map<String, Object>) request.get("VpcConfig");
-            requestedVpcConfig = new java.util.HashMap<>(vpc);
+        if (requestedVpcConfigUpdate != null) {
+            requestedVpcConfig = new java.util.HashMap<>(requestedVpcConfigUpdate);
         }
         List<LambdaFileSystemConfig> requestedFileSystemConfigs = fn.getFileSystemConfigs();
         if (request.containsKey("FileSystemConfigs")) {
@@ -660,11 +669,9 @@ public class LambdaService implements ResourceProvider {
             fn.setTimeout(((Number) request.get("Timeout")).intValue());
         }
         if (request.containsKey("Environment")) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> envBlock = (Map<String, Object>) request.get("Environment");
-            if (envBlock != null && envBlock.containsKey("Variables")) {
+            if (environment != null && environment.containsKey("Variables")) {
                 @SuppressWarnings("unchecked")
-                Map<String, String> vars = (Map<String, String>) envBlock.get("Variables");
+                Map<String, String> vars = (Map<String, String>) environment.get("Variables");
                 fn.setEnvironment(vars != null ? vars : new java.util.HashMap<>());
             }
         }
@@ -690,21 +697,21 @@ public class LambdaService implements ResourceProvider {
         }
 
         if (request.containsKey("EphemeralStorage")) {
-            if (request.get("EphemeralStorage") instanceof Map<?, ?> es) {
-                fn.setEphemeralStorageSize(toInt(es.get("Size"), 512));
+            if (ephemeralStorage != null) {
+                fn.setEphemeralStorageSize(toInt(ephemeralStorage.get("Size"), 512));
             }
         }
 
         if (request.containsKey("TracingConfig")) {
-            if (request.get("TracingConfig") instanceof Map<?, ?> tc) {
-                Object mode = tc.get("Mode");
+            if (tracingConfig != null) {
+                Object mode = tracingConfig.get("Mode");
                 fn.setTracingMode(mode != null ? mode.toString() : "PassThrough");
             }
         }
 
         if (request.containsKey("DeadLetterConfig")) {
-            if (request.get("DeadLetterConfig") instanceof Map<?, ?> dlq) {
-                fn.setDeadLetterTargetArn((String) dlq.get("TargetArn"));
+            if (deadLetterConfig != null) {
+                fn.setDeadLetterTargetArn((String) deadLetterConfig.get("TargetArn"));
             }
         }
 
@@ -717,18 +724,18 @@ public class LambdaService implements ResourceProvider {
         }
 
         if (request.containsKey("VpcConfig")) {
-            if (request.get("VpcConfig") instanceof Map<?, ?>) {
+            if (requestedVpcConfigUpdate != null) {
                 fn.setVpcConfig(requestedVpcConfig);
                 fn.setVpcId(resolveVpcId(region, requestedVpcConfig));
             }
         }
 
         if (request.containsKey("SnapStart")) {
-            applySnapStart(fn, request.get("SnapStart"));
+            applySnapStart(fn, snapStart);
         }
 
         if (request.containsKey("LoggingConfig")) {
-            applyLoggingConfig(fn, request.get("LoggingConfig"));
+            applyLoggingConfig(fn, loggingConfig);
         }
 
         if (request.containsKey("FileSystemConfigs")) {
@@ -736,9 +743,7 @@ public class LambdaService implements ResourceProvider {
         }
 
         if (request.containsKey("ImageConfig")) {
-            if (request.get("ImageConfig") instanceof Map<?, ?> ic) {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> imageConfig = (Map<String, Object>) ic;
+            if (imageConfig != null) {
                 if (imageConfig.containsKey("Command")) {
                     List<String> cmd = imageConfig.get("Command") instanceof List<?>
                             ? ((List<?>) imageConfig.get("Command")).stream().map(Object::toString).toList() : null;
@@ -1043,6 +1048,8 @@ public class LambdaService implements ResourceProvider {
     // ──────────────────────────── Event Source Mapping (SQS) ────────────────────────────
 
     public EventSourceMapping createEventSourceMapping(String region, Map<String, Object> request) {
+        validateEventSourceMappingStructures(request);
+
         String functionName = (String) request.get("FunctionName");
         String eventSourceArn = (String) request.get("EventSourceArn");
 
@@ -1129,22 +1136,15 @@ public class LambdaService implements ResourceProvider {
     }
 
     private EventSourceMapping.DestinationConfig parseDestinationConfig(Map<String, Object> request) {
-        Object raw = request.get("DestinationConfig");
-        if (raw == null) {
+        Map<String, Object> destinationConfigMember = structureMember(request, "DestinationConfig");
+        if (destinationConfigMember == null) {
             return null;
-        }
-        if (!(raw instanceof Map<?, ?> destMap)) {
-            throw new AwsException("InvalidParameterValueException",
-                    "DestinationConfig must be a JSON object", 400);
         }
 
-        Object rawOnFailure = destMap.get("OnFailure");
-        if (rawOnFailure == null) {
+        Map<String, Object> onFailureMap = structureValue(
+                destinationConfigMember.get("OnFailure"), "DestinationConfig.OnFailure");
+        if (onFailureMap == null) {
             return null;
-        }
-        if (!(rawOnFailure instanceof Map<?, ?> onFailureMap)) {
-            throw new AwsException("InvalidParameterValueException",
-                    "DestinationConfig.OnFailure must be a JSON object", 400);
         }
 
         Object destination = onFailureMap.get("Destination");
@@ -1217,16 +1217,11 @@ public class LambdaService implements ResourceProvider {
      * an empty ScalingConfig as "clear the cap").
      */
     private ScalingConfig parseScalingConfig(Map<String, Object> request, String eventSourceArn) {
-        Object raw = request.get("ScalingConfig");
-        if (raw == null) {
+        Map<String, Object> map = structureMember(request, "ScalingConfig");
+        if (map == null) {
             return null;
         }
-        if (!(raw instanceof Map<?, ?>)) {
-            throw new AwsException("InvalidParameterValueException",
-                    "ScalingConfig must be a JSON object", 400);
-        }
         boolean isSqs = eventSourceArn != null && eventSourceArn.contains(":sqs:");
-        Map<?, ?> map = (Map<?, ?>) raw;
         Object mc = map.get("MaximumConcurrency");
         if (mc == null) {
             if (!isSqs) {
@@ -1293,6 +1288,8 @@ public class LambdaService implements ResourceProvider {
     }
 
     public EventSourceMapping updateEventSourceMapping(String uuid, Map<String, Object> request) {
+        validateEventSourceMappingStructures(request);
+
         EventSourceMapping esm = getEventSourceMapping(uuid);
 
         boolean wasEnabled = esm.isEnabled();
@@ -1550,6 +1547,30 @@ public class LambdaService implements ResourceProvider {
             }
         }
         return null;
+    }
+
+    private static Map<String, Object> structureMember(Map<String, Object> request, String member) {
+        return structureValue(request.get(member), member);
+    }
+
+    private static void validateEventSourceMappingStructures(Map<String, Object> request) {
+        structureMember(request, "ScalingConfig");
+        Map<String, Object> destinationConfig = structureMember(request, "DestinationConfig");
+        if (destinationConfig != null) {
+            structureValue(destinationConfig.get("OnFailure"), "DestinationConfig.OnFailure");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> structureValue(Object value, String member) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        throw new AwsException("SerializationException",
+                member + " must be a JSON object or null", 400);
     }
 
     private static void validateSnapStart(Object value) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaStructureSerializationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaStructureSerializationIntegrationTest.java
@@ -57,6 +57,48 @@ class LambdaStructureSerializationIntegrationTest {
     }
 
     @Test
+    void environmentVariablesRejectsScalarBeforeUpdateMutation() {
+        Map<String, Object> createRequest = functionRequest("nested-environment-create");
+        createRequest.put("Environment", Map.of("Variables", 5));
+        given()
+            .contentType("application/json")
+            .body(createRequest)
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+
+        Map<String, Object> initialRequest = functionRequest("nested-environment-update");
+        initialRequest.put("Description", "original description");
+        given()
+            .contentType("application/json")
+            .body(initialRequest)
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body(Map.of(
+                    "Description", "must not be applied",
+                    "Environment", Map.of("Variables", 5)))
+        .when()
+            .put(BASE_PATH + "/functions/nested-environment-update/configuration")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/nested-environment-update/configuration")
+        .then()
+            .statusCode(200)
+            .body("Description", equalTo("original description"));
+    }
+
+    @Test
     void explicitNullStructureMembersRemainOptional() {
         Map<String, Object> request = functionRequest("null-structure-members");
         FUNCTION_STRUCTURE_MEMBERS.forEach(member -> request.put(member, null));

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaStructureSerializationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaStructureSerializationIntegrationTest.java
@@ -1,0 +1,158 @@
+package io.github.hectorvent.floci.services.lambda;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class LambdaStructureSerializationIntegrationTest {
+
+    private static final String BASE_PATH = "/2015-03-31";
+    private static final String QUEUE_ARN = "arn:aws:sqs:us-east-1:000000000000:structure-queue";
+    private static final List<String> FUNCTION_STRUCTURE_MEMBERS = List.of(
+            "Environment", "EphemeralStorage", "TracingConfig", "DeadLetterConfig",
+            "VpcConfig", "SnapStart", "LoggingConfig", "ImageConfig");
+
+    @Test
+    void createFunctionRejectsScalarStructureMembers() {
+        List<String> members = new java.util.ArrayList<>(FUNCTION_STRUCTURE_MEMBERS);
+        members.add("Code");
+
+        for (String member : members) {
+            Map<String, Object> request = functionRequest("create-scalar-" + member.toLowerCase());
+            request.put(member, 5);
+
+            given()
+                .contentType("application/json")
+                .body(request)
+            .when()
+                .post(BASE_PATH + "/functions")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+        }
+    }
+
+    @Test
+    void updateFunctionConfigurationRejectsScalarStructureMembers() {
+        createFunction("update-scalar-members");
+
+        for (String member : FUNCTION_STRUCTURE_MEMBERS) {
+            given()
+                .contentType("application/json")
+                .body(Map.of(member, 5))
+            .when()
+                .put(BASE_PATH + "/functions/update-scalar-members/configuration")
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+        }
+    }
+
+    @Test
+    void explicitNullStructureMembersRemainOptional() {
+        Map<String, Object> request = functionRequest("null-structure-members");
+        FUNCTION_STRUCTURE_MEMBERS.forEach(member -> request.put(member, null));
+        request.put("Code", null);
+
+        given()
+            .contentType("application/json")
+            .body(request)
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201);
+
+        Map<String, Object> update = new HashMap<>();
+        FUNCTION_STRUCTURE_MEMBERS.forEach(member -> update.put(member, null));
+        given()
+            .contentType("application/json")
+            .body(update)
+        .when()
+            .put(BASE_PATH + "/functions/null-structure-members/configuration")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    void eventSourceMappingRejectsScalarStructureMembers() {
+        createFunction("esm-structure-members");
+
+        assertEventSourceMappingSerializationError(Map.of("ScalingConfig", 5));
+        assertEventSourceMappingSerializationError(Map.of("DestinationConfig", 5));
+        assertEventSourceMappingSerializationError(Map.of(
+                "DestinationConfig", Map.of("OnFailure", 5)));
+
+        String uuid = given()
+            .contentType("application/json")
+            .body(Map.of(
+                    "FunctionName", "esm-structure-members",
+                    "EventSourceArn", QUEUE_ARN,
+                    "Enabled", false))
+        .when()
+            .post(BASE_PATH + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("UUID", notNullValue())
+        .extract()
+            .path("UUID");
+
+        List<Map<String, Object>> updates = List.of(
+                Map.<String, Object>of("ScalingConfig", 5),
+                Map.<String, Object>of("DestinationConfig", 5),
+                Map.<String, Object>of("DestinationConfig", Map.of("OnFailure", 5)));
+        for (Map<String, Object> update : updates) {
+            given()
+                .contentType("application/json")
+                .body(update)
+            .when()
+                .put(BASE_PATH + "/event-source-mappings/" + uuid)
+            .then()
+                .statusCode(400)
+                .body("__type", equalTo("SerializationException"));
+        }
+    }
+
+    private static void assertEventSourceMappingSerializationError(Map<String, Object> structureMember) {
+        Map<String, Object> request = new HashMap<>();
+        request.put("FunctionName", "esm-structure-members");
+        request.put("EventSourceArn", QUEUE_ARN);
+        request.put("Enabled", false);
+        request.putAll(structureMember);
+
+        given()
+            .contentType("application/json")
+            .body(request)
+        .when()
+            .post(BASE_PATH + "/event-source-mappings")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    private static void createFunction(String name) {
+        given()
+            .contentType("application/json")
+            .body(functionRequest(name))
+        .when()
+            .post(BASE_PATH + "/functions")
+        .then()
+            .statusCode(201);
+    }
+
+    private static Map<String, Object> functionRequest(String name) {
+        Map<String, Object> request = new HashMap<>();
+        request.put("FunctionName", name);
+        request.put("Runtime", "nodejs20.x");
+        request.put("Role", "arn:aws:iam::000000000000:role/lambda-role");
+        request.put("Handler", "index.handler");
+        return request;
+    }
+}


### PR DESCRIPTION
## Summary
- validate object-shaped Lambda request members before operation-level validation and mutation
- return SerializationException for scalar function configuration and event-source mapping structures
- keep explicit null optional and accepted
- replace the existing DestinationConfig and ScalingConfig InvalidParameterValueException paths with protocol-level serialization errors
- add end-to-end coverage for CreateFunction, UpdateFunctionConfiguration, CreateEventSourceMapping, and UpdateEventSourceMapping

## Testing
- ./mvnw -Dtest=LambdaStructureSerializationIntegrationTest test
- ./mvnw -Dtest=LambdaImageConfigTest,LambdaVpcSnapStartLoggingIntegrationTest,EsmIntegrationTest,LambdaStructureSerializationIntegrationTest test
- 77 focused tests passed

Fixes #2537