### PR TITLE
fix(organizations): return account state

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/organizations/OrganizationsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/organizations/OrganizationsJsonHandler.java
@@ -666,6 +666,7 @@ public class OrganizationsJsonHandler {
         node.put("Arn", account.getArn());
         node.put("Email", account.getEmail());
         node.put("Name", account.getName());
+        node.put("State", account.getStatus());
         node.put("Status", account.getStatus());
         node.put("JoinedMethod", account.getJoinedMethod());
         putTimestamp(node, "JoinedTimestamp", account.getJoinedTimestamp());

--- a/src/test/java/io/github/hectorvent/floci/services/organizations/OrganizationsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/organizations/OrganizationsIntegrationTest.java
@@ -330,6 +330,7 @@ class OrganizationsIntegrationTest {
             .body("Account.Id", equalTo(memberAccountId))
             .body("Account.Email", equalTo("dev@example.com"))
             .body("Account.Name", equalTo("Dev"))
+            .body("Account.State", equalTo("ACTIVE"))
             .body("Account.Status", equalTo("ACTIVE"))
             .body("Account.JoinedMethod", equalTo("CREATED"))
             .body("Account.Arn", startsWith("arn:aws:organizations::000000000000:account/" + organizationId));
@@ -339,7 +340,8 @@ class OrganizationsIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body("Accounts.Id", hasItems("000000000000", memberAccountId));
+            .body("Accounts.Id", hasItems("000000000000", memberAccountId))
+            .body("Accounts.State", hasItems("ACTIVE", "ACTIVE"));
     }
 
     @Test
@@ -359,7 +361,8 @@ class OrganizationsIntegrationTest {
         .then()
             .statusCode(200)
             .body("Accounts", hasSize(1))
-            .body("Accounts[0].Id", equalTo(memberAccountId));
+            .body("Accounts[0].Id", equalTo(memberAccountId))
+            .body("Accounts[0].State", equalTo("ACTIVE"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Return the current AWS Organizations `Account.State` field from account responses while preserving the existing `Status` field.

AWS is retiring `Status` in favor of `State`. Standard clients increasingly consume `State`, so returning both fields keeps current compatibility while allowing callers to migrate without breaking existing behavior.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS Organizations documentation:

- Account model: https://docs.aws.amazon.com/organizations/latest/APIReference/API_Account.html
- Account state migration guidance: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_accounts_account_state.html
- ListAccounts response: https://docs.aws.amazon.com/organizations/latest/APIReference/API_ListAccounts.html

AWS currently exposes both `State` and `Status`, with `State` being the replacement field. This change maps Floci's existing account lifecycle value into both response properties and does not alter stored account state or lifecycle behavior.

Coverage verifies `State=ACTIVE` in `DescribeAccount`, `ListAccounts`, and `ListAccountsForParent` while retaining the existing `Status` assertions.

## How to test

```bash
./mvnw test -Dtest=OrganizationsIntegrationTest
```

Result: 50 tests passed, 0 failures, 0 errors.

## Checklist

- [x] `./mvnw test` passes locally (focused Organizations integration suite)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
