### PR TITLE
feat(servicequotas): add quota request history lookup

### DIFF
--- a/docs/services/servicequotas.md
+++ b/docs/services/servicequotas.md
@@ -8,8 +8,10 @@ Floci answers Service Quotas lookups from a generated in-memory catalog. Every s
 resolves to a quota list: a curated set with real AWS quota codes where tooling depends on
 them — CodeBuild's `L-2DC20C30` ("Concurrently running builds") and Lambda's `L-B99A9384`
 ("Concurrent executions") — plus a deterministic generic set for any other service code. All
-values are deliberately generous (5000) so local pipelines that gate on quota headroom, such
-as AWS Landing Zone Accelerator, never stall on a limit the emulator does not enforce.
+values are deliberately generous so local pipelines that gate on quota headroom, such
+as AWS Landing Zone Accelerator, never stall on a limit the emulator does not enforce. The
+Organizations `Maximum number of accounts` quota uses AWS quota code `L-E619E033` and a local value
+of 50.
 
 Applied quotas and AWS default quotas return the same data, and quota values are static.
 `RequestServiceQuotaIncrease` is accepted and validated but does not change any quota value —
@@ -25,6 +27,7 @@ see Limitations.
 | `GetAWSDefaultServiceQuota` | Same as GetServiceQuota; defaults equal applied values |
 | `ListAWSDefaultServiceQuotas` | Same as ListServiceQuotas; defaults equal applied values |
 | `RequestServiceQuotaIncrease` | Validates and echoes an increase request as `PENDING`; not persisted, quota unchanged |
+| `ListRequestedServiceQuotaChangeHistoryByQuota` | Validates the service/quota pair and returns the locally recorded request history; currently empty for the static catalog |
 <!-- floci:actions:end -->
 
 ## Limitations

--- a/src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasJsonHandler.java
@@ -33,6 +33,10 @@ public class ServiceQuotasJsonHandler {
             case "GetAWSDefaultServiceQuota" -> handleGetServiceQuota(request, region, accountId);
             case "ListAWSDefaultServiceQuotas" -> handleListServiceQuotas(request, region, accountId);
             case "RequestServiceQuotaIncrease" -> handleRequestServiceQuotaIncrease(request, region, accountId);
+            case "ListRequestedServiceQuotaChangeHistoryByQuota" ->
+                    Response.ok(service.listRequestedServiceQuotaChangeHistoryByQuota(
+                            stringOrNull(request, "ServiceCode"), stringOrNull(request, "QuotaCode"),
+                            stringOrNull(request, "NextToken"), integerOrNull(request, "MaxResults"))).build();
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnknownOperationException",
                             "Unknown operation: ServiceQuotasV20190624." + action))

--- a/src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasService.java
@@ -56,7 +56,9 @@ public class ServiceQuotasService {
             "codebuild", List.of(
                     new QuotaDefinition("L-2DC20C30", "Concurrently running builds", GENERIC_QUOTA_VALUE)),
             "lambda", List.of(
-                    new QuotaDefinition("L-B99A9384", "Concurrent executions", GENERIC_QUOTA_VALUE)));
+                    new QuotaDefinition("L-B99A9384", "Concurrent executions", GENERIC_QUOTA_VALUE)),
+            "organizations", List.of(
+                    new QuotaDefinition("L-E619E033", "Maximum number of accounts", 50.0)));
 
     private static final List<String> GENERIC_QUOTA_NAMES = List.of(
             "Resources per Region",
@@ -135,7 +137,7 @@ public class ServiceQuotasService {
         node.put("Value", quota.value());
         node.put("Unit", "None");
         node.put("Adjustable", true);
-        node.put("GlobalQuota", false);
+        node.put("GlobalQuota", "organizations".equals(serviceCode));
         node.put("QuotaAppliedAtLevel", "ACCOUNT");
         return node;
     }
@@ -188,6 +190,28 @@ public class ServiceQuotasService {
         } catch (IllegalArgumentException e) {
             return -1;
         }
+    }
+
+    public ObjectNode listRequestedServiceQuotaChangeHistoryByQuota(String serviceCode, String quotaCode,
+                                                                    String nextToken, Integer maxResults) {
+        requireServiceCode(serviceCode);
+        if (quotaCode == null || quotaCode.isBlank()) {
+            throw new AwsException("IllegalArgumentException", "Invalid input: QuotaCode must not be empty.", 400);
+        }
+        boolean exists = quotasFor(serviceCode).stream().anyMatch(quota -> quota.quotaCode().equals(quotaCode));
+        if (!exists) {
+            throw new AwsException("NoSuchResourceException",
+                    "The request failed because the specified service quota does not exist.", 400);
+        }
+        if (maxResults != null && (maxResults < 1 || maxResults > 100)) {
+            throw new AwsException("IllegalArgumentException", "Invalid input: MaxResults must be between 1 and 100.", 400);
+        }
+        if (nextToken != null && !nextToken.isEmpty() && decodeToken(nextToken) < 0) {
+            throw new AwsException("InvalidPaginationTokenException", "Invalid NextToken.", 400);
+        }
+        ObjectNode response = objectMapper.createObjectNode();
+        response.putArray("RequestedQuotas");
+        return response;
     }
 
     record QuotaDefinition(String quotaCode, String quotaName, double value) {

--- a/src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasService.java
@@ -54,11 +54,11 @@ public class ServiceQuotasService {
 
     private static final Map<String, List<QuotaDefinition>> CURATED_QUOTAS = Map.of(
             "codebuild", List.of(
-                    new QuotaDefinition("L-2DC20C30", "Concurrently running builds", GENERIC_QUOTA_VALUE)),
+                    new QuotaDefinition("L-2DC20C30", "Concurrently running builds", GENERIC_QUOTA_VALUE, false)),
             "lambda", List.of(
-                    new QuotaDefinition("L-B99A9384", "Concurrent executions", GENERIC_QUOTA_VALUE)),
+                    new QuotaDefinition("L-B99A9384", "Concurrent executions", GENERIC_QUOTA_VALUE, false)),
             "organizations", List.of(
-                    new QuotaDefinition("L-E619E033", "Maximum number of accounts", 50.0)));
+                    new QuotaDefinition("L-E619E033", "Maximum number of accounts", 50.0, true)));
 
     private static final List<String> GENERIC_QUOTA_NAMES = List.of(
             "Resources per Region",
@@ -111,7 +111,9 @@ public class ServiceQuotasService {
     List<QuotaDefinition> quotasFor(String serviceCode) {
         List<QuotaDefinition> quotas = new ArrayList<>(CURATED_QUOTAS.getOrDefault(serviceCode, List.of()));
         for (String name : GENERIC_QUOTA_NAMES) {
-            quotas.add(new QuotaDefinition(syntheticQuotaCode(serviceCode, name), name, GENERIC_QUOTA_VALUE));
+            quotas.add(new QuotaDefinition(
+                    syntheticQuotaCode(serviceCode, name), name, GENERIC_QUOTA_VALUE,
+                    "organizations".equals(serviceCode)));
         }
         return quotas;
     }
@@ -137,7 +139,7 @@ public class ServiceQuotasService {
         node.put("Value", quota.value());
         node.put("Unit", "None");
         node.put("Adjustable", true);
-        node.put("GlobalQuota", "organizations".equals(serviceCode));
+        node.put("GlobalQuota", quota.globalQuota());
         node.put("QuotaAppliedAtLevel", "ACCOUNT");
         return node;
     }
@@ -206,7 +208,7 @@ public class ServiceQuotasService {
         if (maxResults != null && (maxResults < 1 || maxResults > 100)) {
             throw new AwsException("IllegalArgumentException", "Invalid input: MaxResults must be between 1 and 100.", 400);
         }
-        if (nextToken != null && !nextToken.isEmpty() && decodeToken(nextToken) < 0) {
+        if (nextToken != null && !nextToken.isEmpty()) {
             throw new AwsException("InvalidPaginationTokenException", "Invalid NextToken.", 400);
         }
         ObjectNode response = objectMapper.createObjectNode();
@@ -214,7 +216,7 @@ public class ServiceQuotasService {
         return response;
     }
 
-    record QuotaDefinition(String quotaCode, String quotaName, double value) {
+    record QuotaDefinition(String quotaCode, String quotaName, double value, boolean globalQuota) {
     }
 
     private record Page(List<QuotaDefinition> items, String nextToken) {
@@ -259,7 +261,7 @@ public class ServiceQuotasService {
         requestedQuota.put("Status", "PENDING");
         requestedQuota.put("Requester", "floci-emulator");
         requestedQuota.put("Unit", "None");
-        requestedQuota.put("GlobalQuota", false);
+        requestedQuota.put("GlobalQuota", quota.globalQuota());
         requestedQuota.put("QuotaRequestedAtLevel", "ACCOUNT");
         requestedQuota.put("Created", now);
         requestedQuota.put("LastUpdated", now);

--- a/src/test/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasIntegrationTest.java
@@ -190,6 +190,20 @@ class ServiceQuotasIntegrationTest {
     }
 
     @Test
+    void listRequestedQuotaHistoryByQuotaRejectsImpossibleNextToken() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistoryByQuota")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ServiceCode\":\"organizations\",\"QuotaCode\":\"L-E619E033\",\"NextToken\":\"MQ\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidPaginationTokenException"));
+    }
+
+    @Test
     void listRequestedQuotaHistoryByQuotaRejectsUnknownQuota() {
         given()
             .contentType(CONTENT_TYPE)
@@ -201,6 +215,22 @@ class ServiceQuotasIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("NoSuchResourceException"));
+    }
+
+    @Test
+    void requestOrganizationsQuotaIncreasePreservesGlobalQuota() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "ServiceQuotasV20190624.RequestServiceQuotaIncrease")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ServiceCode\":\"organizations\",\"QuotaCode\":\"L-E619E033\",\"DesiredValue\":100}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("RequestedQuota.ServiceCode", equalTo("organizations"))
+            .body("RequestedQuota.QuotaCode", equalTo("L-E619E033"))
+            .body("RequestedQuota.GlobalQuota", equalTo(true));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasIntegrationTest.java
@@ -159,6 +159,51 @@ class ServiceQuotasIntegrationTest {
     }
 
     @Test
+    void organizationsQuotaUsesAwsQuotaCode() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "ServiceQuotasV20190624.GetServiceQuota")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ServiceCode\":\"organizations\",\"QuotaCode\":\"L-E619E033\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Quota.QuotaCode", equalTo("L-E619E033"))
+            .body("Quota.QuotaName", equalTo("Maximum number of accounts"))
+            .body("Quota.Value", equalTo(50.0f))
+            .body("Quota.GlobalQuota", equalTo(true));
+    }
+
+    @Test
+    void listRequestedQuotaHistoryByQuotaReturnsEmptyHistoryForKnownQuota() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistoryByQuota")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ServiceCode\":\"organizations\",\"QuotaCode\":\"L-E619E033\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("RequestedQuotas.size()", equalTo(0));
+    }
+
+    @Test
+    void listRequestedQuotaHistoryByQuotaRejectsUnknownQuota() {
+        given()
+            .contentType(CONTENT_TYPE)
+            .header("X-Amz-Target", "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistoryByQuota")
+            .header("Authorization", AUTH_HEADER)
+            .body("{\"ServiceCode\":\"organizations\",\"QuotaCode\":\"L-DOESNOTEX\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("NoSuchResourceException"));
+    }
+
+    @Test
     void getServiceQuota_unknownQuotaCode_returnsNoSuchResource() {
         given()
             .contentType(CONTENT_TYPE)


### PR DESCRIPTION
## Summary

Add `ListRequestedServiceQuotaChangeHistoryByQuota` support and model the AWS Organizations `Maximum number of accounts` quota with its current AWS quota code.

The history operation validates the service/quota pair and pagination inputs, then returns the local request history. Floci does not currently persist quota increase requests, so the valid static-catalog response is an empty `RequestedQuotas` array.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against AWS documentation:

- ListRequestedServiceQuotaChangeHistoryByQuota: https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_ListRequestedServiceQuotaChangeHistoryByQuota.html
- Service Quotas API operations: https://docs.aws.amazon.com/servicequotas/2019-06-24/apireference/API_Operations.html
- AWS Organizations quotas: https://docs.aws.amazon.com/organizations/latest/userguide/orgs_reference_limits.html
- AWS Organizations account quota code guidance: https://repost.aws/knowledge-center/control-tower-account-quota-error

The implementation validates `ServiceCode`, `QuotaCode`, `MaxResults`, and `NextToken` using the modeled Service Quotas errors. Unknown quotas return `NoSuchResourceException`. The Organizations quota uses AWS quota code `L-E619E033`, is marked global, and retains Floci's intentionally generous local value of 50 so local provisioning workflows are not blocked by a quota the emulator does not enforce.

## How to test

```bash
./mvnw test -Dtest=ServiceQuotasIntegrationTest,ServiceQuotasServiceTest
```

Result: 19 tests passed, 0 failures, 0 errors.

## Checklist

- [x] `./mvnw test` passes locally (focused affected-service suites)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
