### PR TITLE
feat(cloudformation): support service-managed stacksets

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationStackSetsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationStackSetsTest.java
@@ -84,6 +84,7 @@ class CloudFormationStackSetsTest {
         assertThat(ss.stackSetName()).isEqualTo(stackSetName);
         assertThat(ss.status()).isEqualTo(StackSetStatus.ACTIVE);
         assertThat(ss.templateBody()).contains(queueName);
+        assertThat(ss.autoDeployment()).isNull();
     }
 
     @Test

--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -90,12 +90,14 @@ cross-resource references.
 | CodePipeline | `Pipeline`, `CustomActionType`, `Webhook` |
 | CodeBuild | `Project` |
 | Batch | `ComputeEnvironment`, `JobQueue`, `JobDefinition` |
-| Cognito | `UserPool`, `UserPoolClient` |
+| Cognito | `UserPool`, `UserPoolClient`, `UserPoolDomain` |
+| ACM | `Certificate` |
 | EventBridge | `Rule`, `EventBus`, `EventBusPolicy` |
 | EventBridge Scheduler | `ScheduleGroup` |
 | Pipes | `Pipe` |
 | Kinesis | `Stream` |
 | Kinesis Data Firehose | `DeliveryStream` |
+| IoT Core | `DomainConfiguration` (`ServerCertificates` resolves to a JSON string) |
 | CloudFront | `Distribution` |
 | CloudWatch | `Alarm` |
 | CloudWatch Logs | `LogGroup` |

--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -29,6 +29,8 @@
 | `SetStackPolicy` | Accepted; no-op (stub — stack policies are not enforced) |
 | `GetStackPolicy` | Accepted; returns an empty policy (stub) |
 | `DescribeStackResource` | Get a specific stack resource |
+| `DescribeOrganizationsAccess` | - |
+| `ActivateOrganizationsAccess` | - |
 | `CreateStackSet` | Create a stack set from a template |
 | `DescribeStackSet` | Get stack set details |
 | `ListStackSets` | List stack sets |
@@ -40,7 +42,16 @@
 | `DeleteStackInstances` | Remove instances and their resources |
 | `ListStackSetOperations` | List operations performed on a stack set |
 | `DescribeStackSetOperation` | - |
+| `ListStackSetAutoDeploymentTargets` | - |
 <!-- floci:actions:end -->
+
+## StackSets compatibility
+
+StackSets support both `SELF_MANAGED` and the Cloud Launchpad `SERVICE_MANAGED` workflow. `ActivateOrganizationsAccess` requires an Organizations management account with all features enabled and enables trusted access for `stacksets.cloudformation.amazonaws.com`. Service-managed organizational-unit deployment targets are resolved from the caller's actual Organizations state rather than converted into synthetic account IDs. Targeting an OU includes eligible accounts directly in that OU and in all descendant OUs, while excluding the organization management account, matching AWS StackSets targeting semantics.
+
+`CreateStackInstances` and `UpdateStackSet` execute the backing CloudFormation stacks in each target account. A failed resource can therefore drive the backing stack through rollback and leave the stack instance `INOPERABLE` with detailed status `FAILED`; the StackSet operation is reported as `FAILED` instead of being forced to success.
+
+Operation IDs are recorded and validated. Duplicate IDs return `OperationIdAlreadyExistsException`, missing stack sets return `StackSetNotFoundException`, and missing operation IDs return `OperationNotFoundException`. Invalid targets and request shapes use the CloudFormation query-protocol validation errors. Operations complete locally, so `OperationInProgressException` is only reachable when local operation state actually overlaps; Floci does not inject concurrency failures solely to exercise an error code.
 
 ## Supported Resource Types
 
@@ -79,14 +90,12 @@ cross-resource references.
 | CodePipeline | `Pipeline`, `CustomActionType`, `Webhook` |
 | CodeBuild | `Project` |
 | Batch | `ComputeEnvironment`, `JobQueue`, `JobDefinition` |
-| Cognito | `UserPool`, `UserPoolClient`, `UserPoolDomain` |
-| ACM | `Certificate` |
+| Cognito | `UserPool`, `UserPoolClient` |
 | EventBridge | `Rule`, `EventBus`, `EventBusPolicy` |
 | EventBridge Scheduler | `ScheduleGroup` |
 | Pipes | `Pipe` |
 | Kinesis | `Stream` |
 | Kinesis Data Firehose | `DeliveryStream` |
-| IoT Core | `DomainConfiguration` (`ServerCertificates` resolves to a JSON string) |
 | CloudFront | `Distribution` |
 | CloudWatch | `Alarm` |
 | CloudWatch Logs | `LogGroup` |
@@ -233,7 +242,7 @@ before provisioning:
 - `AWS::SSM::Parameter::Value<List<String>>` and `AWS::SSM::Parameter::Name` typed parameters are
   **not yet** resolved — they are passed through as their literal input.
 
-The `AWS::SSM::Parameter` **resource** type exposes `Value`, `Type`, `Name`, and `Arn` attributes through
+The `AWS::SSM::Parameter` **resource** type exposes `Value`, `Type`, and `Name` attributes through
 `Ref` / `Fn::GetAtt` so downstream resources can consume a parameter the same stack creates.
 
 ## AWS::Include (`Fn::Transform`)

--- a/docs/services/cloudformation.md
+++ b/docs/services/cloudformation.md
@@ -244,7 +244,7 @@ before provisioning:
 - `AWS::SSM::Parameter::Value<List<String>>` and `AWS::SSM::Parameter::Name` typed parameters are
   **not yet** resolved — they are passed through as their literal input.
 
-The `AWS::SSM::Parameter` **resource** type exposes `Value`, `Type`, and `Name` attributes through
+The `AWS::SSM::Parameter` **resource** type exposes `Value`, `Type`, `Name`, and `Arn` attributes through
 `Ref` / `Fn::GetAtt` so downstream resources can consume a parameter the same stack creates.
 
 ## AWS::Include (`Fn::Transform`)

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationQueryHandler.java
@@ -807,13 +807,15 @@ public class CloudFormationQueryHandler {
                     .elem("Status", ss.getStatus())
                     .elem("Description", ss.getDescription())
                     .elem("TemplateBody", ss.getTemplateBody())
-                    .elem("PermissionModel", ss.getPermissionModel())
-                    .start("AutoDeployment")
-                      .elem("Enabled", Boolean.toString(ss.isAutoDeploymentEnabled()))
-                      .elem("RetainStacksOnAccountRemoval", Boolean.toString(ss.isRetainStacksOnAccountRemoval()))
-                    .end("AutoDeployment")
-                    .start("ManagedExecution")
-                      .elem("Active", Boolean.toString(ss.isManagedExecutionActive()))
+                    .elem("PermissionModel", ss.getPermissionModel());
+            if ("SERVICE_MANAGED".equals(ss.getPermissionModel())) {
+                xml.start("AutoDeployment")
+                        .elem("Enabled", Boolean.toString(ss.isAutoDeploymentEnabled()))
+                        .elem("RetainStacksOnAccountRemoval", Boolean.toString(ss.isRetainStacksOnAccountRemoval()))
+                        .end("AutoDeployment");
+            }
+            xml.start("ManagedExecution")
+                    .elem("Active", Boolean.toString(ss.isManagedExecutionActive()))
                     .end("ManagedExecution");
             appendCapabilities(xml, ss.getCapabilities());
             appendParameters(xml, ss.getParameters());
@@ -961,6 +963,7 @@ public class CloudFormationQueryHandler {
                     params.getFirst("StackSetName"),
                     extractList(params, "Accounts.member."),
                     extractList(params, "Regions.member."),
+                    extractList(params, "DeploymentTargets.OrganizationalUnitIds.member."),
                     Boolean.parseBoolean(params.getFirst("RetainStacks")));
             return operationResponse("DeleteStackInstances", op.getOperationId());
         } catch (AwsException e) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationQueryHandler.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.cloudformation.model.StackEvent;
 import io.github.hectorvent.floci.services.cloudformation.model.StackInstance;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.cloudformation.model.StackSet;
+import io.github.hectorvent.floci.services.cloudformation.model.StackSetAutoDeploymentTarget;
 import io.github.hectorvent.floci.services.cloudformation.model.StackSetOperation;
 import io.github.hectorvent.floci.services.cloudformation.model.TemplateSummary;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -67,6 +68,8 @@ public class CloudFormationQueryHandler {
             case "SetStackPolicy" -> Response.ok(emptyResult("SetStackPolicyResponse")).build();
             case "GetStackPolicy" -> Response.ok(emptyResult("GetStackPolicyResponse")).build();
             case "DescribeStackResource" -> describeStackResource(params, region);
+            case "DescribeOrganizationsAccess" -> describeOrganizationsAccess();
+            case "ActivateOrganizationsAccess" -> activateOrganizationsAccess();
             case "CreateStackSet" -> createStackSet(params);
             case "DescribeStackSet" -> describeStackSet(params);
             case "ListStackSets" -> listStackSets();
@@ -78,6 +81,7 @@ public class CloudFormationQueryHandler {
             case "DeleteStackInstances" -> deleteStackInstances(params);
             case "ListStackSetOperations" -> listStackSetOperations(params);
             case "DescribeStackSetOperation" -> describeStackSetOperation(params);
+            case "ListStackSetAutoDeploymentTargets" -> listStackSetAutoDeploymentTargets(params);
             default -> xmlError("UnknownAction", "Action " + action + " is not supported.", 400);
         };
     }
@@ -724,6 +728,46 @@ public class CloudFormationQueryHandler {
 
     // ── StackSets ─────────────────────────────────────────────────────────────
 
+    private Response describeOrganizationsAccess() {
+        String xml = new XmlBuilder().start("DescribeOrganizationsAccessResponse", CF_NS)
+                .start("DescribeOrganizationsAccessResult")
+                .elem("Status", stackSetService.isOrganizationsAccessEnabled() ? "ENABLED" : "DISABLED")
+                .end("DescribeOrganizationsAccessResult").raw(AwsQueryResponse.responseMetadata())
+                .end("DescribeOrganizationsAccessResponse").build();
+        return Response.ok(xml).type("text/xml").build();
+    }
+
+    private Response activateOrganizationsAccess() {
+        try {
+            stackSetService.activateOrganizationsAccess();
+            String xml = new XmlBuilder().start("ActivateOrganizationsAccessResponse", CF_NS)
+                    .start("ActivateOrganizationsAccessResult").end("ActivateOrganizationsAccessResult")
+                    .raw(AwsQueryResponse.responseMetadata()).end("ActivateOrganizationsAccessResponse").build();
+            return Response.ok(xml).type("text/xml").build();
+        } catch (AwsException e) {
+            return xmlError(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
+        }
+    }
+
+    private Response listStackSetAutoDeploymentTargets(MultivaluedMap<String, String> params) {
+        try {
+            List<StackSetAutoDeploymentTarget> targets =
+                    stackSetService.listStackSetAutoDeploymentTargets(params.getFirst("StackSetName"));
+            XmlBuilder xml = new XmlBuilder().start("ListStackSetAutoDeploymentTargetsResponse", CF_NS)
+                    .start("ListStackSetAutoDeploymentTargetsResult").start("Summaries");
+            for (StackSetAutoDeploymentTarget target : targets) {
+                xml.start("member").elem("OrganizationalUnitId", target.getOrganizationalUnitId()).start("Regions");
+                for (String region : target.getRegions()) xml.elem("member", region);
+                xml.end("Regions").end("member");
+            }
+            xml.end("Summaries").end("ListStackSetAutoDeploymentTargetsResult")
+                    .raw(AwsQueryResponse.responseMetadata()).end("ListStackSetAutoDeploymentTargetsResponse");
+            return Response.ok(xml.build()).type("text/xml").build();
+        } catch (AwsException e) {
+            return xmlError(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
+        }
+    }
+
     private Response createStackSet(MultivaluedMap<String, String> params) {
         try {
             StackSet ss = stackSetService.createStackSet(
@@ -732,7 +776,11 @@ public class CloudFormationQueryHandler {
                     extractParameters(params),
                     extractList(params, "Capabilities.member."),
                     extractTags(params),
-                    params.getFirst("Description"));
+                    params.getFirst("Description"),
+                    params.getFirst("PermissionModel"),
+                    Boolean.parseBoolean(params.getFirst("AutoDeployment.Enabled")),
+                    Boolean.parseBoolean(params.getFirst("AutoDeployment.RetainStacksOnAccountRemoval")),
+                    Boolean.parseBoolean(params.getFirst("ManagedExecution.Active")));
             String xml = new XmlBuilder()
                     .start("CreateStackSetResponse", CF_NS)
                     .start("CreateStackSetResult")
@@ -759,7 +807,14 @@ public class CloudFormationQueryHandler {
                     .elem("Status", ss.getStatus())
                     .elem("Description", ss.getDescription())
                     .elem("TemplateBody", ss.getTemplateBody())
-                    .elem("PermissionModel", ss.getPermissionModel());
+                    .elem("PermissionModel", ss.getPermissionModel())
+                    .start("AutoDeployment")
+                      .elem("Enabled", Boolean.toString(ss.isAutoDeploymentEnabled()))
+                      .elem("RetainStacksOnAccountRemoval", Boolean.toString(ss.isRetainStacksOnAccountRemoval()))
+                    .end("AutoDeployment")
+                    .start("ManagedExecution")
+                      .elem("Active", Boolean.toString(ss.isManagedExecutionActive()))
+                    .end("ManagedExecution");
             appendCapabilities(xml, ss.getCapabilities());
             appendParameters(xml, ss.getParameters());
             xml.end("StackSet").end("DescribeStackSetResult")
@@ -800,7 +855,14 @@ public class CloudFormationQueryHandler {
                     extractParameters(params, previousParameters),
                     extractList(params, "Capabilities.member."),
                     extractTags(params),
-                    params.getFirst("Description"));
+                    params.getFirst("Description"),
+                    params.getFirst("OperationId"),
+                    params.containsKey("AutoDeployment.Enabled")
+                            ? Boolean.parseBoolean(params.getFirst("AutoDeployment.Enabled")) : null,
+                    params.containsKey("AutoDeployment.RetainStacksOnAccountRemoval")
+                            ? Boolean.parseBoolean(params.getFirst("AutoDeployment.RetainStacksOnAccountRemoval")) : null,
+                    params.containsKey("ManagedExecution.Active")
+                            ? Boolean.parseBoolean(params.getFirst("ManagedExecution.Active")) : null);
             return operationResponse("UpdateStackSet", op.getOperationId());
         } catch (AwsException e) {
             return xmlError(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
@@ -821,7 +883,9 @@ public class CloudFormationQueryHandler {
             StackSetOperation op = stackSetService.createStackInstances(
                     params.getFirst("StackSetName"),
                     extractList(params, "Accounts.member."),
-                    resolveRegions(params, region));
+                    resolveRegions(params, region),
+                    extractList(params, "DeploymentTargets.OrganizationalUnitIds.member."),
+                    params.getFirst("OperationId"));
             return operationResponse("CreateStackInstances", op.getOperationId());
         } catch (AwsException e) {
             return xmlError(e.getErrorCode(), e.getMessage(), e.getHttpStatus());
@@ -843,6 +907,7 @@ public class CloudFormationQueryHandler {
                    .elem("StackSetId", inst.getStackSetId())
                    .elem("Account", inst.getAccount())
                    .elem("Region", inst.getRegion())
+                   .elem("OrganizationalUnitId", inst.getOrganizationalUnitId())
                    .elem("StackId", inst.getStackId())
                    .elem("Status", inst.getStatus())
                    .start("StackInstanceStatus")

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -294,6 +294,10 @@ public class StackSetService {
             throw new AwsException("InvalidOperationException",
                     "DeploymentTargets can be used only with SERVICE_MANAGED StackSets.", 400);
         }
+        if (!directAccounts.isEmpty() && "SERVICE_MANAGED".equals(ss.getPermissionModel())) {
+            throw new AwsException("InvalidOperationException",
+                    "Accounts can be used only with SELF_MANAGED StackSets. Use DeploymentTargets for SERVICE_MANAGED StackSets.", 400);
+        }
         if (directAccounts.stream().anyMatch(account -> account == null || !account.matches("[0-9]{12}"))) {
             throw new AwsException("ValidationError",
                     "1 validation error detected: Value '" + directAccounts

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -22,6 +22,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,7 +244,7 @@ public class StackSetService {
                 }
                 StackInstance updated =
                         deployInstance(ss, inst.getAccount(), inst.getRegion(), UPDATE_CHANGE_SET, "UPDATE");
-                updated.setOrganizationalUnitId(inst.getOrganizationalUnitId());
+                applyDeploymentTargets(updated, deploymentTargetsFor(inst));
                 instances.put(instanceKey(name, updated.getAccount(), updated.getRegion()), updated);
                 deployed.add(updated);
             }
@@ -309,7 +310,7 @@ public class StackSetService {
 
         String operationId = reserveOperation(name, "CREATE", requestedOperationId).getOperationId();
         List<TargetAccount> targets = !directAccounts.isEmpty()
-                ? directAccounts.stream().map(account -> new TargetAccount(account, null)).toList()
+                ? directAccounts.stream().map(account -> new TargetAccount(account, Set.of())).toList()
                 : resolveOrganizationTargets(targetOus, regions, name);
 
         List<StackInstance> deployed = new ArrayList<>();
@@ -318,10 +319,20 @@ public class StackSetService {
                 String instanceKey = instanceKey(name, target.accountId(), region);
                 StackInstance existing = instances.get(instanceKey).orElse(null);
                 if (existing != null && !"OUTDATED".equals(existing.getStatus())) {
+                    if (!target.organizationalUnitIds().isEmpty()) {
+                        Set<String> associations = deploymentTargetsFor(existing);
+                        if (associations.addAll(target.organizationalUnitIds())) {
+                            applyDeploymentTargets(existing, associations);
+                            instances.put(instanceKey, existing);
+                        }
+                    }
                     continue;
                 }
                 StackInstance inst = deployInstance(ss, target.accountId(), region, INSTANCE_CHANGE_SET, "CREATE");
-                inst.setOrganizationalUnitId(target.organizationalUnitId());
+                Set<String> associations = existing == null
+                        ? new LinkedHashSet<>() : deploymentTargetsFor(existing);
+                associations.addAll(target.organizationalUnitIds());
+                applyDeploymentTargets(inst, associations);
                 instances.put(instanceKey, inst);
                 deployed.add(inst);
             }
@@ -399,7 +410,7 @@ public class StackSetService {
                 .filter(inst -> requestedRegions.contains(inst.getRegion()))
                 .filter(inst -> !requestedAccounts.isEmpty()
                         ? requestedAccounts.contains(inst.getAccount())
-                        : requestedDeploymentTargets.contains(inst.getOrganizationalUnitId()))
+                        : deploymentTargetsFor(inst).stream().anyMatch(requestedDeploymentTargets::contains))
                 .toList();
 
         List<StackInstance> results = new ArrayList<>();
@@ -407,11 +418,20 @@ public class StackSetService {
             String account = inst.getAccount();
             String region = inst.getRegion();
             String key = instanceKey(name, account, region);
-            // For service-managed StackSets the persisted OrganizationalUnitId is the
-            // DeploymentTargets association that created this instance. Do not resolve the OU's
-            // current membership here: accounts can move after deployment while the instance
-            // remains associated with its original target until an auto-deployment or explicit
-            // StackSets operation changes it.
+            // Service-managed instances can be covered by multiple DeploymentTargets when a
+            // parent OU and one of its descendants are both targeted. Removing one target must not
+            // tear down the backing stack while another recorded target still covers the instance.
+            if (!requestedDeploymentTargets.isEmpty()) {
+                Set<String> remainingTargets = deploymentTargetsFor(inst);
+                remainingTargets.removeAll(requestedDeploymentTargets);
+                if (!remainingTargets.isEmpty()) {
+                    applyDeploymentTargets(inst, remainingTargets);
+                    instances.put(key, inst);
+                    inst.setDetailedStatus("SUCCEEDED");
+                    results.add(inst);
+                    continue;
+                }
+            }
             if (!retainStacks && !await(cfnService.deleteStack(inst.getStackName(), region, account))) {
                 // The underlying stack delete failed. Match AWS: retain the instance record
                 // (now INOPERABLE) and report the operation as FAILED, rather than silently
@@ -466,7 +486,7 @@ public class StackSetService {
             throw new AwsException("InvalidOperationException",
                     "SERVICE_MANAGED StackSets require an AWS Organization.", 400);
         }
-        java.util.LinkedHashMap<String, TargetAccount> targets = new java.util.LinkedHashMap<>();
+        LinkedHashMap<String, TargetAccount> targets = new LinkedHashMap<>();
         for (String ou : organizationalUnits) {
             collectOrganizationTargets(caller, organization, ou, ou, targets);
             if (persistTargets) {
@@ -479,10 +499,15 @@ public class StackSetService {
 
     private void collectOrganizationTargets(String caller, Organization organization, String parentId,
                                             String requestedTargetId,
-                                            java.util.LinkedHashMap<String, TargetAccount> targets) {
+                                            LinkedHashMap<String, TargetAccount> targets) {
         for (OrganizationAccount account : organizationsService.listAccountsForParent(caller, parentId)) {
             if (!organization.getMasterAccountId().equals(account.getId()) && "ACTIVE".equals(account.getStatus())) {
-                targets.putIfAbsent(account.getId(), new TargetAccount(account.getId(), requestedTargetId));
+                targets.compute(account.getId(), (ignored, existing) -> {
+                    Set<String> associations = existing == null
+                            ? new LinkedHashSet<>() : new LinkedHashSet<>(existing.organizationalUnitIds());
+                    associations.add(requestedTargetId);
+                    return new TargetAccount(account.getId(), associations);
+                });
             }
         }
         for (OrganizationalUnit child : organizationsService.listOrganizationalUnitsForParent(caller, parentId)) {
@@ -550,7 +575,24 @@ public class StackSetService {
         }
     }
 
-    private record TargetAccount(String accountId, String organizationalUnitId) {}
+    private static Set<String> deploymentTargetsFor(StackInstance instance) {
+        LinkedHashSet<String> targets = new LinkedHashSet<>();
+        if (instance.getDeploymentTargetIds() != null) {
+            targets.addAll(instance.getDeploymentTargetIds());
+        }
+        if (targets.isEmpty() && instance.getOrganizationalUnitId() != null) {
+            targets.add(instance.getOrganizationalUnitId());
+        }
+        return targets;
+    }
+
+    private static void applyDeploymentTargets(StackInstance instance, Set<String> targets) {
+        List<String> orderedTargets = new ArrayList<>(targets);
+        instance.setDeploymentTargetIds(orderedTargets);
+        instance.setOrganizationalUnitId(orderedTargets.isEmpty() ? null : orderedTargets.getFirst());
+    }
+
+    private record TargetAccount(String accountId, Set<String> organizationalUnitIds) {}
 
     /**
      * Drives the single-stack engine to materialize one instance's resources into the target

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -2,12 +2,18 @@ package io.github.hectorvent.floci.services.cloudformation;
 
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudformation.model.Stack;
 import io.github.hectorvent.floci.services.cloudformation.model.StackInstance;
 import io.github.hectorvent.floci.services.cloudformation.model.StackSet;
+import io.github.hectorvent.floci.services.cloudformation.model.StackSetAutoDeploymentTarget;
 import io.github.hectorvent.floci.services.cloudformation.model.StackSetOperation;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
+import io.github.hectorvent.floci.services.organizations.model.Organization;
+import io.github.hectorvent.floci.services.organizations.model.OrganizationAccount;
+import io.github.hectorvent.floci.services.organizations.model.OrganizationalUnit;
 import com.fasterxml.jackson.core.type.TypeReference;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -18,8 +24,10 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Future;
+import java.util.regex.Pattern;
 
 /**
  * CloudFormation StackSets — manages stack sets and provisions their instances across target
@@ -34,16 +42,32 @@ import java.util.concurrent.Future;
 public class StackSetService {
 
     private static final Logger LOG = Logger.getLogger(StackSetService.class);
+    private static final String STACKSETS_SERVICE_PRINCIPAL = "stacksets.cloudformation.amazonaws.com";
     private static final String INSTANCE_CHANGE_SET = "stackset-instance";
     private static final String UPDATE_CHANGE_SET = "stackset-update";
+    private static final String ORGANIZATIONS_ACCESS_KEY = "organizations-access";
+    private static final int STACK_SET_LIMIT = 1000;
+    private static final Pattern STACK_SET_NAME = Pattern.compile("[A-Za-z][A-Za-z0-9-]{0,127}");
+    private static final Pattern OPERATION_ID = Pattern.compile("[A-Za-z0-9][-A-Za-z0-9]{0,127}");
+    private static final Pattern OU_OR_ROOT_ID = Pattern.compile("(?:ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}|r-[a-z0-9]{4,32})");
+    private static final Pattern REGION_PATTERN = Pattern.compile("[A-Za-z0-9-]{1,128}");
 
     private final CloudFormationService cfnService;
     private final StorageBackend<String, StackSet> stackSets;
     private final StorageBackend<String, StackInstance> instances;
     private final StorageBackend<String, StackSetOperation> operations;
+    private final StorageBackend<String, String> organizationsAccess;
+    private final StorageBackend<String, StackSetAutoDeploymentTarget> autoDeploymentTargets;
+    private final OrganizationsService organizationsService;
+    private final RegionResolver regionResolver;
+
+    StackSetService(CloudFormationService cfnService, StorageFactory storageFactory) {
+        this(cfnService, storageFactory, null, new RegionResolver("us-east-1", "000000000000"));
+    }
 
     @Inject
-    public StackSetService(CloudFormationService cfnService, StorageFactory storageFactory) {
+    public StackSetService(CloudFormationService cfnService, StorageFactory storageFactory,
+                           OrganizationsService organizationsService, RegionResolver regionResolver) {
         this.cfnService = cfnService;
         this.stackSets = storageFactory.create("cloudformation", "cloudformation-stacksets.json",
                 new TypeReference<Map<String, StackSet>>() {});
@@ -51,43 +75,98 @@ public class StackSetService {
                 new TypeReference<Map<String, StackInstance>>() {});
         this.operations = storageFactory.create("cloudformation", "cloudformation-stackset-operations.json",
                 new TypeReference<Map<String, StackSetOperation>>() {});
+        this.organizationsAccess = storageFactory.create("cloudformation", "cloudformation-organizations-access.json",
+                new TypeReference<Map<String, String>>() {});
+        this.autoDeploymentTargets = storageFactory.create("cloudformation", "cloudformation-stackset-auto-targets.json",
+                new TypeReference<Map<String, StackSetAutoDeploymentTarget>>() {});
+        this.organizationsService = organizationsService;
+        this.regionResolver = regionResolver;
     }
 
     // ── StackSet lifecycle ─────────────────────────────────────────────────────
 
     public StackSet createStackSet(String name, String templateBody, Map<String, String> parameters,
                                    List<String> capabilities, Map<String, String> tags, String description) {
-        if (name == null || name.isBlank()) {
-            throw new AwsException("ValidationError", "StackSetName must not be empty", 400);
-        }
+        return createStackSet(name, templateBody, parameters, capabilities, tags, description,
+                "SELF_MANAGED", false, false, false);
+    }
+
+    public synchronized StackSet createStackSet(String name, String templateBody, Map<String, String> parameters,
+                                                List<String> capabilities, Map<String, String> tags, String description,
+                                                String permissionModel, boolean autoDeploymentEnabled,
+                                                boolean retainStacksOnAccountRemoval, boolean managedExecutionActive) {
+        validateStackSetName(name);
         if (stackSets.get(name).isPresent()) {
-            throw new AwsException("NameAlreadyExistsException",
-                    "StackSet already exists: " + name, 409);
+            throw new AwsException("NameAlreadyExistsException", "StackSet already exists: " + name, 409);
         }
-        // AWS rejects CreateStackSet with no template; the handler resolves TemplateBody/TemplateURL
-        // to null when neither is supplied. Without this guard a later CreateStackInstances would
-        // deploy empty ("{}") stacks into every target account.
+        if (stackSets.scan(key -> true).size() >= STACK_SET_LIMIT) {
+            throw new AwsException("LimitExceededException", "The StackSet quota has been reached.", 400);
+        }
         if (templateBody == null || templateBody.isBlank()) {
-            throw new AwsException("ValidationError",
-                    "Either TemplateBody or TemplateURL must be specified", 400);
+            throw new AwsException("ValidationError", "Either TemplateBody or TemplateURL must be specified", 400);
         }
+        if (templateBody.length() > 51_200) {
+            throw new AwsException("ValidationError", "TemplateBody must be no larger than 51200 bytes.", 400);
+        }
+        if (description != null && (description.isBlank() || description.length() > 1024)) {
+            throw new AwsException("ValidationError", "Description must be between 1 and 1024 characters.", 400);
+        }
+        if (tags != null && tags.size() > 50) {
+            throw new AwsException("ValidationError", "A StackSet can have at most 50 tags.", 400);
+        }
+        String resolvedPermissionModel = permissionModel == null || permissionModel.isBlank()
+                ? "SELF_MANAGED" : permissionModel;
+        if (!Set.of("SELF_MANAGED", "SERVICE_MANAGED").contains(resolvedPermissionModel)) {
+            throw new AwsException("ValidationError", "PermissionModel must be SELF_MANAGED or SERVICE_MANAGED.", 400);
+        }
+        if ("SERVICE_MANAGED".equals(resolvedPermissionModel) && !isOrganizationsAccessEnabled()) {
+            throw new AwsException("InvalidOperationException",
+                    "Activate trusted access with AWS Organizations before creating a service-managed StackSet.", 400);
+        }
+        if ("SELF_MANAGED".equals(resolvedPermissionModel) && (autoDeploymentEnabled || retainStacksOnAccountRemoval)) {
+            throw new AwsException("ValidationError", "AutoDeployment is valid only for SERVICE_MANAGED StackSets.", 400);
+        }
+
         StackSet ss = new StackSet();
         ss.setStackSetName(name);
         ss.setStackSetId(name + ":" + UUID.randomUUID());
         ss.setTemplateBody(templateBody);
         ss.setDescription(description);
-        if (parameters != null) {
-            ss.setParameters(new LinkedHashMap<>(parameters));
-        }
-        if (capabilities != null) {
-            ss.getCapabilities().addAll(capabilities);
-        }
-        if (tags != null) {
-            ss.getTags().putAll(tags);
-        }
+        ss.setPermissionModel(resolvedPermissionModel);
+        ss.setAutoDeploymentEnabled(autoDeploymentEnabled);
+        ss.setRetainStacksOnAccountRemoval(retainStacksOnAccountRemoval);
+        ss.setManagedExecutionActive(managedExecutionActive);
+        if (parameters != null) ss.setParameters(new LinkedHashMap<>(parameters));
+        if (capabilities != null) ss.getCapabilities().addAll(capabilities);
+        if (tags != null) ss.getTags().putAll(tags);
         stackSets.put(name, ss);
         LOG.infov("Created StackSet: {0}", name);
         return ss;
+    }
+
+    public boolean isOrganizationsAccessEnabled() {
+        return "ENABLED".equals(organizationsAccess.get(ORGANIZATIONS_ACCESS_KEY).orElse("DISABLED"));
+    }
+
+    public synchronized void activateOrganizationsAccess() {
+        String caller = regionResolver.getAccountId();
+        try {
+            Organization organization = organizationsService.describeOrganization(caller);
+            if (!caller.equals(organization.getMasterAccountId())) {
+                throw new AwsException("InvalidOperationException",
+                        "Only the organization management account can activate trusted access.", 400);
+            }
+            if (!"ALL".equals(organization.getFeatureSet())) {
+                throw new AwsException("InvalidOperationException",
+                        "AWS Organizations must have all features enabled before activating trusted access.", 400);
+            }
+            organizationsService.enableAWSServiceAccess(caller, STACKSETS_SERVICE_PRINCIPAL);
+        } catch (AwsException e) {
+            if ("InvalidOperationException".equals(e.getErrorCode())) throw e;
+            throw new AwsException("InvalidOperationException",
+                    "The calling account must be the management account of an AWS Organization.", 400);
+        }
+        organizationsAccess.put(ORGANIZATIONS_ACCESS_KEY, "ENABLED");
     }
 
     public StackSet describeStackSet(String name) {
@@ -101,7 +180,19 @@ public class StackSetService {
     public StackSetOperation updateStackSet(String name, String templateBody, Map<String, String> parameters,
                                             List<String> capabilities, Map<String, String> tags,
                                             String description) {
+        return updateStackSet(name, templateBody, parameters, capabilities, tags, description,
+                null, null, null, null);
+    }
+
+    public synchronized StackSetOperation updateStackSet(String name, String templateBody,
+                                                         Map<String, String> parameters,
+                                                         List<String> capabilities, Map<String, String> tags,
+                                                         String description, String requestedOperationId,
+                                                         Boolean autoDeploymentEnabled,
+                                                         Boolean retainStacksOnAccountRemoval,
+                                                         Boolean managedExecutionActive) {
         StackSet ss = getStackSetOrThrow(name);
+        String operationId = reserveOperation(name, "UPDATE", requestedOperationId).getOperationId();
         if (templateBody != null && !templateBody.isBlank()) {
             ss.setTemplateBody(templateBody);
         }
@@ -119,33 +210,50 @@ public class StackSetService {
         if (description != null) {
             ss.setDescription(description);
         }
+        if (autoDeploymentEnabled != null) {
+            if (!"SERVICE_MANAGED".equals(ss.getPermissionModel())) {
+                completeOperation(name, operationId, "FAILED");
+                throw new AwsException("InvalidOperationException",
+                        "AutoDeployment is valid only for SERVICE_MANAGED StackSets.", 400);
+            }
+            ss.setAutoDeploymentEnabled(autoDeploymentEnabled);
+        }
+        if (retainStacksOnAccountRemoval != null) ss.setRetainStacksOnAccountRemoval(retainStacksOnAccountRemoval);
+        if (managedExecutionActive != null) ss.setManagedExecutionActive(managedExecutionActive);
         stackSets.put(name, ss);
 
-        // Re-apply the updated definition to every existing instance, refreshing each record.
         List<StackInstance> deployed = new ArrayList<>();
-        for (StackInstance inst : listStackInstances(name, null, null)) {
-            // An instance whose stack is terminal - a failed create that rolled back, or a phase
-            // some earlier operation abandoned - is one the single-stack engine refuses to update.
-            // That is one instance failing, not a malformed request: AWS leaves such an instance
-            // INOPERABLE, updates the rest, and reports the operation FAILED. Deploying into it
-            // anyway would raise the refusal out of here and fail the whole UpdateStackSet call
-            // with a 400, updating no instance at all.
-            String stackStatus = cfnService.stackStatus(inst.getStackName(), inst.getRegion());
-            if (CloudFormationService.refusesUpdate(stackStatus)) {
-                inst.setStatus("INOPERABLE");
-                inst.setDetailedStatus("FAILED");
-                inst.setStatusReason("Stack instance is in " + stackStatus
-                        + " state and can not be updated");
-                instances.put(instanceKey(name, inst.getAccount(), inst.getRegion()), inst);
-                deployed.add(inst);
-                continue;
+        try {
+            for (StackInstance inst : listStackInstances(name, null, null)) {
+                // An instance whose stack is terminal - a failed create that rolled back, or a phase
+                // some earlier operation abandoned - is one the single-stack engine refuses to update.
+                // That is one instance failing, not a malformed request: AWS leaves such an instance
+                // INOPERABLE, updates the rest, and reports the operation FAILED. Deploying into it
+                // anyway would raise the refusal out of here and fail the whole UpdateStackSet call
+                // with a 400, updating no instance at all.
+                String stackStatus = cfnService.stackStatus(inst.getStackName(), inst.getRegion());
+                if (CloudFormationService.refusesUpdate(stackStatus)) {
+                    inst.setStatus("INOPERABLE");
+                    inst.setDetailedStatus("FAILED");
+                    inst.setStatusReason("Stack instance is in " + stackStatus
+                            + " state and can not be updated");
+                    instances.put(instanceKey(name, inst.getAccount(), inst.getRegion()), inst);
+                    deployed.add(inst);
+                    continue;
+                }
+                StackInstance updated =
+                        deployInstance(ss, inst.getAccount(), inst.getRegion(), UPDATE_CHANGE_SET, "UPDATE");
+                updated.setOrganizationalUnitId(inst.getOrganizationalUnitId());
+                instances.put(instanceKey(name, updated.getAccount(), updated.getRegion()), updated);
+                deployed.add(updated);
             }
-            StackInstance updated =
-                    deployInstance(ss, inst.getAccount(), inst.getRegion(), UPDATE_CHANGE_SET, "UPDATE");
-            instances.put(instanceKey(name, updated.getAccount(), updated.getRegion()), updated);
-            deployed.add(updated);
+            completeOperation(name, operationId, deriveOperationStatus(deployed));
+            return describeStackSetOperation(name, operationId);
+        } catch (RuntimeException e) {
+            completeOperation(name, operationId, "FAILED");
+            throw e;
         }
-        return recordOperation(name, "UPDATE", deriveOperationStatus(deployed));
+        }
     }
 
     public void deleteStackSet(String name) {
@@ -161,29 +269,70 @@ public class StackSetService {
     // ── Instances ──────────────────────────────────────────────────────────────
 
     public StackSetOperation createStackInstances(String name, List<String> accounts, List<String> regions) {
+        return createStackInstances(name, accounts, regions, List.of(), null);
+    }
+
+    public StackSetOperation createStackInstances(String name, List<String> accounts, List<String> regions,
+                                                  List<String> organizationalUnits) {
+        return createStackInstances(name, accounts, regions, organizationalUnits, null);
+    }
+
+    public synchronized StackSetOperation createStackInstances(String name, List<String> accounts, List<String> regions,
+                                                               List<String> organizationalUnits, String requestedOperationId) {
         StackSet ss = getStackSetOrThrow(name);
-        if (accounts == null || accounts.isEmpty() || regions == null || regions.isEmpty()) {
-            throw new AwsException("ValidationError",
-                    "Accounts and Regions must each contain at least one value", 400);
+        validateRegions(regions);
+        List<String> directAccounts = accounts == null ? List.of() : accounts;
+        List<String> targetOus = organizationalUnits == null ? List.of() : organizationalUnits;
+        if (!directAccounts.isEmpty() && !targetOus.isEmpty()) {
+            throw new AwsException("InvalidOperationException",
+                    "Specify Accounts or DeploymentTargets, but not both.", 400);
         }
-        if (accounts.stream().anyMatch(account -> account == null || !account.matches("[0-9]{12}"))) {
+        if (directAccounts.isEmpty() && targetOus.isEmpty()) {
+            throw new AwsException("ValidationError", "Accounts or DeploymentTargets must contain at least one value.", 400);
+        }
+        if (!targetOus.isEmpty() && !"SERVICE_MANAGED".equals(ss.getPermissionModel())) {
+            throw new AwsException("InvalidOperationException",
+                    "DeploymentTargets can be used only with SERVICE_MANAGED StackSets.", 400);
+        }
+        if (directAccounts.stream().anyMatch(account -> account == null || !account.matches("[0-9]{12}"))) {
             throw new AwsException("ValidationError",
-                    "1 validation error detected: Value '" + accounts
+                    "1 validation error detected: Value '" + directAccounts
                             + "' at 'accounts' failed to satisfy constraint: Member must satisfy constraint: "
                             + "[Member must have length less than or equal to 12, Member must have length "
                             + "greater than or equal to 12, Member must satisfy regular expression pattern: "
-                            + "^[0-9]{12}$]",
-                    400);
+                            + "^[0-9]{12}$]", 400);
         }
+        for (String ou : targetOus) validateOuOrRoot(ou);
+
+        String operationId = reserveOperation(name, "CREATE", requestedOperationId).getOperationId();
+        List<TargetAccount> targets = !directAccounts.isEmpty()
+                ? directAccounts.stream().map(account -> new TargetAccount(account, null)).toList()
+                : resolveOrganizationTargets(targetOus, regions, name);
+
         List<StackInstance> deployed = new ArrayList<>();
-        for (String account : accounts) {
+        for (TargetAccount target : targets) {
             for (String region : regions) {
-                StackInstance inst = deployInstance(ss, account, region, INSTANCE_CHANGE_SET, "CREATE");
-                instances.put(instanceKey(name, account, region), inst);
+                String instanceKey = instanceKey(name, target.accountId(), region);
+                StackInstance existing = instances.get(instanceKey).orElse(null);
+                if (existing != null && !"OUTDATED".equals(existing.getStatus())) {
+                    continue;
+                }
+                StackInstance inst = deployInstance(ss, target.accountId(), region, INSTANCE_CHANGE_SET, "CREATE");
+                inst.setOrganizationalUnitId(target.organizationalUnitId());
+                instances.put(instanceKey, inst);
                 deployed.add(inst);
             }
         }
-        return recordOperation(name, "CREATE", deriveOperationStatus(deployed));
+        completeOperation(name, operationId, deriveOperationStatus(deployed));
+        return describeStackSetOperation(name, operationId);
+    }
+
+    public List<StackSetAutoDeploymentTarget> listStackSetAutoDeploymentTargets(String name) {
+        getStackSetOrThrow(name);
+        String prefix = name + "::";
+        return autoDeploymentTargets.scan(key -> key.startsWith(prefix)).stream()
+                .sorted(java.util.Comparator.comparing(StackSetAutoDeploymentTarget::getOrganizationalUnitId))
+                .toList();
     }
 
     public List<StackInstance> listStackInstances(String name, String accountFilter, String regionFilter) {
@@ -261,6 +410,100 @@ public class StackSetService {
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────────
+
+    private List<TargetAccount> resolveOrganizationTargets(List<String> organizationalUnits,
+                                                           List<String> regions, String stackSetName) {
+        String caller = regionResolver.getAccountId();
+        Organization organization;
+        try {
+            organization = organizationsService.describeOrganization(caller);
+        } catch (AwsException e) {
+            throw new AwsException("InvalidOperationException",
+                    "SERVICE_MANAGED StackSets require an AWS Organization.", 400);
+        }
+        java.util.LinkedHashMap<String, TargetAccount> targets = new java.util.LinkedHashMap<>();
+        for (String ou : organizationalUnits) {
+            collectOrganizationTargets(caller, organization, ou, ou, targets);
+            autoDeploymentTargets.put(stackSetName + "::" + ou,
+                    new StackSetAutoDeploymentTarget(stackSetName, ou, regions));
+        }
+        return new ArrayList<>(targets.values());
+    }
+
+    private void collectOrganizationTargets(String caller, Organization organization, String parentId,
+                                            String requestedTargetId,
+                                            java.util.LinkedHashMap<String, TargetAccount> targets) {
+        for (OrganizationAccount account : organizationsService.listAccountsForParent(caller, parentId)) {
+            if (!organization.getMasterAccountId().equals(account.getId()) && "ACTIVE".equals(account.getStatus())) {
+                targets.putIfAbsent(account.getId(), new TargetAccount(account.getId(), requestedTargetId));
+            }
+        }
+        for (OrganizationalUnit child : organizationsService.listOrganizationalUnitsForParent(caller, parentId)) {
+            collectOrganizationTargets(caller, organization, child.getId(), requestedTargetId, targets);
+        }
+    }
+
+    private StackSetOperation reserveOperation(String stackSetName, String action, String requestedOperationId) {
+        String operationId = requestedOperationId == null || requestedOperationId.isBlank()
+                ? UUID.randomUUID().toString() : requestedOperationId;
+        if (!OPERATION_ID.matcher(operationId).matches()) {
+            throw new AwsException("ValidationError", "OperationId is invalid.", 400);
+        }
+        if (operations.get(stackSetName + ":" + operationId).isPresent()) {
+            throw new AwsException("OperationIdAlreadyExistsException",
+                    "OperationId " + operationId + " already exists for StackSet " + stackSetName + ".", 409);
+        }
+        boolean running = operations.scan(key -> key.startsWith(stackSetName + ":")).stream()
+                .anyMatch(operation -> "RUNNING".equals(operation.getStatus()));
+        if (running) {
+            throw new AwsException("OperationInProgressException",
+                    "Another operation is currently in progress for StackSet " + stackSetName + ".", 409);
+        }
+        StackSetOperation operation = new StackSetOperation(operationId, stackSetName, action);
+        operation.setStatus("RUNNING");
+        operation.setEndTimestamp(null);
+        operations.put(stackSetName + ":" + operationId, operation);
+        return operation;
+    }
+
+    private void completeOperation(String stackSetName, String operationId, String status) {
+        StackSetOperation operation = operations.get(stackSetName + ":" + operationId)
+                .orElseThrow(() -> new AwsException("OperationNotFoundException",
+                        "Operation " + operationId + " not found for stack set " + stackSetName, 404));
+        operation.setStatus(status);
+        operation.setEndTimestamp(Instant.now());
+        operations.put(stackSetName + ":" + operationId, operation);
+    }
+
+    private static void validateStackSetName(String name) {
+        if (name == null || !STACK_SET_NAME.matcher(name).matches()) {
+            throw new AwsException("ValidationError",
+                    "StackSetName must start with a letter, contain only alphanumeric characters and hyphens, and be at most 128 characters.", 400);
+        }
+    }
+
+    private static void validateAccountId(String account) {
+        if (account == null || !account.matches("[0-9]{12}")) {
+            throw new AwsException("ValidationError", "Accounts must contain 12 digit account IDs.", 400);
+        }
+    }
+
+    private static void validateOuOrRoot(String value) {
+        if (value == null || !OU_OR_ROOT_ID.matcher(value).matches()) {
+            throw new AwsException("ValidationError", "DeploymentTargets contains an invalid organizational unit or root ID.", 400);
+        }
+    }
+
+    private static void validateRegions(List<String> regions) {
+        if (regions == null || regions.isEmpty()) {
+            throw new AwsException("ValidationError", "Regions must contain at least one value.", 400);
+        }
+        if (regions.stream().anyMatch(region -> region == null || !REGION_PATTERN.matcher(region).matches())) {
+            throw new AwsException("ValidationError", "Regions contains an invalid region name.", 400);
+        }
+    }
+
+    private record TargetAccount(String accountId, String organizationalUnitId) {}
 
     /**
      * Drives the single-stack engine to materialize one instance's resources into the target

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -392,36 +392,40 @@ public class StackSetService {
             validateOuOrRoot(ou);
         }
 
-        List<String> targetAccounts = !directAccounts.isEmpty()
-                ? directAccounts
-                : resolveOrganizationTargets(targetOus, regions, name, false).stream()
-                        .map(TargetAccount::accountId)
-                        .toList();
+        Set<String> requestedRegions = Set.copyOf(regions);
+        Set<String> requestedAccounts = Set.copyOf(directAccounts);
+        Set<String> requestedDeploymentTargets = Set.copyOf(targetOus);
+        List<StackInstance> targetInstances = listStackInstances(name, null, null).stream()
+                .filter(inst -> requestedRegions.contains(inst.getRegion()))
+                .filter(inst -> !requestedAccounts.isEmpty()
+                        ? requestedAccounts.contains(inst.getAccount())
+                        : requestedDeploymentTargets.contains(inst.getOrganizationalUnitId()))
+                .toList();
+
         List<StackInstance> results = new ArrayList<>();
-        for (String account : targetAccounts) {
-            for (String region : regions) {
-                String key = instanceKey(name, account, region);
-                StackInstance inst = instances.get(key).orElse(null);
-                if (inst == null) {
-                    continue;
-                }
-                // RetainStacks=true detaches the instance from the StackSet but leaves the
-                // underlying CloudFormation stack and its resources in the target account.
-                if (!retainStacks && !await(cfnService.deleteStack(inst.getStackName(), region, account))) {
-                    // The underlying stack delete failed. Match AWS: retain the instance record
-                    // (now INOPERABLE) and report the operation as FAILED, rather than silently
-                    // dropping the instance and claiming success.
-                    inst.setStatus("INOPERABLE");
-                    inst.setDetailedStatus("FAILED");
-                    inst.setStatusReason("Stack instance deletion failed");
-                    instances.put(key, inst);
-                    results.add(inst);
-                    continue;
-                }
-                inst.setDetailedStatus("SUCCEEDED");
-                instances.delete(key);
+        for (StackInstance inst : targetInstances) {
+            String account = inst.getAccount();
+            String region = inst.getRegion();
+            String key = instanceKey(name, account, region);
+            // For service-managed StackSets the persisted OrganizationalUnitId is the
+            // DeploymentTargets association that created this instance. Do not resolve the OU's
+            // current membership here: accounts can move after deployment while the instance
+            // remains associated with its original target until an auto-deployment or explicit
+            // StackSets operation changes it.
+            if (!retainStacks && !await(cfnService.deleteStack(inst.getStackName(), region, account))) {
+                // The underlying stack delete failed. Match AWS: retain the instance record
+                // (now INOPERABLE) and report the operation as FAILED, rather than silently
+                // dropping the instance and claiming success.
+                inst.setStatus("INOPERABLE");
+                inst.setDetailedStatus("FAILED");
+                inst.setStatusReason("Stack instance deletion failed");
+                instances.put(key, inst);
                 results.add(inst);
+                continue;
             }
+            inst.setDetailedStatus("SUCCEEDED");
+            instances.delete(key);
+            results.add(inst);
         }
         return recordOperation(name, "DELETE", deriveOperationStatus(results));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -447,7 +447,11 @@ public class StackSetService {
             instances.delete(key);
             results.add(inst);
         }
-        return recordOperation(name, "DELETE", deriveOperationStatus(results));
+        String operationStatus = deriveOperationStatus(results);
+        if ("SUCCEEDED".equals(operationStatus) && !requestedDeploymentTargets.isEmpty()) {
+            removeDeploymentTargetRegions(name, requestedDeploymentTargets, requestedRegions);
+        }
+        return recordOperation(name, "DELETE", operationStatus);
     }
 
     public List<StackSetOperation> listStackSetOperations(String name) {
@@ -469,6 +473,26 @@ public class StackSetService {
     }
 
     // ── Internal helpers ────────────────────────────────────────────────────────
+
+    private void removeDeploymentTargetRegions(String stackSetName, Set<String> organizationalUnits,
+                                               Set<String> regions) {
+        for (String organizationalUnit : organizationalUnits) {
+            String key = stackSetName + "::" + organizationalUnit;
+            StackSetAutoDeploymentTarget target = autoDeploymentTargets.get(key).orElse(null);
+            if (target == null) {
+                continue;
+            }
+            List<String> remainingRegions = target.getRegions().stream()
+                    .filter(region -> !regions.contains(region))
+                    .toList();
+            if (remainingRegions.isEmpty()) {
+                autoDeploymentTargets.delete(key);
+            } else {
+                target.setRegions(remainingRegions);
+                autoDeploymentTargets.put(key, target);
+            }
+        }
+    }
 
     private List<TargetAccount> resolveOrganizationTargets(List<String> organizationalUnits,
                                                            List<String> regions, String stackSetName) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -120,7 +120,7 @@ public class StackSetService {
             throw new AwsException("ValidationError", "PermissionModel must be SELF_MANAGED or SERVICE_MANAGED.", 400);
         }
         if ("SERVICE_MANAGED".equals(resolvedPermissionModel) && !isOrganizationsAccessEnabled()) {
-            throw new AwsException("InvalidOperationException",
+            throw new AwsException("ValidationError",
                     "Activate trusted access with AWS Organizations before creating a service-managed StackSet.", 400);
         }
         if ("SELF_MANAGED".equals(resolvedPermissionModel) && (autoDeploymentEnabled || retainStacksOnAccountRemoval)) {
@@ -361,13 +361,45 @@ public class StackSetService {
 
     public StackSetOperation deleteStackInstances(String name, List<String> accounts, List<String> regions,
                                                   boolean retainStacks) {
-        getStackSetOrThrow(name);
-        if (accounts == null || accounts.isEmpty() || regions == null || regions.isEmpty()) {
-            throw new AwsException("ValidationError",
-                    "Accounts and Regions must each contain at least one value", 400);
+        return deleteStackInstances(name, accounts, regions, List.of(), retainStacks);
+    }
+
+    public StackSetOperation deleteStackInstances(String name, List<String> accounts, List<String> regions,
+                                                  List<String> organizationalUnits, boolean retainStacks) {
+        StackSet stackSet = getStackSetOrThrow(name);
+        validateRegions(regions);
+        List<String> directAccounts = accounts == null ? List.of() : accounts;
+        List<String> targetOus = organizationalUnits == null ? List.of() : organizationalUnits;
+        if (!directAccounts.isEmpty() && !targetOus.isEmpty()) {
+            throw new AwsException("InvalidOperationException",
+                    "Specify Accounts or DeploymentTargets, but not both.", 400);
         }
+        if (directAccounts.isEmpty() && targetOus.isEmpty()) {
+            throw new AwsException("ValidationError",
+                    "Accounts or DeploymentTargets must contain at least one value.", 400);
+        }
+        if (!targetOus.isEmpty() && !"SERVICE_MANAGED".equals(stackSet.getPermissionModel())) {
+            throw new AwsException("InvalidOperationException",
+                    "DeploymentTargets can be used only with SERVICE_MANAGED StackSets.", 400);
+        }
+        if (!directAccounts.isEmpty() && "SERVICE_MANAGED".equals(stackSet.getPermissionModel())) {
+            throw new AwsException("InvalidOperationException",
+                    "Accounts can be used only with SELF_MANAGED StackSets. Use DeploymentTargets for SERVICE_MANAGED StackSets.", 400);
+        }
+        for (String account : directAccounts) {
+            validateAccountId(account);
+        }
+        for (String ou : targetOus) {
+            validateOuOrRoot(ou);
+        }
+
+        List<String> targetAccounts = !directAccounts.isEmpty()
+                ? directAccounts
+                : resolveOrganizationTargets(targetOus, regions, name, false).stream()
+                        .map(TargetAccount::accountId)
+                        .toList();
         List<StackInstance> results = new ArrayList<>();
-        for (String account : accounts) {
+        for (String account : targetAccounts) {
             for (String region : regions) {
                 String key = instanceKey(name, account, region);
                 StackInstance inst = instances.get(key).orElse(null);
@@ -417,6 +449,12 @@ public class StackSetService {
 
     private List<TargetAccount> resolveOrganizationTargets(List<String> organizationalUnits,
                                                            List<String> regions, String stackSetName) {
+        return resolveOrganizationTargets(organizationalUnits, regions, stackSetName, true);
+    }
+
+    private List<TargetAccount> resolveOrganizationTargets(List<String> organizationalUnits,
+                                                           List<String> regions, String stackSetName,
+                                                           boolean persistTargets) {
         String caller = regionResolver.getAccountId();
         Organization organization;
         try {
@@ -428,8 +466,10 @@ public class StackSetService {
         java.util.LinkedHashMap<String, TargetAccount> targets = new java.util.LinkedHashMap<>();
         for (String ou : organizationalUnits) {
             collectOrganizationTargets(caller, organization, ou, ou, targets);
-            autoDeploymentTargets.put(stackSetName + "::" + ou,
-                    new StackSetAutoDeploymentTarget(stackSetName, ou, regions));
+            if (persistTargets) {
+                autoDeploymentTargets.put(stackSetName + "::" + ou,
+                        new StackSetAutoDeploymentTarget(stackSetName, ou, regions));
+            }
         }
         return new ArrayList<>(targets.values());
     }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -253,7 +253,6 @@ public class StackSetService {
             completeOperation(name, operationId, "FAILED");
             throw e;
         }
-        }
     }
 
     public void deleteStackSet(String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackInstance.java
@@ -3,6 +3,9 @@ package io.github.hectorvent.floci.services.cloudformation.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class StackInstance {
@@ -19,6 +22,15 @@ public class StackInstance {
     private String detailedStatus = "SUCCEEDED";
     private String statusReason;
     private String organizationalUnitId;
+    /**
+     * Service-managed DeploymentTargets that currently cover this instance.
+     *
+     * <p>A single account/Region stack instance can be covered by more than one requested OU,
+     * for example when both a parent OU and one of its descendants are StackSet targets. AWS
+     * still exposes one {@code OrganizationalUnitId} on the public StackInstance shape, so this
+     * list is emulator-internal persistence used to preserve all target associations.</p>
+     */
+    private List<String> deploymentTargetIds = new ArrayList<>();
 
     public String getStackSetId() { return stackSetId; }
     public void setStackSetId(String stackSetId) { this.stackSetId = stackSetId; }
@@ -40,4 +52,8 @@ public class StackInstance {
     public void setStatusReason(String statusReason) { this.statusReason = statusReason; }
     public String getOrganizationalUnitId() { return organizationalUnitId; }
     public void setOrganizationalUnitId(String organizationalUnitId) { this.organizationalUnitId = organizationalUnitId; }
+    public List<String> getDeploymentTargetIds() { return deploymentTargetIds; }
+    public void setDeploymentTargetIds(List<String> deploymentTargetIds) {
+        this.deploymentTargetIds = deploymentTargetIds == null ? new ArrayList<>() : new ArrayList<>(deploymentTargetIds);
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackInstance.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackInstance.java
@@ -18,6 +18,7 @@ public class StackInstance {
     /** Last operation status (SUCCEEDED, FAILED, ...) reported under StackInstanceStatus.DetailedStatus. */
     private String detailedStatus = "SUCCEEDED";
     private String statusReason;
+    private String organizationalUnitId;
 
     public String getStackSetId() { return stackSetId; }
     public void setStackSetId(String stackSetId) { this.stackSetId = stackSetId; }
@@ -37,4 +38,6 @@ public class StackInstance {
     public void setDetailedStatus(String detailedStatus) { this.detailedStatus = detailedStatus; }
     public String getStatusReason() { return statusReason; }
     public void setStatusReason(String statusReason) { this.statusReason = statusReason; }
+    public String getOrganizationalUnitId() { return organizationalUnitId; }
+    public void setOrganizationalUnitId(String organizationalUnitId) { this.organizationalUnitId = organizationalUnitId; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackSet.java
@@ -21,6 +21,9 @@ public class StackSet {
     private Map<String, String> tags = new LinkedHashMap<>();
     /** SELF_MANAGED or SERVICE_MANAGED; Floci only models SELF_MANAGED behavior. */
     private String permissionModel = "SELF_MANAGED";
+    private boolean autoDeploymentEnabled;
+    private boolean retainStacksOnAccountRemoval;
+    private boolean managedExecutionActive;
 
     public String getStackSetId() { return stackSetId; }
     public void setStackSetId(String stackSetId) { this.stackSetId = stackSetId; }
@@ -40,4 +43,10 @@ public class StackSet {
     public void setTags(Map<String, String> tags) { this.tags = tags; }
     public String getPermissionModel() { return permissionModel; }
     public void setPermissionModel(String permissionModel) { this.permissionModel = permissionModel; }
+    public boolean isAutoDeploymentEnabled() { return autoDeploymentEnabled; }
+    public void setAutoDeploymentEnabled(boolean value) { this.autoDeploymentEnabled = value; }
+    public boolean isRetainStacksOnAccountRemoval() { return retainStacksOnAccountRemoval; }
+    public void setRetainStacksOnAccountRemoval(boolean value) { this.retainStacksOnAccountRemoval = value; }
+    public boolean isManagedExecutionActive() { return managedExecutionActive; }
+    public void setManagedExecutionActive(boolean value) { this.managedExecutionActive = value; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackSetAutoDeploymentTarget.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/model/StackSetAutoDeploymentTarget.java
@@ -1,0 +1,30 @@
+package io.github.hectorvent.floci.services.cloudformation.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class StackSetAutoDeploymentTarget {
+    private String stackSetName;
+    private String organizationalUnitId;
+    private List<String> regions = new ArrayList<>();
+
+    public StackSetAutoDeploymentTarget() {}
+
+    public StackSetAutoDeploymentTarget(String stackSetName, String organizationalUnitId, List<String> regions) {
+        this.stackSetName = stackSetName;
+        this.organizationalUnitId = organizationalUnitId;
+        this.regions = regions == null ? new ArrayList<>() : new ArrayList<>(regions);
+    }
+
+    public String getStackSetName() { return stackSetName; }
+    public void setStackSetName(String stackSetName) { this.stackSetName = stackSetName; }
+    public String getOrganizationalUnitId() { return organizationalUnitId; }
+    public void setOrganizationalUnitId(String organizationalUnitId) { this.organizationalUnitId = organizationalUnitId; }
+    public List<String> getRegions() { return regions; }
+    public void setRegions(List<String> regions) { this.regions = regions == null ? new ArrayList<>() : new ArrayList<>(regions); }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -155,7 +155,7 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
 
     @Test
     void serviceManagedDeleteRequiresDeploymentTargets() {
-        String management = "444444444444";
+        String management = "909090909090";
         organizations(management, "CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
                 .post("/").then().statusCode(200);
         String rootId = organizations(management, "ListRoots", "{}")

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -1,0 +1,167 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.path.json.JsonPath;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+
+/** AWS Organizations semantics required by service-managed CloudFormation StackSets. */
+@QuarkusTest
+class CloudFormationServiceManagedStackSetsIntegrationTest {
+    private static final String MANAGEMENT = "555555555555";
+    private static final String REGION = "us-east-1";
+    private static final String ORG_TARGET = "AWSOrganizationsV20161128.";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void serviceManagedStackSetUsesTrustedAccessAndRecursesIntoChildOus() {
+        organizations("CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
+                .post("/").then().statusCode(200);
+        String rootId = organizations("ListRoots", "{}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("Roots[0].Id");
+
+        String parentOu = organizations("CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + rootId + "\",\"Name\":\"StackSetsParent\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+        String childOu = organizations("CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + parentOu + "\",\"Name\":\"StackSetsChild\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String directAccount = createAccount("stacksets-direct-" + suffix + "@example.com", "StackSetsDirect");
+        String nestedAccount = createAccount("stacksets-nested-" + suffix + "@example.com", "StackSetsNested");
+        moveAccount(directAccount, rootId, parentOu);
+        moveAccount(nestedAccount, rootId, childOu);
+
+        cloudFormation("ActivateOrganizationsAccess")
+                .post("/").then().statusCode(200);
+
+        organizations("ListAWSServiceAccessForOrganization", "{}")
+                .post("/").then().statusCode(200)
+                .body("EnabledServicePrincipals.ServicePrincipal",
+                        hasItem("stacksets.cloudformation.amazonaws.com"));
+
+        cloudFormation("DescribeOrganizationsAccess")
+                .post("/").then().statusCode(200)
+                .body(containsString("<Status>ENABLED</Status>"));
+
+        String stackSet = "nested-ou-" + suffix;
+        String queue = "nested-ou-q-" + suffix;
+        cloudFormation("CreateStackSet")
+                .formParam("StackSetName", stackSet)
+                .formParam("TemplateBody", queueTemplate(queue))
+                .formParam("PermissionModel", "SERVICE_MANAGED")
+                .formParam("AutoDeployment.Enabled", "true")
+                .post("/").then().statusCode(200);
+
+        cloudFormation("CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", parentOu)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(200)
+                .body(containsString("<OperationId>"));
+
+        assertQueueVisible(directAccount, queue);
+        assertQueueVisible(nestedAccount, queue);
+
+        cloudFormation("ListStackSetAutoDeploymentTargets")
+                .formParam("StackSetName", stackSet)
+                .post("/").then().statusCode(200)
+                .body(containsString("<OrganizationalUnitId>" + parentOu + "</OrganizationalUnitId>"))
+                .body(containsString("<member>" + REGION + "</member>"));
+
+        cloudFormation("ListStackInstances")
+                .formParam("StackSetName", stackSet)
+                .post("/").then().statusCode(200)
+                .body(containsString("<Account>" + directAccount + "</Account>"))
+                .body(containsString("<Account>" + nestedAccount + "</Account>"))
+                .body(containsString("<OrganizationalUnitId>" + parentOu + "</OrganizationalUnitId>"));
+    }
+
+    @Test
+    void activateOrganizationsAccessRequiresAllFeatures() {
+        String management = "666666666666";
+        organizations(management, "CreateOrganization", "{\"FeatureSet\":\"CONSOLIDATED_BILLING\"}")
+                .post("/").then().statusCode(200);
+
+        cloudFormation(management, "ActivateOrganizationsAccess")
+                .post("/").then().statusCode(400)
+                .body(containsString("InvalidOperationException"))
+                .body(containsString("all features"));
+    }
+
+    private String createAccount(String email, String name) {
+        JsonPath response = organizations("CreateAccount",
+                "{\"Email\":\"" + email + "\",\"AccountName\":\"" + name + "\"}")
+                .post("/").then().statusCode(200)
+                .body("CreateAccountStatus.State", equalTo("SUCCEEDED"))
+                .extract().jsonPath();
+        return response.getString("CreateAccountStatus.AccountId");
+    }
+
+    private void moveAccount(String accountId, String sourceParent, String destinationParent) {
+        organizations("MoveAccount",
+                "{\"AccountId\":\"" + accountId + "\",\"SourceParentId\":\"" + sourceParent
+                        + "\",\"DestinationParentId\":\"" + destinationParent + "\"}")
+                .post("/").then().statusCode(200);
+    }
+
+    private RequestSpecification organizations(String action, String body) {
+        return organizations(MANAGEMENT, action, body);
+    }
+
+    private RequestSpecification organizations(String account, String action, String body) {
+        return given()
+                .header("Authorization", auth(account, "organizations"))
+                .header("X-Amz-Target", ORG_TARGET + action)
+                .contentType("application/x-amz-json-1.1")
+                .body(body);
+    }
+
+    private RequestSpecification cloudFormation(String action) {
+        return cloudFormation(MANAGEMENT, action);
+    }
+
+    private RequestSpecification cloudFormation(String account, String action) {
+        return given()
+                .header("Authorization", auth(account, "cloudformation"))
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", action);
+    }
+
+    private void assertQueueVisible(String account, String queueName) {
+        given()
+                .header("Authorization", auth(account, "sqs"))
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "GetQueueUrl")
+                .formParam("QueueName", queueName)
+                .post("/").then().statusCode(200)
+                .body(containsString("/" + account + "/" + queueName));
+    }
+
+    private static String queueTemplate(String queueName) {
+        return "{\"Resources\":{\"Q\":{\"Type\":\"AWS::SQS::Queue\",\"Properties\":{\"QueueName\":\""
+                + queueName + "\"}}}}";
+    }
+
+    private static String auth(String account, String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + account + "/20260904/" + REGION + "/" + service
+                + "/aws4_request, SignedHeaders=host, Signature=abc";
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -95,6 +95,34 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
     }
 
     @Test
+    void serviceManagedStackSetRejectsTopLevelAccounts() {
+        String management = "777777777777";
+        String targetAccount = "999999999999";
+        organizations(management, "CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "ActivateOrganizationsAccess")
+                .post("/").then().statusCode(200);
+
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String stackSet = "reject-accounts-" + suffix;
+        String queue = "reject-accounts-q-" + suffix;
+        cloudFormation(management, "CreateStackSet")
+                .formParam("StackSetName", stackSet)
+                .formParam("TemplateBody", queueTemplate(queue))
+                .formParam("PermissionModel", "SERVICE_MANAGED")
+                .post("/").then().statusCode(200);
+
+        cloudFormation(management, "CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("Accounts.member.1", targetAccount)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(400)
+                .body(containsString("InvalidOperationException"));
+
+        assertQueueAbsent(targetAccount, queue);
+    }
+
+    @Test
     void activateOrganizationsAccessRequiresAllFeatures() {
         String management = "666666666666";
         organizations(management, "CreateOrganization", "{\"FeatureSet\":\"CONSOLIDATED_BILLING\"}")
@@ -153,6 +181,16 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
                 .formParam("QueueName", queueName)
                 .post("/").then().statusCode(200)
                 .body(containsString("/" + account + "/" + queueName));
+    }
+
+    private void assertQueueAbsent(String account, String queueName) {
+        given()
+                .header("Authorization", auth(account, "sqs"))
+                .contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "GetQueueUrl")
+                .formParam("QueueName", queueName)
+                .post("/").then().statusCode(400)
+                .body(containsString("AWS.SimpleQueueService.NonExistentQueue"));
     }
 
     private static String queueTemplate(String queueName) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -211,6 +211,89 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
     }
 
     @Test
+    void serviceManagedDeleteUsesPersistedOuAssociationAfterAccountMoves() {
+        String management = "919191919191";
+        organizations(management, "CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
+                .post("/").then().statusCode(200);
+        String rootId = organizations(management, "ListRoots", "{}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("Roots[0].Id");
+        String firstOu = organizations(management, "CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + rootId + "\",\"Name\":\"PersistedTargetA\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+        String secondOu = organizations(management, "CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + rootId + "\",\"Name\":\"PersistedTargetB\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String firstAccount = organizations(management, "CreateAccount",
+                "{\"Email\":\"persisted-a-" + suffix + "@example.com\",\"AccountName\":\"PersistedA\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("CreateAccountStatus.AccountId");
+        String secondAccount = organizations(management, "CreateAccount",
+                "{\"Email\":\"persisted-b-" + suffix + "@example.com\",\"AccountName\":\"PersistedB\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("CreateAccountStatus.AccountId");
+        organizations(management, "MoveAccount",
+                "{\"AccountId\":\"" + firstAccount + "\",\"SourceParentId\":\"" + rootId
+                        + "\",\"DestinationParentId\":\"" + firstOu + "\"}")
+                .post("/").then().statusCode(200);
+        organizations(management, "MoveAccount",
+                "{\"AccountId\":\"" + secondAccount + "\",\"SourceParentId\":\"" + rootId
+                        + "\",\"DestinationParentId\":\"" + secondOu + "\"}")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "ActivateOrganizationsAccess")
+                .post("/").then().statusCode(200);
+
+        String stackSet = "persisted-ou-" + suffix;
+        String queue = "persisted-ou-q-" + suffix;
+        cloudFormation(management, "CreateStackSet")
+                .formParam("StackSetName", stackSet)
+                .formParam("TemplateBody", queueTemplate(queue))
+                .formParam("PermissionModel", "SERVICE_MANAGED")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", firstOu)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", secondOu)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(200);
+        assertQueueVisible(firstAccount, queue);
+        assertQueueVisible(secondAccount, queue);
+
+        organizations(management, "MoveAccount",
+                "{\"AccountId\":\"" + firstAccount + "\",\"SourceParentId\":\"" + firstOu
+                        + "\",\"DestinationParentId\":\"" + secondOu + "\"}")
+                .post("/").then().statusCode(200);
+        organizations(management, "MoveAccount",
+                "{\"AccountId\":\"" + secondAccount + "\",\"SourceParentId\":\"" + secondOu
+                        + "\",\"DestinationParentId\":\"" + firstOu + "\"}")
+                .post("/").then().statusCode(200);
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", firstOu)
+                .formParam("Regions.member.1", REGION)
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(200);
+        assertQueueAbsent(firstAccount, queue);
+        assertQueueVisible(secondAccount, queue);
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", secondOu)
+                .formParam("Regions.member.1", REGION)
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(200);
+        assertQueueAbsent(secondAccount, queue);
+    }
+
+    @Test
     void activateOrganizationsAccessRequiresAllFeatures() {
         String management = "666666666666";
         organizations(management, "CreateOrganization", "{\"FeatureSet\":\"CONSOLIDATED_BILLING\"}")

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -13,6 +13,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
 
 /** AWS Organizations semantics required by service-managed CloudFormation StackSets. */
 @QuarkusTest
@@ -119,6 +120,93 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
                 .post("/").then().statusCode(400)
                 .body(containsString("InvalidOperationException"));
 
+        assertQueueAbsent(targetAccount, queue);
+    }
+
+    @Test
+    void createServiceManagedStackSetWithoutTrustedAccessUsesValidationError() {
+        String management = "888888888888";
+        organizations(management, "CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
+                .post("/").then().statusCode(200);
+
+        cloudFormation(management, "CreateStackSet")
+                .formParam("StackSetName", "no-access-" + UUID.randomUUID().toString().substring(0, 8))
+                .formParam("TemplateBody", queueTemplate("unused"))
+                .formParam("PermissionModel", "SERVICE_MANAGED")
+                .post("/").then().statusCode(400)
+                .body(containsString("ValidationError"))
+                .body(not(containsString("InvalidOperationException")));
+    }
+
+    @Test
+    void describeSelfManagedStackSetOmitsAutoDeployment() {
+        String stackSet = "self-managed-" + UUID.randomUUID().toString().substring(0, 8);
+        cloudFormation("CreateStackSet")
+                .formParam("StackSetName", stackSet)
+                .formParam("TemplateBody", queueTemplate("unused"))
+                .post("/").then().statusCode(200);
+
+        cloudFormation("DescribeStackSet")
+                .formParam("StackSetName", stackSet)
+                .post("/").then().statusCode(200)
+                .body(containsString("<PermissionModel>SELF_MANAGED</PermissionModel>"))
+                .body(not(containsString("<AutoDeployment>")));
+    }
+
+    @Test
+    void serviceManagedDeleteRequiresDeploymentTargets() {
+        String management = "444444444444";
+        organizations(management, "CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
+                .post("/").then().statusCode(200);
+        String rootId = organizations(management, "ListRoots", "{}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("Roots[0].Id");
+        String targetOu = organizations(management, "CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + rootId + "\",\"Name\":\"DeleteTarget\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String targetAccount = organizations(management, "CreateAccount",
+                "{\"Email\":\"delete-target-" + suffix + "@example.com\",\"AccountName\":\"DeleteTarget\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("CreateAccountStatus.AccountId");
+        organizations(management, "MoveAccount",
+                "{\"AccountId\":\"" + targetAccount + "\",\"SourceParentId\":\"" + rootId
+                        + "\",\"DestinationParentId\":\"" + targetOu + "\"}")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "ActivateOrganizationsAccess")
+                .post("/").then().statusCode(200);
+
+        String stackSet = "delete-targets-" + suffix;
+        String queue = "delete-targets-q-" + suffix;
+        cloudFormation(management, "CreateStackSet")
+                .formParam("StackSetName", stackSet)
+                .formParam("TemplateBody", queueTemplate(queue))
+                .formParam("PermissionModel", "SERVICE_MANAGED")
+                .formParam("AutoDeployment.Enabled", "true")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", targetOu)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(200);
+        assertQueueVisible(targetAccount, queue);
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("Accounts.member.1", targetAccount)
+                .formParam("Regions.member.1", REGION)
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(400)
+                .body(containsString("InvalidOperationException"));
+        assertQueueVisible(targetAccount, queue);
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", targetOu)
+                .formParam("Regions.member.1", REGION)
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(200);
         assertQueueAbsent(targetAccount, queue);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -294,6 +294,70 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
     }
 
     @Test
+    void overlappingOuTargetsKeepInstanceUntilLastAssociationIsDeleted() {
+        String management = "929292929292";
+        organizations(management, "CreateOrganization", "{\"FeatureSet\":\"ALL\"}")
+                .post("/").then().statusCode(200);
+        String rootId = organizations(management, "ListRoots", "{}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("Roots[0].Id");
+        String parentOu = organizations(management, "CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + rootId + "\",\"Name\":\"OverlapParent\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+        String childOu = organizations(management, "CreateOrganizationalUnit",
+                "{\"ParentId\":\"" + parentOu + "\",\"Name\":\"OverlapChild\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("OrganizationalUnit.Id");
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String account = organizations(management, "CreateAccount",
+                "{\"Email\":\"overlap-" + suffix + "@example.com\",\"AccountName\":\"Overlap\"}")
+                .post("/").then().statusCode(200)
+                .extract().jsonPath().getString("CreateAccountStatus.AccountId");
+        organizations(management, "MoveAccount",
+                "{\"AccountId\":\"" + account + "\",\"SourceParentId\":\"" + rootId
+                        + "\",\"DestinationParentId\":\"" + childOu + "\"}")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "ActivateOrganizationsAccess")
+                .post("/").then().statusCode(200);
+
+        String stackSet = "overlap-ou-" + suffix;
+        String queue = "overlap-ou-q-" + suffix;
+        cloudFormation(management, "CreateStackSet")
+                .formParam("StackSetName", stackSet)
+                .formParam("TemplateBody", queueTemplate(queue))
+                .formParam("PermissionModel", "SERVICE_MANAGED")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", parentOu)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "CreateStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", childOu)
+                .formParam("Regions.member.1", REGION)
+                .post("/").then().statusCode(200);
+        assertQueueVisible(account, queue);
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", parentOu)
+                .formParam("Regions.member.1", REGION)
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(200);
+        assertQueueVisible(account, queue);
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", childOu)
+                .formParam("Regions.member.1", REGION)
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(200);
+        assertQueueAbsent(account, queue);
+    }
+
+    @Test
     void activateOrganizationsAccessRequiresAllFeatures() {
         String management = "666666666666";
         organizations(management, "CreateOrganization", "{\"FeatureSet\":\"CONSOLIDATED_BILLING\"}")

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceManagedStackSetsIntegrationTest.java
@@ -189,6 +189,7 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
                 .formParam("StackSetName", stackSet)
                 .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", targetOu)
                 .formParam("Regions.member.1", REGION)
+                .formParam("Regions.member.2", "us-west-2")
                 .post("/").then().statusCode(200);
         assertQueueVisible(targetAccount, queue);
 
@@ -208,6 +209,23 @@ class CloudFormationServiceManagedStackSetsIntegrationTest {
                 .formParam("RetainStacks", "false")
                 .post("/").then().statusCode(200);
         assertQueueAbsent(targetAccount, queue);
+        cloudFormation(management, "ListStackSetAutoDeploymentTargets")
+                .formParam("StackSetName", stackSet)
+                .post("/").then().statusCode(200)
+                .body(containsString("<OrganizationalUnitId>" + targetOu + "</OrganizationalUnitId>"))
+                .body(not(containsString("<member>" + REGION + "</member>")))
+                .body(containsString("<member>us-west-2</member>"));
+
+        cloudFormation(management, "DeleteStackInstances")
+                .formParam("StackSetName", stackSet)
+                .formParam("DeploymentTargets.OrganizationalUnitIds.member.1", targetOu)
+                .formParam("Regions.member.1", "us-west-2")
+                .formParam("RetainStacks", "false")
+                .post("/").then().statusCode(200);
+        cloudFormation(management, "ListStackSetAutoDeploymentTargets")
+                .formParam("StackSetName", stackSet)
+                .post("/").then().statusCode(200)
+                .body(not(containsString("<OrganizationalUnitId>" + targetOu + "</OrganizationalUnitId>")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add AWS Organizations-backed service-managed CloudFormation StackSets
- resolve root and OU deployment targets recursively while excluding the management account
- preserve overlapping OU associations and original deployment-target metadata across account movement and deletion
- reconcile automatic-deployment target regions and propagate backing-stack failures into StackSet operations
- add AWS SDK and integration coverage for service-managed and self-managed behavior

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the official AWS CloudFormation and AWS Organizations documentation for service-managed StackSets, `CreateStackSet`, `CreateStackInstances`, `DeleteStackInstances`, StackInstance status fields, trusted access, and organization/OU targeting.

The implementation uses the AWS Query protocol and is exercised with AWS SDK for Java v2 2.52.0 through `CloudFormationStackSetsTest`. It preserves AWS behavior for trusted-access validation, `DeploymentTargets` versus direct `Accounts`, omission of `AutoDeployment` for self-managed StackSets, descendant OU targeting, management-account exclusion, persisted target associations, and operation failure reporting.

Validation on this branch includes the focused StackSet suites, AWS SDK StackSets compatibility suite (7/7), `make docs-check`, and `git diff --check`. A full local `./mvnw test` completed 16,813 tests and exposed only unrelated environment/baseline failures. The affected Organizations CFN, Organizations feature-set, invalid-effective-policy, Runtime API, and JSONata suites all passed when rerun in isolation. The remaining reproducible local issues are Docker foreign-platform image handling and a Lambda credential expectation affected by the local environment. Upstream CI is green for this head, including native and compatibility jobs.

## Checklist

- [ ] `./mvnw test` passes locally (full suite completed; remaining failures are unrelated local environment/baseline issues, while focused tests and upstream CI are green)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
