### PR TITLE
fix(eventbridge): scope replay cancellation by ARN

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeService.java
@@ -1453,7 +1453,7 @@ public class EventBridgeService implements ResourceProvider {
             throw new AwsException("IllegalStatusException",
                     "Replay is not in a cancellable state: " + replay.getState(), 400);
         }
-        boolean signalled = replayDispatcher.requestCancel(replayName);
+        boolean signalled = replayDispatcher.requestCancel(replay.getReplayArn());
         if (!signalled) {
             // already completed between check and cancel
             replay = replayStore.get(key).orElse(replay);

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcher.java
@@ -46,9 +46,10 @@ public class ReplayDispatcher {
                   BiConsumer<String, ReplayState> stateUpdater,
                   Consumer<Instant> progressUpdater) {
 
+        String replayArn = replay.getReplayArn();
         String replayName = replay.getReplayName();
         AtomicBoolean cancelled = new AtomicBoolean(false);
-        cancelFlags.put(replayName, cancelled);
+        cancelFlags.put(replayArn, cancelled);
 
         vertx.executeBlocking(promise -> {
             try {
@@ -88,7 +89,7 @@ public class ReplayDispatcher {
                 stateUpdater.accept(replayName, ReplayState.FAILED);
                 promise.fail(e);
             } finally {
-                cancelFlags.remove(replayName);
+                cancelFlags.remove(replayArn, cancelled);
             }
         });
     }
@@ -97,8 +98,8 @@ public class ReplayDispatcher {
      * Signals a running replay to stop after the current event. Returns false if the replay is
      * not running (already completed, cancelled, or unknown).
      */
-    boolean requestCancel(String replayName) {
-        AtomicBoolean flag = cancelFlags.get(replayName);
+    boolean requestCancel(String replayArn) {
+        AtomicBoolean flag = cancelFlags.get(replayArn);
         if (flag != null) {
             flag.set(true);
             return true;

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/EventBridgeServiceTest.java
@@ -5,7 +5,10 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.services.eventbridge.model.EventBus;
+import io.github.hectorvent.floci.services.eventbridge.model.Replay;
+import io.github.hectorvent.floci.services.eventbridge.model.ReplayState;
 import io.github.hectorvent.floci.services.eventbridge.model.Rule;
 import io.github.hectorvent.floci.services.eventbridge.model.RuleState;
 import io.github.hectorvent.floci.services.eventbridge.model.Target;
@@ -21,6 +24,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 class EventBridgeServiceTest {
@@ -30,25 +34,44 @@ class EventBridgeServiceTest {
 
     private EventBridgeService service;
     private EventBridgeInvoker invokerMock;
+    private StorageBackend<String, Replay> replayStore;
+    private ReplayDispatcher replayDispatcherMock;
 
     @BeforeEach
     void setUp() {
         invokerMock = mock(EventBridgeInvoker.class);
+        replayStore = new InMemoryStorage<>();
+        replayDispatcherMock = mock(ReplayDispatcher.class);
         service = new EventBridgeService(
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
                 new InMemoryStorage<>(),
-                new InMemoryStorage<>(),
+                replayStore,
                 new InMemoryStorage<>(),
                 new RegionResolver("us-east-1", "000000000000"),
                 new ObjectMapper(),
                 null,
                 invokerMock,
-                null,
+                replayDispatcherMock,
                 new ResourceGroupsTaggingService(null)
         );
+    }
+
+    @Test
+    void cancelReplayForwardsTheStoredReplayArn() {
+        Replay replay = new Replay();
+        replay.setReplayName("shared");
+        replay.setReplayArn("arn:aws:events:us-east-1:111111111111:replay/shared");
+        replay.setState(ReplayState.RUNNING);
+        replayStore.put("replay:" + REGION + ":shared", replay);
+        when(replayDispatcherMock.requestCancel(replay.getReplayArn())).thenReturn(true);
+
+        Replay cancelled = service.cancelReplay("shared", REGION);
+
+        assertEquals(ReplayState.CANCELLING, cancelled.getState());
+        verify(replayDispatcherMock).requestCancel(replay.getReplayArn());
     }
 
     // ──────────────────────────── Event Buses ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcherTest.java
@@ -1,0 +1,102 @@
+package io.github.hectorvent.floci.services.eventbridge;
+
+import io.github.hectorvent.floci.services.eventbridge.model.Replay;
+import io.github.hectorvent.floci.services.eventbridge.model.ReplayState;
+import io.vertx.core.Vertx;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ReplayDispatcherTest {
+
+    private Vertx vertx;
+    private ReplayDispatcher dispatcher;
+
+    @BeforeEach
+    void setUp() {
+        vertx = Vertx.vertx();
+        dispatcher = new ReplayDispatcher(vertx);
+    }
+
+    @AfterEach
+    void tearDown() {
+        vertx.close();
+    }
+
+    @Test
+    void cancellationIsScopedToReplayArnWhenNamesRepeat() throws InterruptedException {
+        Replay first = replay("arn:aws:events:us-east-1:111111111111:replay/shared");
+        Replay second = replay("arn:aws:events:us-west-2:222222222222:replay/shared");
+        CountDownLatch firstEventsStarted = new CountDownLatch(2);
+        CountDownLatch releaseEvents = new CountDownLatch(1);
+        CountDownLatch terminalStates = new CountDownLatch(2);
+        Map<String, ReplayState> terminalStateByArn = new ConcurrentHashMap<>();
+
+        dispatch(first, firstEventsStarted, releaseEvents, terminalStates, terminalStateByArn);
+        dispatch(second, firstEventsStarted, releaseEvents, terminalStates, terminalStateByArn);
+
+        assertTrue(firstEventsStarted.await(5, TimeUnit.SECONDS));
+        assertTrue(dispatcher.requestCancel(first.getReplayArn()));
+        releaseEvents.countDown();
+
+        assertTrue(terminalStates.await(5, TimeUnit.SECONDS));
+        assertEquals(ReplayState.CANCELLED, terminalStateByArn.get(first.getReplayArn()));
+        assertEquals(ReplayState.COMPLETED, terminalStateByArn.get(second.getReplayArn()));
+    }
+
+    private void dispatch(Replay replay,
+                          CountDownLatch eventsStarted,
+                          CountDownLatch releaseEvents,
+                          CountDownLatch terminalStates,
+                          Map<String, ReplayState> terminalStateByArn) {
+        dispatcher.dispatch(
+                replay,
+                List.of(archivedEvent(), archivedEvent()),
+                events -> {
+                    eventsStarted.countDown();
+                    await(releaseEvents);
+                },
+                (ignoredName, state) -> {
+                    if (state == ReplayState.CANCELLED || state == ReplayState.COMPLETED) {
+                        terminalStateByArn.put(replay.getReplayArn(), state);
+                        terminalStates.countDown();
+                    }
+                },
+                ignoredTime -> { });
+    }
+
+    private static Replay replay(String arn) {
+        Replay replay = new Replay();
+        replay.setReplayName("shared");
+        replay.setReplayArn(arn);
+        replay.setEventStartTime(Instant.EPOCH);
+        replay.setEventEndTime(Instant.MAX);
+        return replay;
+    }
+
+    private static io.github.hectorvent.floci.services.eventbridge.model.ArchivedEvent archivedEvent() {
+        io.github.hectorvent.floci.services.eventbridge.model.ArchivedEvent event =
+                new io.github.hectorvent.floci.services.eventbridge.model.ArchivedEvent();
+        event.setEventTime(Instant.EPOCH.plusSeconds(1));
+        return event;
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await(5, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcherTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/ReplayDispatcherTest.java
@@ -37,15 +37,15 @@ class ReplayDispatcherTest {
     void cancellationIsScopedToReplayArnWhenNamesRepeat() throws InterruptedException {
         Replay first = replay("arn:aws:events:us-east-1:111111111111:replay/shared");
         Replay second = replay("arn:aws:events:us-west-2:222222222222:replay/shared");
-        CountDownLatch firstEventsStarted = new CountDownLatch(2);
+        CountDownLatch firstEventStarted = new CountDownLatch(1);
         CountDownLatch releaseEvents = new CountDownLatch(1);
         CountDownLatch terminalStates = new CountDownLatch(2);
         Map<String, ReplayState> terminalStateByArn = new ConcurrentHashMap<>();
 
-        dispatch(first, firstEventsStarted, releaseEvents, terminalStates, terminalStateByArn);
-        dispatch(second, firstEventsStarted, releaseEvents, terminalStates, terminalStateByArn);
+        dispatch(first, firstEventStarted, releaseEvents, terminalStates, terminalStateByArn);
+        dispatch(second, firstEventStarted, releaseEvents, terminalStates, terminalStateByArn);
 
-        assertTrue(firstEventsStarted.await(5, TimeUnit.SECONDS));
+        assertTrue(firstEventStarted.await(5, TimeUnit.SECONDS));
         assertTrue(dispatcher.requestCancel(first.getReplayArn()));
         releaseEvents.countDown();
 
@@ -55,7 +55,7 @@ class ReplayDispatcherTest {
     }
 
     private void dispatch(Replay replay,
-                          CountDownLatch eventsStarted,
+                          CountDownLatch firstEventStarted,
                           CountDownLatch releaseEvents,
                           CountDownLatch terminalStates,
                           Map<String, ReplayState> terminalStateByArn) {
@@ -63,7 +63,7 @@ class ReplayDispatcherTest {
                 replay,
                 List.of(archivedEvent(), archivedEvent()),
                 events -> {
-                    eventsStarted.countDown();
+                    firstEventStarted.countDown();
                     await(releaseEvents);
                 },
                 (ignoredName, state) -> {


### PR DESCRIPTION
## Summary

Fix EventBridge replay cancellation when replay names repeat across accounts or regions. Cancellation state is now keyed by the replay ARN instead of only the replay name. Add regression coverage for dispatcher isolation and ARN forwarding through EventBridgeService.

  ## Type of change

  - [x] Bug fix (fix:)
  - [ ] New feature (feat:)
  - [ ] Breaking change (feat!: or fix!:)
  - [ ] Docs / chore

  ## AWS Compatibility

Floci could cancel the wrong replay when two accounts or regions used the same replay name. AWS replay identity includes the account and region through the replay ARN. Cancellation now targets the exact replay ARN. Existing replay state and API responses are unchanged.

  ## Checklist

  - [ ] ./mvnw test passes locally
  - [x] New or updated integration test added
  - [x] Commit messages follow Conventional Commits (https://www.conventionalcommits.org/)