### PR TITLE
fix(wafv2): validate resource names on operations

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/WafV2CfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/WafV2CfnProvisioner.java
@@ -46,15 +46,16 @@ public class WafV2CfnProvisioner implements CfnResourceProvisioner {
         WebAcl desired = fromProperties(resolved);
         WebAcl acl;
         if (existing != null && existing.getName().equals(name) && existing.getScope().equals(scope)) {
-            wafV2Service.updateWebAcl(desired, scope, existing.getId(), existing.getLockToken());
-            acl = wafV2Service.getWebAcl(scope, existing.getId());
+            wafV2Service.updateWebAcl(desired, scope, existing.getId(), name, existing.getLockToken());
+            acl = wafV2Service.getWebAcl(scope, existing.getId(), name);
             reconcileTags(acl, desired.getTags());
         } else {
             acl = wafV2Service.createWebAcl(desired, scope, name, ctx.region());
             setReferences(resource, acl);
             if (existing != null) {
                 try {
-                    wafV2Service.deleteWebAcl(existing.getScope(), existing.getId(), existing.getLockToken());
+                    wafV2Service.deleteWebAcl(existing.getScope(), existing.getId(), existing.getName(),
+                            existing.getLockToken());
                 } catch (RuntimeException e) {
                     // old ACL may still be associated with a resource; new ACL is already tracked
                     LOG.warnv("WAFv2 CFN replacement cleanup of {0}|{1}|{2} tolerated: {3}",
@@ -70,7 +71,8 @@ public class WafV2CfnProvisioner implements CfnResourceProvisioner {
     public void delete(String resourceType, String physicalId, String region) {
         WebAcl existing = findExisting(physicalId);
         if (existing != null) {
-            wafV2Service.deleteWebAcl(existing.getScope(), existing.getId(), existing.getLockToken());
+            wafV2Service.deleteWebAcl(existing.getScope(), existing.getId(), existing.getName(),
+                    existing.getLockToken());
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/wafv2/WafV2Handler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/wafv2/WafV2Handler.java
@@ -118,7 +118,7 @@ public class WafV2Handler {
     }
 
     private Response handleGetWebAcl(JsonNode request) {
-        WebAcl acl = service.getWebAcl(text(request, "Scope"), text(request, "Id"));
+        WebAcl acl = service.getWebAcl(text(request, "Scope"), text(request, "Id"), text(request, "Name"));
         ObjectNode response = objectMapper.createObjectNode();
         response.set("WebACL", webAclNode(acl));
         response.put("LockToken", acl.getLockToken());
@@ -138,12 +138,13 @@ public class WafV2Handler {
         changes.setAssociationConfig(rawObject(request.path("AssociationConfig")));
         changes.setDataProtectionConfig(rawObject(request.path("DataProtectionConfig")));
         String next = service.updateWebAcl(changes, text(request, "Scope"),
-                text(request, "Id"), text(request, "LockToken"));
+                text(request, "Id"), text(request, "Name"), text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode().put("NextLockToken", next)).build();
     }
 
     private Response handleDeleteWebAcl(JsonNode request) {
-        service.deleteWebAcl(text(request, "Scope"), text(request, "Id"), text(request, "LockToken"));
+        service.deleteWebAcl(text(request, "Scope"), text(request, "Id"), text(request, "Name"),
+                text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
@@ -173,7 +174,7 @@ public class WafV2Handler {
     }
 
     private Response handleGetIpSet(JsonNode request) {
-        IpSet ipSet = service.getIpSet(text(request, "Scope"), text(request, "Id"));
+        IpSet ipSet = service.getIpSet(text(request, "Scope"), text(request, "Id"), text(request, "Name"));
         ObjectNode response = objectMapper.createObjectNode();
         response.set("IPSet", ipSetNode(ipSet));
         response.put("LockToken", ipSet.getLockToken());
@@ -183,12 +184,13 @@ public class WafV2Handler {
     private Response handleUpdateIpSet(JsonNode request) {
         String next = service.updateIpSet(text(request, "Scope"), text(request, "Id"),
                 text(request, "Description"), stringList(request.path("Addresses")),
-                text(request, "LockToken"));
+                text(request, "Name"), text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode().put("NextLockToken", next)).build();
     }
 
     private Response handleDeleteIpSet(JsonNode request) {
-        service.deleteIpSet(text(request, "Scope"), text(request, "Id"), text(request, "LockToken"));
+        service.deleteIpSet(text(request, "Scope"), text(request, "Id"), text(request, "Name"),
+                text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
@@ -218,7 +220,8 @@ public class WafV2Handler {
     }
 
     private Response handleGetRegexPatternSet(JsonNode request) {
-        RegexPatternSet set = service.getRegexPatternSet(text(request, "Scope"), text(request, "Id"));
+        RegexPatternSet set = service.getRegexPatternSet(text(request, "Scope"), text(request, "Id"),
+                text(request, "Name"));
         ObjectNode response = objectMapper.createObjectNode();
         response.set("RegexPatternSet", regexSetNode(set));
         response.put("LockToken", set.getLockToken());
@@ -228,12 +231,13 @@ public class WafV2Handler {
     private Response handleUpdateRegexPatternSet(JsonNode request) {
         String next = service.updateRegexPatternSet(text(request, "Scope"), text(request, "Id"),
                 text(request, "Description"), regexList(request.path("RegularExpressionList")),
-                text(request, "LockToken"));
+                text(request, "Name"), text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode().put("NextLockToken", next)).build();
     }
 
     private Response handleDeleteRegexPatternSet(JsonNode request) {
-        service.deleteRegexPatternSet(text(request, "Scope"), text(request, "Id"), text(request, "LockToken"));
+        service.deleteRegexPatternSet(text(request, "Scope"), text(request, "Id"), text(request, "Name"),
+                text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 
@@ -265,7 +269,7 @@ public class WafV2Handler {
     }
 
     private Response handleGetRuleGroup(JsonNode request) {
-        RuleGroup group = service.getRuleGroup(text(request, "Scope"), text(request, "Id"));
+        RuleGroup group = service.getRuleGroup(text(request, "Scope"), text(request, "Id"), text(request, "Name"));
         ObjectNode response = objectMapper.createObjectNode();
         response.set("RuleGroup", ruleGroupNode(group));
         response.put("LockToken", group.getLockToken());
@@ -279,12 +283,13 @@ public class WafV2Handler {
         changes.setVisibilityConfig(rawObject(request.path("VisibilityConfig")));
         changes.setCustomResponseBodies(rawObject(request.path("CustomResponseBodies")));
         String next = service.updateRuleGroup(changes, text(request, "Scope"),
-                text(request, "Id"), text(request, "LockToken"));
+                text(request, "Id"), text(request, "Name"), text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode().put("NextLockToken", next)).build();
     }
 
     private Response handleDeleteRuleGroup(JsonNode request) {
-        service.deleteRuleGroup(text(request, "Scope"), text(request, "Id"), text(request, "LockToken"));
+        service.deleteRuleGroup(text(request, "Scope"), text(request, "Id"), text(request, "Name"),
+                text(request, "LockToken"));
         return Response.ok(objectMapper.createObjectNode()).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/wafv2/WafV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/wafv2/WafV2Service.java
@@ -21,10 +21,10 @@ import java.util.Map;
 import java.util.UUID;
 
 /**
- * WAF v2 management-plane business logic. Resources are identified by the
- * (Scope, Id) pair (storage key {@code scope:id}); Name + Scope find the Id on the
- * duplicate-name check. Updates/deletes enforce the LockToken optimistic-concurrency
- * contract. Recursive rule structures are stored opaquely as raw JSON.
+ * WAF v2 management-plane business logic. Resources are stored by the
+ * (Scope, Id) pair and get, update, and delete operations also validate Name.
+ * Updates/deletes enforce the LockToken optimistic-concurrency contract.
+ * Recursive rule structures are stored opaquely as raw JSON.
  */
 @ApplicationScoped
 public class WafV2Service {
@@ -83,12 +83,12 @@ public class WafV2Service {
         return acl;
     }
 
-    public WebAcl getWebAcl(String scope, String id) {
-        return require(webAclStore, scope, id);
+    public WebAcl getWebAcl(String scope, String id, String name) {
+        return require(webAclStore, scope, id, name);
     }
 
-    public String updateWebAcl(WebAcl changes, String scope, String id, String lockToken) {
-        WebAcl existing = require(webAclStore, scope, id);
+    public String updateWebAcl(WebAcl changes, String scope, String id, String name, String lockToken) {
+        WebAcl existing = require(webAclStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         existing.setDescription(changes.getDescription());
         existing.setDefaultAction(changes.getDefaultAction());
@@ -104,8 +104,8 @@ public class WafV2Service {
         return rotate(existing, webAclStore, scope);
     }
 
-    public void deleteWebAcl(String scope, String id, String lockToken) {
-        WebAcl existing = require(webAclStore, scope, id);
+    public void deleteWebAcl(String scope, String id, String name, String lockToken) {
+        WebAcl existing = require(webAclStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         boolean associated = associationStore.scan(k -> true).stream()
                 .anyMatch(arn -> arn.equals(existing.getArn()));
@@ -140,21 +140,21 @@ public class WafV2Service {
         return ipSet;
     }
 
-    public IpSet getIpSet(String scope, String id) {
-        return require(ipSetStore, scope, id);
+    public IpSet getIpSet(String scope, String id, String name) {
+        return require(ipSetStore, scope, id, name);
     }
 
     public String updateIpSet(String scope, String id, String description,
-                              List<String> addresses, String lockToken) {
-        IpSet existing = require(ipSetStore, scope, id);
+                              List<String> addresses, String name, String lockToken) {
+        IpSet existing = require(ipSetStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         existing.setDescription(description);
         existing.setAddresses(addresses);
         return rotate(existing, ipSetStore, scope);
     }
 
-    public void deleteIpSet(String scope, String id, String lockToken) {
-        IpSet existing = require(ipSetStore, scope, id);
+    public void deleteIpSet(String scope, String id, String name, String lockToken) {
+        IpSet existing = require(ipSetStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         ipSetStore.delete(key(scope, id));
     }
@@ -182,21 +182,21 @@ public class WafV2Service {
         return set;
     }
 
-    public RegexPatternSet getRegexPatternSet(String scope, String id) {
-        return require(regexStore, scope, id);
+    public RegexPatternSet getRegexPatternSet(String scope, String id, String name) {
+        return require(regexStore, scope, id, name);
     }
 
     public String updateRegexPatternSet(String scope, String id, String description,
-                                        List<String> regexList, String lockToken) {
-        RegexPatternSet existing = require(regexStore, scope, id);
+                                        List<String> regexList, String name, String lockToken) {
+        RegexPatternSet existing = require(regexStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         existing.setDescription(description);
         existing.setRegularExpressionList(regexList);
         return rotate(existing, regexStore, scope);
     }
 
-    public void deleteRegexPatternSet(String scope, String id, String lockToken) {
-        RegexPatternSet existing = require(regexStore, scope, id);
+    public void deleteRegexPatternSet(String scope, String id, String name, String lockToken) {
+        RegexPatternSet existing = require(regexStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         regexStore.delete(key(scope, id));
     }
@@ -225,12 +225,12 @@ public class WafV2Service {
         return group;
     }
 
-    public RuleGroup getRuleGroup(String scope, String id) {
-        return require(ruleGroupStore, scope, id);
+    public RuleGroup getRuleGroup(String scope, String id, String name) {
+        return require(ruleGroupStore, scope, id, name);
     }
 
-    public String updateRuleGroup(RuleGroup changes, String scope, String id, String lockToken) {
-        RuleGroup existing = require(ruleGroupStore, scope, id);
+    public String updateRuleGroup(RuleGroup changes, String scope, String id, String name, String lockToken) {
+        RuleGroup existing = require(ruleGroupStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         existing.setDescription(changes.getDescription());
         existing.setRules(changes.getRules());
@@ -239,8 +239,8 @@ public class WafV2Service {
         return rotate(existing, ruleGroupStore, scope);
     }
 
-    public void deleteRuleGroup(String scope, String id, String lockToken) {
-        RuleGroup existing = require(ruleGroupStore, scope, id);
+    public void deleteRuleGroup(String scope, String id, String name, String lockToken) {
+        RuleGroup existing = require(ruleGroupStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
         ruleGroupStore.delete(key(scope, id));
     }
@@ -398,14 +398,22 @@ public class WafV2Service {
         return null;
     }
 
-    private <V> V require(StorageBackend<String, V> store, String scope, String id) {
+    private <V> V require(StorageBackend<String, V> store, String scope, String id, String name) {
         validateScope(scope);
         if (id == null) {
             throw new AwsException("WAFInvalidParameterException", "Id is required.", 400);
         }
-        return store.get(key(scope, id)).orElseThrow(() -> new AwsException(
+        if (name == null || name.isBlank()) {
+            throw new AwsException("WAFInvalidParameterException", "Name is required.", 400);
+        }
+        V resource = store.get(key(scope, id)).orElseThrow(() -> new AwsException(
                 "WAFNonexistentItemException",
                 "AWS WAF couldn't perform the operation because your resource doesn't exist.", 404));
+        if (!name.equals(nameOf(resource))) {
+            throw new AwsException("WAFNonexistentItemException",
+                    "AWS WAF couldn't perform the operation because your resource doesn't exist.", 404);
+        }
+        return resource;
     }
 
     private <V> V findByName(StorageBackend<String, V> store, String scope, String name) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/WafV2CfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/WafV2CfnProvisionerTest.java
@@ -64,14 +64,14 @@ class WafV2CfnProvisionerTest {
         WebAcl updated = acl("portal", "acl-123", "REGIONAL", "lock-2");
         updated.setArn("arn:updated");
         when(wafV2.listWebAcls("REGIONAL")).thenReturn(List.of(existing));
-        when(wafV2.getWebAcl("REGIONAL", "acl-123")).thenReturn(updated);
+        when(wafV2.getWebAcl("REGIONAL", "acl-123", "portal")).thenReturn(updated);
         StackResource resource = resource();
         resource.setPhysicalId("portal|acl-123|REGIONAL");
         ObjectNode props = mapper.createObjectNode().put("Name", "portal").put("Scope", "REGIONAL");
 
         provisioner.provision(resource, props, context());
 
-        verify(wafV2).updateWebAcl(any(), eq("REGIONAL"), eq("acl-123"), eq("lock-1"));
+        verify(wafV2).updateWebAcl(any(), eq("REGIONAL"), eq("acl-123"), eq("portal"), eq("lock-1"));
         assertEquals("portal|acl-123|REGIONAL", resource.getPhysicalId());
     }
 
@@ -84,7 +84,7 @@ class WafV2CfnProvisionerTest {
         when(wafV2.createWebAcl(any(), eq("REGIONAL"), eq("portal-renamed"), eq("us-east-1")))
                 .thenReturn(created);
         org.mockito.Mockito.doThrow(new RuntimeException("WAFAssociatedItemException"))
-                .when(wafV2).deleteWebAcl("REGIONAL", "acl-old", "lock-1");
+                .when(wafV2).deleteWebAcl("REGIONAL", "acl-old", "portal", "lock-1");
         StackResource resource = resource();
         resource.setPhysicalId("portal|acl-old|REGIONAL");
         ObjectNode props = mapper.createObjectNode().put("Name", "portal-renamed").put("Scope", "REGIONAL");

--- a/src/test/java/io/github/hectorvent/floci/services/wafv2/WafV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/wafv2/WafV2IntegrationTest.java
@@ -104,6 +104,54 @@ class WafV2IntegrationTest {
 
     @Test
     @Order(5)
+    void getWebAclWithWrongNameReturnsNotFound() {
+        call("GetWebACL",
+                "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\"}")
+                .then().statusCode(404)
+                .body("__type", equalTo("WAFNonexistentItemException"));
+    }
+
+    @Test
+    @Order(6)
+    void getWebAclWithoutNameReturnsInvalidParameter() {
+        call("GetWebACL", "{\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\"}")
+                .then().statusCode(400)
+                .body("__type", equalTo("WAFInvalidParameterException"));
+    }
+
+    @Test
+    @Order(7)
+    void updateWebAclWithWrongNameDoesNotMutate() {
+        call("UpdateWebACL",
+                "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\","
+                        + "\"LockToken\":\"" + webAclLockToken + "\",\"Description\":\"must-not-apply\","
+                        + "\"VisibilityConfig\":{\"SampledRequestsEnabled\":true,"
+                        + "\"CloudWatchMetricsEnabled\":true,\"MetricName\":\"acl\"}}")
+                .then().statusCode(404)
+                .body("__type", equalTo("WAFNonexistentItemException"));
+
+        call("GetWebACL",
+                "{\"Name\":\"floci-waf-acl\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\"}")
+                .then().statusCode(200)
+                .body("WebACL.Description", not(equalTo("must-not-apply")));
+    }
+
+    @Test
+    @Order(8)
+    void deleteWebAclWithWrongNameDoesNotDelete() {
+        call("DeleteWebACL",
+                "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\","
+                        + "\"LockToken\":\"" + webAclLockToken + "\"}")
+                .then().statusCode(404)
+                .body("__type", equalTo("WAFNonexistentItemException"));
+
+        call("GetWebACL",
+                "{\"Name\":\"floci-waf-acl\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\"}")
+                .then().statusCode(200);
+    }
+
+    @Test
+    @Order(9)
     void updateWebAclRotatesLockToken() {
         Response resp = call("UpdateWebACL",
                 "{\"Name\":\"floci-waf-acl\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\","
@@ -118,7 +166,7 @@ class WafV2IntegrationTest {
     }
 
     @Test
-    @Order(6)
+    @Order(10)
     void staleLockTokenUpdateFails() {
         // webAclLockToken is now stale after the previous update.
         call("UpdateWebACL",
@@ -132,7 +180,7 @@ class WafV2IntegrationTest {
     }
 
     @Test
-    @Order(7)
+    @Order(11)
     void associateAndQuery() {
         call("AssociateWebACL",
                 "{\"WebACLArn\":\"" + webAclArn + "\",\"ResourceArn\":\"" + API_RESOURCE_ARN + "\"}")
@@ -149,7 +197,7 @@ class WafV2IntegrationTest {
     }
 
     @Test
-    @Order(8)
+    @Order(12)
     void deleteWebAclWhileAssociatedFails() {
         String lockToken = call("GetWebACL",
                 "{\"Name\":\"floci-waf-acl\",\"Scope\":\"REGIONAL\",\"Id\":\"" + webAclId + "\"}")
@@ -162,7 +210,7 @@ class WafV2IntegrationTest {
     }
 
     @Test
-    @Order(9)
+    @Order(13)
     void cloudfrontScopeIsolatedFromRegional() {
         // Same Name in CLOUDFRONT scope must not collide with the REGIONAL IP set.
         call("CreateIPSet",
@@ -176,7 +224,86 @@ class WafV2IntegrationTest {
     }
 
     @Test
-    @Order(10)
+    @Order(14)
+    void wrongNamesAreRejectedForAllResourceTypes() {
+        call("GetIPSet",
+                "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\"" + ipSetId + "\"}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+
+        String ipLock = call("GetIPSet",
+                "{\"Name\":\"floci-waf-ips\",\"Scope\":\"REGIONAL\",\"Id\":\"" + ipSetId + "\"}")
+                .then().statusCode(200).extract().jsonPath().getString("LockToken");
+        String ipUpdate = "\"Scope\":\"REGIONAL\",\"Id\":\"" + ipSetId + "\","
+                + "\"Description\":\"must-not-apply\",\"Addresses\":[\"10.0.0.1/32\"],"
+                + "\"LockToken\":\"" + ipLock + "\"";
+        call("UpdateIPSet", "{\"Name\":\"wrong-name\"," + ipUpdate + "}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("UpdateIPSet", "{" + ipUpdate + "}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("DeleteIPSet", "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\""
+                + ipSetId + "\",\"LockToken\":\"" + ipLock + "\"}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("DeleteIPSet", "{\"Scope\":\"REGIONAL\",\"Id\":\"" + ipSetId
+                + "\",\"LockToken\":\"" + ipLock + "\"}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("GetIPSet", "{\"Name\":\"floci-waf-ips\",\"Scope\":\"REGIONAL\",\"Id\":\""
+                + ipSetId + "\"}").then().statusCode(200).body("LockToken", equalTo(ipLock));
+
+        String regexId = call("CreateRegexPatternSet",
+                "{\"Name\":\"floci-waf-regex\",\"Scope\":\"REGIONAL\","
+                        + "\"RegularExpressionList\":[{\"RegexString\":\"foo\"}]}")
+                .then().statusCode(200).extract().jsonPath().getString("Summary.Id");
+        String regexLock = call("GetRegexPatternSet",
+                "{\"Name\":\"floci-waf-regex\",\"Scope\":\"REGIONAL\",\"Id\":\"" + regexId + "\"}")
+                .then().statusCode(200).extract().jsonPath().getString("LockToken");
+        String ruleGroupId = call("CreateRuleGroup",
+                "{\"Name\":\"floci-waf-rules\",\"Scope\":\"REGIONAL\",\"Capacity\":1,\"Rules\":[]}")
+                .then().statusCode(200).extract().jsonPath().getString("Summary.Id");
+        String ruleGroupLock = call("GetRuleGroup",
+                "{\"Name\":\"floci-waf-rules\",\"Scope\":\"REGIONAL\",\"Id\":\"" + ruleGroupId + "\"}")
+                .then().statusCode(200).extract().jsonPath().getString("LockToken");
+
+        call("GetRegexPatternSet",
+                "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\"" + regexId + "\"}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("GetRuleGroup",
+                "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\"" + ruleGroupId + "\"}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+
+        String regexUpdate = "\"Scope\":\"REGIONAL\",\"Id\":\"" + regexId + "\","
+                + "\"Description\":\"must-not-apply\",\"RegularExpressionList\":[{\"RegexString\":\"bar\"}],"
+                + "\"LockToken\":\"" + regexLock + "\"";
+        call("UpdateRegexPatternSet", "{\"Name\":\"wrong-name\"," + regexUpdate + "}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("UpdateRegexPatternSet", "{" + regexUpdate + "}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("DeleteRegexPatternSet", "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\""
+                + regexId + "\",\"LockToken\":\"" + regexLock + "\"}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("DeleteRegexPatternSet", "{\"Scope\":\"REGIONAL\",\"Id\":\"" + regexId
+                + "\",\"LockToken\":\"" + regexLock + "\"}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("GetRegexPatternSet", "{\"Name\":\"floci-waf-regex\",\"Scope\":\"REGIONAL\",\"Id\":\""
+                + regexId + "\"}").then().statusCode(200).body("LockToken", equalTo(regexLock));
+
+        String ruleGroupUpdate = "\"Scope\":\"REGIONAL\",\"Id\":\"" + ruleGroupId + "\","
+                + "\"Rules\":[],\"LockToken\":\"" + ruleGroupLock + "\"";
+        call("UpdateRuleGroup", "{\"Name\":\"wrong-name\"," + ruleGroupUpdate + "}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("UpdateRuleGroup", "{" + ruleGroupUpdate + "}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("DeleteRuleGroup", "{\"Name\":\"wrong-name\",\"Scope\":\"REGIONAL\",\"Id\":\""
+                + ruleGroupId + "\",\"LockToken\":\"" + ruleGroupLock + "\"}")
+                .then().statusCode(404).body("__type", equalTo("WAFNonexistentItemException"));
+        call("DeleteRuleGroup", "{\"Scope\":\"REGIONAL\",\"Id\":\"" + ruleGroupId
+                + "\",\"LockToken\":\"" + ruleGroupLock + "\"}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("GetRuleGroup", "{\"Name\":\"floci-waf-rules\",\"Scope\":\"REGIONAL\",\"Id\":\""
+                + ruleGroupId + "\"}").then().statusCode(200).body("LockToken", equalTo(ruleGroupLock));
+    }
+
+    @Test
+    @Order(15)
     void teardown() {
         call("DisassociateWebACL", "{\"ResourceArn\":\"" + API_RESOURCE_ARN + "\"}")
                 .then().statusCode(200);
@@ -198,7 +325,7 @@ class WafV2IntegrationTest {
     }
 
     @Test
-    @Order(11)
+    @Order(16)
     void getMissingWebAclReturnsNotFound() {
         call("GetWebACL",
                 "{\"Name\":\"nope\",\"Scope\":\"REGIONAL\",\"Id\":\"00000000-0000-0000-0000-000000000000\"}")


### PR DESCRIPTION
## Summary

Validate the required WAFv2 resource `Name` on get, update, and delete operations. Requests with a missing name now return `WAFInvalidParameterException`. Requests with a mismatched name return `WAFNonexistentItemException` without changing or deleting the resource.

## Type of change

  - [x] Bug fix (`fix:`)
  - [ ] New feature (`feat:`)
  - [ ] Breaking change (`feat!:` or `fix!:`)
  - [ ] Docs / chore

  ## AWS Compatibility

- Floci previously used only `Scope` and `Id` to identify WAFv2 resources. A valid ID with an incorrect name could therefore read, update, or delete the resource.
- Floci now validates `Name` for Web ACLs, IP sets, regex pattern sets, and rule groups. CloudFormation callers provide the stored resource name during lifecycle operations.

Valid AWS SDK requests remain unchanged. Invalid requests now match the expected AWS error behavior.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)