### PR TITLE
fix(dynamodb): calculate consumed capacity correctly

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -419,7 +419,7 @@ public class DynamoDbJsonHandler {
             response.set("Item", item);
         }
         addConsumedCapacity(response, request, tableName,
-                readCapacityUnits(itemBytes, request.path("ConsistentRead").asBoolean(false)));
+                readCapacityUnits(itemBytes, request.path("ConsistentRead").asBoolean(false)), null);
         return Response.ok(response).build();
     }
 
@@ -907,7 +907,7 @@ public class DynamoDbJsonHandler {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
         addConsumedCapacity(response, request, tableName,
-                readCapacityUnits(result.scannedBytes(), request.path("ConsistentRead").asBoolean(false)));
+                readCapacityUnits(result.scannedBytes(), request.path("ConsistentRead").asBoolean(false)), queryAccessPath);
         return Response.ok(response).build();
     }
 
@@ -1044,7 +1044,7 @@ public class DynamoDbJsonHandler {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
         addConsumedCapacity(response, request, tableName,
-                readCapacityUnits(result.scannedBytes(), request.path("ConsistentRead").asBoolean(false)));
+                readCapacityUnits(result.scannedBytes(), request.path("ConsistentRead").asBoolean(false)), scanAccessPath);
         return Response.ok(response).build();
     }
 
@@ -1101,6 +1101,12 @@ public class DynamoDbJsonHandler {
 
         // The per-table write cost needs the stored images from before the batch runs.
         var returnCCBatch = request.path("ReturnConsumedCapacity").asText("NONE");
+        if (!VALID_RETURN_CONSUMED_CAPACITY.contains(returnCCBatch)) {
+            throw new AwsException("ValidationException",
+                    "1 validation error detected: Value '" + returnCCBatch
+                    + "' at 'returnConsumedCapacity' failed to satisfy constraint: "
+                    + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]", 400);
+        }
         Map<String, DynamoDbWriteCapacity.Cost> costs = null;
         if (!"NONE".equals(returnCCBatch)) {
             costs = new LinkedHashMap<>();
@@ -2045,7 +2051,7 @@ public class DynamoDbJsonHandler {
     }
 
     private void addConsumedCapacity(ObjectNode response, JsonNode request, String tableName,
-                                      double cu) {
+                                      double cu, DynamoDbAccessPath accessPath) {
         String returnCC = request.path("ReturnConsumedCapacity").asText("NONE");
         if ("NONE".equals(returnCC)) return;
 
@@ -2055,15 +2061,15 @@ public class DynamoDbJsonHandler {
 
         if ("INDEXES".equals(returnCC)) {
             ObjectNode tableCap = objectMapper.createObjectNode();
-            String indexName = request.path("IndexName").asText(null);
-            if (indexName != null) {
+            if (accessPath != null && accessPath.isIndex()) {
                 tableCap.put("CapacityUnits", 0.0);
                 cc.set("Table", tableCap);
-                ObjectNode gsiCaps = objectMapper.createObjectNode();
+                ObjectNode indexCaps = objectMapper.createObjectNode();
                 ObjectNode indexCap = objectMapper.createObjectNode();
                 indexCap.put("CapacityUnits", cu);
-                gsiCaps.set(indexName, indexCap);
-                cc.set("GlobalSecondaryIndexes", gsiCaps);
+                indexCaps.set(accessPath.indexName(), indexCap);
+                cc.set(accessPath.isGlobalSecondaryIndex()
+                        ? "GlobalSecondaryIndexes" : "LocalSecondaryIndexes", indexCaps);
             } else {
                 tableCap.put("CapacityUnits", cu);
                 cc.set("Table", tableCap);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -363,14 +363,15 @@ public class DynamoDbJsonHandler {
             evaluateLegacyExpected(oldItem, expected, conditionalOperator, returnValuesOnConditionCheckFailure);
         }
 
-        dynamoDbService.putItem(tableName, item, conditionExpression, exprAttrNames, exprAttrValues, region, returnValuesOnConditionCheckFailure);
+        var previousItem = dynamoDbService.putItem(tableName, item, conditionExpression,
+                exprAttrNames, exprAttrValues, region, returnValuesOnConditionCheckFailure);
 
         ObjectNode response = objectMapper.createObjectNode();
         if ("ALL_OLD" .equals(returnValues) && oldItem != null) {
             response.set("Attributes", oldItem);
         }
         addItemCollectionMetrics(response, request, tableName, item, region);
-        addConsumedCapacity(response, request, tableName, 1.0);
+        addWriteConsumedCapacity(response, request, tableName, region, previousItem, item);
         return Response.ok(response).build();
     }
 
@@ -404,7 +405,7 @@ public class DynamoDbJsonHandler {
         }
 
         JsonNode item = dynamoDbService.getItem(tableName, key, region);
-        long itemBytes = item != null ? DynamoDbItemSize.calculateItemSize(item) : 0;
+        var itemBytes = item != null ? DynamoDbItemSize.calculateItemSize(item) : 0;
         if (item != null && projectionExpression != null) {
             item = ProjectionEvaluator.project(item, projectionExpression, exprAttrNames);
         } else if (item != null && attributesToGet != null) {
@@ -484,7 +485,7 @@ public class DynamoDbJsonHandler {
             response.set("Attributes", oldItem);
         }
         addItemCollectionMetrics(response, request, tableName, key, region);
-        addConsumedCapacity(response, request, tableName, 1.0);
+        addWriteConsumedCapacity(response, request, tableName, region, oldItem, null);
         return Response.ok(response).build();
     }
 
@@ -596,7 +597,7 @@ public class DynamoDbJsonHandler {
             response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
         }
         addItemCollectionMetrics(response, request, tableName, key, region);
-        addConsumedCapacity(response, request, tableName, 1.0);
+        addWriteConsumedCapacity(response, request, tableName, region, result.oldItem(), result.newItem());
         return Response.ok(response).build();
     }
 
@@ -1098,11 +1099,40 @@ public class DynamoDbJsonHandler {
             }
         }
 
+        // The per-table write cost needs the stored images from before the batch runs.
+        var returnCCBatch = request.path("ReturnConsumedCapacity").asText("NONE");
+        Map<String, DynamoDbWriteCapacity.Cost> costs = null;
+        if (!"NONE".equals(returnCCBatch)) {
+            costs = new LinkedHashMap<>();
+            for (var entry : items.entrySet()) {
+                var costTable = dynamoDbService.describeTable(entry.getKey(), region);
+                var cost = DynamoDbWriteCapacity.Cost.zero();
+                for (var writeReq : entry.getValue()) {
+                    var newItem = writeReq.has("PutRequest")
+                            ? DynamoDbNumberUtils.normalizeNumbersInItem(writeReq.get("PutRequest").get("Item"))
+                            : null;
+                    var keyNode = writeReq.has("PutRequest")
+                            ? writeReq.get("PutRequest").get("Item")
+                            : writeReq.get("DeleteRequest").get("Key");
+                    var previous = dynamoDbService.getItem(entry.getKey(), keyNode, region);
+                    cost = cost.plus(DynamoDbWriteCapacity.forWrite(costTable, previous, newItem));
+                }
+                costs.put(entry.getKey(), cost);
+            }
+        }
+
         dynamoDbService.batchWriteItem(items, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         response.set("UnprocessedItems", objectMapper.createObjectNode());
-        addBatchConsumedCapacity(response, request, items, true);
+        if (costs != null) {
+            var ccArray = objectMapper.createArrayNode();
+            for (var entry : costs.entrySet()) {
+                ccArray.add(writeCapacityNode(entry.getKey(), entry.getValue(),
+                        "INDEXES".equals(returnCCBatch)));
+            }
+            response.set("ConsumedCapacity", ccArray);
+        }
         return Response.ok(response).build();
     }
 
@@ -1966,6 +1996,52 @@ public class DynamoDbJsonHandler {
     private static double readCapacityUnits(long bytes, boolean consistentRead) {
         var units = Math.max(1, (bytes + 4095) / 4096) * 0.5;
         return consistentRead ? units * 2 : units;
+    }
+
+    /**
+     * Write-side ConsumedCapacity with the per-index arms DynamoDB reports under
+     * INDEXES. oldItem and newItem are the stored images around the write; the new
+     * image is normalized the way storage normalizes it so an identical overwrite
+     * compares equal.
+     */
+    private void addWriteConsumedCapacity(ObjectNode response, JsonNode request, String tableName,
+                                           String region, JsonNode oldItem, JsonNode newItem) {
+        String returnCC = request.path("ReturnConsumedCapacity").asText("NONE");
+        if ("NONE".equals(returnCC)) return;
+        TableDefinition table = dynamoDbService.describeTable(tableName, region);
+        var cost = DynamoDbWriteCapacity.forWrite(table, oldItem,
+                newItem != null ? DynamoDbNumberUtils.normalizeNumbersInItem(newItem) : null);
+        response.set("ConsumedCapacity",
+                writeCapacityNode(tableName, cost, "INDEXES".equals(returnCC)));
+    }
+
+    private ObjectNode writeCapacityNode(String tableName, DynamoDbWriteCapacity.Cost cost,
+                                          boolean withBreakdown) {
+        var cc = objectMapper.createObjectNode();
+        cc.put("TableName", DynamoDbTableNames.resolve(tableName));
+        cc.put("CapacityUnits", cost.total());
+        if (withBreakdown) {
+            var tableCap = objectMapper.createObjectNode();
+            tableCap.put("CapacityUnits", cost.table());
+            cc.set("Table", tableCap);
+            if (!cost.gsi().isEmpty()) {
+                cc.set("GlobalSecondaryIndexes", capacityUnitsMap(cost.gsi()));
+            }
+            if (!cost.lsi().isEmpty()) {
+                cc.set("LocalSecondaryIndexes", capacityUnitsMap(cost.lsi()));
+            }
+        }
+        return cc;
+    }
+
+    private ObjectNode capacityUnitsMap(Map<String, Double> unitsByIndex) {
+        var node = objectMapper.createObjectNode();
+        unitsByIndex.forEach((indexName, units) -> {
+            var cap = objectMapper.createObjectNode();
+            cap.put("CapacityUnits", units);
+            node.set(indexName, cap);
+        });
+        return node;
     }
 
     private void addConsumedCapacity(ObjectNode response, JsonNode request, String tableName,

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -370,7 +370,7 @@ public class DynamoDbJsonHandler {
             response.set("Attributes", oldItem);
         }
         addItemCollectionMetrics(response, request, tableName, item, region);
-        addConsumedCapacity(response, request, tableName, 1, true);
+        addConsumedCapacity(response, request, tableName, 1.0);
         return Response.ok(response).build();
     }
 
@@ -404,6 +404,7 @@ public class DynamoDbJsonHandler {
         }
 
         JsonNode item = dynamoDbService.getItem(tableName, key, region);
+        long itemBytes = item != null ? DynamoDbItemSize.calculateItemSize(item) : 0;
         if (item != null && projectionExpression != null) {
             item = ProjectionEvaluator.project(item, projectionExpression, exprAttrNames);
         } else if (item != null && attributesToGet != null) {
@@ -416,7 +417,8 @@ public class DynamoDbJsonHandler {
         if (item != null) {
             response.set("Item", item);
         }
-        addConsumedCapacity(response, request, tableName, item != null ? 1 : 0, false);
+        addConsumedCapacity(response, request, tableName,
+                readCapacityUnits(itemBytes, request.path("ConsistentRead").asBoolean(false)));
         return Response.ok(response).build();
     }
 
@@ -482,7 +484,7 @@ public class DynamoDbJsonHandler {
             response.set("Attributes", oldItem);
         }
         addItemCollectionMetrics(response, request, tableName, key, region);
-        addConsumedCapacity(response, request, tableName, 1, true);
+        addConsumedCapacity(response, request, tableName, 1.0);
         return Response.ok(response).build();
     }
 
@@ -594,7 +596,7 @@ public class DynamoDbJsonHandler {
             response.set("Attributes", getChangedAttributes(result.oldItem(), result.newItem()));
         }
         addItemCollectionMetrics(response, request, tableName, key, region);
-        addConsumedCapacity(response, request, tableName, 1, true);
+        addConsumedCapacity(response, request, tableName, 1.0);
         return Response.ok(response).build();
     }
 
@@ -903,7 +905,8 @@ public class DynamoDbJsonHandler {
         if (result.lastEvaluatedKey() != null) {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
-        addConsumedCapacity(response, request, tableName, queryItems.size(), false);
+        addConsumedCapacity(response, request, tableName,
+                readCapacityUnits(result.scannedBytes(), request.path("ConsistentRead").asBoolean(false)));
         return Response.ok(response).build();
     }
 
@@ -1039,7 +1042,8 @@ public class DynamoDbJsonHandler {
         if (result.lastEvaluatedKey() != null) {
             response.set("LastEvaluatedKey", result.lastEvaluatedKey());
         }
-        addConsumedCapacity(response, request, tableName, scanItems.size(), false);
+        addConsumedCapacity(response, request, tableName,
+                readCapacityUnits(result.scannedBytes(), request.path("ConsistentRead").asBoolean(false)));
         return Response.ok(response).build();
     }
 
@@ -1955,12 +1959,19 @@ public class DynamoDbJsonHandler {
                 .toList();
     }
 
+    /**
+     * Half a read unit per 4KB read, doubled for a strongly consistent read, with the
+     * half-unit minimum DynamoDB charges even when nothing is found.
+     */
+    private static double readCapacityUnits(long bytes, boolean consistentRead) {
+        var units = Math.max(1, (bytes + 4095) / 4096) * 0.5;
+        return consistentRead ? units * 2 : units;
+    }
+
     private void addConsumedCapacity(ObjectNode response, JsonNode request, String tableName,
-                                      int itemCount, boolean isWrite) {
+                                      double cu) {
         String returnCC = request.path("ReturnConsumedCapacity").asText("NONE");
         if ("NONE".equals(returnCC)) return;
-
-        double cu = isWrite ? Math.max(1.0, itemCount) : Math.max(0.5, itemCount * 0.5);
 
         ObjectNode cc = objectMapper.createObjectNode();
         cc.put("TableName", DynamoDbTableNames.resolve(tableName));

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -505,11 +505,12 @@ public class DynamoDbService implements ResourceProvider {
         putItem(tableName, item, null, null, null, region, "NONE");
     }
 
-    public void putItem(String tableName, JsonNode item,
+    /** Returns the previous item stored under the same key, or null when the put inserted. */
+    public JsonNode putItem(String tableName, JsonNode item,
                          String conditionExpression,
                          JsonNode exprAttrNames, JsonNode exprAttrValues,
                          String region, String returnValuesOnConditionCheckFailure) {
-        putItemInternal(tableName, item, conditionExpression, exprAttrNames, exprAttrValues,
+        return putItemInternal(tableName, item, conditionExpression, exprAttrNames, exprAttrValues,
                         region, returnValuesOnConditionCheckFailure, true);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -960,7 +960,7 @@ public class DynamoDbService implements ResourceProvider {
         int accSize = 0;
         int included = -1; // index one past the last included item; -1 = no boundary hit
         for (int i = 0; i < evaluatedItems.size(); i++) {
-            int sz = DynamoDbItemSize.calculateItemSize(evaluatedItems.get(i));
+            int sz = readItemSize(evaluatedItems.get(i), accessPath, table);
             if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
                 included = i; // the 1 MB cap stops the read BEFORE this item
                 break;
@@ -1054,7 +1054,7 @@ public class DynamoDbService implements ResourceProvider {
             // is not read, does not count toward ScannedCount, and the cursor
             // anchors to the previous scanned item (which, with a filter, may well
             // be an item that was not returned).
-            int sz = DynamoDbItemSize.calculateItemSize(item);
+            int sz = readItemSize(item, accessPath, table);
             if (accSize > 0 && accSize + sz > MAX_RESPONSE_BYTES) {
                 lastEvaluatedKey = buildKeyNode(table, lastScanned, lekPkName, lekSkName, indexScan);
                 break;
@@ -1082,6 +1082,17 @@ public class DynamoDbService implements ResourceProvider {
         LOG.tracev("Scan on {0}: returned={1} scanned={2}",
                 canonicalTableName, results.size(), totalScanned);
         return new ScanResult(results, totalScanned, accSize, lastEvaluatedKey);
+    }
+
+    // A read served by a KEYS_ONLY or INCLUDE index is sized on the projection the
+    // index stores, not on the full base item. Characterised on real AWS (us-east-1,
+    // 2026-09-05): querying a 20KB item through a KEYS_ONLY GSI costs 0.5 units.
+    private int readItemSize(JsonNode item, DynamoDbAccessPath accessPath, TableDefinition table) {
+        if (!accessPath.isIndex() || "ALL".equals(accessPath.projectionType())) {
+            return DynamoDbItemSize.calculateItemSize(item);
+        }
+        return DynamoDbItemSize.calculateItemSize(ProjectionEvaluator.trimToAttributes(
+                (ObjectNode) item, accessPath.projectedAttributeNames(table)));
     }
 
     public boolean matchesScanFilterPublic(JsonNode item, JsonNode scanFilter) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -857,7 +857,7 @@ public class DynamoDbService implements ResourceProvider {
         List<String> sortKeyNames = accessPath.sortKeyNames();
 
         var items = itemsByTable.get(scopedItemsKey(storageKey));
-        if (items == null) return new QueryResult(List.of(), 0, null);
+        if (items == null) return new QueryResult(List.of(), 0, 0, null);
 
         List<JsonNode> results = new ArrayList<>();
 
@@ -986,7 +986,7 @@ public class DynamoDbService implements ResourceProvider {
 
         LOG.tracev("Query on {0}: returned={1} scanned={2}",
                 canonicalTableName, evaluatedItems.size(), scannedCount);
-        return new QueryResult(evaluatedItems, scannedCount, lastEvaluatedKey);
+        return new QueryResult(evaluatedItems, scannedCount, accSize, lastEvaluatedKey);
     }
 
     public ScanResult scan(String tableName, String filterExpression,
@@ -1009,7 +1009,7 @@ public class DynamoDbService implements ResourceProvider {
         DynamoDbAccessPath accessPath = DynamoDbAccessPath.resolve(table, indexName);
 
         var items = itemsByTable.get(scopedItemsKey(storageKey));
-        if (items == null) return new ScanResult(List.of(), 0, null);
+        if (items == null) return new ScanResult(List.of(), 0, 0, null);
 
         // ConcurrentSkipListMap keeps items sorted by base item key — no sort needed.
         // Use tailMap for O(log n) pagination instead of O(n) linear search.
@@ -1080,7 +1080,7 @@ public class DynamoDbService implements ResourceProvider {
 
         LOG.tracev("Scan on {0}: returned={1} scanned={2}",
                 canonicalTableName, results.size(), totalScanned);
-        return new ScanResult(results, totalScanned, lastEvaluatedKey);
+        return new ScanResult(results, totalScanned, accSize, lastEvaluatedKey);
     }
 
     public boolean matchesScanFilterPublic(JsonNode item, JsonNode scanFilter) {
@@ -3172,8 +3172,11 @@ public class DynamoDbService implements ResourceProvider {
     }
 
     public record UpdateResult(JsonNode newItem, JsonNode oldItem) {}
-    public record ScanResult(List<JsonNode> items, int scannedCount, JsonNode lastEvaluatedKey) {}
-    public record QueryResult(List<JsonNode> items, int scannedCount, JsonNode lastEvaluatedKey) {}
+
+    // scannedBytes carries the pre-filter size of the read items: DynamoDB bills a
+    // Query or Scan on what it read, not on what survived the filter or projection.
+    public record ScanResult(List<JsonNode> items, int scannedCount, long scannedBytes, JsonNode lastEvaluatedKey) {}
+    public record QueryResult(List<JsonNode> items, int scannedCount, long scannedBytes, JsonNode lastEvaluatedKey) {}
 
     // --- Export Operations ---
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacity.java
@@ -13,9 +13,10 @@ import java.util.Map;
 /**
  * Computes the write ConsumedCapacity of a single item write the way DynamoDB bills it.
  * The table is charged one unit per 1KB of the larger image. Each secondary index is
- * charged by how the write changes what the index stores: one unit for an insert, an
- * in-place update or a delete, two when the index key changes (delete plus insert),
- * and nothing when the stored view is unchanged or the item never touches the index.
+ * charged by how the write changes what the index stores, at one unit per 1KB of the
+ * stored view: one view write for an insert, an in-place update or a delete, two view
+ * writes when the index key changes (delete plus insert), and nothing when the stored
+ * view is unchanged or the item never touches the index.
  */
 final class DynamoDbWriteCapacity {
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacity.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacity.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Computes the write ConsumedCapacity of a single item write the way DynamoDB bills it.
+ * The table is charged one unit per 1KB of the larger image. Each secondary index is
+ * charged by how the write changes what the index stores: one unit for an insert, an
+ * in-place update or a delete, two when the index key changes (delete plus insert),
+ * and nothing when the stored view is unchanged or the item never touches the index.
+ */
+final class DynamoDbWriteCapacity {
+
+    private DynamoDbWriteCapacity() {}
+
+    record Cost(double table, Map<String, Double> gsi, Map<String, Double> lsi) {
+
+        private static final Cost ZERO = new Cost(0, Map.of(), Map.of());
+
+        static Cost zero() {
+            return ZERO;
+        }
+
+        double total() {
+            var sum = table;
+            for (var units : gsi.values()) sum += units;
+            for (var units : lsi.values()) sum += units;
+            return sum;
+        }
+
+        Cost plus(Cost other) {
+            var mergedGsi = new LinkedHashMap<>(gsi);
+            other.gsi().forEach((name, units) -> mergedGsi.merge(name, units, Double::sum));
+            var mergedLsi = new LinkedHashMap<>(lsi);
+            other.lsi().forEach((name, units) -> mergedLsi.merge(name, units, Double::sum));
+            return new Cost(table + other.table(), mergedGsi, mergedLsi);
+        }
+    }
+
+    /** oldItem and newItem are the stored images before and after the write; either may be null. */
+    static Cost forWrite(TableDefinition table, JsonNode oldItem, JsonNode newItem) {
+        var tableUnits = (double) Math.max(1, Math.max(sizeUnits(oldItem), sizeUnits(newItem)));
+        var gsiUnits = new LinkedHashMap<String, Double>();
+        var gsis = table.getGlobalSecondaryIndexes();
+        if (gsis != null) {
+            for (var gsi : gsis) {
+                var units = indexUnits(table, gsi.getKeySchema(), gsi.getProjectionType(),
+                        gsi.getNonKeyAttributes(), oldItem, newItem);
+                if (units > 0) {
+                    gsiUnits.put(gsi.getIndexName(), units);
+                }
+            }
+        }
+        var lsiUnits = new LinkedHashMap<String, Double>();
+        var lsis = table.getLocalSecondaryIndexes();
+        if (lsis != null) {
+            for (var lsi : lsis) {
+                var units = indexUnits(table, lsi.getKeySchema(), lsi.getProjectionType(),
+                        lsi.getNonKeyAttributes(), oldItem, newItem);
+                if (units > 0) {
+                    lsiUnits.put(lsi.getIndexName(), units);
+                }
+            }
+        }
+        return new Cost(tableUnits, gsiUnits, lsiUnits);
+    }
+
+    private static double indexUnits(TableDefinition table, List<KeySchemaElement> keySchema,
+                                     String projectionType, List<String> nonKeyAttributes,
+                                     JsonNode oldItem, JsonNode newItem) {
+        if (keySchema == null) {
+            return 0;
+        }
+        var oldView = indexView(table, keySchema, projectionType, nonKeyAttributes, oldItem);
+        var newView = indexView(table, keySchema, projectionType, nonKeyAttributes, newItem);
+        if (oldView == null) {
+            if (newView == null) {
+                return 0;
+            }
+            return sizeUnits(newView);
+        }
+        if (newView == null) {
+            return sizeUnits(oldView);
+        }
+        if (indexKeyChanged(keySchema, oldItem, newItem)) {
+            return sizeUnits(oldView) + sizeUnits(newView);
+        }
+        if (oldView.equals(newView)) {
+            return 0;
+        }
+        return Math.max(sizeUnits(oldView), sizeUnits(newView));
+    }
+
+    /**
+     * The projection of the item the index stores, or null when the item is absent from
+     * the index because it lacks an index key attribute (sparse index behavior).
+     */
+    private static JsonNode indexView(TableDefinition table, List<KeySchemaElement> keySchema,
+                                      String projectionType, List<String> nonKeyAttributes,
+                                      JsonNode item) {
+        if (item == null) {
+            return null;
+        }
+        for (var element : keySchema) {
+            if (!item.has(element.getAttributeName())) {
+                return null;
+            }
+        }
+        if (projectionType == null || "ALL".equals(projectionType)) {
+            return item;
+        }
+        var keep = new LinkedHashSet<String>();
+        keep.add(table.getPartitionKeyName());
+        if (table.getSortKeyName() != null) {
+            keep.add(table.getSortKeyName());
+        }
+        for (var element : keySchema) {
+            keep.add(element.getAttributeName());
+        }
+        if ("INCLUDE".equals(projectionType) && nonKeyAttributes != null) {
+            keep.addAll(nonKeyAttributes);
+        }
+        var view = JsonNodeFactory.instance.objectNode();
+        for (var name : keep) {
+            if (item.has(name)) {
+                view.set(name, item.get(name));
+            }
+        }
+        return view;
+    }
+
+    private static boolean indexKeyChanged(List<KeySchemaElement> keySchema,
+                                           JsonNode oldItem, JsonNode newItem) {
+        for (var element : keySchema) {
+            var name = element.getAttributeName();
+            if (!oldItem.get(name).equals(newItem.get(name))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static long sizeUnits(JsonNode image) {
+        if (image == null) {
+            return 0;
+        }
+        return Math.max(1, (DynamoDbItemSize.calculateItemSize(image) + 1023) / 1024);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
@@ -48,12 +48,17 @@ class DynamoDbConsumedCapacityIntegrationTest {
                     "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
                     "AttributeDefinitions": [
                         {"AttributeName": "pk", "AttributeType": "S"},
-                        {"AttributeName": "gsiPk", "AttributeType": "S"}
+                        {"AttributeName": "gsiPk", "AttributeType": "S"},
+                        {"AttributeName": "gsi2Pk", "AttributeType": "S"}
                     ],
                     "GlobalSecondaryIndexes": [{
                         "IndexName": "gsi1",
                         "KeySchema": [{"AttributeName": "gsiPk", "KeyType": "HASH"}],
                         "Projection": {"ProjectionType": "ALL"}
+                    }, {
+                        "IndexName": "gsi2",
+                        "KeySchema": [{"AttributeName": "gsi2Pk", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "KEYS_ONLY"}
                     }],
                     "BillingMode": "PAY_PER_REQUEST"
                 }
@@ -229,6 +234,56 @@ class DynamoDbConsumedCapacityIntegrationTest {
             .body("ConsumedCapacity.CapacityUnits", equalTo(2.0f))
             .body("ConsumedCapacity.Table", nullValue())
             .body("ConsumedCapacity.GlobalSecondaryIndexes", nullValue());
+    }
+
+    /**
+     * A read served by a secondary index is billed on what the index stores, not on
+     * the full base item. On real AWS a 20KB item behind a KEYS_ONLY GSI costs 0.5
+     * units to query while the same item through an ALL projection carries its size
+     * (measured us-east-1, 2026-09-05).
+     */
+    @Test
+    @Order(9)
+    void indexReadsAreBilledOnTheProjectedView() {
+        putItem("""
+            {"pk": {"S": "cc-big"}, "gsiPk": {"S": "g-big"}, "gsi2Pk": {"S": "g-big"}, "filler": {"S": "%s"}}
+            """.formatted("x".repeat(9000)));
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "gsi2",
+                    "KeyConditionExpression": "gsi2Pk = :g",
+                    "ExpressionAttributeValues": {":g": {"S": "g-big"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(1))
+            .body("ConsumedCapacity.CapacityUnits", equalTo(0.5f));
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "IndexName": "gsi1",
+                    "KeyConditionExpression": "gsiPk = :g",
+                    "ExpressionAttributeValues": {":g": {"S": "g-big"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Count", equalTo(1))
+            .body("ConsumedCapacity.CapacityUnits", equalTo(1.5f));
     }
 
     private static void putItem(String itemJson) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
@@ -342,6 +342,103 @@ class DynamoDbConsumedCapacityIntegrationTest {
             .body("ConsumedCapacity[0].GlobalSecondaryIndexes", nullValue());
     }
 
+    @Test
+    @Order(12)
+    void batchWriteItemRejectsAnInvalidReturnConsumedCapacity() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchWriteItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": [{"PutRequest": {"Item": {"pk": {"S": "cc-bw-bad"}}}}]
+                    },
+                    "ReturnConsumedCapacity": "BOGUS"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("message", equalTo("1 validation error detected: Value 'BOGUS' at "
+                + "'returnConsumedCapacity' failed to satisfy constraint: "
+                + "Member must satisfy enum value set: [INDEXES, TOTAL, NONE]"));
+    }
+
+    /**
+     * A read served by an LSI reports its units under LocalSecondaryIndexes with a
+     * zero Table entry, measured on real DynamoDB (us-east-1, 2026-09-05).
+     */
+    @Test
+    @Order(13)
+    void lsiReadReportsItsUnitsUnderLocalSecondaryIndexes() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "CapacityLsiTable",
+                    "KeySchema": [
+                        {"AttributeName": "pk", "KeyType": "HASH"},
+                        {"AttributeName": "sk", "KeyType": "RANGE"}
+                    ],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "sk", "AttributeType": "S"},
+                        {"AttributeName": "lsiSk", "AttributeType": "S"}
+                    ],
+                    "LocalSecondaryIndexes": [{
+                        "IndexName": "lsi1",
+                        "KeySchema": [
+                            {"AttributeName": "pk", "KeyType": "HASH"},
+                            {"AttributeName": "lsiSk", "KeyType": "RANGE"}
+                        ],
+                        "Projection": {"ProjectionType": "ALL"}
+                    }],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """)
+        .when().post("/").then().statusCode(200);
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "CapacityLsiTable",
+                    "Item": {"pk": {"S": "p1"}, "sk": {"S": "1"}, "lsiSk": {"S": "L1"}}
+                }
+                """)
+        .when().post("/").then().statusCode(200);
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "CapacityLsiTable",
+                    "IndexName": "lsi1",
+                    "KeyConditionExpression": "pk = :p",
+                    "ExpressionAttributeValues": {":p": {"S": "p1"}},
+                    "ConsistentRead": true,
+                    "ReturnConsumedCapacity": "INDEXES"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.Table.CapacityUnits", equalTo(0.0f))
+            .body("ConsumedCapacity.LocalSecondaryIndexes.lsi1.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.GlobalSecondaryIndexes", nullValue());
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+            .contentType(CT)
+            .body("""
+                {"TableName": "CapacityLsiTable"}
+                """)
+        .when().post("/").then().statusCode(200);
+    }
+
     private static void putItem(String itemJson) {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.PutItem")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
@@ -286,6 +286,62 @@ class DynamoDbConsumedCapacityIntegrationTest {
             .body("ConsumedCapacity.CapacityUnits", equalTo(1.5f));
     }
 
+    @Test
+    @Order(10)
+    void batchWriteItemReportsPerTableEntryWithTouchedArms() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchWriteItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": [
+                            {"PutRequest": {"Item": {"pk": {"S": "cc-bw-1"}, "gsiPk": {"S": "g-bw"}}}},
+                            {"PutRequest": {"Item": {"pk": {"S": "cc-bw-2"}}}}
+                        ]
+                    },
+                    "ReturnConsumedCapacity": "INDEXES"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.size()", equalTo(1))
+            .body("ConsumedCapacity[0].TableName", equalTo(TABLE))
+            .body("ConsumedCapacity[0].CapacityUnits", equalTo(3.0f))
+            .body("ConsumedCapacity[0].Table.CapacityUnits", equalTo(2.0f))
+            .body("ConsumedCapacity[0].GlobalSecondaryIndexes.gsi1.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity[0].LocalSecondaryIndexes", nullValue());
+    }
+
+    @Test
+    @Order(11)
+    void batchWriteItemUnderTotalFoldsTheArmsWithNoBreakdown() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.BatchWriteItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "RequestItems": {
+                        "%s": [
+                            {"PutRequest": {"Item": {"pk": {"S": "cc-bw-3"}, "gsiPk": {"S": "g-bw2"}}}},
+                            {"PutRequest": {"Item": {"pk": {"S": "cc-bw-4"}}}}
+                        ]
+                    },
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.size()", equalTo(1))
+            .body("ConsumedCapacity[0].CapacityUnits", equalTo(3.0f))
+            .body("ConsumedCapacity[0].Table", nullValue())
+            .body("ConsumedCapacity[0].GlobalSecondaryIndexes", nullValue());
+    }
+
     private static void putItem(String itemJson) {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.PutItem")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbConsumedCapacityIntegrationTest.java
@@ -1,0 +1,273 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the ConsumedCapacity magnitudes to the DynamoDB billing model, as measured by
+ * the paritysuite dynamodb-conformance tier1 suite. Reads cost half a unit per 4KB,
+ * doubled for a strongly consistent read, and Query and Scan are sized on what was
+ * read before the filter. Writes charge the table plus each index whose stored view
+ * the write changes, and no operation reports a read/write split.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DynamoDbConsumedCapacityIntegrationTest {
+
+    private static final String CT = "application/x-amz-json-1.0";
+    private static final String TABLE = "CapacityParityTable";
+    private static int testPort;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(1)
+    void createTable() {
+        testPort = RestAssured.port;
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [
+                        {"AttributeName": "pk", "AttributeType": "S"},
+                        {"AttributeName": "gsiPk", "AttributeType": "S"}
+                    ],
+                    "GlobalSecondaryIndexes": [{
+                        "IndexName": "gsi1",
+                        "KeySchema": [{"AttributeName": "gsiPk", "KeyType": "HASH"}],
+                        "Projection": {"ProjectionType": "ALL"}
+                    }],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(2)
+    void strongConsistentGetItemCostsOneUnitWithNoSplit() {
+        putItem("""
+            {"pk": {"S": "cc-get"}, "data": {"S": "x"}}
+            """);
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "cc-get"}},
+                    "ConsistentRead": true,
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.ReadCapacityUnits", nullValue())
+            .body("ConsumedCapacity.WriteCapacityUnits", nullValue());
+    }
+
+    @Test
+    @Order(3)
+    void eventualGetItemCostsHalfAUnit() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Key": {"pk": {"S": "cc-get"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(0.5f));
+    }
+
+    @Test
+    @Order(4)
+    void queryUnderIndexesReportsTableArmWithNoSplit() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Query")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeyConditionExpression": "pk = :pk",
+                    "ExpressionAttributeValues": {":pk": {"S": "cc-get"}},
+                    "ConsistentRead": true,
+                    "ReturnConsumedCapacity": "INDEXES"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.Table.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.Table.ReadCapacityUnits", nullValue())
+            .body("ConsumedCapacity.ReadCapacityUnits", nullValue());
+    }
+
+    /**
+     * A Scan is billed on what it read, not on what survived the filter. Six 1KB
+     * items make the unfiltered read cost more than the half-unit minimum, so a
+     * post-filter or per-returned-item model would report a smaller figure for
+     * the filter that matches nothing.
+     */
+    @Test
+    @Order(5)
+    void scanWithFilterCostsWhatTheUnfilteredScanCosts() {
+        for (var i = 0; i < 6; i++) {
+            putItem("""
+                {"pk": {"S": "cc-scan-%d"}, "keep": {"S": "no"}, "filler": {"S": "%s"}}
+                """.formatted(i, "x".repeat(1000)));
+        }
+        float plain = scanUnits("""
+            {"TableName": "%s", "ReturnConsumedCapacity": "TOTAL"}
+            """.formatted(TABLE));
+        float filtered = scanUnits("""
+            {
+                "TableName": "%s",
+                "FilterExpression": "keep = :k",
+                "ExpressionAttributeValues": {":k": {"S": "yes"}},
+                "ReturnConsumedCapacity": "TOTAL"
+            }
+            """.formatted(TABLE));
+        assertTrue(plain >= 1.0f, "six 1KB items must cost more than the half-unit minimum");
+        assertEquals(plain, filtered, "a filter matching nothing must not change the cost");
+    }
+
+    @Test
+    @Order(6)
+    void putItemReportsTheGsiWriteBesideTheTableWrite() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "cc-idx"}, "gsiPk": {"S": "g1"}},
+                    "ReturnConsumedCapacity": "INDEXES"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(2.0f))
+            .body("ConsumedCapacity.Table.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.GlobalSecondaryIndexes.gsi1.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.LocalSecondaryIndexes", nullValue());
+    }
+
+    @Test
+    @Order(7)
+    void identicalOverwriteChargesNoIndexArms() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "cc-idx"}, "gsiPk": {"S": "g1"}},
+                    "ReturnConsumedCapacity": "INDEXES"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.Table.CapacityUnits", equalTo(1.0f))
+            .body("ConsumedCapacity.GlobalSecondaryIndexes", nullValue());
+    }
+
+    @Test
+    @Order(8)
+    void putItemUnderTotalFoldsTheIndexCostWithNoBreakdown() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(CT)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "cc-idx-total"}, "gsiPk": {"S": "g2"}},
+                    "ReturnConsumedCapacity": "TOTAL"
+                }
+                """.formatted(TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ConsumedCapacity.CapacityUnits", equalTo(2.0f))
+            .body("ConsumedCapacity.Table", nullValue())
+            .body("ConsumedCapacity.GlobalSecondaryIndexes", nullValue());
+    }
+
+    private static void putItem(String itemJson) {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(CT)
+            .body("""
+                {"TableName": "%s", "Item": %s}
+                """.formatted(TABLE, itemJson))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    private static float scanUnits(String body) {
+        return given()
+                .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+                .contentType(CT)
+                .body(body)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract().path("ConsumedCapacity.CapacityUnits");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        given()
+                .port(testPort)
+                .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+                .contentType(CT)
+                .body("""
+                    {"TableName": "%s"}
+                    """.formatted(TABLE))
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacityTest.java
@@ -1,0 +1,176 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.dynamodb.model.GlobalSecondaryIndex;
+import io.github.hectorvent.floci.services.dynamodb.model.KeySchemaElement;
+import io.github.hectorvent.floci.services.dynamodb.model.LocalSecondaryIndex;
+import io.github.hectorvent.floci.services.dynamodb.model.TableDefinition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the write ConsumedCapacity model. The table setup mirrors the
+ * paritysuite dynamodb-conformance index write-capacity ladder: a GSI with an
+ * INCLUDE projection as the projected/non-projected lever, and an ALL-projected
+ * LSI. Every charge below is a value measured on real DynamoDB by that suite.
+ */
+class DynamoDbWriteCapacityTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private TableDefinition table;
+
+    @BeforeEach
+    void setUp() {
+        table = new TableDefinition();
+        table.setKeySchema(List.of(
+                new KeySchemaElement("pk", "HASH"),
+                new KeySchemaElement("sk", "RANGE")));
+        table.setGlobalSecondaryIndexes(List.of(new GlobalSecondaryIndex(
+                "gsi-inc",
+                List.of(new KeySchemaElement("gsiPk", "HASH")),
+                null, "INCLUDE", List.of("proj"))));
+        table.setLocalSecondaryIndexes(List.of(new LocalSecondaryIndex(
+                "lsi1",
+                List.of(new KeySchemaElement("pk", "HASH"),
+                        new KeySchemaElement("lsiSk", "RANGE")),
+                null, "ALL")));
+    }
+
+    private static ObjectNode item(String json) {
+        try {
+            return (ObjectNode) mapper.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static ObjectNode fullItem() {
+        return item("""
+                {
+                  "pk": {"S": "p1"}, "sk": {"S": "1"},
+                  "gsiPk": {"S": "g1"}, "lsiSk": {"S": "L1"},
+                  "proj": {"S": "p"}, "other": {"S": "o"}
+                }
+                """);
+    }
+
+    @Test
+    void insertChargesTableAndEveryIndexTheItemEnters() {
+        var cost = DynamoDbWriteCapacity.forWrite(table, null, fullItem());
+        assertEquals(1.0, cost.table());
+        assertEquals(Map.of("gsi-inc", 1.0), cost.gsi());
+        assertEquals(Map.of("lsi1", 1.0), cost.lsi());
+        assertEquals(3.0, cost.total());
+    }
+
+    @Test
+    void sparseInsertChargesNothingForTheIndexesItMisses() {
+        var sparse = item("""
+                {"pk": {"S": "p1"}, "sk": {"S": "1"}, "other": {"S": "o"}}
+                """);
+        var cost = DynamoDbWriteCapacity.forWrite(table, null, sparse);
+        assertEquals(1.0, cost.total());
+        assertTrue(cost.gsi().isEmpty(), "an item without gsiPk never enters the GSI");
+        assertTrue(cost.lsi().isEmpty(), "an item without lsiSk never enters the LSI");
+    }
+
+    @Test
+    void identicalOverwriteChargesNoIndexWritesAtAll() {
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), fullItem());
+        assertEquals(1.0, cost.table(), "the table write is still charged");
+        assertTrue(cost.gsi().isEmpty());
+        assertTrue(cost.lsi().isEmpty());
+    }
+
+    @Test
+    void nonProjectedAttributeChangeChargesNothingOnTheIncludeIndex() {
+        var updated = fullItem();
+        updated.set("other", item("""
+                {"S": "o2"}
+                """));
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), updated);
+        assertTrue(cost.gsi().isEmpty(), "other is outside the INCLUDE projection");
+        assertEquals(Map.of("lsi1", 1.0), cost.lsi());
+        assertEquals(2.0, cost.total());
+    }
+
+    @Test
+    void projectedAttributeChangeChargesOneIndexWrite() {
+        var updated = fullItem();
+        updated.set("proj", item("""
+                {"S": "p2"}
+                """));
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), updated);
+        assertEquals(Map.of("gsi-inc", 1.0), cost.gsi());
+        assertEquals(Map.of("lsi1", 1.0), cost.lsi());
+        assertEquals(3.0, cost.total());
+    }
+
+    @Test
+    void indexKeyChangeChargesDeletePlusInsert() {
+        var moved = fullItem();
+        moved.set("gsiPk", item("""
+                {"S": "g-moved"}
+                """));
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), moved);
+        assertEquals(Map.of("gsi-inc", 2.0), cost.gsi());
+        assertEquals(Map.of("lsi1", 1.0), cost.lsi());
+        assertEquals(4.0, cost.total());
+    }
+
+    @Test
+    void removingTheIndexKeyChargesDeleteOnly() {
+        var removed = fullItem();
+        removed.remove("gsiPk");
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), removed);
+        assertEquals(Map.of("gsi-inc", 1.0), cost.gsi());
+        assertEquals(Map.of("lsi1", 1.0), cost.lsi());
+        assertEquals(3.0, cost.total());
+    }
+
+    @Test
+    void lsiKeyChangeWalksTheSameLadder() {
+        var moved = fullItem();
+        moved.set("lsiSk", item("""
+                {"S": "L2"}
+                """));
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), moved);
+        assertTrue(cost.gsi().isEmpty(), "lsiSk is outside the GSI projection, its view never changed");
+        assertEquals(Map.of("lsi1", 2.0), cost.lsi());
+        assertEquals(3.0, cost.total());
+    }
+
+    @Test
+    void deleteChargesOneWritePerIndexTheItemOccupied() {
+        var cost = DynamoDbWriteCapacity.forWrite(table, fullItem(), null);
+        assertEquals(1.0, cost.table());
+        assertEquals(Map.of("gsi-inc", 1.0), cost.gsi());
+        assertEquals(Map.of("lsi1", 1.0), cost.lsi());
+        assertEquals(3.0, cost.total());
+    }
+
+    @Test
+    void deleteOfAMissingItemStillChargesOneTableUnit() {
+        var cost = DynamoDbWriteCapacity.forWrite(table, null, null);
+        assertEquals(1.0, cost.total());
+    }
+
+    @Test
+    void tableUnitsFollowTheLargerImagePerKilobyte() {
+        var big = item("""
+                {"pk": {"S": "p1"}, "sk": {"S": "1"}}
+                """);
+        big.set("filler", item("""
+                {"S": "%s"}
+                """.formatted("x".repeat(2500))));
+        var cost = DynamoDbWriteCapacity.forWrite(table, big, fullItem());
+        assertEquals(3.0, cost.table(), "the larger of the two images rounds up per 1KB");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbWriteCapacityTest.java
@@ -163,6 +163,19 @@ class DynamoDbWriteCapacityTest {
     }
 
     @Test
+    void costPlusSumsTheTableAndMergesIndexArms() {
+        var indexed = DynamoDbWriteCapacity.forWrite(table, null, fullItem());
+        var sparse = DynamoDbWriteCapacity.forWrite(table, null, item("""
+                {"pk": {"S": "p2"}, "sk": {"S": "1"}, "other": {"S": "o"}}
+                """));
+        var sum = DynamoDbWriteCapacity.Cost.zero().plus(indexed).plus(sparse);
+        assertEquals(2.0, sum.table());
+        assertEquals(Map.of("gsi-inc", 1.0), sum.gsi());
+        assertEquals(Map.of("lsi1", 1.0), sum.lsi());
+        assertEquals(4.0, sum.total());
+    }
+
+    @Test
     void tableUnitsFollowTheLargerImagePerKilobyte() {
         var big = item("""
                 {"pk": {"S": "p1"}, "sk": {"S": "1"}}


### PR DESCRIPTION
## Summary

This PR fixes consumed-capacity calculation per [dynamodb-conformance](https://github.com/paritysuite/dynamodb-conformance)

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Fixes 19 tier1 tests, 7 read-side and 12 write-side in @hicksy's https://github.com/paritysuite/dynamodb-conformance
(Thanks hicksy! 👍 )


Read billing

- The flat-rate (0.5-per-returned-item) is replaced with the real model
- GetItem is charged on the stored item size and now honours ConsistentRead
- Query and Scan are charged on the pre-filter bytes they read, so a filter or projection no longer makes a read look cheaper

Index write billing

- New DynamoDbWriteCapacity computes each write's cost (table cost + per-index costs)
- An index is charged by how the write changes its stored view
- BatchWriteItem pre-fetches images when capacity is requested and sums costs per table
- TOTAL folds everything into one number, INDEXES adds Table plus per-index maps, never a read/write split

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

