### PR TITLE
fix(dynamodb): merge shared-prefix projection paths and compact list indices

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -134,6 +134,7 @@ final class ProjectionEvaluator {
                 while (i < rest.length() && rest.charAt(i) == '[') {
                     int close = rest.indexOf(']', i);
                     if (close < 0) break;
+                    validateListIndex(rest.substring(i + 1, close));
                     segments.add(rest.substring(i, close + 1)); // e.g. "[0]"
                     i = close + 1;
                 }
@@ -142,6 +143,30 @@ final class ProjectionEvaluator {
             }
         }
         return segments;
+    }
+
+    // DynamoDB rejects a non-numeric bracket segment as a syntax error and a numeric
+    // index above 4294967294 as out of the allowable range, both at expression level.
+    // Characterised on real DynamoDB (us-east-1, 2026-09-05).
+    private static void validateListIndex(String content) {
+        for (int i = 0; i < content.length(); i++) {
+            if (!Character.isDigit(content.charAt(i))) {
+                throw new AwsException("ValidationException",
+                        "Invalid ProjectionExpression: Syntax error; token: \"" + content.charAt(i)
+                        + "\", near: \"[" + content + "]\"", 400);
+            }
+        }
+        if (content.isEmpty()) {
+            throw new AwsException("ValidationException",
+                    "Invalid ProjectionExpression: Syntax error; token: \"]\", near: \"[]\"", 400);
+        }
+        var canonical = content.replaceFirst("^0+(?=.)", "");
+        if (canonical.length() > 10
+                || (canonical.length() == 10 && canonical.compareTo("4294967294") > 0)) {
+            throw new AwsException("ValidationException",
+                    "Invalid ProjectionExpression: List index is not within the allowable range; "
+                    + "index: [" + content + "]", 400);
+        }
     }
 
     private static String resolveSegment(String seg, JsonNode exprAttrNames) {
@@ -163,13 +188,14 @@ final class ProjectionEvaluator {
     private static final class PathTrie {
         private boolean terminal;
         private final Map<String, PathTrie> names = new LinkedHashMap<>();
-        private final TreeMap<Integer, PathTrie> indices = new TreeMap<>();
+        // Long keys: the allowable index range (up to 4294967294) exceeds Integer.MAX_VALUE.
+        private final TreeMap<Long, PathTrie> indices = new TreeMap<>();
 
         void insert(List<String> segments) {
             PathTrie node = this;
             for (String seg : segments) {
                 if (seg.startsWith("[")) {
-                    int idx = Integer.parseInt(seg.substring(1, seg.length() - 1));
+                    long idx = Long.parseLong(seg.substring(1, seg.length() - 1));
                     node = node.indices.computeIfAbsent(idx, k -> new PathTrie());
                 } else {
                     node = node.names.computeIfAbsent(seg, k -> new PathTrie());
@@ -190,10 +216,10 @@ final class ProjectionEvaluator {
         if (!node.indices.isEmpty() && src.has("L")) {
             JsonNode list = src.get("L");
             ArrayNode projectedList = MAPPER.createArrayNode();
-            for (Map.Entry<Integer, PathTrie> entry : node.indices.entrySet()) {
-                int idx = entry.getKey();
-                if (idx < 0 || idx >= list.size()) continue;
-                JsonNode projected = projectValue(list.get(idx), entry.getValue());
+            for (Map.Entry<Long, PathTrie> entry : node.indices.entrySet()) {
+                long idx = entry.getKey();
+                if (idx >= list.size()) continue;
+                JsonNode projected = projectValue(list.get((int) idx), entry.getValue());
                 if (projected != null) {
                     projectedList.add(projected);
                 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -145,9 +145,9 @@ final class ProjectionEvaluator {
         return segments;
     }
 
-    // DynamoDB rejects a non-numeric bracket segment as a syntax error and a numeric
-    // index above 4294967294 as out of the allowable range, both at expression level.
-    // Characterised on real DynamoDB (us-east-1, 2026-09-05).
+    // DynamoDB rejects a non-numeric bracket segment and a leading zero as syntax
+    // errors, and a numeric index above 4294967294 as out of the allowable range,
+    // all at expression level. Verified on real DynamoDB (us-east-1, 2026-09-05).
     private static void validateListIndex(String content) {
         if (content.isEmpty()) {
             throw syntaxError("ProjectionExpression", "]", "[]");
@@ -158,12 +158,11 @@ final class ProjectionEvaluator {
                         String.valueOf(content.charAt(i)), "[" + content + "]");
             }
         }
-        int firstDigit = 0;
-        while (firstDigit < content.length() - 1 && content.charAt(firstDigit) == '0') {
-            firstDigit++;
+        if (content.length() > 1 && content.charAt(0) == '0') {
+            throw syntaxError("ProjectionExpression", "0",
+                    content.substring(0, Math.min(3, content.length())));
         }
-        var canonical = content.substring(firstDigit);
-        if (canonical.length() > 10 || Long.parseLong(canonical) > MAX_LIST_INDEX) {
+        if (content.length() > 10 || Long.parseLong(content) > MAX_LIST_INDEX) {
             throw new AwsException("ValidationException",
                     "Invalid ProjectionExpression: List index is not within the allowable range; "
                     + "index: [" + content + "]", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -40,7 +40,9 @@ final class ProjectionEvaluator {
         PathTrie root = new PathTrie();
         for (String rawPath : splitProjectionPaths(projectionExpression)) {
             List<String> segments = resolvePath(rawPath.trim(), exprAttrNames);
-            if (segments.isEmpty()) continue;
+            if (segments.isEmpty()) {
+                continue;
+            }
             root.insert(segments);
         }
         ObjectNode projected = projectMapEntries(item, root);
@@ -217,7 +219,9 @@ final class ProjectionEvaluator {
             ArrayNode projectedList = MAPPER.createArrayNode();
             for (Map.Entry<Long, PathTrie> entry : node.indices.entrySet()) {
                 long idx = entry.getKey();
-                if (idx >= list.size()) continue;
+                if (idx >= list.size()) {
+                    continue;
+                }
                 JsonNode projected = projectValue(list.get((int) idx), entry.getValue());
                 if (projected != null) {
                     projectedList.add(projected);
@@ -250,7 +254,9 @@ final class ProjectionEvaluator {
         ObjectNode projectedMap = MAPPER.createObjectNode();
         for (Map.Entry<String, PathTrie> entry : node.names.entrySet()) {
             JsonNode child = map.get(entry.getKey());
-            if (child == null) continue;
+            if (child == null) {
+                continue;
+            }
             JsonNode projected = projectValue(child, entry.getValue());
             if (projected != null) {
                 projectedMap.set(entry.getKey(), projected);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -7,8 +7,11 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Applies a DynamoDB ProjectionExpression to a result item, returning a new
@@ -23,17 +26,28 @@ final class ProjectionEvaluator {
     /**
      * Returns a new ObjectNode containing only the paths named in the expression.
      * Resolves #alias references via exprAttrNames. Handles dot-path and [n] list index segments.
+     * Paths sharing a prefix merge into one reconstructed structure; projected list indices
+     * compact to ascending source order, the way DynamoDB reconstructs projected items.
      */
     static ObjectNode project(JsonNode item, String projectionExpression, JsonNode exprAttrNames) {
         if (item == null || projectionExpression == null || projectionExpression.isBlank()) {
             return (ObjectNode) item;
         }
         validateExpression(projectionExpression);
-        ObjectNode result = MAPPER.createObjectNode();
+        PathTrie root = new PathTrie();
         for (String rawPath : splitProjectionPaths(projectionExpression)) {
             List<String> segments = resolvePath(rawPath.trim(), exprAttrNames);
             if (segments.isEmpty()) continue;
-            copyPath(item, result, segments, 0);
+            root.insert(segments);
+        }
+        ObjectNode result = MAPPER.createObjectNode();
+        for (Map.Entry<String, PathTrie> entry : root.names.entrySet()) {
+            JsonNode child = item.get(entry.getKey());
+            if (child == null) continue;
+            JsonNode projected = projectValue(child, entry.getValue());
+            if (projected != null) {
+                result.set(entry.getKey(), projected);
+            }
         }
         return result;
     }
@@ -140,61 +154,83 @@ final class ProjectionEvaluator {
 
     // ── Tree walking ──
 
-    private static void copyPath(JsonNode src, ObjectNode dest, List<String> segments, int idx) {
-        if (idx >= segments.size()) return;
-        String seg = segments.get(idx);
+    /**
+     * Merged view of every projected path. Map-name children and list-index children are
+     * kept separately; index children stay sorted so a projected list compacts to
+     * ascending source order. A node marked terminal ends a path and copies the whole
+     * subtree it points at.
+     */
+    private static final class PathTrie {
+        private boolean terminal;
+        private final Map<String, PathTrie> names = new LinkedHashMap<>();
+        private final TreeMap<Integer, PathTrie> indices = new TreeMap<>();
 
-        if (seg.matches("\\[\\d+\\]")) {
-            // List index at root level — handled by the caller
-            return;
+        void insert(List<String> segments) {
+            PathTrie node = this;
+            for (String seg : segments) {
+                if (seg.startsWith("[")) {
+                    int idx = Integer.parseInt(seg.substring(1, seg.length() - 1));
+                    node = node.indices.computeIfAbsent(idx, k -> new PathTrie());
+                } else {
+                    node = node.names.computeIfAbsent(seg, k -> new PathTrie());
+                }
+            }
+            node.terminal = true;
         }
+    }
 
-        JsonNode child = src.get(seg);
-        if (child == null) return;
+    /**
+     * Projects a typed attribute value through a trie node. Returns null when nothing
+     * under this value matches, so the caller can drop the branch entirely.
+     */
+    private static JsonNode projectValue(JsonNode src, PathTrie node) {
+        if (node.terminal) {
+            return src.deepCopy();
+        }
+        if (!node.indices.isEmpty() && src.has("L")) {
+            JsonNode list = src.get("L");
+            ArrayNode projectedList = MAPPER.createArrayNode();
+            for (Map.Entry<Integer, PathTrie> entry : node.indices.entrySet()) {
+                int idx = entry.getKey();
+                if (idx < 0 || idx >= list.size()) continue;
+                JsonNode projected = projectValue(list.get(idx), entry.getValue());
+                if (projected != null) {
+                    projectedList.add(projected);
+                }
+            }
+            if (projectedList.isEmpty()) {
+                return null;
+            }
+            ObjectNode wrapper = MAPPER.createObjectNode();
+            wrapper.set("L", projectedList);
+            return wrapper;
+        }
+        if (!node.names.isEmpty() && src.has("M")) {
+            JsonNode projectedMap = projectMapEntries(src.get("M"), node);
+            if (projectedMap == null) {
+                return null;
+            }
+            ObjectNode wrapper = MAPPER.createObjectNode();
+            wrapper.set("M", projectedMap);
+            return wrapper;
+        }
+        if (!node.names.isEmpty() && src.isObject()) {
+            // Defensive fallback for plain (non-DynamoDB-typed) nested objects.
+            return projectMapEntries(src, node);
+        }
+        return null;
+    }
 
-        if (idx == segments.size() - 1) {
-            // Leaf: deep-copy to avoid placing a live source reference into the
-            // destination, which could be mutated by a subsequent sibling path.
-            dest.set(seg, child.deepCopy());
-        } else {
-            String nextSeg = segments.get(idx + 1);
-            if (nextSeg.matches("\\[\\d+\\]")) {
-                // Next is a list index — extract just that element.
-                // Reuse existing wrapper if already projected (same fix as the M branch).
-                int listIdx = Integer.parseInt(nextSeg.substring(1, nextSeg.length() - 1));
-                JsonNode listNode = child.has("L") ? child.get("L") : child;
-                if (listNode.isArray() && listIdx < listNode.size() && !dest.has(seg)) {
-                    JsonNode element = listNode.get(listIdx);
-                    // Build {"L": [element]} wrapper
-                    ObjectNode wrapper = MAPPER.createObjectNode();
-                    ArrayNode newList = MAPPER.createArrayNode();
-                    newList.add(element);
-                    wrapper.set("L", newList);
-                    dest.set(seg, wrapper);
-                }
-            } else if (child.has("M")) {
-                // Nested map — reuse existing projected map if present
-                ObjectNode existing = dest.has(seg) && dest.get(seg).has("M")
-                        ? (ObjectNode) dest.get(seg).get("M") : null;
-                ObjectNode nestedDest = existing != null ? existing : MAPPER.createObjectNode();
-                copyPath(child.get("M"), nestedDest, segments, idx + 1);
-                if (existing == null) {
-                    ObjectNode wrapper = MAPPER.createObjectNode();
-                    wrapper.set("M", nestedDest);
-                    dest.set(seg, wrapper);
-                }
-            } else if (child.isObject()) {
-                // Reuse existing nested object if present
-                ObjectNode existing = dest.has(seg) && dest.get(seg).isObject()
-                        ? (ObjectNode) dest.get(seg) : null;
-                ObjectNode nestedDest = existing != null ? existing : MAPPER.createObjectNode();
-                copyPath(child, nestedDest, segments, idx + 1);
-                if (existing == null) {
-                    dest.set(seg, nestedDest);
-                }
-            } else {
-                dest.set(seg, child);
+    private static ObjectNode projectMapEntries(JsonNode map, PathTrie node) {
+        ObjectNode projectedMap = MAPPER.createObjectNode();
+        for (Map.Entry<String, PathTrie> entry : node.names.entrySet()) {
+            JsonNode child = map.get(entry.getKey());
+            if (child == null) continue;
+            JsonNode projected = projectValue(child, entry.getValue());
+            if (projected != null) {
+                projectedMap.set(entry.getKey(), projected);
             }
         }
+        return projectedMap.isEmpty() ? null : projectedMap;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -21,6 +21,9 @@ final class ProjectionEvaluator {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    // The highest list index real DynamoDB accepts in a document path.
+    private static final long MAX_LIST_INDEX = 4_294_967_294L;
+
     private ProjectionEvaluator() {}
 
     /**
@@ -40,16 +43,8 @@ final class ProjectionEvaluator {
             if (segments.isEmpty()) continue;
             root.insert(segments);
         }
-        ObjectNode result = MAPPER.createObjectNode();
-        for (Map.Entry<String, PathTrie> entry : root.names.entrySet()) {
-            JsonNode child = item.get(entry.getKey());
-            if (child == null) continue;
-            JsonNode projected = projectValue(child, entry.getValue());
-            if (projected != null) {
-                result.set(entry.getKey(), projected);
-            }
-        }
-        return result;
+        ObjectNode projected = projectMapEntries(item, root);
+        return projected != null ? projected : MAPPER.createObjectNode();
     }
 
     /**
@@ -81,11 +76,14 @@ final class ProjectionEvaluator {
         if (expression == null || expression.isBlank()) return;
         char first = expression.charAt(0);
         if (!Character.isLetterOrDigit(first) && first != '#' && first != '_') {
-            String token = String.valueOf(first);
             String near = expression.length() > 2 ? expression.substring(1, 3) : expression.substring(1);
-            throw new AwsException("ValidationException",
-                    "Invalid " + expressionType + ": Syntax error; token: \"" + token + "\", near: \"" + near + "\"", 400);
+            throw syntaxError(expressionType, String.valueOf(first), near);
         }
+    }
+
+    private static AwsException syntaxError(String expressionType, String token, String near) {
+        return new AwsException("ValidationException",
+                "Invalid " + expressionType + ": Syntax error; token: \"" + token + "\", near: \"" + near + "\"", 400);
     }
 
     static void validateExpression(String expression) {
@@ -149,20 +147,21 @@ final class ProjectionEvaluator {
     // index above 4294967294 as out of the allowable range, both at expression level.
     // Characterised on real DynamoDB (us-east-1, 2026-09-05).
     private static void validateListIndex(String content) {
+        if (content.isEmpty()) {
+            throw syntaxError("ProjectionExpression", "]", "[]");
+        }
         for (int i = 0; i < content.length(); i++) {
             if (!Character.isDigit(content.charAt(i))) {
-                throw new AwsException("ValidationException",
-                        "Invalid ProjectionExpression: Syntax error; token: \"" + content.charAt(i)
-                        + "\", near: \"[" + content + "]\"", 400);
+                throw syntaxError("ProjectionExpression",
+                        String.valueOf(content.charAt(i)), "[" + content + "]");
             }
         }
-        if (content.isEmpty()) {
-            throw new AwsException("ValidationException",
-                    "Invalid ProjectionExpression: Syntax error; token: \"]\", near: \"[]\"", 400);
+        int firstDigit = 0;
+        while (firstDigit < content.length() - 1 && content.charAt(firstDigit) == '0') {
+            firstDigit++;
         }
-        var canonical = content.replaceFirst("^0+(?=.)", "");
-        if (canonical.length() > 10
-                || (canonical.length() == 10 && canonical.compareTo("4294967294") > 0)) {
+        var canonical = content.substring(firstDigit);
+        if (canonical.length() > 10 || Long.parseLong(canonical) > MAX_LIST_INDEX) {
             throw new AwsException("ValidationException",
                     "Invalid ProjectionExpression: List index is not within the allowable range; "
                     + "index: [" + content + "]", 400);
@@ -231,16 +230,16 @@ final class ProjectionEvaluator {
             wrapper.set("L", projectedList);
             return wrapper;
         }
-        if (!node.names.isEmpty() && src.has("M")) {
-            JsonNode projectedMap = projectMapEntries(src.get("M"), node);
-            if (projectedMap == null) {
-                return null;
+        if (!node.names.isEmpty()) {
+            if (src.has("M")) {
+                JsonNode projectedMap = projectMapEntries(src.get("M"), node);
+                if (projectedMap == null) {
+                    return null;
+                }
+                ObjectNode wrapper = MAPPER.createObjectNode();
+                wrapper.set("M", projectedMap);
+                return wrapper;
             }
-            ObjectNode wrapper = MAPPER.createObjectNode();
-            wrapper.set("M", projectedMap);
-            return wrapper;
-        }
-        if (!node.names.isEmpty() && src.isObject()) {
             // Defensive fallback for plain (non-DynamoDB-typed) nested objects.
             return projectMapEntries(src, node);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluator.java
@@ -152,17 +152,20 @@ final class ProjectionEvaluator {
         if (content.isEmpty()) {
             throw syntaxError("ProjectionExpression", "]", "[]");
         }
-        for (int i = 0; i < content.length(); i++) {
-            if (!Character.isDigit(content.charAt(i))) {
-                throw syntaxError("ProjectionExpression",
-                        String.valueOf(content.charAt(i)), "[" + content + "]");
+        final var contentLength = content.length();
+        for (var i = 0; i < contentLength; i++) {
+            var c = content.charAt(i);
+            if (c < '0' || '9' < c) {
+                var near = "[" + content + "]";
+                throw syntaxError("ProjectionExpression", String.valueOf(c),
+                        near.substring(0, Math.min(3, near.length())));
             }
         }
-        if (content.length() > 1 && content.charAt(0) == '0') {
+        if (contentLength > 1 && content.charAt(0) == '0') {
             throw syntaxError("ProjectionExpression", "0",
-                    content.substring(0, Math.min(3, content.length())));
+                    content.substring(0, Math.min(3, contentLength)));
         }
-        if (content.length() > 10 || Long.parseLong(content) > MAX_LIST_INDEX) {
+        if (contentLength > 10 || Long.parseLong(content) > MAX_LIST_INDEX) {
             throw new AwsException("ValidationException",
                     "Invalid ProjectionExpression: List index is not within the allowable range; "
                     + "index: [" + content + "]", 400);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
@@ -1,0 +1,124 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for ProjectionExpression evaluation over list indices. Paths sharing a
+ * prefix must merge into one reconstructed structure, and projected list indices must
+ * compact to ascending source order, matching real DynamoDB. Mirrors the paritysuite
+ * dynamodb-conformance tier1 projection cases.
+ */
+class ProjectionEvaluatorTest {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static ObjectNode listItem() {
+        return readValue("""
+                {
+                  "pk": {"S": "p"},
+                  "l": {"L": [
+                    {"M": {
+                      "a": {"S": "a0"},
+                      "b": {"S": "b0"},
+                      "m": {"M": {"x": {"S": "x0"}, "y": {"S": "y0"}}},
+                      "n": {"L": [
+                        {"M": {"p": {"S": "p00"}, "q": {"S": "q00"}}},
+                        {"M": {"p": {"S": "p01"}, "q": {"S": "q01"}}}
+                      ]}
+                    }},
+                    {"M": {"a": {"S": "a1"}, "b": {"S": "b1"}}},
+                    {"M": {"a": {"S": "a2"}, "b": {"S": "b2"}, "c": {"S": "c2"}}}
+                  ]}
+                }
+                """);
+    }
+
+    @Test
+    void projectsMultipleListIndicesCompactedAndIndexOrdered() {
+        var item = mapper.createObjectNode();
+        item.set("mylist", readValue("""
+                {"L": [{"S": "zero"}, {"S": "one"}, {"S": "two"}]}
+                """));
+
+        var result = ProjectionEvaluator.project(item, "#l[2], #l[0]",
+                readValue("""
+                        {"#l": "mylist"}
+                        """));
+
+        var list = result.get("mylist").get("L");
+        assertEquals(2, list.size(), "both requested elements must survive");
+        assertEquals("zero", list.get(0).get("S").asText());
+        assertEquals("two", list.get(1).get("S").asText());
+    }
+
+    @Test
+    void mergesTwoScalarPathsUnderOneListIndex() {
+        var result = ProjectionEvaluator.project(listItem(), "l[0].a, l[0].b", null);
+
+        var list = result.get("l").get("L");
+        assertEquals(1, list.size());
+        var element = list.get(0).get("M");
+        assertEquals("a0", element.get("a").get("S").asText());
+        assertEquals("b0", element.get("b").get("S").asText());
+        assertNull(element.get("m"), "unprojected sibling must be dropped");
+    }
+
+    @Test
+    void mergesScalarSiblingAndNestedMapSiblingUnderOneListIndex() {
+        var result = ProjectionEvaluator.project(listItem(), "l[0].a, l[0].m.x", null);
+
+        var element = result.get("l").get("L").get(0).get("M");
+        assertEquals("a0", element.get("a").get("S").asText());
+        assertEquals("x0", element.get("m").get("M").get("x").get("S").asText());
+        assertNull(element.get("m").get("M").get("y"), "only x was projected inside m");
+        assertNull(element.get("b"), "unprojected sibling must be dropped");
+    }
+
+    @Test
+    void mergesTwoPathsSharingAnElementOfANestedList() {
+        var result = ProjectionEvaluator.project(listItem(), "l[0].n[0].p, l[0].n[0].q", null);
+
+        var outer = result.get("l").get("L");
+        assertEquals(1, outer.size());
+        var inner = outer.get(0).get("M").get("n").get("L");
+        assertEquals(1, inner.size(), "both paths share inner index 0");
+        assertEquals("p00", inner.get(0).get("M").get("p").get("S").asText());
+        assertEquals("q00", inner.get(0).get("M").get("q").get("S").asText());
+    }
+
+    @Test
+    void keepsDistinctInnerListIndicesSeparateUnderOneSharedOuterIndex() {
+        var result = ProjectionEvaluator.project(listItem(), "l[0].n[0].p, l[0].n[1].q", null);
+
+        var inner = result.get("l").get("L").get(0).get("M").get("n").get("L");
+        assertEquals(2, inner.size());
+        assertEquals("p00", inner.get(0).get("M").get("p").get("S").asText());
+        assertNull(inner.get(0).get("M").get("q"));
+        assertEquals("q01", inner.get(1).get("M").get("q").get("S").asText());
+        assertNull(inner.get(1).get("M").get("p"));
+    }
+
+    @Test
+    void mergesSharedIndexAndKeepsDistinctIndexSeparateCompacted() {
+        var result = ProjectionEvaluator.project(listItem(), "l[0].a, l[0].b, l[2].c", null);
+
+        var list = result.get("l").get("L");
+        assertEquals(2, list.size(), "index 0 (merged) and index 2 compact to two elements");
+        assertEquals("a0", list.get(0).get("M").get("a").get("S").asText());
+        assertEquals("b0", list.get(0).get("M").get("b").get("S").asText());
+        assertEquals("c2", list.get(1).get("M").get("c").get("S").asText());
+        assertNull(list.get(1).get("M").get("a"));
+    }
+
+    private static ObjectNode readValue(String json) {
+        try {
+            return (ObjectNode) mapper.readTree(json);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
@@ -151,6 +151,15 @@ class ProjectionEvaluatorTest {
     }
 
     @Test
+    void rejectsUnicodeDigitListIndexAsSyntaxError() {
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[１２３]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: Syntax error; token: \"１\", near: \"[１２\"",
+                ex.getMessage());
+    }
+
+    @Test
     void rejectsLeadingZeroListIndexAsSyntaxError() {
         var ex = assertThrows(AwsException.class,
                 () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[001]", null));

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
@@ -114,11 +114,6 @@ class ProjectionEvaluatorTest {
         assertNull(list.get(1).get("M").get("a"));
     }
 
-    // Malformed and out-of-range list indices, characterised on real DynamoDB
-    // (us-east-1, 2026-09-05): non-digit content is a syntax error, and a numeric
-    // index above 4294967294 is rejected as out of the allowable range. The empty
-    // item states that rejection happens before any item content is read.
-
     @Test
     void rejectsNonNumericListIndexAsSyntaxError() {
         var ex = assertThrows(AwsException.class,
@@ -153,6 +148,24 @@ class ProjectionEvaluatorTest {
         assertEquals("ValidationException", ex.getErrorCode());
         assertEquals("Invalid ProjectionExpression: List index is not within the allowable range; "
                 + "index: [4294967295]", ex.getMessage());
+    }
+
+    @Test
+    void rejectsLeadingZeroListIndexAsSyntaxError() {
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[001]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: Syntax error; token: \"0\", near: \"001\"",
+                ex.getMessage());
+    }
+
+    @Test
+    void rejectsLongZeroPaddedListIndexAsSyntaxError() {
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[0000000000001]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: Syntax error; token: \"0\", near: \"000\"",
+                ex.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.dynamodb;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,10 +40,9 @@ class ProjectionEvaluatorTest {
 
     @Test
     void projectsMultipleListIndicesCompactedAndIndexOrdered() {
-        var item = mapper.createObjectNode();
-        item.set("mylist", readValue("""
-                {"L": [{"S": "zero"}, {"S": "one"}, {"S": "two"}]}
-                """));
+        var item = readValue("""
+                {"mylist": {"L": [{"S": "zero"}, {"S": "one"}, {"S": "two"}]}}
+                """);
 
         var result = ProjectionEvaluator.project(item, "#l[2], #l[0]",
                 readValue("""
@@ -116,12 +116,13 @@ class ProjectionEvaluatorTest {
 
     // Malformed and out-of-range list indices, characterised on real DynamoDB
     // (us-east-1, 2026-09-05): non-digit content is a syntax error, and a numeric
-    // index above 4294967294 is rejected as out of the allowable range.
+    // index above 4294967294 is rejected as out of the allowable range. The empty
+    // item states that rejection happens before any item content is read.
 
     @Test
     void rejectsNonNumericListIndexAsSyntaxError() {
-        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
-                () -> ProjectionEvaluator.project(listItem(), "l[a]", null));
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[a]", null));
         assertEquals("ValidationException", ex.getErrorCode());
         assertEquals("Invalid ProjectionExpression: Syntax error; token: \"a\", near: \"[a]\"",
                 ex.getMessage());
@@ -129,8 +130,8 @@ class ProjectionEvaluatorTest {
 
     @Test
     void rejectsEmptyListIndexAsSyntaxError() {
-        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
-                () -> ProjectionEvaluator.project(listItem(), "l[]", null));
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[]", null));
         assertEquals("ValidationException", ex.getErrorCode());
         assertEquals("Invalid ProjectionExpression: Syntax error; token: \"]\", near: \"[]\"",
                 ex.getMessage());
@@ -138,8 +139,8 @@ class ProjectionEvaluatorTest {
 
     @Test
     void rejectsListIndexAboveTheAllowableRange() {
-        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
-                () -> ProjectionEvaluator.project(listItem(), "l[999999999999999999999]", null));
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[999999999999999999999]", null));
         assertEquals("ValidationException", ex.getErrorCode());
         assertEquals("Invalid ProjectionExpression: List index is not within the allowable range; "
                 + "index: [999999999999999999999]", ex.getMessage());
@@ -147,8 +148,8 @@ class ProjectionEvaluatorTest {
 
     @Test
     void rejectsFirstListIndexPastTheAllowableRange() {
-        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
-                () -> ProjectionEvaluator.project(listItem(), "l[4294967295]", null));
+        var ex = assertThrows(AwsException.class,
+                () -> ProjectionEvaluator.project(mapper.createObjectNode(), "l[4294967295]", null));
         assertEquals("ValidationException", ex.getErrorCode());
         assertEquals("Invalid ProjectionExpression: List index is not within the allowable range; "
                 + "index: [4294967295]", ex.getMessage());

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ProjectionEvaluatorTest.java
@@ -114,6 +114,52 @@ class ProjectionEvaluatorTest {
         assertNull(list.get(1).get("M").get("a"));
     }
 
+    // Malformed and out-of-range list indices, characterised on real DynamoDB
+    // (us-east-1, 2026-09-05): non-digit content is a syntax error, and a numeric
+    // index above 4294967294 is rejected as out of the allowable range.
+
+    @Test
+    void rejectsNonNumericListIndexAsSyntaxError() {
+        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> ProjectionEvaluator.project(listItem(), "l[a]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: Syntax error; token: \"a\", near: \"[a]\"",
+                ex.getMessage());
+    }
+
+    @Test
+    void rejectsEmptyListIndexAsSyntaxError() {
+        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> ProjectionEvaluator.project(listItem(), "l[]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: Syntax error; token: \"]\", near: \"[]\"",
+                ex.getMessage());
+    }
+
+    @Test
+    void rejectsListIndexAboveTheAllowableRange() {
+        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> ProjectionEvaluator.project(listItem(), "l[999999999999999999999]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: List index is not within the allowable range; "
+                + "index: [999999999999999999999]", ex.getMessage());
+    }
+
+    @Test
+    void rejectsFirstListIndexPastTheAllowableRange() {
+        var ex = assertThrows(io.github.hectorvent.floci.core.common.AwsException.class,
+                () -> ProjectionEvaluator.project(listItem(), "l[4294967295]", null));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals("Invalid ProjectionExpression: List index is not within the allowable range; "
+                + "index: [4294967295]", ex.getMessage());
+    }
+
+    @Test
+    void allowableIndexBeyondTheListJustDropsTheAttribute() {
+        var result = ProjectionEvaluator.project(listItem(), "l[4294967294]", null);
+        assertNull(result.get("l"), "an in-range index past the list end matches nothing");
+    }
+
     private static ObjectNode readValue(String json) {
         try {
             return (ObjectNode) mapper.readTree(json);


### PR DESCRIPTION
## Summary

ProjectionExpression paths, that share a prefix, now merge into one reconstructed structure instead of the first or last path winning.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Matches DynamoDB behavior verified by the paritysuite [dynamodb-conformance](https://github.com/paritysuite/dynamodb-conformance) tier1 suite (not full list):

- [GetItem projects multiple list indices compacted and index-ordered](https://github.com/paritysuite/dynamodb-conformance/blob/14a8d928f8b7c53d6681d79e6ae8035918b56d34/tests/tier1/getItem/projection.test.ts#L85)
- [Query accepts distinct list indices (l[0], l[1]) and returns both elements in order](https://github.com/paritysuite/dynamodb-conformance/blob/14a8d928f8b7c53d6681d79e6ae8035918b56d34/tests/tier1/query/projection.test.ts#L68)
- [BatchGetItemItem accepts distinct list indices (l[0], l[1]) and returns both elements in order](https://github.com/paritysuite/dynamodb-conformance/blob/14a8d928f8b7c53d6681d79e6ae8035918b56d34/tests/tier1/batchGetItem/projection.test.ts#L72)

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
