### PR TITLE
fix(elasticache): resolve order-dependent crossGroupAuthIsRejected test failure (#1991)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -248,10 +248,12 @@ public class ElastiCacheService implements ResourceProvider {
                     : 1);
             applyCommonAttributes(group, request, resolvedSettings);
 
-            groups.put(groupId, group);
-            proxyManager.startProxy(groupId, authMode, proxyPort,
-                    handle.getHost(), handle.getPort(),
-                    (username, password) -> validatePassword(groupId, username, password));
+            synchronized (lockFor("rg:" + groupId)) {
+                groups.put(groupId, group);
+                proxyManager.startProxy(groupId, authMode, proxyPort,
+                        handle.getHost(), handle.getPort(),
+                        (username, password) -> validatePassword(groupId, username, password));
+            }
 
             LOG.infov("Replication group {0} created, endpoint={1}:{2}", groupId, endpointHost, String.valueOf(proxyPort));
             return group;

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -248,11 +248,11 @@ public class ElastiCacheService implements ResourceProvider {
                     : 1);
             applyCommonAttributes(group, request, resolvedSettings);
 
+            groups.put(groupId, group);
             proxyManager.startProxy(groupId, authMode, proxyPort,
                     handle.getHost(), handle.getPort(),
                     (username, password) -> validatePassword(groupId, username, password));
 
-            groups.put(groupId, group);
             LOG.infov("Replication group {0} created, endpoint={1}:{2}", groupId, endpointHost, String.valueOf(proxyPort));
             return group;
         } catch (RuntimeException e) {
@@ -615,6 +615,7 @@ public class ElastiCacheService implements ResourceProvider {
         } catch (RuntimeException e) {
             LOG.warnv("Error stopping container for replication group {0}: {1}", groupId, e.getMessage());
         } finally {
+            groups.delete(groupId);
             releaseProxyPort(proxyPort);
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
@@ -213,7 +213,14 @@ public class ElastiCacheAuthProxy {
     }
 
     private static void closeQuietly(Socket s) {
-        try { s.close(); } catch (IOException ignored) {}
+        try {
+            if (!s.isClosed()) {
+                try {
+                    s.shutdownOutput();
+                } catch (IOException ignored) {}
+                s.close();
+            }
+        } catch (IOException ignored) {}
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/proxy/ElastiCacheAuthProxy.java
@@ -212,15 +212,19 @@ public class ElastiCacheAuthProxy {
         out.flush();
     }
 
-    private static void closeQuietly(Socket s) {
+    private void closeQuietly(Socket s) {
         try {
             if (!s.isClosed()) {
                 try {
                     s.shutdownOutput();
-                } catch (IOException ignored) {}
+                } catch (IOException e) {
+                    LOG.debugv(e, "Error shutting down socket output for group {0}", groupId);
+                }
                 s.close();
             }
-        } catch (IOException ignored) {}
+        } catch (IOException e) {
+            LOG.debugv(e, "Error closing socket for group {0}", groupId);
+        }
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
@@ -201,34 +201,49 @@ class ElastiCacheIntegrationTest {
     @Test
     @Order(10)
     void crossGroupAuthIsRejected() throws Exception {
+        // Ensure user exists if this test is run in isolation
+        try {
+            given()
+                .formParam("Action", "CreateUser")
+                .formParam("UserId", USER_ID)
+                .formParam("UserName", USER_NAME)
+                .formParam("AuthenticationMode.Type", "password")
+                .formParam("AuthenticationMode.Passwords.member.1", INITIAL_PASSWORD)
+                .formParam("AccessString", "on ~* +@all")
+                .header("Authorization", AUTH_HEADER)
+                .post("/");
+        } catch (Exception ignored) {}
+
         // Create a second group and verify the user (associated with GROUP_ID only) cannot auth
-        crossGroupPort = given()
-                .formParam("Action", "CreateReplicationGroup")
+        try {
+            crossGroupPort = given()
+                    .formParam("Action", "CreateReplicationGroup")
+                    .formParam("ReplicationGroupId", CROSS_GROUP_ID)
+                    .formParam("ReplicationGroupDescription", "Cross-group isolation test")
+                    .formParam("AuthToken", CROSS_GROUP_AUTH_TOKEN)
+                    .header("Authorization", AUTH_HEADER)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(200)
+                .extract()
+                    .xmlPath()
+                    .getInt("CreateReplicationGroupResponse.CreateReplicationGroupResult.ReplicationGroup.ConfigurationEndpoint.Port");
+
+            // User associated with GROUP_ID should be rejected on CROSS_GROUP_ID
+            String reply = sendCommand(crossGroupPort, respArray("AUTH", USER_NAME, INITIAL_PASSWORD));
+            assertEquals("-ERR invalid username-password pair or user is disabled.\r\n", reply);
+        } finally {
+            // Clean up the cross-group
+            given()
+                .formParam("Action", "DeleteReplicationGroup")
                 .formParam("ReplicationGroupId", CROSS_GROUP_ID)
-                .formParam("ReplicationGroupDescription", "Cross-group isolation test")
-                .formParam("AuthToken", CROSS_GROUP_AUTH_TOKEN)
                 .header("Authorization", AUTH_HEADER)
             .when()
                 .post("/")
             .then()
-                .statusCode(200)
-            .extract()
-                .xmlPath()
-                .getInt("CreateReplicationGroupResponse.CreateReplicationGroupResult.ReplicationGroup.ConfigurationEndpoint.Port");
-
-        // User associated with GROUP_ID should be rejected on CROSS_GROUP_ID
-        String reply = sendCommand(crossGroupPort, respArray("AUTH", USER_NAME, INITIAL_PASSWORD));
-        assertEquals("-ERR invalid username-password pair or user is disabled.\r\n", reply);
-
-        // Clean up the cross-group
-        given()
-            .formParam("Action", "DeleteReplicationGroup")
-            .formParam("ReplicationGroupId", CROSS_GROUP_ID)
-            .header("Authorization", AUTH_HEADER)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200);
+                .statusCode(200);
+        }
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
@@ -17,6 +17,8 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
 
+import org.jboss.logging.Logger;
+
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.Matchers.equalTo;
@@ -25,6 +27,8 @@ import static org.hamcrest.Matchers.notNullValue;
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ElastiCacheIntegrationTest {
+
+    private static final Logger LOG = Logger.getLogger(ElastiCacheIntegrationTest.class);
 
     private static final String AUTH_HEADER =
             "AWS4-HMAC-SHA256 Credential=test/20260412/us-east-1/elasticache/aws4_request";
@@ -214,7 +218,7 @@ class ElastiCacheIntegrationTest {
                 .post("/");
         } catch (Exception e) {
             // User already created when tests run in full class order; tolerated in isolation
-            System.err.println("Note: User creation tolerated: " + e.getMessage());
+            LOG.debugv(e, "User creation tolerated during crossGroupAuthIsRejected isolation setup");
         }
 
         // Create a second group and verify the user (associated with GROUP_ID only) cannot auth
@@ -239,13 +243,18 @@ class ElastiCacheIntegrationTest {
         } finally {
             // Clean up the cross-group without masking test assertions if creation/auth failed
             try {
-                given()
+                int status = given()
                     .formParam("Action", "DeleteReplicationGroup")
                     .formParam("ReplicationGroupId", CROSS_GROUP_ID)
                     .header("Authorization", AUTH_HEADER)
-                    .post("/");
+                .when()
+                    .post("/")
+                .getStatusCode();
+                if (status != 200 && status != 404) {
+                    LOG.warnv("Cross-group cleanup returned unexpected status {0}", status);
+                }
             } catch (Exception e) {
-                System.err.println("Cross-group cleanup failed: " + e.getMessage());
+                LOG.debugv(e, "Cross-group cleanup failed during teardown");
             }
         }
     }

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheIntegrationTest.java
@@ -212,7 +212,10 @@ class ElastiCacheIntegrationTest {
                 .formParam("AccessString", "on ~* +@all")
                 .header("Authorization", AUTH_HEADER)
                 .post("/");
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            // User already created when tests run in full class order; tolerated in isolation
+            System.err.println("Note: User creation tolerated: " + e.getMessage());
+        }
 
         // Create a second group and verify the user (associated with GROUP_ID only) cannot auth
         try {
@@ -234,15 +237,16 @@ class ElastiCacheIntegrationTest {
             String reply = sendCommand(crossGroupPort, respArray("AUTH", USER_NAME, INITIAL_PASSWORD));
             assertEquals("-ERR invalid username-password pair or user is disabled.\r\n", reply);
         } finally {
-            // Clean up the cross-group
-            given()
-                .formParam("Action", "DeleteReplicationGroup")
-                .formParam("ReplicationGroupId", CROSS_GROUP_ID)
-                .header("Authorization", AUTH_HEADER)
-            .when()
-                .post("/")
-            .then()
-                .statusCode(200);
+            // Clean up the cross-group without masking test assertions if creation/auth failed
+            try {
+                given()
+                    .formParam("Action", "DeleteReplicationGroup")
+                    .formParam("ReplicationGroupId", CROSS_GROUP_ID)
+                    .header("Authorization", AUTH_HEADER)
+                    .post("/");
+            } catch (Exception e) {
+                System.err.println("Cross-group cleanup failed: " + e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #1991

This PR resolves an order-dependent and environment-sensitive failure in `ElastiCacheIntegrationTest.crossGroupAuthIsRejected`:
1. In `ElastiCacheAuthProxy.closeQuietly`: performs `s.shutdownOutput()` before `s.close()` to cleanly initiate a TCP FIN handshake rather than sending an abrupt TCP RST, ensuring the client finishes reading the `-ERR invalid username-password pair or user is disabled.` response.
2. In `ElastiCacheService.provisionSingleNodeGroup`: persists the replication group in storage (`groups.put(groupId, group)`) before launching the auth proxy so concurrent incoming auth requests never encounter an unpersisted group in `validatePassword`. Added `groups.delete(groupId)` to `rollbackReplicationGroup`'s `finally` block to ensure rollback cleans up appropriately.
3. In `ElastiCacheIntegrationTest.crossGroupAuthIsRejected`: ensures the test user is provisioned when running in isolation, and ensures `DeleteReplicationGroup` cleanup is executed inside a `finally` block.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

When authentication fails on ElastiCache proxy, Redis/Valkey clients expect to read the standard `-ERR invalid username-password pair or user is disabled.\r\n` error message before the connection is terminated. Hard-closing the socket immediately without flushing and shutting down the output caused clients (especially across container/VM boundaries like Docker via Colima) to receive TCP RST / EOF before reading the full error line.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
