### PR TITLE
fix(ses): align v1 Query boolean parsing with probed xsd 1.1 behavior

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -272,7 +272,7 @@ public class SesQueryHandler {
     }
 
     private Response handleUpdateAccountSendingEnabled(MultivaluedMap<String, String> params, String region) {
-        boolean enabled = parseOptionalBoolean(params, "Enabled", false);
+        boolean enabled = parseXsdBoolean(params, "Enabled");
         sesService.setAccountSendingEnabled(region, enabled);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("UpdateAccountSendingEnabled", AwsNamespaces.SES)).build();
     }
@@ -359,14 +359,14 @@ public class SesQueryHandler {
 
     private Response handleSetIdentityFeedbackForwardingEnabled(MultivaluedMap<String, String> params, String region) {
         String identityValue = getParam(params, "Identity");
-        boolean enabled = parseRequiredBoolean(params, "ForwardingEnabled");
+        boolean enabled = parseXsdBoolean(params, "ForwardingEnabled");
         sesService.setFeedbackForwardingEnabled(identityValue, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("SetIdentityFeedbackForwardingEnabled", AwsNamespaces.SES)).build();
     }
 
     private Response handleSetIdentityDkimEnabled(MultivaluedMap<String, String> params, String region) {
         String identityValue = getParam(params, "Identity");
-        boolean enabled = parseRequiredBoolean(params, "DkimEnabled");
+        boolean enabled = parseXsdBoolean(params, "DkimEnabled");
         sesService.setDkimAttributes(identityValue, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("SetIdentityDkimEnabled", AwsNamespaces.SES)).build();
     }
@@ -385,7 +385,7 @@ public class SesQueryHandler {
     private Response handleSetIdentityHeadersInNotificationsEnabled(MultivaluedMap<String, String> params, String region) {
         String identityValue = getParam(params, "Identity");
         String notificationType = getParam(params, "NotificationType");
-        boolean enabled = parseRequiredBoolean(params, "Enabled");
+        boolean enabled = parseXsdBoolean(params, "Enabled");
         sesService.setHeadersInNotificationsEnabled(identityValue, notificationType, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("SetIdentityHeadersInNotificationsEnabled", AwsNamespaces.SES)).build();
     }
@@ -402,28 +402,26 @@ public class SesQueryHandler {
         return Response.ok(AwsQueryResponse.envelopeEmptyResult("SetIdentityMailFromDomain", AwsNamespaces.SES)).build();
     }
 
-    private static boolean parseRequiredBoolean(MultivaluedMap<String, String> params, String name) {
+    /**
+     * Strict xsd 1.1 boolean parse for Query-protocol boolean members: only {@code true},
+     * {@code false}, {@code 1}, and {@code 0} are accepted, case-sensitively, and anything else
+     * is the probed {@code MalformedInput} error. An absent member takes the AWS default of
+     * {@code false}; a present-but-empty value is the probed "missing value" error.
+     */
+    private static boolean parseXsdBoolean(MultivaluedMap<String, String> params, String name) {
         String raw = params.getFirst(name);
         if (raw == null) {
-            throw new AwsException("InvalidParameterValue", name + " is required.", 400);
+            return false;
         }
-        if (!"true".equalsIgnoreCase(raw) && !"false".equalsIgnoreCase(raw)) {
-            throw new AwsException("InvalidParameterValue",
-                    name + " must be \"true\" or \"false\".", 400);
+        if (raw.isEmpty()) {
+            throw new AwsException("MalformedInput", "missing value for boolean type", 400);
         }
-        return Boolean.parseBoolean(raw);
-    }
-
-    private static boolean parseOptionalBoolean(MultivaluedMap<String, String> params, String name, boolean defaultValue) {
-        String raw = params.getFirst(name);
-        if (raw == null || raw.isBlank()) {
-            return defaultValue;
-        }
-        if (!"true".equalsIgnoreCase(raw) && !"false".equalsIgnoreCase(raw)) {
-            throw new AwsException("InvalidParameterValue",
-                    name + " must be \"true\" or \"false\".", 400);
-        }
-        return Boolean.parseBoolean(raw);
+        return switch (raw) {
+            case "true", "1" -> true;
+            case "false", "0" -> false;
+            default -> throw new AwsException("MalformedInput",
+                    "boolean must follow xsd1.1 definition", 400);
+        };
     }
 
     private Response handleGetIdentityMailFromDomainAttributes(MultivaluedMap<String, String> params, String region) {
@@ -890,7 +888,7 @@ public class SesQueryHandler {
     private Response handleUpdateConfigurationSetSendingEnabled(MultivaluedMap<String, String> params,
                                                                 String region) {
         String configSet = requireParam(params, "ConfigurationSetName");
-        boolean enabled = parseRequiredBoolean(params, "Enabled");
+        boolean enabled = parseXsdBoolean(params, "Enabled");
         sesService.setConfigurationSetSendingEnabled(configSet, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult(
                 "UpdateConfigurationSetSendingEnabled", AwsNamespaces.SES)).build();
@@ -925,7 +923,7 @@ public class SesQueryHandler {
     private Response handleUpdateConfigurationSetReputationMetricsEnabled(MultivaluedMap<String, String> params,
                                                                           String region) {
         String configSet = requireParam(params, "ConfigurationSetName");
-        boolean enabled = parseRequiredBoolean(params, "Enabled");
+        boolean enabled = parseXsdBoolean(params, "Enabled");
         sesService.setConfigurationSetReputationOptions(configSet, enabled, region);
         return Response.ok(AwsQueryResponse.envelopeEmptyResult(
                 "UpdateConfigurationSetReputationMetricsEnabled", AwsNamespaces.SES)).build();
@@ -1075,7 +1073,7 @@ public class SesQueryHandler {
     private EventDestination readEventDestination(MultivaluedMap<String, String> params, String prefix) {
         EventDestination dest = new EventDestination();
         dest.setName(getParam(params, prefix + ".Name"));
-        dest.setEnabled(parseOptionalBoolean(params, prefix + ".Enabled", false));
+        dest.setEnabled(parseXsdBoolean(params, prefix + ".Enabled"));
         List<String> rawTypes = extractMembers(params, prefix + ".MatchingEventTypes");
         List<String> normalizedTypes = new ArrayList<>(rawTypes.size());
         for (String t : rawTypes) {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetEventDestinationV1IntegrationTest.java
@@ -308,6 +308,129 @@ class SesConfigurationSetEventDestinationV1IntegrationTest {
     }
 
     @Test
+    @Order(15)
+    void createConfigurationSetEventDestination_nonXsdEnabled_returnsMalformedInput() {
+        // EventDestination.Enabled follows the same strict xsd 1.1 lexical space as top-level
+        // Query booleans (probed against real AWS 2026-09-05): even "TRUE" is MalformedInput.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", "v1-ed-bool-bad")
+            .formParam("EventDestination.Enabled", "TRUE")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>MalformedInput</Code>"))
+            .body(containsString("boolean must follow xsd1.1 definition"));
+    }
+
+    @Test
+    @Order(16)
+    void createConfigurationSetEventDestination_emptyEnabled_returnsMalformedInput() {
+        // Probed against real AWS 2026-09-05: a present-but-empty nested boolean is the
+        // dedicated "missing value" MalformedInput, same as top-level members.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", "v1-ed-bool-empty")
+            .formParam("EventDestination.Enabled", "")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>MalformedInput</Code>"))
+            .body(containsString("missing value for boolean type"));
+    }
+
+    @Test
+    @Order(17)
+    void createConfigurationSetEventDestination_absentEnabled_defaultsToFalse() {
+        // Probed against real AWS 2026-09-05: an absent nested boolean deserializes to false
+        // and the request proceeds, it is not a validation error.
+        String ed = "v1-ed-bool-absent";
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", ed)
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("CreateConfigurationSetEventDestinationResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "eventDestinations")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Name>" + ed + "</Name>"))
+            .body(containsString("<Enabled>false</Enabled>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestinationName", ed)
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
+    @Test
+    @Order(18)
+    void createConfigurationSetEventDestination_numericEnabled_isAccepted() {
+        // xsd 1.1 booleans: "1" is true for nested members too (probed 2026-09-05).
+        String ed = "v1-ed-bool-numeric";
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "CreateConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestination.Name", ed)
+            .formParam("EventDestination.Enabled", "1")
+            .formParam("EventDestination.MatchingEventTypes.member.1", "send")
+            .formParam("EventDestination.SNSDestination.TopicARN", TOPIC_ARN_A)
+        .when().post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DescribeConfigurationSet")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("ConfigurationSetAttributeNames.member.1", "eventDestinations")
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Name>" + ed + "</Name>"))
+            .body(containsString("<Enabled>true</Enabled>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "DeleteConfigurationSetEventDestination")
+            .formParam("ConfigurationSetName", CS)
+            .formParam("EventDestinationName", ed)
+        .when().post("/")
+        .then().statusCode(200);
+    }
+
+    @Test
     @Order(99)
     void cleanup() {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetSendingOptionsV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetSendingOptionsV2IntegrationTest.java
@@ -246,10 +246,10 @@ class SesConfigurationSetSendingOptionsV2IntegrationTest {
 
     @Test
     @Order(16)
-    void v1_updateConfigurationSetSendingEnabled_nonBooleanEnabled_returnsInvalidParameterValue() {
-        // parseRequiredBoolean enforces AWS-style "true"|"false". Anything else (e.g.
-        // "yes") must surface as InvalidParameterValue instead of being silently
-        // coerced to false (which would disable sending without the caller realizing).
+    void v1_updateConfigurationSetSendingEnabled_nonBooleanEnabled_returnsMalformedInput() {
+        // Query-protocol booleans are strict xsd 1.1 (probed against real AWS 2026-09-05):
+        // anything but case-sensitive true/false/1/0 is MalformedInput rather than being
+        // silently coerced to false (which would disable sending without the caller realizing).
         given()
                 .contentType("application/x-www-form-urlencoded")
                 .header("Authorization", SES_AUTH)
@@ -260,8 +260,8 @@ class SesConfigurationSetSendingOptionsV2IntegrationTest {
                 .post("/")
         .then()
                 .statusCode(400)
-                .body(containsString("<Code>InvalidParameterValue</Code>"))
-                .body(containsString("Enabled"));
+                .body(containsString("<Code>MalformedInput</Code>"))
+                .body(containsString("boolean must follow xsd1.1 definition"));
     }
 
     private static io.restassured.response.Response sendEmail(String configSet) {

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV1IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIdentityAttributesV1IntegrationTest.java
@@ -160,7 +160,20 @@ class SesIdentityAttributesV1IntegrationTest {
 
     @Test
     @Order(12)
-    void setIdentityFeedbackForwardingEnabled_missingForwardingEnabled_returnsInvalidParameterValue() {
+    void setIdentityFeedbackForwardingEnabled_missingForwardingEnabled_defaultsToFalse() {
+        // Real AWS treats an absent Query-protocol boolean member as false instead of
+        // rejecting the request (probed 2026-09-05): the call succeeds and disables forwarding.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SetIdentityFeedbackForwardingEnabled")
+            .formParam("Identity", "v1-attrs.floci.test")
+            .formParam("ForwardingEnabled", "true")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", AUTH)
@@ -169,40 +182,124 @@ class SesIdentityAttributesV1IntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(400)
-            .body(containsString("InvalidParameterValue"));
+            .statusCode(200)
+            .body(containsString("SetIdentityFeedbackForwardingEnabledResponse"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetIdentityNotificationAttributes")
+            .formParam("Identities.member.1", "v1-attrs.floci.test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ForwardingEnabled>false</ForwardingEnabled>"));
     }
 
     @Test
     @Order(13)
-    void setIdentityHeadersInNotificationsEnabled_missingEnabled_returnsInvalidParameterValue() {
+    void setIdentityHeadersInNotificationsEnabled_missingEnabled_defaultsToFalse() {
+        // Same absent-boolean default as Order(12); Delivery is used so the Bounce flag
+        // set in Order(6) and asserted in Order(17) stays untouched.
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", AUTH)
             .formParam("Action", "SetIdentityHeadersInNotificationsEnabled")
             .formParam("Identity", "v1-attrs.floci.test")
-            .formParam("NotificationType", "Bounce")
+            .formParam("NotificationType", "Delivery")
+            .formParam("Enabled", "true")
         .when()
             .post("/")
         .then()
-            .statusCode(400)
-            .body(containsString("InvalidParameterValue"));
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SetIdentityHeadersInNotificationsEnabled")
+            .formParam("Identity", "v1-attrs.floci.test")
+            .formParam("NotificationType", "Delivery")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetIdentityNotificationAttributes")
+            .formParam("Identities.member.1", "v1-attrs.floci.test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<HeadersInDeliveryNotificationsEnabled>false</HeadersInDeliveryNotificationsEnabled>"));
     }
 
     @Test
     @Order(14)
-    void setIdentityFeedbackForwardingEnabled_invalidBoolean_returnsInvalidParameterValue() {
+    void setIdentityFeedbackForwardingEnabled_invalidBoolean_returnsMalformedInput() {
+        // Probed against real AWS 2026-09-05: anything but case-sensitive true/false/1/0
+        // (even "TRUE") is MalformedInput, not InvalidParameterValue.
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", AUTH)
             .formParam("Action", "SetIdentityFeedbackForwardingEnabled")
             .formParam("Identity", "v1-attrs.floci.test")
-            .formParam("ForwardingEnabled", "yes")
+            .formParam("ForwardingEnabled", "TRUE")
         .when()
             .post("/")
         .then()
             .statusCode(400)
-            .body(containsString("InvalidParameterValue"));
+            .body(containsString("<Code>MalformedInput</Code>"))
+            .body(containsString("boolean must follow xsd1.1 definition"));
+    }
+
+    @Test
+    @Order(24)
+    void setIdentityFeedbackForwardingEnabled_emptyBoolean_returnsMalformedInput() {
+        // Probed against real AWS 2026-09-05: a present-but-empty boolean value is its
+        // own MalformedInput message, distinct from both the absent and malformed cases.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SetIdentityFeedbackForwardingEnabled")
+            .formParam("Identity", "v1-attrs.floci.test")
+            .formParam("ForwardingEnabled", "")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>MalformedInput</Code>"))
+            .body(containsString("missing value for boolean type"));
+    }
+
+    @Test
+    @Order(25)
+    void setIdentityFeedbackForwardingEnabled_numericBoolean_isAccepted() {
+        // xsd 1.1 booleans: "1" is true (probed against real AWS 2026-09-05).
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "SetIdentityFeedbackForwardingEnabled")
+            .formParam("Identity", "v1-attrs.floci.test")
+            .formParam("ForwardingEnabled", "1")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH)
+            .formParam("Action", "GetIdentityNotificationAttributes")
+            .formParam("Identities.member.1", "v1-attrs.floci.test")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<ForwardingEnabled>true</ForwardingEnabled>"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesIntegrationTest.java
@@ -519,8 +519,8 @@ class SesIntegrationTest {
 
     @Test
     @Order(26)
-    void updateAccountSendingEnabled_treatsMissingOrBlankEnabledAsFalse() {
-        // Missing Enabled parameter
+    void updateAccountSendingEnabled_missingEnabledDefaultsToFalse_blankEnabledIsMalformed() {
+        // Missing Enabled parameter defaults to false (probed against real AWS 2026-09-05)
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", authorization("email"))
@@ -540,18 +540,8 @@ class SesIntegrationTest {
             .statusCode(200)
             .body(containsString("<Enabled>false</Enabled>"));
 
-        // restore so the next assertion observes the blank-string default cleanly
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .header("Authorization", authorization("email"))
-            .formParam("Action", "UpdateAccountSendingEnabled")
-            .formParam("Enabled", "true")
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200);
-
-        // Blank Enabled parameter (e.g. AWS CLI passing --enabled "") behaves the same
+        // A present-but-blank Enabled (e.g. AWS CLI passing --enabled "") is rejected,
+        // unlike the absent case (probed against real AWS 2026-09-05)
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", authorization("email"))
@@ -560,17 +550,9 @@ class SesIntegrationTest {
         .when()
             .post("/")
         .then()
-            .statusCode(200);
-
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .header("Authorization", authorization("email"))
-            .formParam("Action", "GetAccountSendingEnabled")
-        .when()
-            .post("/")
-        .then()
-            .statusCode(200)
-            .body(containsString("<Enabled>false</Enabled>"));
+            .statusCode(400)
+            .body(containsString("<Code>MalformedInput</Code>"))
+            .body(containsString("missing value for boolean type"));
 
         // restore default state for downstream tests
         given()
@@ -645,7 +627,8 @@ class SesIntegrationTest {
 
     @Test
     @Order(28)
-    void updateAccountSendingEnabled_invalidValue_returns400() {
+    void updateAccountSendingEnabled_invalidValue_returnsMalformedInput() {
+        // Probed against real AWS 2026-09-05: non-xsd boolean values are MalformedInput
         given()
             .contentType("application/x-www-form-urlencoded")
             .header("Authorization", authorization("email"))
@@ -655,6 +638,7 @@ class SesIntegrationTest {
             .post("/")
         .then()
             .statusCode(400)
-            .body(containsString("InvalidParameterValue"));
+            .body(containsString("<Code>MalformedInput</Code>"))
+            .body(containsString("boolean must follow xsd1.1 definition"));
     }
 }


### PR DESCRIPTION
## Summary

Align SES v1 Query-protocol boolean member parsing with real AWS behavior. Floci invented its own `InvalidParameterValue` errors for these members; the probed AWS contract is different in all three cases (absent, empty, malformed).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Probed against real AWS SES (us-west-2, raw SigV4, 2026-09-05) for SetIdentityDkimEnabled, SetIdentityFeedbackForwardingEnabled, SetIdentityHeadersInNotificationsEnabled, UpdateConfigurationSetSendingEnabled, UpdateConfigurationSetReputationMetricsEnabled, and UpdateAccountSendingEnabled:

- An absent boolean member is not an error: it deserializes to `false` and the request proceeds to semantic validation. Floci returned `InvalidParameterValue` "X is required.".
- A present-but-empty value (`Enabled=`) returns `MalformedInput` "missing value for boolean type".
- Any value other than case-sensitive `true`/`false`/`1`/`0` (even `TRUE`) returns `MalformedInput` "boolean must follow xsd1.1 definition". Floci accepted case-insensitive `true`/`false`, rejected `1`/`0`, and returned an invented `InvalidParameterValue` message.

`parseRequiredBoolean` and `parseOptionalBoolean` are replaced by a single `parseXsdBoolean` implementing the probed contract at all seven call sites, including the v1 event destination `Enabled` member. Affected integration tests are updated, with new cases for the absent-defaults-to-false, empty-value, and numeric-form behaviors.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
