### PR TITLE
fix(cloudformation): delete AWS::IAM::User on stack deletion (#2490)

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -512,12 +512,6 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>efs</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-            <version>3.6.3.Final</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -512,6 +512,12 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>efs</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.6.3.Final</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
@@ -20,6 +20,8 @@ import software.amazon.awssdk.services.iam.model.User;
 
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -27,6 +29,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("CloudFormation AWS::IAM::User")
 class CloudFormationIamUserTest {
+
+    private static final Logger LOG = Logger.getLogger(CloudFormationIamUserTest.class.getName());
 
     private static CloudFormationClient cloudFormation;
     private static IamClient iam;
@@ -48,7 +52,7 @@ class CloudFormationIamUserTest {
                 cloudFormation.deleteStack(
                         DeleteStackRequest.builder().stackName(stackName).build());
             } catch (Exception e) {
-                System.err.println("CloudFormation IAM user cleanup skipped: " + e.getMessage());
+                LOG.log(Level.WARNING, "Failed to delete CloudFormation IAM user test stack: " + stackName, e);
             }
             cloudFormation.close();
         }
@@ -56,7 +60,7 @@ class CloudFormationIamUserTest {
             try {
                 iam.deleteUser(DeleteUserRequest.builder().userName(userName).build());
             } catch (Exception e) {
-                System.err.println("IAM user direct cleanup skipped: " + e.getMessage());
+                LOG.log(Level.WARNING, "Failed to delete IAM user directly during cleanup: " + userName, e);
             }
             iam.close();
         }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
@@ -18,10 +18,10 @@ import software.amazon.awssdk.services.iam.model.GetUserResponse;
 import software.amazon.awssdk.services.iam.model.NoSuchEntityException;
 import software.amazon.awssdk.services.iam.model.User;
 
-import org.jboss.logging.Logger;
-
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("CloudFormation AWS::IAM::User")
 class CloudFormationIamUserTest {
 
-    private static final Logger LOG = Logger.getLogger(CloudFormationIamUserTest.class);
+    private static final Logger LOG = Logger.getLogger(CloudFormationIamUserTest.class.getName());
 
     private static CloudFormationClient cloudFormation;
     private static IamClient iam;
@@ -52,7 +52,7 @@ class CloudFormationIamUserTest {
                 cloudFormation.deleteStack(
                         DeleteStackRequest.builder().stackName(stackName).build());
             } catch (Exception e) {
-                LOG.warn("Failed to delete CloudFormation IAM user test stack: " + stackName, e);
+                LOG.log(Level.WARNING, "Failed to delete CloudFormation IAM user test stack: " + stackName, e);
             }
             cloudFormation.close();
         }
@@ -60,7 +60,7 @@ class CloudFormationIamUserTest {
             try {
                 iam.deleteUser(DeleteUserRequest.builder().userName(userName).build());
             } catch (Exception e) {
-                LOG.warn("Failed to delete IAM user directly during cleanup: " + userName, e);
+                LOG.log(Level.WARNING, "Failed to delete IAM user directly during cleanup: " + userName, e);
             }
             iam.close();
         }
@@ -83,15 +83,14 @@ class CloudFormationIamUserTest {
         assertThat(outputs).containsEntry("UserRef", userName);
         String userArn = outputs.get("UserArn");
         assertThat(userArn).startsWith("arn:aws:iam::").endsWith(":user/initial/" + userName);
-        String userId = outputs.get("UserId");
-        assertThat(userId).startsWith("AIDA");
 
         GetUserResponse userResponse = iam.getUser(GetUserRequest.builder().userName(userName).build());
         User user = userResponse.user();
         assertThat(user.userName()).isEqualTo(userName);
         assertThat(user.path()).isEqualTo("/initial/");
         assertThat(user.arn()).isEqualTo(userArn);
-        assertThat(user.userId()).isEqualTo(userId);
+        String userId = user.userId();
+        assertThat(userId).startsWith("AIDA");
 
         // Update path on existing user
         cloudFormation.updateStack(r -> r
@@ -125,8 +124,7 @@ class CloudFormationIamUserTest {
                   },
                   "Outputs": {
                     "UserRef": {"Value": {"Ref": "AppUser"}},
-                    "UserArn": {"Value": {"Fn::GetAtt": ["AppUser", "Arn"]}},
-                    "UserId": {"Value": {"Fn::GetAtt": ["AppUser", "UserId"]}}
+                    "UserArn": {"Value": {"Fn::GetAtt": ["AppUser", "Arn"]}}
                   }
                 }
                 """.formatted(name, path);

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
@@ -1,0 +1,168 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudformation.CloudFormationClient;
+import software.amazon.awssdk.services.cloudformation.model.CloudFormationException;
+import software.amazon.awssdk.services.cloudformation.model.CreateStackRequest;
+import software.amazon.awssdk.services.cloudformation.model.DeleteStackRequest;
+import software.amazon.awssdk.services.cloudformation.model.DescribeStacksRequest;
+import software.amazon.awssdk.services.cloudformation.model.Output;
+import software.amazon.awssdk.services.cloudformation.model.Stack;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.DeleteUserRequest;
+import software.amazon.awssdk.services.iam.model.GetUserRequest;
+import software.amazon.awssdk.services.iam.model.GetUserResponse;
+import software.amazon.awssdk.services.iam.model.NoSuchEntityException;
+import software.amazon.awssdk.services.iam.model.User;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("CloudFormation AWS::IAM::User")
+class CloudFormationIamUserTest {
+
+    private static CloudFormationClient cloudFormation;
+    private static IamClient iam;
+    private static String stackName;
+    private static String userName;
+
+    @BeforeAll
+    static void setup() {
+        cloudFormation = TestFixtures.cloudFormationClient();
+        iam = TestFixtures.iamClient();
+        stackName = TestFixtures.uniqueName("compat-cfn-iam-user");
+        userName = TestFixtures.uniqueName("compat-user");
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (cloudFormation != null) {
+            try {
+                cloudFormation.deleteStack(
+                        DeleteStackRequest.builder().stackName(stackName).build());
+            } catch (Exception e) {
+                System.err.println("CloudFormation IAM user cleanup skipped: " + e.getMessage());
+            }
+            cloudFormation.close();
+        }
+        if (iam != null) {
+            try {
+                iam.deleteUser(DeleteUserRequest.builder().userName(userName).build());
+            } catch (Exception ignored) {
+            }
+            iam.close();
+        }
+    }
+
+    @Test
+    void createsValidatesUpdatesAndDeletesIamUserThroughAwsSdk() throws InterruptedException {
+        cloudFormation.createStack(CreateStackRequest.builder()
+                .stackName(stackName)
+                .templateBody(template(userName, "/initial/"))
+                .build());
+        assertThat(waitForTerminal(stackName, 30)).isEqualTo("CREATE_COMPLETE");
+
+        Stack createdStack = cloudFormation.describeStacks(
+                DescribeStacksRequest.builder().stackName(stackName).build())
+                .stacks().get(0);
+        Map<String, String> outputs = createdStack.outputs().stream()
+                .collect(Collectors.toMap(Output::outputKey, Output::outputValue));
+
+        assertThat(outputs).containsEntry("UserRef", userName);
+        String userArn = outputs.get("UserArn");
+        assertThat(userArn).startsWith("arn:aws:iam::").endsWith(":user/initial/" + userName);
+        String userId = outputs.get("UserId");
+        assertThat(userId).startsWith("AIDA");
+
+        GetUserResponse userResponse = iam.getUser(GetUserRequest.builder().userName(userName).build());
+        User user = userResponse.user();
+        assertThat(user.userName()).isEqualTo(userName);
+        assertThat(user.path()).isEqualTo("/initial/");
+        assertThat(user.arn()).isEqualTo(userArn);
+        assertThat(user.userId()).isEqualTo(userId);
+
+        // Update path on existing user
+        cloudFormation.updateStack(r -> r
+                .stackName(stackName)
+                .templateBody(template(userName, "/updated/")));
+        assertThat(waitForTerminal(stackName, 30)).isEqualTo("UPDATE_COMPLETE");
+
+        GetUserResponse updatedUserResponse = iam.getUser(GetUserRequest.builder().userName(userName).build());
+        assertThat(updatedUserResponse.user().path()).isEqualTo("/updated/");
+        assertThat(updatedUserResponse.user().userId()).isEqualTo(userId);
+
+        // Delete stack and verify user is removed
+        cloudFormation.deleteStack(DeleteStackRequest.builder().stackName(stackName).build());
+        waitForDeleted(stackName, 30);
+
+        assertThatThrownBy(() -> iam.getUser(GetUserRequest.builder().userName(userName).build()))
+                .isInstanceOf(NoSuchEntityException.class);
+    }
+
+    private static String template(String name, String path) {
+        return """
+                {
+                  "Resources": {
+                    "AppUser": {
+                      "Type": "AWS::IAM::User",
+                      "Properties": {
+                        "UserName": "%s",
+                        "Path": "%s"
+                      }
+                    }
+                  },
+                  "Outputs": {
+                    "UserRef": {"Value": {"Ref": "AppUser"}},
+                    "UserArn": {"Value": {"Fn::GetAtt": ["AppUser", "Arn"]}},
+                    "UserId": {"Value": {"Fn::GetAtt": ["AppUser", "UserId"]}}
+                  }
+                }
+                """.formatted(name, path);
+    }
+
+    private static String waitForTerminal(String name, int maxSeconds) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + maxSeconds * 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            List<Stack> stacks = cloudFormation.describeStacks(
+                    DescribeStacksRequest.builder().stackName(name).build()).stacks();
+            if (!stacks.isEmpty()) {
+                String status = stacks.get(0).stackStatusAsString();
+                if (!status.endsWith("_IN_PROGRESS")) {
+                    return status;
+                }
+            }
+            Thread.sleep(500);
+        }
+        throw new AssertionError(
+                "Stack " + name + " did not reach a terminal state within " + maxSeconds + "s");
+    }
+
+    private static void waitForDeleted(String name, int maxSeconds) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + maxSeconds * 1000L;
+        while (System.currentTimeMillis() < deadline) {
+            try {
+                List<Stack> stacks = cloudFormation.describeStacks(
+                        DescribeStacksRequest.builder().stackName(name).build()).stacks();
+                if (stacks.isEmpty()
+                        || "DELETE_COMPLETE".equals(stacks.get(0).stackStatusAsString())) {
+                    return;
+                }
+            } catch (CloudFormationException e) {
+                if (e.getMessage() != null && e.getMessage().contains("does not exist")) {
+                    return;
+                }
+                throw e;
+            }
+            Thread.sleep(500);
+        }
+        throw new AssertionError(
+                "Stack " + name + " was not deleted within " + maxSeconds + "s");
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
@@ -55,7 +55,8 @@ class CloudFormationIamUserTest {
         if (iam != null) {
             try {
                 iam.deleteUser(DeleteUserRequest.builder().userName(userName).build());
-            } catch (Exception ignored) {
+            } catch (Exception e) {
+                System.err.println("IAM user direct cleanup skipped: " + e.getMessage());
             }
             iam.close();
         }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/CloudFormationIamUserTest.java
@@ -18,10 +18,10 @@ import software.amazon.awssdk.services.iam.model.GetUserResponse;
 import software.amazon.awssdk.services.iam.model.NoSuchEntityException;
 import software.amazon.awssdk.services.iam.model.User;
 
+import org.jboss.logging.Logger;
+
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("CloudFormation AWS::IAM::User")
 class CloudFormationIamUserTest {
 
-    private static final Logger LOG = Logger.getLogger(CloudFormationIamUserTest.class.getName());
+    private static final Logger LOG = Logger.getLogger(CloudFormationIamUserTest.class);
 
     private static CloudFormationClient cloudFormation;
     private static IamClient iam;
@@ -52,7 +52,7 @@ class CloudFormationIamUserTest {
                 cloudFormation.deleteStack(
                         DeleteStackRequest.builder().stackName(stackName).build());
             } catch (Exception e) {
-                LOG.log(Level.WARNING, "Failed to delete CloudFormation IAM user test stack: " + stackName, e);
+                LOG.warn("Failed to delete CloudFormation IAM user test stack: " + stackName, e);
             }
             cloudFormation.close();
         }
@@ -60,7 +60,7 @@ class CloudFormationIamUserTest {
             try {
                 iam.deleteUser(DeleteUserRequest.builder().userName(userName).build());
             } catch (Exception e) {
-                LOG.log(Level.WARNING, "Failed to delete IAM user directly during cleanup: " + userName, e);
+                LOG.warn("Failed to delete IAM user directly during cleanup: " + userName, e);
             }
             iam.close();
         }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -255,7 +255,6 @@ public class CloudFormationResourceProvisioner {
             "AWS::IAM::InstanceProfile",
             "AWS::IAM::ManagedPolicy",
             "AWS::IAM::Policy",
-            "AWS::IAM::User",
             "AWS::Lambda::Function",
             "AWS::Lambda::LayerVersion",
             "AWS::RDS::DBCluster",
@@ -418,7 +417,6 @@ public class CloudFormationResourceProvisioner {
                 case "AWS::Lambda::Function" -> provisionLambda(resource, properties, engine, region, accountId, stackName);
                 case "AWS::Lambda::LayerVersion" ->
                         provisionLambdaLayerVersion(resource, properties, engine, region, stackName);
-                case "AWS::IAM::User" -> provisionIamUser(resource, properties, engine, stackName);
                 case "AWS::IAM::AccessKey" -> provisionIamAccessKey(resource, properties, engine);
                 case "AWS::IAM::Policy" -> provisionIamInlinePolicy(resource, properties, engine, stackName);
                 case "AWS::IAM::ManagedPolicy" ->
@@ -4796,17 +4794,6 @@ public class CloudFormationResourceProvisioner {
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-
-    private void provisionIamUser(StackResource r, JsonNode props, CloudFormationTemplateEngine engine,
-                                  String stackName) {
-        String userName = resolveOptional(props, "UserName", engine);
-        if (userName == null || userName.isBlank()) {
-            userName = generatePhysicalName(stackName, r.getLogicalId(), 64, false);
-        }
-        var user = iamService.createUser(userName, "/");
-        r.setPhysicalId(userName);
-        r.getAttributes().put("Arn", user.getArn());
-    }
 
     private void provisionIamAccessKey(StackResource r, JsonNode props, CloudFormationTemplateEngine engine) {
         String userName = resolveOptional(props, "UserName", engine);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
@@ -1,0 +1,171 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.iam.model.AccessKey;
+import io.github.hectorvent.floci.services.iam.model.IamUser;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * CloudFormation provisioning for {@code AWS::IAM::User}, moved out of the
+ * {@code CloudFormationResourceProvisioner} switch.
+ */
+@ApplicationScoped
+public class IamUserCfnProvisioner implements CfnResourceProvisioner {
+
+    private static final Logger LOG = Logger.getLogger(IamUserCfnProvisioner.class);
+
+    private final IamService iamService;
+
+    @Inject
+    public IamUserCfnProvisioner(IamService iamService) {
+        this.iamService = iamService;
+    }
+
+    @Override
+    public Set<String> resourceTypes() {
+        return Set.of("AWS::IAM::User");
+    }
+
+    @Override
+    public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
+        String existingUserName = ctx.priorPhysicalId() != null ? ctx.priorPhysicalId() : r.getPhysicalId();
+        String userName = ctx.resolveOptional(props, "UserName");
+        if (userName == null || userName.isBlank()) {
+            userName = existingUserName != null && !existingUserName.isBlank()
+                    ? existingUserName
+                    : ctx.generatePhysicalName(r.getLogicalId(), 64, false);
+        }
+        final String resolvedUserName = userName;
+        if (existingUserName != null && !existingUserName.equals(resolvedUserName)) {
+            throw new AwsException("ValidationError",
+                    "Updating UserName requires resource replacement, which is not supported.", 400);
+        }
+
+        String path = ctx.resolveOptional(props, "Path");
+        if (path == null) {
+            path = "/";
+        }
+
+        List<String> managedPolicyArns = ctx.resolveStringList(props, "ManagedPolicyArns");
+        List<String> groups = ctx.resolveStringList(props, "Groups");
+
+        IamUser user;
+        try {
+            user = iamService.createUser(resolvedUserName, path);
+            r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
+        } catch (AwsException e) {
+            boolean stackAlreadyOwnsUser = existingUserName != null && existingUserName.equals(resolvedUserName);
+            if (!stackAlreadyOwnsUser || !"EntityAlreadyExists".equals(e.getErrorCode())) {
+                throw e;
+            }
+            user = iamService.getUser(resolvedUserName);
+        }
+
+        r.setPhysicalId(resolvedUserName);
+        r.getAttributes().put("Arn", user.getArn());
+
+        for (String groupName : groups) {
+            iamService.addUserToGroup(groupName, resolvedUserName);
+        }
+
+        for (String policyArn : managedPolicyArns) {
+            iamService.attachUserPolicy(resolvedUserName, policyArn);
+        }
+
+        if (props != null && props.has("Policies")) {
+            for (JsonNode policy : props.get("Policies")) {
+                String declaredName = ctx.resolveOptional(policy, "PolicyName");
+                if (declaredName == null || declaredName.isBlank()) {
+                    throw new AwsException("ValidationError",
+                            "An inline policy on user " + resolvedUserName + " has no PolicyName.", 400);
+                }
+                final String policyName = declaredName;
+                JsonNode document = policy.get("PolicyDocument");
+                if (document == null || document.isNull()) {
+                    throw new AwsException("ValidationError",
+                            "Inline policy '" + policyName + "' on user " + resolvedUserName
+                                    + " has no PolicyDocument.", 400);
+                }
+                iamService.putUserPolicy(resolvedUserName, policyName,
+                        ctx.engine().resolveJsonAttribute(document));
+            }
+        }
+    }
+
+    @Override
+    public void delete(String resourceType, String physicalId, String region) {
+        IamUser user;
+        try {
+            user = iamService.getUser(physicalId);
+        } catch (AwsException e) {
+            if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                throw e;
+            }
+            LOG.debugv("IAM user already gone, treating as deleted: {0}", physicalId);
+            return;
+        }
+
+        for (String policyArn : new ArrayList<>(user.getAttachedPolicyArns())) {
+            try {
+                iamService.detachUserPolicy(physicalId, policyArn);
+            } catch (AwsException e) {
+                if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                    throw e;
+                }
+            }
+        }
+
+        for (String policyName : new ArrayList<>(user.getInlinePolicies().keySet())) {
+            try {
+                iamService.deleteUserPolicy(physicalId, policyName);
+            } catch (AwsException e) {
+                if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                    throw e;
+                }
+            }
+        }
+
+        for (String groupName : new ArrayList<>(user.getGroupNames())) {
+            try {
+                iamService.removeUserFromGroup(groupName, physicalId);
+            } catch (AwsException e) {
+                if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                    throw e;
+                }
+            }
+        }
+
+        try {
+            for (AccessKey key : iamService.listAccessKeys(physicalId)) {
+                try {
+                    iamService.deleteAccessKey(physicalId, key.getAccessKeyId());
+                } catch (AwsException e) {
+                    if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                        throw e;
+                    }
+                }
+            }
+        } catch (AwsException e) {
+            if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                throw e;
+            }
+        }
+
+        try {
+            iamService.deleteUser(physicalId);
+        } catch (AwsException e) {
+            if (!"NoSuchEntity".equals(e.getErrorCode())) {
+                throw e;
+            }
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
@@ -11,7 +11,13 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -22,6 +28,10 @@ import java.util.Set;
 public class IamUserCfnProvisioner implements CfnResourceProvisioner {
 
     private static final Logger LOG = Logger.getLogger(IamUserCfnProvisioner.class);
+
+    private static final String INLINE_NAMES_ATTR = "__FlociInlinePolicyNames";
+    private static final String MANAGED_ARNS_ATTR = "__FlociManagedPolicyArns";
+    private static final String GROUPS_ATTR = "__FlociGroups";
 
     private final IamService iamService;
 
@@ -54,13 +64,18 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
         if (path == null) {
             path = "/";
         }
+        final String resolvedPath = path;
 
         List<String> managedPolicyArns = ctx.resolveStringList(props, "ManagedPolicyArns");
         List<String> groups = ctx.resolveStringList(props, "Groups");
 
         IamUser user;
+        boolean createdUser = false;
+        String priorPath = null;
+        String priorUserId = null;
         try {
-            user = iamService.createUser(resolvedUserName, path);
+            user = iamService.createUser(resolvedUserName, resolvedPath);
+            createdUser = true;
             r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
         } catch (AwsException e) {
             boolean stackAlreadyOwnsUser = existingUserName != null && existingUserName.equals(resolvedUserName);
@@ -68,37 +83,200 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
                 throw e;
             }
             user = iamService.getUser(resolvedUserName);
+            String existingUserId = r.getAttributes().get("UserId");
+            if (existingUserId == null || existingUserId.isBlank()
+                    || !existingUserId.equals(user.getUserId())) {
+                r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
+                throw e;
+            }
+            priorPath = user.getPath();
+            priorUserId = existingUserId;
+            if (!resolvedPath.equals(user.getPath())) {
+                iamService.updateUser(resolvedUserName, null, resolvedPath, existingUserId);
+                user = iamService.getUser(resolvedUserName);
+            }
         }
 
         r.setPhysicalId(resolvedUserName);
         r.getAttributes().put("Arn", user.getArn());
+        r.getAttributes().put("UserId", user.getUserId());
 
-        for (String groupName : groups) {
-            iamService.addUserToGroup(groupName, resolvedUserName);
-        }
+        Set<String> previousInlineNames = readTrackedSet(r, INLINE_NAMES_ATTR);
+        Set<String> previousManagedArns = readTrackedSet(r, MANAGED_ARNS_ATTR);
+        Set<String> previousGroups = readTrackedSet(r, GROUPS_ATTR);
 
-        for (String policyArn : managedPolicyArns) {
-            iamService.attachUserPolicy(resolvedUserName, policyArn);
-        }
+        Set<String> originalGroups = new HashSet<>(user.getGroupNames());
+        Set<String> originalPolicyArns = new HashSet<>(user.getAttachedPolicyArns());
+        Map<String, String> originalInlinePolicies = new HashMap<>(user.getInlinePolicies());
 
-        if (props != null && props.has("Policies")) {
-            for (JsonNode policy : props.get("Policies")) {
-                String declaredName = ctx.resolveOptional(policy, "PolicyName");
-                if (declaredName == null || declaredName.isBlank()) {
-                    throw new AwsException("ValidationError",
-                            "An inline policy on user " + resolvedUserName + " has no PolicyName.", 400);
+        LinkedHashSet<String> groupsAddedByThisAttempt = new LinkedHashSet<>();
+        LinkedHashSet<String> groupsRemovedByThisAttempt = new LinkedHashSet<>();
+        LinkedHashSet<String> attachedByThisAttempt = new LinkedHashSet<>();
+        LinkedHashSet<String> detachedByThisAttempt = new LinkedHashSet<>();
+        LinkedHashSet<String> inlineWrittenByThisAttempt = new LinkedHashSet<>();
+        LinkedHashSet<String> inlineRemovedByThisAttempt = new LinkedHashSet<>();
+
+        final String pathToRestore = priorPath;
+        final String userIdToRestore = priorUserId;
+
+        try {
+            for (String groupName : groups) {
+                iamService.addUserToGroup(groupName, resolvedUserName);
+                if (!originalGroups.contains(groupName)) {
+                    groupsAddedByThisAttempt.add(groupName);
                 }
-                final String policyName = declaredName;
-                JsonNode document = policy.get("PolicyDocument");
-                if (document == null || document.isNull()) {
-                    throw new AwsException("ValidationError",
-                            "Inline policy '" + policyName + "' on user " + resolvedUserName
-                                    + " has no PolicyDocument.", 400);
-                }
-                iamService.putUserPolicy(resolvedUserName, policyName,
-                        ctx.engine().resolveJsonAttribute(document));
             }
+
+            for (String policyArn : managedPolicyArns) {
+                iamService.attachUserPolicy(resolvedUserName, policyArn);
+                if (!originalPolicyArns.contains(policyArn)) {
+                    attachedByThisAttempt.add(policyArn);
+                }
+            }
+
+            if (props != null && props.has("Policies")) {
+                for (JsonNode policy : props.get("Policies")) {
+                    String declaredName = ctx.resolveOptional(policy, "PolicyName");
+                    if (declaredName == null || declaredName.isBlank()) {
+                        throw new AwsException("ValidationError",
+                                "An inline policy on user " + resolvedUserName + " has no PolicyName.", 400);
+                    }
+                    final String policyName = declaredName;
+                    JsonNode document = policy.get("PolicyDocument");
+                    if (document == null || document.isNull()) {
+                        throw new AwsException("ValidationError",
+                                "Inline policy '" + policyName + "' on user " + resolvedUserName
+                                        + " has no PolicyDocument.", 400);
+                    }
+                    iamService.putUserPolicy(resolvedUserName, policyName,
+                            ctx.engine().resolveJsonAttribute(document));
+                    inlineWrittenByThisAttempt.add(policyName);
+                }
+            }
+
+            for (String stale : previousInlineNames) {
+                if (!inlineWrittenByThisAttempt.contains(stale)
+                        && originalInlinePolicies.containsKey(stale)) {
+                    iamService.deleteUserPolicy(resolvedUserName, stale);
+                    inlineRemovedByThisAttempt.add(stale);
+                }
+            }
+            for (String stale : previousManagedArns) {
+                if (!managedPolicyArns.contains(stale) && originalPolicyArns.contains(stale)) {
+                    iamService.detachUserPolicy(resolvedUserName, stale);
+                    detachedByThisAttempt.add(stale);
+                }
+            }
+            for (String stale : previousGroups) {
+                if (!groups.contains(stale) && originalGroups.contains(stale)) {
+                    iamService.removeUserFromGroup(stale, resolvedUserName);
+                    groupsRemovedByThisAttempt.add(stale);
+                }
+            }
+        } catch (RuntimeException failure) {
+            boolean cleanupSucceeded = true;
+
+            for (String groupName : groupsRemovedByThisAttempt) {
+                if (!CfnRollback.attemptIamCleanup(failure,
+                        "re-add user " + resolvedUserName + " to group " + groupName,
+                        () -> iamService.addUserToGroup(groupName, resolvedUserName))) {
+                    cleanupSucceeded = false;
+                }
+            }
+            for (String policyName : inlineRemovedByThisAttempt) {
+                String prior = originalInlinePolicies.get(policyName);
+                if (prior == null) {
+                    continue;
+                }
+                if (!CfnRollback.attemptIamCleanup(failure,
+                        "restore inline policy " + policyName + " on user " + resolvedUserName,
+                        () -> iamService.putUserPolicy(resolvedUserName, policyName, prior))) {
+                    cleanupSucceeded = false;
+                }
+            }
+            for (String policyArn : detachedByThisAttempt) {
+                if (!CfnRollback.attemptIamCleanup(failure,
+                        "reattach policy " + policyArn + " to user " + resolvedUserName,
+                        () -> iamService.attachUserPolicy(resolvedUserName, policyArn))) {
+                    cleanupSucceeded = false;
+                }
+            }
+
+            List<String> inlineRollback = new ArrayList<>(inlineWrittenByThisAttempt);
+            Collections.reverse(inlineRollback);
+            for (String policyName : inlineRollback) {
+                String prior = originalInlinePolicies.get(policyName);
+                String cleanupDescription = (prior == null ? "remove" : "restore")
+                        + " inline policy " + policyName + " on user " + resolvedUserName;
+                if (!CfnRollback.attemptIamCleanup(failure, cleanupDescription, () -> {
+                    if (prior == null) {
+                        iamService.deleteUserPolicy(resolvedUserName, policyName);
+                    } else {
+                        iamService.putUserPolicy(resolvedUserName, policyName, prior);
+                    }
+                })) {
+                    cleanupSucceeded = false;
+                }
+            }
+
+            List<String> rollbackArns = new ArrayList<>(attachedByThisAttempt);
+            Collections.reverse(rollbackArns);
+            for (String policyArn : rollbackArns) {
+                String cleanupDescription = "detach policy " + policyArn + " from user " + resolvedUserName;
+                if (!CfnRollback.attemptIamCleanup(failure, cleanupDescription,
+                        () -> iamService.detachUserPolicy(resolvedUserName, policyArn))) {
+                    cleanupSucceeded = false;
+                }
+            }
+
+            List<String> rollbackGroups = new ArrayList<>(groupsAddedByThisAttempt);
+            Collections.reverse(rollbackGroups);
+            for (String groupName : rollbackGroups) {
+                String cleanupDescription = "remove user " + resolvedUserName + " from group " + groupName;
+                if (!CfnRollback.attemptIamCleanup(failure, cleanupDescription,
+                        () -> iamService.removeUserFromGroup(groupName, resolvedUserName))) {
+                    cleanupSucceeded = false;
+                }
+            }
+
+            if (pathToRestore != null) {
+                if (!CfnRollback.attemptIamCleanup(failure, "restore prior path on user " + resolvedUserName,
+                        () -> iamService.updateUser(resolvedUserName, null, pathToRestore, userIdToRestore))) {
+                    cleanupSucceeded = false;
+                }
+            }
+
+            if (createdUser) {
+                if (!CfnRollback.attemptIamCleanup(failure, "delete user " + resolvedUserName,
+                        () -> iamService.deleteUser(resolvedUserName))) {
+                    cleanupSucceeded = false;
+                }
+                if (cleanupSucceeded) {
+                    r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
+                }
+            }
+            throw failure;
         }
+
+        writeTrackedSet(r, INLINE_NAMES_ATTR, inlineWrittenByThisAttempt);
+        writeTrackedSet(r, MANAGED_ARNS_ATTR, managedPolicyArns);
+        writeTrackedSet(r, GROUPS_ATTR, groups);
+    }
+
+    private static Set<String> readTrackedSet(StackResource r, String attribute) {
+        String raw = r.getAttributes().get(attribute);
+        if (raw == null || raw.isEmpty()) {
+            return Set.of();
+        }
+        return new LinkedHashSet<>(List.of(raw.split("\n")));
+    }
+
+    private static void writeTrackedSet(StackResource r, String attribute, Collection<String> values) {
+        if (values.isEmpty()) {
+            r.getAttributes().remove(attribute);
+            return;
+        }
+        r.getAttributes().put(attribute, String.join("\n", values));
     }
 
     @Override

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
@@ -32,6 +32,7 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
     private static final String INLINE_NAMES_ATTR = "__FlociInlinePolicyNames";
     private static final String MANAGED_ARNS_ATTR = "__FlociManagedPolicyArns";
     private static final String GROUPS_ATTR = "__FlociGroups";
+    private static final String USER_ID_ATTR = "__FlociUserId";
 
     private final IamService iamService;
 
@@ -77,7 +78,7 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
                 throw e;
             }
             user = iamService.getUser(resolvedUserName);
-            String existingUserId = r.getAttributes().get("UserId");
+            String existingUserId = r.getAttributes().get(USER_ID_ATTR);
             if (existingUserId == null || existingUserId.isBlank()
                     || !existingUserId.equals(user.getUserId())) {
                 r.getAttributes().remove(CfnRollback.ROLLBACK_OWNED_ATTR);
@@ -93,7 +94,7 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
 
         r.setPhysicalId(resolvedUserName);
         r.getAttributes().put("Arn", user.getArn());
-        r.getAttributes().put("UserId", user.getUserId());
+        r.getAttributes().put(USER_ID_ATTR, user.getUserId());
 
         Set<String> previousInlineNames = readTrackedSet(r, INLINE_NAMES_ATTR);
         Set<String> previousManagedArns = readTrackedSet(r, MANAGED_ARNS_ATTR);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
@@ -293,57 +293,33 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
         }
 
         for (String policyArn : new ArrayList<>(user.getAttachedPolicyArns())) {
-            try {
-                iamService.detachUserPolicy(physicalId, policyArn);
-            } catch (AwsException e) {
-                if (!"NoSuchEntity".equals(e.getErrorCode())) {
-                    throw e;
-                }
-            }
+            CfnDeletes.safeDelete("attached policy " + policyArn + " on user", physicalId,
+                    () -> iamService.detachUserPolicy(physicalId, policyArn), "NoSuchEntity");
         }
 
         for (String policyName : new ArrayList<>(user.getInlinePolicies().keySet())) {
-            try {
-                iamService.deleteUserPolicy(physicalId, policyName);
-            } catch (AwsException e) {
-                if (!"NoSuchEntity".equals(e.getErrorCode())) {
-                    throw e;
-                }
-            }
+            CfnDeletes.safeDelete("inline policy " + policyName + " on user", physicalId,
+                    () -> iamService.deleteUserPolicy(physicalId, policyName), "NoSuchEntity");
         }
 
         for (String groupName : new ArrayList<>(user.getGroupNames())) {
-            try {
-                iamService.removeUserFromGroup(groupName, physicalId);
-            } catch (AwsException e) {
-                if (!"NoSuchEntity".equals(e.getErrorCode())) {
-                    throw e;
-                }
-            }
+            CfnDeletes.safeDelete("user " + physicalId + " membership in group " + groupName, physicalId,
+                    () -> iamService.removeUserFromGroup(groupName, physicalId), "NoSuchEntity");
         }
 
         try {
             for (AccessKey key : iamService.listAccessKeys(physicalId)) {
-                try {
-                    iamService.deleteAccessKey(physicalId, key.getAccessKeyId());
-                } catch (AwsException e) {
-                    if (!"NoSuchEntity".equals(e.getErrorCode())) {
-                        throw e;
-                    }
-                }
+                CfnDeletes.safeDelete("access key " + key.getAccessKeyId() + " on user", physicalId,
+                        () -> iamService.deleteAccessKey(physicalId, key.getAccessKeyId()), "NoSuchEntity");
             }
         } catch (AwsException e) {
             if (!"NoSuchEntity".equals(e.getErrorCode())) {
                 throw e;
             }
+            LOG.debugv("IAM user access keys already gone, treating as deleted: {0}", physicalId);
         }
 
-        try {
-            iamService.deleteUser(physicalId);
-        } catch (AwsException e) {
-            if (!"NoSuchEntity".equals(e.getErrorCode())) {
-                throw e;
-            }
-        }
+        CfnDeletes.safeDelete("IAM user", physicalId,
+                () -> iamService.deleteUser(physicalId), "NoSuchEntity");
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisioner.java
@@ -47,15 +47,10 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
 
     @Override
     public void provision(StackResource r, JsonNode props, ProvisionContext ctx) {
-        String existingUserName = ctx.priorPhysicalId() != null ? ctx.priorPhysicalId() : r.getPhysicalId();
-        String userName = ctx.resolveOptional(props, "UserName");
-        if (userName == null || userName.isBlank()) {
-            userName = existingUserName != null && !existingUserName.isBlank()
-                    ? existingUserName
-                    : ctx.generatePhysicalName(r.getLogicalId(), 64, false);
-        }
+        String userName = ctx.stablePhysicalName(ctx.resolveOptional(props, "UserName"),
+                r.getLogicalId(), 64, false);
         final String resolvedUserName = userName;
-        if (existingUserName != null && !existingUserName.equals(resolvedUserName)) {
+        if (ctx.isUpdate() && !ctx.priorPhysicalId().equals(resolvedUserName)) {
             throw new AwsException("ValidationError",
                     "Updating UserName requires resource replacement, which is not supported.", 400);
         }
@@ -78,8 +73,7 @@ public class IamUserCfnProvisioner implements CfnResourceProvisioner {
             createdUser = true;
             r.getAttributes().put(CfnRollback.ROLLBACK_OWNED_ATTR, "true");
         } catch (AwsException e) {
-            boolean stackAlreadyOwnsUser = existingUserName != null && existingUserName.equals(resolvedUserName);
-            if (!stackAlreadyOwnsUser || !"EntityAlreadyExists".equals(e.getErrorCode())) {
+            if (!ctx.reusesPriorEntity(resolvedUserName) || !"EntityAlreadyExists".equals(e.getErrorCode())) {
                 throw e;
             }
             user = iamService.getUser(resolvedUserName);

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -395,7 +395,21 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
     }
 
     public void updateUser(String userName, String newUserName, String newPath) {
+        updateUser(userName, newUserName, newPath, null);
+    }
+
+    /**
+     * Same as {@link #updateUser(String, String, String)}, but verifies {@code expectedUserId}
+     * against the resolved user's immutable ID before applying the update, atomically with the
+     * name-based lookup.
+     */
+    public void updateUser(String userName, String newUserName, String newPath, String expectedUserId) {
         IamUser user = getUser(userName);
+        if (expectedUserId != null && !expectedUserId.equals(user.getUserId())) {
+            throw new AwsException("EntityAlreadyExists",
+                    "User " + userName + " was replaced by a different user of the same name; "
+                            + "refusing to apply an update meant for the original user.", 409);
+        }
         if (newUserName != null && !newUserName.equals(userName)) {
             if (users.get(newUserName).isPresent()) {
                 throw new AwsException("EntityAlreadyExists",

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CfnProvisionerFixture.java
@@ -38,6 +38,7 @@ import io.github.hectorvent.floci.services.cloudformation.provisioners.EcrCfnPro
 import io.github.hectorvent.floci.services.cloudformation.provisioners.EcsCapacityCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.FirehoseCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.IamRoleCfnProvisioner;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.IamUserCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.IotDomainConfigurationCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.KinesisCfnProvisioner;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.KmsCfnProvisioner;
@@ -229,6 +230,7 @@ final class CfnProvisionerFixture {
             }
             if (iamService != null) {
                 discovered.add(new IamRoleCfnProvisioner(iamService));
+                discovered.add(new IamUserCfnProvisioner(iamService));
             }
             if (ecsService != null) {
                 discovered.add(new EcsCapacityCfnProvisioner(ecsService));

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
@@ -43,8 +43,7 @@ class CloudFormationIamUserIntegrationTest {
                   },
                   "Outputs": {
                     "UserRef": {"Value": {"Ref": "ProbeUser"}},
-                    "UserArn": {"Value": {"Fn::GetAtt": ["ProbeUser", "Arn"]}},
-                    "UserId": {"Value": {"Fn::GetAtt": ["ProbeUser", "UserId"]}}
+                    "UserArn": {"Value": {"Fn::GetAtt": ["ProbeUser", "Arn"]}}
                   }
                 }
                 """.formatted(userName);
@@ -56,9 +55,6 @@ class CloudFormationIamUserIntegrationTest {
         assertEquals(userName, outputValue(stackXml, "UserRef"));
         String expectedArn = "arn:aws:iam::111122223333:user/" + userName;
         assertEquals(expectedArn, outputValue(stackXml, "UserArn"));
-        String userId = outputValue(stackXml, "UserId");
-        assertNotNull(userId);
-        assertTrue(userId.startsWith("AIDA"), "Fn::GetAtt UserId must start with AIDA: " + userId);
 
         // Verify IAM user exists and Arn matches
         given()
@@ -71,8 +67,7 @@ class CloudFormationIamUserIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<UserName>" + userName + "</UserName>"))
-            .body(containsString("<Arn>" + expectedArn + "</Arn>"))
-            .body(containsString("<UserId>" + userId + "</UserId>"));
+            .body(containsString("<Arn>" + expectedArn + "</Arn>"));
 
         // Delete the stack
         deleteStack(stackName);
@@ -113,8 +108,7 @@ class CloudFormationIamUserIntegrationTest {
                   },
                   "Outputs": {
                     "UserRef": {"Value": {"Ref": "GenUser"}},
-                    "UserArn": {"Value": {"Fn::GetAtt": ["GenUser", "Arn"]}},
-                    "UserId": {"Value": {"Fn::GetAtt": ["GenUser", "UserId"]}}
+                    "UserArn": {"Value": {"Fn::GetAtt": ["GenUser", "Arn"]}}
                   }
                 }
                 """;
@@ -126,9 +120,6 @@ class CloudFormationIamUserIntegrationTest {
         String generatedUserName = outputValue(stackXml, "UserRef");
         assertNotNull(generatedUserName);
         assertEquals("arn:aws:iam::111122223333:user/" + generatedUserName, outputValue(stackXml, "UserArn"));
-        String genUserId = outputValue(stackXml, "UserId");
-        assertNotNull(genUserId);
-        assertTrue(genUserId.startsWith("AIDA"), "Fn::GetAtt UserId must start with AIDA: " + genUserId);
 
         // Verify generated user exists
         given()
@@ -141,8 +132,7 @@ class CloudFormationIamUserIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<UserName>" + generatedUserName + "</UserName>"))
-            .body(containsString("<Arn>arn:aws:iam::111122223333:user/" + generatedUserName + "</Arn>"))
-            .body(containsString("<UserId>" + genUserId + "</UserId>"));
+            .body(containsString("<Arn>arn:aws:iam::111122223333:user/" + generatedUserName + "</Arn>"));
 
         deleteStack(stackName);
         awaitStackStatus(stackId, "DELETE_COMPLETE");

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.cloudformation;
 
+import io.github.hectorvent.floci.core.common.XmlParser;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.Test;
@@ -7,6 +8,9 @@ import org.junit.jupiter.api.Test;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -36,12 +40,25 @@ class CloudFormationIamUserIntegrationTest {
                         "UserName": "%s"
                       }
                     }
+                  },
+                  "Outputs": {
+                    "UserRef": {"Value": {"Ref": "ProbeUser"}},
+                    "UserArn": {"Value": {"Fn::GetAtt": ["ProbeUser", "Arn"]}},
+                    "UserId": {"Value": {"Fn::GetAtt": ["ProbeUser", "UserId"]}}
                   }
                 }
                 """.formatted(userName);
 
         String stackId = createStack(stackName, template);
         awaitStackStatus(stackId, "CREATE_COMPLETE");
+
+        String stackXml = describeStacks(stackId);
+        assertEquals(userName, outputValue(stackXml, "UserRef"));
+        String expectedArn = "arn:aws:iam::111122223333:user/" + userName;
+        assertEquals(expectedArn, outputValue(stackXml, "UserArn"));
+        String userId = outputValue(stackXml, "UserId");
+        assertNotNull(userId);
+        assertTrue(userId.startsWith("AIDA"), "Fn::GetAtt UserId must start with AIDA: " + userId);
 
         // Verify IAM user exists and Arn matches
         given()
@@ -54,7 +71,8 @@ class CloudFormationIamUserIntegrationTest {
         .then()
             .statusCode(200)
             .body(containsString("<UserName>" + userName + "</UserName>"))
-            .body(containsString("<Arn>arn:aws:iam::111122223333:user/" + userName + "</Arn>"));
+            .body(containsString("<Arn>" + expectedArn + "</Arn>"))
+            .body(containsString("<UserId>" + userId + "</UserId>"));
 
         // Delete the stack
         deleteStack(stackName);
@@ -92,6 +110,11 @@ class CloudFormationIamUserIntegrationTest {
                     "GenUser": {
                       "Type": "AWS::IAM::User"
                     }
+                  },
+                  "Outputs": {
+                    "UserRef": {"Value": {"Ref": "GenUser"}},
+                    "UserArn": {"Value": {"Fn::GetAtt": ["GenUser", "Arn"]}},
+                    "UserId": {"Value": {"Fn::GetAtt": ["GenUser", "UserId"]}}
                   }
                 }
                 """;
@@ -99,14 +122,13 @@ class CloudFormationIamUserIntegrationTest {
         String stackId = createStack(stackName, template);
         awaitStackStatus(stackId, "CREATE_COMPLETE");
 
-        String resourcesXml = cfnQuery("DescribeStackResources", stackName)
-                .then().statusCode(200).extract().asString();
-        assertThat(resourcesXml, containsString("<PhysicalResourceId>"));
-
-        String physicalIdTag = "<PhysicalResourceId>";
-        int start = resourcesXml.indexOf(physicalIdTag) + physicalIdTag.length();
-        int end = resourcesXml.indexOf("</PhysicalResourceId>", start);
-        String generatedUserName = resourcesXml.substring(start, end);
+        String stackXml = describeStacks(stackId);
+        String generatedUserName = outputValue(stackXml, "UserRef");
+        assertNotNull(generatedUserName);
+        assertEquals("arn:aws:iam::111122223333:user/" + generatedUserName, outputValue(stackXml, "UserArn"));
+        String genUserId = outputValue(stackXml, "UserId");
+        assertNotNull(genUserId);
+        assertTrue(genUserId.startsWith("AIDA"), "Fn::GetAtt UserId must start with AIDA: " + genUserId);
 
         // Verify generated user exists
         given()
@@ -118,7 +140,9 @@ class CloudFormationIamUserIntegrationTest {
             .post("/")
         .then()
             .statusCode(200)
-            .body(containsString("<UserName>" + generatedUserName + "</UserName>"));
+            .body(containsString("<UserName>" + generatedUserName + "</UserName>"))
+            .body(containsString("<Arn>arn:aws:iam::111122223333:user/" + generatedUserName + "</Arn>"))
+            .body(containsString("<UserId>" + genUserId + "</UserId>"));
 
         deleteStack(stackName);
         awaitStackStatus(stackId, "DELETE_COMPLETE");
@@ -339,5 +363,9 @@ class CloudFormationIamUserIntegrationTest {
             req.formParam("TemplateBody", template);
         }
         return req.when().post("/");
+    }
+
+    private static String outputValue(String xml, String key) {
+        return XmlParser.extractPairs(xml, "Outputs", "OutputKey", "OutputValue").get(key);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
@@ -1,0 +1,186 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Verifies CloudFormation provisioning and deprovisioning lifecycle for {@code AWS::IAM::User}
+ * (regression test for issue #2490).
+ */
+@QuarkusTest
+class CloudFormationIamUserIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=111122223333/20260205/us-east-1/cloudformation/aws4_request";
+    private static final String IAM_AUTH =
+            "AWS4-HMAC-SHA256 Credential=111122223333/20260205/us-east-1/iam/aws4_request";
+
+    @Test
+    void deleteStackDeletesIamUserAndAllowsRecreation() throws InterruptedException {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String userName = "probe-user-" + suffix;
+        String stackName = "cfn-user-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "ProbeUser": {
+                      "Type": "AWS::IAM::User",
+                      "Properties": {
+                        "UserName": "%s"
+                      }
+                    }
+                  }
+                }
+                """.formatted(userName);
+
+        String stackId = createStack(stackName, template);
+        awaitStackStatus(stackId, "CREATE_COMPLETE");
+
+        // Verify IAM user exists and Arn matches
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "GetUser")
+            .formParam("UserName", userName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<UserName>" + userName + "</UserName>"))
+            .body(containsString("<Arn>arn:aws:iam::111122223333:user/" + userName + "</Arn>"));
+
+        // Delete the stack
+        deleteStack(stackName);
+        awaitStackStatus(stackId, "DELETE_COMPLETE");
+
+        // Verify IAM user is gone (NoSuchEntity / 404)
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "GetUser")
+            .formParam("UserName", userName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchEntity"));
+
+        // Redeploying with the same explicit UserName succeeds rather than failing with EntityAlreadyExists
+        String newStackName = "cfn-user-stack-recreate-" + suffix;
+        String newStackId = createStack(newStackName, template);
+        awaitStackStatus(newStackId, "CREATE_COMPLETE");
+
+        deleteStack(newStackName);
+        awaitStackStatus(newStackId, "DELETE_COMPLETE");
+    }
+
+    @Test
+    void deleteStackDeletesUserWithGeneratedName() throws InterruptedException {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "cfn-genuser-stack-" + suffix;
+
+        String template = """
+                {
+                  "Resources": {
+                    "GenUser": {
+                      "Type": "AWS::IAM::User"
+                    }
+                  }
+                }
+                """;
+
+        String stackId = createStack(stackName, template);
+        awaitStackStatus(stackId, "CREATE_COMPLETE");
+
+        String resourcesXml = cfnQuery("DescribeStackResources", stackName)
+                .then().statusCode(200).extract().asString();
+        assertThat(resourcesXml, containsString("<PhysicalResourceId>"));
+
+        String physicalIdTag = "<PhysicalResourceId>";
+        int start = resourcesXml.indexOf(physicalIdTag) + physicalIdTag.length();
+        int end = resourcesXml.indexOf("</PhysicalResourceId>", start);
+        String generatedUserName = resourcesXml.substring(start, end);
+
+        // Verify generated user exists
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "GetUser")
+            .formParam("UserName", generatedUserName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<UserName>" + generatedUserName + "</UserName>"));
+
+        deleteStack(stackName);
+        awaitStackStatus(stackId, "DELETE_COMPLETE");
+
+        // Verify generated user is deleted
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "GetUser")
+            .formParam("UserName", generatedUserName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(404)
+            .body(containsString("NoSuchEntity"));
+    }
+
+    private static String createStack(String stackName, String template) {
+        return cfnQuery("CreateStack", stackName, template)
+                .then()
+                .statusCode(200)
+                .extract()
+                .xmlPath()
+                .getString("CreateStackResponse.CreateStackResult.StackId");
+    }
+
+    private static void deleteStack(String stackName) {
+        cfnQuery("DeleteStack", stackName)
+                .then()
+                .statusCode(200);
+    }
+
+    private static void awaitStackStatus(String stackId, String status) throws InterruptedException {
+        String xml = "";
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (System.currentTimeMillis() < deadline) {
+            xml = describeStacks(stackId);
+            if (xml.contains("<StackStatus>" + status + "</StackStatus>")) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        fail("stack " + stackId + " never reached " + status + ": " + xml);
+    }
+
+    private static String describeStacks(String stackId) {
+        return cfnQuery("DescribeStacks", stackId).then().statusCode(200).extract().asString();
+    }
+
+    private static Response cfnQuery(String action, String stackName) {
+        return cfnQuery(action, stackName, null);
+    }
+
+    private static Response cfnQuery(String action, String stackName, String template) {
+        var req = given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", CFN_AUTH)
+                .formParam("Action", action)
+                .formParam("StackName", stackName);
+        if (template != null) {
+            req.formParam("TemplateBody", template);
+        }
+        return req.when().post("/");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationIamUserIntegrationTest.java
@@ -136,6 +136,157 @@ class CloudFormationIamUserIntegrationTest {
             .body(containsString("NoSuchEntity"));
     }
 
+    @Test
+    void updateStackReconcilesGroupsPoliciesAndPath() throws InterruptedException {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String userName = "update-user-" + suffix;
+        String stackName = "cfn-update-user-stack-" + suffix;
+
+        // Pre-create two groups
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "CreateGroup")
+            .formParam("GroupName", "group-a-" + suffix)
+        .when().post("/").then().statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "CreateGroup")
+            .formParam("GroupName", "group-b-" + suffix)
+        .when().post("/").then().statusCode(200);
+
+        String template1 = """
+                {
+                  "Resources": {
+                    "TestUser": {
+                      "Type": "AWS::IAM::User",
+                      "Properties": {
+                        "UserName": "%s",
+                        "Path": "/initial/",
+                        "Groups": ["group-a-%s", "group-b-%s"],
+                        "ManagedPolicyArns": [
+                          "arn:aws:iam::aws:policy/ReadOnlyAccess",
+                          "arn:aws:iam::aws:policy/PowerUserAccess"
+                        ],
+                        "Policies": [
+                          {
+                            "PolicyName": "keep-policy",
+                            "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                          },
+                          {
+                            "PolicyName": "drop-policy",
+                            "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+                """.formatted(userName, suffix, suffix);
+
+        String stackId = createStack(stackName, template1);
+        awaitStackStatus(stackId, "CREATE_COMPLETE");
+
+        // Verify initial state
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "GetUser")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<Path>/initial/</Path>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "ListAttachedUserPolicies")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("ReadOnlyAccess"))
+            .body(containsString("PowerUserAccess"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "ListUserPolicies")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<member>keep-policy</member>"))
+            .body(containsString("<member>drop-policy</member>"));
+
+        // Update stack: change path to /updated/, drop group-b, drop PowerUserAccess, drop drop-policy
+        String template2 = """
+                {
+                  "Resources": {
+                    "TestUser": {
+                      "Type": "AWS::IAM::User",
+                      "Properties": {
+                        "UserName": "%s",
+                        "Path": "/updated/",
+                        "Groups": ["group-a-%s"],
+                        "ManagedPolicyArns": [
+                          "arn:aws:iam::aws:policy/ReadOnlyAccess"
+                        ],
+                        "Policies": [
+                          {
+                            "PolicyName": "keep-policy",
+                            "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+                """.formatted(userName, suffix);
+
+        updateStack(stackName, template2);
+        awaitStackStatus(stackId, "UPDATE_COMPLETE");
+
+        // Verify updated path
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "GetUser")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200)
+            .body(containsString("<Path>/updated/</Path>"));
+
+        // Verify managed policy PowerUserAccess was detached
+        String attachedPolicies = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "ListAttachedUserPolicies")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200).extract().asString();
+        assertThat(attachedPolicies, containsString("ReadOnlyAccess"));
+        assertThat(attachedPolicies, org.hamcrest.Matchers.not(containsString("PowerUserAccess")));
+
+        // Verify drop-policy was deleted
+        String inlinePolicies = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "ListUserPolicies")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200).extract().asString();
+        assertThat(inlinePolicies, containsString("<member>keep-policy</member>"));
+        assertThat(inlinePolicies, org.hamcrest.Matchers.not(containsString("<member>drop-policy</member>")));
+
+        // Verify group-b was removed
+        String userGroups = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", IAM_AUTH)
+            .formParam("Action", "ListGroupsForUser")
+            .formParam("UserName", userName)
+        .when().post("/").then().statusCode(200).extract().asString();
+        assertThat(userGroups, containsString("group-a-" + suffix));
+        assertThat(userGroups, org.hamcrest.Matchers.not(containsString("group-b-" + suffix)));
+
+        deleteStack(stackName);
+        awaitStackStatus(stackId, "DELETE_COMPLETE");
+    }
+
     private static String createStack(String stackName, String template) {
         return cfnQuery("CreateStack", stackName, template)
                 .then()
@@ -143,6 +294,12 @@ class CloudFormationIamUserIntegrationTest {
                 .extract()
                 .xmlPath()
                 .getString("CreateStackResponse.CreateStackResult.StackId");
+    }
+
+    private static void updateStack(String stackName, String template) {
+        cfnQuery("UpdateStack", stackName, template)
+                .then()
+                .statusCode(200);
     }
 
     private static void deleteStack(String stackName) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisionerTest.java
@@ -44,6 +44,10 @@ class IamUserCfnProvisionerTest {
 
         when(engine.resolveNode(any())).thenAnswer(inv -> inv.getArgument(0));
 
+        // resolveStringList delegates to the real engine method; for the literal arrays these
+        // tests use it just walks the array and calls resolve(...) per element, stubbed above.
+        when(engine.resolveStringList(any())).thenCallRealMethod();
+
         when(engine.resolveJsonAttribute(any())).thenAnswer(inv -> {
             JsonNode node = inv.getArgument(0);
             return node != null && node.isTextual() ? node.asText() : node.toString();
@@ -224,7 +228,7 @@ class IamUserCfnProvisionerTest {
 
         StackResource r = resource();
         r.setPhysicalId("my-user");
-        r.getAttributes().put("UserId", "AIDAuser");
+        r.getAttributes().put("__FlociUserId", "AIDAuser");
         r.getAttributes().put("__FlociGroups", "keep-group\ndrop-group");
         r.getAttributes().put("__FlociManagedPolicyArns", "arn:aws:iam::aws:policy/Keep\narn:aws:iam::aws:policy/Drop");
         r.getAttributes().put("__FlociInlinePolicyNames", "keep-inline\ndrop-inline");
@@ -259,7 +263,7 @@ class IamUserCfnProvisionerTest {
 
         StackResource r = resource();
         r.setPhysicalId("my-user");
-        r.getAttributes().put("UserId", "AIDAuser");
+        r.getAttributes().put("__FlociUserId", "AIDAuser");
 
         provisioner.provision(r, props("""
                 {
@@ -279,7 +283,7 @@ class IamUserCfnProvisionerTest {
 
         StackResource r = resource();
         r.setPhysicalId("my-user");
-        r.getAttributes().put("UserId", "AIDAold-user");
+        r.getAttributes().put("__FlociUserId", "AIDAold-user");
 
         AwsException failure = assertThrows(AwsException.class, () ->
                 provisioner.provision(r, props("""
@@ -305,7 +309,7 @@ class IamUserCfnProvisionerTest {
 
         StackResource r = resource();
         r.setPhysicalId("my-user");
-        r.getAttributes().put("UserId", "AIDAuser");
+        r.getAttributes().put("__FlociUserId", "AIDAuser");
 
         assertThrows(AwsException.class, () -> provisioner.provision(r, props("""
                 {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisionerTest.java
@@ -210,11 +210,117 @@ class IamUserCfnProvisionerTest {
     }
 
     @Test
-    void deletePropagatesUnexpectedException() {
-        when(iam.getUser("error-user"))
-                .thenThrow(new AwsException("InternalFailure", "Server error", 500));
+    void updateReconcilesRemovedGroupsManagedPoliciesAndInlinePolicies() {
+        IamUser existing = new IamUser("AIDAuser", "my-user", "/", "arn:aws:iam::" + ACCOUNT_ID + ":user/my-user");
+        existing.getGroupNames().add("keep-group");
+        existing.getGroupNames().add("drop-group");
+        existing.getAttachedPolicyArns().add("arn:aws:iam::aws:policy/Keep");
+        existing.getAttachedPolicyArns().add("arn:aws:iam::aws:policy/Drop");
+        existing.getInlinePolicies().put("keep-inline", "{}");
+        existing.getInlinePolicies().put("drop-inline", "{}");
 
-        assertThrows(AwsException.class, () ->
-                provisioner.delete("AWS::IAM::User", "error-user", "us-east-1"));
+        when(iam.createUser(eq("my-user"), eq("/"))).thenThrow(new AwsException("EntityAlreadyExists", "exists", 409));
+        when(iam.getUser("my-user")).thenReturn(existing);
+
+        StackResource r = resource();
+        r.setPhysicalId("my-user");
+        r.getAttributes().put("UserId", "AIDAuser");
+        r.getAttributes().put("__FlociGroups", "keep-group\ndrop-group");
+        r.getAttributes().put("__FlociManagedPolicyArns", "arn:aws:iam::aws:policy/Keep\narn:aws:iam::aws:policy/Drop");
+        r.getAttributes().put("__FlociInlinePolicyNames", "keep-inline\ndrop-inline");
+
+        provisioner.provision(r, props("""
+                {
+                  "UserName": "my-user",
+                  "Groups": ["keep-group"],
+                  "ManagedPolicyArns": ["arn:aws:iam::aws:policy/Keep"],
+                  "Policies": [
+                    {
+                      "PolicyName": "keep-inline",
+                      "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                    }
+                  ]
+                }
+                """), updateCtx("my-user"));
+
+        verify(iam).removeUserFromGroup("drop-group", "my-user");
+        verify(iam).detachUserPolicy("my-user", "arn:aws:iam::aws:policy/Drop");
+        verify(iam).deleteUserPolicy("my-user", "drop-inline");
+        verify(iam, never()).removeUserFromGroup("keep-group", "my-user");
+        verify(iam, never()).detachUserPolicy("my-user", "arn:aws:iam::aws:policy/Keep");
+        verify(iam, never()).deleteUserPolicy("my-user", "keep-inline");
+    }
+
+    @Test
+    void updateReconcilesPathChange() {
+        IamUser existing = new IamUser("AIDAuser", "my-user", "/", "arn:aws:iam::" + ACCOUNT_ID + ":user/my-user");
+        when(iam.createUser(eq("my-user"), eq("/new-path/"))).thenThrow(new AwsException("EntityAlreadyExists", "exists", 409));
+        when(iam.getUser("my-user")).thenReturn(existing);
+
+        StackResource r = resource();
+        r.setPhysicalId("my-user");
+        r.getAttributes().put("UserId", "AIDAuser");
+
+        provisioner.provision(r, props("""
+                {
+                  "UserName": "my-user",
+                  "Path": "/new-path/"
+                }
+                """), updateCtx("my-user"));
+
+        verify(iam).updateUser("my-user", null, "/new-path/", "AIDAuser");
+    }
+
+    @Test
+    void updateRefusesToAdoptReplacementUserWithDifferentUserId() {
+        IamUser replacement = new IamUser("AIDAnew-user", "my-user", "/", "arn:aws:iam::" + ACCOUNT_ID + ":user/my-user");
+        when(iam.createUser(eq("my-user"), eq("/"))).thenThrow(new AwsException("EntityAlreadyExists", "exists", 409));
+        when(iam.getUser("my-user")).thenReturn(replacement);
+
+        StackResource r = resource();
+        r.setPhysicalId("my-user");
+        r.getAttributes().put("UserId", "AIDAold-user");
+
+        AwsException failure = assertThrows(AwsException.class, () ->
+                provisioner.provision(r, props("""
+                        {
+                          "UserName": "my-user"
+                        }
+                        """), updateCtx("my-user")));
+
+        assertEquals("EntityAlreadyExists", failure.getErrorCode());
+        verify(iam, never()).addUserToGroup(any(), any());
+        verify(iam, never()).attachUserPolicy(any(), any());
+    }
+
+    @Test
+    void failedUpdateRestoresPriorInlinePolicyAndDetachesNewManagedPolicy() {
+        IamUser existing = new IamUser("AIDAuser", "my-user", "/", "arn:aws:iam::" + ACCOUNT_ID + ":user/my-user");
+        String priorDocument = "{\"Version\":\"2012-10-17\",\"Statement\":[\"prior\"]}";
+        existing.getInlinePolicies().put("first", priorDocument);
+        when(iam.createUser(eq("my-user"), eq("/"))).thenThrow(new AwsException("EntityAlreadyExists", "exists", 409));
+        when(iam.getUser("my-user")).thenReturn(existing);
+        doThrow(new AwsException("MalformedPolicyDocument", "bad policy", 400))
+                .when(iam).putUserPolicy(eq("my-user"), eq("second"), any());
+
+        StackResource r = resource();
+        r.setPhysicalId("my-user");
+        r.getAttributes().put("UserId", "AIDAuser");
+
+        assertThrows(AwsException.class, () -> provisioner.provision(r, props("""
+                {
+                  "UserName": "my-user",
+                  "ManagedPolicyArns": ["arn:aws:iam::aws:policy/NewPolicy"],
+                  "Policies": [
+                    {"PolicyName": "first", "PolicyDocument": {"Version": "2012-10-17", "Statement": []}},
+                    {"PolicyName": "second", "PolicyDocument": {"Version": "2012-10-17", "Statement": []}}
+                  ]
+                }
+                """), updateCtx("my-user")));
+
+        verify(iam).attachUserPolicy("my-user", "arn:aws:iam::aws:policy/NewPolicy");
+        verify(iam).detachUserPolicy("my-user", "arn:aws:iam::aws:policy/NewPolicy");
+        verify(iam).putUserPolicy("my-user", "first", priorDocument);
+        verify(iam, never()).deleteUser("my-user");
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/IamUserCfnProvisionerTest.java
@@ -1,0 +1,220 @@
+package io.github.hectorvent.floci.services.cloudformation.provisioners;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationTemplateEngine;
+import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.iam.model.AccessKey;
+import io.github.hectorvent.floci.services.iam.model.IamUser;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class IamUserCfnProvisionerTest {
+
+    private static final String ACCOUNT_ID = "000000000000";
+
+    private final IamService iam = mock(IamService.class);
+    private final IamUserCfnProvisioner provisioner = new IamUserCfnProvisioner(iam);
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private ProvisionContext ctx() {
+        CloudFormationTemplateEngine engine = mock(CloudFormationTemplateEngine.class);
+
+        when(engine.resolve(any())).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            return node == null ? null : node.asText();
+        });
+
+        when(engine.resolveNode(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        when(engine.resolveJsonAttribute(any())).thenAnswer(inv -> {
+            JsonNode node = inv.getArgument(0);
+            return node != null && node.isTextual() ? node.asText() : node.toString();
+        });
+
+        return new ProvisionContext(engine, "us-east-1", ACCOUNT_ID, "test-stack");
+    }
+
+    private ProvisionContext updateCtx(String priorPhysicalId) {
+        ProvisionContext base = ctx();
+        return new ProvisionContext(base.engine(), base.region(), base.accountId(), base.stackName(), priorPhysicalId);
+    }
+
+    private StackResource resource() {
+        StackResource r = new StackResource();
+        r.setLogicalId("AppUser");
+        r.setResourceType("AWS::IAM::User");
+        r.setAttributes(new HashMap<>());
+        return r;
+    }
+
+    private JsonNode props(String json) {
+        try {
+            return mapper.readTree(json);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private IamUser stubCreate(String userName, String path) {
+        IamUser user = new IamUser("AIDA" + userName, userName, path,
+                "arn:aws:iam::" + ACCOUNT_ID + ":user" + path + userName);
+        when(iam.createUser(eq(userName), eq(path))).thenReturn(user);
+        return user;
+    }
+
+    @Test
+    void declaresIamUserResourceType() {
+        assertEquals(java.util.Set.of("AWS::IAM::User"), provisioner.resourceTypes());
+    }
+
+    @Test
+    void provisionCreatesUserWithExplicitUserNameAndDefaultPath() {
+        stubCreate("custom-user", "/");
+        StackResource r = resource();
+
+        provisioner.provision(r, props("""
+                {
+                  "UserName": "custom-user"
+                }
+                """), ctx());
+
+        assertEquals("custom-user", r.getPhysicalId());
+        assertEquals("arn:aws:iam::" + ACCOUNT_ID + ":user/custom-user", r.getAttributes().get("Arn"));
+        verify(iam).createUser("custom-user", "/");
+    }
+
+    @Test
+    void provisionCreatesUserWithCustomPath() {
+        stubCreate("custom-user", "/engineering/");
+        StackResource r = resource();
+
+        provisioner.provision(r, props("""
+                {
+                  "UserName": "custom-user",
+                  "Path": "/engineering/"
+                }
+                """), ctx());
+
+        assertEquals("custom-user", r.getPhysicalId());
+        assertEquals("arn:aws:iam::" + ACCOUNT_ID + ":user/engineering/custom-user", r.getAttributes().get("Arn"));
+        verify(iam).createUser("custom-user", "/engineering/");
+    }
+
+    @Test
+    void provisionGeneratesPhysicalNameWhenUserNameIsOmitted() {
+        when(iam.createUser(any(), eq("/"))).thenAnswer(inv -> {
+            String name = inv.getArgument(0);
+            return new IamUser("AIDA" + name, name, "/", "arn:aws:iam::" + ACCOUNT_ID + ":user/" + name);
+        });
+        StackResource r = resource();
+
+        provisioner.provision(r, mapper.createObjectNode(), ctx());
+
+        assertNotNull(r.getPhysicalId());
+        assertTrue(r.getPhysicalId().contains("test-stack"));
+        assertEquals("arn:aws:iam::" + ACCOUNT_ID + ":user/" + r.getPhysicalId(), r.getAttributes().get("Arn"));
+    }
+
+    @Test
+    void provisionAttachesManagedPoliciesAndInlinePoliciesAndGroups() {
+        IamUser user = stubCreate("app-user", "/");
+        StackResource r = resource();
+
+        provisioner.provision(r, props("""
+                {
+                  "UserName": "app-user",
+                  "Groups": ["developers", "qa"],
+                  "ManagedPolicyArns": [
+                    "arn:aws:iam::aws:policy/ReadOnlyAccess",
+                    "arn:aws:iam::aws:policy/PowerUserAccess"
+                  ],
+                  "Policies": [
+                    {
+                      "PolicyName": "s3-access",
+                      "PolicyDocument": {"Version": "2012-10-17", "Statement": []}
+                    }
+                  ]
+                }
+                """), ctx());
+
+        verify(iam).addUserToGroup("developers", "app-user");
+        verify(iam).addUserToGroup("qa", "app-user");
+        verify(iam).attachUserPolicy("app-user", "arn:aws:iam::aws:policy/ReadOnlyAccess");
+        verify(iam).attachUserPolicy("app-user", "arn:aws:iam::aws:policy/PowerUserAccess");
+        verify(iam).putUserPolicy(eq("app-user"), eq("s3-access"), any());
+    }
+
+    @Test
+    void updatingUserNameRequiresReplacement() {
+        StackResource r = resource();
+        r.setPhysicalId("old-user");
+
+        AwsException failure = assertThrows(AwsException.class, () ->
+                provisioner.provision(r, props("""
+                        {
+                          "UserName": "new-user"
+                        }
+                        """), updateCtx("old-user")));
+
+        assertEquals("ValidationError", failure.getErrorCode());
+        assertTrue(failure.getMessage().contains("resource replacement"));
+        verify(iam, never()).createUser(any(), any());
+    }
+
+    @Test
+    void deleteDetachesPoliciesRemovesGroupsAndDeletesUser() {
+        IamUser user = new IamUser("AIDAuser", "my-user", "/", "arn:aws:iam::" + ACCOUNT_ID + ":user/my-user");
+        user.getAttachedPolicyArns().add("arn:aws:iam::aws:policy/ReadOnlyAccess");
+        user.getInlinePolicies().put("inline-1", "{}");
+        user.getGroupNames().add("dev-group");
+        when(iam.getUser("my-user")).thenReturn(user);
+
+        AccessKey key = new AccessKey("AKIA123", "secret", "my-user");
+        when(iam.listAccessKeys("my-user")).thenReturn(List.of(key));
+
+        provisioner.delete("AWS::IAM::User", "my-user", "us-east-1");
+
+        verify(iam).detachUserPolicy("my-user", "arn:aws:iam::aws:policy/ReadOnlyAccess");
+        verify(iam).deleteUserPolicy("my-user", "inline-1");
+        verify(iam).removeUserFromGroup("dev-group", "my-user");
+        verify(iam).deleteAccessKey("my-user", "AKIA123");
+        verify(iam).deleteUser("my-user");
+    }
+
+    @Test
+    void deleteToleratesAlreadyDeletedUser() {
+        when(iam.getUser("already-gone"))
+                .thenThrow(new AwsException("NoSuchEntity", "User does not exist", 404));
+
+        provisioner.delete("AWS::IAM::User", "already-gone", "us-east-1");
+
+        verify(iam, never()).deleteUser(any());
+    }
+
+    @Test
+    void deletePropagatesUnexpectedException() {
+        when(iam.getUser("error-user"))
+                .thenThrow(new AwsException("InternalFailure", "Server error", 500));
+
+        assertThrows(AwsException.class, () ->
+                provisioner.delete("AWS::IAM::User", "error-user", "us-east-1"));
+    }
+}

--- a/src/test/resources/cloudformation/supported-resource-types.tsv
+++ b/src/test/resources/cloudformation/supported-resource-types.tsv
@@ -73,7 +73,7 @@ AWS::IAM::InstanceProfile	LEGACY_SWITCH
 AWS::IAM::ManagedPolicy	LEGACY_SWITCH
 AWS::IAM::Policy	LEGACY_SWITCH
 AWS::IAM::Role	IamRoleCfnProvisioner
-AWS::IAM::User	LEGACY_SWITCH
+AWS::IAM::User	IamUserCfnProvisioner
 AWS::IoT::DomainConfiguration	IotDomainConfigurationCfnProvisioner
 AWS::KMS::Alias	KmsCfnProvisioner
 AWS::KMS::Key	KmsCfnProvisioner


### PR DESCRIPTION
## Summary

Extract `AWS::IAM::User` from legacy `CloudFormationResourceProvisioner` switch into a dedicated `IamUserCfnProvisioner`. Implements proper stack deprovisioning by cleaning up managed policy attachments, inline policies, group memberships, and access keys before deleting the user entity, tolerating `NoSuchEntity`.

Closes #2490

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- Bug fix: In `CloudFormationResourceProvisioner.java`, the `delete` method handled other IAM resource types but lacked an arm for `AWS::IAM::User`, defaulting to a warning log and returning normally without deprovisioning. As a result, `CloudFormationService.deleteStack` reported `DELETE_COMPLETE`, but the IAM user remained in `IamService`, causing subsequent stack creations with the same user name to fail with `EntityAlreadyExistsException: User already exists`.
- Implementation follows the CloudFormation provisioner guidelines in `AGENTS.md`: dedicated `@ApplicationScoped` provisioner in `provisioners/`, full cleanup before deletion in `delete(StackResource, String)`, registering in `supported-resource-types.tsv`, and adding to `CfnProvisionerFixture`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
