### PR TITLE
refactor(acm): one issuer-signing primitive in CertificateGenerator

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
@@ -373,11 +373,11 @@ public class AcmService implements ResourceProvider {
         cert.setIssuedAt(now);
         cert.setNotBefore(x509Cert.getNotBefore().toInstant());
         cert.setNotAfter(x509Cert.getNotAfter().toInstant());
-        cert.setSerial(x509Cert.getSerialNumber().toString());
+        cert.setSerial(CertificateGenerator.colonHex(x509Cert.getSerialNumber()));
         cert.setSubject(x509Cert.getSubjectX500Principal().getName());
         cert.setIssuer(x509Cert.getIssuerX500Principal().getName());
         cert.setKeyAlgorithm(keyAlg);
-        cert.setSignatureAlgorithm(x509Cert.getSigAlgName());
+        cert.setSignatureAlgorithm(x509Cert.getSigAlgName().toUpperCase(Locale.ROOT));
         cert.setCertificateBody(certificatePem);
         cert.setPrivateKey(privateKeyPem);
         cert.setCertificateChain(chainPem);

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -35,12 +35,14 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
 import java.time.Instant;
@@ -149,22 +151,43 @@ public class CertificateGenerator {
     /**
      * A leaf signed by {@code issuer}. {@code subjectKeyPair} may be {@code null} to mint a new
      * one; pass the previous pair to reissue with an updated SAN list and an unchanged public key.
+     * The result is checked before it is returned: the leaf must verify against the issuer's
+     * certificate, and a supplied key pair must be a pair, so a caller can never get back a
+     * certificate its own issuer rejects or a private key that does not fit it.
      */
     public GeneratedCertificate generateIssuedCertificate(String domainName, List<String> sans,
                                                           KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
                                                           Issuer issuer, LeafUsage usage) {
         try {
+            if (subjectKeyPair != null && !isPair(subjectKeyPair.getPrivate(), subjectKeyPair.getPublic())) {
+                throw new IllegalArgumentException("supplied private key does not match its public key");
+            }
             KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
             X500Name subject = new X500Name("CN=" + domainName);
             X500Name issuerDn = X500Name.getInstance(issuer.certificate().getSubjectX500Principal().getEncoded());
             X509Certificate cert = signCertificate(subject, keyPair.getPublic(), issuerDn, issuer.key(),
                     withDomainFirst(domainName, sans), false, usage, 365);
+            cert.verify(issuer.certificate().getPublicKey());
             return toGenerated(cert, keyPair.getPrivate(), subject.toString(),
                     issuer.certificate().getSubjectX500Principal().getName());
         } catch (Exception e) {
             LOG.error("Failed to generate issued certificate", e);
             throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
         }
+    }
+
+    /** True when {@code privateKey} signs what {@code publicKey} verifies. */
+    public static boolean isPair(PrivateKey privateKey, PublicKey publicKey) throws Exception {
+        String algorithm = "EC".equals(privateKey.getAlgorithm()) ? "SHA256withECDSA" : "SHA256withRSA";
+        byte[] probe = "floci".getBytes(StandardCharsets.US_ASCII);
+        Signature signer = Signature.getInstance(algorithm);
+        signer.initSign(privateKey);
+        signer.update(probe);
+        byte[] signature = signer.sign();
+        Signature verifier = Signature.getInstance(algorithm);
+        verifier.initVerify(publicKey);
+        verifier.update(probe);
+        return verifier.verify(signature);
     }
 
     private GeneratedCertificate buildCertificate(String domainName, List<String> sans, KeyAlgorithm keyAlgorithm,

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -13,6 +13,9 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
+import org.bouncycastle.asn1.x9.X962Parameters;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -161,12 +164,11 @@ public class CertificateGenerator {
                                                           KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
                                                           Issuer issuer, LeafUsage usage) {
         try {
+            if (subjectKeyPair != null && !isOfAlgorithm(subjectKeyPair.getPublic(), keyAlgorithm)) {
+                throw new IllegalArgumentException("supplied key pair is not the requested " + keyAlgorithm);
+            }
             if (subjectKeyPair != null && !isPair(subjectKeyPair.getPrivate(), subjectKeyPair.getPublic())) {
                 throw new IllegalArgumentException("supplied private key does not match its public key");
-            }
-            if (subjectKeyPair != null && detectKeyAlgorithm(subjectKeyPair.getPublic()) != keyAlgorithm) {
-                throw new IllegalArgumentException("supplied key pair is " + detectKeyAlgorithm(subjectKeyPair.getPublic())
-                        + ", not the requested " + keyAlgorithm);
             }
             KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
             X500Name subject = new X500Name("CN=" + domainName);
@@ -180,6 +182,24 @@ public class CertificateGenerator {
             LOG.error("Failed to generate issued certificate", e);
             throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * True when {@code key} is exactly what {@code keyAlgorithm} names: the RSA size, or for EC the
+     * named curve read from the key's encoding, so a curve that only shares a field size
+     * (secp256k1 for {@code EC_prime256v1}) does not pass.
+     */
+    boolean isOfAlgorithm(PublicKey key, KeyAlgorithm keyAlgorithm) {
+        if ("EC".equals(keyAlgorithm.getAlgorithm())) {
+            if (!"EC".equals(key.getAlgorithm())) {
+                return false;
+            }
+            X962Parameters parameters = X962Parameters.getInstance(
+                    SubjectPublicKeyInfo.getInstance(key.getEncoded()).getAlgorithm().getParameters());
+            return parameters.isNamedCurve()
+                    && ECNamedCurveTable.getOID(keyAlgorithm.getCurveName()).equals(parameters.getParameters());
+        }
+        return "RSA".equals(key.getAlgorithm()) && detectKeyAlgorithm(key) == keyAlgorithm;
     }
 
     /** True when {@code privateKey} signs what {@code publicKey} verifies. */

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -7,9 +7,11 @@ import org.bouncycastle.asn1.pkcs.EncryptedPrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -45,7 +47,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
@@ -76,6 +80,16 @@ public class CertificateGenerator {
         String issuer,
         String signatureAlgorithm
     ) {}
+
+    /**
+     * What an issued leaf is for. Decides the Extended Key Usage. A CA passes {@code null}.
+     * {@code SERVER} carries both serverAuth and clientAuth, as ACM-issued certificates do (and as
+     * {@code DescribeCertificate} already advertises); {@code CLIENT} is clientAuth only.
+     */
+    public enum LeafUsage { SERVER, CLIENT }
+
+    /** A signer: the issuer's certificate (for its DN) and its private key. */
+    public record Issuer(X509Certificate certificate, PrivateKey key) {}
 
     /**
      * Generates a certificate for local emulation that mimics an ACM-issued certificate:
@@ -115,86 +129,143 @@ public class CertificateGenerator {
         return buildCertificate(domainName, sans, keyAlgorithm, "CN=" + domainName, true, keyPair);
     }
 
+    /**
+     * A root CA: self-signed, {@code cA=true}, {@code keyCertSign}, ten years. RSA 2048 because
+     * every client in the emulator's reach accepts it and it keeps key generation under a second.
+     */
+    public GeneratedCertificate generateCaCertificate(String commonName) {
+        try {
+            KeyPair keyPair = generateKeyPair(KeyAlgorithm.RSA_2048);
+            X500Name dn = new X500Name("CN=" + commonName);
+            X509Certificate cert = signCertificate(dn, keyPair.getPublic(), dn, keyPair.getPrivate(),
+                    List.of(), true, null, 3650);
+            return toGenerated(cert, keyPair.getPrivate(), dn.toString(), dn.toString());
+        } catch (Exception e) {
+            LOG.error("Failed to generate CA certificate", e);
+            throw new CertificateGenerationException("CA generation failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * A leaf signed by {@code issuer}. {@code subjectKeyPair} may be {@code null} to mint a new
+     * one; pass the previous pair to reissue with an updated SAN list and an unchanged public key.
+     */
+    public GeneratedCertificate generateIssuedCertificate(String domainName, List<String> sans,
+                                                          KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
+                                                          Issuer issuer, LeafUsage usage) {
+        try {
+            KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
+            X500Name subject = new X500Name("CN=" + domainName);
+            X500Name issuerDn = X500Name.getInstance(issuer.certificate().getSubjectX500Principal().getEncoded());
+            X509Certificate cert = signCertificate(subject, keyPair.getPublic(), issuerDn, issuer.key(),
+                    withDomainFirst(domainName, sans), false, usage, 365);
+            return toGenerated(cert, keyPair.getPrivate(), subject.toString(),
+                    issuer.certificate().getSubjectX500Principal().getName());
+        } catch (Exception e) {
+            LOG.error("Failed to generate issued certificate", e);
+            throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
+        }
+    }
+
     private GeneratedCertificate buildCertificate(String domainName, List<String> sans, KeyAlgorithm keyAlgorithm,
                                                   String issuerDn, boolean asCa, KeyPair suppliedKeyPair) {
         try {
             KeyPair keyPair = suppliedKeyPair != null ? suppliedKeyPair : generateKeyPair(keyAlgorithm);
-
-            Instant now = Instant.now();
-            Instant notBefore = now;
-            Instant notAfter = now.plus(365, ChronoUnit.DAYS);
-
-            BigInteger serial = new BigInteger(128, SECURE_RANDOM);
             String subjectDn = "CN=" + domainName;
-
-            X500Name issuer = new X500Name(issuerDn);
-            X500Name subject = new X500Name(subjectDn);
-
-            String signatureAlgorithm = keyAlgorithm.getAlgorithm().equals("EC")
-                ? "SHA512withECDSA"
-                : "SHA512WithRSA";
-
-            X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
-                issuer,
-                serial,
-                Date.from(notBefore),
-                Date.from(notAfter),
-                subject,
-                keyPair.getPublic()
-            );
-
-            // Add Subject Alternative Names
-            List<GeneralName> sanList = new ArrayList<>();
-            sanList.add(toGeneralName(domainName));
-            if (sans != null) {
-                for (String san : sans) {
-                    if (!san.equals(domainName)) {
-                        sanList.add(toGeneralName(san));
-                    }
-                }
-            }
-            GeneralNames generalNames = new GeneralNames(sanList.toArray(new GeneralName[0]));
-            certBuilder.addExtension(Extension.subjectAlternativeName, false, generalNames);
-
-            // Add Key Usage — a trust-anchor self-signed cert also needs keyCertSign so it can
-            // act as its own issuer; an ACM-style leaf only needs digitalSignature/keyEncipherment.
-            int keyUsageBits = KeyUsage.digitalSignature | KeyUsage.keyEncipherment;
-            if (asCa) {
-                keyUsageBits |= KeyUsage.keyCertSign;
-            }
-            certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsageBits));
-
-            // Add Basic Constraints — a trust anchor must be a CA so clients accept it as one.
-            certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(asCa));
-
-            // Signed with the subject's own private key. For generateCertificate() the issuer DN is
-            // a cosmetic Amazon DN (mimicking ACM); for generateSelfSignedCertificate() issuer ==
-            // subject, so the cert is a valid self-signed trust anchor.
-            ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm)
-                .build(keyPair.getPrivate());
-
-            X509CertificateHolder certHolder = certBuilder.build(signer);
-            X509Certificate cert = new JcaX509CertificateConverter()
-                .getCertificate(certHolder);
-
-            String certPem = toPem(cert);
-            String keyPem = toPem(keyPair.getPrivate());
-
-            return new GeneratedCertificate(
-                certPem,
-                keyPem,
-                serial.toString(),
-                notBefore,
-                notAfter,
-                subjectDn,
-                issuerDn,
-                signatureAlgorithm
-            );
-
+            // Signed with the subject's own key, as before: generateCertificate keeps its cosmetic
+            // Amazon issuer DN, generateSelfSignedCertificate keeps issuer == subject.
+            X509Certificate cert = signCertificate(new X500Name(subjectDn), keyPair.getPublic(),
+                    new X500Name(issuerDn), keyPair.getPrivate(), withDomainFirst(domainName, sans), asCa, null, 365);
+            return toGenerated(cert, keyPair.getPrivate(), subjectDn, issuerDn);
         } catch (Exception e) {
             LOG.error("Failed to generate certificate", e);
             throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * The one place a certificate is signed. Everything else in this class, and
+     * {@code CloudHsmV2Service}, goes through here.
+     *
+     * @param sans  DNS names or IP addresses, written once each in order; empty for a CA
+     * @param asCa  sets {@code BasicConstraints(cA)}, {@code keyCertSign} and {@code cRLSign}
+     * @param usage EKU for a leaf, {@code null} for a CA or a leaf without one
+     */
+    public X509Certificate signCertificate(X500Name subject, PublicKey subjectKey, X500Name issuerDn,
+                                           PrivateKey issuerKey, List<String> sans, boolean asCa,
+                                           LeafUsage usage, int validityDays) throws Exception {
+        Instant now = Instant.now();
+        BigInteger serial = new BigInteger(128, SECURE_RANDOM);
+        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuerDn, serial, Date.from(now), Date.from(now.plus(validityDays, ChronoUnit.DAYS)),
+                subject, subjectKey);
+
+        if (sans != null && !sans.isEmpty()) {
+            List<GeneralName> sanList = new ArrayList<>();
+            for (String san : new LinkedHashSet<>(sans)) {
+                sanList.add(toGeneralName(san));
+            }
+            certBuilder.addExtension(Extension.subjectAlternativeName, false,
+                    new GeneralNames(sanList.toArray(new GeneralName[0])));
+        }
+
+        // keyEncipherment is an RSA key-transport bit; EC keys sign (and agree), they never encipher.
+        int keyUsageBits = KeyUsage.digitalSignature;
+        if ("RSA".equals(subjectKey.getAlgorithm())) {
+            keyUsageBits |= KeyUsage.keyEncipherment;
+        }
+        if (asCa) {
+            keyUsageBits |= KeyUsage.keyCertSign | KeyUsage.cRLSign;
+        }
+        certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsageBits));
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(asCa));
+        if (usage == LeafUsage.SERVER) {
+            certBuilder.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(
+                    new KeyPurposeId[] {KeyPurposeId.id_kp_serverAuth, KeyPurposeId.id_kp_clientAuth}));
+        } else if (usage == LeafUsage.CLIENT) {
+            certBuilder.addExtension(Extension.extendedKeyUsage, false,
+                    new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth));
+        }
+
+        String signatureAlgorithm = "EC".equals(issuerKey.getAlgorithm()) ? "SHA512withECDSA" : "SHA512WithRSA";
+        ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm).build(issuerKey);
+        X509CertificateHolder holder = certBuilder.build(signer);
+        return new JcaX509CertificateConverter().getCertificate(holder);
+    }
+
+    private static List<String> withDomainFirst(String domainName, List<String> sans) {
+        List<String> allSans = new ArrayList<>();
+        allSans.add(domainName);
+        if (sans != null) {
+            allSans.addAll(sans);
+        }
+        return allSans;
+    }
+
+    /**
+     * Metadata comes from the certificate, not from the arguments: the signature algorithm is the
+     * issuer's (an RSA CA signing an EC leaf yields SHA512WITHRSA, spelled in upper case as ACM
+     * does), and ACM shows the serial as colon-separated hex ({@code 07:71:71:f4:...}).
+     */
+    private GeneratedCertificate toGenerated(X509Certificate cert, PrivateKey key, String subjectDn,
+                                             String issuerDn) throws Exception {
+        return new GeneratedCertificate(
+                toPem(cert),
+                toPem(key),
+                colonHex(cert.getSerialNumber()),
+                cert.getNotBefore().toInstant(),
+                cert.getNotAfter().toInstant(),
+                subjectDn,
+                issuerDn,
+                cert.getSigAlgName().toUpperCase(Locale.ROOT));
+    }
+
+    static String colonHex(BigInteger serial) {
+        String hex = serial.toString(16);
+        if (hex.length() % 2 == 1) {
+            hex = "0" + hex;
+        }
+        return String.join(":", hex.split("(?<=\\G..)"));
     }
 
     private KeyPair generateKeyPair(KeyAlgorithm keyAlgorithm) throws Exception {
@@ -244,7 +315,7 @@ public class CertificateGenerator {
         return IP_ADDRESS_PATTERN.matcher(value).matches();
     }
 
-    private String toPem(Object obj) throws Exception {
+    public String toPem(Object obj) throws Exception {
         StringWriter sw = new StringWriter();
         try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
             pemWriter.writeObject(obj);

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -150,10 +150,12 @@ public class CertificateGenerator {
 
     /**
      * A leaf signed by {@code issuer}. {@code subjectKeyPair} may be {@code null} to mint a new
-     * one; pass the previous pair to reissue with an updated SAN list and an unchanged public key.
-     * The result is checked before it is returned: the leaf must verify against the issuer's
-     * certificate, and a supplied key pair must be a pair, so a caller can never get back a
-     * certificate its own issuer rejects or a private key that does not fit it.
+     * one of {@code keyAlgorithm}; pass the previous pair to reissue with an updated SAN list and
+     * an unchanged public key, in which case it must be of {@code keyAlgorithm}. The result is
+     * checked before it is returned: the leaf must verify against the issuer's certificate, and a
+     * supplied key pair must be a pair of the requested algorithm, so a caller can never get back
+     * a certificate its own issuer rejects, a private key that does not fit it, or a key type it
+     * did not ask for.
      */
     public GeneratedCertificate generateIssuedCertificate(String domainName, List<String> sans,
                                                           KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
@@ -161,6 +163,10 @@ public class CertificateGenerator {
         try {
             if (subjectKeyPair != null && !isPair(subjectKeyPair.getPrivate(), subjectKeyPair.getPublic())) {
                 throw new IllegalArgumentException("supplied private key does not match its public key");
+            }
+            if (subjectKeyPair != null && detectKeyAlgorithm(subjectKeyPair.getPublic()) != keyAlgorithm) {
+                throw new IllegalArgumentException("supplied key pair is " + detectKeyAlgorithm(subjectKeyPair.getPublic())
+                        + ", not the requested " + keyAlgorithm);
             }
             KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
             X500Name subject = new X500Name("CN=" + domainName);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.acm.CertificateGenerator;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.Certificates;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.Cluster;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.ClusterState;
@@ -11,9 +12,7 @@ import io.github.hectorvent.floci.services.cloudhsmv2.model.Hsm;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
@@ -27,15 +26,11 @@ import org.jboss.logging.Logger;
 
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.Backup;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.BackupRetentionPolicy;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Collectors;
 import java.time.Instant;
@@ -64,20 +59,24 @@ public class CloudHsmV2Service {
     private final StorageBackend<String, Cluster> clusters;
     private final StorageBackend<String, Backup> backups;
     private final Ec2Service ec2Service;
+    private final CertificateGenerator certificateGenerator;
 
     @Inject
-    public CloudHsmV2Service(StorageFactory storageFactory, Ec2Service ec2Service) {
-        this.clusters = storageFactory.create("cloudhsmv2", "cloudhsmv2-clusters.json",
-                new TypeReference<Map<String, Cluster>>() {});
-        this.backups = storageFactory.create("cloudhsmv2", "cloudhsmv2-backups.json",
-                new TypeReference<Map<String, Backup>>() {});
-        this.ec2Service = ec2Service;
+    public CloudHsmV2Service(StorageFactory storageFactory, Ec2Service ec2Service,
+                             CertificateGenerator certificateGenerator) {
+        this(storageFactory.create("cloudhsmv2", "cloudhsmv2-clusters.json",
+                        new TypeReference<Map<String, Cluster>>() {}),
+                storageFactory.create("cloudhsmv2", "cloudhsmv2-backups.json",
+                        new TypeReference<Map<String, Backup>>() {}),
+                ec2Service, certificateGenerator);
     }
 
-    CloudHsmV2Service(StorageBackend<String, Cluster> clusters, StorageBackend<String, Backup> backups, Ec2Service ec2Service) {
+    CloudHsmV2Service(StorageBackend<String, Cluster> clusters, StorageBackend<String, Backup> backups,
+                      Ec2Service ec2Service, CertificateGenerator certificateGenerator) {
         this.clusters = clusters;
         this.backups = backups;
         this.ec2Service = ec2Service;
+        this.certificateGenerator = certificateGenerator;
     }
 
     // ──────────────────────────── CreateCluster ────────────────────────────
@@ -173,15 +172,18 @@ public class CloudHsmV2Service {
         try {
             KeyPair mfrKeyPair = generateKeyPair();
             X500Name mfrName = new X500Name("CN=HSM Manufacturer CA,O=AWS,C=US");
-            certs.setManufacturerHardwareCertificate(generateCert(mfrName, mfrName, mfrKeyPair.getPublic(), mfrKeyPair.getPrivate()));
+            certs.setManufacturerHardwareCertificate(certificateGenerator.toPem(certificateGenerator.signCertificate(
+                    mfrName, mfrKeyPair.getPublic(), mfrName, mfrKeyPair.getPrivate(), List.of(), true, null, 365)));
 
             KeyPair awsKeyPair = generateKeyPair();
             X500Name awsName = new X500Name("CN=AWS CloudHSM Hardware CA,O=AWS,C=US");
-            certs.setAwsHardwareCertificate(generateCert(awsName, mfrName, awsKeyPair.getPublic(), mfrKeyPair.getPrivate()));
+            certs.setAwsHardwareCertificate(certificateGenerator.toPem(certificateGenerator.signCertificate(
+                    awsName, awsKeyPair.getPublic(), mfrName, mfrKeyPair.getPrivate(), List.of(), true, null, 365)));
 
             KeyPair hsmKeyPair = generateKeyPair();
             X500Name hsmName = new X500Name("CN=HSM Instance " + clusterId + ",O=AWS,C=US");
-            certs.setHsmCertificate(generateCert(hsmName, awsName, hsmKeyPair.getPublic(), awsKeyPair.getPrivate()));
+            certs.setHsmCertificate(certificateGenerator.toPem(certificateGenerator.signCertificate(
+                    hsmName, hsmKeyPair.getPublic(), awsName, awsKeyPair.getPrivate(), List.of(), false, null, 365)));
         } catch (Exception e) {
             LOG.warnv("Failed to generate emulated hardware certs: {0}", e.getMessage());
         }
@@ -532,25 +534,6 @@ public class CloudHsmV2Service {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         keyGen.initialize(2048, SECURE_RANDOM);
         return keyGen.generateKeyPair();
-    }
-
-    private String generateCert(X500Name subject, X500Name issuer, PublicKey pubKey, PrivateKey signerKey) throws Exception {
-        BigInteger serial = new BigInteger(128, SECURE_RANDOM);
-        Instant now = Instant.now();
-        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
-                issuer, serial, Date.from(now), Date.from(now.plusSeconds(365L * 24 * 3600)), subject, pubKey);
-
-        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
-                .build(signerKey);
-        X509CertificateHolder holder = certBuilder.build(signer);
-        X509Certificate cert = new JcaX509CertificateConverter()
-                .getCertificate(holder);
-
-        StringWriter sw = new StringWriter();
-        try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
-            pemWriter.writeObject(cert);
-        }
-        return sw.toString();
     }
 
     private void validatePemCertificate(String pem, String fieldName) {

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmImportExportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmImportExportTest.java
@@ -95,7 +95,9 @@ class AcmImportExportTest {
             .body("Certificate.DomainName", equalTo("test-import.example.com"))
             .body("Certificate.Status", equalTo("ISSUED"))
             .body("Certificate.Type", equalTo("IMPORTED"))
-            .body("Certificate.KeyAlgorithm", equalTo("RSA-2048"));
+            .body("Certificate.KeyAlgorithm", equalTo("RSA-2048"))
+            .body("Certificate.Serial", matchesPattern("([0-9a-f]{2}:)+[0-9a-f]{2}"))
+            .body("Certificate.SignatureAlgorithm", matchesPattern("SHA[0-9]+WITH[A-Z]+"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -151,6 +151,21 @@ class CertificateGeneratorIssuerTest {
     }
 
     @Test
+    void aSuppliedKeyPairOfAnotherAlgorithmIsRefused() {
+        var issuer = newIssuer();
+        var rsa = generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var rsaPair = new KeyPair(generator.parseCertificate(rsa.certificatePem()).getPublicKey(),
+                generator.parsePrivateKey(rsa.privateKeyPem()));
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, rsaPair, issuer,
+                        CertificateGenerator.LeafUsage.CLIENT));
+        assertTrue(refused.getMessage().contains("RSA_2048") && refused.getMessage().contains("EC_prime256v1"),
+                refused.getMessage());
+    }
+
+    @Test
     void duplicateSansAreWrittenOnce() throws Exception {
         var leaf = generator.generateIssuedCertificate("dup.example.test", List.of("dup.example.test", "other.example.test",
                 "other.example.test"), KeyAlgorithm.RSA_2048, null, newIssuer(), CertificateGenerator.LeafUsage.SERVER);

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.acm;
+
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The issuer-signing primitive: a CA that can sign, leaves that verify against it, and the
+ * Extended Key Usage split between server and client leaves.
+ */
+class CertificateGeneratorIssuerTest {
+
+    private static CertificateGenerator generator;
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        generator = new CertificateGenerator();
+    }
+
+    private static CertificateGenerator.Issuer newIssuer() {
+        var ca = generator.generateCaCertificate("Floci Local CA");
+        return new CertificateGenerator.Issuer(
+                generator.parseCertificate(ca.certificatePem()), generator.parsePrivateKey(ca.privateKeyPem()));
+    }
+
+    @Test
+    void caCertificateIsSelfSignedAndCanSign() throws Exception {
+        var ca = generator.generateCaCertificate("Floci Local CA");
+        X509Certificate cert = generator.parseCertificate(ca.certificatePem());
+
+        assertEquals(cert.getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertEquals("CN=Floci Local CA", cert.getSubjectX500Principal().getName());
+        assertTrue(cert.getBasicConstraints() >= 0, "CA must carry cA=true");
+        assertTrue(cert.getKeyUsage()[5], "CA must assert keyCertSign");
+        assertTrue(cert.getKeyUsage()[6], "CA must assert cRLSign");
+        assertNull(cert.getExtendedKeyUsage(), "a CA carries no EKU");
+        assertNull(cert.getSubjectAlternativeNames(), "a CA carries no SAN");
+        cert.verify(cert.getPublicKey());
+        assertEquals(ca.subject(), ca.issuer());
+    }
+
+    @Test
+    void issuedLeafVerifiesAgainstIssuerAndCarriesServerAuth() throws Exception {
+        var issuer = newIssuer();
+
+        var leaf = generator.generateIssuedCertificate("api.example.test", List.of("*.example.test"),
+                KeyAlgorithm.RSA_2048, null, issuer, CertificateGenerator.LeafUsage.SERVER);
+        X509Certificate cert = generator.parseCertificate(leaf.certificatePem());
+
+        assertEquals(issuer.certificate().getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertNotEquals(cert.getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertEquals(-1, cert.getBasicConstraints(), "leaf must not be a CA");
+        assertFalse(cert.getKeyUsage()[5], "leaf must not assert keyCertSign");
+        assertTrue(cert.getKeyUsage()[0] && cert.getKeyUsage()[2], "RSA leaf: digitalSignature and keyEncipherment");
+        assertEquals(List.of("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"), cert.getExtendedKeyUsage(),
+                "serverAuth and clientAuth, as ACM issues and DescribeCertificate advertises");
+        assertEquals(List.of("api.example.test", "*.example.test"),
+                cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+        assertEquals("SHA512WITHRSA", leaf.signatureAlgorithm(), "ACM spells the algorithm in upper case");
+        assertTrue(cert.getSigAlgName().equalsIgnoreCase(leaf.signatureAlgorithm()),
+                "metadata reports the real signature algorithm: " + cert.getSigAlgName());
+        assertTrue(leaf.serial().matches("([0-9a-f]{2}:)+[0-9a-f]{2}"),
+                "colon-separated hex serial: " + leaf.serial());
+        assertEquals(cert.getSerialNumber(), new BigInteger(leaf.serial().replace(":", ""), 16));
+        assertEquals(cert.getNotBefore().toInstant(), leaf.notBefore());
+        assertEquals(cert.getNotAfter().toInstant(), leaf.notAfter());
+        assertEquals("CN=api.example.test", leaf.subject());
+        assertEquals(issuer.certificate().getSubjectX500Principal().getName(), leaf.issuer());
+        cert.verify(issuer.certificate().getPublicKey());
+    }
+
+    @Test
+    void issuedLeafReusesSuppliedKeyPairAndClientUsage() throws Exception {
+        var issuer = newIssuer();
+        var first = generator.generateIssuedCertificate("device-1", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var keyPair = new KeyPair(
+                generator.parseCertificate(first.certificatePem()).getPublicKey(),
+                generator.parsePrivateKey(first.privateKeyPem()));
+
+        var second = generator.generateIssuedCertificate("device-1", List.of(), KeyAlgorithm.RSA_2048, keyPair, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        X509Certificate cert = generator.parseCertificate(second.certificatePem());
+
+        assertEquals(keyPair.getPublic(), cert.getPublicKey(), "supplied key pair must be reused");
+        assertEquals(first.privateKeyPem(), second.privateKeyPem(), "the same private key is returned");
+        assertNotEquals(first.serial(), second.serial(), "every issue gets a fresh serial");
+        assertEquals(List.of("1.3.6.1.5.5.7.3.2"), cert.getExtendedKeyUsage(), "clientAuth only");
+        cert.verify(issuer.certificate().getPublicKey());
+    }
+
+    @Test
+    void ecLeafSignedByRsaCaReportsTheIssuerAlgorithmAndNoKeyEncipherment() throws Exception {
+        var issuer = newIssuer();
+
+        var leaf = generator.generateIssuedCertificate("ec.example.test", null, KeyAlgorithm.EC_prime256v1, null,
+                issuer, CertificateGenerator.LeafUsage.SERVER);
+        X509Certificate cert = generator.parseCertificate(leaf.certificatePem());
+
+        assertEquals("EC", cert.getPublicKey().getAlgorithm());
+        assertEquals("SHA512WITHRSA", leaf.signatureAlgorithm(), "the signature is the RSA issuer's");
+        assertTrue(cert.getKeyUsage()[0], "digitalSignature");
+        assertFalse(cert.getKeyUsage()[2], "an EC key never enciphers");
+        assertEquals(List.of("ec.example.test"), cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+        cert.verify(issuer.certificate().getPublicKey());
+    }
+
+    @Test
+    void duplicateSansAreWrittenOnce() throws Exception {
+        var leaf = generator.generateIssuedCertificate("dup.example.test", List.of("dup.example.test", "other.example.test",
+                "other.example.test"), KeyAlgorithm.RSA_2048, null, newIssuer(), CertificateGenerator.LeafUsage.SERVER);
+        X509Certificate cert = generator.parseCertificate(leaf.certificatePem());
+
+        assertEquals(List.of("dup.example.test", "other.example.test"),
+                cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+    }
+
+    @Test
+    void existingSelfSignedAndAcmStylePathsAreUnchanged() throws Exception {
+        var selfSigned = generator.generateSelfSignedCertificate("localhost", List.of("localhost"), KeyAlgorithm.RSA_2048);
+        X509Certificate ss = generator.parseCertificate(selfSigned.certificatePem());
+        assertEquals(ss.getSubjectX500Principal(), ss.getIssuerX500Principal());
+        assertTrue(ss.getBasicConstraints() >= 0);
+        assertNull(ss.getExtendedKeyUsage(), "the self-signed trust anchor carries no EKU, as before");
+        ss.verify(ss.getPublicKey());
+
+        var acmStyle = generator.generateCertificate("localhost", List.of("localhost"), KeyAlgorithm.RSA_2048);
+        X509Certificate acm = generator.parseCertificate(acmStyle.certificatePem());
+        assertTrue(acm.getIssuerX500Principal().getName().contains("Amazon"));
+        assertEquals(-1, acm.getBasicConstraints());
+        assertEquals("CN=Amazon,OU=Server CA 1B,O=Amazon,C=US", acmStyle.issuer());
+        assertTrue(acmStyle.serial().matches("([0-9a-f]{2}:)+[0-9a-f]{2}"));
+    }
+
+    @Test
+    void colonHexPadsOddLengthAndSplitsBytes() {
+        assertEquals("0a", CertificateGenerator.colonHex(BigInteger.TEN));
+        assertEquals("01:00", CertificateGenerator.colonHex(BigInteger.valueOf(256)));
+        assertEquals("ff:ff:ff", CertificateGenerator.colonHex(new BigInteger("ffffff", 16)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -161,8 +161,25 @@ class CertificateGeneratorIssuerTest {
         var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
                 () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, rsaPair, issuer,
                         CertificateGenerator.LeafUsage.CLIENT));
-        assertTrue(refused.getMessage().contains("RSA_2048") && refused.getMessage().contains("EC_prime256v1"),
-                refused.getMessage());
+        assertTrue(refused.getMessage().contains("not the requested EC_prime256v1"), refused.getMessage());
+    }
+
+    @Test
+    void aSuppliedEcKeyPairOnACurveOfTheSameSizeIsRefused() throws Exception {
+        var issuer = newIssuer();
+        java.security.KeyPairGenerator kpg = java.security.KeyPairGenerator.getInstance("EC", "BC");
+        kpg.initialize(new java.security.spec.ECGenParameterSpec("secp256k1"));
+        KeyPair k1 = kpg.generateKeyPair();
+        kpg.initialize(new java.security.spec.ECGenParameterSpec("secp256r1"));
+        KeyPair p256 = kpg.generateKeyPair();
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, k1, issuer,
+                        CertificateGenerator.LeafUsage.CLIENT));
+        assertTrue(refused.getMessage().contains("not the requested EC_prime256v1"), refused.getMessage());
+        var accepted = generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, p256, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        assertEquals(p256.getPublic(), generator.parseCertificate(accepted.certificatePem()).getPublicKey());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -122,6 +122,35 @@ class CertificateGeneratorIssuerTest {
     }
 
     @Test
+    void anIssuerWhoseKeyDoesNotMatchItsCertificateIsRefused() {
+        var one = generator.generateCaCertificate("One");
+        var other = generator.generateCaCertificate("Other");
+        var mismatched = new CertificateGenerator.Issuer(
+                generator.parseCertificate(one.certificatePem()), generator.parsePrivateKey(other.privateKeyPem()));
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("x.example.test", List.of(), KeyAlgorithm.RSA_2048, null,
+                        mismatched, CertificateGenerator.LeafUsage.SERVER));
+        assertTrue(refused.getMessage().contains("Signature"), refused.getMessage());
+    }
+
+    @Test
+    void aSuppliedKeyPairThatIsNotAPairIsRefused() {
+        var issuer = newIssuer();
+        var a = generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var b = generator.generateIssuedCertificate("b", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var notAPair = new KeyPair(generator.parseCertificate(a.certificatePem()).getPublicKey(),
+                generator.parsePrivateKey(b.privateKeyPem()));
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.RSA_2048, notAPair, issuer,
+                        CertificateGenerator.LeafUsage.CLIENT));
+        assertTrue(refused.getMessage().contains("does not match"), refused.getMessage());
+    }
+
+    @Test
     void duplicateSansAreWrittenOnce() throws Exception {
         var leaf = generator.generateIssuedCertificate("dup.example.test", List.of("dup.example.test", "other.example.test",
                 "other.example.test"), KeyAlgorithm.RSA_2048, null, newIssuer(), CertificateGenerator.LeafUsage.SERVER);


### PR DESCRIPTION
## Summary

`CertificateGenerator` could only sign a certificate with the subject's own key, so nothing in Floci could issue a certificate from a CA. `CloudHsmV2Service` had its own private copy of the signing code to build its three-level hardware chain.

This change adds one signing primitive and two generators on top of it, and deletes the CloudHSM copy. No public method changes its signature. Nothing new is wired into a service yet; this is the groundwork for a local root CA in the next pull request.

- `signCertificate(subject, subjectKey, issuerDn, issuerKey, sans, asCa, usage, days)` is the one place a certificate is signed. `buildCertificate` routes through it.
- `generateCaCertificate(commonName)`: self-signed, `cA=true`, `keyCertSign` and `cRLSign`, ten years.
- `generateIssuedCertificate(domain, sans, algorithm, keyPair, issuer, usage)`: a leaf signed by an `Issuer` (certificate plus key), with a `serverAuth` or `clientAuth` Extended Key Usage. An existing key pair can be reused so a reissue keeps its public key.
- `CloudHsmV2Service.generateCert` is deleted. Its three call sites use the shared primitive, which now also marks the two CA levels of the emulated chain as CAs.

## What is covered

The metadata `DescribeCertificate` returns for a generated certificate now follows the ACM shape.

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| ACM `CertificateDetail` | `Serial` | ✅ | Colon-separated hex (`07:71:71:f4:...`), as ACM reports it, for generated and imported certificates. Was the decimal value. |
| ACM `CertificateDetail` | `SignatureAlgorithm` | ✅ | Read from the certificate and spelled in upper case (`SHA512WITHRSA`), as ACM does. Was derived from the subject key type. |
| ACM `CertificateDetail` | `KeyUsages` | 🟡 | The certificate itself now carries `digitalSignature` only for an EC key and adds `keyEncipherment` for RSA. The JSON list `DescribeCertificate` returns is unchanged. |
| ACM `CertificateDetail` | `ExtendedKeyUsages` | 🟡 | A `SERVER` leaf carries `serverAuth` and `clientAuth` in the certificate, which is what `DescribeCertificate` already advertises. The existing `generateCertificate` path still emits no EKU; it switches to the CA in the next pull request. |
| ACM `CertificateDetail` | `Issuer` | ✅ | Unchanged for existing paths. An issued leaf reports its issuer's subject name. |
| CloudHSM `Certificates` | `ManufacturerHardwareCertificate`, `AwsHardwareCertificate`, `HsmCertificate` | ✅ | Same chain, signed through the shared primitive. `InitializeCluster` still verifies the trust anchor and signed certificate against it. |

## Files

- `CertificateGenerator`: new `LeafUsage`, `Issuer`, `signCertificate`, `generateCaCertificate`, `generateIssuedCertificate`; `toPem` is public.
- `CloudHsmV2Service`: injects `CertificateGenerator`, private `generateCert` removed.
- `AcmService`: an imported certificate stores its serial and signature algorithm in the same shape a generated one does.
- `CertificateGeneratorIssuerTest` (new): the CA is self-signed and can sign, a leaf verifies against its issuer, EKU per usage, key pair reuse, an EC leaf under an RSA CA reports the issuer's algorithm, duplicate SANs are written once, a mismatched issuer key, a key pair that is not a pair, a key pair of another algorithm and the existing self-signed and ACM-style paths, serial formatting. `AcmImportExportTest` asserts the imported shape.

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [x] Docs / chore (refactor)

### Checklist

* [ ] `./mvnw test` passes locally. Ran per class instead: `CertificateGenerator*Test`, `Acm*Test`, `CloudHsmV2*Test`, `TlsConfigSource*Test`, `TlsCertificateHostnameTest`, `RdsProxyTls*Test`, `ContainerLauncherCaTrustTest` (220 tests, all green).
* [x] New or updated integration test added
* [x] Commit messages follow Conventional Commits
