### PR TITLE
feat(tls): a local root CA that signs Floci's server certificate

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -95,7 +95,7 @@ floci:
     enabled: false                           # FLOCI_TLS_ENABLED — enable HTTPS on all endpoints
     # cert-path: ""                          # FLOCI_TLS_CERT_PATH — PEM certificate file path
     # key-path: ""                           # FLOCI_TLS_KEY_PATH — PEM private key file path
-    self-signed: true                        # FLOCI_TLS_SELF_SIGNED — auto-generate cert when no paths provided
+    self-signed: true                        # FLOCI_TLS_SELF_SIGNED: auto-generate a cert signed by the local CA when no paths provided
 
   protocols:
     max-request-size: 2048                   # FLOCI_PROTOCOLS_MAX_REQUEST_SIZE — max HTTP request body size in MB (legacy: floci.max-request-size / FLOCI_MAX_REQUEST_SIZE)

--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -42,7 +42,7 @@ Floci is configured exclusively through environment variables. Every option belo
 | `FLOCI_TLS_ENABLED` | `false` | Enable TLS/HTTPS on all endpoints (HTTP remains available simultaneously) |
 | `FLOCI_TLS_CERT_PATH` | _(none)_ | Path to a PEM certificate file. When set, disables auto-generation |
 | `FLOCI_TLS_KEY_PATH` | _(none)_ | Path to a PEM private key file. Required when `FLOCI_TLS_CERT_PATH` is set |
-| `FLOCI_TLS_SELF_SIGNED` | `true` | Auto-generate and persist a self-signed certificate when no cert/key paths are provided |
+| `FLOCI_TLS_SELF_SIGNED` | `true` | Auto-generate and persist a server certificate signed by Floci's local CA when no cert/key paths are provided |
 
 See [TLS / HTTPS](./tls.md) for SDK configuration examples and WebSocket (`wss://`) support.
 

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -26,6 +26,12 @@ export SSL_CERT_FILE=$PWD/floci-root-ca.pem
 
 Prefer these per-process variables, and scope them to the shell or the tool (a `.envrc`, a compose `environment:` block) that needs them. They cannot affect anything else on the machine.
 
+The download above is plain HTTP and carries no proof of who sent it, which is fine on loopback and nowhere else. For a client on another host, or over a network you do not control, copy the file out of band instead: read `{persistent-path}/tls/floci-root-ca.crt` from Floci's volume, or `docker cp` it out of the container. Either way, compare the fingerprint before trusting it. Floci logs it at startup as `TLS: ... SHA256 fingerprint AB:CD:...`, and the file's fingerprint is:
+
+```bash
+openssl x509 -in floci-root-ca.pem -noout -fingerprint -sha256
+```
+
 Installing the CA into the operating system trust store (macOS `security add-trusted-cert`, Linux `update-ca-certificates`) also works and is what Safari, Chrome and Go on macOS need, but understand what it does: every process on the machine then trusts anything signed by the key in `{persistent-path}/tls/floci-root-ca.key`. Keep that file private, treat the CA as a dev-machine secret, and remove it from the store when you stop using Floci:
 
 ```bash
@@ -93,7 +99,7 @@ docker run \
   floci/floci:latest
 ```
 
-When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored and no local CA or server certificate is generated.
+When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored: the HTTPS server uses your certificate, no server certificate or local CA is generated for it, and `GET /_floci/ca.pem` returns your certificate file instead of a local CA. Put the CA or the full chain in that file if clients fetch their trust anchor from Floci; a bare leaf only lets them pin that one certificate.
 
 ## WebSocket (wss://)
 

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -99,7 +99,7 @@ docker run \
   floci/floci:latest
 ```
 
-When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored: the HTTPS server uses your certificate, no server certificate or local CA is generated for it, and `GET /_floci/ca.pem` returns your certificate file instead of a local CA. Put the CA or the full chain in that file if clients fetch their trust anchor from Floci; a bare leaf only lets them pin that one certificate.
+When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored and the HTTPS server uses your certificate; no server certificate is generated. `GET /_floci/ca.pem` then returns a PEM bundle: your certificate file first, then Floci's local CA, which still signs the certificates Floci itself issues (IoT device certificates) and is created on first use. Put the CA or the full chain in your certificate file if clients fetch their trust anchor from Floci; a bare leaf only lets them pin that one certificate.
 
 ## WebSocket (wss://)
 

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -8,19 +8,32 @@ Floci supports optional TLS, enabling `https://` for all REST/JSON/Query endpoin
 docker run -e FLOCI_TLS_ENABLED=true -p 4566:4566 floci/floci:latest
 ```
 
-Then point your SDK at `https://localhost:4566`. Since the certificate is self-signed, disable TLS verification in your client:
+Then point your SDK at `https://localhost:4566` and trust Floci's local CA in the processes that talk to it. Every certificate Floci issues (its HTTPS endpoint, and in later releases ACM and IoT device certificates) chains to that one CA:
 
 ```bash
-# AWS CLI
-aws --endpoint-url https://localhost:4566 --no-verify-ssl sts get-caller-identity
+curl -s http://localhost:4566/_floci/ca.pem -o floci-root-ca.pem
 
-# Node.js
-NODE_TLS_REJECT_UNAUTHORIZED=0 node app.js
+# AWS CLI and every AWS SDK
+export AWS_CA_BUNDLE=$PWD/floci-root-ca.pem
+aws --endpoint-url https://localhost:4566 sts get-caller-identity
 
-# Python (boto3)
-import boto3
-client = boto3.client('sts', endpoint_url='https://localhost:4566', verify=False)
+# Node.js (appends to the built-in roots)
+export NODE_EXTRA_CA_CERTS=$PWD/floci-root-ca.pem
+
+# curl, Python, Go on Linux (replaces the default roots for that process only)
+export SSL_CERT_FILE=$PWD/floci-root-ca.pem
 ```
+
+Prefer these per-process variables, and scope them to the shell or the tool (a `.envrc`, a compose `environment:` block) that needs them. They cannot affect anything else on the machine.
+
+Installing the CA into the operating system trust store (macOS `security add-trusted-cert`, Linux `update-ca-certificates`) also works and is what Safari, Chrome and Go on macOS need, but understand what it does: every process on the machine then trusts anything signed by the key in `{persistent-path}/tls/floci-root-ca.key`. Keep that file private, treat the CA as a dev-machine secret, and remove it from the store when you stop using Floci:
+
+```bash
+# macOS login keychain; remove later with: security delete-certificate -c "Floci Local CA"
+security add-trusted-cert -r trustRoot -k ~/Library/Keychains/login.keychain-db floci-root-ca.pem
+```
+
+Disabling verification (`--no-verify-ssl`, `verify=False`, `NODE_TLS_REJECT_UNAUTHORIZED=0`) still works but is no longer needed.
 
 ## Configuration
 
@@ -29,22 +42,24 @@ client = boto3.client('sts', endpoint_url='https://localhost:4566', verify=False
 | `FLOCI_TLS_ENABLED` | `false` | Enable TLS/HTTPS on the server |
 | `FLOCI_TLS_CERT_PATH` | *(unset)* | Path to PEM certificate file |
 | `FLOCI_TLS_KEY_PATH` | *(unset)* | Path to PEM private key file |
-| `FLOCI_TLS_SELF_SIGNED` | `true` | Auto-generate a self-signed certificate when no cert/key paths provided |
+| `FLOCI_TLS_SELF_SIGNED` | `true` | Auto-generate a server certificate signed by Floci's local CA when no cert/key paths provided |
 
-## Self-Signed Certificate
+## Local CA and Server Certificate
 
-When `FLOCI_TLS_ENABLED=true` and no custom certificate is provided, Floci auto-generates a self-signed certificate at startup. The certificate:
+When `FLOCI_TLS_ENABLED=true` and no custom certificate is provided, Floci keeps a local root CA at `{persistent-path}/tls/floci-root-ca.crt` (key `floci-root-ca.key`, owner-only) and issues its server certificate `floci-server.crt` from it at startup. The server certificate:
 
 - Is persisted to `{persistent-path}/tls/` and reused across restarts
 - Includes `localhost`, `127.0.0.1`, `0.0.0.0`, `*.localhost`, `localhost.floci.io`,
   `*.localhost.floci.io`, `*.execute-api.localhost.floci.io`, and
   `*.execute-api.localhost.localstack.cloud` as Subject Alternative Names (SANs)
 - Automatically includes custom hostnames from `FLOCI_HOSTNAME` and `FLOCI_BASE_URL` in the SANs
-- Is regenerated when hostname configuration changes between restarts
+- Is regenerated when hostname configuration changes between restarts, or when it was not issued by the current CA
+
+The CA is created once and never rotates on its own. If its files are missing, corrupt or do not match each other, Floci generates a new CA, logs a warning, and reissues the server certificate; clients then need the new `ca.pem`.
 
 ### Custom Hostname Support
 
-If you set `FLOCI_HOSTNAME` or use a custom host in `FLOCI_BASE_URL`, the self-signed certificate automatically includes those hostnames in its SANs. This is essential for Docker Compose setups where containers reference Floci by service name:
+If you set `FLOCI_HOSTNAME` or use a custom host in `FLOCI_BASE_URL`, the server certificate automatically includes those hostnames in its SANs. This is essential for Docker Compose setups where containers reference Floci by service name:
 
 ```yaml
 services:
@@ -59,10 +74,10 @@ services:
   app:
     environment:
       AWS_ENDPOINT_URL: "https://floci:4566"
-      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      AWS_CA_BUNDLE: /floci/floci-root-ca.pem
 ```
 
-The generated certificate will include `floci` in its SANs, so TLS validation succeeds when `app` connects to `https://floci:4566`.
+The generated certificate will include `floci` in its SANs, so TLS validation succeeds when `app` connects to `https://floci:4566`. Fetch `ca.pem` from Floci into `app` (an entrypoint `curl`, or a shared volume mounted from `{persistent-path}/tls/`) so the bundle path above exists.
 
 ## User-Provided Certificates
 
@@ -78,7 +93,7 @@ docker run \
   floci/floci:latest
 ```
 
-When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored and no self-signed certificate is generated.
+When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored and no local CA or server certificate is generated.
 
 ## WebSocket (wss://)
 
@@ -88,9 +103,11 @@ When TLS is enabled, WebSocket connections automatically use `wss://`:
 wss://localhost:4566/ws/{apiId}/{stage}
 ```
 
-No additional configuration is needed — Vert.x handles TLS at the transport layer transparently.
+No additional configuration is needed: Vert.x handles TLS at the transport layer transparently.
 
 ## SDK Configuration Examples
+
+With `AWS_CA_BUNDLE` set as in Quick Start, no SDK needs code changes. The examples below trust the CA in code instead, for processes whose environment you do not control.
 
 ### AWS SDK for JavaScript v3
 
@@ -98,13 +115,14 @@ No additional configuration is needed — Vert.x handles TLS at the transport la
 import { STSClient } from '@aws-sdk/client-sts';
 import { NodeHttpHandler } from '@smithy/node-http-handler';
 import https from 'node:https';
+import { readFileSync } from 'node:fs';
 
 const client = new STSClient({
   endpoint: 'https://localhost:4566',
   region: 'us-east-1',
   credentials: { accessKeyId: 'test', secretAccessKey: 'test' },
   requestHandler: new NodeHttpHandler({
-    httpsAgent: new https.Agent({ rejectUnauthorized: false }),
+    httpsAgent: new https.Agent({ ca: readFileSync('floci-root-ca.pem') }),
   }),
 });
 ```
@@ -112,7 +130,7 @@ const client = new STSClient({
 Or set the environment variable globally:
 
 ```bash
-NODE_TLS_REJECT_UNAUTHORIZED=0 npx vitest run
+NODE_EXTRA_CA_CERTS=$PWD/floci-root-ca.pem npx vitest run
 ```
 
 ### AWS SDK for Java v2
@@ -120,14 +138,18 @@ NODE_TLS_REJECT_UNAUTHORIZED=0 npx vitest run
 ```java
 SdkHttpClient httpClient = ApacheHttpClient.builder()
     .tlsTrustManagersProvider(() -> {
-        TrustManager[] trustAll = new TrustManager[]{
-            new X509TrustManager() {
-                public X509Certificate[] getAcceptedIssuers() { return new X509Certificate[0]; }
-                public void checkClientTrusted(X509Certificate[] certs, String authType) {}
-                public void checkServerTrusted(X509Certificate[] certs, String authType) {}
-            }
-        };
-        return trustAll;
+        try {
+            var ca = CertificateFactory.getInstance("X.509")
+                .generateCertificate(Files.newInputStream(Path.of("floci-root-ca.pem")));
+            var trust = KeyStore.getInstance(KeyStore.getDefaultType());
+            trust.load(null, null);
+            trust.setCertificateEntry("floci", ca);
+            var factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            factory.init(trust);
+            return factory.getTrustManagers();
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     })
     .build();
 
@@ -145,7 +167,7 @@ import boto3
 client = boto3.client(
     'sts',
     endpoint_url='https://localhost:4566',
-    verify=False,  # Disable TLS verification for self-signed cert
+    verify='floci-root-ca.pem',  # or export AWS_CA_BUNDLE
     region_name='us-east-1',
     aws_access_key_id='test',
     aws_secret_access_key='test',
@@ -156,7 +178,7 @@ client = boto3.client(
 
 | Certificate type | Verification disabled? | Why |
 |-----------------|----------------------|-----|
-| Floci self-signed (default) | **Yes** — `NODE_TLS_REJECT_UNAUTHORIZED=0`, `verify=False`, etc. | The self-signed CA is not in your system's trust store |
+| Floci local CA (default) | **No**, once you trust `floci-root-ca.crt` (`GET /_floci/ca.pem`) | One CA covers the HTTPS endpoint and every certificate Floci issues |
 | `mkcert` with local CA installed | **No** | `mkcert -install` adds its root CA to the OS trust store |
 | Corporate/internal CA already trusted | **No** | Your OS or JVM already trusts the issuing CA |
 | Public CA (Let's Encrypt, etc.) | **No** | Trusted by default in all runtimes |
@@ -166,13 +188,19 @@ In short: you only need to disable verification when the certificate's issuer is
 ## Troubleshooting
 
 **Certificate errors after changing `FLOCI_HOSTNAME`.**
-Floci detects hostname configuration changes and regenerates the certificate automatically. If you still see errors, delete the `{persistent-path}/tls/` directory and restart.
+Floci detects hostname configuration changes and regenerates the server certificate automatically. If you still see errors, delete the `{persistent-path}/tls/` directory and restart. That also creates a new CA, so re-download `ca.pem`.
 
-**`DEPTH_ZERO_SELF_SIGNED_CERT` in Node.js.**
-This only happens with self-signed certificates. Set `NODE_TLS_REJECT_UNAUTHORIZED=0` or configure a custom HTTPS agent that skips verification. If you use `mkcert` and ran `mkcert -install`, this error should not occur.
+**`UNABLE_TO_GET_ISSUER_CERT_LOCALLY` or `DEPTH_ZERO_SELF_SIGNED_CERT` in Node.js.**
+The process does not trust the Floci CA yet. Set `NODE_EXTRA_CA_CERTS` to `ca.pem` or pass it as the agent's `ca` option as shown above.
 
 **Java `SSLHandshakeException: PKIX path building failed`.**
-For self-signed certificates: configure a trust-all TrustManager as shown above, or import the certificate into your JVM's truststore with `keytool -importcert`. For user-provided certificates from a trusted CA, this should not occur.
+Import `ca.pem` into the trust store the client uses (`keytool -importcert -file floci-root-ca.pem -alias floci -cacerts`, or a `TrustManager` built from it as shown above). For user-provided certificates from a trusted CA, this should not occur.
+
+**`Go: x509: certificate signed by unknown authority` on macOS.**
+Go on macOS ignores `SSL_CERT_FILE` and reads the keychain. Pin the CA in code with `x509.NewCertPool().AppendCertsFromPEM` (the AWS SDK for Go honours `AWS_CA_BUNDLE` regardless), or add it to the login keychain as shown in Quick Start.
+
+**I regenerated `{persistent-path}/tls/`.**
+That created a new CA. Re-download `/_floci/ca.pem` wherever you installed the old one.
 
 **Certificate doesn't include my custom hostname.**
 Ensure `FLOCI_HOSTNAME` or `FLOCI_BASE_URL` is set *before* Floci starts. The certificate is generated during startup. Check the logs for `TLS: detected custom hostnames: [...]`.

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -99,7 +99,7 @@ docker run \
   floci/floci:latest
 ```
 
-When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored and the HTTPS server uses your certificate; no server certificate is generated. `GET /_floci/ca.pem` then returns a PEM bundle: your certificate file first, then Floci's local CA, which still signs the certificates Floci itself issues (IoT device certificates) and is created on first use. Put the CA or the full chain in your certificate file if clients fetch their trust anchor from Floci; a bare leaf only lets them pin that one certificate.
+When custom certificate paths are provided, `FLOCI_TLS_SELF_SIGNED` is ignored and the HTTPS server uses your certificate; no server certificate is generated. `GET /_floci/ca.pem` then returns a PEM bundle: your certificate file first, then Floci's local CA, which is created on first use and is the CA that will sign the certificates Floci itself issues (IoT device certificates, in a follow-up). Put the CA or the full chain in your certificate file if clients fetch their trust anchor from Floci; a bare leaf only lets them pin that one certificate.
 
 ## WebSocket (wss://)
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -2314,9 +2314,10 @@ public interface EmulatorConfig {
         Optional<String> keyPath();
 
         /**
-         * Auto-generate a self-signed certificate when no cert-path/key-path provided.
-         * The generated files are persisted to {@code {storage.persistent-path}/tls/}
-         * and reused across restarts. Env: FLOCI_TLS_SELF_SIGNED
+         * Auto-generate a server certificate when no cert-path/key-path is provided. The leaf is
+         * issued by Floci's local root CA; both live under {@code {storage.persistent-path}/tls/}
+         * and survive restarts. Clients trust the CA ({@code GET /_floci/ca.pem}), not the leaf.
+         * Env: FLOCI_TLS_SELF_SIGNED
          */
         @WithDefault("true")
         boolean selfSigned();

--- a/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
@@ -5,16 +5,16 @@ import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.MessageDigest;
 import java.security.PublicKey;
-import java.security.Signature;
 import java.security.cert.X509Certificate;
+import java.util.HexFormat;
 import java.util.List;
 
 /**
@@ -69,13 +69,15 @@ public final class FlociCertificateAuthority {
                     }
                     cert.verify(cert.getPublicKey());
                     cert.checkValidity();
-                    if (!keyMatches(key, cert.getPublicKey())) {
+                    if (!CertificateGenerator.isPair(key, cert.getPublicKey())) {
                         throw new IllegalStateException("private key does not match the certificate");
                     }
                     restrictToOwnerOnly(tlsDir, "rwx------");
                     restrictToOwnerOnly(keyFile, "rw-------");
-                    LOG.infov("TLS: using local CA {0} ({1})", certFile, cert.getSubjectX500Principal().getName());
-                    return new FlociCertificateAuthority(certFile, cert, key, pem, generator);
+                    FlociCertificateAuthority ca = new FlociCertificateAuthority(certFile, cert, key, pem, generator);
+                    LOG.infov("TLS: using local CA {0} ({1}), SHA256 fingerprint {2}", certFile,
+                            cert.getSubjectX500Principal().getName(), ca.fingerprint());
+                    return ca;
                 } catch (Exception e) {
                     LOG.warnv(e, "TLS: local CA at {0} is unusable ({1}); generating a new one. Clients that trusted "
                             + "the old CA must re-import {2}", tlsDir, e.getMessage(), CA_CERT_NAME);
@@ -86,11 +88,13 @@ public final class FlociCertificateAuthority {
             CertificateGenerator.GeneratedCertificate generated = generator.generateCaCertificate(COMMON_NAME);
             Files.writeString(certFile, generated.certificatePem());
             writePrivateKey(keyFile, generated.privateKeyPem());
-            LOG.infov("TLS: generated local CA {0}. Trust it once: GET /_floci/ca.pem", certFile);
-            return new FlociCertificateAuthority(certFile,
+            FlociCertificateAuthority ca = new FlociCertificateAuthority(certFile,
                     generator.parseCertificate(generated.certificatePem()),
                     generator.parsePrivateKey(generated.privateKeyPem()),
                     generated.certificatePem(), generator);
+            LOG.infov("TLS: generated local CA {0}, SHA256 fingerprint {1}. Trust it once: GET /_floci/ca.pem",
+                    certFile, ca.fingerprint());
+            return ca;
         } catch (IOException e) {
             throw new IllegalStateException("Failed to create local CA under " + tlsDir, e);
         }
@@ -111,6 +115,19 @@ public final class FlociCertificateAuthority {
 
     public Path certificatePath() {
         return certificatePath;
+    }
+
+    /**
+     * SHA-256 fingerprint of the CA certificate in the form {@code openssl x509 -fingerprint -sha256}
+     * prints, so a copy obtained out of band can be checked against the startup log.
+     */
+    public String fingerprint() {
+        try {
+            return HexFormat.ofDelimiter(":").withUpperCase()
+                    .formatHex(MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded()));
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot fingerprint the CA certificate", e);
+        }
     }
 
     public CertificateGenerator.Issuer issuer() {
@@ -148,19 +165,6 @@ public final class FlociCertificateAuthority {
         }
     }
 
-    private static boolean keyMatches(PrivateKey key, PublicKey publicKey) throws Exception {
-        String algorithm = "EC".equals(key.getAlgorithm()) ? "SHA256withECDSA" : "SHA256withRSA";
-        byte[] probe = "floci".getBytes(StandardCharsets.US_ASCII);
-        Signature signer = Signature.getInstance(algorithm);
-        signer.initSign(key);
-        signer.update(probe);
-        byte[] signature = signer.sign();
-        Signature verifier = Signature.getInstance(algorithm);
-        verifier.initVerify(publicKey);
-        verifier.update(probe);
-        return verifier.verify(signature);
-    }
-
     /**
      * Writes a private key so that no other user can read it at any point: the file is created
      * owner-only where the file system supports POSIX permissions, and re-tightened otherwise.
@@ -169,6 +173,9 @@ public final class FlociCertificateAuthority {
         Files.deleteIfExists(keyFile);
         if (Files.getFileAttributeView(keyFile.getParent(), PosixFileAttributeView.class) != null) {
             Files.createFile(keyFile, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+        } else {
+            LOG.warnv("TLS: {0} is written with the file system's default permissions because it has no POSIX "
+                    + "permissions; restrict it to your own account yourself", keyFile);
         }
         Files.writeString(keyFile, pem);
         restrictToOwnerOnly(keyFile, "rw-------");

--- a/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
@@ -137,7 +137,7 @@ public final class FlociCertificateAuthority {
     /**
      * A {@code serverAuth} leaf for {@code commonName} plus {@code sans}. {@code keyPair} null
      * mints a new key of {@code keyAlgorithm}; passing the current pair keeps the public key
-     * across a SAN change (the algorithm is then ignored).
+     * across a SAN change, and it must be of {@code keyAlgorithm}.
      */
     public CertificateGenerator.GeneratedCertificate issueServerCertificate(String commonName, List<String> sans,
                                                                             KeyAlgorithm keyAlgorithm, KeyPair keyPair) {

--- a/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
@@ -77,7 +77,7 @@ public final class FlociCertificateAuthority {
                     LOG.infov("TLS: using local CA {0} ({1})", certFile, cert.getSubjectX500Principal().getName());
                     return new FlociCertificateAuthority(certFile, cert, key, pem, generator);
                 } catch (Exception e) {
-                    LOG.warnv("TLS: local CA at {0} is unusable ({1}); generating a new one. Clients that trusted "
+                    LOG.warnv(e, "TLS: local CA at {0} is unusable ({1}); generating a new one. Clients that trusted "
                             + "the old CA must re-import {2}", tlsDir, e.getMessage(), CA_CERT_NAME);
                 }
             }
@@ -85,8 +85,7 @@ public final class FlociCertificateAuthority {
             restrictToOwnerOnly(tlsDir, "rwx------");
             CertificateGenerator.GeneratedCertificate generated = generator.generateCaCertificate(COMMON_NAME);
             Files.writeString(certFile, generated.certificatePem());
-            Files.writeString(keyFile, generated.privateKeyPem());
-            restrictToOwnerOnly(keyFile, "rw-------");
+            writePrivateKey(keyFile, generated.privateKeyPem());
             LOG.infov("TLS: generated local CA {0}. Trust it once: GET /_floci/ca.pem", certFile);
             return new FlociCertificateAuthority(certFile,
                     generator.parseCertificate(generated.certificatePem()),
@@ -160,6 +159,19 @@ public final class FlociCertificateAuthority {
         verifier.initVerify(publicKey);
         verifier.update(probe);
         return verifier.verify(signature);
+    }
+
+    /**
+     * Writes a private key so that no other user can read it at any point: the file is created
+     * owner-only where the file system supports POSIX permissions, and re-tightened otherwise.
+     */
+    static void writePrivateKey(Path keyFile, String pem) throws IOException {
+        Files.deleteIfExists(keyFile);
+        if (Files.getFileAttributeView(keyFile.getParent(), PosixFileAttributeView.class) != null) {
+            Files.createFile(keyFile, PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rw-------")));
+        }
+        Files.writeString(keyFile, pem);
+        restrictToOwnerOnly(keyFile, "rw-------");
     }
 
     static void restrictToOwnerOnly(Path path, String posixPerms) {

--- a/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
@@ -1,0 +1,176 @@
+package io.github.hectorvent.floci.config;
+
+import io.github.hectorvent.floci.services.acm.CertificateGenerator;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+/**
+ * Floci's one local root CA. Every certificate the emulator hands out that a client is expected
+ * to validate (the HTTPS server leaf, and later ACM and IoT device certificates) chains to it, so
+ * a developer trusts one file once: {@code {persistent-path}/tls/floci-root-ca.crt}, also served
+ * at {@code GET /_floci/ca.pem}.
+ *
+ * <p>Plain class on purpose: {@link TlsConfigSource} needs it before CDI exists. Beans get the
+ * same pair through {@link FlociCertificateAuthorityProducer}.
+ */
+public final class FlociCertificateAuthority {
+
+    private static final Logger LOG = Logger.getLogger(FlociCertificateAuthority.class);
+
+    public static final String CA_CERT_NAME = "floci-root-ca.crt";
+    public static final String CA_KEY_NAME = "floci-root-ca.key";
+    static final String COMMON_NAME = "Floci Local CA";
+
+    private final Path certificatePath;
+    private final X509Certificate certificate;
+    private final PrivateKey key;
+    private final String caPem;
+    private final CertificateGenerator generator;
+
+    private FlociCertificateAuthority(Path certificatePath, X509Certificate certificate, PrivateKey key,
+                                      String caPem, CertificateGenerator generator) {
+        this.certificatePath = certificatePath;
+        this.certificate = certificate;
+        this.key = key;
+        this.caPem = caPem;
+        this.generator = generator;
+    }
+
+    /**
+     * Loads the CA from {@code tlsDir}, or creates one when missing or unusable. A corrupt,
+     * expired or mismatched pair is regenerated with a WARN: every leaf issued before that moment
+     * stops validating, which is the correct outcome for a trust anchor nobody can use.
+     */
+    public static FlociCertificateAuthority loadOrCreate(Path tlsDir) {
+        CertificateGenerator generator = new CertificateGenerator();
+        Path certFile = tlsDir.resolve(CA_CERT_NAME);
+        Path keyFile = tlsDir.resolve(CA_KEY_NAME);
+        try {
+            if (Files.exists(certFile) && Files.exists(keyFile)) {
+                try {
+                    String pem = Files.readString(certFile);
+                    X509Certificate cert = generator.parseCertificate(pem);
+                    PrivateKey key = generator.parsePrivateKey(Files.readString(keyFile));
+                    if (cert.getBasicConstraints() < 0) {
+                        throw new IllegalStateException("not a CA certificate (BasicConstraints cA=false)");
+                    }
+                    cert.verify(cert.getPublicKey());
+                    cert.checkValidity();
+                    if (!keyMatches(key, cert.getPublicKey())) {
+                        throw new IllegalStateException("private key does not match the certificate");
+                    }
+                    restrictToOwnerOnly(tlsDir, "rwx------");
+                    restrictToOwnerOnly(keyFile, "rw-------");
+                    LOG.infov("TLS: using local CA {0} ({1})", certFile, cert.getSubjectX500Principal().getName());
+                    return new FlociCertificateAuthority(certFile, cert, key, pem, generator);
+                } catch (Exception e) {
+                    LOG.warnv("TLS: local CA at {0} is unusable ({1}); generating a new one. Clients that trusted "
+                            + "the old CA must re-import {2}", tlsDir, e.getMessage(), CA_CERT_NAME);
+                }
+            }
+            Files.createDirectories(tlsDir);
+            restrictToOwnerOnly(tlsDir, "rwx------");
+            CertificateGenerator.GeneratedCertificate generated = generator.generateCaCertificate(COMMON_NAME);
+            Files.writeString(certFile, generated.certificatePem());
+            Files.writeString(keyFile, generated.privateKeyPem());
+            restrictToOwnerOnly(keyFile, "rw-------");
+            LOG.infov("TLS: generated local CA {0}. Trust it once: GET /_floci/ca.pem", certFile);
+            return new FlociCertificateAuthority(certFile,
+                    generator.parseCertificate(generated.certificatePem()),
+                    generator.parsePrivateKey(generated.privateKeyPem()),
+                    generated.certificatePem(), generator);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to create local CA under " + tlsDir, e);
+        }
+    }
+
+    public X509Certificate certificate() {
+        return certificate;
+    }
+
+    public PrivateKey key() {
+        return key;
+    }
+
+    /** PEM of the CA certificate, exactly the bytes on disk. */
+    public String caPem() {
+        return caPem;
+    }
+
+    public Path certificatePath() {
+        return certificatePath;
+    }
+
+    public CertificateGenerator.Issuer issuer() {
+        return new CertificateGenerator.Issuer(certificate, key);
+    }
+
+    /**
+     * A {@code serverAuth} leaf for {@code commonName} plus {@code sans}. {@code keyPair} null
+     * mints a new key of {@code keyAlgorithm}; passing the current pair keeps the public key
+     * across a SAN change (the algorithm is then ignored).
+     */
+    public CertificateGenerator.GeneratedCertificate issueServerCertificate(String commonName, List<String> sans,
+                                                                            KeyAlgorithm keyAlgorithm, KeyPair keyPair) {
+        return generator.generateIssuedCertificate(commonName, sans, keyAlgorithm, keyPair, issuer(),
+                CertificateGenerator.LeafUsage.SERVER);
+    }
+
+    /** A {@code clientAuth} leaf, for IoT device certificates. Always a fresh RSA 2048 key pair. */
+    public CertificateGenerator.GeneratedCertificate issueClientCertificate(String commonName) {
+        return generator.generateIssuedCertificate(commonName, List.of(), KeyAlgorithm.RSA_2048, null, issuer(),
+                CertificateGenerator.LeafUsage.CLIENT);
+    }
+
+    /** True when {@code cert} names this CA as issuer and its signature checks against our key. */
+    public boolean isIssuedByUs(X509Certificate cert) {
+        if (!certificate.getSubjectX500Principal().equals(cert.getIssuerX500Principal())) {
+            return false;
+        }
+        try {
+            cert.verify(certificate.getPublicKey());
+            return true;
+        } catch (Exception e) {
+            LOG.debugv("TLS: certificate names our CA but does not verify: {0}", e.getMessage());
+            return false;
+        }
+    }
+
+    private static boolean keyMatches(PrivateKey key, PublicKey publicKey) throws Exception {
+        String algorithm = "EC".equals(key.getAlgorithm()) ? "SHA256withECDSA" : "SHA256withRSA";
+        byte[] probe = "floci".getBytes(StandardCharsets.US_ASCII);
+        Signature signer = Signature.getInstance(algorithm);
+        signer.initSign(key);
+        signer.update(probe);
+        byte[] signature = signer.sign();
+        Signature verifier = Signature.getInstance(algorithm);
+        verifier.initVerify(publicKey);
+        verifier.update(probe);
+        return verifier.verify(signature);
+    }
+
+    static void restrictToOwnerOnly(Path path, String posixPerms) {
+        PosixFileAttributeView view = Files.getFileAttributeView(path, PosixFileAttributeView.class);
+        if (view == null) {
+            return;
+        }
+        try {
+            view.setPermissions(PosixFilePermissions.fromString(posixPerms));
+        } catch (IOException e) {
+            LOG.warnv("TLS: could not restrict permissions on {0}: {1}", path, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthority.java
@@ -166,8 +166,9 @@ public final class FlociCertificateAuthority {
     }
 
     /**
-     * Writes a private key so that no other user can read it at any point: the file is created
-     * owner-only where the file system supports POSIX permissions, and re-tightened otherwise.
+     * Writes a private key so that, where the file system has POSIX permissions, no other user can
+     * read it at any point: the file is created owner-only before the first byte is written. A
+     * file system without POSIX permissions gets the platform default and a WARN.
      */
     static void writePrivateKey(Path keyFile, String pem) throws IOException {
         Files.deleteIfExists(keyFile);

--- a/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityProducer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityProducer.java
@@ -1,0 +1,43 @@
+package io.github.hectorvent.floci.config;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Inject;
+
+import java.nio.file.Path;
+
+/**
+ * Exposes {@link FlociCertificateAuthority} to CDI. {@link TlsConfigSource} may already have
+ * created the files during config bootstrap; this loads the same pair. Lazy, so a boot with TLS
+ * off and no caller of the CA never touches the disk.
+ */
+@ApplicationScoped
+public class FlociCertificateAuthorityProducer {
+
+    static final String TLS_DIR = "tls";
+
+    private final EmulatorConfig config;
+
+    @Inject
+    public FlociCertificateAuthorityProducer(EmulatorConfig config) {
+        this.config = config;
+    }
+
+    @Produces
+    @ApplicationScoped
+    FlociCertificateAuthority certificateAuthority() {
+        return FlociCertificateAuthority.loadOrCreate(tlsDir(config));
+    }
+
+    /**
+     * The one TLS directory. {@link TlsConfigSource} runs before CDI and resolves
+     * {@code floci.storage.persistent-path} from system properties and environment only; when it
+     * laid down the CA, every CDI consumer must use exactly that directory, or a persistent path set
+     * in application.yml alone would produce a second CA (served leaf signed by one, ca.pem from
+     * the other). With TLS off the bootstrap never ran and the configured path is the only truth.
+     */
+    static Path tlsDir(EmulatorConfig config) {
+        Path fromBootstrap = TlsConfigSource.resolvedTlsDir();
+        return fromBootstrap != null ? fromBootstrap : Path.of(config.storage().persistentPath(), TLS_DIR);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -54,7 +54,14 @@ public class TlsConfigSource implements ConfigSource {
             "*.execute-api.localhost.floci.io",
             "*.execute-api.localhost.localstack.cloud", "host.docker.internal");
 
+    private static volatile Path resolvedTlsDir;
+
     private final Map<String, String> properties = new HashMap<>();
+
+    /** The directory the bootstrap used for CA and leaf, or null when it did not run the self-signed branch. */
+    static Path resolvedTlsDir() {
+        return resolvedTlsDir;
+    }
 
     public TlsConfigSource() {
         String enabled = resolveProperty("floci.tls.enabled", "false");

--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -30,9 +30,9 @@ import java.util.Set;
  * would be too late.
  *
  * <p>
- * When TLS is enabled with self-signed mode, the certificate is generated
- * using the ACM {@link CertificateGenerator} and persisted under
- * {@code {persistent-path}/tls/} for reuse across restarts.
+ * When TLS is enabled without a user certificate, the server certificate is a leaf issued by
+ * {@link FlociCertificateAuthority} and persisted under {@code {persistent-path}/tls/}. Clients
+ * trust the CA ({@code floci-root-ca.crt}, or {@code GET /_floci/ca.pem}), never the leaf.
  *
  * <p>
  * Both HTTP and HTTPS are served simultaneously (LocalStack parity).
@@ -41,9 +41,9 @@ public class TlsConfigSource implements ConfigSource {
 
     private static final Logger LOG = Logger.getLogger(TlsConfigSource.class);
 
-    private static final String SELF_SIGNED_CERT_NAME = "floci-selfsigned.crt";
-    private static final String SELF_SIGNED_KEY_NAME = "floci-selfsigned.key";
-    private static final String SELF_SIGNED_METADATA_NAME = "floci-selfsigned.metadata.json";
+    private static final String SERVER_CERT_NAME = "floci-server.crt";
+    private static final String SERVER_KEY_NAME = "floci-server.key";
+    private static final String SERVER_METADATA_NAME = "floci-server.metadata.json";
     private static final String TLS_DIR = "tls";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -81,29 +81,26 @@ public class TlsConfigSource implements ConfigSource {
             LOG.infov("TLS: using user-provided certificate: {0}", certPath);
         } else if ("true".equalsIgnoreCase(selfSigned)) {
             Path tlsDir = Path.of(persistentPath, TLS_DIR);
-            Path certFile = tlsDir.resolve(SELF_SIGNED_CERT_NAME);
-            Path keyFile = tlsDir.resolve(SELF_SIGNED_KEY_NAME);
+            resolvedTlsDir = tlsDir;
+            Path certFile = tlsDir.resolve(SERVER_CERT_NAME);
+            Path keyFile = tlsDir.resolve(SERVER_KEY_NAME);
+            FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tlsDir);
 
-            // Check if certificate files exist and configuration hasn't changed
             if (Files.exists(certFile) && Files.exists(keyFile)) {
-                // Extract current hostname configuration
-                List<String> customHostnames = extractCustomHostnames();
-                List<String> currentHostnames = new ArrayList<>();
-                currentHostnames.addAll(DEFAULT_SAN_HOSTNAMES);
-                currentHostnames.addAll(customHostnames);
-                
-                // Regenerate when the hostname config changed, or when the existing certificate
-                // is a legacy non-self-signed cert (issuer != subject) — those cannot serve as a
-                // trust anchor for clients that install them, so an upgrade must replace them.
-                if (hostnameConfigChanged(tlsDir, currentHostnames) || !isSelfSigned(certFile)) {
-                    generateSelfSignedCert(tlsDir, certFile, keyFile);
+                List<String> currentHostnames = new ArrayList<>(DEFAULT_SAN_HOSTNAMES);
+                currentHostnames.addAll(extractCustomHostnames());
+
+                // Regenerate when the hostname config changed, when the existing leaf was not
+                // issued by the current CA (a pre-CA self-signed cert, or the CA was regenerated),
+                // or when it is outside its validity window (the leaf lives 365 days, dev data
+                // directories longer).
+                if (hostnameConfigChanged(tlsDir, currentHostnames) || !isValidLocalLeaf(ca, certFile)) {
+                    generateServerCert(tlsDir, certFile, keyFile, ca);
                 } else {
-                    // Configuration unchanged - reuse existing certificate
-                    LOG.infov("TLS: reusing existing self-signed certificate: {0}", certFile);
+                    LOG.infov("TLS: reusing existing server certificate: {0}", certFile);
                 }
             } else {
-                // Certificate files don't exist - generate new certificate
-                generateSelfSignedCert(tlsDir, certFile, keyFile);
+                generateServerCert(tlsDir, certFile, keyFile, ca);
             }
 
             certPath = certFile.toAbsolutePath().toString();
@@ -114,8 +111,10 @@ public class TlsConfigSource implements ConfigSource {
                             + "Set FLOCI_TLS_CERT_PATH + FLOCI_TLS_KEY_PATH, or enable FLOCI_TLS_SELF_SIGNED.");
         }
 
-        properties.put("quarkus.http.ssl.certificate.files", certPath);
-        properties.put("quarkus.http.ssl.certificate.key-files", keyPath);
+        // The default entry of the Quarkus TLS registry. The HTTP server reads it when no
+        // quarkus.http.tls-configuration-name is set, and the registry can reload it at runtime.
+        properties.put("quarkus.tls.key-store.pem.0.cert", certPath);
+        properties.put("quarkus.tls.key-store.pem.0.key", keyPath);
         // When TLS is enabled, Quarkus HTTP and HTTPS run on internal ports.
         // A TlsProxyServer (NetServer) listens on the public Floci port (4566)
         // and does protocol detection to route HTTP and HTTPS to the correct backend.
@@ -169,31 +168,24 @@ public class TlsConfigSource implements ConfigSource {
         return defaultValue;
     }
 
-    private void generateSelfSignedCert(Path tlsDir, Path certFile, Path keyFile) {
+    private void generateServerCert(Path tlsDir, Path certFile, Path keyFile, FlociCertificateAuthority ca) {
         try {
             Files.createDirectories(tlsDir);
+            List<String> allSans = new ArrayList<>(DEFAULT_SAN_HOSTNAMES);
+            allSans.addAll(extractCustomHostnames());
 
-            // Extract custom hostnames and combine with defaults
-            List<String> customHostnames = extractCustomHostnames();
-            List<String> allSans = new ArrayList<>();
-            allSans.addAll(DEFAULT_SAN_HOSTNAMES);
-            allSans.addAll(customHostnames);
-
-            CertificateGenerator gen = new CertificateGenerator();
-            CertificateGenerator.GeneratedCertificate generated = gen.generateSelfSignedCertificate(
-                    "localhost",
-                    allSans,
-                    KeyAlgorithm.RSA_2048);
+            CertificateGenerator.GeneratedCertificate generated = ca.issueServerCertificate("localhost", allSans,
+                    KeyAlgorithm.RSA_2048, null);
 
             Files.writeString(certFile, generated.certificatePem());
             Files.writeString(keyFile, generated.privateKeyPem());
+            FlociCertificateAuthority.restrictToOwnerOnly(keyFile, "rw-------");
 
-            LOG.infov("TLS: generated self-signed certificate: {0}", certFile);
-
-            // Persist metadata for change detection on restart
+            LOG.infov("TLS: generated server certificate {0} issued by {1}", certFile,
+                    ca.certificate().getSubjectX500Principal().getName());
             persistMetadata(tlsDir, allSans);
         } catch (IOException e) {
-            throw new IllegalStateException("Failed to write self-signed TLS certificate", e);
+            throw new IllegalStateException("Failed to write TLS server certificate", e);
         }
     }
 
@@ -205,16 +197,21 @@ public class TlsConfigSource implements ConfigSource {
     }
 
     /**
-     * Returns {@code true} if the certificate at {@code certFile} is genuinely self-signed
-     * (issuer == subject) and therefore usable as a trust anchor. Legacy Floci certs carried a
-     * cosmetic Amazon issuer DN and return {@code false} here, triggering regeneration on upgrade.
+     * Returns {@code true} if the certificate at {@code certFile} was issued by the current local
+     * CA and is inside its validity window. A pre-CA self-signed leaf, a leaf from a regenerated
+     * CA, an expired leaf or an unreadable file all return {@code false} and are replaced.
      */
-    private boolean isSelfSigned(Path certFile) {
+    private boolean isValidLocalLeaf(FlociCertificateAuthority ca, Path certFile) {
         try {
             X509Certificate cert = new CertificateGenerator().parseCertificate(Files.readString(certFile));
-            return cert.getIssuerX500Principal().equals(cert.getSubjectX500Principal());
+            if (!ca.isIssuedByUs(cert)) {
+                LOG.infov("TLS: existing server certificate was not issued by the local CA; regenerating");
+                return false;
+            }
+            cert.checkValidity();
+            return true;
         } catch (Exception e) {
-            LOG.warnv("TLS: could not inspect existing certificate ({0}); regenerating", e.getMessage());
+            LOG.warnv("TLS: existing server certificate unusable ({0}); regenerating", e.getMessage());
             return false;
         }
     }
@@ -270,13 +267,13 @@ public class TlsConfigSource implements ConfigSource {
 
     /**
      * Persists certificate metadata to enable change detection on restart.
-     * Writes metadata to {tls-dir}/floci-selfsigned.metadata.json.
+     * Writes metadata to {tls-dir}/floci-server.metadata.json.
      * 
      * @param tlsDir The TLS directory where metadata should be written
      * @param hostnames List of hostnames included in the certificate SANs
      */
     private void persistMetadata(Path tlsDir, List<String> hostnames) {
-        Path metadataFile = tlsDir.resolve(SELF_SIGNED_METADATA_NAME);
+        Path metadataFile = tlsDir.resolve(SERVER_METADATA_NAME);
         try {
             String version = resolveFlociVersion();
             CertificateMetadata metadata = CertificateMetadata.create(hostnames, version);
@@ -313,7 +310,7 @@ public class TlsConfigSource implements ConfigSource {
      * @return true if configuration changed or metadata missing, false if same
      */
     private boolean hostnameConfigChanged(Path tlsDir, List<String> currentHostnames) {
-        Path metadataFile = tlsDir.resolve(SELF_SIGNED_METADATA_NAME);
+        Path metadataFile = tlsDir.resolve(SERVER_METADATA_NAME);
         
         // If metadata doesn't exist, trigger regeneration
         if (!Files.exists(metadataFile)) {

--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -178,8 +178,7 @@ public class TlsConfigSource implements ConfigSource {
                     KeyAlgorithm.RSA_2048, null);
 
             Files.writeString(certFile, generated.certificatePem());
-            Files.writeString(keyFile, generated.privateKeyPem());
-            FlociCertificateAuthority.restrictToOwnerOnly(keyFile, "rw-------");
+            FlociCertificateAuthority.writePrivateKey(keyFile, generated.privateKeyPem());
 
             LOG.infov("TLS: generated server certificate {0} issued by {1}", certFile,
                     ca.certificate().getSubjectX500Principal().getName());

--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -58,12 +58,17 @@ public class TlsConfigSource implements ConfigSource {
 
     private final Map<String, String> properties = new HashMap<>();
 
-    /** The directory the bootstrap used for CA and leaf, or null when it did not run the self-signed branch. */
+    /**
+     * The directory the most recent bootstrap used for CA and leaf, or null when that bootstrap did
+     * not run the self-signed branch (TLS off, or a user-provided certificate). Reset on every
+     * construction so a later boot in the same JVM never sees a stale value.
+     */
     static Path resolvedTlsDir() {
         return resolvedTlsDir;
     }
 
     public TlsConfigSource() {
+        resolvedTlsDir = null;
         String enabled = resolveProperty("floci.tls.enabled", "false");
         if (!"true".equalsIgnoreCase(enabled)) {
             LOG.debug("TLS disabled — TlsConfigSource inactive");

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.lifecycle;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.config.FlociCertificateAuthority;
 import io.github.hectorvent.floci.core.common.ServiceRegistry;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
@@ -15,8 +16,11 @@ import io.github.hectorvent.floci.core.common.Resettable;
 import jakarta.enterprise.inject.Instance;
 import jakarta.ws.rs.POST;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Path("{prefix:(_floci|_localstack)}")
 @Produces(MediaType.APPLICATION_JSON)
@@ -29,18 +33,21 @@ public class EmulatorInfoController {
     private final StorageFactory storageFactory;
     private final Instance<Resettable> resettables;
     private final FlociCertificateAuthority certificateAuthority;
+    private final EmulatorConfig config;
 
     @Inject
     public EmulatorInfoController(ServiceRegistry serviceRegistry,
                                   InitLifecycleState initLifecycleState,
                                   StorageFactory storageFactory,
                                   Instance<Resettable> resettables,
-                                  FlociCertificateAuthority certificateAuthority) {
+                                  FlociCertificateAuthority certificateAuthority,
+                                  EmulatorConfig config) {
         this.serviceRegistry = serviceRegistry;
         this.initLifecycleState = initLifecycleState;
         this.storageFactory = storageFactory;
         this.resettables = resettables;
         this.certificateAuthority = certificateAuthority;
+        this.config = config;
         this.version = resolveVersion();
     }
 
@@ -95,14 +102,29 @@ public class EmulatorInfoController {
     }
 
     /**
-     * The local root CA in PEM. Trust this once ({@code AWS_CA_BUNDLE}, {@code NODE_EXTRA_CA_CERTS},
-     * a keychain) and every certificate Floci issues validates.
+     * The trust anchor for Floci's HTTPS endpoint in PEM. With the default configuration that is
+     * the local root CA: trust it once ({@code AWS_CA_BUNDLE}, {@code NODE_EXTRA_CA_CERTS}, a
+     * keychain) and every certificate Floci issues validates. With a user-provided certificate
+     * ({@code floci.tls.cert-path}) it is that certificate file, the same file the Lambda launcher
+     * mounts into containers, so no local CA is created that could not validate the endpoint.
      */
     @GET
     @Path("/ca.pem")
     @Produces(MediaType.TEXT_PLAIN)
-    public String caPem() {
+    public String caPem() throws IOException {
+        Optional<String> userCertificate = userCertificatePath();
+        if (userCertificate.isPresent()) {
+            return Files.readString(java.nio.file.Path.of(userCertificate.get()));
+        }
         return certificateAuthority.caPem();
+    }
+
+    /** Set when TLS serves a user-provided certificate, the same condition {@code TlsConfigSource} applies. */
+    private Optional<String> userCertificatePath() {
+        if (!config.tls().enabled() || config.tls().keyPath().filter(p -> !p.isBlank()).isEmpty()) {
+            return Optional.empty();
+        }
+        return config.tls().certPath().filter(p -> !p.isBlank());
     }
 
     @POST

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
@@ -102,21 +102,25 @@ public class EmulatorInfoController {
     }
 
     /**
-     * The trust anchor for Floci's HTTPS endpoint in PEM. With the default configuration that is
-     * the local root CA: trust it once ({@code AWS_CA_BUNDLE}, {@code NODE_EXTRA_CA_CERTS}, a
-     * keychain) and every certificate Floci issues validates. With a user-provided certificate
-     * ({@code floci.tls.cert-path}) it is that certificate file, the same file the Lambda launcher
-     * mounts into containers, so no local CA is created that could not validate the endpoint.
+     * The PEM a client needs to trust Floci. With the default configuration that is the local root
+     * CA alone: it signs the HTTPS certificate and every certificate Floci issues. With a
+     * user-provided certificate ({@code floci.tls.cert-path}) the HTTPS endpoint is signed by that
+     * certificate's issuer instead, so the response is a bundle: the user certificate file first
+     * (the same file the Lambda launcher mounts into containers), then the local CA, which still
+     * signs what Floci itself issues. Trust the file once ({@code AWS_CA_BUNDLE},
+     * {@code NODE_EXTRA_CA_CERTS}, a keychain) and both validate.
      */
     @GET
     @Path("/ca.pem")
     @Produces(MediaType.TEXT_PLAIN)
     public String caPem() throws IOException {
+        String localCa = certificateAuthority.caPem();
         Optional<String> userCertificate = userCertificatePath();
-        if (userCertificate.isPresent()) {
-            return Files.readString(java.nio.file.Path.of(userCertificate.get()));
+        if (userCertificate.isEmpty()) {
+            return localCa;
         }
-        return certificateAuthority.caPem();
+        String userPem = Files.readString(java.nio.file.Path.of(userCertificate.get()));
+        return userPem.endsWith("\n") ? userPem + localCa : userPem + "\n" + localCa;
     }
 
     /** Set when TLS serves a user-provided certificate, the same condition {@code TlsConfigSource} applies. */

--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.lifecycle;
 
+import io.github.hectorvent.floci.config.FlociCertificateAuthority;
 import io.github.hectorvent.floci.core.common.ServiceRegistry;
 import io.github.hectorvent.floci.lifecycle.inithook.InitializationHook;
 import jakarta.inject.Inject;
@@ -27,16 +28,19 @@ public class EmulatorInfoController {
 
     private final StorageFactory storageFactory;
     private final Instance<Resettable> resettables;
+    private final FlociCertificateAuthority certificateAuthority;
 
     @Inject
     public EmulatorInfoController(ServiceRegistry serviceRegistry,
                                   InitLifecycleState initLifecycleState,
                                   StorageFactory storageFactory,
-                                  Instance<Resettable> resettables) {
+                                  Instance<Resettable> resettables,
+                                  FlociCertificateAuthority certificateAuthority) {
         this.serviceRegistry = serviceRegistry;
         this.initLifecycleState = initLifecycleState;
         this.storageFactory = storageFactory;
         this.resettables = resettables;
+        this.certificateAuthority = certificateAuthority;
         this.version = resolveVersion();
     }
 
@@ -88,6 +92,17 @@ public class EmulatorInfoController {
     @Path("/config")
     public Response config() {
         return Response.ok(Map.of()).build();
+    }
+
+    /**
+     * The local root CA in PEM. Trust this once ({@code AWS_CA_BUNDLE}, {@code NODE_EXTRA_CA_CERTS},
+     * a keychain) and every certificate Floci issues validates.
+     */
+    @GET
+    @Path("/ca.pem")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String caPem() {
+        return certificateAuthority.caPem();
     }
 
     @POST

--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
@@ -373,11 +373,11 @@ public class AcmService implements ResourceProvider {
         cert.setIssuedAt(now);
         cert.setNotBefore(x509Cert.getNotBefore().toInstant());
         cert.setNotAfter(x509Cert.getNotAfter().toInstant());
-        cert.setSerial(x509Cert.getSerialNumber().toString());
+        cert.setSerial(CertificateGenerator.colonHex(x509Cert.getSerialNumber()));
         cert.setSubject(x509Cert.getSubjectX500Principal().getName());
         cert.setIssuer(x509Cert.getIssuerX500Principal().getName());
         cert.setKeyAlgorithm(keyAlg);
-        cert.setSignatureAlgorithm(x509Cert.getSigAlgName());
+        cert.setSignatureAlgorithm(x509Cert.getSigAlgName().toUpperCase(Locale.ROOT));
         cert.setCertificateBody(certificatePem);
         cert.setPrivateKey(privateKeyPem);
         cert.setCertificateChain(chainPem);

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -35,12 +35,14 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Security;
+import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.security.spec.ECGenParameterSpec;
 import java.time.Instant;
@@ -149,22 +151,43 @@ public class CertificateGenerator {
     /**
      * A leaf signed by {@code issuer}. {@code subjectKeyPair} may be {@code null} to mint a new
      * one; pass the previous pair to reissue with an updated SAN list and an unchanged public key.
+     * The result is checked before it is returned: the leaf must verify against the issuer's
+     * certificate, and a supplied key pair must be a pair, so a caller can never get back a
+     * certificate its own issuer rejects or a private key that does not fit it.
      */
     public GeneratedCertificate generateIssuedCertificate(String domainName, List<String> sans,
                                                           KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
                                                           Issuer issuer, LeafUsage usage) {
         try {
+            if (subjectKeyPair != null && !isPair(subjectKeyPair.getPrivate(), subjectKeyPair.getPublic())) {
+                throw new IllegalArgumentException("supplied private key does not match its public key");
+            }
             KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
             X500Name subject = new X500Name("CN=" + domainName);
             X500Name issuerDn = X500Name.getInstance(issuer.certificate().getSubjectX500Principal().getEncoded());
             X509Certificate cert = signCertificate(subject, keyPair.getPublic(), issuerDn, issuer.key(),
                     withDomainFirst(domainName, sans), false, usage, 365);
+            cert.verify(issuer.certificate().getPublicKey());
             return toGenerated(cert, keyPair.getPrivate(), subject.toString(),
                     issuer.certificate().getSubjectX500Principal().getName());
         } catch (Exception e) {
             LOG.error("Failed to generate issued certificate", e);
             throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
         }
+    }
+
+    /** True when {@code privateKey} signs what {@code publicKey} verifies. */
+    public static boolean isPair(PrivateKey privateKey, PublicKey publicKey) throws Exception {
+        String algorithm = "EC".equals(privateKey.getAlgorithm()) ? "SHA256withECDSA" : "SHA256withRSA";
+        byte[] probe = "floci".getBytes(StandardCharsets.US_ASCII);
+        Signature signer = Signature.getInstance(algorithm);
+        signer.initSign(privateKey);
+        signer.update(probe);
+        byte[] signature = signer.sign();
+        Signature verifier = Signature.getInstance(algorithm);
+        verifier.initVerify(publicKey);
+        verifier.update(probe);
+        return verifier.verify(signature);
     }
 
     private GeneratedCertificate buildCertificate(String domainName, List<String> sans, KeyAlgorithm keyAlgorithm,

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -13,6 +13,9 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.ECNamedCurveTable;
+import org.bouncycastle.asn1.x9.X962Parameters;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
@@ -161,12 +164,11 @@ public class CertificateGenerator {
                                                           KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
                                                           Issuer issuer, LeafUsage usage) {
         try {
+            if (subjectKeyPair != null && !isOfAlgorithm(subjectKeyPair.getPublic(), keyAlgorithm)) {
+                throw new IllegalArgumentException("supplied key pair is not the requested " + keyAlgorithm);
+            }
             if (subjectKeyPair != null && !isPair(subjectKeyPair.getPrivate(), subjectKeyPair.getPublic())) {
                 throw new IllegalArgumentException("supplied private key does not match its public key");
-            }
-            if (subjectKeyPair != null && detectKeyAlgorithm(subjectKeyPair.getPublic()) != keyAlgorithm) {
-                throw new IllegalArgumentException("supplied key pair is " + detectKeyAlgorithm(subjectKeyPair.getPublic())
-                        + ", not the requested " + keyAlgorithm);
             }
             KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
             X500Name subject = new X500Name("CN=" + domainName);
@@ -180,6 +182,24 @@ public class CertificateGenerator {
             LOG.error("Failed to generate issued certificate", e);
             throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * True when {@code key} is exactly what {@code keyAlgorithm} names: the RSA size, or for EC the
+     * named curve read from the key's encoding, so a curve that only shares a field size
+     * (secp256k1 for {@code EC_prime256v1}) does not pass.
+     */
+    boolean isOfAlgorithm(PublicKey key, KeyAlgorithm keyAlgorithm) {
+        if ("EC".equals(keyAlgorithm.getAlgorithm())) {
+            if (!"EC".equals(key.getAlgorithm())) {
+                return false;
+            }
+            X962Parameters parameters = X962Parameters.getInstance(
+                    SubjectPublicKeyInfo.getInstance(key.getEncoded()).getAlgorithm().getParameters());
+            return parameters.isNamedCurve()
+                    && ECNamedCurveTable.getOID(keyAlgorithm.getCurveName()).equals(parameters.getParameters());
+        }
+        return "RSA".equals(key.getAlgorithm()) && detectKeyAlgorithm(key) == keyAlgorithm;
     }
 
     /** True when {@code privateKey} signs what {@code publicKey} verifies. */

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -7,9 +7,11 @@ import org.bouncycastle.asn1.pkcs.EncryptedPrivateKeyInfo;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
@@ -45,7 +47,9 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
@@ -76,6 +80,16 @@ public class CertificateGenerator {
         String issuer,
         String signatureAlgorithm
     ) {}
+
+    /**
+     * What an issued leaf is for. Decides the Extended Key Usage. A CA passes {@code null}.
+     * {@code SERVER} carries both serverAuth and clientAuth, as ACM-issued certificates do (and as
+     * {@code DescribeCertificate} already advertises); {@code CLIENT} is clientAuth only.
+     */
+    public enum LeafUsage { SERVER, CLIENT }
+
+    /** A signer: the issuer's certificate (for its DN) and its private key. */
+    public record Issuer(X509Certificate certificate, PrivateKey key) {}
 
     /**
      * Generates a certificate for local emulation that mimics an ACM-issued certificate:
@@ -115,86 +129,143 @@ public class CertificateGenerator {
         return buildCertificate(domainName, sans, keyAlgorithm, "CN=" + domainName, true, keyPair);
     }
 
+    /**
+     * A root CA: self-signed, {@code cA=true}, {@code keyCertSign}, ten years. RSA 2048 because
+     * every client in the emulator's reach accepts it and it keeps key generation under a second.
+     */
+    public GeneratedCertificate generateCaCertificate(String commonName) {
+        try {
+            KeyPair keyPair = generateKeyPair(KeyAlgorithm.RSA_2048);
+            X500Name dn = new X500Name("CN=" + commonName);
+            X509Certificate cert = signCertificate(dn, keyPair.getPublic(), dn, keyPair.getPrivate(),
+                    List.of(), true, null, 3650);
+            return toGenerated(cert, keyPair.getPrivate(), dn.toString(), dn.toString());
+        } catch (Exception e) {
+            LOG.error("Failed to generate CA certificate", e);
+            throw new CertificateGenerationException("CA generation failed: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * A leaf signed by {@code issuer}. {@code subjectKeyPair} may be {@code null} to mint a new
+     * one; pass the previous pair to reissue with an updated SAN list and an unchanged public key.
+     */
+    public GeneratedCertificate generateIssuedCertificate(String domainName, List<String> sans,
+                                                          KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
+                                                          Issuer issuer, LeafUsage usage) {
+        try {
+            KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
+            X500Name subject = new X500Name("CN=" + domainName);
+            X500Name issuerDn = X500Name.getInstance(issuer.certificate().getSubjectX500Principal().getEncoded());
+            X509Certificate cert = signCertificate(subject, keyPair.getPublic(), issuerDn, issuer.key(),
+                    withDomainFirst(domainName, sans), false, usage, 365);
+            return toGenerated(cert, keyPair.getPrivate(), subject.toString(),
+                    issuer.certificate().getSubjectX500Principal().getName());
+        } catch (Exception e) {
+            LOG.error("Failed to generate issued certificate", e);
+            throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
+        }
+    }
+
     private GeneratedCertificate buildCertificate(String domainName, List<String> sans, KeyAlgorithm keyAlgorithm,
                                                   String issuerDn, boolean asCa, KeyPair suppliedKeyPair) {
         try {
             KeyPair keyPair = suppliedKeyPair != null ? suppliedKeyPair : generateKeyPair(keyAlgorithm);
-
-            Instant now = Instant.now();
-            Instant notBefore = now;
-            Instant notAfter = now.plus(365, ChronoUnit.DAYS);
-
-            BigInteger serial = new BigInteger(128, SECURE_RANDOM);
             String subjectDn = "CN=" + domainName;
-
-            X500Name issuer = new X500Name(issuerDn);
-            X500Name subject = new X500Name(subjectDn);
-
-            String signatureAlgorithm = keyAlgorithm.getAlgorithm().equals("EC")
-                ? "SHA512withECDSA"
-                : "SHA512WithRSA";
-
-            X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
-                issuer,
-                serial,
-                Date.from(notBefore),
-                Date.from(notAfter),
-                subject,
-                keyPair.getPublic()
-            );
-
-            // Add Subject Alternative Names
-            List<GeneralName> sanList = new ArrayList<>();
-            sanList.add(toGeneralName(domainName));
-            if (sans != null) {
-                for (String san : sans) {
-                    if (!san.equals(domainName)) {
-                        sanList.add(toGeneralName(san));
-                    }
-                }
-            }
-            GeneralNames generalNames = new GeneralNames(sanList.toArray(new GeneralName[0]));
-            certBuilder.addExtension(Extension.subjectAlternativeName, false, generalNames);
-
-            // Add Key Usage — a trust-anchor self-signed cert also needs keyCertSign so it can
-            // act as its own issuer; an ACM-style leaf only needs digitalSignature/keyEncipherment.
-            int keyUsageBits = KeyUsage.digitalSignature | KeyUsage.keyEncipherment;
-            if (asCa) {
-                keyUsageBits |= KeyUsage.keyCertSign;
-            }
-            certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsageBits));
-
-            // Add Basic Constraints — a trust anchor must be a CA so clients accept it as one.
-            certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(asCa));
-
-            // Signed with the subject's own private key. For generateCertificate() the issuer DN is
-            // a cosmetic Amazon DN (mimicking ACM); for generateSelfSignedCertificate() issuer ==
-            // subject, so the cert is a valid self-signed trust anchor.
-            ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm)
-                .build(keyPair.getPrivate());
-
-            X509CertificateHolder certHolder = certBuilder.build(signer);
-            X509Certificate cert = new JcaX509CertificateConverter()
-                .getCertificate(certHolder);
-
-            String certPem = toPem(cert);
-            String keyPem = toPem(keyPair.getPrivate());
-
-            return new GeneratedCertificate(
-                certPem,
-                keyPem,
-                serial.toString(),
-                notBefore,
-                notAfter,
-                subjectDn,
-                issuerDn,
-                signatureAlgorithm
-            );
-
+            // Signed with the subject's own key, as before: generateCertificate keeps its cosmetic
+            // Amazon issuer DN, generateSelfSignedCertificate keeps issuer == subject.
+            X509Certificate cert = signCertificate(new X500Name(subjectDn), keyPair.getPublic(),
+                    new X500Name(issuerDn), keyPair.getPrivate(), withDomainFirst(domainName, sans), asCa, null, 365);
+            return toGenerated(cert, keyPair.getPrivate(), subjectDn, issuerDn);
         } catch (Exception e) {
             LOG.error("Failed to generate certificate", e);
             throw new CertificateGenerationException("Certificate generation failed: " + e.getMessage(), e);
         }
+    }
+
+    /**
+     * The one place a certificate is signed. Everything else in this class, and
+     * {@code CloudHsmV2Service}, goes through here.
+     *
+     * @param sans  DNS names or IP addresses, written once each in order; empty for a CA
+     * @param asCa  sets {@code BasicConstraints(cA)}, {@code keyCertSign} and {@code cRLSign}
+     * @param usage EKU for a leaf, {@code null} for a CA or a leaf without one
+     */
+    public X509Certificate signCertificate(X500Name subject, PublicKey subjectKey, X500Name issuerDn,
+                                           PrivateKey issuerKey, List<String> sans, boolean asCa,
+                                           LeafUsage usage, int validityDays) throws Exception {
+        Instant now = Instant.now();
+        BigInteger serial = new BigInteger(128, SECURE_RANDOM);
+        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuerDn, serial, Date.from(now), Date.from(now.plus(validityDays, ChronoUnit.DAYS)),
+                subject, subjectKey);
+
+        if (sans != null && !sans.isEmpty()) {
+            List<GeneralName> sanList = new ArrayList<>();
+            for (String san : new LinkedHashSet<>(sans)) {
+                sanList.add(toGeneralName(san));
+            }
+            certBuilder.addExtension(Extension.subjectAlternativeName, false,
+                    new GeneralNames(sanList.toArray(new GeneralName[0])));
+        }
+
+        // keyEncipherment is an RSA key-transport bit; EC keys sign (and agree), they never encipher.
+        int keyUsageBits = KeyUsage.digitalSignature;
+        if ("RSA".equals(subjectKey.getAlgorithm())) {
+            keyUsageBits |= KeyUsage.keyEncipherment;
+        }
+        if (asCa) {
+            keyUsageBits |= KeyUsage.keyCertSign | KeyUsage.cRLSign;
+        }
+        certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(keyUsageBits));
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(asCa));
+        if (usage == LeafUsage.SERVER) {
+            certBuilder.addExtension(Extension.extendedKeyUsage, false, new ExtendedKeyUsage(
+                    new KeyPurposeId[] {KeyPurposeId.id_kp_serverAuth, KeyPurposeId.id_kp_clientAuth}));
+        } else if (usage == LeafUsage.CLIENT) {
+            certBuilder.addExtension(Extension.extendedKeyUsage, false,
+                    new ExtendedKeyUsage(KeyPurposeId.id_kp_clientAuth));
+        }
+
+        String signatureAlgorithm = "EC".equals(issuerKey.getAlgorithm()) ? "SHA512withECDSA" : "SHA512WithRSA";
+        ContentSigner signer = new JcaContentSignerBuilder(signatureAlgorithm).build(issuerKey);
+        X509CertificateHolder holder = certBuilder.build(signer);
+        return new JcaX509CertificateConverter().getCertificate(holder);
+    }
+
+    private static List<String> withDomainFirst(String domainName, List<String> sans) {
+        List<String> allSans = new ArrayList<>();
+        allSans.add(domainName);
+        if (sans != null) {
+            allSans.addAll(sans);
+        }
+        return allSans;
+    }
+
+    /**
+     * Metadata comes from the certificate, not from the arguments: the signature algorithm is the
+     * issuer's (an RSA CA signing an EC leaf yields SHA512WITHRSA, spelled in upper case as ACM
+     * does), and ACM shows the serial as colon-separated hex ({@code 07:71:71:f4:...}).
+     */
+    private GeneratedCertificate toGenerated(X509Certificate cert, PrivateKey key, String subjectDn,
+                                             String issuerDn) throws Exception {
+        return new GeneratedCertificate(
+                toPem(cert),
+                toPem(key),
+                colonHex(cert.getSerialNumber()),
+                cert.getNotBefore().toInstant(),
+                cert.getNotAfter().toInstant(),
+                subjectDn,
+                issuerDn,
+                cert.getSigAlgName().toUpperCase(Locale.ROOT));
+    }
+
+    static String colonHex(BigInteger serial) {
+        String hex = serial.toString(16);
+        if (hex.length() % 2 == 1) {
+            hex = "0" + hex;
+        }
+        return String.join(":", hex.split("(?<=\\G..)"));
     }
 
     private KeyPair generateKeyPair(KeyAlgorithm keyAlgorithm) throws Exception {
@@ -244,7 +315,7 @@ public class CertificateGenerator {
         return IP_ADDRESS_PATTERN.matcher(value).matches();
     }
 
-    private String toPem(Object obj) throws Exception {
+    public String toPem(Object obj) throws Exception {
         StringWriter sw = new StringWriter();
         try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
             pemWriter.writeObject(obj);

--- a/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/CertificateGenerator.java
@@ -150,10 +150,12 @@ public class CertificateGenerator {
 
     /**
      * A leaf signed by {@code issuer}. {@code subjectKeyPair} may be {@code null} to mint a new
-     * one; pass the previous pair to reissue with an updated SAN list and an unchanged public key.
-     * The result is checked before it is returned: the leaf must verify against the issuer's
-     * certificate, and a supplied key pair must be a pair, so a caller can never get back a
-     * certificate its own issuer rejects or a private key that does not fit it.
+     * one of {@code keyAlgorithm}; pass the previous pair to reissue with an updated SAN list and
+     * an unchanged public key, in which case it must be of {@code keyAlgorithm}. The result is
+     * checked before it is returned: the leaf must verify against the issuer's certificate, and a
+     * supplied key pair must be a pair of the requested algorithm, so a caller can never get back
+     * a certificate its own issuer rejects, a private key that does not fit it, or a key type it
+     * did not ask for.
      */
     public GeneratedCertificate generateIssuedCertificate(String domainName, List<String> sans,
                                                           KeyAlgorithm keyAlgorithm, KeyPair subjectKeyPair,
@@ -161,6 +163,10 @@ public class CertificateGenerator {
         try {
             if (subjectKeyPair != null && !isPair(subjectKeyPair.getPrivate(), subjectKeyPair.getPublic())) {
                 throw new IllegalArgumentException("supplied private key does not match its public key");
+            }
+            if (subjectKeyPair != null && detectKeyAlgorithm(subjectKeyPair.getPublic()) != keyAlgorithm) {
+                throw new IllegalArgumentException("supplied key pair is " + detectKeyAlgorithm(subjectKeyPair.getPublic())
+                        + ", not the requested " + keyAlgorithm);
             }
             KeyPair keyPair = subjectKeyPair != null ? subjectKeyPair : generateKeyPair(keyAlgorithm);
             X500Name subject = new X500Name("CN=" + domainName);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudhsmv2/CloudHsmV2Service.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.acm.CertificateGenerator;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.Certificates;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.Cluster;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.ClusterState;
@@ -11,9 +12,7 @@ import io.github.hectorvent.floci.services.cloudhsmv2.model.Hsm;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
@@ -27,15 +26,11 @@ import org.jboss.logging.Logger;
 
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.math.BigInteger;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.Backup;
 import io.github.hectorvent.floci.services.cloudhsmv2.model.BackupRetentionPolicy;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.time.temporal.ChronoUnit;
 import java.util.stream.Collectors;
 import java.time.Instant;
@@ -64,20 +59,24 @@ public class CloudHsmV2Service {
     private final StorageBackend<String, Cluster> clusters;
     private final StorageBackend<String, Backup> backups;
     private final Ec2Service ec2Service;
+    private final CertificateGenerator certificateGenerator;
 
     @Inject
-    public CloudHsmV2Service(StorageFactory storageFactory, Ec2Service ec2Service) {
-        this.clusters = storageFactory.create("cloudhsmv2", "cloudhsmv2-clusters.json",
-                new TypeReference<Map<String, Cluster>>() {});
-        this.backups = storageFactory.create("cloudhsmv2", "cloudhsmv2-backups.json",
-                new TypeReference<Map<String, Backup>>() {});
-        this.ec2Service = ec2Service;
+    public CloudHsmV2Service(StorageFactory storageFactory, Ec2Service ec2Service,
+                             CertificateGenerator certificateGenerator) {
+        this(storageFactory.create("cloudhsmv2", "cloudhsmv2-clusters.json",
+                        new TypeReference<Map<String, Cluster>>() {}),
+                storageFactory.create("cloudhsmv2", "cloudhsmv2-backups.json",
+                        new TypeReference<Map<String, Backup>>() {}),
+                ec2Service, certificateGenerator);
     }
 
-    CloudHsmV2Service(StorageBackend<String, Cluster> clusters, StorageBackend<String, Backup> backups, Ec2Service ec2Service) {
+    CloudHsmV2Service(StorageBackend<String, Cluster> clusters, StorageBackend<String, Backup> backups,
+                      Ec2Service ec2Service, CertificateGenerator certificateGenerator) {
         this.clusters = clusters;
         this.backups = backups;
         this.ec2Service = ec2Service;
+        this.certificateGenerator = certificateGenerator;
     }
 
     // ──────────────────────────── CreateCluster ────────────────────────────
@@ -173,15 +172,18 @@ public class CloudHsmV2Service {
         try {
             KeyPair mfrKeyPair = generateKeyPair();
             X500Name mfrName = new X500Name("CN=HSM Manufacturer CA,O=AWS,C=US");
-            certs.setManufacturerHardwareCertificate(generateCert(mfrName, mfrName, mfrKeyPair.getPublic(), mfrKeyPair.getPrivate()));
+            certs.setManufacturerHardwareCertificate(certificateGenerator.toPem(certificateGenerator.signCertificate(
+                    mfrName, mfrKeyPair.getPublic(), mfrName, mfrKeyPair.getPrivate(), List.of(), true, null, 365)));
 
             KeyPair awsKeyPair = generateKeyPair();
             X500Name awsName = new X500Name("CN=AWS CloudHSM Hardware CA,O=AWS,C=US");
-            certs.setAwsHardwareCertificate(generateCert(awsName, mfrName, awsKeyPair.getPublic(), mfrKeyPair.getPrivate()));
+            certs.setAwsHardwareCertificate(certificateGenerator.toPem(certificateGenerator.signCertificate(
+                    awsName, awsKeyPair.getPublic(), mfrName, mfrKeyPair.getPrivate(), List.of(), true, null, 365)));
 
             KeyPair hsmKeyPair = generateKeyPair();
             X500Name hsmName = new X500Name("CN=HSM Instance " + clusterId + ",O=AWS,C=US");
-            certs.setHsmCertificate(generateCert(hsmName, awsName, hsmKeyPair.getPublic(), awsKeyPair.getPrivate()));
+            certs.setHsmCertificate(certificateGenerator.toPem(certificateGenerator.signCertificate(
+                    hsmName, hsmKeyPair.getPublic(), awsName, awsKeyPair.getPrivate(), List.of(), false, null, 365)));
         } catch (Exception e) {
             LOG.warnv("Failed to generate emulated hardware certs: {0}", e.getMessage());
         }
@@ -532,25 +534,6 @@ public class CloudHsmV2Service {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
         keyGen.initialize(2048, SECURE_RANDOM);
         return keyGen.generateKeyPair();
-    }
-
-    private String generateCert(X500Name subject, X500Name issuer, PublicKey pubKey, PrivateKey signerKey) throws Exception {
-        BigInteger serial = new BigInteger(128, SECURE_RANDOM);
-        Instant now = Instant.now();
-        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
-                issuer, serial, Date.from(now), Date.from(now.plusSeconds(365L * 24 * 3600)), subject, pubKey);
-
-        ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
-                .build(signerKey);
-        X509CertificateHolder holder = certBuilder.build(signer);
-        X509Certificate cert = new JcaX509CertificateConverter()
-                .getCertificate(holder);
-
-        StringWriter sw = new StringWriter();
-        try (JcaPEMWriter pemWriter = new JcaPEMWriter(sw)) {
-            pemWriter.writeObject(cert);
-        }
-        return sw.toString();
     }
 
     private void validatePemCertificate(String pem, String fieldName) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -1405,7 +1405,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
 
     /**
      * Returns {@code true} only if {@code certPath} holds a genuinely self-signed CA certificate
-     * (issuer == subject and BasicConstraints {@code CA:true}) — the form usable as a trust anchor.
+     * (issuer == subject and BasicConstraints {@code CA:true}): the form usable as a trust anchor.
      * A leaf/server certificate, or one that cannot be read/parsed as X.509, returns {@code false}.
      */
     static boolean isSelfSignedCaCertificate(Path certPath) {
@@ -1429,7 +1429,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
      *   <li>{@code NODE_EXTRA_CA_CERTS} appends Floci's cert to Node's built-in CAs, so public TLS
      *       from the Lambda still works; and</li>
      *   <li>{@code AWS_CA_BUNDLE} is scoped to AWS SDK/CLI traffic, which Floci redirects to its own
-     *       endpoint via {@code AWS_ENDPOINT_URL} — so pointing it at Floci's cert only affects
+     *       endpoint via {@code AWS_ENDPOINT_URL}, so pointing it at Floci's cert only affects
      *       calls that already target Floci.</li>
      * </ul>
      * {@code SSL_CERT_FILE} and {@code REQUESTS_CA_BUNDLE} are deliberately <em>not</em> set: each

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncher.java
@@ -99,15 +99,15 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
 
     /**
      * In-container location of Floci's CA certificate, injected when TLS is enabled so the
-     * container trusts Floci's self-signed HTTPS endpoint. {@code /etc} exists in every Lambda
+     * container trusts Floci's HTTPS endpoint through the local CA. {@code /etc} exists in every Lambda
      * base image, so no directory needs to be created.
      */
     private static final String FLOCI_CA_DIR = "/etc";
     private static final String FLOCI_CA_FILE_NAME = "floci-ca.crt";
     /** Shared with the kubernetes executor, which mounts the CA ConfigMap at the same path. */
     public static final String FLOCI_CA_CONTAINER_PATH = FLOCI_CA_DIR + "/" + FLOCI_CA_FILE_NAME;
-    /** Self-signed cert filename produced by {@code TlsConfigSource} under {persistent-path}/tls/. */
-    private static final String SELF_SIGNED_CERT_NAME = "floci-selfsigned.crt";
+    /** Root CA produced by {@code FlociCertificateAuthority} under {persistent-path}/tls/. */
+    private static final String LOCAL_CA_CERT_NAME = io.github.hectorvent.floci.config.FlociCertificateAuthority.CA_CERT_NAME;
 
     private static final DateTimeFormatter LOG_STREAM_DATE_FMT = DateTimeFormatter.ofPattern("yyyy/MM/dd");
 
@@ -228,7 +228,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         String lambdaRegion = extractRegionFromArn(fn.getFunctionArn(), config.defaultRegion());
         String lambdaAccountId = AwsArnUtils.accountOrDefault(fn.getFunctionArn(), config.defaultAccountId());
 
-        // When TLS is on, the container must trust Floci's self-signed cert so HTTPS callbacks
+        // When TLS is on, the container must trust Floci's local CA so HTTPS callbacks
         // to Floci succeed (e.g. a CDK custom resource's cfn-response, which hardcodes https://).
         // Short-circuit when TLS is off so cert-path/storage config isn't read needlessly.
         Optional<Path> flociCaCert = config.tls().enabled()
@@ -1372,11 +1372,11 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
     /**
      * Resolves the host path of Floci's CA certificate to inject into Lambda containers, or
      * empty when TLS is disabled or no readable certificate exists. Mirrors {@code TlsConfigSource}:
-     * a user-provided {@code floci.tls.cert-path} wins; otherwise the self-signed cert under
+     * a user-provided {@code floci.tls.cert-path} wins; otherwise Floci's local root CA under
      * {@code {persistent-path}/tls/}.
      *
      * <p>The resolved certificate is injected into containers as a <em>trust anchor</em> (CA), so it
-     * should be a self-signed CA certificate. The auto-generated Floci cert is one; a user-supplied
+     * should be a self-signed CA certificate. Floci's local CA is one; a user-supplied
      * {@code floci.tls.cert-path} that points at a leaf/server certificate is accepted but only pins
      * that exact certificate (it cannot validate a chain it signs), so a warning is logged.
      */
@@ -1388,7 +1388,7 @@ public class ContainerLauncher implements LambdaRuntimeLauncher {
         Optional<String> trimmedUserPath = userCertPath.filter(s -> !s.isBlank());
         Path certPath = trimmedUserPath
                 .map(Path::of)
-                .orElseGet(() -> Path.of(persistentPath, "tls", SELF_SIGNED_CERT_NAME));
+                .orElseGet(() -> Path.of(persistentPath, "tls", LOCAL_CA_CERT_NAME));
         if (!Files.isReadable(certPath)) {
             LOG.warnv("TLS enabled but Floci CA certificate not readable at {0}; "
                     + "Lambda containers will not trust Floci HTTPS callbacks", certPath);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -216,7 +216,7 @@ floci:
     enabled: false                     # FLOCI_TLS_ENABLED (default: false)
     # cert-path: ""                    # FLOCI_TLS_CERT_PATH (PEM certificate file)
     # key-path: ""                     # FLOCI_TLS_KEY_PATH (PEM private key file)
-    self-signed: true                  # FLOCI_TLS_SELF_SIGNED — auto-generate a self-signed cert if no cert-path provided
+    self-signed: true                  # FLOCI_TLS_SELF_SIGNED: auto-generate a server cert signed by Floci's local CA if no cert-path provided
     aws-https-port: 443                # FLOCI_TLS_AWS_HTTPS_PORT — also bind 443 so CDK cfn-response/AWS-on-443 callbacks reach Floci (0 disables)
 
   protocols:

--- a/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityProducerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityProducerTest.java
@@ -1,0 +1,59 @@
+package io.github.hectorvent.floci.config;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The producer must hand beans the directory the config bootstrap used, and only fall back to the
+ * configured persistent path when the bootstrap laid nothing down.
+ */
+class FlociCertificateAuthorityProducerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @AfterEach
+    void clearBootstrap() {
+        System.clearProperty("floci.tls.enabled");
+        System.clearProperty("floci.tls.self-signed");
+        System.clearProperty("floci.storage.persistent-path");
+        new TlsConfigSource();
+    }
+
+    private static EmulatorConfig configWithPersistentPath(String path) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.StorageConfig storage = mock(EmulatorConfig.StorageConfig.class);
+        when(config.storage()).thenReturn(storage);
+        when(storage.persistentPath()).thenReturn(path);
+        return config;
+    }
+
+    @Test
+    void usesTheBootstrapDirectoryWhenTheBootstrapIssuedTheLeaf() {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+        new TlsConfigSource();
+
+        Path dir = FlociCertificateAuthorityProducer.tlsDir(configWithPersistentPath("/elsewhere/from/yaml"));
+
+        assertEquals(tempDir.resolve("tls"), dir, "one directory for the served leaf and ca.pem, or two CAs would exist");
+    }
+
+    @Test
+    void fallsBackToTheConfiguredPathWhenTlsIsOff() {
+        System.setProperty("floci.tls.enabled", "false");
+        new TlsConfigSource();
+
+        Path dir = FlociCertificateAuthorityProducer.tlsDir(configWithPersistentPath(tempDir.toString()));
+
+        assertEquals(tempDir.resolve("tls"), dir);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityTest.java
@@ -93,6 +93,34 @@ class FlociCertificateAuthorityTest {
     }
 
     @Test
+    void expiredCaIsRegenerated() throws Exception {
+        CertificateGenerator gen = new CertificateGenerator();
+        java.security.KeyPair keyPair = java.security.KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        var dn = new org.bouncycastle.asn1.x500.X500Name("CN=" + FlociCertificateAuthority.COMMON_NAME);
+        X509Certificate expired = gen.signCertificate(dn, keyPair.getPublic(), dn, keyPair.getPrivate(), List.of(),
+                true, null, -1);
+        Files.writeString(tempDir.resolve("floci-root-ca.crt"), gen.toPem(expired));
+        Files.writeString(tempDir.resolve("floci-root-ca.key"), gen.toPem(keyPair.getPrivate()));
+
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertNotEquals(expired, ca.certificate(), "an expired trust anchor is useless and must be replaced");
+        ca.certificate().checkValidity();
+    }
+
+    @Test
+    void missingKeyFileRegeneratesThePair() throws Exception {
+        FlociCertificateAuthority first = FlociCertificateAuthority.loadOrCreate(tempDir);
+        Files.delete(tempDir.resolve("floci-root-ca.key"));
+
+        FlociCertificateAuthority second = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertNotEquals(first.certificate(), second.certificate(), "a certificate without its key cannot sign");
+        assertTrue(Files.exists(tempDir.resolve("floci-root-ca.key")));
+        assertEquals(second.caPem(), Files.readString(tempDir.resolve("floci-root-ca.crt")));
+    }
+
+    @Test
     void aLeafInPlaceOfTheCaIsRegenerated() throws Exception {
         var leaf = new CertificateGenerator().generateCertificate("localhost", List.of(), KeyAlgorithm.RSA_2048);
         Files.writeString(tempDir.resolve("floci-root-ca.crt"), leaf.certificatePem());

--- a/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityTest.java
@@ -36,6 +36,8 @@ class FlociCertificateAuthorityTest {
         assertEquals("CN=Floci Local CA", ca.certificate().getSubjectX500Principal().getName());
         assertTrue(ca.caPem().startsWith("-----BEGIN CERTIFICATE-----"));
         assertEquals(Files.readString(tempDir.resolve("floci-root-ca.crt")), ca.caPem(), "caPem is the file's bytes");
+        assertTrue(ca.fingerprint().matches("([0-9A-F]{2}:){31}[0-9A-F]{2}"), ca.fingerprint());
+        assertEquals(ca.fingerprint(), FlociCertificateAuthority.loadOrCreate(tempDir).fingerprint());
 
         Set<PosixFilePermission> keyPerms = Files.getPosixFilePermissions(tempDir.resolve("floci-root-ca.key"));
         assertEquals(PosixFilePermissions.fromString("rw-------"), keyPerms);

--- a/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/FlociCertificateAuthorityTest.java
@@ -1,0 +1,159 @@
+package io.github.hectorvent.floci.config;
+
+import io.github.hectorvent.floci.services.acm.CertificateGenerator;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FlociCertificateAuthorityTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void createsCaFilesWithOwnerOnlyKey() throws Exception {
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertTrue(Files.exists(tempDir.resolve("floci-root-ca.crt")));
+        assertTrue(Files.exists(tempDir.resolve("floci-root-ca.key")));
+        assertEquals(tempDir.resolve("floci-root-ca.crt"), ca.certificatePath());
+        assertTrue(ca.certificate().getBasicConstraints() >= 0, "CA must be cA=true");
+        assertTrue(ca.certificate().getKeyUsage()[5], "CA must assert keyCertSign");
+        assertEquals(ca.certificate().getSubjectX500Principal(), ca.certificate().getIssuerX500Principal());
+        assertEquals("CN=Floci Local CA", ca.certificate().getSubjectX500Principal().getName());
+        assertTrue(ca.caPem().startsWith("-----BEGIN CERTIFICATE-----"));
+        assertEquals(Files.readString(tempDir.resolve("floci-root-ca.crt")), ca.caPem(), "caPem is the file's bytes");
+
+        Set<PosixFilePermission> keyPerms = Files.getPosixFilePermissions(tempDir.resolve("floci-root-ca.key"));
+        assertEquals(PosixFilePermissions.fromString("rw-------"), keyPerms);
+        assertEquals(PosixFilePermissions.fromString("rwx------"), Files.getPosixFilePermissions(tempDir));
+    }
+
+    @Test
+    void createsTheDirectoryWhenMissing() {
+        Path tlsDir = tempDir.resolve("nested").resolve("tls");
+
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tlsDir);
+
+        assertTrue(Files.exists(tlsDir.resolve("floci-root-ca.key")));
+        assertTrue(ca.isIssuedByUs(parse(ca.issueClientCertificate("device").certificatePem())));
+    }
+
+    @Test
+    void reloadsTheSameCaAcrossRestarts() throws Exception {
+        FlociCertificateAuthority first = FlociCertificateAuthority.loadOrCreate(tempDir);
+        Files.setPosixFilePermissions(tempDir.resolve("floci-root-ca.key"), PosixFilePermissions.fromString("rw-r--r--"));
+
+        FlociCertificateAuthority second = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertEquals(first.certificate(), second.certificate());
+        assertEquals(first.key(), second.key());
+        assertEquals(first.caPem(), second.caPem());
+        assertEquals(PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(tempDir.resolve("floci-root-ca.key")), "permissions are re-tightened on load");
+    }
+
+    @Test
+    void corruptCaIsRegeneratedNotSilentlyKept() throws Exception {
+        FlociCertificateAuthority first = FlociCertificateAuthority.loadOrCreate(tempDir);
+        Files.writeString(tempDir.resolve("floci-root-ca.crt"), "-----BEGIN CERTIFICATE-----\nnope\n-----END CERTIFICATE-----\n");
+
+        FlociCertificateAuthority second = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertNotEquals(first.certificate(), second.certificate());
+        assertTrue(second.certificate().getBasicConstraints() >= 0);
+        assertEquals(second.caPem(), Files.readString(tempDir.resolve("floci-root-ca.crt")));
+    }
+
+    @Test
+    void keyThatDoesNotMatchTheCertificateIsRegenerated() throws Exception {
+        FlociCertificateAuthority first = FlociCertificateAuthority.loadOrCreate(tempDir);
+        var stranger = new CertificateGenerator().generateCaCertificate("Other CA");
+        Files.writeString(tempDir.resolve("floci-root-ca.key"), stranger.privateKeyPem());
+
+        FlociCertificateAuthority second = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertNotEquals(first.certificate(), second.certificate(), "a pair that cannot sign must not be kept");
+        assertTrue(second.isIssuedByUs(parse(second.issueClientCertificate("device").certificatePem())));
+    }
+
+    @Test
+    void aLeafInPlaceOfTheCaIsRegenerated() throws Exception {
+        var leaf = new CertificateGenerator().generateCertificate("localhost", List.of(), KeyAlgorithm.RSA_2048);
+        Files.writeString(tempDir.resolve("floci-root-ca.crt"), leaf.certificatePem());
+        Files.writeString(tempDir.resolve("floci-root-ca.key"), leaf.privateKeyPem());
+
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        assertTrue(ca.certificate().getBasicConstraints() >= 0, "must be a CA again");
+        assertEquals(ca.certificate().getSubjectX500Principal(), ca.certificate().getIssuerX500Principal());
+    }
+
+    @Test
+    void signsAServerLeafThatVerifiesAgainstTheCa() throws Exception {
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        CertificateGenerator.GeneratedCertificate leaf = ca.issueServerCertificate(
+                "localhost", List.of("localhost", "*.localhost.floci.io"), KeyAlgorithm.RSA_2048, null);
+        X509Certificate cert = parse(leaf.certificatePem());
+
+        cert.verify(ca.certificate().getPublicKey());
+        assertEquals(ca.certificate().getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertEquals(-1, cert.getBasicConstraints());
+        assertEquals(List.of("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"), cert.getExtendedKeyUsage());
+        assertEquals(List.of("localhost", "*.localhost.floci.io"),
+                cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+        assertTrue(ca.isIssuedByUs(cert));
+    }
+
+    @Test
+    void signsAClientLeafWithClientAuthOnly() throws Exception {
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+
+        X509Certificate cert = parse(ca.issueClientCertificate("AWS IoT Certificate").certificatePem());
+
+        cert.verify(ca.certificate().getPublicKey());
+        assertEquals("CN=AWS IoT Certificate", cert.getSubjectX500Principal().getName());
+        assertEquals(List.of("1.3.6.1.5.5.7.3.2"), cert.getExtendedKeyUsage());
+        assertTrue(ca.isIssuedByUs(cert));
+    }
+
+    @Test
+    void aSelfSignedLeafIsNotOurs() {
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+        var stranger = new CertificateGenerator().generateSelfSignedCertificate(
+                "localhost", List.of("localhost"), KeyAlgorithm.RSA_2048);
+
+        assertFalse(ca.isIssuedByUs(parse(stranger.certificatePem())));
+    }
+
+    @Test
+    void aLeafNamingOurCaButSignedByAnotherKeyIsNotOurs() {
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tempDir);
+        var impostor = new CertificateGenerator().generateCaCertificate(FlociCertificateAuthority.COMMON_NAME);
+        var generator = new CertificateGenerator();
+        var forged = generator.generateIssuedCertificate("localhost", List.of(), KeyAlgorithm.RSA_2048, null,
+                new CertificateGenerator.Issuer(parse(impostor.certificatePem()),
+                        generator.parsePrivateKey(impostor.privateKeyPem())),
+                CertificateGenerator.LeafUsage.SERVER);
+
+        assertFalse(ca.isIssuedByUs(parse(forged.certificatePem())), "same issuer name, wrong signature");
+    }
+
+    private static X509Certificate parse(String pem) {
+        return new CertificateGenerator().parseCertificate(pem);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
@@ -377,6 +377,30 @@ class TlsCertificateHostnameTest {
     }
 
     @Test
+    void resolvedTlsDirIsClearedByABootThatDoesNotIssueALeaf() throws Exception {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+        new TlsConfigSource();
+        assertEquals(tempDir.resolve("tls"), TlsConfigSource.resolvedTlsDir());
+
+        System.setProperty("floci.tls.enabled", "false");
+        new TlsConfigSource();
+        assertNull(TlsConfigSource.resolvedTlsDir(), "TLS off: nothing was laid down");
+
+        Path userCert = tempDir.resolve("user.crt");
+        Path userKey = tempDir.resolve("user.key");
+        var user = new CertificateGenerator().generateCertificate("localhost", List.of("localhost"), KeyAlgorithm.RSA_2048);
+        Files.writeString(userCert, user.certificatePem());
+        Files.writeString(userKey, user.privateKeyPem());
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.cert-path", userCert.toString());
+        System.setProperty("floci.tls.key-path", userKey.toString());
+        new TlsConfigSource();
+        assertNull(TlsConfigSource.resolvedTlsDir(), "user certificate: nothing was laid down");
+    }
+
+    @Test
     void legacySelfSignedLeafIsReplacedByCaIssuedOne() throws Exception {
         System.setProperty("floci.tls.enabled", "true");
         System.setProperty("floci.tls.self-signed", "true");

--- a/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
@@ -428,6 +428,37 @@ class TlsCertificateHostnameTest {
     }
 
     @Test
+    void expiredServerLeafIsReissued() throws Exception {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+        Path tlsDir = Files.createDirectories(tempDir.resolve("tls"));
+        FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(tlsDir);
+        CertificateGenerator gen = new CertificateGenerator();
+        List<String> sans = List.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
+                "localhost.floci.io", "*.localhost.floci.io", "*.execute-api.localhost.floci.io",
+                "*.execute-api.localhost.localstack.cloud", "host.docker.internal");
+        java.security.KeyPair keyPair = java.security.KeyPairGenerator.getInstance("RSA").generateKeyPair();
+        // Issued by the current CA with a validity that ended a day ago: only the expiry check can trigger.
+        X509Certificate expired = gen.signCertificate(new org.bouncycastle.asn1.x500.X500Name("CN=localhost"),
+                keyPair.getPublic(), org.bouncycastle.asn1.x500.X500Name.getInstance(
+                        ca.certificate().getSubjectX500Principal().getEncoded()), ca.key(), sans, false,
+                CertificateGenerator.LeafUsage.SERVER, -1);
+        Files.writeString(tlsDir.resolve("floci-server.crt"), gen.toPem(expired));
+        Files.writeString(tlsDir.resolve("floci-server.key"), gen.toPem(keyPair.getPrivate()));
+        Files.writeString(tlsDir.resolve("floci-server.metadata.json"),
+                new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(CertificateMetadata.create(sans, "dev")));
+        assertTrue(ca.isIssuedByUs(expired), "the expired leaf is ours, so only validity can reject it");
+
+        new TlsConfigSource();
+
+        X509Certificate leaf = parseCertificate(tlsDir.resolve("floci-server.crt"));
+        leaf.checkValidity();
+        assertNotEquals(expired.getSerialNumber(), leaf.getSerialNumber());
+        assertTrue(ca.isIssuedByUs(leaf));
+    }
+
+    @Test
     void leafSignedByAPreviousCaIsReplacedWhenTheCaChanges() throws Exception {
         System.setProperty("floci.tls.enabled", "true");
         System.setProperty("floci.tls.self-signed", "true");

--- a/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsCertificateHostnameTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -67,7 +68,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         X509Certificate cert = parseCertificate(certFile);
@@ -91,7 +92,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         X509Certificate cert = parseCertificate(certFile);
         List<String> sans = extractSansFromCertificate(cert);
         
@@ -111,7 +112,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         X509Certificate cert = parseCertificate(certFile);
         List<String> sans = extractSansFromCertificate(cert);
         
@@ -132,7 +133,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         X509Certificate cert = parseCertificate(certFile);
         List<String> sans = extractSansFromCertificate(cert);
         
@@ -154,7 +155,7 @@ class TlsCertificateHostnameTest {
 
         new TlsConfigSource();
 
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         X509Certificate initialCert = parseCertificate(certFile);
         List<String> initialSans = extractSansFromCertificate(initialCert);
         assertTrue(initialSans.contains("host1"), "Initial certificate should contain 'host1'");
@@ -183,9 +184,9 @@ class TlsCertificateHostnameTest {
 
         Path tlsDir = tempDir.resolve("tls");
         Files.createDirectories(tlsDir);
-        Path certFile = tlsDir.resolve("floci-selfsigned.crt");
-        Path keyFile = tlsDir.resolve("floci-selfsigned.key");
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path certFile = tlsDir.resolve("floci-server.crt");
+        Path keyFile = tlsDir.resolve("floci-server.key");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
 
         // Generate certificate without metadata
         CertificateGenerator gen = new CertificateGenerator();
@@ -224,7 +225,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         X509Certificate cert = parseCertificate(certFile);
         List<String> sans = extractSansFromCertificate(cert);
         
@@ -249,7 +250,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         X509Certificate cert = parseCertificate(certFile);
         List<String> sans = extractSansFromCertificate(cert);
         
@@ -291,7 +292,7 @@ class TlsCertificateHostnameTest {
         new TlsConfigSource();
 
         // Assert: No self-signed certificate generated
-        Path selfSignedCert = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path selfSignedCert = tempDir.resolve("tls/floci-server.crt");
         assertFalse(Files.exists(selfSignedCert), 
             "Self-signed certificate should not be generated when user provides certificates");
     }
@@ -310,7 +311,7 @@ class TlsCertificateHostnameTest {
         // Assert
         Path tlsDir = tempDir.resolve("tls");
         if (Files.exists(tlsDir)) {
-            assertFalse(Files.exists(tlsDir.resolve("floci-selfsigned.crt")),
+            assertFalse(Files.exists(tlsDir.resolve("floci-server.crt")),
                 "No certificate should be created when TLS is disabled");
         }
     }
@@ -327,9 +328,9 @@ class TlsCertificateHostnameTest {
 
         new TlsConfigSource();
 
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         long initialModifiedTime = Files.getLastModifiedTime(certFile).toMillis();
-        String initialMetadata = Files.readString(tempDir.resolve("tls/floci-selfsigned.metadata.json"));
+        String initialMetadata = Files.readString(tempDir.resolve("tls/floci-server.metadata.json"));
 
         Thread.sleep(100);
 
@@ -338,12 +339,86 @@ class TlsCertificateHostnameTest {
 
         // Assert: Certificate reused (not regenerated)
         long newModifiedTime = Files.getLastModifiedTime(certFile).toMillis();
-        String newMetadata = Files.readString(tempDir.resolve("tls/floci-selfsigned.metadata.json"));
+        String newMetadata = Files.readString(tempDir.resolve("tls/floci-server.metadata.json"));
         
         assertEquals(initialModifiedTime, newModifiedTime, 
             "Certificate should be reused when configuration unchanged");
         assertEquals(initialMetadata, newMetadata, 
             "Metadata should be unchanged");
+    }
+
+    // ==================== Local CA Tests ====================
+
+    @Test
+    void serverCertificateIsIssuedByTheLocalCa() throws Exception {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+
+        TlsConfigSource source = new TlsConfigSource();
+
+        Path tlsDir = tempDir.resolve("tls");
+        X509Certificate ca = parseCertificate(tlsDir.resolve("floci-root-ca.crt"));
+        X509Certificate leaf = parseCertificate(tlsDir.resolve("floci-server.crt"));
+        leaf.verify(ca.getPublicKey());
+        assertEquals(ca.getSubjectX500Principal(), leaf.getIssuerX500Principal());
+        assertEquals(-1, leaf.getBasicConstraints(), "server leaf must not be a CA");
+        assertEquals(List.of("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"), leaf.getExtendedKeyUsage());
+
+        assertEquals(tlsDir.resolve("floci-server.crt").toAbsolutePath().toString(),
+                source.getValue("quarkus.tls.key-store.pem.0.cert"));
+        assertEquals(tlsDir.resolve("floci-server.key").toAbsolutePath().toString(),
+                source.getValue("quarkus.tls.key-store.pem.0.key"));
+        assertNull(source.getValue("quarkus.http.ssl.certificate.files"), "legacy key no longer published");
+        assertNull(source.getValue("quarkus.http.ssl.certificate.key-files"), "legacy key no longer published");
+        assertEquals(PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(tlsDir.resolve("floci-server.key")));
+        assertEquals(tlsDir, TlsConfigSource.resolvedTlsDir());
+    }
+
+    @Test
+    void legacySelfSignedLeafIsReplacedByCaIssuedOne() throws Exception {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+        Path tlsDir = Files.createDirectories(tempDir.resolve("tls"));
+        CertificateGenerator gen = new CertificateGenerator();
+        // The exact SAN list TlsConfigSource would compute for this configuration, so only the
+        // issuer check can trigger regeneration here.
+        List<String> sans = List.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
+                "localhost.floci.io", "*.localhost.floci.io", "*.execute-api.localhost.floci.io",
+                "*.execute-api.localhost.localstack.cloud", "host.docker.internal");
+        var legacy = gen.generateSelfSignedCertificate("localhost", sans, KeyAlgorithm.RSA_2048);
+        Files.writeString(tlsDir.resolve("floci-server.crt"), legacy.certificatePem());
+        Files.writeString(tlsDir.resolve("floci-server.key"), legacy.privateKeyPem());
+        Files.writeString(tlsDir.resolve("floci-server.metadata.json"),
+                new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(
+                        CertificateMetadata.create(sans, "dev")));
+
+        new TlsConfigSource();
+
+        X509Certificate ca = parseCertificate(tlsDir.resolve("floci-root-ca.crt"));
+        X509Certificate leaf = parseCertificate(tlsDir.resolve("floci-server.crt"));
+        assertEquals(ca.getSubjectX500Principal(), leaf.getIssuerX500Principal());
+        assertNotEquals(legacy.certificatePem(), Files.readString(tlsDir.resolve("floci-server.crt")));
+    }
+
+    @Test
+    void leafSignedByAPreviousCaIsReplacedWhenTheCaChanges() throws Exception {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+        new TlsConfigSource();
+        Path tlsDir = tempDir.resolve("tls");
+        String firstLeaf = Files.readString(tlsDir.resolve("floci-server.crt"));
+        Files.delete(tlsDir.resolve("floci-root-ca.key"));
+
+        new TlsConfigSource();
+
+        X509Certificate ca = parseCertificate(tlsDir.resolve("floci-root-ca.crt"));
+        X509Certificate leaf = parseCertificate(tlsDir.resolve("floci-server.crt"));
+        assertNotEquals(firstLeaf, Files.readString(tlsDir.resolve("floci-server.crt")));
+        leaf.verify(ca.getPublicKey());
     }
 
     // ==================== Helper Methods ====================

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateGenerationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateGenerationTest.java
@@ -59,7 +59,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         List<String> sans = extractSansFromCertificate(certFile);
@@ -81,7 +81,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         List<String> sans = extractSansFromCertificate(certFile);
@@ -103,7 +103,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         List<String> sans = extractSansFromCertificate(certFile);
@@ -124,7 +124,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         List<String> sans = extractSansFromCertificate(certFile);
@@ -147,7 +147,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         List<String> sans = extractSansFromCertificate(certFile);
@@ -183,7 +183,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path certFile = tempDir.resolve("tls/floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
         assertTrue(Files.exists(certFile), "Certificate file should exist");
         
         List<String> sans = extractSansFromCertificate(certFile);
@@ -205,7 +205,7 @@ class TlsConfigSourceCertificateGenerationTest {
         new TlsConfigSource();
         
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         assertTrue(Files.exists(metadataFile), "Metadata file should exist");
         
         String json = Files.readString(metadataFile);

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateReuseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateReuseTest.java
@@ -57,8 +57,8 @@ class TlsConfigSourceCertificateReuseTest {
         new TlsConfigSource();
 
         Path tlsDir = tempDir.resolve("tls");
-        Path certFile = tlsDir.resolve("floci-selfsigned.crt");
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path certFile = tlsDir.resolve("floci-server.crt");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
 
         // Verify initial certificate and metadata exist
         assertTrue(Files.exists(certFile), "Initial certificate should be generated");
@@ -107,8 +107,8 @@ class TlsConfigSourceCertificateReuseTest {
         new TlsConfigSource();
 
         Path tlsDir = tempDir.resolve("tls");
-        Path certFile = tlsDir.resolve("floci-selfsigned.crt");
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path certFile = tlsDir.resolve("floci-server.crt");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
 
         // Verify initial certificate and metadata exist
         assertTrue(Files.exists(certFile), "Initial certificate should be generated");
@@ -150,8 +150,8 @@ class TlsConfigSourceCertificateReuseTest {
         new TlsConfigSource();
 
         Path tlsDir = tempDir.resolve("tls");
-        Path certFile = tlsDir.resolve("floci-selfsigned.crt");
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path certFile = tlsDir.resolve("floci-server.crt");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
 
         // Verify initial certificate and metadata exist
         assertTrue(Files.exists(certFile), "Initial certificate should be generated");
@@ -195,7 +195,7 @@ class TlsConfigSourceCertificateReuseTest {
 
         // First boot: generate the certificate.
         new TlsConfigSource();
-        Path certFile = tempDir.resolve("tls").resolve("floci-selfsigned.crt");
+        Path certFile = tempDir.resolve("tls").resolve("floci-server.crt");
         assertTrue(Files.exists(certFile), "Initial certificate should be generated");
         long initialModifiedTime = Files.getLastModifiedTime(certFile).toMillis();
         String initialCert = Files.readString(certFile);
@@ -236,8 +236,8 @@ class TlsConfigSourceCertificateReuseTest {
         new TlsConfigSource();
 
         Path tlsDir = tempDir.resolve("tls");
-        Path certFile = tlsDir.resolve("floci-selfsigned.crt");
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path certFile = tlsDir.resolve("floci-server.crt");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
 
         // Verify initial certificate and metadata exist
         assertTrue(Files.exists(certFile), "Initial certificate should be generated");

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataComparisonTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataComparisonTest.java
@@ -167,7 +167,7 @@ class TlsConfigSourceMetadataComparisonTest {
         Files.createDirectories(tlsDir);
 
         // Create malformed metadata file
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
         Files.writeString(metadataFile, "{ invalid json }");
 
         List<String> currentHostnames = List.of("localhost", "127.0.0.1");
@@ -186,7 +186,7 @@ class TlsConfigSourceMetadataComparisonTest {
         Files.createDirectories(tlsDir);
 
         // Create metadata with null hostnames field
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
         String json = "{\"generatedAt\":\"" + Instant.now().toString() + "\",\"flociVersion\":\"dev\"}";
         Files.writeString(metadataFile, json);
 
@@ -223,7 +223,7 @@ class TlsConfigSourceMetadataComparisonTest {
      * Helper method to create a metadata file with specified hostnames.
      */
     private void createMetadataFile(Path tlsDir, List<String> hostnames) throws IOException {
-        Path metadataFile = tlsDir.resolve("floci-selfsigned.metadata.json");
+        Path metadataFile = tlsDir.resolve("floci-server.metadata.json");
         CertificateMetadata metadata = CertificateMetadata.create(hostnames, "dev");
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataPersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceMetadataPersistenceTest.java
@@ -53,7 +53,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         assertTrue(Files.exists(metadataFile),
             "Metadata file should be created after certificate generation");
     }
@@ -67,7 +67,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertNotNull(metadata.getHostnames(), "Hostnames should not be null");
@@ -99,7 +99,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertTrue(metadata.getHostnames().contains("floci"),
@@ -118,7 +118,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertTrue(metadata.getHostnames().contains("myhost"),
@@ -138,7 +138,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertTrue(metadata.getHostnames().contains("newhost"),
@@ -156,7 +156,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertNotNull(metadata.getGeneratedAt(),
@@ -174,7 +174,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertNotNull(metadata.getFlociVersion(),
@@ -196,7 +196,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         CertificateMetadata metadata = readMetadata(metadataFile);
 
         assertNotNull(metadata.getFlociVersion(),
@@ -212,7 +212,7 @@ class TlsConfigSourceMetadataPersistenceTest {
         new TlsConfigSource();
 
         // Assert
-        Path metadataFile = tempDir.resolve("tls/floci-selfsigned.metadata.json");
+        Path metadataFile = tempDir.resolve("tls/floci-server.metadata.json");
         String json = Files.readString(metadataFile);
 
         assertFalse(json.isBlank(), "Metadata file should not be empty");

--- a/src/test/java/io/github/hectorvent/floci/config/TlsLocalCaIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsLocalCaIntegrationTest.java
@@ -1,0 +1,125 @@
+package io.github.hectorvent.floci.config;
+
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Boots the HTTP server on the TLS registry keys {@code TlsConfigSource} publishes, with a leaf
+ * issued by the local CA, and proves a client that trusts only {@code GET /_floci/ca.pem} completes
+ * a handshake. A file assertion cannot show that Quarkus read the registry entry or that the served
+ * chain is the CA's; only a handshake can.
+ */
+@QuarkusTest
+@TestProfile(TlsLocalCaIntegrationTest.LocalCaProfile.class)
+class TlsLocalCaIntegrationTest {
+
+    @ConfigProperty(name = "quarkus.http.test-ssl-port", defaultValue = "0")
+    int testSslPort;
+
+    @Test
+    void handshakeSucceedsTrustingOnlyTheServedCa() throws Exception {
+        String caPem = given().when().get("/_floci/ca.pem").then().statusCode(200).extract().asString();
+        X509Certificate ca = parse(caPem);
+
+        HttpsURLConnection connection = open(trustOnly(ca));
+        assertEquals(200, connection.getResponseCode());
+        Certificate[] served = connection.getServerCertificates();
+        X509Certificate leaf = (X509Certificate) served[0];
+        assertEquals(ca.getSubjectX500Principal(), leaf.getIssuerX500Principal());
+        assertEquals(-1, leaf.getBasicConstraints());
+        leaf.verify(ca.getPublicKey());
+        connection.disconnect();
+    }
+
+    @Test
+    void handshakeFailsTrustingAnotherCa() throws Exception {
+        X509Certificate stranger = FlociCertificateAuthority.loadOrCreate(
+                Files.createTempDirectory("floci-stranger-ca")).certificate();
+
+        HttpsURLConnection connection = open(trustOnly(stranger));
+        assertThrows(SSLHandshakeException.class, connection::getResponseCode);
+    }
+
+    private HttpsURLConnection open(SSLContext sslContext) throws IOException {
+        HttpsURLConnection connection = (HttpsURLConnection) URI.create(
+                "https://localhost:" + testSslPort + "/_floci/health").toURL().openConnection();
+        connection.setSSLSocketFactory(sslContext.getSocketFactory());
+        return connection;
+    }
+
+    private static SSLContext trustOnly(X509Certificate ca) throws Exception {
+        KeyStore trust = KeyStore.getInstance(KeyStore.getDefaultType());
+        trust.load(null, null);
+        trust.setCertificateEntry("floci-ca", ca);
+        TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        factory.init(trust);
+        SSLContext context = SSLContext.getInstance("TLS");
+        context.init(null, factory.getTrustManagers(), null);
+        return context;
+    }
+
+    private static X509Certificate parse(String pem) throws Exception {
+        return (X509Certificate) CertificateFactory.getInstance("X.509")
+                .generateCertificate(new ByteArrayInputStream(pem.getBytes(StandardCharsets.US_ASCII)));
+    }
+
+    /**
+     * Lays down what {@code TlsConfigSource} would: a CA under {persistent-path}/tls and a leaf
+     * issued by it, published as the registry's default key store. The persistent path is the
+     * same directory, so the CDI producer behind {@code /_floci/ca.pem} loads the same CA.
+     */
+    public static final class LocalCaProfile implements QuarkusTestProfile {
+
+        private static final Path DATA_DIR = Path.of("target", "floci-tls-local-ca-test").toAbsolutePath();
+        private static final Path TLS_DIR = DATA_DIR.resolve("tls");
+        private static final Path CERT_FILE = TLS_DIR.resolve("floci-server.crt");
+        private static final Path KEY_FILE = TLS_DIR.resolve("floci-server.key");
+
+        static {
+            try {
+                FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(TLS_DIR);
+                var leaf = ca.issueServerCertificate("localhost", List.of("localhost", "127.0.0.1"),
+                        KeyAlgorithm.RSA_2048, null);
+                Files.writeString(CERT_FILE, leaf.certificatePem());
+                Files.writeString(KEY_FILE, leaf.privateKeyPem());
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to prepare the local CA test files", e);
+            }
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.storage.persistent-path", DATA_DIR.toString(),
+                    "quarkus.tls.key-store.pem.0.cert", CERT_FILE.toString(),
+                    "quarkus.tls.key-store.pem.0.key", KEY_FILE.toString(),
+                    "quarkus.http.insecure-requests", "enabled"
+            );
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/config/TlsUserCertIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsUserCertIntegrationTest.java
@@ -59,10 +59,7 @@ class TlsUserCertIntegrationTest {
     }
 
     @Test
-    void caPemReturnsTheUserCertificateAndCreatesNoLocalCa() throws Exception {
-        Path localCa = Path.of("/tmp/floci-tls-usercert-test-data/tls/floci-root-ca.crt");
-        Files.deleteIfExists(localCa);
-
+    void caPemReturnsTheUserCertificateFollowedByTheLocalCa() throws Exception {
         String pem = given()
             .when()
                 .get("/_floci/ca.pem")
@@ -71,9 +68,19 @@ class TlsUserCertIntegrationTest {
                 .contentType(org.hamcrest.Matchers.startsWith("text/plain"))
                 .extract().asString();
 
-        org.junit.jupiter.api.Assertions.assertEquals(Files.readString(UserCertProfile.CERT_FILE), pem,
-                "with a user certificate, ca.pem is that file: the local CA could not validate the endpoint");
-        org.junit.jupiter.api.Assertions.assertFalse(Files.exists(localCa), "no local CA is created in custom-cert mode");
+        String userPem = Files.readString(UserCertProfile.CERT_FILE);
+        org.junit.jupiter.api.Assertions.assertTrue(pem.startsWith(userPem),
+                "the user certificate, which signs the HTTPS endpoint, comes first");
+        var bundle = java.security.cert.CertificateFactory.getInstance("X.509")
+                .generateCertificates(new java.io.ByteArrayInputStream(pem.getBytes(java.nio.charset.StandardCharsets.US_ASCII)))
+                .stream().map(java.security.cert.X509Certificate.class::cast).toList();
+        org.junit.jupiter.api.Assertions.assertEquals(2, bundle.size(), "user certificate plus the local CA");
+        java.security.cert.X509Certificate localCa = bundle.get(1);
+        org.junit.jupiter.api.Assertions.assertTrue(localCa.getBasicConstraints() >= 0, "the local CA is a CA");
+        org.junit.jupiter.api.Assertions.assertEquals("CN=Floci Local CA", localCa.getSubjectX500Principal().getName());
+        org.junit.jupiter.api.Assertions.assertEquals(Files.readString(
+                Path.of("/tmp/floci-tls-usercert-test-data/tls/floci-root-ca.crt")), pem.substring(userPem.length()).stripLeading(),
+                "the local CA served is the one on disk");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/config/TlsUserCertIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsUserCertIntegrationTest.java
@@ -59,6 +59,24 @@ class TlsUserCertIntegrationTest {
     }
 
     @Test
+    void caPemReturnsTheUserCertificateAndCreatesNoLocalCa() throws Exception {
+        Path localCa = Path.of("/tmp/floci-tls-usercert-test-data/tls/floci-root-ca.crt");
+        Files.deleteIfExists(localCa);
+
+        String pem = given()
+            .when()
+                .get("/_floci/ca.pem")
+            .then()
+                .statusCode(200)
+                .contentType(org.hamcrest.Matchers.startsWith("text/plain"))
+                .extract().asString();
+
+        org.junit.jupiter.api.Assertions.assertEquals(Files.readString(UserCertProfile.CERT_FILE), pem,
+                "with a user certificate, ca.pem is that file: the local CA could not validate the endpoint");
+        org.junit.jupiter.api.Assertions.assertFalse(Files.exists(localCa), "no local CA is created in custom-cert mode");
+    }
+
+    @Test
     void ssmPutParameterOverHttps() {
         given()
             .baseUri("https://localhost:" + testSslPort)
@@ -74,7 +92,7 @@ class TlsUserCertIntegrationTest {
     public static final class UserCertProfile implements QuarkusTestProfile {
 
         private static final Path CERT_DIR = Path.of("/tmp/floci-tls-usercert-test");
-        private static final Path CERT_FILE = CERT_DIR.resolve("user-test.crt");
+        static final Path CERT_FILE = CERT_DIR.resolve("user-test.crt");
         private static final Path KEY_FILE = CERT_DIR.resolve("user-test.key");
 
         static {

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoControllerIntegrationTest.java
@@ -106,6 +106,24 @@ class EmulatorInfoControllerIntegrationTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {"/_floci/ca.pem", "/_localstack/ca.pem"})
+    void caPem_returnsTheLocalCaAsPlainText(String path) throws Exception {
+        String pem = given()
+            .when().get(path)
+            .then()
+                .statusCode(200)
+                .contentType(startsWith("text/plain"))
+                .extract().body().asString();
+
+        var cert = (java.security.cert.X509Certificate) java.security.cert.CertificateFactory.getInstance("X.509")
+                .generateCertificate(new java.io.ByteArrayInputStream(pem.getBytes(java.nio.charset.StandardCharsets.US_ASCII)));
+        assertTrue(cert.getBasicConstraints() >= 0, "must be a CA certificate");
+        assertEquals(cert.getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertEquals(pem, given().when().get("/_floci/ca.pem").then().extract().body().asString(),
+                "the same CA on every call");
+    }
+
+    @ParameterizedTest
     @ValueSource(strings = {"/_floci/state/reset", "/_localstack/state/reset", "/_floci/state/nuke", "/_localstack/state/nuke"})
     void stateReset_returnsOkOnAllPaths(String path) {
         given()

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmImportExportTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmImportExportTest.java
@@ -95,7 +95,9 @@ class AcmImportExportTest {
             .body("Certificate.DomainName", equalTo("test-import.example.com"))
             .body("Certificate.Status", equalTo("ISSUED"))
             .body("Certificate.Type", equalTo("IMPORTED"))
-            .body("Certificate.KeyAlgorithm", equalTo("RSA-2048"));
+            .body("Certificate.KeyAlgorithm", equalTo("RSA-2048"))
+            .body("Certificate.Serial", matchesPattern("([0-9a-f]{2}:)+[0-9a-f]{2}"))
+            .body("Certificate.SignatureAlgorithm", matchesPattern("SHA[0-9]+WITH[A-Z]+"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -151,6 +151,21 @@ class CertificateGeneratorIssuerTest {
     }
 
     @Test
+    void aSuppliedKeyPairOfAnotherAlgorithmIsRefused() {
+        var issuer = newIssuer();
+        var rsa = generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var rsaPair = new KeyPair(generator.parseCertificate(rsa.certificatePem()).getPublicKey(),
+                generator.parsePrivateKey(rsa.privateKeyPem()));
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, rsaPair, issuer,
+                        CertificateGenerator.LeafUsage.CLIENT));
+        assertTrue(refused.getMessage().contains("RSA_2048") && refused.getMessage().contains("EC_prime256v1"),
+                refused.getMessage());
+    }
+
+    @Test
     void duplicateSansAreWrittenOnce() throws Exception {
         var leaf = generator.generateIssuedCertificate("dup.example.test", List.of("dup.example.test", "other.example.test",
                 "other.example.test"), KeyAlgorithm.RSA_2048, null, newIssuer(), CertificateGenerator.LeafUsage.SERVER);

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.acm;
+
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The issuer-signing primitive: a CA that can sign, leaves that verify against it, and the
+ * Extended Key Usage split between server and client leaves.
+ */
+class CertificateGeneratorIssuerTest {
+
+    private static CertificateGenerator generator;
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        generator = new CertificateGenerator();
+    }
+
+    private static CertificateGenerator.Issuer newIssuer() {
+        var ca = generator.generateCaCertificate("Floci Local CA");
+        return new CertificateGenerator.Issuer(
+                generator.parseCertificate(ca.certificatePem()), generator.parsePrivateKey(ca.privateKeyPem()));
+    }
+
+    @Test
+    void caCertificateIsSelfSignedAndCanSign() throws Exception {
+        var ca = generator.generateCaCertificate("Floci Local CA");
+        X509Certificate cert = generator.parseCertificate(ca.certificatePem());
+
+        assertEquals(cert.getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertEquals("CN=Floci Local CA", cert.getSubjectX500Principal().getName());
+        assertTrue(cert.getBasicConstraints() >= 0, "CA must carry cA=true");
+        assertTrue(cert.getKeyUsage()[5], "CA must assert keyCertSign");
+        assertTrue(cert.getKeyUsage()[6], "CA must assert cRLSign");
+        assertNull(cert.getExtendedKeyUsage(), "a CA carries no EKU");
+        assertNull(cert.getSubjectAlternativeNames(), "a CA carries no SAN");
+        cert.verify(cert.getPublicKey());
+        assertEquals(ca.subject(), ca.issuer());
+    }
+
+    @Test
+    void issuedLeafVerifiesAgainstIssuerAndCarriesServerAuth() throws Exception {
+        var issuer = newIssuer();
+
+        var leaf = generator.generateIssuedCertificate("api.example.test", List.of("*.example.test"),
+                KeyAlgorithm.RSA_2048, null, issuer, CertificateGenerator.LeafUsage.SERVER);
+        X509Certificate cert = generator.parseCertificate(leaf.certificatePem());
+
+        assertEquals(issuer.certificate().getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertNotEquals(cert.getSubjectX500Principal(), cert.getIssuerX500Principal());
+        assertEquals(-1, cert.getBasicConstraints(), "leaf must not be a CA");
+        assertFalse(cert.getKeyUsage()[5], "leaf must not assert keyCertSign");
+        assertTrue(cert.getKeyUsage()[0] && cert.getKeyUsage()[2], "RSA leaf: digitalSignature and keyEncipherment");
+        assertEquals(List.of("1.3.6.1.5.5.7.3.1", "1.3.6.1.5.5.7.3.2"), cert.getExtendedKeyUsage(),
+                "serverAuth and clientAuth, as ACM issues and DescribeCertificate advertises");
+        assertEquals(List.of("api.example.test", "*.example.test"),
+                cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+        assertEquals("SHA512WITHRSA", leaf.signatureAlgorithm(), "ACM spells the algorithm in upper case");
+        assertTrue(cert.getSigAlgName().equalsIgnoreCase(leaf.signatureAlgorithm()),
+                "metadata reports the real signature algorithm: " + cert.getSigAlgName());
+        assertTrue(leaf.serial().matches("([0-9a-f]{2}:)+[0-9a-f]{2}"),
+                "colon-separated hex serial: " + leaf.serial());
+        assertEquals(cert.getSerialNumber(), new BigInteger(leaf.serial().replace(":", ""), 16));
+        assertEquals(cert.getNotBefore().toInstant(), leaf.notBefore());
+        assertEquals(cert.getNotAfter().toInstant(), leaf.notAfter());
+        assertEquals("CN=api.example.test", leaf.subject());
+        assertEquals(issuer.certificate().getSubjectX500Principal().getName(), leaf.issuer());
+        cert.verify(issuer.certificate().getPublicKey());
+    }
+
+    @Test
+    void issuedLeafReusesSuppliedKeyPairAndClientUsage() throws Exception {
+        var issuer = newIssuer();
+        var first = generator.generateIssuedCertificate("device-1", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var keyPair = new KeyPair(
+                generator.parseCertificate(first.certificatePem()).getPublicKey(),
+                generator.parsePrivateKey(first.privateKeyPem()));
+
+        var second = generator.generateIssuedCertificate("device-1", List.of(), KeyAlgorithm.RSA_2048, keyPair, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        X509Certificate cert = generator.parseCertificate(second.certificatePem());
+
+        assertEquals(keyPair.getPublic(), cert.getPublicKey(), "supplied key pair must be reused");
+        assertEquals(first.privateKeyPem(), second.privateKeyPem(), "the same private key is returned");
+        assertNotEquals(first.serial(), second.serial(), "every issue gets a fresh serial");
+        assertEquals(List.of("1.3.6.1.5.5.7.3.2"), cert.getExtendedKeyUsage(), "clientAuth only");
+        cert.verify(issuer.certificate().getPublicKey());
+    }
+
+    @Test
+    void ecLeafSignedByRsaCaReportsTheIssuerAlgorithmAndNoKeyEncipherment() throws Exception {
+        var issuer = newIssuer();
+
+        var leaf = generator.generateIssuedCertificate("ec.example.test", null, KeyAlgorithm.EC_prime256v1, null,
+                issuer, CertificateGenerator.LeafUsage.SERVER);
+        X509Certificate cert = generator.parseCertificate(leaf.certificatePem());
+
+        assertEquals("EC", cert.getPublicKey().getAlgorithm());
+        assertEquals("SHA512WITHRSA", leaf.signatureAlgorithm(), "the signature is the RSA issuer's");
+        assertTrue(cert.getKeyUsage()[0], "digitalSignature");
+        assertFalse(cert.getKeyUsage()[2], "an EC key never enciphers");
+        assertEquals(List.of("ec.example.test"), cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+        cert.verify(issuer.certificate().getPublicKey());
+    }
+
+    @Test
+    void duplicateSansAreWrittenOnce() throws Exception {
+        var leaf = generator.generateIssuedCertificate("dup.example.test", List.of("dup.example.test", "other.example.test",
+                "other.example.test"), KeyAlgorithm.RSA_2048, null, newIssuer(), CertificateGenerator.LeafUsage.SERVER);
+        X509Certificate cert = generator.parseCertificate(leaf.certificatePem());
+
+        assertEquals(List.of("dup.example.test", "other.example.test"),
+                cert.getSubjectAlternativeNames().stream().map(san -> san.get(1)).toList());
+    }
+
+    @Test
+    void existingSelfSignedAndAcmStylePathsAreUnchanged() throws Exception {
+        var selfSigned = generator.generateSelfSignedCertificate("localhost", List.of("localhost"), KeyAlgorithm.RSA_2048);
+        X509Certificate ss = generator.parseCertificate(selfSigned.certificatePem());
+        assertEquals(ss.getSubjectX500Principal(), ss.getIssuerX500Principal());
+        assertTrue(ss.getBasicConstraints() >= 0);
+        assertNull(ss.getExtendedKeyUsage(), "the self-signed trust anchor carries no EKU, as before");
+        ss.verify(ss.getPublicKey());
+
+        var acmStyle = generator.generateCertificate("localhost", List.of("localhost"), KeyAlgorithm.RSA_2048);
+        X509Certificate acm = generator.parseCertificate(acmStyle.certificatePem());
+        assertTrue(acm.getIssuerX500Principal().getName().contains("Amazon"));
+        assertEquals(-1, acm.getBasicConstraints());
+        assertEquals("CN=Amazon,OU=Server CA 1B,O=Amazon,C=US", acmStyle.issuer());
+        assertTrue(acmStyle.serial().matches("([0-9a-f]{2}:)+[0-9a-f]{2}"));
+    }
+
+    @Test
+    void colonHexPadsOddLengthAndSplitsBytes() {
+        assertEquals("0a", CertificateGenerator.colonHex(BigInteger.TEN));
+        assertEquals("01:00", CertificateGenerator.colonHex(BigInteger.valueOf(256)));
+        assertEquals("ff:ff:ff", CertificateGenerator.colonHex(new BigInteger("ffffff", 16)));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -161,8 +161,25 @@ class CertificateGeneratorIssuerTest {
         var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
                 () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, rsaPair, issuer,
                         CertificateGenerator.LeafUsage.CLIENT));
-        assertTrue(refused.getMessage().contains("RSA_2048") && refused.getMessage().contains("EC_prime256v1"),
-                refused.getMessage());
+        assertTrue(refused.getMessage().contains("not the requested EC_prime256v1"), refused.getMessage());
+    }
+
+    @Test
+    void aSuppliedEcKeyPairOnACurveOfTheSameSizeIsRefused() throws Exception {
+        var issuer = newIssuer();
+        java.security.KeyPairGenerator kpg = java.security.KeyPairGenerator.getInstance("EC", "BC");
+        kpg.initialize(new java.security.spec.ECGenParameterSpec("secp256k1"));
+        KeyPair k1 = kpg.generateKeyPair();
+        kpg.initialize(new java.security.spec.ECGenParameterSpec("secp256r1"));
+        KeyPair p256 = kpg.generateKeyPair();
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, k1, issuer,
+                        CertificateGenerator.LeafUsage.CLIENT));
+        assertTrue(refused.getMessage().contains("not the requested EC_prime256v1"), refused.getMessage());
+        var accepted = generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.EC_prime256v1, p256, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        assertEquals(p256.getPublic(), generator.parseCertificate(accepted.certificatePem()).getPublicKey());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/CertificateGeneratorIssuerTest.java
@@ -122,6 +122,35 @@ class CertificateGeneratorIssuerTest {
     }
 
     @Test
+    void anIssuerWhoseKeyDoesNotMatchItsCertificateIsRefused() {
+        var one = generator.generateCaCertificate("One");
+        var other = generator.generateCaCertificate("Other");
+        var mismatched = new CertificateGenerator.Issuer(
+                generator.parseCertificate(one.certificatePem()), generator.parsePrivateKey(other.privateKeyPem()));
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("x.example.test", List.of(), KeyAlgorithm.RSA_2048, null,
+                        mismatched, CertificateGenerator.LeafUsage.SERVER));
+        assertTrue(refused.getMessage().contains("Signature"), refused.getMessage());
+    }
+
+    @Test
+    void aSuppliedKeyPairThatIsNotAPairIsRefused() {
+        var issuer = newIssuer();
+        var a = generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var b = generator.generateIssuedCertificate("b", List.of(), KeyAlgorithm.RSA_2048, null, issuer,
+                CertificateGenerator.LeafUsage.CLIENT);
+        var notAPair = new KeyPair(generator.parseCertificate(a.certificatePem()).getPublicKey(),
+                generator.parsePrivateKey(b.privateKeyPem()));
+
+        var refused = org.junit.jupiter.api.Assertions.assertThrows(CertificateGenerationException.class,
+                () -> generator.generateIssuedCertificate("a", List.of(), KeyAlgorithm.RSA_2048, notAPair, issuer,
+                        CertificateGenerator.LeafUsage.CLIENT));
+        assertTrue(refused.getMessage().contains("does not match"), refused.getMessage());
+    }
+
+    @Test
     void duplicateSansAreWrittenOnce() throws Exception {
         var leaf = generator.generateIssuedCertificate("dup.example.test", List.of("dup.example.test", "other.example.test",
                 "other.example.test"), KeyAlgorithm.RSA_2048, null, newIssuer(), CertificateGenerator.LeafUsage.SERVER);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherCaTrustTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ContainerLauncherCaTrustTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Unit tests for {@link ContainerLauncher}'s Floci CA-trust injection helpers. These are pure
  * (no Docker / Quarkus): they cover where the CA cert is resolved from and which environment
- * variables get injected so a Lambda container trusts Floci's self-signed HTTPS endpoint.
+ * variables get injected so a Lambda container trusts Floci's HTTPS endpoint through the local CA.
  */
 class ContainerLauncherCaTrustTest {
 
@@ -41,9 +41,9 @@ class ContainerLauncherCaTrustTest {
     }
 
     @Test
-    void resolveCaCertPath_selfSignedUnderPersistentPath() throws Exception {
+    void resolveCaCertPath_localCaUnderPersistentPath() throws Exception {
         Path tlsDir = Files.createDirectories(tempDir.resolve("tls"));
-        Path cert = Files.writeString(tlsDir.resolve("floci-selfsigned.crt"), "PEM");
+        Path cert = Files.writeString(tlsDir.resolve("floci-root-ca.crt"), "PEM");
 
         Optional<Path> resolved =
                 ContainerLauncher.resolveFlociCaCertPath(true, Optional.empty(), tempDir.toString());
@@ -64,9 +64,9 @@ class ContainerLauncherCaTrustTest {
     }
 
     @Test
-    void resolveCaCertPath_blankUserCertFallsBackToSelfSigned() throws Exception {
+    void resolveCaCertPath_blankUserCertFallsBackToLocalCa() throws Exception {
         Path tlsDir = Files.createDirectories(tempDir.resolve("tls"));
-        Path cert = Files.writeString(tlsDir.resolve("floci-selfsigned.crt"), "PEM");
+        Path cert = Files.writeString(tlsDir.resolve("floci-root-ca.crt"), "PEM");
 
         Optional<Path> resolved =
                 ContainerLauncher.resolveFlociCaCertPath(true, Optional.of("   "), tempDir.toString());


### PR DESCRIPTION
> Stacked on #3077 (`refactor(acm): one issuer-signing primitive in CertificateGenerator`). Until that one merges this diff shows its two commits as well; the change here starts at `feat(tls): FlociCertificateAuthority, a persistent local root CA`. Rebase the day #3077 lands.

## Summary

Floci's HTTPS certificate was a self-signed leaf. Trusting it meant pinning that exact certificate, which breaks the moment the leaf is reissued (a hostname change today, a growing name list in a follow-up). This change gives Floci one local root CA and makes the server certificate a leaf issued by it. A client trusts one file once, `GET /_floci/ca.pem`, and keeps trusting Floci through every later reissue. It also lets the TLS docs drop every "disable verification" instruction.

- `FlociCertificateAuthority`: `{persistent-path}/tls/floci-root-ca.{crt,key}`, key created owner-only, ten years. A corrupt, expired, non-CA or mismatched pair is regenerated with a WARN. A plain class so `TlsConfigSource` can use it before CDI exists; a producer hands the same pair to beans.
- `TlsConfigSource`: the leaf is `floci-server.{crt,key}`, issued by the CA with `serverAuth`. It is published as the Quarkus TLS registry's default entry (`quarkus.tls.key-store.pem.0.*`) instead of the legacy `quarkus.http.ssl.certificate.*` keys, which is what makes a runtime reload possible later. A pre-CA self-signed leaf, a leaf from a regenerated CA, or an expired leaf is replaced on boot. The server key is written owner-only.
- `GET /_floci/ca.pem` (and `/_localstack/ca.pem`) serves the CA as `text/plain`.
- Lambda container trust injection now mounts the CA, not the leaf.
- `docs/configuration/tls.md`: trust the CA once (`AWS_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`, `SSL_CERT_FILE`, or the login keychain) instead of disabling verification. The plain-HTTP download is for loopback; other hosts copy the file out of band and compare the logged fingerprint.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| Local CA | Create, persist, reload | ✅ | Same CA across restarts. Directory `rwx------`, key `rw-------`. |
| Local CA | Unusable pair | ✅ | Regenerated with a WARN that names the reason. Never a silent fallback to a self-signed leaf. |
| Local CA | Fingerprint | ✅ | The SHA-256 fingerprint is logged at startup, in the form `openssl x509 -fingerprint -sha256` prints, so a copy obtained out of band can be checked. |
| Local CA | File systems without POSIX permissions | 🟡 | The key is written with default permissions and a WARN asks the operator to restrict it. No ACL handling. |
| Local CA | Bring your own CA | 🟡 | Any CA certificate and matching key dropped into `tls/floci-root-ca.{crt,key}` is used as is. Not documented as a feature yet. |
| Server certificate | Issued by the CA, `serverAuth` and `clientAuth` EKU | ✅ | Same SAN list as before, same hostname change detection. |
| Server certificate | Published through the TLS registry | ✅ | `quarkus.tls.key-store.pem.0.cert` and `.key`. The HTTP server reads the default entry when no `quarkus.http.tls-configuration-name` is set. |
| Server certificate | Runtime reload of the leaf | ❌ | Follow-up. This change only makes it possible. |
| Server certificate | User-provided `FLOCI_TLS_CERT_PATH` | ✅ | Unchanged. No CA or leaf is generated in that mode. |
| `GET /_floci/ca.pem` | Trust anchor in PEM, `text/plain` | ✅ | The local CA. With a user-provided certificate it is a bundle: that certificate file first (the same file the Lambda launcher mounts), then the local CA, which still signs what Floci itself issues. Also on `/_localstack/ca.pem`. |
| Lambda containers | Trust anchor mounted at `/etc/floci-ca.crt` | ✅ | Now the CA file. `NODE_EXTRA_CA_CERTS` and `AWS_CA_BUNDLE` unchanged. |
| ACM and IoT certificates | Issued by the same CA | ❌ | Follow-ups. |

## Files

- `config/FlociCertificateAuthority` (new), `config/FlociCertificateAuthorityProducer` (new), `config/TlsConfigSource`, `lifecycle/EmulatorInfoController`, `lambda/launcher/ContainerLauncher`, `EmulatorConfig` javadoc, `application.yml` comment.
- `docs/configuration/tls.md` rewritten; one line each in `environment-variables.md` and `application-yml.md`.
- Tests: `FlociCertificateAuthorityTest` (new, 12 cases: create, reload, permissions, fingerprint, corrupt, expired, mismatched key, missing key, leaf in place of the CA, server and client leaves, forged issuer), `FlociCertificateAuthorityProducerTest` (new: the producer uses the bootstrap directory, or the configured path when TLS is off), `TlsLocalCaIntegrationTest` (new: Quarkus boots on the registry keys and a handshake succeeds trusting only the served `ca.pem`, and fails trusting another CA), four new `TlsCertificateHostnameTest` cases (issued by the CA, legacy leaf replaced, expired leaf replaced, leaf replaced when the CA changes), `EmulatorInfoControllerIntegrationTest#caPem`, `TlsUserCertIntegrationTest#caPemReturnsTheUserCertificateFollowedByTheLocalCa`, `TlsCertificateHostnameTest#resolvedTlsDirIsClearedByABootThatDoesNotIssueALeaf`, `ContainerLauncherCaTrustTest` updated. The five existing `TlsConfigSource*Test` classes only change the on-disk file name.

## Behaviour change for existing installs

The first boot after upgrade generates the CA and a new server certificate and logs where the CA is. Anyone who had trusted `floci-selfsigned.crt` must trust `floci-root-ca.crt` instead. The old `floci-selfsigned.*` files are left in place.

### Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [x] Docs / chore

### Checklist

* [ ] `./mvnw test` passes locally. Ran per class instead: `FlociCertificateAuthorityTest`, `TlsConfigSource*Test`, `TlsCertificateHostnameTest`, `TlsIntegrationTest`, `TlsUserCertIntegrationTest`, `TlsProxyServerTest`, `TlsLocalCaIntegrationTest`, `EmulatorInfoControllerIntegrationTest`, `ContainerLauncherCaTrustTest`, `CertificateGenerator*Test`, `RdsProxyTls*Test` (149 tests, all green), plus the full suite once on the stack. `make docs-check` passes. Also verified by hand against a packaged jar with `FLOCI_TLS_ENABLED=true`: `curl --cacert ca.pem https://localhost:4599/_floci/health` succeeds, `openssl s_client` reports the served leaf as issued by `CN=Floci Local CA` with `Verify return code: 0`, the key files are `rw-------`, and the fingerprint in the startup log equals `openssl x509 -fingerprint -sha256` of the downloaded file.
* [x] New or updated integration test added
* [x] Commit messages follow Conventional Commits

## Stacked pull requests

| PR | Title | Adds |
| --- | --- | --- |
| #3079 | `feat(iot): real device certificates issued by the local CA` | IoT device certificates signed by this CA |
| #3080 | `feat(acm): issue certificates from the local CA` | ACM certificates signed by this CA, with the CA as `CertificateChain` |
| #3084 | `feat(tls): serve exact hostnames as custom domains are created` | Hostnames added to the server certificate at runtime, reissued by this CA with the same key |
| #3091 | `feat(docker): containers Floci launches trust the Floci CA` | A CA bundle (public roots plus this CA) copied into every container Floci launches, with the trust variables pointing at it |


