### PR TITLE
perf(docker): shrink image by 28% using ubi9-micro (109 MB to 78 MB compressed)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !bin/awslocal
 !docker/entrypoint.sh
 !docker/localstack-parity.sh
+!docker/healthcheck.sh
 !pom.xml
 !src/**
 !target/*.so

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -9,6 +9,7 @@ on:
       - 'docker/Dockerfile.compat'
       - 'docker/entrypoint.sh'
       - 'docker/localstack-parity.sh'
+      - 'docker/healthcheck.sh'
       - 'compatibility-tests/**'
       - '.github/ci/compat-timing-report.py'
       - '.github/ci/compat-opentofu-drift-check.py'
@@ -41,11 +42,15 @@ jobs:
           build-args: VERSION=latest
           load: true
           tags: floci-compat-shim-test
+          # The tools stage has the aws CLI and the shim. The final stage only adds
+          # the Floci binary copied out of a published floci/floci tag, which these
+          # tests never start.
+          target: tools
           # Read-only; warm-compat-caches.yml produces this scope on main. Unlike
-          # floci-native above, these layers are worth caching: the image builds
-          # FROM a published floci/floci tag and its cost is a microdnf install
-          # that changes only when the Dockerfile does. Writing from here would
-          # put a per-PR copy no other PR can read back into the budget.
+          # floci-native above, these layers are worth caching: the tools stage
+          # depends only on ubi9-minimal and the Dockerfile, so it changes only
+          # when the Dockerfile does. Writing from here would put a per-PR copy
+          # no other PR can read back into the budget.
           cache-from: type=gha,scope=compat-shim
 
       - name: Unflagged aws sqs call routes to AWS_ENDPOINT_URL

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -42,16 +42,26 @@ jobs:
           build-args: VERSION=latest
           load: true
           tags: floci-compat-shim-test
-          # The tools stage has the aws CLI and the shim. The final stage only adds
-          # the Floci binary copied out of a published floci/floci tag, which these
-          # tests never start.
-          target: tools
-          # Read-only; warm-compat-caches.yml produces this scope on main. Unlike
-          # floci-native above, these layers are worth caching: the tools stage
-          # depends only on ubi9-minimal and the Dockerfile, so it changes only
-          # when the Dockerfile does. Writing from here would put a per-PR copy
-          # no other PR can read back into the budget.
+          # Read-only; warm-compat-caches.yml produces this scope on main from the
+          # tools stage. Unlike floci-native above, those layers are worth caching:
+          # the tools stage depends only on ubi9-minimal and the Dockerfile, so it
+          # changes only when the Dockerfile does. The final stage copies the binary
+          # out of the published floci/floci:latest and is never cacheable. Writing
+          # from here would put a per-PR copy no other PR can read back into the
+          # budget.
           cache-from: type=gha,scope=compat-shim
+
+      - name: Compat image starts and reports healthy
+        run: |
+          docker run -d --name compat-smoke floci-compat-shim-test
+          for _ in $(seq 1 30); do
+            health=$(docker inspect -f '{{.State.Health.Status}}' compat-smoke)
+            [ "$health" = healthy ] && break
+            sleep 1
+          done
+          docker logs compat-smoke 2>&1 | tail -20
+          docker rm -f compat-smoke >/dev/null
+          [ "$health" = healthy ] || { echo "::error::compat image did not become healthy: $health"; exit 1; }
 
       - name: Unflagged aws sqs call routes to AWS_ENDPOINT_URL
         run: |

--- a/.github/workflows/warm-compat-caches.yml
+++ b/.github/workflows/warm-compat-caches.yml
@@ -100,10 +100,10 @@ jobs:
   shim:
     name: warm / compat-shim
     # Produces the scope that compatibility.yml's compat-aws-cli-shim job reads.
-    # Worth warming, unlike floci-native: this image builds FROM a published
-    # floci/floci tag and its cost is a microdnf install of python3/pip/unzip that
-    # changes only when the Dockerfile does — genuinely stable layers, with nothing
-    # volatile above them.
+    # Worth warming, unlike floci-native: the tools stage of Dockerfile.compat is a
+    # microdnf install of python3/pip/unzip plus the aws CLI, and it depends only on
+    # ubi9-minimal and the Dockerfile. Genuinely stable layers. The final stage,
+    # which copies the binary out of a published floci/floci tag, is left out.
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
 
@@ -118,9 +118,10 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.compat
-          # Must match the consumer's build-args, or the layers key differently
-          # and the warm is silently useless (compatibility.yml:38).
+          # Must match the consumer's build-args and target, or the layers key
+          # differently and the warm is silently useless (compatibility.yml:38).
           build-args: VERSION=latest
+          target: tools
           # No `load:` — the image is discarded; only the cache is wanted.
           cache-from: type=gha,scope=compat-shim
           cache-to: type=gha,scope=compat-shim,mode=max

--- a/.github/workflows/warm-compat-caches.yml
+++ b/.github/workflows/warm-compat-caches.yml
@@ -118,8 +118,9 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile.compat
-          # Must match the consumer's build-args and target, or the layers key
-          # differently and the warm is silently useless (compatibility.yml:38).
+          # Must match the consumer's build-args, or the layers key differently
+          # and the warm is silently useless (compatibility.yml:38). The consumer
+          # builds the whole image; its tools layers key the same as this target.
           build-args: VERSION=latest
           target: tools
           # No `load:` — the image is discarded; only the cache is wanted.

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -93,7 +93,9 @@ ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 COPY --from=native --chown=1001:root /app/ /app/
 VOLUME /app/data
 
-COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/localstack-parity.sh /usr/local/bin/healthcheck.sh /usr/local/bin/
+COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/localstack-parity.sh /usr/local/bin/
+# From the build context, not the native image: a published native image may predate the script.
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/
 
 EXPOSE 4566
 

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -3,18 +3,13 @@ ARG VERSION=latest
 # tags use VERSION; reusable builds override BASE_IMAGE with the digest-qualified
 # native image they just published.
 #
-# That image is ubi9-micro and has no package manager, so this image cannot extend
-# it. It starts from ubi9-minimal, copies /app and the entrypoint scripts out of the
-# native image, and repeats what the native image declares (user, env, volume,
-# healthcheck, entrypoint, labels).
+# That image is ubi9-micro and has no package manager, so this image cannot extend it.
 ARG BASE_IMAGE=floci/floci:${VERSION}
 FROM ${BASE_IMAGE} AS native
 
-FROM registry.access.redhat.com/ubi9-minimal:9.7
-
-ARG VERSION
-ENV FLOCI_VERSION=${VERSION}
-ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
+# Everything that does not depend on the Floci version. CI builds this stage alone
+# (target: tools) to test the aws CLI shim and to warm the layer cache.
+FROM registry.access.redhat.com/ubi9-minimal:9.7 AS tools
 
 LABEL org.opencontainers.image.title="Floci (compat)" \
       org.opencontainers.image.description="Floci compatibility image with AWS CLI and boto3 pre-installed" \
@@ -86,20 +81,23 @@ RUN mkdir -p /etc/localstack/init/boot.d /etc/localstack/init/start.d /etc/local
     && chown -R 1001:root /etc/localstack /etc/floci
 
 WORKDIR /app
-# Ownership and group bits go on the empty directory first. A chmod after the copy
-# would rewrite the 200 MB binary into a second layer.
-RUN mkdir -p /app/data \
-    && chown -R 1001:root /app \
-    && chmod -R g+rwX /app
+# A chmod after the copy below would rewrite the 200 MB binary into a second layer.
+RUN chown 1001:root /app && chmod g+rwX /app
+
+FROM tools
+
+ARG VERSION
+ENV FLOCI_VERSION=${VERSION}
+ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
+
 COPY --from=native --chown=1001:root /app/ /app/
 VOLUME /app/data
 
-COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/localstack-parity.sh /usr/local/bin/
+COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/localstack-parity.sh /usr/local/bin/healthcheck.sh /usr/local/bin/
 
 EXPOSE 4566
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD curl -f http://localhost:4566/_floci/health || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,16 +1,37 @@
 ARG VERSION=latest
-# This must be the UBI-based image produced by Dockerfile.native-package.
-# Release and nightly tags use VERSION; reusable builds override BASE_IMAGE
-# with the digest-qualified native image they just published.
+# BASE_IMAGE is the image produced by Dockerfile.native-package. Release and nightly
+# tags use VERSION; reusable builds override BASE_IMAGE with the digest-qualified
+# native image they just published.
+#
+# That image is ubi9-micro and has no package manager, so this image cannot extend
+# it. It starts from ubi9-minimal, copies /app and the entrypoint scripts out of the
+# native image, and repeats what the native image declares (user, env, volume,
+# healthcheck, entrypoint, labels).
 ARG BASE_IMAGE=floci/floci:${VERSION}
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS native
+
+FROM registry.access.redhat.com/ubi9-minimal:9.7
+
+ARG VERSION
+ENV FLOCI_VERSION=${VERSION}
+ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
 LABEL org.opencontainers.image.title="Floci (compat)" \
       org.opencontainers.image.description="Floci compatibility image with AWS CLI and boto3 pre-installed" \
       org.opencontainers.image.url="https://floci.io" \
       org.opencontainers.image.source="https://github.com/floci-io/floci" \
       org.opencontainers.image.licenses="MIT" \
-      org.opencontainers.image.vendor="Floci"
+      org.opencontainers.image.vendor="Floci" \
+      description="Floci compatibility image with AWS CLI and boto3 pre-installed" \
+      io.k8s.description="Floci compatibility image with AWS CLI and boto3 pre-installed" \
+      io.k8s.display-name="Floci (compat)" \
+      io.openshift.expose-services="4566:tcp" \
+      io.openshift.tags="floci aws-emulator" \
+      maintainer="Floci <https://github.com/floci-io/floci>" \
+      name="floci/floci" \
+      summary="Floci compatibility image with AWS CLI and boto3 pre-installed" \
+      url="https://floci.io" \
+      vendor="Floci"
 
 ENV AWS_DEFAULT_REGION=us-east-1
 ENV AWS_ACCESS_KEY_ID=test
@@ -36,8 +57,8 @@ ENV AWS_PAGER=""
 # a v2 install against real AWS. A hook passing raw bytes (e.g.
 # aws lambda invoke --payload) needs --cli-binary-format raw-in-base64-out.
 ARG AWSCLI_VERSION=2.36.24
-USER root
-RUN microdnf install -y --nodocs python3 python3-pip unzip \
+RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci \
+    && microdnf install -y --nodocs python3 python3-pip unzip \
     && pip3 install --no-cache-dir boto3 \
     && case "$(uname -m)" in \
          x86_64)  arch=x86_64 ;; \
@@ -63,5 +84,24 @@ RUN chmod +x /usr/local/bin/awslocal
 RUN mkdir -p /etc/localstack/init/boot.d /etc/localstack/init/start.d /etc/localstack/init/ready.d \
              /etc/floci/init/boot.d /etc/floci/init/start.d /etc/floci/init/ready.d \
     && chown -R 1001:root /etc/localstack /etc/floci
+
+WORKDIR /app
+# Ownership and group bits go on the empty directory first. A chmod after the copy
+# would rewrite the 200 MB binary into a second layer.
+RUN mkdir -p /app/data \
+    && chown -R 1001:root /app \
+    && chmod -R g+rwX /app
+COPY --from=native --chown=1001:root /app/ /app/
+VOLUME /app/data
+
+COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/localstack-parity.sh /usr/local/bin/
+
+EXPOSE 4566
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD curl -f http://localhost:4566/_floci/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]
 
 USER 1001

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -13,41 +13,11 @@ COPY src ./src
 
 RUN mvn clean package -Dnative -DskipTests -B
 
-# See: https://www.redhat.com/en/blog/build-ubi-micro-images
-FROM registry.access.redhat.com/ubi9:9.7 AS tools
+# Stage 2: Minimal runtime. Same base and user setup as Dockerfile.native-package.
+FROM registry.access.redhat.com/ubi9-micro:9.7
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
-
-RUN set -eux; \
-    mkdir -p /toolsroot; \
-    dnf install -y --installroot=/toolsroot --releasever=9 \
-        --setopt=install_weak_deps=0 --nodocs \
-        shadow-utils; \
-    dnf -y --installroot=/toolsroot clean all; \
-    rm -rf /toolsroot/var/cache/* /toolsroot/var/log/dnf* /toolsroot/var/log/yum* \
-           /toolsroot/var/lib/rpm /toolsroot/var/lib/dnf; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    mkdir -p /toolsroot/usr/local/bin; \
-    curl -fsSL -o /toolsroot/usr/local/bin/gosu \
-        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /toolsroot/usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /toolsroot/usr/local/bin/gosu
-
-# Stage 3: Minimal runtime
-FROM quay.io/quarkus/quarkus-micro-image:2.0
-
-USER root
 WORKDIR /app
-COPY --from=tools /toolsroot/ /
-
-RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd
 
 RUN mkdir -p /app/data \
     && chown -R 1001:root /app \
@@ -57,7 +27,7 @@ VOLUME /app/data
 EXPOSE 4566
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD bash -c 'echo -e "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" > /dev/tcp/localhost/4566' || exit 1
+    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/4566 && printf "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && read -r proto status rest <&3 && [ "$status" = 200 ]'
 
 ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -17,17 +17,15 @@ RUN mvn clean package -Dnative -DskipTests -B
 FROM registry.access.redhat.com/ubi9-micro:9.7
 
 WORKDIR /app
-RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd
-
-RUN mkdir -p /app/data \
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd \
+    && mkdir -p /app/data \
     && chown -R 1001:root /app \
     && chmod -R g+rwX /app
 VOLUME /app/data
 
 EXPOSE 4566
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/4566 && printf "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && read -r proto status rest <&3 && [ "$status" = 200 ]'
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}
@@ -35,7 +33,7 @@ ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
 COPY --chmod=755 --from=build /app/target/*-runner /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh
+COPY --chmod=755 docker/localstack-parity.sh docker/healthcheck.sh /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -1,29 +1,26 @@
 FROM registry.access.redhat.com/ubi9-micro:9.7
 
-ARG VERSION=latest
 # Automatically set by Docker BuildKit to "amd64" or "arm64"
 ARG TARGETARCH
 
-ENV FLOCI_VERSION=${VERSION}
-ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
-
-# ubi9-micro has no package manager and no shadow-utils, so the runtime user is one
-# /etc/passwd line. The entrypoint drops privileges with coreutils `chroot --userspec`
-# and adds the Docker socket's group with `chroot --groups`; both ship in the base image.
-RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd
-
 WORKDIR /app
 
-RUN mkdir -p /app/data \
+# ubi9-micro has no shadow-utils, so the runtime user is one /etc/passwd line.
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd \
+    && mkdir -p /app/data \
     && chown -R 1001:root /app \
     && chmod -R g+rwX /app
 
 VOLUME /app/data
 
-COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
-
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-COPY --chmod=755 docker/localstack-parity.sh /usr/local/bin/localstack-parity.sh
+COPY --chmod=755 docker/localstack-parity.sh docker/healthcheck.sh /usr/local/bin/
+
+ARG VERSION=latest
+ENV FLOCI_VERSION=${VERSION}
+ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
+
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 LABEL org.opencontainers.image.title="Floci" \
       org.opencontainers.image.description="Local AWS emulator — open-source alternative to LocalStack Community" \
@@ -44,9 +41,7 @@ LABEL org.opencontainers.image.title="Floci" \
 
 EXPOSE 4566
 
-# No curl in ubi9-micro, so bash does the HTTP probe.
-HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/4566 && printf "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && read -r proto status rest <&3 && [ "$status" = 200 ]'
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-minimal:9.7
+FROM registry.access.redhat.com/ubi9-micro:9.7
 
 ARG VERSION=latest
 # Automatically set by Docker BuildKit to "amd64" or "arm64"
@@ -7,12 +7,10 @@ ARG TARGETARCH
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
-# ubi9-minimal already ships shadow-utils (useradd) and coreutils (chroot), so no package is
-# installed and no binary is downloaded: the entrypoint drops privileges with
-# `chroot --userspec`, which replaces gosu, and adds the Docker socket's group with
-# `chroot --groups`, which replaces the runtime usermod. Measured on 2.0.1 the layer this
-# replaces was 3.66 MB compressed and 19 MB on disk.
-RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
+# ubi9-micro has no package manager and no shadow-utils, so the runtime user is one
+# /etc/passwd line. The entrypoint drops privileges with coreutils `chroot --userspec`
+# and adds the Docker socket's group with `chroot --groups`; both ship in the base image.
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd
 
 WORKDIR /app
 
@@ -46,8 +44,9 @@ LABEL org.opencontainers.image.title="Floci" \
 
 EXPOSE 4566
 
+# No curl in ubi9-micro, so bash does the HTTP probe.
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD curl -f http://localhost:4566/_floci/health || exit 1
+    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/4566 && printf "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && read -r proto status rest <&3 && [ "$status" = 200 ]'
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Container health probe. Bash only, because ubi9-micro has no curl.
+exec 3<>/dev/tcp/127.0.0.1/4566 || exit 1
+printf 'GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3
+read -r _proto status _rest <&3
+[ "$status" = 200 ]

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -13,6 +13,8 @@ Every image tag combines two independent choices: **what's inside** (variant) an
 
 The compat image runs the same native binary as the standard image, so startup time and memory footprint are identical. Only the image size increases.
 
+The standard image is built on Red Hat UBI 9 micro. Besides Floci it contains only bash and coreutils. There is no package manager, curl, grep or sed inside. Pick the compat image when you need tools inside the container.
+
 ## Axis 2: Channel (how stable)
 
 | Channel | Source | Published |

--- a/docs/configuration/docker-images.md
+++ b/docs/configuration/docker-images.md
@@ -11,7 +11,7 @@ Every image tag combines two independent choices: **what's inside** (variant) an
 | **Standard** | Floci native binary only | General use: CI, local dev, Testcontainers **(recommended)** |
 | **Compat** | Floci + Python 3 + AWS CLI + boto3 | Workflows that need AWS tooling available inside the container |
 
-The compat image is built on top of the standard image, so startup time and memory footprint are identical. Only the image size increases.
+The compat image runs the same native binary as the standard image, so startup time and memory footprint are identical. Only the image size increases.
 
 ## Axis 2: Channel (how stable)
 
@@ -119,7 +119,7 @@ ghcr.io/example/floci@sha256:...
 
 ## What's in the Compat Image
 
-The compat image installs the following on top of the standard image:
+The compat image adds the following to the standard image contents:
 
 - Python 3 + pip
 - [AWS CLI](https://pypi.org/project/awscli/) (via pip)


### PR DESCRIPTION
## Summary

The native image (aarch64) size is cut by 28%:

Format | BEFORE | AFTER | Change
---|---:|---:|---:
Uncompressed | 313.4 MB | 228.7 MB | -84.7 MB (-27%)
GZIP | 105.1 MB | 75.3 MB | -29.8 MB  (-28%)

The binary needs only libc and the loader, and since #3037 the entrypoint needs only bash and coreutils.
[ubi9-micro](https://catalog.redhat.com/en/software/containers/ubi9/ubi-micro/615bdf943f6014fa45ae1b58) has all of that at 7 MB.

What changed to make ubi9-micro work.

- No useradd in ubi9-micro, so the user is one /etc/passwd line
- No curl, so the healthcheck is docker/healthcheck.sh (a bash /dev/tcp probe)
- Dockerfile.native still had a gosu tools stage that nothing calls since #3037, so its runtime stage is now the same as Dockerfile.native-package.
- Dockerfile.compat needs microdnf, so it starts from ubi9-minimal and copies /app out of the native image (no size change, no layer share)
- The compat install layer would rebuild on every version, so it lives in a tools stage and the cache warm job builds 1target: tools1. The PR shim job builds the whole image and checks that it starts healthy

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No surface changes.
Verified on mac aarch64 image.
Container healthy in 6 s, 102 services running, PID 1 is uid 1001 gid 0, /app/data writable.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

