### PR TITLE
fix(dynamodb): append list values for out-of-range indexes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -2552,8 +2552,10 @@ public class DynamoDbService implements ResourceProvider {
         }
         return tokens;
     }
-    // Sets an existing list element or appends the value when the index is past the end.
-    // Pads arr with NULL elements up to idx-1, then sets/appends value at idx.
+    /**
+     * Replaces the element at idx when the index is within the list bounds;
+     * otherwise appends the value to the end of the list.
+    */
 
     private void setOrAppend(ArrayNode arr, long idx, JsonNode value) {
         if (idx < arr.size()) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -106,6 +106,7 @@ public class DynamoDbService implements ResourceProvider {
     private DynamoDbStreamService streamService;
     private KinesisStreamingForwarder kinesisForwarder;
     private S3Service s3Service;
+    private static final long MAX_DYNAMODB_LIST_INDEX = 4_294_967_294L;
 
     @Inject
     public DynamoDbService(StorageFactory storageFactory, RegionResolver regionResolver,
@@ -2499,51 +2500,82 @@ public class DynamoDbService implements ResourceProvider {
     }
 
     // Tokenizes a DynamoDB path like "a.b[0].c" or "#l[5]" into a list of
-    // String (attr name) and Integer (list index) tokens.
+    // String (attr name) and Long (list index) tokens.
     private List<Object> parsePath(String path, JsonNode exprAttrNames) {
         List<Object> tokens = new ArrayList<>();
         for (String dotSeg : path.split("\\.")) {
             dotSeg = dotSeg.trim();
             if (dotSeg.isEmpty()) continue;
+
             int brk = dotSeg.indexOf('[');
             if (brk < 0) {
                 tokens.add(resolveAttributeName(dotSeg, exprAttrNames));
             } else {
                 String namePart = dotSeg.substring(0, brk);
-                if (!namePart.isEmpty()) tokens.add(resolveAttributeName(namePart, exprAttrNames));
+                if (!namePart.isEmpty()) {
+                    tokens.add(resolveAttributeName(namePart, exprAttrNames));
+                }
+
                 String rest = dotSeg.substring(brk);
                 int p = 0;
+
                 while (p < rest.length() && rest.charAt(p) == '[') {
                     int close = rest.indexOf(']', p);
                     if (close < 0) break;
-                    tokens.add(Integer.parseInt(rest.substring(p + 1, close)));
+
+                    String indexText = rest.substring(p + 1, close);
+
+                    final long index;
+                    try {
+                        index = Long.parseLong(indexText);
+                    } catch (NumberFormatException e) {
+                        throw new AwsException(
+                                "ValidationException",
+                                "Invalid list index: " + indexText,
+                                400);
+                    }
+
+                    if (index < 0 || index > MAX_DYNAMODB_LIST_INDEX) {
+                        throw new AwsException(
+                                "ValidationException",
+                                "1 validation error detected: Invalid UpdateExpression: "
+                                        + "List index is not within the allowable range; index: ["
+                                        + indexText
+                                        + "]. The maximum allowed index is 4294967294",
+                                400);
+                    }
+
+                    tokens.add(index);
                     p = close + 1;
                 }
             }
         }
         return tokens;
     }
-
+    // Sets an existing list element or appends the value when the index is past the end.
     // Pads arr with NULL elements up to idx-1, then sets/appends value at idx.
-    private void padAndSet(ArrayNode arr, int idx, JsonNode value) {
-        ObjectNode nullNode =
-                JsonNodeFactory.instance.objectNode();
-        nullNode.put("NULL", true);
-        while (arr.size() < idx) arr.add(nullNode.deepCopy());
-        if (idx < arr.size()) arr.set(idx, value);
-        else arr.add(value);
-    }
 
+    private void setOrAppend(ArrayNode arr, long idx, JsonNode value) {
+        if (idx < arr.size()) {
+            arr.set((int) idx, value);
+        } else {
+            arr.add(value);
+        }
+    }
+    
     private void setValueAtPath(ObjectNode item, String path, JsonNode value, JsonNode exprAttrNames) {
         List<Object> tokens = parsePath(path, exprAttrNames);
         if (tokens.isEmpty()) return;
 
         if (tokens.size() == 1) {
-            if (tokens.get(0) instanceof String attrName) item.set(attrName, value);
+            if (tokens.get(0) instanceof String attrName) {
+                item.set(attrName, value);
+            }
             return;
         }
 
         JsonNode container = item;
+
         for (int i = 0; i < tokens.size() - 1; i++) {
             Object tok = tokens.get(i);
             Object nextTok = tokens.get(i + 1);
@@ -2551,70 +2583,124 @@ public class DynamoDbService implements ResourceProvider {
 
             if (tok instanceof String attrName) {
                 if (!(container instanceof ObjectNode obj)) return;
+
                 JsonNode child = obj.get(attrName);
+
                 if (last) {
                     if (nextTok instanceof String finalAttr) {
                         if (child == null) {
                             ObjectNode newMap = objectMapper.createObjectNode();
                             newMap.set(finalAttr, value);
+
                             ObjectNode wrapper = objectMapper.createObjectNode();
                             wrapper.set("M", newMap);
+
                             obj.set(attrName, wrapper);
                         } else if (!child.has("M")) {
-                            throw new AwsException("ValidationException",
-                                    "The document path provided in the update expression is invalid for update", 400);
+                            throw new AwsException(
+                                    "ValidationException",
+                                    "The document path provided in the update expression is invalid for update",
+                                    400);
                         } else {
                             ((ObjectNode) child.get("M")).set(finalAttr, value);
                         }
-                    } else if (nextTok instanceof Integer finalIdx) {
-                        if (child == null || !child.has("L")) throw new AwsException("ValidationException",
-                                "The document path provided in the update expression is invalid for update", 400);
-                        padAndSet((ArrayNode) child.get("L"), finalIdx, value);
+                    } else if (nextTok instanceof Long finalIdx) {
+                        if (child == null || !child.has("L")) {
+                            throw new AwsException(
+                                    "ValidationException",
+                                    "The document path provided in the update expression is invalid for update",
+                                    400);
+                        }
+
+                        setOrAppend((ArrayNode) child.get("L"), finalIdx, value);
                     }
+
                     return;
                 }
+
                 if (nextTok instanceof String) {
                     if (child == null) {
                         ObjectNode newMap = objectMapper.createObjectNode();
                         ObjectNode wrapper = objectMapper.createObjectNode();
                         wrapper.set("M", newMap);
                         obj.set(attrName, wrapper);
+
                         container = newMap;
                     } else if (!child.has("M")) {
-                        throw new AwsException("ValidationException",
-                                "The document path provided in the update expression is invalid for update", 400);
+                        throw new AwsException(
+                                "ValidationException",
+                                "The document path provided in the update expression is invalid for update",
+                                400);
                     } else {
                         container = child.get("M");
                     }
-                } else if (nextTok instanceof Integer) {
-                    if (child == null || !child.has("L")) throw new AwsException("ValidationException",
-                            "The document path provided in the update expression is invalid for update", 400);
+
+                } else if (nextTok instanceof Long) {
+                    if (child == null || !child.has("L")) {
+                        throw new AwsException(
+                                "ValidationException",
+                                "The document path provided in the update expression is invalid for update",
+                                400);
+                    }
+
                     container = child.get("L");
                 }
-            } else if (tok instanceof Integer listIdx) {
+
+            } else if (tok instanceof Long listIdx) {
                 if (!(container instanceof ArrayNode arr)) return;
-                if (listIdx >= arr.size()) throw new AwsException("ValidationException",
-                        "The document path provided in the update expression is invalid for update", 400);
-                JsonNode element = arr.get(listIdx);
+
+                if (listIdx >= arr.size()) {
+                    throw new AwsException(
+                            "ValidationException",
+                            "The document path provided in the update expression is invalid for update",
+                            400);
+                }
+
+                JsonNode element = arr.get(listIdx.intValue());
+
                 if (last) {
                     if (nextTok instanceof String finalAttr) {
-                        if (!element.has("M")) throw new AwsException("ValidationException",
-                                "The document path provided in the update expression is invalid for update", 400);
+                        if (!element.has("M")) {
+                            throw new AwsException(
+                                    "ValidationException",
+                                    "The document path provided in the update expression is invalid for update",
+                                    400);
+                        }
+
                         ((ObjectNode) element.get("M")).set(finalAttr, value);
-                    } else if (nextTok instanceof Integer finalIdx) {
-                        if (!element.has("L")) throw new AwsException("ValidationException",
-                                "The document path provided in the update expression is invalid for update", 400);
-                        padAndSet((ArrayNode) element.get("L"), finalIdx, value);
+
+                    } else if (nextTok instanceof Long finalIdx) {
+                        if (!element.has("L")) {
+                            throw new AwsException(
+                                    "ValidationException",
+                                    "The document path provided in the update expression is invalid for update",
+                                    400);
+                        }
+
+                        setOrAppend((ArrayNode) element.get("L"), finalIdx, value);
                     }
+
                     return;
                 }
+
                 if (nextTok instanceof String) {
-                    if (!element.has("M")) throw new AwsException("ValidationException",
-                            "The document path provided in the update expression is invalid for update", 400);
+                    if (!element.has("M")) {
+                        throw new AwsException(
+                                "ValidationException",
+                                "The document path provided in the update expression is invalid for update",
+                                400);
+                    }
+
                     container = element.get("M");
-                } else if (nextTok instanceof Integer) {
-                    if (!element.has("L")) throw new AwsException("ValidationException",
-                            "The document path provided in the update expression is invalid for update", 400);
+
+                } else if (nextTok instanceof Long) {
+                    if (!element.has("L")) {
+                        throw new AwsException(
+                                "ValidationException",
+                                "The document path provided in the update expression is invalid for update",
+                                400);
+                    }
+
                     container = element.get("L");
                 }
             }
@@ -2637,20 +2723,20 @@ public class DynamoDbService implements ResourceProvider {
                 if (nextTok instanceof String) {
                     if (!child.has("M")) return null;
                     current = child.get("M");
-                } else if (nextTok instanceof Integer) {
+                } else if (nextTok instanceof Long) {
                     if (!child.has("L")) return null;
                     current = child.get("L");
                 } else return null;
-            } else if (tok instanceof Integer listIdx) {
+            } else if (tok instanceof Long listIdx) {
                 if (!current.isArray() || listIdx >= current.size()) return null;
-                JsonNode element = current.get(listIdx);
+                JsonNode element = current.get(listIdx.intValue());
                 if (element == null) return null;
                 if (isLast) return element;
                 Object nextTok = tokens.get(i + 1);
                 if (nextTok instanceof String) {
                     if (!element.has("M")) return null;
                     current = element.get("M");
-                } else if (nextTok instanceof Integer) {
+                } else if (nextTok instanceof Long) {
                     if (!element.has("L")) return null;
                     current = element.get("L");
                 } else return null;
@@ -2668,11 +2754,14 @@ public class DynamoDbService implements ResourceProvider {
         if (tokens.isEmpty()) return;
 
         if (tokens.size() == 1) {
-            if (tokens.get(0) instanceof String attrName) item.remove(attrName);
+            if (tokens.get(0) instanceof String attrName) {
+                item.remove(attrName);
+            }
             return;
         }
 
         JsonNode container = item;
+
         for (int i = 0; i < tokens.size() - 1; i++) {
             Object tok = tokens.get(i);
             Object nextTok = tokens.get(i + 1);
@@ -2680,46 +2769,57 @@ public class DynamoDbService implements ResourceProvider {
 
             if (tok instanceof String attrName) {
                 if (!(container instanceof ObjectNode obj)) return;
+
                 JsonNode child = obj.get(attrName);
+
                 if (last) {
                     if (nextTok instanceof String finalAttr) {
                         if (child == null || !child.has("M")) return;
                         ((ObjectNode) child.get("M")).remove(finalAttr);
-                    } else if (nextTok instanceof Integer finalIdx) {
+                    } else if (nextTok instanceof Long finalIdx) {
                         if (child == null || !child.has("L")) return;
-                        ArrayNode lArr =
-                                (ArrayNode) child.get("L");
-                        if (finalIdx < lArr.size()) lArr.remove(finalIdx);
+
+                        ArrayNode lArr = (ArrayNode) child.get("L");
+                        if (finalIdx < lArr.size()) {
+                            lArr.remove(finalIdx.intValue());
+                        }
                     }
                     return;
                 }
+
                 if (nextTok instanceof String) {
                     if (child == null || !child.has("M")) return;
                     container = child.get("M");
-                } else if (nextTok instanceof Integer) {
+                } else if (nextTok instanceof Long) {
                     if (child == null || !child.has("L")) return;
                     container = child.get("L");
                 }
-            } else if (tok instanceof Integer listIdx) {
+
+            } else if (tok instanceof Long listIdx) {
                 if (!(container instanceof ArrayNode arr)) return;
                 if (listIdx >= arr.size()) return;
-                JsonNode element = arr.get(listIdx);
+
+                JsonNode element = arr.get(listIdx.intValue());
+
                 if (last) {
                     if (nextTok instanceof String finalAttr) {
                         if (!element.has("M")) return;
                         ((ObjectNode) element.get("M")).remove(finalAttr);
-                    } else if (nextTok instanceof Integer finalIdx) {
+                    } else if (nextTok instanceof Long finalIdx) {
                         if (!element.has("L")) return;
-                        ArrayNode lArr =
-                                (ArrayNode) element.get("L");
-                        if (finalIdx < lArr.size()) lArr.remove(finalIdx);
+
+                        ArrayNode lArr = (ArrayNode) element.get("L");
+                        if (finalIdx < lArr.size()) {
+                            lArr.remove(finalIdx.intValue());
+                        }
                     }
                     return;
                 }
+
                 if (nextTok instanceof String) {
                     if (!element.has("M")) return;
                     container = element.get("M");
-                } else if (nextTok instanceof Integer) {
+                } else if (nextTok instanceof Long) {
                     if (!element.has("L")) return;
                     container = element.get("L");
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -1686,7 +1686,150 @@ class DynamoDbServiceTest {
         assertTrue(stored.get("isActive").get("BOOL").asBoolean(),
                 "isActive should still be true after get");
     }
+    
+    @Test
+    void updateItemSetListIndexPastEndAppendsWithoutNullPadding() {
+        String region = "eu-west-1";
+        createUsersTable(region);
 
+        ObjectNode initialItem = item("userId", "list-test");
+        ObjectNode listValue = mapper.createObjectNode();
+        var list = listValue.putArray("L");
+
+        list.add(attributeValue("S", "a"));
+        list.add(attributeValue("S", "b"));
+        initialItem.set("l", listValue);
+
+        service.putItem("Users", initialItem, region);
+
+        ObjectNode key = item("userId", "list-test");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":v", attributeValue("S", "c"));
+
+        DynamoDbService.UpdateResult result = service.updateItem(
+                "Users",
+                key,
+                null,
+                "SET l[10] = :v",
+                null,
+                exprValues,
+                "ALL_NEW",
+                region);
+
+        JsonNode updatedList = result.newItem().get("l").get("L");
+
+        assertEquals(3, updatedList.size());
+        assertEquals("a", updatedList.get(0).get("S").asText());
+        assertEquals("b", updatedList.get(1).get("S").asText());
+        assertEquals("c", updatedList.get(2).get("S").asText());
+    }
+    @Test
+    void updateItemSetHugeListIndexAppendsWithoutAllocatingPadding() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+
+        ObjectNode initialItem = item("userId", "huge-index-test");
+        ObjectNode listValue = mapper.createObjectNode();
+        var list = listValue.putArray("L");
+
+        list.add(attributeValue("S", "a"));
+        list.add(attributeValue("S", "b"));
+        initialItem.set("l", listValue);
+
+        service.putItem("Users", initialItem, region);
+
+        ObjectNode key = item("userId", "huge-index-test");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":v", attributeValue("S", "c"));
+
+        DynamoDbService.UpdateResult result = service.updateItem(
+                "Users",
+                key,
+                null,
+                "SET l[2000000000] = :v",
+                null,
+                exprValues,
+                "ALL_NEW",
+                region);
+
+        JsonNode updatedList = result.newItem().get("l").get("L");
+
+        assertEquals(3, updatedList.size());
+        assertEquals("c", updatedList.get(2).get("S").asText());
+    }
+    @Test
+    void updateItemSetMaximumValidListIndexAppends() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+
+        ObjectNode initialItem = item("userId", "max-index-test");
+        ObjectNode listValue = mapper.createObjectNode();
+        var list = listValue.putArray("L");
+
+        list.add(attributeValue("S", "a"));
+        list.add(attributeValue("S", "b"));
+        initialItem.set("l", listValue);
+
+        service.putItem("Users", initialItem, region);
+
+        ObjectNode key = item("userId", "max-index-test");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":v", attributeValue("S", "c"));
+
+        DynamoDbService.UpdateResult result = service.updateItem(
+                "Users",
+                key,
+                null,
+                "SET l[4294967294] = :v",
+                null,
+                exprValues,
+                "ALL_NEW",
+                region);
+
+        JsonNode updatedList = result.newItem().get("l").get("L");
+
+        assertEquals(3, updatedList.size());
+        assertEquals("c", updatedList.get(2).get("S").asText());
+    }
+    @Test
+    void updateItemSetListIndexAboveMaximumThrowsValidationException() {
+        String region = "eu-west-1";
+        createUsersTable(region);
+
+        ObjectNode initialItem = item("userId", "invalid-index-test");
+        ObjectNode listValue = mapper.createObjectNode();
+        var list = listValue.putArray("L");
+
+        list.add(attributeValue("S", "a"));
+        list.add(attributeValue("S", "b"));
+        initialItem.set("l", listValue);
+
+        service.putItem("Users", initialItem, region);
+
+        ObjectNode key = item("userId", "invalid-index-test");
+
+        ObjectNode exprValues = mapper.createObjectNode();
+        exprValues.set(":v", attributeValue("S", "c"));
+
+        AwsException exception = assertThrows(AwsException.class, () ->
+                service.updateItem(
+                        "Users",
+                        key,
+                        null,
+                        "SET l[4294967295] = :v",
+                        null,
+                        exprValues,
+                        "ALL_NEW",
+                        region));
+
+        assertEquals("ValidationException", exception.getErrorCode());
+        assertEquals(400, exception.getHttpStatus());
+        assertTrue(exception.getMessage().contains("List index is not within the allowable range"));
+        assertTrue(exception.getMessage().contains("4294967295"));
+    }
     /**
      * Test REMOVE with nested map paths (e.g. "ratings.foo").
      * Reproduces GitHub issue #402: REMOVE on a map key succeeds but data is unchanged.


### PR DESCRIPTION
## Summary

Fixes #3073.

- Make DynamoDB list indexes use `long` instead of `int`
- Append to the list when `SET` uses an index past the current list size
- Prevent large list indexes from allocating unnecessary NULL padding
- Reject indexes above DynamoDB's maximum allowed index with a ValidationException
- Add regression tests for out-of-range, huge, maximum-valid, and invalid indexes

## Testing

- `mvn -Dtest=DynamoDbServiceTest test`
- 112 tests passed