### PR TITLE
refactor(ses): move the tag dispatch helpers into their domain services

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.ses.model.CloudWatchDimensionConfigur
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
 import io.github.hectorvent.floci.services.ses.model.EventDestination;
 import io.github.hectorvent.floci.services.ses.model.SuppressionOptions;
+import io.github.hectorvent.floci.services.ses.model.Tag;
 import io.github.hectorvent.floci.services.ses.model.VdmOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -17,6 +18,7 @@ import org.jboss.logging.Logger;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -31,9 +33,9 @@ import java.util.regex.Pattern;
  * <p>The boundary follows the cross-domain seams: option validation that reads OTHER domains stays
  * in the facade (tracking options check a verified domain identity, delivery options check a
  * dedicated IP pool), which validates first (or resolves existence through {@link #get}) and then
- * mutates through {@link #save}. The facade also keeps the send-path reads (pause check, event
- * publishing, effective suppression reasons), the ARN-dispatched tagging, and the tenant
- * delete-guard around {@link #remove}.
+ * mutates through {@link #save}. The ARN-dispatched configuration-set tagging lives here; the
+ * facade keeps the send-path reads (pause check, event publishing, effective suppression reasons)
+ * and the tenant delete-guard around {@link #remove}.
  */
 @ApplicationScoped
 public class SesConfigurationSetService {
@@ -102,13 +104,42 @@ public class SesConfigurationSetService {
         LOG.infov("Deleted SES configuration set: {0} in region {1}", name, region);
     }
 
+    /** The ARN-dispatched tag operations, sharing the store behind {@code CreateConfigurationSet.Tags}. */
+    public List<Tag> listTags(String name, String region) {
+        return new ArrayList<>(requireForTags(name, region).getTags());
+    }
+
+    public void tag(String name, String region, List<Tag> newTags) {
+        ConfigurationSet cs = requireForTags(name, region);
+        cs.setTags(SesTags.merge(cs.getTags(), newTags));
+        configSetStore.put(configSetKey(region, name), cs);
+        LOG.infov("Tagged SES configuration set: {0} (region {1}, +{2} tags)", name, region, newTags.size());
+    }
+
+    public void untag(String name, String region, List<String> tagKeys) {
+        ConfigurationSet cs = requireForTags(name, region);
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        // Copy-on-write: the stored list may be immutable, and unlocked readers iterate it.
+        List<Tag> remaining = new ArrayList<>(cs.getTags());
+        remaining.removeIf(t -> toRemove.contains(t.key()));
+        cs.setTags(remaining);
+        configSetStore.put(configSetKey(region, name), cs);
+        LOG.infov("Untagged SES configuration set: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
+    }
+
+    private ConfigurationSet requireForTags(String name, String region) {
+        return configSetStore.get(configSetKey(region, name))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No ConfigurationSet present with name: " + name, 404));
+    }
+
     /** Reads without throwing on absence (the name is still validated, as the key derivation always
-     * has), for the facade's send-path and tagging lookups. */
+     * has), for the facade's send-path lookups. */
     public Optional<ConfigurationSet> find(String name, String region) {
         return configSetStore.get(configSetKey(region, name));
     }
 
-    /** Persists a configuration set the facade mutated (cross-domain option setters, tagging). */
+    /** Persists a configuration set the facade mutated (the cross-domain option setters). */
     public void save(ConfigurationSet configSet, String region) {
         configSetStore.put(configSetKey(region, configSet.getName()), configSet);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1483,13 +1483,13 @@ public class SesService {
         ResourceRef ref = parseSesArn(arn);
         requireCallerAccount(ref);
         List<Tag> tags = switch (ref.type()) {
-            case "configuration-set" -> listConfigurationSetTags(ref.name(), region);
-            case "template" -> listEmailTemplateTags(ref.name(), region);
+            case "configuration-set" -> configSetService.listTags(ref.name(), region);
+            case "template" -> templateService.listTags(ref.name(), region);
             case "identity" -> identityService.listTags(ref.name(), region);
             case "contact-list" -> contactService.listTags(ref.name(), region);
             case "custom-verification-email-template" -> cvetService.listTags(ref.name(), region);
             case "dedicated-ip-pool" -> dedicatedIpService.listTags(ref.name(), region);
-            case "tenant" -> listTenantTags(ref.name(), region);
+            case "tenant" -> tenantService.listTags(ref.name(), region);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         };
@@ -1514,13 +1514,13 @@ public class SesService {
         List<Tag> tags = newTags == null ? List.of() : newTags;
         SesTags.validate(tags);
         switch (ref.type()) {
-            case "configuration-set" -> tagConfigurationSet(ref.name(), region, tags);
-            case "template" -> tagEmailTemplate(ref.name(), region, tags);
+            case "configuration-set" -> configSetService.tag(ref.name(), region, tags);
+            case "template" -> templateService.tag(ref.name(), region, tags);
             case "identity" -> identityService.tag(ref.name(), region, tags);
             case "contact-list" -> contactService.tag(ref.name(), region, tags);
             case "custom-verification-email-template" -> cvetService.tag(ref.name(), region, tags);
             case "dedicated-ip-pool" -> dedicatedIpService.tag(ref.name(), region, tags);
-            case "tenant" -> tagTenant(ref.name(), region, tags);
+            case "tenant" -> tenantService.tag(ref.name(), region, tags);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         }
@@ -1541,13 +1541,13 @@ public class SesService {
             throw new AwsException("BadRequestException", "Failed to untag resource", 400);
         }
         switch (ref.type()) {
-            case "configuration-set" -> untagConfigurationSet(ref.name(), region, tagKeys);
-            case "template" -> untagEmailTemplate(ref.name(), region, tagKeys);
+            case "configuration-set" -> configSetService.untag(ref.name(), region, tagKeys);
+            case "template" -> templateService.untag(ref.name(), region, tagKeys);
             case "identity" -> identityService.untag(ref.name(), region, tagKeys);
             case "contact-list" -> contactService.untag(ref.name(), region, tagKeys);
             case "custom-verification-email-template" -> cvetService.untag(ref.name(), region, tagKeys);
             case "dedicated-ip-pool" -> dedicatedIpService.untag(ref.name(), region, tagKeys);
-            case "tenant" -> untagTenant(ref.name(), region, tagKeys);
+            case "tenant" -> tenantService.untag(ref.name(), region, tagKeys);
             default -> throw new AwsException("NotFoundException",
                     "Resource " + arn + " was not found.", 404);
         }
@@ -1557,91 +1557,8 @@ public class SesService {
     // first-slash split leaves "<name>/<tenantId>" as the resource name; the tenant domain owns
     // that remainder's decomposition and the id-only resolution (see SesTenantService.TenantTagArn).
 
-    private List<Tag> listTenantTags(String resourceName, String region) {
-        Tenant tenant = tenantService.tenantForTagArn(resourceName, region);
-        // AWS returns a tenant's tags ordered by key (probe-confirmed).
-        return (tenant.tags() == null ? List.<Tag>of() : tenant.tags()).stream()
-                .sorted(Comparator.comparing(Tag::key, Comparator.nullsLast(Comparator.naturalOrder())))
-                .toList();
-    }
-
-    private void tagTenant(String resourceName, String region, List<Tag> newTags) {
-        tenantService.mutateTags(resourceName, region, tags -> SesTags.merge(tags, newTags));
-        LOG.infov("Tagged SES tenant <{0}> (region {1}, +{2} tags)",
-                resourceName, region, newTags.size());
-    }
-
-    private void untagTenant(String resourceName, String region, List<String> tagKeys) {
-        Set<String> toRemove = new HashSet<>(tagKeys);
-        tenantService.mutateTags(resourceName, region, tags -> {
-            List<Tag> remaining = new ArrayList<>(tags);
-            remaining.removeIf(t -> toRemove.contains(t.key()));
-            return remaining;
-        });
-        LOG.infov("Untagged SES tenant <{0}> (region {1}, -{2} keys)",
-                resourceName, region, tagKeys.size());
-    }
-
-    private List<Tag> listConfigurationSetTags(String name, String region) {
-        ConfigurationSet cs = configSetService.find(name, region)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No ConfigurationSet present with name: " + name, 404));
-        return new ArrayList<>(cs.getTags());
-    }
-
-    private void tagConfigurationSet(String name, String region, List<Tag> newTags) {
-        ConfigurationSet cs = configSetService.find(name, region)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No ConfigurationSet present with name: " + name, 404));
-        cs.setTags(SesTags.merge(cs.getTags(), newTags));
-        configSetService.save(cs, region);
-        LOG.infov("Tagged SES configuration set: {0} (region {1}, +{2} tags)", name, region, newTags.size());
-    }
-
-    private void untagConfigurationSet(String name, String region, List<String> tagKeys) {
-        ConfigurationSet cs = configSetService.find(name, region)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No ConfigurationSet present with name: " + name, 404));
-        Set<String> toRemove = new HashSet<>(tagKeys);
-        // Copy-on-write: the stored list may be immutable, and unlocked readers iterate it.
-        List<Tag> remaining = new ArrayList<>(cs.getTags());
-        remaining.removeIf(t -> toRemove.contains(t.key()));
-        cs.setTags(remaining);
-        configSetService.save(cs, region);
-        LOG.infov("Untagged SES configuration set: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
-    }
-
-    private List<Tag> listEmailTemplateTags(String name, String region) {
-        EmailTemplate template = templateService.find(name, region)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No Template present with name: " + name, 404));
-        return new ArrayList<>(template.getTags());
-    }
-
-    private void tagEmailTemplate(String name, String region, List<Tag> newTags) {
-        EmailTemplate template = templateService.find(name, region)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No Template present with name: " + name, 404));
-        template.setTags(SesTags.merge(template.getTags(), newTags));
-        templateService.save(template, region);
-        LOG.infov("Tagged SES template: {0} (region {1}, +{2} tags)", name, region, newTags.size());
-    }
-
     public void setIdentityTags(String identityValue, String region, List<Tag> tags) {
         identityService.setTags(identityValue, region, tags);
-    }
-
-    private void untagEmailTemplate(String name, String region, List<String> tagKeys) {
-        EmailTemplate template = templateService.find(name, region)
-                .orElseThrow(() -> new AwsException("NotFoundException",
-                        "No Template present with name: " + name, 404));
-        Set<String> toRemove = new HashSet<>(tagKeys);
-        // Copy-on-write: the stored list may be immutable, and unlocked readers iterate it.
-        List<Tag> remaining = new ArrayList<>(template.getTags());
-        remaining.removeIf(t -> toRemove.contains(t.key()));
-        template.setTags(remaining);
-        templateService.save(template, region);
-        LOG.infov("Untagged SES template: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
     }
 
     private record ResourceRef(String account, String region, String type, String name) {}

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1553,14 +1553,12 @@ public class SesService {
         }
     }
 
-    // A tenant tag ARN carries two path segments (tenant/<name>/<tenantId>), so parseSesArn's
-    // first-slash split leaves "<name>/<tenantId>" as the resource name; the tenant domain owns
-    // that remainder's decomposition and the id-only resolution (see SesTenantService.TenantTagArn).
-
     public void setIdentityTags(String identityValue, String region, List<Tag> tags) {
         identityService.setTags(identityValue, region, tags);
     }
 
+    // name is everything after the type's first slash and may itself contain one: a tenant ARN's
+    // <name>/<tenantId> remainder passes through whole, decomposed by the tenant domain.
     private record ResourceRef(String account, String region, String type, String name) {}
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ses.model.EmailTemplate;
+import io.github.hectorvent.floci.services.ses.model.Tag;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -18,18 +19,20 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Email templates (the {@code templateStore}), extracted from {@link SesService} as part of the
  * store-based domain split. Reached through the {@code SesService} facade, which delegates the CRUD
- * here; the facade's templated-send path reads templates back through {@link #getTemplate}, and its
- * ARN-dispatched tagging reads/writes through {@link #find} / {@link #save}.
+ * here, along with the ARN-dispatched template tagging; the facade's templated-send path reads
+ * templates back through {@link #getTemplate}.
  *
  * <p>Template rendering is domain logic too: {@code TestRenderTemplate} (data parsing, variable
  * substitution, and the MIME assembly) lives here, and the facade's templated-send paths call the
@@ -124,16 +127,16 @@ public class SesTemplateService {
     }
 
     /**
-     * Reads a template without throwing, so the facade's ARN-dispatched tagging can look one up by
-     * name and reuse this service's key derivation.
+     * Reads a template without throwing, for the facade's orchestration lookups (the tenant
+     * association check and the send-path reads).
      */
     public Optional<EmailTemplate> find(String templateName, String region) {
         return templateStore.get(templateKey(region, templateName));
     }
 
     /**
-     * Persists a template under its canonical key, so the facade's tagging can write the merged tags
-     * back without owning the key derivation.
+     * Persists a template under its canonical key, so facade orchestration that mutates a found
+     * template can write it back without owning the key derivation.
      */
     public void save(EmailTemplate template, String region) {
         templateStore.put(templateKey(region, template.getTemplateName()), template);
@@ -167,6 +170,35 @@ public class SesTemplateService {
     private static String templateKey(String region, String templateName) {
         validateTemplateName(templateName);
         return "template::" + region + "::" + templateName;
+    }
+
+    /** The ARN-dispatched tag operations, sharing the store behind {@code CreateEmailTemplate.Tags}. */
+    public List<Tag> listTags(String name, String region) {
+        return new ArrayList<>(requireForTags(name, region).getTags());
+    }
+
+    public void tag(String name, String region, List<Tag> newTags) {
+        EmailTemplate template = requireForTags(name, region);
+        template.setTags(SesTags.merge(template.getTags(), newTags));
+        templateStore.put(templateKey(region, name), template);
+        LOG.infov("Tagged SES template: {0} (region {1}, +{2} tags)", name, region, newTags.size());
+    }
+
+    public void untag(String name, String region, List<String> tagKeys) {
+        EmailTemplate template = requireForTags(name, region);
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        // Copy-on-write: the stored list may be immutable, and unlocked readers iterate it.
+        List<Tag> remaining = new ArrayList<>(template.getTags());
+        remaining.removeIf(t -> toRemove.contains(t.key()));
+        template.setTags(remaining);
+        templateStore.put(templateKey(region, name), template);
+        LOG.infov("Untagged SES template: {0} (region {1}, -{2} keys)", name, region, tagKeys.size());
+    }
+
+    private EmailTemplate requireForTags(String name, String region) {
+        return templateStore.get(templateKey(region, name))
+                .orElseThrow(() -> new AwsException("NotFoundException",
+                        "No Template present with name: " + name, 404));
     }
 
     // ──────────────────────── Rendering (TestRenderTemplate + send-path substitution) ────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesTenantService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesTenantService.java
@@ -15,6 +15,7 @@ import org.jboss.logging.Logger;
 import java.security.SecureRandom;
 import java.time.Clock;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.HashSet;
@@ -201,20 +202,46 @@ public class SesTenantService {
         }
     }
 
-    /** Resolves a tenant from a tag ARN's resource remainder, for the facade's tag listing. */
-    public Tenant tenantForTagArn(String resourceRemainder, String region) {
+    /** The ARN-dispatched tag operations; {@code resourceRemainder} is the ARN's {@code <name>/<tenantId>} part. */
+    public List<Tag> listTags(String resourceRemainder, String region) {
+        Tenant tenant = tenantForTagArn(resourceRemainder, region);
+        // AWS returns a tenant's tags ordered by key (probe-confirmed).
+        return (tenant.tags() == null ? List.<Tag>of() : tenant.tags()).stream()
+                .sorted(Comparator.comparing(Tag::key, Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+    }
+
+    public void tag(String resourceRemainder, String region, List<Tag> newTags) {
+        mutateTags(resourceRemainder, region, tags -> SesTags.merge(tags, newTags));
+        LOG.infov("Tagged SES tenant <{0}> (region {1}, +{2} tags)",
+                resourceRemainder, region, newTags.size());
+    }
+
+    public void untag(String resourceRemainder, String region, List<String> tagKeys) {
+        Set<String> toRemove = new HashSet<>(tagKeys);
+        mutateTags(resourceRemainder, region, tags -> {
+            List<Tag> remaining = new ArrayList<>(tags);
+            remaining.removeIf(t -> toRemove.contains(t.key()));
+            return remaining;
+        });
+        LOG.infov("Untagged SES tenant <{0}> (region {1}, -{2} keys)",
+                resourceRemainder, region, tagKeys.size());
+    }
+
+    /** Resolves a tenant from a tag ARN's resource remainder; package-private for the unit tests. */
+    Tenant tenantForTagArn(String resourceRemainder, String region) {
         TenantTagArn arn = TenantTagArn.parse(resourceRemainder);
         return findByTenantId(arn.tenantId(), region)
                 .orElseThrow(() -> tagArnTenantNotFound(arn));
     }
 
     /**
-     * Applies a tag mutation for the facade's ARN-dispatched tagging. The tenant is re-resolved by
+     * Applies a tag mutation for the ARN-dispatched tagging above. The tenant is re-resolved by
      * TenantId and mutated INSIDE the shared lock, so concurrent tag calls can't lose each other's
      * merges, a concurrent suppression-attribute update isn't overwritten by a stale copy, and a
      * delete/recreate between the caller's lookup and this write can't resurrect the old record.
      */
-    public void mutateTags(String resourceRemainder, String region, UnaryOperator<List<Tag>> mutation) {
+    void mutateTags(String resourceRemainder, String region, UnaryOperator<List<Tag>> mutation) {
         TenantTagArn arn = TenantTagArn.parse(resourceRemainder);
         synchronized (tenantMutationLock) {
             Tenant current = findByTenantId(arn.tenantId(), region)

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetServiceTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ses;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.ses.model.ConfigurationSet;
+import io.github.hectorvent.floci.services.ses.model.Tag;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -99,5 +100,23 @@ class SesConfigurationSetServiceTest {
         assertTrue(SesConfigurationSetService.isValidName("my-cs"));
         assertFalse(SesConfigurationSetService.isValidName("bad name!"));
         assertFalse(SesConfigurationSetService.isValidName(null));
+    }
+
+    @Test
+    void tagOps_lifecycle_notFoundMessage() {
+        service.create(cs("my-cs"), REGION);
+        service.tag("my-cs", REGION, List.of(new Tag("team", "floci"), new Tag("env", "dev")));
+        assertEquals(2, service.listTags("my-cs", REGION).size());
+
+        // Re-tagging an existing key replaces its value; untagging a missing key is a silent success.
+        service.tag("my-cs", REGION, List.of(new Tag("env", "prod")));
+        service.untag("my-cs", REGION, List.of("team", "ghost-key"));
+        List<Tag> tags = service.listTags("my-cs", REGION);
+        assertEquals(1, tags.size());
+        assertEquals("env", tags.get(0).key());
+        assertEquals("prod", tags.get(0).value());
+
+        AwsException e = assertThrows(AwsException.class, () -> service.listTags("ghost", REGION));
+        assertEquals("No ConfigurationSet present with name: ghost", e.getMessage());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTemplateServiceTest.java
@@ -114,4 +114,22 @@ class SesTemplateServiceTest {
         assertEquals("team", reloaded.getTags().get(0).key());
         assertEquals("ses", reloaded.getTags().get(0).value());
     }
+
+    @Test
+    void tagOps_lifecycle_notFoundMessage() {
+        service.createTemplate(template("welcome"), REGION);
+        service.tag("welcome", REGION, List.of(new Tag("team", "floci"), new Tag("env", "dev")));
+        assertEquals(2, service.listTags("welcome", REGION).size());
+
+        // Re-tagging an existing key replaces its value; untagging a missing key is a silent success.
+        service.tag("welcome", REGION, List.of(new Tag("env", "prod")));
+        service.untag("welcome", REGION, List.of("team", "ghost-key"));
+        List<Tag> tags = service.listTags("welcome", REGION);
+        assertEquals(1, tags.size());
+        assertEquals("env", tags.get(0).key());
+        assertEquals("prod", tags.get(0).value());
+
+        AwsException e = assertThrows(AwsException.class, () -> service.listTags("ghost", REGION));
+        assertEquals("No Template present with name: ghost", e.getMessage());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesTenantServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesTenantServiceTest.java
@@ -199,6 +199,28 @@ class SesTenantServiceTest {
         assertEquals("team", tags.get(0).key());
     }
 
+    @Test
+    void tagOps_lifecycle_listSortedByKey_notFoundMessage() {
+        Tenant tenant = service.createTenant("acme", List.of(new Tag("team", "floci")), ACCOUNT, REGION);
+        String remainder = "acme/" + tenant.tenantId();
+
+        service.tag(remainder, REGION, List.of(new Tag("env", "dev")));
+        // Ordered by key: env before team (probe-confirmed).
+        assertEquals(List.of("env", "team"),
+                service.listTags(remainder, REGION).stream().map(Tag::key).toList());
+
+        // Re-tagging an existing key replaces its value; untagging a missing key is a silent success.
+        service.tag(remainder, REGION, List.of(new Tag("env", "prod")));
+        service.untag(remainder, REGION, List.of("team", "ghost-key"));
+        List<Tag> tags = service.listTags(remainder, REGION);
+        assertEquals(1, tags.size());
+        assertEquals("prod", tags.get(0).value());
+
+        assertEquals("No Tenant present with name: acmewith tenantId: tn-0000",
+                assertThrows(AwsException.class,
+                        () -> service.listTags("acme/tn-0000", REGION)).getMessage());
+    }
+
     // ──────────────────────── Resource associations (Phase 2) ────────────────────────
 
     private static SesTenantService.AssociationResource identityRef(String name) {


### PR DESCRIPTION
## Summary

Follow-up to #2356, continuing the post-split cleanup (#2881, #2984, #3030): moves the last nine
tag-dispatch helpers out of the `SesService` facade into their domain services, matching the
pattern the other four taggable types already follow. The tenant, configuration-set, and template
`listTags` / `tag` / `untag` operations now live on `SesTenantService`,
`SesConfigurationSetService`, and `SesTemplateService` respectively, and the three dispatch
switches call `<domain>Service.listTags/tag/untag` uniformly for all seven types.

Each helper depended only on its own domain service plus the shared dependency-free `SesTags`, so
this is mesh-free code motion. As a bonus, `SesTenantService.tenantForTagArn` and `mutateTags`
lose their last external callers and drop to package-private (kept non-private for the existing
unit tests that pin the stale-id and defensive-copy regressions).

No behavior change: wordings, ordering, and log lines are verbatim.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Pure code motion behind the facade; no wire-visible change. The full SES suite (1037 tests,
including the per-type tag integration tests and the tenant tag lifecycle) passes unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (behavior-preserving refactor: the existing tag integration tests pin the wire behavior, and each service gained a unit test pinning the new public listTags/tag/untag surface)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
