### PR TITLE
fix(appconfigdata): honor requested poll interval

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AppConfigTest.java
@@ -204,8 +204,8 @@ class AppConfigTest {
 
     @Test
     @Order(12)
-    @DisplayName("Poll interval: requested 60s but emulator returns 15s (known deviation from AWS)")
-    void requiredMinimumPollIntervalIsAcceptedButNotEnforced() {
+    @DisplayName("Poll interval: requested minimum is returned to the client")
+    void requiredMinimumPollIntervalIsReturned() {
         var sessionResponse = appConfigData.startConfigurationSession(StartConfigurationSessionRequest.builder()
                 .applicationIdentifier(applicationId)
                 .environmentIdentifier(environmentId)
@@ -218,16 +218,14 @@ class AppConfigTest {
                 .configurationToken(intervalSessionToken)
                 .build());
 
-        // Emulator always returns 15s regardless of the requested interval.
-        // AWS would return the requested 60s. Pinning current emulator behavior.
-        assertThat(firstResponse.nextPollIntervalInSeconds()).isEqualTo(15);
+        assertThat(firstResponse.nextPollIntervalInSeconds()).isEqualTo(60);
         assertThat(firstResponse.nextPollConfigurationToken()).isNotNull();
 
         GetLatestConfigurationResponse secondResponse = appConfigData.getLatestConfiguration(GetLatestConfigurationRequest.builder()
                 .configurationToken(firstResponse.nextPollConfigurationToken())
                 .build());
 
-        assertThat(secondResponse.nextPollIntervalInSeconds()).isEqualTo(15);
+        assertThat(secondResponse.nextPollIntervalInSeconds()).isEqualTo(60);
         assertThat(secondResponse.nextPollConfigurationToken()).isNotNull();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataController.java
@@ -48,7 +48,7 @@ public class AppConfigDataController {
                 .header("Content-Type", data.contentType())
                 .header("Version-Label", data.configurationVersion())
                 .header("Next-Poll-Configuration-Token", data.nextPollConfigurationToken())
-                .header("Next-Poll-Interval-In-Seconds", 15)
+                .header("Next-Poll-Interval-In-Seconds", data.nextPollIntervalInSeconds())
                 .build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/AppConfigDataService.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.UUID;
 
@@ -40,7 +41,8 @@ public class AppConfigDataService {
         session.setApplicationId(appId);
         session.setEnvironmentId(envId);
         session.setConfigurationProfileId(profileId);
-        session.setRequiredMinimumPollIntervalInSeconds((Integer) request.getOrDefault("RequiredMinimumPollIntervalInSeconds", 15));
+        int pollInterval = parsePollInterval(request.getOrDefault("RequiredMinimumPollIntervalInSeconds", 15));
+        session.setRequiredMinimumPollIntervalInSeconds(pollInterval);
         session.setCurrentToken(UUID.randomUUID().toString());
 
         sessionStore.put(session.getCurrentToken(), session);
@@ -48,9 +50,32 @@ public class AppConfigDataService {
         return session.getCurrentToken();
     }
 
+    private static int parsePollInterval(Object value) {
+        if (!(value instanceof Number)) {
+            throw invalidPollInterval();
+        }
+        try {
+            long interval = new BigDecimal(value.toString()).longValueExact();
+            if (interval < 15 || interval > 86400) {
+                throw invalidPollInterval();
+            }
+            return (int) interval;
+        } catch (NumberFormatException | ArithmeticException e) {
+            throw invalidPollInterval();
+        }
+    }
+
+    private static AwsException invalidPollInterval() {
+        return new AwsException("BadRequestException",
+                "RequiredMinimumPollIntervalInSeconds must be an integer between 15 and 86400", 400);
+    }
+
     public ConfigurationData getLatestConfiguration(String token) {
         ConfigurationSession session = sessionStore.get(token)
                 .orElseThrow(() -> new AwsException("BadRequestException", "Invalid configuration token", 400));
+
+        int pollInterval = normalizePollInterval(session.getRequiredMinimumPollIntervalInSeconds());
+        session.setRequiredMinimumPollIntervalInSeconds(pollInterval);
 
         String activeVersion = appConfigService.getActiveVersion(session.getEnvironmentId(), session.getConfigurationProfileId());
         
@@ -73,8 +98,14 @@ public class AppConfigDataService {
         String contentType = (version != null) ? version.getContentType() : "application/octet-stream";
         String versionLabel = (version != null) ? String.valueOf(version.getVersionNumber()) : "";
 
-        return new ConfigurationData(content, contentType, versionLabel, nextToken);
+        return new ConfigurationData(content, contentType, versionLabel, nextToken,
+                pollInterval);
     }
 
-    public record ConfigurationData(byte[] content, String contentType, String configurationVersion, String nextPollConfigurationToken) {}
+    static int normalizePollInterval(int interval) {
+        return interval >= 15 && interval <= 86400 ? interval : 15;
+    }
+
+    public record ConfigurationData(byte[] content, String contentType, String configurationVersion,
+                                    String nextPollConfigurationToken, int nextPollIntervalInSeconds) {}
 }

--- a/src/main/java/io/github/hectorvent/floci/services/appconfig/model/ConfigurationSession.java
+++ b/src/main/java/io/github/hectorvent/floci/services/appconfig/model/ConfigurationSession.java
@@ -10,7 +10,7 @@ public class ConfigurationSession {
     private String applicationId;
     private String environmentId;
     private String configurationProfileId;
-    private int requiredMinimumPollIntervalInSeconds;
+    private int requiredMinimumPollIntervalInSeconds = 15;
     private String currentToken;
     private String lastConfigurationVersion;
 

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/AppConfigIntegrationTest.java
@@ -182,8 +182,8 @@ class AppConfigIntegrationTest {
     }
 
     @Test @Order(12)
-    @DisplayName("Poll interval: requested 60s but emulator returns 15s (known deviation from AWS)")
-    void requiredMinimumPollIntervalIsStoredButNotEnforced() {
+    @DisplayName("Poll interval: requested minimum is returned to the client")
+    void requiredMinimumPollIntervalIsReturned() {
         intervalToken = given()
                 .contentType(ContentType.JSON)
                 .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": 60}")
@@ -199,7 +199,7 @@ class AppConfigIntegrationTest {
                 .then()
                 .statusCode(200)
                 .header("Next-Poll-Configuration-Token", notNullValue())
-                .header("Next-Poll-Interval-In-Seconds", equalTo("15"))
+                .header("Next-Poll-Interval-In-Seconds", equalTo("60"))
                 .extract().header("Next-Poll-Configuration-Token");
 
         given()
@@ -208,6 +208,72 @@ class AppConfigIntegrationTest {
                 .then()
                 .statusCode(200)
                 .header("Next-Poll-Configuration-Token", notNullValue());
+    }
+
+    @Test @Order(32)
+    void requiredMinimumPollIntervalMustBeWithinAwsLimits() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": 14}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test @Order(33)
+    void requiredMinimumPollIntervalAcceptsAwsUpperBoundary() {
+        String token = startSessionWithInterval(86400);
+
+        given()
+                .queryParam("configuration_token", token)
+                .when().get("/configuration")
+                .then()
+                .statusCode(200)
+                .header("Next-Poll-Interval-In-Seconds", equalTo("86400"));
+    }
+
+    @Test @Order(34)
+    void requiredMinimumPollIntervalRejectsValuesAboveAwsMaximum() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": 86401}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test @Order(35)
+    void requiredMinimumPollIntervalRejectsFractionalValues() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": 60.5}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"));
+    }
+
+    @Test @Order(36)
+    void requiredMinimumPollIntervalRejectsOversizedValues() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": 4294967296}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(400)
+                .body("__type", equalTo("BadRequestException"));
+    }
+
+    private String startSessionWithInterval(int interval) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body("{\"ApplicationIdentifier\": \"" + appId + "\", \"EnvironmentIdentifier\": \"" + envId + "\", \"ConfigurationProfileIdentifier\": \"" + profileId + "\", \"RequiredMinimumPollIntervalInSeconds\": " + interval + "}")
+                .when().post("/configurationsessions")
+                .then()
+                .statusCode(201)
+                .extract().path("InitialConfigurationToken");
     }
 
     // ──────────────────────────── Hosted Configuration Version list ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/appconfig/ConfigurationSessionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/appconfig/ConfigurationSessionTest.java
@@ -1,0 +1,24 @@
+package io.github.hectorvent.floci.services.appconfig;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.services.appconfig.model.ConfigurationSession;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigurationSessionTest {
+    @Test
+    void legacySessionWithoutPollIntervalUsesAwsDefault() throws Exception {
+        ConfigurationSession session = new ObjectMapper().readValue(
+                "{\"id\":\"legacy\",\"applicationId\":\"app\",\"environmentId\":\"env\",\"configurationProfileId\":\"profile\"}",
+                ConfigurationSession.class);
+
+        assertEquals(15, session.getRequiredMinimumPollIntervalInSeconds());
+    }
+
+    @Test
+    void invalidPersistedPollIntervalUsesAwsDefault() {
+        assertEquals(15, AppConfigDataService.normalizePollInterval(0));
+        assertEquals(15, AppConfigDataService.normalizePollInterval(86401));
+    }
+}


### PR DESCRIPTION
## Summary

Fix AppConfigData poll interval handling.

Floci now returns the requested RequiredMinimumPollIntervalInSeconds value instead of always returning 15. It validates the AWS range of 15 to 86400 seconds and normalizes missing or invalid legacy session values to the 15-second default.

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Floci previously ignored the requested poll interval and always returned 15 seconds. Clients requesting another valid interval received incorrect polling guidance.

The implementation now:

- Returns the requested interval on every poll.
- Rejects fractional, null, non-numeric, and out-of-range values with BadRequestException.
- Normalizes missing or invalid values in legacy sessions to 15.
- Preserves the requested interval across successive polls.

Verified with AppConfig integration tests, boundary tests, malformed-input tests, legacy-session tests, and updated Java SDK compatibility assertions. All 38 focused tests passed.

## Checklist

- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits (https://www.conventionalcommits.org/)