### PR TITLE
perf(docker): build the native image on the ubi9 Quarkus micro image

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -280,8 +280,28 @@ jobs:
             -e FLOCI_SERVICES_REDSHIFT_ENDPOINT_HOST=floci \
             floci:test-native
 
-      - name: Wait for floci to be ready
-        run: timeout 60 bash -c 'until curl -sf http://localhost:4566/ >/dev/null 2>&1; do sleep 1; done'
+      # Waits on Docker's health status rather than curling the port so the image's
+      # HEALTHCHECK runs under CI on every arch: the native image has no curl and probes
+      # over bash's /dev/tcp, and a malformed probe would otherwise leave the container
+      # "unhealthy" while the suites pass against the open port. Healthy takes one
+      # interval (5 s); unhealthy takes retries x interval (25 s) and fails fast here.
+      - name: Wait for floci to be healthy
+        run: |
+          health=starting
+          for _ in $(seq 1 60); do
+            health=$(docker inspect -f '{{.State.Health.Status}}' floci)
+            if [ "$health" = healthy ]; then
+              exit 0
+            fi
+            if [ "$health" = unhealthy ]; then
+              break
+            fi
+            sleep 1
+          done
+          echo "::error::floci did not report healthy (last status: $health)"
+          docker inspect -f '{{json .State.Health}}' floci
+          docker logs --tail 50 floci
+          exit 1
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,9 +1,36 @@
 ARG VERSION=latest
-# This must be the UBI-based image produced by Dockerfile.native-package.
-# Release and nightly tags use VERSION; reusable builds override BASE_IMAGE
-# with the digest-qualified native image they just published.
+# The native image is built on the Quarkus micro image, which has no package manager, so the
+# compat image starts from ubi9-minimal (microdnf, curl) and copies the emulator, its entrypoint
+# and the parity script from the published native image. Release and nightly tags use VERSION;
+# reusable builds override BASE_IMAGE with the digest-qualified native image they just published.
 ARG BASE_IMAGE=floci/floci:${VERSION}
-FROM ${BASE_IMAGE}
+FROM ${BASE_IMAGE} AS floci
+
+FROM registry.access.redhat.com/ubi9-minimal:9.7
+ARG VERSION=latest
+
+ENV FLOCI_VERSION=${VERSION}
+ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
+
+RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci \
+    && mkdir -p /app/data \
+    && chown -R 1001:root /app \
+    && chmod -R g+rwX /app
+
+WORKDIR /app
+VOLUME /app/data
+
+COPY --from=floci --chown=1001:root /app/ /app/
+COPY --from=floci /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --from=floci /usr/local/bin/localstack-parity.sh /usr/local/bin/localstack-parity.sh
+
+EXPOSE 4566
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD curl -f http://localhost:4566/_floci/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]
 
 LABEL org.opencontainers.image.title="Floci (compat)" \
       org.opencontainers.image.description="Floci compatibility image with AWS CLI and boto3 pre-installed" \

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -1,4 +1,10 @@
-FROM registry.access.redhat.com/ubi9-minimal:9.7
+# Runtime base: the ubi9 Quarkus micro image, built for dynamically linked native binaries. It
+# carries glibc 2.34 (the Mandrel builder's), libz and libstdc++ (the binary and snappy's JNI
+# library link them), bash and coreutils (the entrypoint uses sh, id, stat, chown and chroot).
+# It has no package manager and no curl: the healthcheck below speaks HTTP over bash's
+# /dev/tcp, and Dockerfile.compat builds on ubi9-minimal and copies /app from this image.
+# Measured on 2.0.1: ubi9-minimal was 40.02 MB compressed, this base is 7.61 MB.
+FROM quay.io/quarkus/ubi9-quarkus-micro-image:2.0
 
 ARG VERSION=latest
 # Automatically set by Docker BuildKit to "amd64" or "arm64"
@@ -7,12 +13,10 @@ ARG TARGETARCH
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
-# ubi9-minimal already ships shadow-utils (useradd) and coreutils (chroot), so no package is
-# installed and no binary is downloaded: the entrypoint drops privileges with
-# `chroot --userspec`, which replaces gosu, and adds the Docker socket's group with
-# `chroot --groups`, which replaces the runtime usermod. Measured on 2.0.1 the layer this
-# replaces was 3.66 MB compressed and 19 MB on disk.
-RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
+# No useradd in the micro image: the passwd entry is written directly (uid 1001, primary group
+# root, home /app). The entrypoint drops privileges with `chroot --userspec` and grants the
+# Docker socket's group by number, so no shadow-utils, gosu or /etc/group entry is needed.
+RUN echo 'floci:x:1001:0:floci:/app:/sbin/nologin' >> /etc/passwd
 
 WORKDIR /app
 
@@ -46,8 +50,9 @@ LABEL org.opencontainers.image.title="Floci" \
 
 EXPOSE 4566
 
+# No curl in the micro image: bash opens the TCP connection and checks the status line.
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
-    CMD curl -f http://localhost:4566/_floci/health || exit 1
+    CMD bash -c 'exec 3<>/dev/tcp/127.0.0.1/4566 && printf "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" >&3 && read -r status <&3 && [[ "$status" == *" 200 "* ]]' || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]


### PR DESCRIPTION
## Summary

Moves the native runtime image from `ubi9-minimal:9.7` (40.02 MB compressed) to
`quay.io/quarkus/ubi9-quarkus-micro-image:2.0` (7.61 MB compressed), the base Quarkus
builds for exactly this kind of binary: glibc 2.34 matching the Mandrel builder, libz,
libstdc++ for snappy's JNI library, bash and coreutils with `chroot` for the entrypoint.
Follow-up to #3037, which removed the gosu layer this base could not have carried.

The micro image has no `useradd`, `curl` or `microdnf`, so three things change:

- the `floci` passwd entry is written directly (uid 1001, group root, home `/app`);
  the entrypoint already drops privileges with `chroot --userspec` and grants the
  Docker socket group by number, so no `/etc/group` entry is needed
- the `HEALTHCHECK` speaks HTTP over bash's `/dev/tcp` and checks the status line
- `Dockerfile.compat` no longer derives from the native image; it builds on
  `ubi9-minimal` (needs `microdnf` and `curl`) and copies `/app`, the entrypoint and
  the parity script from the published native image

Measured on arm64 on top of #3037: native image content 114 → 83.1 MB compressed,
compat image 217 MB against 224.3 MB for the arm64 nightly, binary start 32 ms,
Docker health probe healthy in 6 s. amd64 numbers arrive in this PR's job summary.

Rejected alternatives: `ubi9-micro` lacks libz; `quarkus-micro-image:2.0` is ubi8
with glibc 2.28.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire-protocol change. Verified on the new image: identity uid=1001 gid=0, a gid 999
Docker socket yields groups=0,999, `/app/data` writable, cwd `/app`; outbound TLS
without a system CA bundle (a CloudFront https-only custom origin served 200 through
the emulator, GraalVM embeds the build-time truststore); the four compat CLI
endpoint-resolution checks pass on the compat image; `sdk-test-java` on the native
image 1,667/1,667 with the Docker socket mounted.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added (Dockerfile-only change; covered by the
      compat suites on the native image in CI, which since #3039 run on arm64 with one
      amd64 leg)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
