### PR TITLE
fix(ec2): honor AMI architecture for containers

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/AmiImageResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/AmiImageResolver.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.ec2;
 
+import io.github.hectorvent.floci.core.common.AwsException;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -37,16 +38,33 @@ public class AmiImageResolver {
         }
 
         return imageCatalog.findByIdOrAlias(imageId)
-                .map(image -> new ResolvedAmiImage(
-                        image.dockerImage,
-                        image.guestRuntime == null || image.guestRuntime.isBlank()
-                                ? ResolvedAmiImage.DEFAULT_RUNTIME
-                                : image.guestRuntime,
-                        Boolean.TRUE.equals(image.cloudInit)))
+                .map(image -> resolveCatalogImage(image))
                 .orElseGet(() -> {
                     LOG.warnv("Unknown AMI ID {0}; falling back to default image {1}",
                             imageId, imageCatalog.defaultDockerImage());
                     return ResolvedAmiImage.minimal(imageCatalog.defaultDockerImage());
                 });
+    }
+
+    private ResolvedAmiImage resolveCatalogImage(Ec2ImageCatalog.CatalogImage image) {
+        if ("windows".equalsIgnoreCase(image.platform)) {
+            throw new AwsException("UnsupportedOperation",
+                    "Windows AMI execution is not supported by Floci's Linux container runtime.", 400);
+        }
+        return new ResolvedAmiImage(
+                image.dockerImage,
+                image.guestRuntime == null || image.guestRuntime.isBlank()
+                        ? ResolvedAmiImage.DEFAULT_RUNTIME
+                        : image.guestRuntime,
+                Boolean.TRUE.equals(image.cloudInit),
+                dockerPlatform(image.architecture));
+    }
+
+    private static String dockerPlatform(String architecture) {
+        return switch (architecture) {
+            case "arm64" -> "linux/arm64";
+            case "x86_64" -> "linux/amd64";
+            default -> null;
+        };
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManager.java
@@ -298,7 +298,9 @@ public class Ec2ContainerManager {
             String containerId = null;
             boolean recorded = false;
             try {
-                containerId = lifecycleManager.create(spec);
+                containerId = image.dockerPlatform() == null
+                        ? lifecycleManager.create(spec)
+                        : lifecycleManager.create(spec, image.dockerPlatform());
                 if (!recordCreatedContainer(instance, containerId, sshHostPort)) {
                     lifecycleManager.removeIfExists(containerId);
                     portAllocator.release(sshHostPort);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2321,6 +2321,11 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         validateArchitectureCompatibility(imageId, effectiveInstanceType);
         int count = Math.min(maxCount, Math.max(minCount, 1));
         String architecture = architectureFor(imageId, effectiveInstanceType);
+        ResolvedAmiImage dockerImage = null;
+        if (!config.services().ec2().mock()) {
+            // A CreateImage AMI is not in the catalog, so resolve through its source.
+            dockerImage = amiImageResolver.resolveImage(resolveLaunchableImageId(region, imageId));
+        }
         for (int i = 0; i < count; i++) {
             String instanceId = "i-" + randomHex(17);
             String privateIp = suppliedEni != null
@@ -2420,9 +2425,6 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
             reservation.getInstances().add(inst);
 
             if (!config.services().ec2().mock()) {
-                // A CreateImage AMI is not in the catalog, so resolve through its source.
-                ResolvedAmiImage dockerImage =
-                        amiImageResolver.resolveImage(resolveLaunchableImageId(region, imageId));
                 String publicKey = null;
                 if (keyName != null) {
                     KeyPair kp = findKeyPair(region, keyName);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -2318,9 +2318,9 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         reservation.setOwnerId(accountId);
 
         String effectiveInstanceType = instanceType != null ? instanceType : "t2.micro";
-        validateArchitectureCompatibility(imageId, effectiveInstanceType);
+        validateArchitectureCompatibility(region, imageId, effectiveInstanceType);
         int count = Math.min(maxCount, Math.max(minCount, 1));
-        String architecture = architectureFor(imageId, effectiveInstanceType);
+        String architecture = architectureFor(region, imageId, effectiveInstanceType);
         ResolvedAmiImage dockerImage = null;
         if (!config.services().ec2().mock()) {
             // A CreateImage AMI is not in the catalog, so resolve through its source.
@@ -2533,9 +2533,10 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         }
     }
 
-    private void validateArchitectureCompatibility(String imageId, String instanceType) {
-        Optional<String> imageArchitecture = imageCatalog.findByIdOrAlias(imageId)
-                .map(image -> image.architecture)
+    private void validateArchitectureCompatibility(String region, String imageId, String instanceType) {
+        Optional<String> imageArchitecture = registeredImages.get(key(region, imageId))
+                .map(Image::getArchitecture)
+                .or(() -> imageCatalog.findByIdOrAlias(imageId).map(image -> image.architecture))
                 .filter(value -> !value.isBlank());
         if (imageArchitecture.isEmpty()) {
             return;
@@ -2552,9 +2553,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 });
     }
 
-    private String architectureFor(String imageId, String instanceType) {
-        Optional<Ec2ImageCatalog.CatalogImage> image = imageCatalog.findByIdOrAlias(imageId);
-        return image.map(catalogImage -> catalogImage.architecture)
+    private String architectureFor(String region, String imageId, String instanceType) {
+        Optional<String> registeredArchitecture = registeredImages.get(key(region, imageId))
+                .map(Image::getArchitecture);
+        return registeredArchitecture
+                .filter(value -> !value.isBlank())
+                .or(() -> imageCatalog.findByIdOrAlias(imageId).map(image -> image.architecture))
                 .filter(value -> !value.isBlank())
                 .or(() -> instanceTypeCatalog.find(instanceType)
                         .flatMap(type -> type.supportedArchitectures.stream()

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/ResolvedAmiImage.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/ResolvedAmiImage.java
@@ -1,11 +1,12 @@
 package io.github.hectorvent.floci.services.ec2;
 
-public record ResolvedAmiImage(String dockerImage, String guestRuntime, boolean cloudInit) {
+public record ResolvedAmiImage(String dockerImage, String guestRuntime, boolean cloudInit,
+                               String dockerPlatform) {
     public static final String DEFAULT_RUNTIME = "minimal";
     public static final String SYSTEMD_RUNTIME = "systemd";
 
     public static ResolvedAmiImage minimal(String dockerImage) {
-        return new ResolvedAmiImage(dockerImage, DEFAULT_RUNTIME, false);
+        return new ResolvedAmiImage(dockerImage, DEFAULT_RUNTIME, false, null);
     }
 
     public boolean systemd() {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ContainerManagerTest.java
@@ -538,6 +538,8 @@ class Ec2ContainerManagerTest {
         Ec2ContainerManager.containerBridgeIpAttempts = 1;
         Ec2ContainerManager.containerBridgeIpPollMillis = 1;
         LaunchHarness harness = launchHarness();
+        when(harness.lifecycleManager.create(any(ContainerSpec.class), eq("linux/arm64")))
+                .thenReturn(TEST_CONTAINER_ID);
         InspectContainerCmd inspect = mock(InspectContainerCmd.class);
         InspectContainerResponse withIp = inspectResponse("172.18.0.11");
         when(harness.dockerClient.inspectContainerCmd(TEST_CONTAINER_ID)).thenReturn(inspect);
@@ -546,7 +548,8 @@ class Ec2ContainerManagerTest {
         Instance instance = instance("i-systemd");
 
         harness.manager.launch(instance,
-                new ResolvedAmiImage("floci/ami-ubuntu:24.04-arm64", ResolvedAmiImage.SYSTEMD_RUNTIME, true),
+                new ResolvedAmiImage("floci/ami-ubuntu:24.04-arm64", ResolvedAmiImage.SYSTEMD_RUNTIME, true,
+                        "linux/arm64"),
                 null,
                 "us-west-2");
 
@@ -554,6 +557,7 @@ class Ec2ContainerManagerTest {
         verify(harness.builder).withCmd(List.of("/sbin/init"));
         verify(harness.builder).withCgroupnsMode("host");
         verify(harness.builder).withBind("/sys/fs/cgroup", "/sys/fs/cgroup");
+        verify(harness.lifecycleManager).create(any(ContainerSpec.class), eq("linux/arm64"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ImageCatalogTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ImageCatalogTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.ec2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.github.hectorvent.floci.core.common.AwsException;
 import jakarta.inject.Inject;
 
 @QuarkusTest
@@ -50,6 +52,8 @@ class Ec2ImageCatalogTest {
     @Test
     void resolverUsesCatalogDockerImagesForIdsAndAliases() {
         imageCatalog.images()
+                .stream()
+                .filter(image -> !"windows".equalsIgnoreCase(image.platform))
                 .forEach(image -> assertEquals(image.dockerImage, amiImageResolver.resolve(image.imageId)));
 
         List.of("ami-amazonlinux2", "ami-amazonlinux2023", "ami-ubuntu2004", "ami-ubuntu2404")
@@ -66,6 +70,20 @@ class Ec2ImageCatalogTest {
         assertEquals(ResolvedAmiImage.SYSTEMD_RUNTIME, image.guestRuntime());
         assertTrue(image.cloudInit());
         assertTrue(image.systemd());
+    }
+
+    @Test
+    void resolverMapsImageArchitectureToDockerPlatform() {
+        assertEquals("linux/arm64", amiImageResolver.resolveImage("ami-ubuntu2404-cloud-arm64").dockerPlatform());
+        assertEquals("linux/amd64", amiImageResolver.resolveImage("ami-0abcdef1234567891").dockerPlatform());
+    }
+
+    @Test
+    void resolverRejectsWindowsImagesForContainerExecution() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> amiImageResolver.resolveImage("ami-0abcdef1234567893"));
+
+        assertEquals("UnsupportedOperation", error.getErrorCode());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -838,6 +838,39 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void runInstancesRejectsIncompatibleInstanceTypeForCreatedArmImage() {
+        Ec2ImageCatalog catalog = mock(Ec2ImageCatalog.class);
+        Ec2ImageCatalog.CatalogImage source = new Ec2ImageCatalog.CatalogImage();
+        source.imageId = "ami-arm-source";
+        source.architecture = "arm64";
+        source.rootDeviceName = "/dev/xvda";
+        when(catalog.findByIdOrAlias("ami-arm-source")).thenReturn(Optional.of(source));
+
+        AmiImageResolver resolver = mock(AmiImageResolver.class);
+        when(resolver.resolveImage("ami-arm-source"))
+                .thenReturn(new ResolvedAmiImage("arm-image", ResolvedAmiImage.DEFAULT_RUNTIME, false,
+                        "linux/arm64"));
+        Ec2Service service = liveService(mock(Ec2ContainerManager.class), resolver, catalog);
+        Reservation sourceReservation = service.runInstances("us-east-1", "ami-arm-source", "t4g.medium",
+                1, 1, null, List.of(), null, null, List.of(), null, null);
+
+        String createdAmi = service.createImage("us-east-1",
+                sourceReservation.getInstances().getFirst().getInstanceId(), "captured-arm", null, true)
+                .getImageId();
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.runInstances("us-east-1", createdAmi, "t3.micro", 1, 1,
+                        null, List.of(), null, null, List.of(), null, null));
+
+        assertEquals("InvalidParameterValue", error.getErrorCode());
+        verify(resolver, never()).resolveImage(createdAmi);
+
+        Reservation compatible = service.runInstances("us-east-1", createdAmi, "t4g.medium", 1, 1,
+                null, List.of(), null, null, List.of(), null, null);
+        assertEquals("arm64", compatible.getInstances().getFirst().getArchitecture());
+    }
+
+    @Test
     void runInstancesRejectsUnsupportedImageBeforeCreatingInstance() {
         Ec2ContainerManager containerManager = mock(Ec2ContainerManager.class);
         AmiImageResolver resolver = mock(AmiImageResolver.class);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -838,6 +838,23 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void runInstancesRejectsUnsupportedImageBeforeCreatingInstance() {
+        Ec2ContainerManager containerManager = mock(Ec2ContainerManager.class);
+        AmiImageResolver resolver = mock(AmiImageResolver.class);
+        AwsException unsupported = new AwsException("UnsupportedOperation", "Windows AMIs are not supported", 400);
+        when(resolver.resolveImage("ami-windows")).thenThrow(unsupported);
+        Ec2Service service = liveService(containerManager, resolver);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.runInstances("us-east-1", "ami-windows", "t3.micro", 1, 1,
+                        null, List.of(), null, null, List.of(), null, null));
+
+        assertEquals("UnsupportedOperation", error.getErrorCode());
+        assertTrue(service.describeInstances("us-east-1", List.of(), Map.of()).isEmpty());
+        verifyNoInteractions(containerManager);
+    }
+
+    @Test
     void createImageOnACatalogSourceCarriesItsRootDevice() {
         Ec2ImageCatalog catalog = mock(Ec2ImageCatalog.class);
         Ec2ImageCatalog.CatalogImage source = new Ec2ImageCatalog.CatalogImage();


### PR DESCRIPTION
## Summary

Honor the declared architecture of EC2 AMIs when starting Docker-backed instances.

Map arm64 to linux/arm64 and x86_64 to linux/amd64 for image pulls and container creation. Reject Windows AMIs before creating instance state. Keep unknown AMIs on the existing host-native path.

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Floci previously stored an AMI architecture but did not use it when starting the Docker container. This could run an image on the wrong architecture or cause a misleading launch timeout.

The selected Linux platform now applies to both Docker image pulls and container creation. Windows AMIs return an AWS-shaped UnsupportedOperation error because Floci runs EC2 guests as Linux containers.

Focused EC2 tests and the Docker platform integration test pass.

## Checklist

- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits (https://www.conventionalcommits.org/)