### PR TITLE
fix(kinesis): reject non-string tag members instead of coercing them

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -114,13 +114,15 @@ public class KinesisJsonHandler {
                 streamMode = mode;
             }
         }
-        service.createStream(streamName, shardCount, streamMode,
-                optionalMaxRecordSize(request), region);
         // CreateStream's optional Tags member was being dropped. That is invisible to a
         // hand-written script but not to Terraform: aws_kinesis_stream sets tags at create
         // time and then reads them back with ListTagsForStream, so an empty read produces a
         // permanent "tags will be updated in-place" diff on an unchanged configuration.
+        // Parsed before the stream exists so a malformed Tags member rejects the whole
+        // request instead of leaving an untagged stream behind.
         Map<String, String> tags = parseTags(request);
+        service.createStream(streamName, shardCount, streamMode,
+                optionalMaxRecordSize(request), region);
         if (!tags.isEmpty()) {
             service.addTagsToStream(streamName, tags, region);
         }
@@ -402,8 +404,19 @@ public class KinesisJsonHandler {
 
     private Response handleRemoveTagsFromStream(JsonNode request, String region) {
         String streamName = resolveStreamName(request);
-        java.util.List<String> tagKeys = new java.util.ArrayList<>();
-        request.path("TagKeys").forEach(node -> tagKeys.add(node.asText()));
+        JsonNode tagKeysNode = request.path("TagKeys");
+        List<String> tagKeys = new ArrayList<>();
+        if (!tagKeysNode.isMissingNode() && !tagKeysNode.isNull()) {
+            if (!tagKeysNode.isArray()) {
+                throw new AwsException("SerializationException", "TagKeys must be a list of strings.", 400);
+            }
+            for (JsonNode node : tagKeysNode) {
+                if (!node.isTextual()) {
+                    throw new AwsException("SerializationException", "TagKeys must be a list of strings.", 400);
+                }
+                tagKeys.add(node.textValue());
+            }
+        }
         service.removeTagsFromStream(streamName, tagKeys, region);
         return Response.ok(objectMapper.createObjectNode()).build();
     }
@@ -424,12 +437,24 @@ public class KinesisJsonHandler {
 
     // Shared by CreateStream and AddTagsToStream so the two paths cannot drift: the same
     // request shape has to produce the same stored tags whichever operation carries it.
-    // A missing or non-object Tags member yields an empty map rather than an error, which
-    // is what AddTagsToStream already did before CreateStream started calling this.
+    // A missing or null Tags member yields an empty map; anything else that is not a map
+    // of strings is a wire deserialization error rather than a value to coerce, so a
+    // number or boolean is rejected instead of being stored as its text.
     private Map<String, String> parseTags(JsonNode request) {
         Map<String, String> tags = new HashMap<>();
-        request.path("Tags").fields()
-                .forEachRemaining(entry -> tags.put(entry.getKey(), entry.getValue().asText()));
+        JsonNode tagsNode = request.path("Tags");
+        if (tagsNode.isMissingNode() || tagsNode.isNull()) {
+            return tags;
+        }
+        if (!tagsNode.isObject()) {
+            throw new AwsException("SerializationException", "Tags must be a map of string values.", 400);
+        }
+        tagsNode.fields().forEachRemaining(entry -> {
+            if (!entry.getValue().isTextual()) {
+                throw new AwsException("SerializationException", "Tags must be a map of string values.", 400);
+            }
+            tags.put(entry.getKey(), entry.getValue().textValue());
+        });
         return tags;
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisIntegrationTest.java
@@ -1255,4 +1255,35 @@ class KinesisIntegrationTest {
         buf.get(payload);
         return new ObjectMapper().readTree(payload);
     }
+
+    @Test
+    @Order(67)
+    void createStreamRejectsANonStringTagValueWithSerializationException() {
+        // A non-string tag value is a wire deserialization error, not a value to coerce:
+        // it used to be stored as its text ("5"), and the stream was created before the
+        // tags were parsed. Now the whole request is rejected and nothing is created.
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.CreateStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "create-with-bad-tags", "ShardCount": 1, "Tags": {"Foo": 5}}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+
+        given()
+            .header("X-Amz-Target", "Kinesis_20131202.DescribeStream")
+            .contentType(KINESIS_CONTENT_TYPE)
+            .body("""
+                {"StreamName": "create-with-bad-tags"}
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ResourceNotFoundException"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.kinesis;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.BinaryNode;
@@ -1114,5 +1115,149 @@ class KinesisJsonHandlerTest {
 
         assertEquals(Map.of("Foo", "Bar", "gw:example", "kinesis"),
                 service.listTagsForStream("test-stream", REGION));
+    }
+
+    @Test
+    void createStreamRejectsANonStringTagValueBeforeCreatingTheStream() {
+        for (ObjectNode tags : nonStringTagValues()) {
+            ObjectNode create = MAPPER.createObjectNode();
+            create.put("StreamName", "rejected-tags-stream");
+            create.put("ShardCount", 1);
+            create.set("Tags", tags);
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> handler.handle("CreateStream", create, REGION));
+            assertEquals("SerializationException", ex.getErrorCode());
+            assertEquals("Tags must be a map of string values.", ex.getMessage());
+            assertEquals(400, ex.getHttpStatus());
+        }
+
+        ObjectNode describe = MAPPER.createObjectNode();
+        describe.put("StreamName", "rejected-tags-stream");
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("DescribeStream", describe, REGION));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void createStreamRejectsANonObjectTagsMember() {
+        for (JsonNode tags : List.of(MAPPER.getNodeFactory().textNode("Foo=Bar"),
+                MAPPER.getNodeFactory().numberNode(5), MAPPER.createArrayNode().add("Foo"))) {
+            ObjectNode create = MAPPER.createObjectNode();
+            create.put("StreamName", "rejected-tags-stream");
+            create.put("ShardCount", 1);
+            create.set("Tags", tags);
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> handler.handle("CreateStream", create, REGION));
+            assertEquals("SerializationException", ex.getErrorCode());
+        }
+    }
+
+    @Test
+    void createStreamWithANullTagsMemberLeavesTheStreamUntagged() {
+        ObjectNode create = MAPPER.createObjectNode();
+        create.put("StreamName", "null-tags-stream");
+        create.put("ShardCount", 1);
+        create.putNull("Tags");
+        assertThat(handler.handle("CreateStream", create, REGION).getStatus(), is(200));
+
+        assertTrue(service.listTagsForStream("null-tags-stream", REGION).isEmpty());
+    }
+
+    @Test
+    void addTagsToStreamRejectsANonStringTagValueWithoutTouchingExistingTags() {
+        createStream("test-stream");
+        ObjectNode add = MAPPER.createObjectNode();
+        add.put("StreamName", "test-stream");
+        add.putObject("Tags").put("Foo", "Bar");
+        assertThat(handler.handle("AddTagsToStream", add, REGION).getStatus(), is(200));
+
+        for (ObjectNode tags : nonStringTagValues()) {
+            ObjectNode bad = MAPPER.createObjectNode();
+            bad.put("StreamName", "test-stream");
+            bad.set("Tags", tags);
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> handler.handle("AddTagsToStream", bad, REGION));
+            assertEquals("SerializationException", ex.getErrorCode());
+            assertEquals(400, ex.getHttpStatus());
+        }
+
+        assertEquals(Map.of("Foo", "Bar"), service.listTagsForStream("test-stream", REGION));
+    }
+
+    @Test
+    void removeTagsFromStreamRejectsANonStringTagKey() {
+        createStream("test-stream");
+        ObjectNode add = MAPPER.createObjectNode();
+        add.put("StreamName", "test-stream");
+        add.putObject("Tags").put("Foo", "Bar");
+        assertThat(handler.handle("AddTagsToStream", add, REGION).getStatus(), is(200));
+
+        for (JsonNode tagKeys : List.of(MAPPER.createArrayNode().add(5), MAPPER.createArrayNode().add(true),
+                MAPPER.createArrayNode().addNull(), MAPPER.createArrayNode().add("Foo").add(5),
+                MAPPER.getNodeFactory().textNode("Foo"), MAPPER.createObjectNode().put("a", "Foo"))) {
+            ObjectNode remove = MAPPER.createObjectNode();
+            remove.put("StreamName", "test-stream");
+            remove.set("TagKeys", tagKeys);
+            AwsException ex = assertThrows(AwsException.class,
+                    () -> handler.handle("RemoveTagsFromStream", remove, REGION));
+            assertEquals("SerializationException", ex.getErrorCode());
+            assertEquals("TagKeys must be a list of strings.", ex.getMessage());
+            assertEquals(400, ex.getHttpStatus());
+        }
+
+        assertEquals(Map.of("Foo", "Bar"), service.listTagsForStream("test-stream", REGION));
+    }
+
+    @Test
+    void removeTagsFromStreamStillRemovesStringTagKeys() {
+        createStream("test-stream");
+        ObjectNode add = MAPPER.createObjectNode();
+        add.put("StreamName", "test-stream");
+        add.putObject("Tags").put("Foo", "Bar").put("Baz", "Qux");
+        assertThat(handler.handle("AddTagsToStream", add, REGION).getStatus(), is(200));
+
+        ObjectNode remove = MAPPER.createObjectNode();
+        remove.put("StreamName", "test-stream");
+        remove.putArray("TagKeys").add("Foo");
+        assertThat(handler.handle("RemoveTagsFromStream", remove, REGION).getStatus(), is(200));
+
+        assertEquals(Map.of("Baz", "Qux"), service.listTagsForStream("test-stream", REGION));
+    }
+
+    @Test
+    void removeTagsFromStreamWithANullOrMissingTagKeysLeavesTagsUntouched() {
+        createStream("test-stream");
+        ObjectNode add = MAPPER.createObjectNode();
+        add.put("StreamName", "test-stream");
+        add.putObject("Tags").put("Foo", "Bar");
+        assertThat(handler.handle("AddTagsToStream", add, REGION).getStatus(), is(200));
+
+        ObjectNode nullKeys = MAPPER.createObjectNode();
+        nullKeys.put("StreamName", "test-stream");
+        nullKeys.putNull("TagKeys");
+        assertThat(handler.handle("RemoveTagsFromStream", nullKeys, REGION).getStatus(), is(200));
+        ObjectNode missingKeys = MAPPER.createObjectNode();
+        missingKeys.put("StreamName", "test-stream");
+        assertThat(handler.handle("RemoveTagsFromStream", missingKeys, REGION).getStatus(), is(200));
+
+        assertEquals(Map.of("Foo", "Bar"), service.listTagsForStream("test-stream", REGION));
+    }
+
+    /** Every non-string tag value shape — number, boolean, null, object, array — plus a map mixing a valid and an invalid value. */
+    private static List<ObjectNode> nonStringTagValues() {
+        ObjectNode number = MAPPER.createObjectNode();
+        number.put("Foo", 5);
+        ObjectNode bool = MAPPER.createObjectNode();
+        bool.put("Foo", true);
+        ObjectNode nul = MAPPER.createObjectNode();
+        nul.putNull("Foo");
+        ObjectNode object = MAPPER.createObjectNode();
+        object.putObject("Foo");
+        ObjectNode array = MAPPER.createObjectNode();
+        array.putArray("Foo");
+        ObjectNode mixed = MAPPER.createObjectNode();
+        mixed.put("Foo", "Bar");
+        mixed.put("Baz", 5);
+        return List.of(number, bool, nul, object, array, mixed);
     }
 }


### PR DESCRIPTION
## Summary

`CreateStream`, `AddTagsToStream` and `RemoveTagsFromStream` read tag values and `TagKeys` entries with `asText()`, so a number, boolean or null member was stored as its text — `"Foo": 5` landed as the tag value `"5"` — and an object or array member as the empty string, instead of being rejected. Follow-up to #2494, whose commit message split this out as a fix to land on its own; it takes the same line #2512 took for the SES tag parser.

Both parse sites on those three operations now reject a present-but-non-string tag value or `TagKeys` entry, a `Tags` member that isn't an object, and a `TagKeys` member that isn't a list, with `SerializationException` 400. A missing or null `Tags`/`TagKeys` member still yields no tags, as before. Two ordering effects ride along: `CreateStream` created the stream before parsing `Tags`, so a rejected `Tags` member would have left an untagged stream behind — it now parses first and the whole request is rejected with nothing created; and because the tags are parsed before the stream is created or looked up, a malformed member on an unknown or already-existing stream answers `SerializationException` where it previously answered `ResourceNotFoundException` or `ResourceInUseException` — all 400s, in the deserialize-before-validate order Smithy's server SDK documents.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS models `Tags` as a string-to-string map on `CreateStream` and `AddTagsToStream`, and `TagKeys` as an array of strings on `RemoveTagsFromStream`, so none of the rejected shapes is a valid request under that model. The route reuses the `SerializationException` 400 the emulator already answers for a non-string SES tag member (#2512, where it was probe-confirmed against AWS) and for undecodable Kinesis `Data`. A null map value is rejected as well: the model's `TagMap` is a dense string map with no `sparse` trait, and unlike SES's `Key`/`Value` members nothing downstream validates it — that shape was not probed against real AWS, since no credentials are available here.

## Checklist

- [x] `./mvnw test` run locally: 15,960 tests, with the failures confined to 46 classes that fail identically on the pristine `c3d977a3` tip in a clean checkout — 24 Docker-backed classes (no Docker socket on this machine) and all 22 nested classes of the new `ResourceExplorer2IntegrationTest`, which trip on a duplicate DynamoDB `CreateTable` between nested classes — and none of them is a Kinesis class.
  - The Kinesis-adjacent suites are fully green: 365/365 across the Kinesis, KinesisAnalytics, DynamoDB-streaming, Pipes and AwsJsonCbor suites, with `KinesisJsonHandlerTest` at 76/76 including seven new tests — every non-string value shape rejected on `CreateStream` (stream proven not created) and on `AddTagsToStream` (existing tags untouched), a non-object `Tags` rejected, `RemoveTagsFromStream` rejecting non-string, non-list and object-shaped `TagKeys` with tags untouched, the preserved null and missing arms, and string `TagKeys` still removed — plus a wire-level test in `KinesisIntegrationTest` pinning the `__type: SerializationException` body and that no stream was created.
  - Red-proof: five of the eight new tests go red against the unfixed handler; the null-`Tags`, null-or-missing-`TagKeys` and string-`TagKeys` tests pass there by design.
  - Mutation check: eleven mutants — the four gates removed and the `TagKeys` list gate also loosened, the `CreateStream` ordering, the null arms and the message and status values, each killed by a named test.
- [x] New or updated integration test added — `createStreamRejectsANonStringTagValueWithSerializationException` in `KinesisIntegrationTest`.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
