### PR TITLE
feat(ssoadmin): add permission sets and assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Floci supports local emulation for application services, data services, eventing
 | Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
 | Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
 | Messaging and transfer | SES, Kinesis, MSK, Amazon MQ, Transfer Family, IoT Core, Amazon Connect |
-| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, Control Tower, Service Catalog |
+| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, IAM Identity Center (SSO Admin), Control Tower, Service Catalog |
 | Cost and billing | Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |
 | Resilience, backup, and config | AWS FIS, AWS Backup, AWS Config, AppConfig, AppConfigData, CloudFormation, Cloud Control API |
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -230,6 +230,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>organizations</artifactId>
         </dependency>
+        <!-- IAM Identity Center (SSO Admin) client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ssoadmin</artifactId>
+        </dependency>
         <!-- Cloud Map (servicediscovery) client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -30,6 +30,7 @@ import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.guardduty.GuardDutyClient;
 import software.amazon.awssdk.services.fis.FisClient;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
+import software.amazon.awssdk.services.ssoadmin.SsoAdminClient;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -267,6 +268,14 @@ public final class TestFixtures {
 
     public static OrganizationsClient organizationsClient() {
         return OrganizationsClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static SsoAdminClient ssoAdminClient() {
+        return SsoAdminClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsoAdminAccountAssignmentTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsoAdminAccountAssignmentTest.java
@@ -1,0 +1,55 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ssoadmin.SsoAdminClient;
+import software.amazon.awssdk.services.ssoadmin.model.PrincipalType;
+import software.amazon.awssdk.services.ssoadmin.model.TargetType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@DisplayName("IAM Identity Center account assignments")
+class SsoAdminAccountAssignmentTest {
+
+    @Test
+    @DisplayName("creates and describes account assignments through the AWS SDK")
+    void accountAssignmentLifecycleUsesAwsSdk() {
+        assumeFalse(TestFixtures.isRealAws(), "Uses emulator-only account and principal identifiers");
+
+        try (SsoAdminClient sso = TestFixtures.ssoAdminClient()) {
+            String instanceArn = sso.listInstances(request -> {}).instances().get(0).instanceArn();
+            String permissionSetArn = sso.createPermissionSet(request -> request
+                            .instanceArn(instanceArn)
+                            .name("FlociPlatformAdmins"))
+                    .permissionSet()
+                    .permissionSetArn();
+
+            var created = sso.createAccountAssignment(request -> request
+                    .instanceArn(instanceArn)
+                    .targetId("123456789012")
+                    .targetType(TargetType.AWS_ACCOUNT)
+                    .permissionSetArn(permissionSetArn)
+                    .principalType(PrincipalType.GROUP)
+                    .principalId("11111111-2222-3333-4444-555555555555"));
+
+            assertThat(created.accountAssignmentCreationStatus()).isNotNull();
+            assertThat(created.accountAssignmentCreationStatus().requestId()).isNotBlank();
+
+            var status = sso.describeAccountAssignmentCreationStatus(request -> request
+                    .instanceArn(instanceArn)
+                    .accountAssignmentCreationRequestId(created.accountAssignmentCreationStatus().requestId()));
+            assertThat(status.accountAssignmentCreationStatus().statusAsString()).isEqualTo("SUCCEEDED");
+
+            var assignments = sso.listAccountAssignments(request -> request
+                    .instanceArn(instanceArn)
+                    .accountId("123456789012")
+                    .permissionSetArn(permissionSetArn));
+            assertThat(assignments.accountAssignments())
+                    .anySatisfy(assignment -> {
+                        assertThat(assignment.principalType()).isEqualTo(PrincipalType.GROUP);
+                        assertThat(assignment.principalId()).isEqualTo("11111111-2222-3333-4444-555555555555");
+                    });
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsoAdminAccountAssignmentTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SsoAdminAccountAssignmentTest.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.ssoadmin.SsoAdminClient;
 import software.amazon.awssdk.services.ssoadmin.model.PrincipalType;
 import software.amazon.awssdk.services.ssoadmin.model.TargetType;
+import software.amazon.awssdk.services.ssoadmin.model.ValidationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("IAM Identity Center account assignments")
@@ -50,6 +52,33 @@ class SsoAdminAccountAssignmentTest {
                         assertThat(assignment.principalType()).isEqualTo(PrincipalType.GROUP);
                         assertThat(assignment.principalId()).isEqualTo("11111111-2222-3333-4444-555555555555");
                     });
+
+            for (String policy : new String[] {"ReadOnlyAccess", "SecurityAudit", "ViewOnlyAccess"}) {
+                sso.attachManagedPolicyToPermissionSet(request -> request
+                        .instanceArn(instanceArn)
+                        .permissionSetArn(permissionSetArn)
+                        .managedPolicyArn("arn:aws:iam::aws:policy/" + policy));
+            }
+            var firstPolicies = sso.listManagedPoliciesInPermissionSet(request -> request
+                    .instanceArn(instanceArn)
+                    .permissionSetArn(permissionSetArn)
+                    .maxResults(1));
+            assertThat(firstPolicies.attachedManagedPolicies()).hasSize(1);
+            assertThat(firstPolicies.nextToken()).isNotBlank();
+            var secondPolicies = sso.listManagedPoliciesInPermissionSet(request -> request
+                    .instanceArn(instanceArn)
+                    .permissionSetArn(permissionSetArn)
+                    .maxResults(1)
+                    .nextToken(firstPolicies.nextToken()));
+            assertThat(secondPolicies.attachedManagedPolicies()).hasSize(1);
+            assertThat(secondPolicies.attachedManagedPolicies().get(0).arn())
+                    .isNotEqualTo(firstPolicies.attachedManagedPolicies().get(0).arn());
+
+            assertThatThrownBy(() -> sso.listManagedPoliciesInPermissionSet(request -> request
+                    .instanceArn(instanceArn)
+                    .permissionSetArn(permissionSetArn)
+                    .maxResults(101)))
+                    .isInstanceOf(ValidationException.class);
         }
     }
 }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -44,6 +44,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [CloudWatch Metrics](cloudwatch.md#metrics) | `POST /` with `Action=` or JSON 1.1 | Query / JSON | 11 |
 | [CloudWatch RUM](rum.md) | `/appmonitor`, `/appmonitor/{name}`, `/appmonitors` | REST JSON | 5 |
 | [GuardDuty](guardduty.md) | `/detector`, `/detector/{detectorId}`, `/detector/{detectorId}/admin`, `/admin/*`, `/tags/*` | REST JSON | 13 |
+| [IAM Identity Center (SSO Admin)](ssoadmin.md) | `POST /` + `X-Amz-Target: SWBExternalService.*` | JSON 1.1 | 13 |
 | [Amazon Connect](connect.md) | `/instance`, `/instance/{instanceId}/*`, `/tags/*` | REST JSON | 15 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
 | [MemoryDB](memorydb.md) | `POST /` + `X-Amz-Target: AmazonMemoryDB.*` + TCP proxy | JSON 1.1 + RESP | 7 |

--- a/docs/services/ssoadmin.md
+++ b/docs/services/ssoadmin.md
@@ -5,9 +5,25 @@
 
 Floci supports the SSO Admin operations used to manage IAM Identity Center permission sets and account assignments locally.
 
-## Supported operations
+## Supported Actions
 
-`ListInstances`, `ListPermissionSets`, `CreatePermissionSet`, `DescribePermissionSet`, `UpdatePermissionSet`, `ListManagedPoliciesInPermissionSet`, `AttachManagedPolicyToPermissionSet`, `DetachManagedPolicyFromPermissionSet`, `DeleteInlinePolicyFromPermissionSet`, `PutInlinePolicyToPermissionSet`, `ListAccountAssignments`, `CreateAccountAssignment`, and `DescribeAccountAssignmentCreationStatus`.
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `ListInstances` | Lists the local IAM Identity Center instance. |
+| `ListPermissionSets` | Lists permission sets with AWS-compatible pagination. |
+| `CreatePermissionSet` | Creates a permission set. |
+| `DescribePermissionSet` | Describes a permission set. |
+| `UpdatePermissionSet` | Updates mutable permission-set settings. |
+| `ListManagedPoliciesInPermissionSet` | Lists attached AWS managed policies with AWS-compatible pagination. |
+| `AttachManagedPolicyToPermissionSet` | Attaches an AWS managed policy. |
+| `DetachManagedPolicyFromPermissionSet` | Detaches an AWS managed policy. |
+| `DeleteInlinePolicyFromPermissionSet` | Deletes the inline policy. |
+| `PutInlinePolicyToPermissionSet` | Creates or replaces the inline policy. |
+| `ListAccountAssignments` | Lists account assignments with AWS-compatible pagination. |
+| `CreateAccountAssignment` | Creates an account assignment and operation record. |
+| `DescribeAccountAssignmentCreationStatus` | Describes account-assignment creation status. |
+<!-- floci:actions:end -->
 
 State is isolated by caller account through Floci storage.
 

--- a/docs/services/ssoadmin.md
+++ b/docs/services/ssoadmin.md
@@ -1,0 +1,20 @@
+# IAM Identity Center (SSO Admin)
+
+**Protocol:** JSON 1.1 (`X-Amz-Target: SWBExternalService.*`)
+**Signing name:** `sso`
+
+Floci supports the SSO Admin operations used to manage IAM Identity Center permission sets and account assignments locally.
+
+## Supported operations
+
+`ListInstances`, `ListPermissionSets`, `CreatePermissionSet`, `DescribePermissionSet`, `UpdatePermissionSet`, `ListManagedPoliciesInPermissionSet`, `AttachManagedPolicyToPermissionSet`, `DetachManagedPolicyFromPermissionSet`, `DeleteInlinePolicyFromPermissionSet`, `PutInlinePolicyToPermissionSet`, `ListAccountAssignments`, `CreateAccountAssignment`, and `DescribeAccountAssignmentCreationStatus`.
+
+State is isolated by caller account through Floci storage.
+
+## AWS-compatible failures and state
+
+Permission-set names, ARNs, session durations, managed-policy ARNs, inline policies, account IDs, principal types, pagination, and duplicate assignments are validated before state is changed. Missing resources return `ResourceNotFoundException`; duplicate or incompatible state returns `ConflictException`; invalid input returns `ValidationException`; enforced local limits return `ServiceQuotaExceededException`.
+
+Account-assignment creation returns an operation record that can be read with `DescribeAccountAssignmentCreationStatus`. Provider-side `InternalServerException` and `ThrottlingException` are part of the AWS model but are not injected artificially by Floci.
+
+See the [AWS SSO Admin API Reference](https://docs.aws.amazon.com/singlesignon/latest/APIReference/welcome.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
     - IAM: services/iam.md
     - STS: services/sts.md
     - Organizations: services/organizations.md
+    - IAM Identity Center (SSO Admin): services/ssoadmin.md
     - Control Tower: services/controltower.md
     - AWS Service Catalog: services/service-catalog.md
     - ElastiCache: services/elasticache.md

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminJsonHandler.java
@@ -2,15 +2,18 @@ package io.github.hectorvent.floci.services.ssoadmin;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.ssoadmin.model.Assignment;
+import io.github.hectorvent.floci.services.ssoadmin.model.AssignmentOperation;
+import io.github.hectorvent.floci.services.ssoadmin.model.PermissionSet;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 @ApplicationScoped
 public class SsoAdminJsonHandler {
-
     private final SsoAdminService service;
     private final ObjectMapper mapper;
 
@@ -23,8 +26,19 @@ public class SsoAdminJsonHandler {
     public Response handle(String action, JsonNode request, String callerAccountId) {
         return switch (action) {
             case "ListInstances" -> listInstances(callerAccountId);
-            default -> throw new AwsException("UnknownOperationException",
-                    "Operation " + action + " is not supported.", 400);
+            case "ListPermissionSets" -> listPermissionSets(request);
+            case "CreatePermissionSet" -> createPermissionSet(request);
+            case "DescribePermissionSet" -> describePermissionSet(request);
+            case "UpdatePermissionSet" -> updatePermissionSet(request);
+            case "ListManagedPoliciesInPermissionSet" -> listManagedPolicies(request);
+            case "AttachManagedPolicyToPermissionSet" -> attachManagedPolicy(request);
+            case "DetachManagedPolicyFromPermissionSet" -> detachManagedPolicy(request);
+            case "DeleteInlinePolicyFromPermissionSet" -> deleteInlinePolicy(request);
+            case "PutInlinePolicyToPermissionSet" -> putInlinePolicy(request);
+            case "ListAccountAssignments" -> listAccountAssignments(request);
+            case "CreateAccountAssignment" -> createAccountAssignment(request);
+            case "DescribeAccountAssignmentCreationStatus" -> describeAssignment(request);
+            default -> throw new AwsException("UnknownOperationException", "Operation " + action + " is not supported.", 400);
         };
     }
 
@@ -37,5 +51,113 @@ public class SsoAdminJsonHandler {
         instance.put("OwnerAccountId", callerAccountId);
         instance.put("Status", "ACTIVE");
         return Response.ok(response).build();
+    }
+
+    private Response listPermissionSets(JsonNode request) {
+        var page = service.listPermissionSets(request);
+        ObjectNode response = mapper.createObjectNode();
+        ArrayNode arns = response.putArray("PermissionSets");
+        page.items().forEach(p -> arns.add(p.arn()));
+        if (page.nextToken() != null) response.put("NextToken", page.nextToken());
+        return Response.ok(response).build();
+    }
+
+    private Response createPermissionSet(JsonNode request) {
+        PermissionSet p = service.createPermissionSet(request);
+        ObjectNode response = mapper.createObjectNode();
+        response.set("PermissionSet", permissionSetNode(p));
+        return Response.ok(response).build();
+    }
+
+    private Response describePermissionSet(JsonNode request) {
+        PermissionSet p = service.getPermissionSet(
+                SsoAdminService.required(request, "InstanceArn"), SsoAdminService.required(request, "PermissionSetArn"));
+        ObjectNode response = mapper.createObjectNode();
+        response.set("PermissionSet", permissionSetNode(p));
+        return Response.ok(response).build();
+    }
+
+    private Response updatePermissionSet(JsonNode request) {
+        service.updatePermissionSet(request);
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response listManagedPolicies(JsonNode request) {
+        PermissionSet p = service.getPermissionSet(
+                SsoAdminService.required(request, "InstanceArn"), SsoAdminService.required(request, "PermissionSetArn"));
+        ObjectNode response = mapper.createObjectNode();
+        ArrayNode policies = response.putArray("AttachedManagedPolicies");
+        p.managedPolicies().forEach((arn, name) -> policies.addObject().put("Arn", arn).put("Name", name));
+        return Response.ok(response).build();
+    }
+
+    private Response attachManagedPolicy(JsonNode request) {
+        service.attachPolicy(SsoAdminService.required(request, "InstanceArn"),
+                SsoAdminService.required(request, "PermissionSetArn"), SsoAdminService.required(request, "ManagedPolicyArn"));
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response detachManagedPolicy(JsonNode request) {
+        service.detachPolicy(SsoAdminService.required(request, "InstanceArn"),
+                SsoAdminService.required(request, "PermissionSetArn"), SsoAdminService.required(request, "ManagedPolicyArn"));
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response deleteInlinePolicy(JsonNode request) {
+        service.deleteInlinePolicy(SsoAdminService.required(request, "InstanceArn"), SsoAdminService.required(request, "PermissionSetArn"));
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response putInlinePolicy(JsonNode request) {
+        service.putInlinePolicy(SsoAdminService.required(request, "InstanceArn"), SsoAdminService.required(request, "PermissionSetArn"),
+                SsoAdminService.required(request, "InlinePolicy"));
+        return Response.ok(mapper.createObjectNode()).build();
+    }
+
+    private Response listAccountAssignments(JsonNode request) {
+        var page = service.listAssignments(request);
+        ObjectNode response = mapper.createObjectNode();
+        ArrayNode array = response.putArray("AccountAssignments");
+        for (Assignment a : page.items()) {
+            array.addObject().put("AccountId", a.accountId()).put("PermissionSetArn", a.permissionSetArn())
+                    .put("PrincipalId", a.principalId()).put("PrincipalType", a.principalType());
+        }
+        if (page.nextToken() != null) response.put("NextToken", page.nextToken());
+        return Response.ok(response).build();
+    }
+
+    private Response createAccountAssignment(JsonNode request) {
+        AssignmentOperation op = service.createAssignment(request);
+        ObjectNode response = mapper.createObjectNode();
+        response.set("AccountAssignmentCreationStatus", assignmentOperationNode(op));
+        return Response.ok(response).build();
+    }
+
+    private Response describeAssignment(JsonNode request) {
+        AssignmentOperation op = service.getAssignmentOperation(
+                SsoAdminService.required(request, "InstanceArn"),
+                SsoAdminService.required(request, "AccountAssignmentCreationRequestId"));
+        ObjectNode response = mapper.createObjectNode();
+        response.set("AccountAssignmentCreationStatus", assignmentOperationNode(op));
+        return Response.ok(response).build();
+    }
+
+    private ObjectNode permissionSetNode(PermissionSet p) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("PermissionSetArn", p.arn());
+        node.put("Name", p.name());
+        if (p.description() != null) node.put("Description", p.description());
+        node.put("SessionDuration", p.sessionDuration());
+        return node;
+    }
+
+    private ObjectNode assignmentOperationNode(AssignmentOperation op) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("RequestId", op.requestId()); node.put("Status", op.status());
+        node.put("TargetId", op.accountId()); node.put("TargetType", "AWS_ACCOUNT");
+        node.put("PermissionSetArn", op.permissionSetArn()); node.put("PrincipalId", op.principalId());
+        node.put("PrincipalType", op.principalType());
+        if (op.failureReason() != null) node.put("FailureReason", op.failureReason());
+        return node;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminJsonHandler.java
@@ -58,7 +58,9 @@ public class SsoAdminJsonHandler {
         ObjectNode response = mapper.createObjectNode();
         ArrayNode arns = response.putArray("PermissionSets");
         page.items().forEach(p -> arns.add(p.arn()));
-        if (page.nextToken() != null) response.put("NextToken", page.nextToken());
+        if (page.nextToken() != null) {
+            response.put("NextToken", page.nextToken());
+        }
         return Response.ok(response).build();
     }
 
@@ -83,11 +85,14 @@ public class SsoAdminJsonHandler {
     }
 
     private Response listManagedPolicies(JsonNode request) {
-        PermissionSet p = service.getPermissionSet(
-                SsoAdminService.required(request, "InstanceArn"), SsoAdminService.required(request, "PermissionSetArn"));
+        var page = service.listManagedPolicies(request);
         ObjectNode response = mapper.createObjectNode();
         ArrayNode policies = response.putArray("AttachedManagedPolicies");
-        p.managedPolicies().forEach((arn, name) -> policies.addObject().put("Arn", arn).put("Name", name));
+        page.items().forEach(policy -> policies.addObject()
+                .put("Arn", policy.getKey()).put("Name", policy.getValue()));
+        if (page.nextToken() != null) {
+            response.put("NextToken", page.nextToken());
+        }
         return Response.ok(response).build();
     }
 
@@ -122,7 +127,9 @@ public class SsoAdminJsonHandler {
             array.addObject().put("AccountId", a.accountId()).put("PermissionSetArn", a.permissionSetArn())
                     .put("PrincipalId", a.principalId()).put("PrincipalType", a.principalType());
         }
-        if (page.nextToken() != null) response.put("NextToken", page.nextToken());
+        if (page.nextToken() != null) {
+            response.put("NextToken", page.nextToken());
+        }
         return Response.ok(response).build();
     }
 
@@ -146,7 +153,9 @@ public class SsoAdminJsonHandler {
         ObjectNode node = mapper.createObjectNode();
         node.put("PermissionSetArn", p.arn());
         node.put("Name", p.name());
-        if (p.description() != null) node.put("Description", p.description());
+        if (p.description() != null) {
+            node.put("Description", p.description());
+        }
         node.put("SessionDuration", p.sessionDuration());
         return node;
     }
@@ -157,7 +166,9 @@ public class SsoAdminJsonHandler {
         node.put("TargetId", op.accountId()); node.put("TargetType", "AWS_ACCOUNT");
         node.put("PermissionSetArn", op.permissionSetArn()); node.put("PrincipalId", op.principalId());
         node.put("PrincipalType", op.principalType());
-        if (op.failureReason() != null) node.put("FailureReason", op.failureReason());
+        if (op.failureReason() != null) {
+            node.put("FailureReason", op.failureReason());
+        }
         return node;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.PaginatedResult;
 import io.github.hectorvent.floci.core.common.Pagination;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.ssoadmin.model.Assignment;
@@ -23,7 +24,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class SsoAdminService {
+public class SsoAdminService implements Resettable {
     private static final String INSTANCE_ARN = "arn:aws:sso:::instance/ssoins-7223b02a5d9f7c8e";
     private static final String IDENTITY_STORE_ID = "d-9067f2a3c1";
     private static final Pattern PERMISSION_SET_NAME = Pattern.compile("[\\w+=,.@-]+");
@@ -68,6 +69,16 @@ public class SsoAdminService {
     public List<PermissionSet> listPermissionSets(String instanceArn) {
         requireInstance(instanceArn);
         return permissionSets.scan(key -> true).stream().sorted(Comparator.comparing(PermissionSet::name)).toList();
+    }
+
+    public PaginatedResult<Map.Entry<String, String>> listManagedPolicies(JsonNode request) {
+        PermissionSet permissionSet = getPermissionSet(
+                required(request, "InstanceArn"), required(request, "PermissionSetArn"));
+        List<Map.Entry<String, String>> policies = permissionSet.managedPolicies().entrySet().stream()
+                .map(entry -> Map.entry(entry.getKey(), entry.getValue()))
+                .toList();
+        return Pagination.paginate(policies, Map.Entry::getKey,
+                optionalMaxResults(request), text(request, "NextToken"), 50, 100, "ValidationException");
     }
 
     public synchronized PermissionSet createPermissionSet(JsonNode request) {
@@ -172,7 +183,9 @@ public class SsoAdminService {
         getPermissionSet(INSTANCE_ARN, permission);
         String principal = validatePrincipalId(required(request, "PrincipalId"));
         String principalType = required(request, "PrincipalType");
-        if (!PRINCIPAL_TYPES.contains(principalType)) throw validation("PrincipalType must be USER or GROUP.");
+        if (!PRINCIPAL_TYPES.contains(principalType)) {
+            throw validation("PrincipalType must be USER or GROUP.");
+        }
         String key = account + "::" + permission + "::" + principal;
         if (assignments.get(key).isPresent()) {
             throw conflict("The account assignment already exists.");
@@ -196,7 +209,9 @@ public class SsoAdminService {
 
     static String required(JsonNode request, String field) {
         String value = text(request, field);
-        if (value == null || value.isBlank()) throw validation(field + " must be a non-empty string.");
+        if (value == null || value.isBlank()) {
+            throw validation(field + " must be a non-empty string.");
+        }
         return value;
     }
 
@@ -207,8 +222,12 @@ public class SsoAdminService {
 
     private static Integer optionalMaxResults(JsonNode request) {
         JsonNode node = request == null ? null : request.get("MaxResults");
-        if (node == null || node.isNull()) return null;
-        if (!node.isIntegralNumber()) throw validation("MaxResults must be an integer.");
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (!node.isIntegralNumber()) {
+            throw validation("MaxResults must be an integer.");
+        }
         return node.intValue();
     }
 
@@ -220,7 +239,9 @@ public class SsoAdminService {
     }
 
     private static String optionalDescription(JsonNode request) {
-        if (!request.has("Description") || request.get("Description").isNull()) return null;
+        if (!request.has("Description") || request.get("Description").isNull()) {
+            return null;
+        }
         String description = text(request, "Description");
         if (description == null || description.length() < 1 || description.length() > 700) {
             throw validation("Description must be between 1 and 700 characters.");
@@ -229,7 +250,9 @@ public class SsoAdminService {
     }
 
     private static String validateSession(String value) {
-        if (value == null || value.length() > 100) throw validation("SessionDuration is invalid.");
+        if (value == null || value.length() > 100) {
+            throw validation("SessionDuration is invalid.");
+        }
         try {
             Duration duration = Duration.parse(value);
             if (duration.compareTo(Duration.ofHours(1)) < 0 || duration.compareTo(Duration.ofHours(12)) > 0) {
@@ -242,7 +265,9 @@ public class SsoAdminService {
     }
 
     private static void validatePermissionSetArn(String arn) {
-        if (arn == null || !PERMISSION_SET_ARN.matcher(arn).matches()) throw validation("PermissionSetArn is invalid.");
+        if (arn == null || !PERMISSION_SET_ARN.matcher(arn).matches()) {
+            throw validation("PermissionSetArn is invalid.");
+        }
     }
 
     private static void validateManagedPolicyArn(String arn) {
@@ -256,16 +281,22 @@ public class SsoAdminService {
             throw validation("InlinePolicy must be between 1 and 32768 bytes.");
         }
         long nonWhitespace = policy.chars().filter(ch -> !Character.isWhitespace(ch)).count();
-        if (nonWhitespace > MAX_INLINE_NON_WHITESPACE) throw quota("InlinePolicy exceeds the non-whitespace quota.");
+        if (nonWhitespace > MAX_INLINE_NON_WHITESPACE) {
+            throw quota("InlinePolicy exceeds the non-whitespace quota.");
+        }
     }
 
     private static String validateAccountId(String value) {
-        if (value == null || !value.matches("\\d{12}")) throw validation("AWS account identifiers must contain 12 digits.");
+        if (value == null || !value.matches("\\d{12}")) {
+            throw validation("AWS account identifiers must contain 12 digits.");
+        }
         return value;
     }
 
     private static String validatePrincipalId(String value) {
-        if (value == null || !PRINCIPAL_ID.matcher(value).matches()) throw validation("PrincipalId is invalid.");
+        if (value == null || !PRINCIPAL_ID.matcher(value).matches()) {
+            throw validation("PrincipalId is invalid.");
+        }
         return value;
     }
 
@@ -279,7 +310,16 @@ public class SsoAdminService {
     private static AwsException conflict(String message) { return new AwsException("ConflictException", message, 400); }
     private static AwsException quota(String message) { return new AwsException("ServiceQuotaExceededException", message, 400); }
     private static void requireInstance(String arn) {
-        if (arn == null || !arn.equals(INSTANCE_ARN)) throw notFound("IAM Identity Center instance not found: " + arn);
+        if (arn == null || !arn.equals(INSTANCE_ARN)) {
+            throw notFound("IAM Identity Center instance not found: " + arn);
+        }
+    }
+
+    @Override
+    public void clear() {
+        permissionSets.clear();
+        assignments.clear();
+        assignmentOperations.clear();
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
@@ -1,27 +1,285 @@
 package io.github.hectorvent.floci.services.ssoadmin;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ssoadmin.model.Assignment;
+import io.github.hectorvent.floci.services.ssoadmin.model.AssignmentOperation;
+import io.github.hectorvent.floci.services.ssoadmin.model.PermissionSet;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
-/**
- * IAM Identity Center (SSO Admin) business logic.
- *
- * <p>Models the single organization Identity Center instance LZA's
- * Custom::GetIdentityCenterInstanceMetadata Lambda expects: its {@code ListInstances} call
- * succeeds only when exactly one instance is returned, carrying both {@code InstanceArn} and
- * {@code IdentityStoreId}. The identifiers are fixed so they stay stable across calls and
- * container restarts — LZA persists them into SSM parameters between stages.
- */
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
 @ApplicationScoped
 public class SsoAdminService {
-
     private static final String INSTANCE_ARN = "arn:aws:sso:::instance/ssoins-7223b02a5d9f7c8e";
     private static final String IDENTITY_STORE_ID = "d-9067f2a3c1";
+    private static final Pattern PERMISSION_SET_NAME = Pattern.compile("[\\w+=,.@-]+");
+    private static final Pattern PERMISSION_SET_ARN = Pattern.compile("arn:aws(?:-[a-z]{1,5}){0,3}:sso:::permissionSet/(?:sso)?ins-[a-zA-Z0-9-.]{16}/ps-[a-zA-Z0-9-./]{16}");
+    private static final Pattern PRINCIPAL_ID = Pattern.compile("([0-9a-f]{10}-|)[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}");
+    private static final Pattern MANAGED_POLICY_ARN = Pattern.compile("arn:aws:iam::aws:policy/.+");
+    private static final int PERMISSION_SET_QUOTA = 3500;
+    private static final int MANAGED_POLICY_QUOTA = 25;
+    private static final int MAX_INLINE_POLICY_BYTES = 32_768;
+    private static final int MAX_INLINE_NON_WHITESPACE = 10_240;
+    private static final Set<String> PRINCIPAL_TYPES = Set.of("USER", "GROUP");
 
-    public String getInstanceArn() {
-        return INSTANCE_ARN;
+    private final StorageBackend<String, PermissionSet> permissionSets;
+    private final StorageBackend<String, Assignment> assignments;
+    private final StorageBackend<String, AssignmentOperation> assignmentOperations;
+
+    @Inject
+    public SsoAdminService(StorageFactory storageFactory) {
+        this(
+                storageFactory.create("ssoadmin", "ssoadmin-permission-sets.json", new TypeReference<Map<String, PermissionSet>>() {}),
+                storageFactory.create("ssoadmin", "ssoadmin-assignments.json", new TypeReference<Map<String, Assignment>>() {}),
+                storageFactory.create("ssoadmin", "ssoadmin-assignment-operations.json", new TypeReference<Map<String, AssignmentOperation>>() {}));
     }
 
-    public String getIdentityStoreId() {
-        return IDENTITY_STORE_ID;
+    SsoAdminService(StorageBackend<String, PermissionSet> permissionSets,
+                    StorageBackend<String, Assignment> assignments,
+                    StorageBackend<String, AssignmentOperation> assignmentOperations) {
+        this.permissionSets = permissionSets;
+        this.assignments = assignments;
+        this.assignmentOperations = assignmentOperations;
     }
+
+    public String getInstanceArn() { return INSTANCE_ARN; }
+    public String getIdentityStoreId() { return IDENTITY_STORE_ID; }
+
+    public PaginatedResult<PermissionSet> listPermissionSets(JsonNode request) {
+        requireInstance(required(request, "InstanceArn"));
+        return Pagination.paginate(permissionSets.scan(key -> true), PermissionSet::arn,
+                optionalMaxResults(request), text(request, "NextToken"), 50, 100, "ValidationException");
+    }
+
+    public List<PermissionSet> listPermissionSets(String instanceArn) {
+        requireInstance(instanceArn);
+        return permissionSets.scan(key -> true).stream().sorted(Comparator.comparing(PermissionSet::name)).toList();
+    }
+
+    public synchronized PermissionSet createPermissionSet(JsonNode request) {
+        requireInstance(required(request, "InstanceArn"));
+        String name = validateName(required(request, "Name"));
+        String description = optionalDescription(request);
+        String sessionDuration = validateSession(valueOr(request, "SessionDuration", "PT1H"));
+        if (permissionSets.scan(key -> true).stream().anyMatch(p -> name.equals(p.name()))) {
+            throw conflict("Permission set already exists: " + name);
+        }
+        if (permissionSets.scan(key -> true).size() >= PERMISSION_SET_QUOTA) {
+            throw quota("The IAM Identity Center permission set quota has been exceeded.");
+        }
+        String arn = "arn:aws:sso:::permissionSet/ssoins-7223b02a5d9f7c8e/ps-" + shortId();
+        PermissionSet permissionSet = new PermissionSet(arn, name, description, sessionDuration,
+                new LinkedHashMap<>(), null);
+        permissionSets.put(arn, permissionSet);
+        return permissionSet;
+    }
+
+    public PermissionSet getPermissionSet(String instanceArn, String arn) {
+        requireInstance(instanceArn);
+        validatePermissionSetArn(arn);
+        return permissionSets.get(arn).orElseThrow(() -> notFound("Permission set not found: " + arn));
+    }
+
+    public synchronized PermissionSet updatePermissionSet(JsonNode request) {
+        PermissionSet current = getPermissionSet(required(request, "InstanceArn"), required(request, "PermissionSetArn"));
+        String description = request.has("Description") ? optionalDescription(request) : current.description();
+        String session = request.has("SessionDuration")
+                ? validateSession(required(request, "SessionDuration")) : current.sessionDuration();
+        PermissionSet updated = new PermissionSet(current.arn(), current.name(), description, session,
+                new LinkedHashMap<>(current.managedPolicies()), current.inlinePolicy());
+        permissionSets.put(updated.arn(), updated);
+        return updated;
+    }
+
+    public synchronized void attachPolicy(String instanceArn, String arn, String policyArn) {
+        PermissionSet current = getPermissionSet(instanceArn, arn);
+        validateManagedPolicyArn(policyArn);
+        if (current.managedPolicies().containsKey(policyArn)) {
+            throw conflict("The managed policy is already attached to the permission set.");
+        }
+        if (current.managedPolicies().size() >= MANAGED_POLICY_QUOTA) {
+            throw quota("A permission set can have at most 25 managed policies.");
+        }
+        current.managedPolicies().put(policyArn, policyArn.substring(policyArn.lastIndexOf('/') + 1));
+        permissionSets.put(arn, current);
+    }
+
+    public synchronized void detachPolicy(String instanceArn, String arn, String policyArn) {
+        PermissionSet current = getPermissionSet(instanceArn, arn);
+        validateManagedPolicyArn(policyArn);
+        if (current.managedPolicies().remove(policyArn) == null) {
+            throw conflict("The managed policy is not attached to the permission set.");
+        }
+        permissionSets.put(arn, current);
+    }
+
+    public synchronized void putInlinePolicy(String instanceArn, String arn, String policy) {
+        PermissionSet current = getPermissionSet(instanceArn, arn);
+        validateInlinePolicy(policy);
+        permissionSets.put(arn, new PermissionSet(current.arn(), current.name(), current.description(),
+                current.sessionDuration(), new LinkedHashMap<>(current.managedPolicies()), policy));
+    }
+
+    public synchronized void deleteInlinePolicy(String instanceArn, String arn) {
+        PermissionSet current = getPermissionSet(instanceArn, arn);
+        permissionSets.put(arn, new PermissionSet(current.arn(), current.name(), current.description(),
+                current.sessionDuration(), new LinkedHashMap<>(current.managedPolicies()), null));
+    }
+
+    public PaginatedResult<Assignment> listAssignments(JsonNode request) {
+        String instanceArn = required(request, "InstanceArn");
+        requireInstance(instanceArn);
+        String accountId = validateAccountId(required(request, "AccountId"));
+        String permissionSetArn = required(request, "PermissionSetArn");
+        getPermissionSet(instanceArn, permissionSetArn);
+        List<Assignment> matching = assignments.scan(key -> true).stream()
+                .filter(a -> accountId.equals(a.accountId()) && permissionSetArn.equals(a.permissionSetArn()))
+                .toList();
+        return Pagination.paginate(matching, Assignment::principalId,
+                optionalMaxResults(request), text(request, "NextToken"), 50, 100, "ValidationException");
+    }
+
+    public List<Assignment> listAssignments(String instanceArn, String accountId, String permissionSetArn) {
+        requireInstance(instanceArn);
+        validateAccountId(accountId);
+        getPermissionSet(instanceArn, permissionSetArn);
+        return assignments.scan(key -> true).stream()
+                .filter(a -> accountId.equals(a.accountId()) && permissionSetArn.equals(a.permissionSetArn()))
+                .sorted(Comparator.comparing(Assignment::principalId)).toList();
+    }
+
+    public synchronized AssignmentOperation createAssignment(JsonNode request) {
+        requireInstance(required(request, "InstanceArn"));
+        String account = validateAccountId(required(request, "TargetId"));
+        if (!"AWS_ACCOUNT".equals(required(request, "TargetType"))) {
+            throw validation("TargetType must be AWS_ACCOUNT.");
+        }
+        String permission = required(request, "PermissionSetArn");
+        getPermissionSet(INSTANCE_ARN, permission);
+        String principal = validatePrincipalId(required(request, "PrincipalId"));
+        String principalType = required(request, "PrincipalType");
+        if (!PRINCIPAL_TYPES.contains(principalType)) throw validation("PrincipalType must be USER or GROUP.");
+        String key = account + "::" + permission + "::" + principal;
+        if (assignments.get(key).isPresent()) {
+            throw conflict("The account assignment already exists.");
+        }
+        Assignment assignment = new Assignment(account, permission, principal, principalType);
+        assignments.put(key, assignment);
+        String requestId = UUID.randomUUID().toString();
+        AssignmentOperation operation = new AssignmentOperation(requestId, "SUCCEEDED", account, permission,
+                principal, principalType, null);
+        assignmentOperations.put(requestId, operation);
+        return operation;
+    }
+
+    public AssignmentOperation getAssignmentOperation(String instanceArn, String requestId) {
+        requireInstance(instanceArn);
+        if (requestId == null || !requestId.matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")) {
+            throw validation("AccountAssignmentCreationRequestId must be a UUID.");
+        }
+        return assignmentOperations.get(requestId).orElseThrow(() -> notFound("Assignment operation not found: " + requestId));
+    }
+
+    static String required(JsonNode request, String field) {
+        String value = text(request, field);
+        if (value == null || value.isBlank()) throw validation(field + " must be a non-empty string.");
+        return value;
+    }
+
+    static String text(JsonNode request, String field) {
+        JsonNode node = request == null ? null : request.get(field);
+        return node != null && node.isTextual() ? node.textValue() : null;
+    }
+
+    private static Integer optionalMaxResults(JsonNode request) {
+        JsonNode node = request == null ? null : request.get("MaxResults");
+        if (node == null || node.isNull()) return null;
+        if (!node.isIntegralNumber()) throw validation("MaxResults must be an integer.");
+        return node.intValue();
+    }
+
+    private static String validateName(String name) {
+        if (name.length() > 32 || !PERMISSION_SET_NAME.matcher(name).matches()) {
+            throw validation("Name must be 1-32 characters and match [\\w+=,.@-]+.");
+        }
+        return name;
+    }
+
+    private static String optionalDescription(JsonNode request) {
+        if (!request.has("Description") || request.get("Description").isNull()) return null;
+        String description = text(request, "Description");
+        if (description == null || description.length() < 1 || description.length() > 700) {
+            throw validation("Description must be between 1 and 700 characters.");
+        }
+        return description;
+    }
+
+    private static String validateSession(String value) {
+        if (value == null || value.length() > 100) throw validation("SessionDuration is invalid.");
+        try {
+            Duration duration = Duration.parse(value);
+            if (duration.compareTo(Duration.ofHours(1)) < 0 || duration.compareTo(Duration.ofHours(12)) > 0) {
+                throw validation("SessionDuration must be between 1 and 12 hours.");
+            }
+        } catch (java.time.format.DateTimeParseException e) {
+            throw validation("SessionDuration must use ISO-8601 duration syntax.");
+        }
+        return value;
+    }
+
+    private static void validatePermissionSetArn(String arn) {
+        if (arn == null || !PERMISSION_SET_ARN.matcher(arn).matches()) throw validation("PermissionSetArn is invalid.");
+    }
+
+    private static void validateManagedPolicyArn(String arn) {
+        if (arn == null || arn.length() > 2048 || !MANAGED_POLICY_ARN.matcher(arn).matches()) {
+            throw validation("ManagedPolicyArn must identify an AWS managed IAM policy.");
+        }
+    }
+
+    private static void validateInlinePolicy(String policy) {
+        if (policy == null || policy.isEmpty() || policy.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > MAX_INLINE_POLICY_BYTES) {
+            throw validation("InlinePolicy must be between 1 and 32768 bytes.");
+        }
+        long nonWhitespace = policy.chars().filter(ch -> !Character.isWhitespace(ch)).count();
+        if (nonWhitespace > MAX_INLINE_NON_WHITESPACE) throw quota("InlinePolicy exceeds the non-whitespace quota.");
+    }
+
+    private static String validateAccountId(String value) {
+        if (value == null || !value.matches("\\d{12}")) throw validation("AWS account identifiers must contain 12 digits.");
+        return value;
+    }
+
+    private static String validatePrincipalId(String value) {
+        if (value == null || !PRINCIPAL_ID.matcher(value).matches()) throw validation("PrincipalId is invalid.");
+        return value;
+    }
+
+    private static String valueOr(JsonNode request, String field, String fallback) {
+        String value = text(request, field);
+        return value == null || value.isBlank() ? fallback : value;
+    }
+    private static String shortId() { return UUID.randomUUID().toString().replace("-", "").substring(0, 16); }
+    private static AwsException notFound(String message) { return new AwsException("ResourceNotFoundException", message, 400); }
+    private static AwsException validation(String message) { return new AwsException("ValidationException", message, 400); }
+    private static AwsException conflict(String message) { return new AwsException("ConflictException", message, 400); }
+    private static AwsException quota(String message) { return new AwsException("ServiceQuotaExceededException", message, 400); }
+    private static void requireInstance(String arn) {
+        if (arn == null || !arn.equals(INSTANCE_ARN)) throw notFound("IAM Identity Center instance not found: " + arn);
+    }
+
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/model/Assignment.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/model/Assignment.java
@@ -1,0 +1,6 @@
+package io.github.hectorvent.floci.services.ssoadmin.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record Assignment(String accountId, String permissionSetArn, String principalId, String principalType) {}

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/model/AssignmentOperation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/model/AssignmentOperation.java
@@ -1,0 +1,7 @@
+package io.github.hectorvent.floci.services.ssoadmin.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+public record AssignmentOperation(String requestId, String status, String accountId, String permissionSetArn,
+                                  String principalId, String principalType, String failureReason) {}

--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/model/PermissionSet.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/model/PermissionSet.java
@@ -1,0 +1,9 @@
+package io.github.hectorvent.floci.services.ssoadmin.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.Map;
+
+@RegisterForReflection
+public record PermissionSet(String arn, String name, String description, String sessionDuration,
+                            Map<String, String> managedPolicies, String inlinePolicy) {}

--- a/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminAssignmentsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminAssignmentsIntegrationTest.java
@@ -1,0 +1,61 @@
+package io.github.hectorvent.floci.services.ssoadmin;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class SsoAdminAssignmentsIntegrationTest {
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260904/us-east-1/sso/aws4_request";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void permissionSetAndAccountAssignmentLifecycle() {
+        String instanceArn = json("SWBExternalService.ListInstances", "{}")
+                .then().statusCode(200).extract().path("Instances[0].InstanceArn");
+        String permissionSetArn = json("SWBExternalService.CreatePermissionSet",
+                "{\"InstanceArn\":\"" + instanceArn + "\",\"Name\":\"PlatformAdmins\"}")
+                .then().statusCode(200).body("PermissionSet.PermissionSetArn", notNullValue())
+                .extract().path("PermissionSet.PermissionSetArn");
+        json("SWBExternalService.ListPermissionSets", "{\"InstanceArn\":\"" + instanceArn + "\"}")
+                .then().statusCode(200).body("PermissionSets", hasSize(1));
+
+        String assignment = "{\"InstanceArn\":\"" + instanceArn
+                + "\",\"TargetId\":\"123456789012\",\"TargetType\":\"AWS_ACCOUNT\",\"PermissionSetArn\":\""
+                + permissionSetArn + "\",\"PrincipalType\":\"GROUP\",\"PrincipalId\":\"11111111-2222-3333-4444-555555555555\"}";
+        String requestId = json("SWBExternalService.CreateAccountAssignment", assignment)
+                .then().statusCode(200).extract().path("AccountAssignmentCreationStatus.RequestId");
+        json("SWBExternalService.DescribeAccountAssignmentCreationStatus",
+                "{\"InstanceArn\":\"" + instanceArn + "\",\"AccountAssignmentCreationRequestId\":\"" + requestId + "\"}")
+                .then().statusCode(200).body("AccountAssignmentCreationStatus.Status", equalTo("SUCCEEDED"));
+        json("SWBExternalService.ListAccountAssignments",
+                "{\"InstanceArn\":\"" + instanceArn + "\",\"AccountId\":\"123456789012\",\"PermissionSetArn\":\""
+                        + permissionSetArn + "\"}")
+                .then().statusCode(200).body("AccountAssignments[0].PrincipalType", equalTo("GROUP"));
+    }
+
+    @Test
+    void invalidAssignmentRequestIdReturnsResourceNotFound() {
+        String instanceArn = json("SWBExternalService.ListInstances", "{}")
+                .then().statusCode(200).extract().path("Instances[0].InstanceArn");
+        json("SWBExternalService.DescribeAccountAssignmentCreationStatus",
+                "{\"InstanceArn\":\"" + instanceArn + "\",\"AccountAssignmentCreationRequestId\":\"00000000-0000-0000-0000-000000000000\"}")
+                .then().statusCode(400).body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    private static io.restassured.response.Response json(String target, String body) {
+        return given().contentType(CONTENT_TYPE).header("Authorization", AUTH).header("X-Amz-Target", target)
+                .body(body).post("/");
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminServiceTest.java
@@ -1,0 +1,139 @@
+package io.github.hectorvent.floci.services.ssoadmin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ssoadmin.model.Assignment;
+import io.github.hectorvent.floci.services.ssoadmin.model.AssignmentOperation;
+import io.github.hectorvent.floci.services.ssoadmin.model.PermissionSet;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SsoAdminServiceTest {
+    private static final String ACCOUNT_ID = "123456789012";
+    private static final String PRINCIPAL_ID = "11111111-2222-3333-4444-555555555555";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private SsoAdminService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new SsoAdminService(
+                new InMemoryStorage<String, PermissionSet>(),
+                new InMemoryStorage<String, Assignment>(),
+                new InMemoryStorage<String, AssignmentOperation>());
+    }
+
+    @Test
+    void managedPolicyPaginationHonorsMaxResultsAndNextToken() {
+        PermissionSet permissionSet = createPermissionSet("PlatformAdmins");
+        service.attachPolicy(service.getInstanceArn(), permissionSet.arn(), "arn:aws:iam::aws:policy/ReadOnlyAccess");
+        service.attachPolicy(service.getInstanceArn(), permissionSet.arn(), "arn:aws:iam::aws:policy/SecurityAudit");
+        service.attachPolicy(service.getInstanceArn(), permissionSet.arn(), "arn:aws:iam::aws:policy/ViewOnlyAccess");
+
+        ObjectNode firstRequest = managedPoliciesRequest(permissionSet.arn());
+        firstRequest.put("MaxResults", 1);
+        var first = service.listManagedPolicies(firstRequest);
+
+        assertEquals(1, first.items().size());
+        assertNotNull(first.nextToken());
+
+        ObjectNode secondRequest = managedPoliciesRequest(permissionSet.arn());
+        secondRequest.put("MaxResults", 1);
+        secondRequest.put("NextToken", first.nextToken());
+        var second = service.listManagedPolicies(secondRequest);
+
+        assertEquals(1, second.items().size());
+        assertNotNull(second.nextToken());
+        assertFalse(first.items().get(0).getKey().equals(second.items().get(0).getKey()));
+    }
+
+    @Test
+    void managedPolicyPaginationRejectsInvalidInputs() {
+        PermissionSet permissionSet = createPermissionSet("AuditAdmins");
+
+        ObjectNode badLimit = managedPoliciesRequest(permissionSet.arn());
+        badLimit.put("MaxResults", 101);
+        assertError("ValidationException", () -> service.listManagedPolicies(badLimit));
+
+        ObjectNode badToken = managedPoliciesRequest(permissionSet.arn());
+        badToken.put("NextToken", "not%base64");
+        assertError("ValidationException", () -> service.listManagedPolicies(badToken));
+    }
+
+    @Test
+    void duplicateManagedPolicyReturnsConflict() {
+        PermissionSet permissionSet = createPermissionSet("SecurityAdmins");
+        String policyArn = "arn:aws:iam::aws:policy/SecurityAudit";
+        service.attachPolicy(service.getInstanceArn(), permissionSet.arn(), policyArn);
+
+        assertError("ConflictException",
+                () -> service.attachPolicy(service.getInstanceArn(), permissionSet.arn(), policyArn));
+    }
+
+    @Test
+    void assignmentValidationAndDuplicateDetectionAreModeled() {
+        PermissionSet permissionSet = createPermissionSet("AssignmentAdmins");
+        ObjectNode request = assignmentRequest(permissionSet.arn());
+        AssignmentOperation created = service.createAssignment(request);
+        assertEquals("SUCCEEDED", created.status());
+
+        assertError("ConflictException", () -> service.createAssignment(request));
+
+        ObjectNode invalidPrincipalType = assignmentRequest(permissionSet.arn());
+        invalidPrincipalType.put("PrincipalType", "ROLE");
+        invalidPrincipalType.put("PrincipalId", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        assertError("ValidationException", () -> service.createAssignment(invalidPrincipalType));
+    }
+
+    @Test
+    void clearRemovesPersistedServiceState() {
+        PermissionSet permissionSet = createPermissionSet("ResetAdmins");
+        AssignmentOperation operation = service.createAssignment(assignmentRequest(permissionSet.arn()));
+        assertFalse(service.listPermissionSets(service.getInstanceArn()).isEmpty());
+        assertNotNull(service.getAssignmentOperation(service.getInstanceArn(), operation.requestId()));
+
+        service.clear();
+
+        assertTrue(service.listPermissionSets(service.getInstanceArn()).isEmpty());
+        assertError("ResourceNotFoundException",
+                () -> service.getAssignmentOperation(service.getInstanceArn(), operation.requestId()));
+    }
+
+    private PermissionSet createPermissionSet(String name) {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("InstanceArn", service.getInstanceArn());
+        request.put("Name", name);
+        return service.createPermissionSet(request);
+    }
+
+    private ObjectNode managedPoliciesRequest(String permissionSetArn) {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("InstanceArn", service.getInstanceArn());
+        request.put("PermissionSetArn", permissionSetArn);
+        return request;
+    }
+
+    private ObjectNode assignmentRequest(String permissionSetArn) {
+        ObjectNode request = mapper.createObjectNode();
+        request.put("InstanceArn", service.getInstanceArn());
+        request.put("TargetId", ACCOUNT_ID);
+        request.put("TargetType", "AWS_ACCOUNT");
+        request.put("PermissionSetArn", permissionSetArn);
+        request.put("PrincipalType", "GROUP");
+        request.put("PrincipalId", PRINCIPAL_ID);
+        return request;
+    }
+
+    private static void assertError(String expectedCode, Runnable operation) {
+        AwsException error = assertThrows(AwsException.class, operation::run);
+        assertEquals(expectedCode, error.getErrorCode());
+    }
+}

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -198,6 +198,10 @@ services:
     doc: docs/services/servicequotas.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/servicequotas/ServiceQuotasJsonHandler.java, mode: switch }
+  - service: ssoadmin
+    doc: docs/services/ssoadmin.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminJsonHandler.java, mode: switch }
   - service: sqs
     doc: docs/services/sqs.md
     sources:
@@ -219,7 +223,6 @@ services:
 # Switch handlers that exist but are intentionally not yet covered (see reasons).
 # A NEW switch handler not listed here and not registered above fails `--strict`.
 deferred_handlers:
-  - { path: src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminJsonHandler.java }  # single-op Identity Center stub, no standalone doc page yet
   - { path: src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2JsonHandler.java }  # non-tabular doc (grouped/inline)
   - { path: src/main/java/io/github/hectorvent/floci/services/applicationautoscaling/ScalingPolicyAlarmActionHandler.java }  # not a JSON/Query action dispatcher — its `case "X" ->` arms are the StepScaling AdjustmentType switch, not AWS actions
   - { path: src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java }  # non-tabular doc (grouped/inline)


### PR DESCRIPTION
## Summary
- add IAM Identity Center permission set and account assignment lifecycle support
- model assignment operation status and listing behavior using AWS-shaped responses
- add focused integration coverage and AWS SDK v2 compatibility coverage

## Validation
- `./mvnw -Dtest=SsoAdminAssignmentsIntegrationTest test` (2/2)
- `FLOCI_ENDPOINT=http://localhost:4567 ../../mvnw -Dtest=SsoAdminAccountAssignmentTest test` (1/1)
- `make docs-check`
- `git diff --check`

AWS reference: https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_CreateAccountAssignment.html