### PR TITLE
fix(cloudformation): refuse UpdateStack on a ROLLBACK_COMPLETE stack

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -167,6 +167,38 @@ public class CloudFormationService implements ResourceProvider {
         return stack != null ? stack.getParameters() : Map.of();
     }
 
+    /**
+     * The status of a stack, or {@code null} when no stack of that name exists in the region.
+     * Unlike {@link #describeStacks}, asking about a stack that is not there is not an error:
+     * StackSet deployment uses this to decide what to do with an instance before it acts on it.
+     */
+    String stackStatus(String stackName, String region) {
+        Stack stack = resolveStack(stackName, region);
+        return stack != null ? stack.getStatus() : null;
+    }
+
+    /**
+     * Whether a stack in this status refuses an update, on the two grounds AWS refuses one.
+     *
+     * <p>A status ending in {@code _IN_PROGRESS} says an operation owns the stack: a create, an
+     * update, a rollback or the cleanup phase of a committed update. AWS refuses to start a second
+     * one over it, and offers nothing that finishes a phase whose process is gone - DeleteStack is
+     * the only way out of one. Refusing keeps every abandoned phase out of the next update's
+     * transaction.
+     *
+     * <p>{@code ROLLBACK_COMPLETE} is terminal for a different reason: a create that failed rolled
+     * its resources back, so the stack holds the name and nothing else, and only DeleteStack frees
+     * it. The CDK CLI keys on this state and tells the user to delete the stack; a client that is
+     * accepted here instead proceeds against a stack AWS would have rejected. It is matched exactly
+     * rather than by suffix, because {@code UPDATE_ROLLBACK_COMPLETE} ends the same way and is a
+     * perfectly updatable stack: it is where an update that failed and rolled back settles, and
+     * retrying the update is how it is repaired.
+     */
+    static boolean refusesUpdate(String status) {
+        return status != null
+                && (status.endsWith("_IN_PROGRESS") || "ROLLBACK_COMPLETE".equals(status));
+    }
+
     // ── CreateChangeSet ───────────────────────────────────────────────────────
 
     public ChangeSet createChangeSet(String stackName, String changeSetName, String changeSetType,
@@ -293,17 +325,10 @@ public class CloudFormationService implements ResourceProvider {
                     throw new AwsException("AlreadyExistsException",
                             "Stack [" + stackName + "] already exists", 400);
                 }
-                // A status ending in _IN_PROGRESS says an operation owns the stack: a create, an
-                // update, a rollback or the cleanup phase of a committed update. AWS refuses to
-                // start a second one over it, and offers nothing that finishes a phase whose
-                // process is gone - DeleteStack is the only way out of one. Refusing here keeps
-                // every abandoned phase out of the next update's transaction.
-                //
                 // The message is the one real CloudFormation emits, down to its own "can not"
                 // spelling and the stack id carried as "Stack:<arn>" with no space: clients match
                 // on this string.
-                if (!isCreateType && existing.getStatus() != null
-                        && existing.getStatus().endsWith("_IN_PROGRESS")) {
+                if (!isCreateType && refusesUpdate(existing.getStatus())) {
                     throw new AwsException("ValidationError",
                             "Stack:" + existing.getStackId() + " is in " + existing.getStatus()
                                     + " state and can not be updated.", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/StackSetService.java
@@ -124,7 +124,24 @@ public class StackSetService {
         // Re-apply the updated definition to every existing instance, refreshing each record.
         List<StackInstance> deployed = new ArrayList<>();
         for (StackInstance inst : listStackInstances(name, null, null)) {
-            StackInstance updated = deployInstance(ss, inst.getAccount(), inst.getRegion(), UPDATE_CHANGE_SET, "UPDATE");
+            // An instance whose stack is terminal - a failed create that rolled back, or a phase
+            // some earlier operation abandoned - is one the single-stack engine refuses to update.
+            // That is one instance failing, not a malformed request: AWS leaves such an instance
+            // INOPERABLE, updates the rest, and reports the operation FAILED. Deploying into it
+            // anyway would raise the refusal out of here and fail the whole UpdateStackSet call
+            // with a 400, updating no instance at all.
+            String stackStatus = cfnService.stackStatus(inst.getStackName(), inst.getRegion());
+            if (CloudFormationService.refusesUpdate(stackStatus)) {
+                inst.setStatus("INOPERABLE");
+                inst.setDetailedStatus("FAILED");
+                inst.setStatusReason("Stack instance is in " + stackStatus
+                        + " state and can not be updated");
+                instances.put(instanceKey(name, inst.getAccount(), inst.getRegion()), inst);
+                deployed.add(inst);
+                continue;
+            }
+            StackInstance updated =
+                    deployInstance(ss, inst.getAccount(), inst.getRegion(), UPDATE_CHANGE_SET, "UPDATE");
             instances.put(instanceKey(name, updated.getAccount(), updated.getRegion()), updated);
             deployed.add(updated);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationRollbackCompleteUpdateIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationRollbackCompleteUpdateIntegrationTest.java
@@ -1,0 +1,231 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * A create that fails rolls its resources back and leaves the stack in ROLLBACK_COMPLETE, which
+ * AWS treats as terminal: the stack holds the name and nothing else, and the only way forward is
+ * DeleteStack. UpdateStack and an UPDATE change set are both refused there, with the message real
+ * CloudFormation emits, while DeleteStack and an update over UPDATE_ROLLBACK_COMPLETE keep working.
+ */
+@QuarkusTest
+class CloudFormationRollbackCompleteUpdateIntegrationTest {
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void updateStackIsRefusedOnARollbackCompleteStack() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "rollback-complete-update-" + suffix;
+        String topicName = "rollback-complete-update-t-" + suffix;
+
+        createRolledBackStack(stackName, suffix);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", topicTemplate(topicName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ValidationError</Code>"))
+            .body(containsString(
+                    "Stack:arn:aws:cloudformation:us-east-1:000000000000:stack/" + stackName + "/"))
+            .body(containsString(" is in ROLLBACK_COMPLETE state and can not be updated."));
+
+        // The refusal changes nothing: the stack keeps its status and gains no resource.
+        assertStackStatus(stackName, "ROLLBACK_COMPLETE");
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackResources")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString(topicName)));
+
+        deleteStack(stackName);
+    }
+
+    /**
+     * CreateChangeSet with ChangeSetType=UPDATE is refused on the same terms as UpdateStack: both
+     * reach the same guard, so a client cannot route around the refusal by building the change set
+     * itself.
+     */
+    @Test
+    void aChangeSetIsRefusedOnARollbackCompleteStack() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "rollback-complete-changeset-" + suffix;
+        String topicName = "rollback-complete-changeset-t-" + suffix;
+
+        createRolledBackStack(stackName, suffix);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateChangeSet")
+            .formParam("StackName", stackName)
+            .formParam("ChangeSetName", "rollback-complete-cs-" + suffix)
+            .formParam("ChangeSetType", "UPDATE")
+            .formParam("TemplateBody", topicTemplate(topicName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body(containsString("<Code>ValidationError</Code>"))
+            .body(containsString(" is in ROLLBACK_COMPLETE state and can not be updated."));
+
+        assertStackStatus(stackName, "ROLLBACK_COMPLETE");
+        deleteStack(stackName);
+    }
+
+    /**
+     * DeleteStack is the way out of ROLLBACK_COMPLETE, so refusing the update must not touch it:
+     * the stack goes away and its name is free for a fresh CreateStack.
+     */
+    @Test
+    void deleteStackStillClearsARollbackCompleteStack() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "rollback-complete-delete-" + suffix;
+        String topicName = "rollback-complete-delete-t-" + suffix;
+
+        createRolledBackStack(stackName, suffix);
+        deleteStack(stackName);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", topicTemplate(topicName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        assertStackStatus(stackName, "CREATE_COMPLETE");
+        deleteStack(stackName);
+    }
+
+    /**
+     * UPDATE_ROLLBACK_COMPLETE ends in the same eleven characters and means the opposite: an update
+     * failed over a stack that is still live and intact, and retrying the update is how it is
+     * repaired. Refusing it would strand every stack whose update ever failed.
+     */
+    @Test
+    void updateStaysAllowedAfterAnUpdateRolledBack() {
+        String suffix = Long.toString(System.nanoTime(), 36);
+        String stackName = "update-rollback-complete-" + suffix;
+        String topicName = "update-rollback-complete-t-" + suffix;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", topicTemplate(topicName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+        assertStackStatus(stackName, "CREATE_COMPLETE");
+
+        // An update whose added resource cannot provision rolls back over a live stack.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", topicTemplate(topicName, unprovisionableNestedStack()))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+        assertStackStatus(stackName, "UPDATE_ROLLBACK_COMPLETE");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", topicTemplate(topicName))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+        assertStackStatus(stackName, "UPDATE_COMPLETE");
+
+        deleteStack(stackName);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** Creates a stack whose only resource fails, so it settles in ROLLBACK_COMPLETE. */
+    private static void createRolledBackStack(String stackName, String suffix) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", stackName)
+            .formParam("TemplateBody", "{\"Resources\":{" + unprovisionableNestedStack() + "}}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+        assertStackStatus(stackName, "ROLLBACK_COMPLETE");
+    }
+
+    /** A nested stack with no TemplateURL cannot provision, and its rollback deletes nothing. */
+    private static String unprovisionableNestedStack() {
+        return "\"Nested\":{\"Type\":\"AWS::CloudFormation::Stack\",\"Properties\":{}}";
+    }
+
+    private static String topicTemplate(String topicName) {
+        return topicTemplate(topicName, null);
+    }
+
+    /**
+     * The topic depends on the added resource, so an update that adds a resource which cannot
+     * provision fails before the topic is reached. That keeps the rollback to the one resource the
+     * failed update created and lands the stack in UPDATE_ROLLBACK_COMPLETE, rather than in
+     * UPDATE_ROLLBACK_FAILED over a topic no provisioner knows how to restore.
+     */
+    private static String topicTemplate(String topicName, String extraResource) {
+        return "{\"Resources\":{"
+                + "\"Topic\":{\"Type\":\"AWS::SNS::Topic\""
+                + (extraResource == null ? "" : ",\"DependsOn\":\"Nested\"")
+                + ",\"Properties\":{\"TopicName\":\"" + topicName + "\"}}"
+                + (extraResource == null ? "" : "," + extraResource)
+                + "}}";
+    }
+
+    private static void assertStackStatus(String stackName, String status) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>" + status + "</StackStatus>"));
+    }
+
+    private static void deleteStack(String stackName) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DeleteStack")
+            .formParam("StackName", stackName)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationStackSetsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationStackSetsIntegrationTest.java
@@ -548,6 +548,73 @@ class CloudFormationStackSetsIntegrationTest {
             .body(containsString("<Status>FAILED</Status>"));
     }
 
+    /**
+     * An instance whose stack rolled back is terminal, and the single-stack engine refuses to
+     * update it. That is one instance failing, not a malformed request: UpdateStackSet still
+     * answers, leaves the instance INOPERABLE, and reports the operation FAILED. Letting the
+     * refusal out would fail the whole call with a 400 and update no instance at all.
+     */
+    @Test
+    void updateStackSetReportsFailedRatherThanRefusingOverARolledBackInstance() {
+        String setName = "failset-update-" + UUID.randomUUID().toString().substring(0, 8);
+        String queueName = "failset-update-q-" + UUID.randomUUID().toString().substring(0, 8);
+        String badTemplate =
+            "{\"Resources\":{\"Nested\":{\"Type\":\"AWS::CloudFormation::Stack\",\"Properties\":{}}}}";
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStackSet")
+            .formParam("StackSetName", setName)
+            .formParam("TemplateBody", badTemplate)
+            .header("Authorization", auth(ADMIN, "cloudformation"))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStackInstances")
+            .formParam("StackSetName", setName)
+            .formParam("Accounts.member.1", ACCOUNT_B)
+            .formParam("Regions.member.1", REGION)
+            .header("Authorization", auth(ADMIN, "cloudformation"))
+        .when().post("/")
+        .then().statusCode(200);
+
+        String operationId = given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "UpdateStackSet")
+            .formParam("StackSetName", setName)
+            .formParam("TemplateBody", queueTemplate(queueName))
+            .header("Authorization", auth(ADMIN, "cloudformation"))
+        .when().post("/")
+        .then().statusCode(200)
+            .extract().path("UpdateStackSetResponse.UpdateStackSetResult.OperationId");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackSetOperation")
+            .formParam("StackSetName", setName)
+            .formParam("OperationId", operationId)
+            .header("Authorization", auth(ADMIN, "cloudformation"))
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<Status>FAILED</Status>"));
+
+        // The instance is kept and still INOPERABLE, carrying the refusal as its reason.
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStackInstance")
+            .formParam("StackSetName", setName)
+            .formParam("StackInstanceAccount", ACCOUNT_B)
+            .formParam("StackInstanceRegion", REGION)
+            .header("Authorization", auth(ADMIN, "cloudformation"))
+        .when().post("/")
+        .then().statusCode(200)
+            .body(containsString("<DetailedStatus>FAILED</DetailedStatus>"))
+            .body(containsString(
+                    "Stack instance is in ROLLBACK_COMPLETE state and can not be updated"));
+    }
+
     @Test
     void stackSetConditionPreflightUsesTargetAccountOnCreateInstances() {
         // Regression: condition-dependency preflight for a StackSet instance must run in the target


### PR DESCRIPTION
## Summary

Closes #3097. Follow-up promised in the #2970 review.

A stack whose creation failed sits in `ROLLBACK_COMPLETE` holding nothing but its name, and AWS refuses to update it — only `DeleteStack` frees the name. #2970 added a guard that refuses an update while a status ends in `_IN_PROGRESS`; `ROLLBACK_COMPLETE` was not part of it, so Floci accepted the update and re-provisioned a stack AWS treats as terminal. The CDK CLI keys on this state and tells the user to delete the stack; a client that gets a 200 here instead proceeds against something real AWS would have rejected.

The guard now covers both grounds, and `UpdateStack` and `CreateChangeSet` with `ChangeSetType=UPDATE` share it, so a client cannot route around the refusal by building the change set itself.

**`ROLLBACK_COMPLETE` is matched exactly, not by suffix.** `UPDATE_ROLLBACK_COMPLETE` ends in the same eleven characters and means the opposite: an update failed over a stack that is still live and intact, and retrying the update is how it is repaired. Refusing it would strand every stack whose update ever failed. `updateStaysAllowedAfterAnUpdateRolledBack` pins that.

## StackSets

Adding the condition alone regressed `UpdateStackSet`: an instance whose stack rolled back is `INOPERABLE`, and deploying into it would raise the refusal out of the loop and fail the **whole call with a 400**, updating no instance at all. That is not what AWS does — it leaves such an instance alone, updates the rest, and reports the operation `FAILED`.

`updateStackSet` now pre-checks the instance's stack status through the same predicate rather than deploying and catching, so nothing is swallowed: only a stack that genuinely refuses an update is skipped, and a real validation error still surfaces as a 400. Verified by reverting only `StackSetService` with the guard in place — the new StackSets test then fails with `Expected status code <200> but was <400>`.

## AWS Compatibility

**Incorrect behavior:** `UpdateStack` on a `ROLLBACK_COMPLETE` stack returned 200 and re-provisioned the stack's resources. Real AWS refuses it synchronously:

```
An error occurred (ValidationError) when calling the UpdateStack operation:
Stack:arn:aws:cloudformation:us-east-1:000000000000:stack/demo/<id> is in
ROLLBACK_COMPLETE state and can not be updated.
```

moto emits the same string from `_validate_status` (`moto/cloudformation/responses.py`). The message is reproduced exactly, down to AWS's own "can not" spelling and the `Stack:<arn>` with no space, since clients match on it.

`DeleteStack` on a `ROLLBACK_COMPLETE` stack keeps working — the #2207 path — and `deleteStackStillClearsARollbackCompleteStack` covers it: the stack goes away and its name is free for a fresh `CreateStack`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Tests

New `CloudFormationRollbackCompleteUpdateIntegrationTest`, four cases: `UpdateStack` refused with the pinned message, `CreateChangeSet` refused on the same terms, `DeleteStack` still clearing the stack, and `UPDATE_ROLLBACK_COMPLETE` still updatable. Plus `updateStackSetReportsFailedRatherThanRefusingOverARolledBackInstance` in `CloudFormationStackSetsIntegrationTest`.

Run against the unfixed service, the three that should fail do; the two control cases pass either way, which is the point of including them.

Full CloudFormation package: 1176 tests, 1 failure — `SamTransformIntegrationTest#samFunction_withAutoPublishAlias_createsVersionAndAlias`, a Docker-backed Lambda invocation that fails identically on a clean `main` in this environment.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
