### PR TITLE
feat(macie2): add organization administration operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Floci supports local emulation for application services, data services, eventing
 | Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
 | Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
 | Messaging and transfer | SES, Kinesis, MSK, Amazon MQ, Transfer Family, IoT Core, Amazon Connect |
-| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, IAM Identity Center (SSO Admin), Control Tower, Service Catalog |
+| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, IAM Identity Center (SSO Admin), Amazon Macie, Control Tower, Service Catalog |
 | Cost and billing | Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |
 | Resilience, backup, and config | AWS FIS, AWS Backup, AWS Config, AppConfig, AppConfigData, CloudFormation, Cloud Control API |
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -239,6 +239,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>ssoadmin</artifactId>
         </dependency>
+        <!-- Amazon Macie client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>macie2</artifactId>
+        </dependency>
         <!-- Cloud Map (servicediscovery) client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.guardduty.GuardDutyClient;
 import software.amazon.awssdk.services.fis.FisClient;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.ssoadmin.SsoAdminClient;
+import software.amazon.awssdk.services.macie2.Macie2Client;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
@@ -278,6 +279,14 @@ public final class TestFixtures {
 
     public static SsoAdminClient ssoAdminClient() {
         return SsoAdminClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static Macie2Client macie2Client() {
+        return Macie2Client.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -286,10 +286,14 @@ public final class TestFixtures {
     }
 
     public static Macie2Client macie2Client() {
+        return macie2Client("test");
+    }
+
+    public static Macie2Client macie2Client(String accountId) {
         return Macie2Client.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
-                .credentialsProvider(CREDENTIALS)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))
                 .build();
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MacieOrganizationAdministrationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MacieOrganizationAdministrationTest.java
@@ -1,0 +1,35 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.macie2.Macie2Client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@DisplayName("Macie organization administration")
+class MacieOrganizationAdministrationTest {
+
+    @Test
+    @DisplayName("uses AWS SDK models for delegated administration and organization configuration")
+    void organizationAdministrationUsesAwsSdk() {
+        assumeFalse(TestFixtures.isRealAws(), "Avoids changing Macie organization settings in real AWS");
+
+        try (Macie2Client macie = TestFixtures.macie2Client()) {
+            assertThat(macie.listOrganizationAdminAccounts(request -> {}).adminAccounts()).isEmpty();
+
+            macie.enableOrganizationAdminAccount(request -> request.adminAccountId("111111111111"));
+
+            assertThat(macie.listOrganizationAdminAccounts(request -> {}).adminAccounts())
+                    .anySatisfy(account -> {
+                        assertThat(account.accountId()).isEqualTo("111111111111");
+                        assertThat(account.statusAsString()).isEqualTo("ENABLED");
+                    });
+
+            macie.enableMacie(request -> {});
+            macie.updateOrganizationConfiguration(request -> request.autoEnable(true));
+
+            assertThat(macie.describeOrganizationConfiguration(request -> {}).autoEnable()).isTrue();
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MacieOrganizationAdministrationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MacieOrganizationAdministrationTest.java
@@ -9,27 +9,30 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("Macie organization administration")
 class MacieOrganizationAdministrationTest {
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+    private static final String ADMIN_ACCOUNT = "111111111111";
 
     @Test
     @DisplayName("uses AWS SDK models for delegated administration and organization configuration")
     void organizationAdministrationUsesAwsSdk() {
         assumeFalse(TestFixtures.isRealAws(), "Avoids changing Macie organization settings in real AWS");
 
-        try (Macie2Client macie = TestFixtures.macie2Client()) {
-            assertThat(macie.listOrganizationAdminAccounts(request -> {}).adminAccounts()).isEmpty();
+        try (Macie2Client management = TestFixtures.macie2Client(MANAGEMENT_ACCOUNT);
+             Macie2Client administrator = TestFixtures.macie2Client(ADMIN_ACCOUNT)) {
+            assertThat(management.listOrganizationAdminAccounts(request -> {}).adminAccounts()).isEmpty();
 
-            macie.enableOrganizationAdminAccount(request -> request.adminAccountId("111111111111"));
+            management.enableOrganizationAdminAccount(request -> request.adminAccountId(ADMIN_ACCOUNT));
 
-            assertThat(macie.listOrganizationAdminAccounts(request -> {}).adminAccounts())
+            assertThat(management.listOrganizationAdminAccounts(request -> {}).adminAccounts())
                     .anySatisfy(account -> {
-                        assertThat(account.accountId()).isEqualTo("111111111111");
+                        assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT);
                         assertThat(account.statusAsString()).isEqualTo("ENABLED");
                     });
 
-            macie.enableMacie(request -> {});
-            macie.updateOrganizationConfiguration(request -> request.autoEnable(true));
+            assertThat(administrator.getMacieSession(request -> {}).statusAsString()).isEqualTo("ENABLED");
+            administrator.updateOrganizationConfiguration(request -> request.autoEnable(true));
 
-            assertThat(macie.describeOrganizationConfiguration(request -> {}).autoEnable()).isTrue();
+            assertThat(administrator.describeOrganizationConfiguration(request -> {}).autoEnable()).isTrue();
         }
     }
 }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -45,6 +45,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [CloudWatch RUM](rum.md) | `/appmonitor`, `/appmonitor/{name}`, `/appmonitors` | REST JSON | 5 |
 | [GuardDuty](guardduty.md) | `/detector`, `/detector/{detectorId}`, `/detector/{detectorId}/admin`, `/admin/*`, `/tags/*` | REST JSON | 13 |
 | [IAM Identity Center (SSO Admin)](ssoadmin.md) | `POST /` + `X-Amz-Target: SWBExternalService.*` | JSON 1.1 | 13 |
+| [Amazon Macie](macie2.md) | `/admin`, `/macie`, `/admin/configuration` | REST JSON | 6 |
 | [Amazon Connect](connect.md) | `/instance`, `/instance/{instanceId}/*`, `/tags/*` | REST JSON | 15 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |
 | [MemoryDB](memorydb.md) | `POST /` + `X-Amz-Target: AmazonMemoryDB.*` + TCP proxy | JSON 1.1 + RESP | 7 |

--- a/docs/services/macie2.md
+++ b/docs/services/macie2.md
@@ -2,9 +2,20 @@
 
 Floci implements the REST JSON organization surfaces used to configure Macie locally.
 
-## Supported behavior
+## Supported Actions
 
-The supported surface includes delegated administrator listing and enablement, Macie session lookup and enablement, and organization auto-enable configuration. Delegation is visible in both the management-account and delegated-account request scopes so the delegated account can continue the workflow using the normal AWS API.
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `EnableOrganizationAdminAccount` | Designates the delegated Macie administrator account. |
+| `GetMacieSession` | Returns the current account Macie session. |
+| `EnableMacie` | Enables Macie for the current account. |
+| `UpdateOrganizationConfiguration` | Updates organization auto-enable settings as the delegated administrator. |
+| `DescribeOrganizationConfiguration` | Reads organization auto-enable settings as the delegated administrator. |
+| `ListOrganizationAdminAccounts` | Lists the delegated Macie administrator for the organization. |
+<!-- floci:actions:end -->
+
+Delegation is visible in both the management-account and delegated-account request scopes. Designating the delegated administrator enables Macie for that account in the Region, matching AWS Organizations integration behavior.
 
 `GetMacieSession` returns `ResourceNotFoundException` before Macie is enabled. Enabling an already enabled session or attempting incompatible administrator state returns `ConflictException`. Request validation and missing-resource behavior use the modeled `ValidationException` and `ResourceNotFoundException` responses.
 

--- a/docs/services/macie2.md
+++ b/docs/services/macie2.md
@@ -1,0 +1,13 @@
+# Amazon Macie
+
+Floci implements the REST JSON organization surfaces used to configure Macie locally.
+
+## Supported behavior
+
+The supported surface includes delegated administrator listing and enablement, Macie session lookup and enablement, and organization auto-enable configuration. Delegation is visible in both the management-account and delegated-account request scopes so the delegated account can continue the workflow using the normal AWS API.
+
+`GetMacieSession` returns `ResourceNotFoundException` before Macie is enabled. Enabling an already enabled session or attempting incompatible administrator state returns `ConflictException`. Request validation and missing-resource behavior use the modeled `ValidationException` and `ResourceNotFoundException` responses.
+
+AWS also models provider-side `InternalServerException`, `ServiceQuotaExceededException`, and `ThrottlingException`; these are not injected artificially.
+
+See the [Amazon Macie API Reference](https://docs.aws.amazon.com/macie/latest/APIReference/Welcome.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,6 +120,7 @@ nav:
     - STS: services/sts.md
     - Organizations: services/organizations.md
     - IAM Identity Center (SSO Admin): services/ssoadmin.md
+    - Amazon Macie: services/macie2.md
     - Control Tower: services/controltower.md
     - AWS Service Catalog: services/service-catalog.md
     - ElastiCache: services/elasticache.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -710,6 +710,7 @@ public interface EmulatorConfig {
         NetworkFirewallServiceConfig networkfirewall();
         ServiceCatalogServiceConfig servicecatalog();
         SsoAdminServiceConfig ssoadmin();
+        Macie2ServiceConfig macie2();
         ServiceQuotasServiceConfig servicequotas();
         RamServiceConfig ram();
         ControlTowerServiceConfig controltower();
@@ -734,6 +735,11 @@ public interface EmulatorConfig {
     }
 
     interface SsoAdminServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface Macie2ServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -33,7 +33,6 @@ import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import io.github.hectorvent.floci.services.rdsdata.RdsDataController;
 import io.github.hectorvent.floci.services.guardduty.GuardDutyController;
 import io.github.hectorvent.floci.services.macie2.MacieController;
-import io.github.hectorvent.floci.services.securityadmin.SecurityAdminController;
 import io.github.hectorvent.floci.services.aps.ApsController;
 import io.github.hectorvent.floci.services.controltower.ControlTowerControlController;
 import io.github.hectorvent.floci.services.controltower.ControlTowerController;
@@ -412,7 +411,7 @@ public class ResolvedServiceCatalog {
                         Set.of("SWBExternalService."), Set.of("sso"), Set.of(), Set.of()),
                 descriptor("macie2", "macie2", config.services().macie2().enabled(), true,
                         "macie2", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
-                        protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("macie2"), Set.of(), Set.of(MacieController.class, SecurityAdminController.class)),
+                        protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("macie2"), Set.of(), Set.of(MacieController.class)),
                 descriptor("autoscaling", "autoscaling", config.services().autoscaling().enabled(), true,
                         "autoscaling", config.storage().mode(), 5000L, AwsNamespaces.AUTOSCALING, ServiceProtocol.QUERY,
                         protocols(ServiceProtocol.QUERY),
@@ -551,7 +550,7 @@ public class ResolvedServiceCatalog {
                         storageMode(config.storage().services().guardduty().mode(), config.storage().mode()),
                         config.storage().services().guardduty().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
-                        Set.of(), Set.of("guardduty"), Set.of(), Set.of(GuardDutyController.class, SecurityAdminController.class)),
+                        Set.of(), Set.of("guardduty"), Set.of(), Set.of(GuardDutyController.class)),
                 descriptor("route53resolver", "route53resolver", config.services().route53resolver().enabled(), true,
                         "route53resolver", config.storage().mode(), 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -32,6 +32,8 @@ import io.github.hectorvent.floci.services.ses.SesController;
 import io.github.hectorvent.floci.services.appsync.AppSyncController;
 import io.github.hectorvent.floci.services.rdsdata.RdsDataController;
 import io.github.hectorvent.floci.services.guardduty.GuardDutyController;
+import io.github.hectorvent.floci.services.macie2.MacieController;
+import io.github.hectorvent.floci.services.securityadmin.SecurityAdminController;
 import io.github.hectorvent.floci.services.aps.ApsController;
 import io.github.hectorvent.floci.services.controltower.ControlTowerControlController;
 import io.github.hectorvent.floci.services.controltower.ControlTowerController;
@@ -408,6 +410,9 @@ public class ResolvedServiceCatalog {
                         null, null, 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
                         Set.of("SWBExternalService."), Set.of("sso"), Set.of(), Set.of()),
+                descriptor("macie2", "macie2", config.services().macie2().enabled(), true,
+                        "macie2", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("macie2"), Set.of(), Set.of(MacieController.class, SecurityAdminController.class)),
                 descriptor("autoscaling", "autoscaling", config.services().autoscaling().enabled(), true,
                         "autoscaling", config.storage().mode(), 5000L, AwsNamespaces.AUTOSCALING, ServiceProtocol.QUERY,
                         protocols(ServiceProtocol.QUERY),
@@ -546,7 +551,7 @@ public class ResolvedServiceCatalog {
                         storageMode(config.storage().services().guardduty().mode(), config.storage().mode()),
                         config.storage().services().guardduty().flushIntervalMs(), null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON),
-                        Set.of(), Set.of("guardduty"), Set.of(), Set.of(GuardDutyController.class)),
+                        Set.of(), Set.of("guardduty"), Set.of(), Set.of(GuardDutyController.class, SecurityAdminController.class)),
                 descriptor("route53resolver", "route53resolver", config.services().route53resolver().enabled(), true,
                         "route53resolver", config.storage().mode(), 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),

--- a/src/main/java/io/github/hectorvent/floci/core/common/ServiceEnabledFilter.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ServiceEnabledFilter.java
@@ -59,6 +59,8 @@ public class ServiceEnabledFilter implements ContainerRequestFilter {
         }
 
         return SigV4CredentialScope.serviceName(ctx.getHeaderString("Authorization"))
+                .or(() -> SigV4CredentialScope.serviceNameFromCredential(
+                        ctx.getUriInfo().getQueryParameters().getFirst("X-Amz-Credential")))
                 .flatMap(catalog::byCredentialScope)
                 .map(descriptor -> new ResolvedRequest(
                         descriptor.externalKey(), protocolFor(claim, descriptor)))

--- a/src/main/java/io/github/hectorvent/floci/core/common/SigV4CredentialScope.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/SigV4CredentialScope.java
@@ -26,4 +26,11 @@ public final class SigV4CredentialScope {
         }
         return Optional.empty();
     }
+
+    public static Optional<String> serviceNameFromCredential(String credential) {
+        if (credential == null) {
+            return Optional.empty();
+        }
+        return serviceName("Credential=" + credential);
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
 import io.github.hectorvent.floci.services.guardduty.model.MemberAccount;
 import io.github.hectorvent.floci.services.guardduty.model.Detector;
 import io.github.hectorvent.floci.services.guardduty.model.DetectorFeature;
@@ -215,24 +214,5 @@ public class GuardDutyController {
     public Response disableOrganizationAdminAccount(@Context HttpHeaders headers, String body) {
         service.disableOrganizationAdminAccount(regionResolver.resolveRegion(headers), parse(body));
         return Response.ok(objectMapper.createObjectNode()).build();
-    }
-
-    @GET
-    @Path("/admin")
-    public Response listOrganizationAdminAccounts(
-            @Context HttpHeaders headers,
-            @QueryParam("maxResults") String maxResults,
-            @QueryParam("nextToken") String nextToken) {
-        GuardDutyService.Page<AdminAccount> page = service.listOrganizationAdminAccounts(
-                regionResolver.resolveRegion(headers), maxResults, nextToken);
-        ObjectNode response = objectMapper.createObjectNode();
-        ArrayNode accounts = response.putArray("adminAccounts");
-        for (AdminAccount account : page.items()) {
-            accounts.add(objectMapper.valueToTree(account));
-        }
-        if (page.nextToken() != null) {
-            response.put("nextToken", page.nextToken());
-        }
-        return Response.ok(response).build();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java
@@ -33,8 +33,8 @@ public class MacieController {
         this.objectMapper = objectMapper;
     }
 
-    public Response listAdminInternal(@Context HttpHeaders headers) {
-        MacieState state = macieService.state(region(headers));
+    public Response listAdminInternal(String region) {
+        MacieState state = macieService.state(region);
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("adminAccounts");
         if (state.getAdminAccountId() != null) {
@@ -70,13 +70,14 @@ public class MacieController {
         if (!request.has("autoEnable") || !request.get("autoEnable").isBoolean()) {
             throw new io.github.hectorvent.floci.core.common.AwsException("ValidationException", "autoEnable is required.", 400);
         }
-        macieService.updateOrganizationConfiguration(region(headers), request.path("autoEnable").asBoolean());
+        macieService.updateOrganizationConfiguration(
+                region(headers), regionResolver.getAccountId(), request.path("autoEnable").asBoolean());
         return empty();
     }
 
     @GET @Path("/admin/configuration")
     public Response describeOrganizationConfiguration(@Context HttpHeaders headers) {
-        MacieState state = macieService.requireSession(region(headers));
+        MacieState state = macieService.requireAdministratorSession(region(headers), regionResolver.getAccountId());
         var response = objectMapper.createObjectNode();
         response.put("autoEnable", state.isAutoEnable());
         return Response.ok(response).build();

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java
@@ -1,0 +1,86 @@
+package io.github.hectorvent.floci.services.macie2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.JsonErrorResponseUtils;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.macie2.model.MacieState;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class MacieController {
+    private final MacieService macieService;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public MacieController(MacieService macieService, RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.macieService = macieService;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    public Response listAdminInternal(@Context HttpHeaders headers) {
+        MacieState state = macieService.state(region(headers));
+        var response = objectMapper.createObjectNode();
+        var accounts = response.putArray("adminAccounts");
+        if (state.getAdminAccountId() != null) accounts.addObject().put("accountId", state.getAdminAccountId()).put("status", "ENABLED");
+        return Response.ok(response).build();
+    }
+
+    @POST @Path("/admin")
+    public Response enableOrganizationAdminAccount(@Context HttpHeaders headers, String body) {
+        macieService.enableOrganizationAdminAccount(region(headers), readTree(body).path("adminAccountId").asText(null));
+        return empty();
+    }
+
+    @GET @Path("/macie")
+    public Response getMacieSession(@Context HttpHeaders headers) {
+        macieService.requireSession(region(headers));
+        var response = objectMapper.createObjectNode();
+        response.put("status", "ENABLED");
+        response.put("serviceRole", "arn:aws:iam::" + regionResolver.getAccountId() + ":role/aws-service-role/macie.amazonaws.com/AWSServiceRoleForAmazonMacie");
+        return Response.ok(response).build();
+    }
+
+    @POST @Path("/macie")
+    public Response enableMacie(@Context HttpHeaders headers, String body) {
+        macieService.enableMacie(region(headers));
+        return empty();
+    }
+
+    @PATCH @Path("/admin/configuration")
+    public Response updateOrganizationConfiguration(@Context HttpHeaders headers, String body) {
+        JsonNode request = readTree(body);
+        if (!request.has("autoEnable") || !request.get("autoEnable").isBoolean()) {
+            throw new io.github.hectorvent.floci.core.common.AwsException("ValidationException", "autoEnable is required.", 400);
+        }
+        macieService.updateOrganizationConfiguration(region(headers), request.path("autoEnable").asBoolean());
+        return empty();
+    }
+
+    @GET @Path("/admin/configuration")
+    public Response describeOrganizationConfiguration(@Context HttpHeaders headers) {
+        MacieState state = macieService.requireSession(region(headers));
+        var response = objectMapper.createObjectNode();
+        response.put("autoEnable", state.isAutoEnable());
+        return Response.ok(response).build();
+    }
+
+    private String region(HttpHeaders headers) { return regionResolver.resolveRegion(headers); }
+    private Response empty() { return Response.ok(objectMapper.createObjectNode()).build(); }
+    private JsonNode readTree(String body) { try { return objectMapper.readTree(body == null || body.isBlank() ? "{}" : body); } catch (Exception e) { throw new WebApplicationException(JsonErrorResponseUtils.createSerializationErrorResponse()); } }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java
@@ -37,7 +37,9 @@ public class MacieController {
         MacieState state = macieService.state(region(headers));
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("adminAccounts");
-        if (state.getAdminAccountId() != null) accounts.addObject().put("accountId", state.getAdminAccountId()).put("status", "ENABLED");
+        if (state.getAdminAccountId() != null) {
+            accounts.addObject().put("accountId", state.getAdminAccountId()).put("status", "ENABLED");
+        }
         return Response.ok(response).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/MacieService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/MacieService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.macie2;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.macie2.model.MacieState;
@@ -11,16 +12,22 @@ import jakarta.inject.Inject;
 import java.util.Map;
 
 @ApplicationScoped
-public class MacieService {
+public class MacieService implements Resettable {
     private final AccountAwareStorageBackend<MacieState> states;
 
     @Inject
     public MacieService(StorageFactory storageFactory) {
-        this.states = storageFactory.create("macie2", "macie2-state.json",
-                new TypeReference<Map<String, MacieState>>() {});
+        this(storageFactory.create("macie2", "macie2-state.json",
+                new TypeReference<Map<String, MacieState>>() {}));
     }
 
-    public MacieState state(String region) { return states.get(region).orElseGet(MacieState::new); }
+    MacieService(AccountAwareStorageBackend<MacieState> states) {
+        this.states = states;
+    }
+
+    public MacieState state(String region) {
+        return states.get(region).orElseGet(MacieState::new);
+    }
 
     public synchronized void enableOrganizationAdminAccount(String region, String accountId) {
         requireAccountId(accountId);
@@ -30,8 +37,10 @@ public class MacieService {
         }
         state.setAdminAccountId(accountId);
         states.put(region, state);
+
         MacieState delegated = states.getForAccount(accountId, region).orElseGet(MacieState::new);
         delegated.setAdminAccountId(accountId);
+        delegated.setEnabled(true);
         states.putForAccount(accountId, region, delegated);
     }
 
@@ -52,14 +61,30 @@ public class MacieService {
         return state;
     }
 
-    public synchronized void updateOrganizationConfiguration(String region, boolean autoEnable) {
-        MacieState state = requireSession(region);
-        if (state.getAdminAccountId() == null) {
-            throw new AwsException("AccessDeniedException",
-                    "Only the Macie administrator account can update organization configuration.", 403);
+    public MacieState requireAdministratorSession(String region, String callerAccountId) {
+        MacieState state = states.getForAccount(callerAccountId, region).orElseGet(MacieState::new);
+        if (state.getAdminAccountId() == null && !state.isEnabled()) {
+            throw notFound("Macie is not enabled for this account.");
         }
+        if (!callerAccountId.equals(state.getAdminAccountId())) {
+            throw accessDenied();
+        }
+        if (!state.isEnabled()) {
+            throw notFound("Macie is not enabled for this account.");
+        }
+        return state;
+    }
+
+    public synchronized void updateOrganizationConfiguration(
+            String region, String callerAccountId, boolean autoEnable) {
+        MacieState state = requireAdministratorSession(region, callerAccountId);
         state.setAutoEnable(autoEnable);
-        states.put(region, state);
+        states.putForAccount(callerAccountId, region, state);
+    }
+
+    @Override
+    public void clear() {
+        states.clear();
     }
 
     private static void requireAccountId(String accountId) {
@@ -67,6 +92,17 @@ public class MacieService {
             throw new AwsException("ValidationException", "adminAccountId must be a 12 digit account ID.", 400);
         }
     }
-    private static AwsException conflict(String message) { return new AwsException("ConflictException", message, 409); }
-    private static AwsException notFound(String message) { return new AwsException("ResourceNotFoundException", message, 404); }
+
+    private static AwsException conflict(String message) {
+        return new AwsException("ConflictException", message, 409);
+    }
+
+    private static AwsException notFound(String message) {
+        return new AwsException("ResourceNotFoundException", message, 404);
+    }
+
+    private static AwsException accessDenied() {
+        return new AwsException("AccessDeniedException",
+                "Only the delegated Macie administrator account can manage organization configuration.", 403);
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/MacieService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/MacieService.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.macie2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.macie2.model.MacieState;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Map;
+
+@ApplicationScoped
+public class MacieService {
+    private final AccountAwareStorageBackend<MacieState> states;
+
+    @Inject
+    public MacieService(StorageFactory storageFactory) {
+        this.states = storageFactory.create("macie2", "macie2-state.json",
+                new TypeReference<Map<String, MacieState>>() {});
+    }
+
+    public MacieState state(String region) { return states.get(region).orElseGet(MacieState::new); }
+
+    public synchronized void enableOrganizationAdminAccount(String region, String accountId) {
+        requireAccountId(accountId);
+        MacieState state = state(region);
+        if (state.getAdminAccountId() != null && !state.getAdminAccountId().equals(accountId)) {
+            throw conflict("A different Macie administrator account is already configured.");
+        }
+        state.setAdminAccountId(accountId);
+        states.put(region, state);
+        MacieState delegated = states.getForAccount(accountId, region).orElseGet(MacieState::new);
+        delegated.setAdminAccountId(accountId);
+        states.putForAccount(accountId, region, delegated);
+    }
+
+    public synchronized void enableMacie(String region) {
+        MacieState state = state(region);
+        if (state.isEnabled()) throw conflict("Macie is already enabled for this account.");
+        state.setEnabled(true);
+        states.put(region, state);
+    }
+
+    public MacieState requireSession(String region) {
+        MacieState state = state(region);
+        if (!state.isEnabled()) throw notFound("Macie is not enabled for this account.");
+        return state;
+    }
+
+    public synchronized void updateOrganizationConfiguration(String region, boolean autoEnable) {
+        MacieState state = requireSession(region);
+        if (state.getAdminAccountId() == null) {
+            throw new AwsException("AccessDeniedException",
+                    "Only the Macie administrator account can update organization configuration.", 403);
+        }
+        state.setAutoEnable(autoEnable);
+        states.put(region, state);
+    }
+
+    private static void requireAccountId(String accountId) {
+        if (accountId == null || !accountId.matches("\\d{12}")) {
+            throw new AwsException("ValidationException", "adminAccountId must be a 12 digit account ID.", 400);
+        }
+    }
+    private static AwsException conflict(String message) { return new AwsException("ConflictException", message, 409); }
+    private static AwsException notFound(String message) { return new AwsException("ResourceNotFoundException", message, 404); }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/MacieService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/MacieService.java
@@ -37,14 +37,18 @@ public class MacieService {
 
     public synchronized void enableMacie(String region) {
         MacieState state = state(region);
-        if (state.isEnabled()) throw conflict("Macie is already enabled for this account.");
+        if (state.isEnabled()) {
+            throw conflict("Macie is already enabled for this account.");
+        }
         state.setEnabled(true);
         states.put(region, state);
     }
 
     public MacieState requireSession(String region) {
         MacieState state = state(region);
-        if (!state.isEnabled()) throw notFound("Macie is not enabled for this account.");
+        if (!state.isEnabled()) {
+            throw notFound("Macie is not enabled for this account.");
+        }
         return state;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/macie2/model/MacieState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/macie2/model/MacieState.java
@@ -1,0 +1,20 @@
+package io.github.hectorvent.floci.services.macie2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MacieState {
+    private String adminAccountId;
+    private boolean enabled;
+    private boolean autoEnable;
+
+    public MacieState() {}
+    public String getAdminAccountId() { return adminAccountId; }
+    public void setAdminAccountId(String adminAccountId) { this.adminAccountId = adminAccountId; }
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public boolean isAutoEnable() { return autoEnable; }
+    public void setAutoEnable(boolean autoEnable) { this.autoEnable = autoEnable; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/securityadmin/SecurityAdminController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityadmin/SecurityAdminController.java
@@ -1,0 +1,61 @@
+package io.github.hectorvent.floci.services.securityadmin;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.SigV4CredentialScope;
+import io.github.hectorvent.floci.services.guardduty.GuardDutyService;
+import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
+import io.github.hectorvent.floci.services.macie2.MacieController;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public class SecurityAdminController {
+    private final GuardDutyService guardDutyService;
+    private final MacieController macieController;
+    private final ObjectMapper mapper;
+    private final RegionResolver regionResolver;
+
+    @Inject
+    public SecurityAdminController(GuardDutyService guardDutyService, MacieController macieController,
+                                   ObjectMapper mapper, RegionResolver regionResolver) {
+        this.guardDutyService = guardDutyService;
+        this.macieController = macieController;
+        this.mapper = mapper;
+        this.regionResolver = regionResolver;
+    }
+
+    @GET
+    @Path("/admin")
+    public Response listAdmin(@Context HttpHeaders headers,
+                              @QueryParam("maxResults") String maxResults,
+                              @QueryParam("nextToken") String nextToken) {
+        String service = SigV4CredentialScope.serviceName(headers.getHeaderString("Authorization")).orElse("");
+        if ("macie2".equals(service)) {
+            return macieController.listAdminInternal(headers);
+        }
+        if ("guardduty".equals(service) || service.isBlank()) {
+            GuardDutyService.Page<AdminAccount> page = guardDutyService.listOrganizationAdminAccounts(
+                    regionResolver.resolveRegion(headers), maxResults, nextToken);
+            var response = mapper.createObjectNode();
+            var accounts = response.putArray("adminAccounts");
+            for (AdminAccount account : page.items()) {
+                accounts.add(mapper.valueToTree(account));
+            }
+            if (page.nextToken() != null) {
+                response.put("nextToken", page.nextToken());
+            }
+            return Response.ok(response).build();
+        }
+        throw new AwsException("UnknownOperationException", "GET /admin is not supported for " + service + ".", 400);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/securityadmin/SecurityAdminController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityadmin/SecurityAdminController.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
@@ -37,11 +38,19 @@ public class SecurityAdminController {
     @GET
     @Path("/admin")
     public Response listAdmin(@Context HttpHeaders headers,
+                              @Context UriInfo uriInfo,
                               @QueryParam("maxResults") String maxResults,
                               @QueryParam("nextToken") String nextToken) {
-        String service = SigV4CredentialScope.serviceName(headers.getHeaderString("Authorization")).orElse("");
+        String service = SigV4CredentialScope.serviceName(headers.getHeaderString("Authorization"))
+                .or(() -> SigV4CredentialScope.serviceNameFromCredential(
+                        uriInfo.getQueryParameters().getFirst("X-Amz-Credential")))
+                .orElse("");
         if ("macie2".equals(service)) {
-            return macieController.listAdminInternal(headers);
+            String region = headers.getHeaderString("Authorization") != null
+                    ? regionResolver.resolveRegion(headers)
+                    : regionResolver.resolveRegionFromPresignedCredential(
+                            uriInfo.getQueryParameters().getFirst("X-Amz-Credential"));
+            return macieController.listAdminInternal(region);
         }
         if ("guardduty".equals(service) || service.isBlank()) {
             GuardDutyService.Page<AdminAccount> page = guardDutyService.listOrganizationAdminAccounts(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -605,6 +605,8 @@ floci:
       enabled: true
     ssoadmin:
       enabled: true
+    macie2:
+      enabled: true
     controltower:
       enabled: true
       seed-landing-zone: false

--- a/src/test/java/io/github/hectorvent/floci/core/common/ServiceCatalogRoutingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/ServiceCatalogRoutingIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.core.common;
 
+import io.github.hectorvent.floci.services.securityadmin.SecurityAdminController;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,13 @@ class ServiceCatalogRoutingIntegrationTest {
         assertEquals("fis", descriptor.storageKey());
         assertEquals(ServiceProtocol.REST_JSON, descriptor.defaultProtocol());
         assertTrue(descriptor.supportsProtocol(ServiceProtocol.REST_JSON));
+    }
+
+    @Test
+    void sharedSecurityAdminRouteResolvesOnlyBySigningScope() {
+        assertTrue(catalog.byResourceClass(SecurityAdminController.class).isEmpty());
+        assertEquals("macie2", catalog.byCredentialScope("macie2").orElseThrow().externalKey());
+        assertEquals("guardduty", catalog.byCredentialScope("guardduty").orElseThrow().externalKey());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/core/common/SigV4CredentialScopeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/SigV4CredentialScopeTest.java
@@ -28,6 +28,12 @@ class SigV4CredentialScopeTest {
     }
 
     @Test
+    void parsesPresignedCredentialScope() {
+        assertEquals(Optional.of("macie2"), SigV4CredentialScope.serviceNameFromCredential(
+                "222222222222/20260707/us-east-1/macie2/aws4_request"));
+    }
+
+    @Test
     void ignoresSigV4aBecauseItsCredentialOmitsTheRegion() {
         // SigV4a carries the region in X-Amz-Region-Set, so its credential is
         // <key>/<date>/<service>/aws4_request — one segment shorter than SigV4.

--- a/src/test/java/io/github/hectorvent/floci/services/macie2/MacieOrganizationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/macie2/MacieOrganizationIntegrationTest.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.macie2;
 
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -9,28 +11,67 @@ import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 class MacieOrganizationIntegrationTest {
-    private static final String MACIE_AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/macie2/aws4_request";
-    private static final String GUARDDUTY_AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/guardduty/aws4_request";
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+    private static final String ADMIN_ACCOUNT = "111111111111";
+    private static final String GUARDDUTY_ACCOUNT = "333333333333";
+
+    @Inject
+    MacieService macieService;
+
+    @BeforeEach
+    void resetMacieState() {
+        macieService.clear();
+    }
 
     @Test
-    void macieAdminAndOrganizationConfigurationLifecycle() {
-        given().header("Authorization", MACIE_AUTH).get("/admin").then().statusCode(200)
-                .body("adminAccounts", hasSize(0));
-        given().contentType("application/json").header("Authorization", MACIE_AUTH)
-                .body("{\"adminAccountId\":\"111111111111\"}").post("/admin").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", MACIE_AUTH).body("{}")
-                .post("/macie").then().statusCode(200);
-        given().header("Authorization", MACIE_AUTH).get("/admin").then().statusCode(200)
-                .body("adminAccounts[0].accountId", equalTo("111111111111"));
-        given().contentType("application/json").header("Authorization", MACIE_AUTH)
-                .body("{\"autoEnable\":true}").patch("/admin/configuration").then().statusCode(200);
-        given().header("Authorization", MACIE_AUTH).get("/admin/configuration").then().statusCode(200)
-                .body("autoEnable", equalTo(true));
+    void delegatedAdministratorOwnsOrganizationConfiguration() {
+        given().header("Authorization", auth(MANAGEMENT_ACCOUNT, "macie2"))
+                .get("/admin").then().statusCode(200).body("adminAccounts", hasSize(0));
+
+        given().contentType("application/json").header("Authorization", auth(MANAGEMENT_ACCOUNT, "macie2"))
+                .body("{\"adminAccountId\":\"" + ADMIN_ACCOUNT + "\"}")
+                .post("/admin").then().statusCode(200);
+
+        given().header("Authorization", auth(MANAGEMENT_ACCOUNT, "macie2"))
+                .get("/admin").then().statusCode(200)
+                .body("adminAccounts[0].accountId", equalTo(ADMIN_ACCOUNT));
+
+        given().header("Authorization", auth(ADMIN_ACCOUNT, "macie2"))
+                .get("/macie").then().statusCode(200).body("status", equalTo("ENABLED"));
+
+        given().contentType("application/json").header("Authorization", auth(MANAGEMENT_ACCOUNT, "macie2"))
+                .body("{\"autoEnable\":true}")
+                .patch("/admin/configuration").then().statusCode(403)
+                .body("__type", equalTo("AccessDeniedException"));
+
+        given().contentType("application/json").header("Authorization", auth(ADMIN_ACCOUNT, "macie2"))
+                .body("{\"autoEnable\":true}")
+                .patch("/admin/configuration").then().statusCode(200);
+        given().header("Authorization", auth(ADMIN_ACCOUNT, "macie2"))
+                .get("/admin/configuration").then().statusCode(200).body("autoEnable", equalTo(true));
     }
 
     @Test
     void sharedAdminRouteKeepsGuardDutyBehavior() {
-        given().header("Authorization", GUARDDUTY_AUTH).get("/admin").then().statusCode(200)
-                .body("adminAccounts", hasSize(0));
+        given().header("Authorization", auth(GUARDDUTY_ACCOUNT, "guardduty"))
+                .get("/admin").then().statusCode(200).body("adminAccounts", hasSize(0));
+    }
+
+    @Test
+    void presignedMacieAdminRequestUsesCredentialScope() {
+        given().contentType("application/json").header("Authorization", auth(MANAGEMENT_ACCOUNT, "macie2"))
+                .body("{\"adminAccountId\":\"" + ADMIN_ACCOUNT + "\"}")
+                .post("/admin").then().statusCode(200);
+
+        given().queryParam("X-Amz-Credential",
+                        MANAGEMENT_ACCOUNT + "/20260101/us-east-1/macie2/aws4_request")
+                .get("/admin").then().statusCode(200)
+                .body("adminAccounts[0].accountId", equalTo(ADMIN_ACCOUNT));
+    }
+
+    private static String auth(String accountId, String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + accountId
+                + "/20260101/us-east-1/" + service
+                + "/aws4_request, SignedHeaders=host, Signature=abc";
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/macie2/MacieOrganizationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/macie2/MacieOrganizationIntegrationTest.java
@@ -1,0 +1,36 @@
+package io.github.hectorvent.floci.services.macie2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+@QuarkusTest
+class MacieOrganizationIntegrationTest {
+    private static final String MACIE_AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/macie2/aws4_request";
+    private static final String GUARDDUTY_AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/guardduty/aws4_request";
+
+    @Test
+    void macieAdminAndOrganizationConfigurationLifecycle() {
+        given().header("Authorization", MACIE_AUTH).get("/admin").then().statusCode(200)
+                .body("adminAccounts", hasSize(0));
+        given().contentType("application/json").header("Authorization", MACIE_AUTH)
+                .body("{\"adminAccountId\":\"111111111111\"}").post("/admin").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", MACIE_AUTH).body("{}")
+                .post("/macie").then().statusCode(200);
+        given().header("Authorization", MACIE_AUTH).get("/admin").then().statusCode(200)
+                .body("adminAccounts[0].accountId", equalTo("111111111111"));
+        given().contentType("application/json").header("Authorization", MACIE_AUTH)
+                .body("{\"autoEnable\":true}").patch("/admin/configuration").then().statusCode(200);
+        given().header("Authorization", MACIE_AUTH).get("/admin/configuration").then().statusCode(200)
+                .body("autoEnable", equalTo(true));
+    }
+
+    @Test
+    void sharedAdminRouteKeepsGuardDutyBehavior() {
+        given().header("Authorization", GUARDDUTY_AUTH).get("/admin").then().statusCode(200)
+                .body("adminAccounts", hasSize(0));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/macie2/MacieServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/macie2/MacieServiceTest.java
@@ -1,0 +1,75 @@
+package io.github.hectorvent.floci.services.macie2;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.services.macie2.model.MacieState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MacieServiceTest {
+    private static final String REGION = "us-east-1";
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+    private static final String ADMIN_ACCOUNT = "111111111111";
+
+    private MacieService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MacieService(AccountAwareStorageBackend.inMemory(MANAGEMENT_ACCOUNT));
+    }
+
+    @Test
+    void delegationEnablesMacieForAdministratorAccount() {
+        service.enableOrganizationAdminAccount(REGION, ADMIN_ACCOUNT);
+
+        MacieState delegated = service.requireAdministratorSession(REGION, ADMIN_ACCOUNT);
+        assertTrue(delegated.isEnabled());
+        assertEquals(ADMIN_ACCOUNT, delegated.getAdminAccountId());
+    }
+
+    @Test
+    void managementAccountCannotUpdateAdministratorConfiguration() {
+        service.enableOrganizationAdminAccount(REGION, ADMIN_ACCOUNT);
+        service.enableMacie(REGION);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateOrganizationConfiguration(REGION, MANAGEMENT_ACCOUNT, true));
+        assertEquals("AccessDeniedException", error.getErrorCode());
+    }
+
+    @Test
+    void delegatedAdministratorCanUpdateConfiguration() {
+        service.enableOrganizationAdminAccount(REGION, ADMIN_ACCOUNT);
+
+        service.updateOrganizationConfiguration(REGION, ADMIN_ACCOUNT, true);
+
+        assertTrue(service.requireAdministratorSession(REGION, ADMIN_ACCOUNT).isAutoEnable());
+    }
+
+    @Test
+    void conflictingAdministratorDesignationIsRejected() {
+        service.enableOrganizationAdminAccount(REGION, ADMIN_ACCOUNT);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.enableOrganizationAdminAccount(REGION, "333333333333"));
+        assertEquals("ConflictException", error.getErrorCode());
+    }
+
+    @Test
+    void clearRemovesMacieState() {
+        service.enableOrganizationAdminAccount(REGION, ADMIN_ACCOUNT);
+        assertTrue(service.requireAdministratorSession(REGION, ADMIN_ACCOUNT).isEnabled());
+
+        service.clear();
+
+        assertFalse(service.state(REGION).isEnabled());
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.requireAdministratorSession(REGION, ADMIN_ACCOUNT));
+        assertEquals("ResourceNotFoundException", error.getErrorCode());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -372,6 +372,8 @@ floci:
       enabled: true
     ssoadmin:
       enabled: true
+    macie2:
+      enabled: true
     controltower:
       enabled: true
       seed-landing-zone: true

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -142,6 +142,13 @@ services:
     doc: docs/services/memorydb.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/memorydb/MemoryDbHandler.java, mode: switch }
+  - service: macie2
+    doc: docs/services/macie2.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/macie2/MacieController.java, mode: rest }
+      - { path: src/main/java/io/github/hectorvent/floci/services/securityadmin/SecurityAdminController.java, mode: rest }
+    rename_actions:
+      ListAdmin: ListOrganizationAdminAccounts
   - service: neptune
     doc: docs/services/neptune.md
     sources:


### PR DESCRIPTION
## Summary
- add Amazon Macie delegated administrator and organization configuration operations
- share the `/admin` route safely with GuardDuty using SigV4 service dispatch
- preserve GuardDuty organization-admin listing behavior after the shared-route change
- add focused integration and AWS SDK v2 compatibility coverage

## Validation
- `./mvnw -Dtest=MacieOrganizationIntegrationTest,GuardDutyMembersIntegrationTest,GuardDutyServiceTest test` (25/25)
- `FLOCI_ENDPOINT=http://localhost:4567 ../../mvnw -Dtest=MacieOrganizationAdministrationTest test` (1/1)
- `make docs-check`
- `git diff --check`

AWS reference: https://docs.aws.amazon.com/macie/latest/user/accounts-mgmt-ao-integrate.html