### PR TITLE
ci(compat): wait on the container's health status before running the suites

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -295,8 +295,28 @@ jobs:
             -e FLOCI_SERVICES_REDSHIFT_ENDPOINT_HOST=floci \
             floci:test-native
 
-      - name: Wait for floci to be ready
-        run: timeout 60 bash -c 'until curl -sf http://localhost:4566/ >/dev/null 2>&1; do sleep 1; done'
+      # Waits on Docker's health status rather than curling the port so the image's
+      # HEALTHCHECK runs under CI on every arch: the native image has no curl and probes
+      # over bash's /dev/tcp, and a malformed probe would otherwise leave the container
+      # "unhealthy" while the suites pass against the open port. Healthy takes one
+      # interval (5 s); unhealthy takes retries x interval (25 s) and fails fast here.
+      - name: Wait for floci to be healthy
+        run: |
+          health=starting
+          for _ in $(seq 1 60); do
+            health=$(docker inspect -f '{{.State.Health.Status}}' floci)
+            if [ "$health" = healthy ]; then
+              exit 0
+            fi
+            if [ "$health" = unhealthy ]; then
+              break
+            fi
+            sleep 1
+          done
+          echo "::error::floci did not report healthy (last status: $health)"
+          docker inspect -f '{{json .State.Health}}' floci
+          docker logs --tail 50 floci
+          exit 1
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Follow-up to #3085. The native suite jobs waited for Floci by curling the port, so the
image's `HEALTHCHECK` never ran under CI: a malformed probe would leave the container
`unhealthy` while every suite passed against the open port. Greptile flagged this on
#3094, and #3085 asserts health only on the compat image in the shim job.

The readiness step now polls `docker inspect -f '{{.State.Health.Status}}'`, exits as
soon as the container is `healthy`, and fails with the health log and the last container
logs on `unhealthy` or after 60 s. Every suite leg on both arches therefore exercises
`docker/healthcheck.sh` on the native image before any test runs.

Checked locally on a CI-built arm64 image: `healthy` after 5 s; with the app forced onto
another port, `unhealthy` after 26 s and the step fails with the connection-refused log.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire-protocol change. CI only.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added (workflow-only change; the step itself is
      the check and runs on every suite leg)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
