### PR TITLE
perf(docker): trim the compat image's CLI extras and Python build packages

### DIFF
--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -64,12 +64,21 @@ RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci \
     && unzip -q /tmp/awscliv2.zip -d /tmp \
     && /tmp/aws/install --bin-dir /usr/bin --install-dir /usr/local/aws-cli \
     && rm -rf /tmp/awscliv2.zip /tmp/aws \
+    # The CLI's `aws <cmd> help` example pages are 26 MB of text nobody reads inside a container;
+    # the command reference itself (dist/awscli/data) stays. unzip exists only to unpack the CLI.
+    # pip stays: the image documents it and init hooks use it to install packages.
+    && rm -rf /usr/local/aws-cli/v2/*/dist/awscli/examples \
+    # Tab completion has no user inside a container: aws_completer and its 21 MB ac.index go.
+    # The system Python keeps pip, setuptools and what boto3 imports; the optimised .pyc
+    # variants, lib2to3 and ensurepip (pip is already installed) are build-time extras.
+    && rm -rf /usr/local/aws-cli/v2/*/dist/awscli/data/ac.index /usr/local/aws-cli/v2/*/dist/aws_completer /usr/bin/aws_completer \
+    && rm -rf /usr/lib64/python3.9/lib2to3 /usr/lib64/python3.9/ensurepip \
+    && python3 -c 'import pathlib; [p.unlink() for d in ("/usr/lib64/python3.9","/usr/lib/python3.9") for p in pathlib.Path(d).rglob("*.opt-[12].pyc")]' \
     && microdnf remove -y unzip \
     && microdnf clean all \
     && rm -rf /root/.cache/pip
 
-COPY bin/awslocal /usr/local/bin/awslocal
-RUN chmod +x /usr/local/bin/awslocal
+COPY --chmod=755 bin/awslocal /usr/local/bin/awslocal
 
 # Pre-create the init-hook directories so archive-based copies (Testcontainers
 # withCopyFileToContainer / `docker cp`) can drop hooks straight into them.


### PR DESCRIPTION
## Summary

Follow-up to #3085, inside the compat image's tools stage. Removes what the compat
image carries but cannot use:

- the AWS CLI's `aws <command> help` example pages (26 MB): help rendering needs groff
  or mandoc, ubi9-minimal has neither, so `aws sqs help` already failed before this PR
- tab completion: `aws_completer` (9 MB), its `ac.index` database (21 MB) and the
  `/usr/bin` symlink the installer creates
- the system Python's build-time leftovers nothing imports at run time: the optimised
  `.pyc` variants, `lib2to3` and `ensurepip` (pip itself stays, the image documents it
  and init hooks use it to install packages)
- the separate `chmod` layer for awslocal, folded into the `COPY`

The command reference the CLI reads at run time (`dist/awscli/data`) stays. boto3 stays
on the system Python, since the CLI's bundled interpreter is not a general one.

Measured on arm64 on top of #3085:

| Compat image | Before | After |
|---|---|---|
| On disk | 924 MB | 839 MB |
| docker save gzip | 214.0 MB | 197.7 MB |
| `/usr/local/aws-cli` | 264 MB | 209 MB |

The only capability lost is tab completion inside the container.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire-protocol change. Verified on the built image: aws 2.36.24, `aws sqs list-queues`
still resolves its service model, `pip3 install` works, boto3 1.42.97 imports with json,
ssl and sqlite3, awslocal works, init hooks calling all three run to completion, the
container is healthy in 5 s, and the four endpoint-resolution checks in the compat shim job pass.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added (Dockerfile-only change; the compat shim job
      builds this image and runs the health smoke and the four CLI checks against it)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
