### PR TITLE
fix(redshift): emit ClusterAvailabilityStatus and AvailabilityZoneRelocationStatus

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
@@ -44,6 +44,9 @@ public class RedshiftTest {
                 
         Cluster cluster = describeRes.clusters().get(0);
         assertEquals("test-cluster", cluster.clusterIdentifier());
+        // Terraform's AWS provider polls these two on create and validates them on read (issue #3098).
+        assertEquals("Available", cluster.clusterAvailabilityStatus());
+        assertEquals("disabled", cluster.availabilityZoneRelocationStatus());
         assertNotNull(cluster.endpoint());
         String address = cluster.endpoint().address();
         int port = cluster.endpoint().port();

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -425,6 +425,8 @@ public class RedshiftQueryHandler {
             .elem("NodeType", cluster.getNodeType())
             .elem("MasterUsername", cluster.getMasterUsername())
             .elem("ClusterStatus", cluster.getClusterStatus())
+            .elem("ClusterAvailabilityStatus", availabilityStatus(cluster.getClusterStatus()))
+            .elem("AvailabilityZoneRelocationStatus", "disabled")
             .elem("ClusterSubnetGroupName", cluster.getClusterSubnetGroupName());
 
         if (cluster.getVpcSecurityGroupIds() != null && !cluster.getVpcSecurityGroupIds().isEmpty()) {
@@ -463,6 +465,21 @@ public class RedshiftQueryHandler {
         }
 
         return builder.end("Cluster").build();
+    }
+
+    // Terraform's AWS provider polls ClusterAvailabilityStatus during create and validates it on
+    // read, so DescribeClusters must always carry it. Floci has no maintenance window concept, and
+    // every transient lifecycle state (creating, deleting, rebooting, modifying) maps to Modifying.
+    private static String availabilityStatus(String clusterStatus) {
+        if (clusterStatus == null) {
+            return "Modifying";
+        }
+        return switch (clusterStatus) {
+            case "available" -> "Available";
+            case "unavailable" -> "Unavailable";
+            case "failed" -> "Failed";
+            default -> "Modifying";
+        };
     }
 
     private String buildSnapshotXml(Snapshot snapshot) {

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftOperationsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftOperationsTest.java
@@ -133,7 +133,9 @@ public class RedshiftOperationsTest {
             .statusCode(200)
             .contentType("application/xml")
             .body(containsString("<ClusterIdentifier>cluster-src</ClusterIdentifier>"))
-            .body(containsString("<ClusterStatus>available</ClusterStatus>"));
+            .body(containsString("<ClusterStatus>available</ClusterStatus>"))
+            .body(containsString("<ClusterAvailabilityStatus>Available</ClusterAvailabilityStatus>"))
+            .body(containsString("<AvailabilityZoneRelocationStatus>disabled</AvailabilityZoneRelocationStatus>"));
 
         // 1b. RebootCluster — must preserve data (no Docker volume backs this container)
         when(containerManager.getContainer(any(), eq("cluster-src")))

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -69,7 +69,53 @@ class RedshiftQueryHandlerTest {
         String xml = (String) response.getEntity();
         assertTrue(xml.contains("<ClusterIdentifier>test-cluster</ClusterIdentifier>"));
     }
-    
+
+    @Test
+    void testDescribeClustersIncludesAvailabilityStatuses() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "test-cluster");
+
+        Cluster cluster = new Cluster();
+        cluster.setClusterIdentifier("test-cluster");
+        cluster.setClusterStatus("available");
+        when(service.describeClusters(any())).thenReturn(List.of(cluster));
+
+        Response response = handler.handle("DescribeClusters", params);
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<ClusterAvailabilityStatus>Available</ClusterAvailabilityStatus>"));
+        assertTrue(xml.contains("<AvailabilityZoneRelocationStatus>disabled</AvailabilityZoneRelocationStatus>"));
+    }
+
+    @Test
+    void testClusterAvailabilityStatusMapsTransientStatesToModifying() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "test-cluster");
+
+        Cluster cluster = new Cluster();
+        cluster.setClusterIdentifier("test-cluster");
+        cluster.setClusterStatus("creating");
+        when(service.createCluster(any(), any(), any(), any(), any(), any())).thenReturn(cluster);
+
+        Response response = handler.handle("CreateCluster", params);
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<ClusterAvailabilityStatus>Modifying</ClusterAvailabilityStatus>"));
+    }
+
+    @Test
+    void testClusterAvailabilityStatusMapsFailed() {
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "test-cluster");
+
+        Cluster cluster = new Cluster();
+        cluster.setClusterIdentifier("test-cluster");
+        cluster.setClusterStatus("failed");
+        when(service.describeClusters(any())).thenReturn(List.of(cluster));
+
+        Response response = handler.handle("DescribeClusters", params);
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<ClusterAvailabilityStatus>Failed</ClusterAvailabilityStatus>"));
+    }
+
     @Test
     void testDeleteCluster() {
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();


### PR DESCRIPTION
## Summary

`DescribeClusters` (and every other cluster response, since they all share `buildClusterXml`) omitted two fields the Terraform AWS provider requires:

- `ClusterAvailabilityStatus`
- `AvailabilityZoneRelocationStatus`

`ClusterAvailabilityStatus` is derived from the existing `clusterStatus`: `available` -> `Available`, `unavailable` -> `Unavailable`, `failed` -> `Failed`, and every transient lifecycle state (`creating`, `deleting`, `rebooting`, `modifying`) -> `Modifying`. Floci has no availability-zone relocation feature, so `AvailabilityZoneRelocationStatus` is the constant `disabled` (the value a cluster created without AZ relocation reports on real AWS).

Closes #3098

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `DescribeClusters` returned no `ClusterAvailabilityStatus` or `AvailabilityZoneRelocationStatus`. The Terraform AWS provider's create waiter polled `ClusterAvailabilityStatus` and got an empty string (`unexpected state '', wanted target 'Available'`), and import/read rejected the empty `AvailabilityZoneRelocationStatus`.

Verified against AWS SDK for Java v2 `redshift` 2.52.0: `Cluster.clusterAvailabilityStatus()` and `Cluster.availabilityZoneRelocationStatus()` are now populated (asserted in the SDK compatibility test).

## Checklist

- [x] `./mvnw test` passes locally (`RedshiftQueryHandlerTest`, `RedshiftOperationsTest`)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
