### PR TITLE
fix(acm): report SUCCESS domain validation once a certificate is issued

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AcmTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AcmTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.core.retry.backoff.FixedDelayBackoffStrategy;
+import software.amazon.awssdk.core.waiters.WaiterResponse;
 import software.amazon.awssdk.services.acm.AcmClient;
 import software.amazon.awssdk.services.acm.model.*;
 
@@ -18,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -118,6 +121,26 @@ class AcmTest {
         CertificateDetail detail = response.certificate();
         assertThat(detail.domainName()).contains("example.com");
         assertThat(detail.statusAsString()).isNotNull();
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("CertificateValidated waiter completes for an issued certificate")
+    void testCertificateValidatedWaiterCompletes() {
+        Assumptions.assumeTrue(requestedCertArn != null, "RequestCertificate must succeed first");
+        Assumptions.assumeFalse(TestFixtures.isRealAws(), "real ACM waits for DNS validation");
+
+        // The waiter polls DomainValidationOptions[].ValidationStatus, as the CDK
+        // DnsValidatedCertificate handler does, and never returns while any domain is pending.
+        WaiterResponse<DescribeCertificateResponse> waited = acm.waiter().waitUntilCertificateValidated(
+                b -> b.certificateArn(requestedCertArn),
+                o -> o.maxAttempts(3).backoffStrategy(FixedDelayBackoffStrategy.create(Duration.ofSeconds(1))));
+
+        CertificateDetail detail = waited.matched().response().orElseThrow().certificate();
+        assertThat(detail.status()).isEqualTo(CertificateStatus.ISSUED);
+        assertThat(detail.domainValidationOptions()).isNotEmpty();
+        assertThat(detail.domainValidationOptions())
+                .allSatisfy(v -> assertThat(v.validationStatus()).isEqualTo(DomainStatus.SUCCESS));
     }
 
     @Test

--- a/docs/services/acm.md
+++ b/docs/services/acm.md
@@ -28,7 +28,7 @@
 
 ## Emulation Behavior
 
-- **Auto-Issuance:** All requested certificates are immediately issued with status `ISSUED` (no DNS/email validation required)
+- **Auto-Issuance:** All requested certificates are immediately issued with status `ISSUED`, and every entry in `DomainValidationOptions` reports `ValidationStatus: SUCCESS` (no DNS/email validation required). With a validation wait configured, both stay pending until the wait has passed.
 - **Real Cryptography:** Certificates are generated with real RSA/EC keys and valid X.509 structure
 - **One Local CA:** Every issued certificate (`AMAZON_ISSUED` and `PRIVATE`) is signed by Floci's local root CA, and `GetCertificate` returns that CA as `CertificateChain`. Trust it once (`GET /_floci/ca.pem`, see [TLS](../configuration/tls.md)) and both Floci's HTTPS endpoint and every ACM certificate validate. `DescribeCertificate` reports `Issuer` as the CA's name, `CN=Floci Local CA`, where AWS reports `Amazon`. `ImportCertificate` keeps the chain you upload.
 - **CA on First Use:** The CA is created under `{persistent-path}/tls/` the first time a certificate is issued, also with TLS off and in `memory` storage mode, so that directory must be writable. A certificate keeps the chain it was issued with; after a CA regeneration, delete and re-request it.

--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
@@ -176,10 +176,9 @@ public class AcmService implements ResourceProvider {
         cert.setIdempotencyToken(idempotencyToken);
         cert.setTags(tags != null ? new HashMap<>(tags) : new HashMap<>());
 
-        // Generate domain validation options with correct status based on type
         List<DomainValidation> validations = new ArrayList<>();
         for (String san : allSans) {
-            validations.add(generateDomainValidation(san, validationMethod, type));
+            validations.add(generateDomainValidation(san, validationMethod, status));
         }
         cert.setDomainValidationOptions(validations);
 
@@ -236,6 +235,7 @@ public class AcmService implements ResourceProvider {
 
         List<Certificate> allCerts = store.scan(k -> true).stream()
             .filter(c -> c.getArn().contains(":acm:" + region + ":"))
+            .map(c -> settleValidation(c, region))
             .filter(c -> statuses == null || statuses.isEmpty() || statuses.contains(c.getStatus()))
             .filter(c -> keyTypes == null || keyTypes.isEmpty() || keyTypes.contains(c.getKeyAlgorithm()))
             .sorted(Comparator.comparing(Certificate::getArn))
@@ -572,9 +572,42 @@ public class AcmService implements ResourceProvider {
         String certId = extractCertificateIdFromArn(arn);
         String storageKey = regionKey(region, certId);
 
-        return store.get(storageKey).orElseThrow(() ->
+        Certificate cert = store.get(storageKey).orElseThrow(() ->
             new AwsException("ResourceNotFoundException",
                 "The certificate " + arn + " does not exist.", 404));
+        return settleValidation(cert, region);
+    }
+
+    /**
+     * Brings a stored certificate in line on read. A PENDING_VALIDATION certificate whose configured
+     * validation wait has passed is issued, since nothing else moves it along; and a certificate
+     * that has been issued (status ISSUED, or IssuedAt set on one revoked or expired since) reports
+     * SUCCESS for every domain, which also repairs records stored by earlier releases as ISSUED
+     * with pending entries. A certificate revoked before it was ever issued keeps its pending
+     * entries. Changes are stored, which is what a client polling ACM observes.
+     */
+    private Certificate settleValidation(Certificate cert, String region) {
+        boolean changed = false;
+        if (cert.getStatus() == CertificateStatus.PENDING_VALIDATION && cert.getCreatedAt() != null
+                && !Instant.now().isBefore(cert.getCreatedAt().plusSeconds(validationWaitSeconds))) {
+            cert.setStatus(CertificateStatus.ISSUED);
+            cert.setIssuedAt(Instant.now());
+            LOG.debugv("Certificate {0} issued after the validation wait", cert.getArn());
+            changed = true;
+        }
+        boolean issued = cert.getStatus() == CertificateStatus.ISSUED || cert.getIssuedAt() != null;
+        if (issued && !cert.getDomainValidationOptions().stream()
+                .allMatch(validation -> "SUCCESS".equals(validation.validationStatus()))) {
+            cert.setDomainValidationOptions(cert.getDomainValidationOptions().stream()
+                .map(validation -> new DomainValidation(validation.domainName(), validation.validationDomain(),
+                    "SUCCESS", validation.validationMethod(), validation.resourceRecord(), validation.validationEmails()))
+                .toList());
+            changed = true;
+        }
+        if (changed) {
+            store.put(regionKey(region, cert.extractCertificateId()), cert);
+        }
+        return cert;
     }
 
     /**
@@ -673,11 +706,10 @@ public class AcmService implements ResourceProvider {
     }
 
     /**
-     * Generates domain validation options with status based on certificate type.
-     * Private certificates have SUCCESS status immediately; public certificates
-     * start with PENDING_VALIDATION until DNS/email validation completes.
+     * Generates a domain validation entry whose status follows the certificate: an ISSUED
+     * certificate has validated every domain, a PENDING_VALIDATION one has not yet.
      */
-    private DomainValidation generateDomainValidation(String domain, ValidationMethod method, CertificateType type) {
+    private DomainValidation generateDomainValidation(String domain, ValidationMethod method, CertificateStatus status) {
         String validationToken = generateValidationToken(domain);
         String validationDomain = baseDomain(domain);
         ResourceRecord resourceRecord = new ResourceRecord(
@@ -686,8 +718,7 @@ public class AcmService implements ResourceProvider {
             "_" + validationToken.substring(32) + ".acm-validations.aws."
         );
 
-        // Private certificates don't need validation; public certificates do
-        String validationStatus = (type == CertificateType.PRIVATE) ? "SUCCESS" : "PENDING_VALIDATION";
+        String validationStatus = status == CertificateStatus.ISSUED ? "SUCCESS" : "PENDING_VALIDATION";
 
         return new DomainValidation(
             domain,

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmIntegrationTest.java
@@ -243,7 +243,9 @@ class AcmIntegrationTest {
             .body("Certificate.Issuer", equalTo("CN=Floci Local CA"))
             .body("Certificate.KeyAlgorithm", equalTo("RSA-2048"))
             .body("Certificate.NotBefore", notNullValue())
-            .body("Certificate.NotAfter", notNullValue());
+            .body("Certificate.NotAfter", notNullValue())
+            .body("Certificate.DomainValidationOptions.ValidationStatus", everyItem(equalTo("SUCCESS")))
+            .body("Certificate.DomainValidationOptions.ResourceRecord.Type", everyItem(equalTo("CNAME")));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmIssuanceServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmIssuanceServiceTest.java
@@ -1,0 +1,216 @@
+package io.github.hectorvent.floci.services.acm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.FlociCertificateAuthority;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.PersistentStorage;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.services.acm.model.Certificate;
+import io.github.hectorvent.floci.services.acm.model.CertificateOptions;
+import io.github.hectorvent.floci.services.acm.model.CertificateStatus;
+import io.github.hectorvent.floci.services.acm.model.DomainValidation;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import io.github.hectorvent.floci.services.acm.model.ResourceRecord;
+import io.github.hectorvent.floci.services.acm.model.RevocationReason;
+import io.github.hectorvent.floci.services.acm.model.ValidationMethod;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.security.Security;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The domain validation status a certificate reports must follow its issuance. Clients such as the
+ * AWS SDK {@code CertificateValidated} waiter and the CDK {@code DnsValidatedCertificate} handler
+ * poll {@code DomainValidationOptions[].ValidationStatus}, not {@code Status}, and never finish
+ * while an issued certificate still reports PENDING_VALIDATION.
+ */
+class AcmIssuanceServiceTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String PRIVATE_CA =
+            "arn:aws:acm-pca:us-east-1:000000000000:certificate-authority/11111111-2222-3333-4444-555555555555";
+    private static CertificateGenerator generator;
+
+    @BeforeAll
+    static void setup() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+        generator = new CertificateGenerator();
+    }
+
+    @Test
+    void issuedCertificateReportsSuccessfulValidationForEveryDomain(@TempDir Path dir) {
+        Certificate cert = request(newService(dir, 0), null);
+
+        assertEquals(CertificateStatus.ISSUED, cert.getStatus());
+        assertEquals(2, cert.getDomainValidationOptions().size());
+        for (DomainValidation validation : cert.getDomainValidationOptions()) {
+            assertEquals("SUCCESS", validation.validationStatus(), validation.domainName());
+            assertEquals("DNS", validation.validationMethod());
+            assertNotNull(validation.resourceRecord(), "the validation CNAME stays on an issued certificate");
+        }
+    }
+
+    @Test
+    void privateCertificateReportsSuccessfulValidationRegardlessOfTheWait(@TempDir Path dir) {
+        Certificate cert = request(newService(dir, 3600), PRIVATE_CA);
+
+        assertEquals(CertificateStatus.ISSUED, cert.getStatus());
+        assertTrue(cert.getDomainValidationOptions().stream()
+                .allMatch(validation -> "SUCCESS".equals(validation.validationStatus())));
+    }
+
+    @Test
+    void pendingCertificateReportsPendingValidationUntilTheWaitHasPassed(@TempDir Path dir) throws Exception {
+        AcmService service = newService(dir, 1);
+        Certificate requested = request(service, null);
+        String arn = requested.getArn();
+
+        assertEquals(CertificateStatus.PENDING_VALIDATION, requested.getStatus());
+        assertNull(requested.getIssuedAt());
+        Certificate stillPending = service.describeCertificate(arn, REGION);
+        assertEquals(CertificateStatus.PENDING_VALIDATION, stillPending.getStatus(),
+                "a read before the wait has passed must not issue the certificate");
+        assertTrue(stillPending.getDomainValidationOptions().stream()
+                .allMatch(validation -> "PENDING_VALIDATION".equals(validation.validationStatus())));
+
+        Thread.sleep(1200);
+
+        Certificate issued = service.describeCertificate(arn, REGION);
+        assertEquals(CertificateStatus.ISSUED, issued.getStatus());
+        assertNotNull(issued.getIssuedAt());
+        assertTrue(issued.getDomainValidationOptions().stream()
+                .allMatch(validation -> "SUCCESS".equals(validation.validationStatus())));
+    }
+
+    @Test
+    void settledCertificateIsPersistedNotRecomputed(@TempDir Path dir) throws Exception {
+        AcmService service = newService(dir, 1);
+        String arn = request(service, null).getArn();
+        Thread.sleep(1200);
+        service.getCertificate(arn, REGION);
+
+        // A restarted service with a wait that has not passed yet would leave a pending certificate
+        // pending, so an ISSUED status here can only have come from the store.
+        Certificate reloaded = newService(dir, 3600).describeCertificate(arn, REGION);
+
+        assertEquals(CertificateStatus.ISSUED, reloaded.getStatus());
+        assertTrue(reloaded.getDomainValidationOptions().stream()
+                .allMatch(validation -> "SUCCESS".equals(validation.validationStatus())));
+    }
+
+    @Test
+    void listCertificatesSettlesPendingCertificatesBeforeFilteringByStatus(@TempDir Path dir) throws Exception {
+        AcmService service = newService(dir, 1);
+        String arn = request(service, null).getArn();
+        assertTrue(service.listCertificates(List.of(CertificateStatus.ISSUED), null, REGION, 100, null)
+                .certificates().isEmpty(), "still pending");
+
+        Thread.sleep(1200);
+
+        List<Certificate> issued = service.listCertificates(List.of(CertificateStatus.ISSUED), null, REGION, 100, null)
+                .certificates();
+        assertEquals(1, issued.size());
+        assertEquals(arn, issued.get(0).getArn());
+        assertEquals(CertificateStatus.ISSUED, issued.get(0).getStatus());
+    }
+
+    @Test
+    void issuedCertificateStoredWithPendingValidationIsRepairedOnRead(@TempDir Path dir) {
+        // Earlier releases stored ISSUED certificates whose validation entries stayed
+        // PENDING_VALIDATION. The first read after an upgrade repairs and stores them.
+        String id = "11111111-2222-3333-4444-555555555555";
+        String arn = "arn:aws:acm:us-east-1:000000000000:certificate/" + id;
+        Certificate legacy = new Certificate();
+        legacy.setArn(arn);
+        legacy.setDomainName("legacy.example.com");
+        legacy.setStatus(CertificateStatus.ISSUED);
+        legacy.setCreatedAt(Instant.now());
+        legacy.setDomainValidationOptions(List.of(new DomainValidation("legacy.example.com", "example.com",
+                "PENDING_VALIDATION", "DNS", new ResourceRecord("_a.legacy.example.com.", "CNAME", "_b.acm-validations.aws."), null)));
+        PersistentStorage<String, Certificate> store = store(dir);
+        store.put(REGION + "::" + id, legacy);
+
+        Certificate repaired = newService(dir, store, 0).describeCertificate(arn, REGION);
+
+        assertEquals(CertificateStatus.ISSUED, repaired.getStatus());
+        assertEquals("SUCCESS", repaired.getDomainValidationOptions().get(0).validationStatus());
+        assertEquals("_a.legacy.example.com.", repaired.getDomainValidationOptions().get(0).resourceRecord().name());
+        Certificate reloaded = store(dir).get(REGION + "::" + id).orElseThrow();
+        assertEquals("SUCCESS", reloaded.getDomainValidationOptions().get(0).validationStatus(), "repair is stored");
+    }
+
+    @Test
+    void certificateRevokedAfterIssuanceStoredWithPendingValidationIsRepaired(@TempDir Path dir) {
+        String id = "22222222-2222-3333-4444-555555555555";
+        String arn = "arn:aws:acm:us-east-1:000000000000:certificate/" + id;
+        Certificate legacy = new Certificate();
+        legacy.setArn(arn);
+        legacy.setDomainName("revoked.example.com");
+        legacy.setStatus(CertificateStatus.REVOKED);
+        legacy.setCreatedAt(Instant.now().minusSeconds(60));
+        legacy.setIssuedAt(Instant.now().minusSeconds(60));
+        legacy.setDomainValidationOptions(List.of(new DomainValidation("revoked.example.com", "example.com",
+                "PENDING_VALIDATION", "DNS", null, null)));
+        PersistentStorage<String, Certificate> store = store(dir);
+        store.put(REGION + "::" + id, legacy);
+
+        Certificate repaired = newService(dir, store, 0).describeCertificate(arn, REGION);
+
+        assertEquals(CertificateStatus.REVOKED, repaired.getStatus());
+        assertEquals("SUCCESS", repaired.getDomainValidationOptions().get(0).validationStatus());
+    }
+
+    @Test
+    void certificateRevokedWhileStillPendingKeepsItsPendingValidation(@TempDir Path dir) {
+        // Never issued, so nothing was ever validated: leaving PENDING_VALIDATION is the honest answer.
+        AcmService service = newService(dir, 3600);
+        String arn = request(service, null).getArn();
+        service.updateCertificateOptions(arn, new CertificateOptions(null, "ENABLED"), REGION);
+        service.revokeCertificate(arn, RevocationReason.UNSPECIFIED, REGION);
+
+        Certificate revoked = service.describeCertificate(arn, REGION);
+
+        assertEquals(CertificateStatus.REVOKED, revoked.getStatus());
+        assertNull(revoked.getIssuedAt());
+        assertTrue(revoked.getDomainValidationOptions().stream()
+                .allMatch(validation -> "PENDING_VALIDATION".equals(validation.validationStatus())));
+    }
+
+    private static Certificate request(AcmService service, String certificateAuthorityArn) {
+        return service.requestCertificate("example.com", List.of("www.example.com"), ValidationMethod.DNS,
+                null, KeyAlgorithm.RSA_2048, certificateAuthorityArn, null, Map.of(), REGION);
+    }
+
+    private static AcmService newService(Path dir, int validationWaitSeconds) {
+        return newService(dir, store(dir), validationWaitSeconds);
+    }
+
+    private static AcmService newService(Path dir, StorageBackend<String, Certificate> store, int validationWaitSeconds) {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+        return new AcmService(store, generator, FlociCertificateAuthority.loadOrCreate(dir.resolve("tls")),
+                regionResolver, validationWaitSeconds);
+    }
+
+    private static PersistentStorage<String, Certificate> store(Path dir) {
+        PersistentStorage<String, Certificate> store = new PersistentStorage<>(
+                dir.resolve("acm-certificates.json"), new TypeReference<Map<String, Certificate>>() {});
+        store.load();
+        return store;
+    }
+}


### PR DESCRIPTION
## Summary

`DescribeCertificate` now reports `ValidationStatus: SUCCESS` for every domain of an issued certificate.

Before this change a public certificate was `ISSUED` at once, but each entry in `DomainValidationOptions` stayed `PENDING_VALIDATION` forever. Clients that wait on the validation status instead of the certificate status never finished. The AWS SDK `CertificateValidated` waiter polls only `DomainValidationOptions[].ValidationStatus`, and the CDK `DnsValidatedCertificate` custom resource uses that waiter: deploying a CDK stack with one against Floci logged "Waiting for validation..." until the Lambda timed out, and the stack rolled back.

Now the validation status follows issuance:

- An `ISSUED` certificate reports `SUCCESS` for every domain. The validation CNAME stays in the response, as on AWS.
- With `FLOCI_SERVICES_ACM_VALIDATION_WAIT_SECONDS` above zero, the certificate and its validations stay pending until the wait has passed. On the first read after that (`DescribeCertificate`, `GetCertificate`, `ListCertificates`, or any other call that loads the certificate) it becomes `ISSUED`, its validations become `SUCCESS`, `IssuedAt` is set, and the change is stored. Before this change that documented transition never happened.

- Certificates stored by an earlier release as `ISSUED` with pending validation entries are repaired on their first read after the upgrade, and the repair is stored. The repair applies to certificates that have been issued (status `ISSUED`, or `IssuedAt` set on one revoked or expired since); a certificate revoked while still pending keeps its pending entries.

Private certificates are unchanged: they were already `ISSUED` with `SUCCESS` validations.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| `DescribeCertificate` | `DomainValidationOptions[].ValidationStatus` | ✅ | `SUCCESS` once issued, `PENDING_VALIDATION` while the wait runs. `FAILED` is not emulated: nothing fails validation locally. |
| `DescribeCertificate` | `Status`, `IssuedAt` after the wait | ✅ | Set on the first read after the wait, stored, and kept across restarts. |
| `ListCertificates` | Status filter after the wait | ✅ | Pending certificates settle before the filter is applied. |
| SDK waiter | `CertificateValidated` | ✅ | Completes on the first poll for an issued certificate. |
| Upgrade | Certificates stored by earlier releases | ✅ | `ISSUED` records with pending entries are repaired on the first read. |
| `DomainValidationOptions` | Entries on private certificates | 🟡 | Unchanged. AWS omits the field for private certificates; Floci still lists them with `SUCCESS`. |

## Files

- `AcmService`: the validation status is derived from the certificate status when the certificate is requested; `settleValidation` issues a pending certificate whose wait has passed on read and stores it. Called from the single certificate lookup every operation uses and from `ListCertificates`.
- `AcmIssuanceServiceTest` (new): issued certificate reports `SUCCESS` for every domain; private certificate unaffected by the wait; pending until the wait passes, then issued with `IssuedAt`; the settled state is stored, not recomputed; `ListCertificates` settles before filtering; a record stored by an earlier release as `ISSUED` with pending entries is repaired and stored on read; a revoked record with `IssuedAt` is repaired too; a certificate revoked while still pending keeps its pending entries.
- `AcmIntegrationTest`: `DescribeCertificate` asserts `SUCCESS` and the CNAME record type.
- `compatibility-tests/sdk-test-java` `AcmTest`: runs the AWS SDK `CertificateValidated` waiter against a requested certificate (skipped against real AWS, which waits for real DNS validation).
- `docs/services/acm.md`: one line in the emulation behaviour list.

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Docs / chore

### AWS Compatibility

The waiter definition is from botocore's `acm/2015-12-08/waiters-2.json`: success when every `Certificate.DomainValidationOptions[].ValidationStatus` is `SUCCESS`, retry while any is `PENDING_VALIDATION`, failure on `Certificate.Status` `FAILED`. The ACM API reference documents `SUCCESS`, `PENDING_VALIDATION` and `FAILED` as the values of `DomainValidation.ValidationStatus`. Verified with AWS SDK for Java 2.52.0 (the compat suite) and with CDK 2.264.0's `DnsValidatedCertificate` handler, which completed against this change.

### Checklist

* [ ] `./mvnw test` passes locally. Ran per class instead: `AcmIssuanceServiceTest`, `AcmIntegrationTest`, every test under `services.acm` and `cloudformation.provisioners`, plus `AcmTest` from the Java SDK suite against the packaged jar. `make docs-check` passes.
* [x] New or updated integration test added
* [x] Commit messages follow Conventional Commits
