### PR TITLE
fix(rds): format unexpected query errors as XML error envelope

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryResponse.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryResponse.java
@@ -102,10 +102,21 @@ public final class AwsQueryResponse {
      * @param xmlns the namespace URI, or {@code null} for namespace-free error responses (e.g. SQS)
      */
     public static Response error(String code, String message, String xmlns, int status) {
+        String type = status >= 500 ? "Receiver" : "Sender";
+        return error(code, message, xmlns, status, type);
+    }
+
+    /**
+     * Builds a Query-protocol XML error response with an explicit error type and returns a JAX-RS {@link Response}.
+     *
+     * @param xmlns the namespace URI, or {@code null} for namespace-free error responses (e.g. SQS)
+     * @param type  the error type, typically "Sender" for 4xx or "Receiver" for 5xx
+     */
+    public static Response error(String code, String message, String xmlns, int status, String type) {
         String xml = new XmlBuilder()
                 .start("ErrorResponse", xmlns)
                   .start("Error")
-                    .elem("Type", "Sender")
+                    .elem("Type", type)
                     .elem("Code", code)
                     .elem("Message", message)
                   .end("Error")

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -65,7 +65,8 @@ public class NeptuneQueryHandler {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
         } catch (Exception e) {
             LOG.errorv(e, "Unexpected error in Neptune {0}", action);
-            return Response.serverError().entity("Unexpected error: " + e.getMessage()).build();
+            return AwsQueryResponse.error("InternalFailure",
+                    "Unexpected error: " + e.getMessage(), AwsNamespaces.RDS, 500);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -114,7 +114,8 @@ public class RdsQueryHandler {
             return AwsQueryResponse.error(e.getErrorCode(), e.getMessage(), AwsNamespaces.RDS, e.getHttpStatus());
         } catch (Exception e) {
             LOG.errorv(e, "Unexpected error in RDS {0}", action);
-            return Response.serverError().entity("Unexpected error: " + e.getMessage()).build();
+            return AwsQueryResponse.error("InternalFailure",
+                    "Unexpected error: " + e.getMessage(), AwsNamespaces.RDS, 500);
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
@@ -207,6 +207,37 @@ class ImageCacheServiceTest {
     }
 
     @Test
+    void repullsDefaultImageWhenCachedImageWasRemoved() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        InspectImageCmd inspectCachedImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        when(dockerClient.inspectImageCmd("sha256:default-old")).thenReturn(inspectCachedImage);
+        when(inspectImage.exec())
+                .thenReturn(new InspectImageResponse()
+                        .withId("sha256:default-old")
+                        .withOs("linux")
+                        .withArch("amd64"))
+                .thenThrow(new NotFoundException("image not found locally"))
+                .thenReturn(new InspectImageResponse()
+                        .withId("sha256:default-new")
+                        .withOs("linux")
+                        .withArch("amd64"));
+        when(inspectCachedImage.exec()).thenThrow(new NotFoundException("image was removed"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        ImageCacheService service = newService(dockerClient);
+        assertEquals("sha256:default-old", service.ensureImageExists(IMAGE));
+
+        assertEquals("sha256:default-new", service.ensureImageExists(IMAGE));
+        verify(pullImage).exec(any(PullImageResultCallback.class));
+    }
+
+    @Test
     void succeedsOnFirstAttempt() throws Exception {
         AtomicInteger calls = new AtomicInteger();
         ImageCacheService.runWithRetry(IMAGE, 3, 1L, calls::incrementAndGet);

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandlerTest.java
@@ -1,0 +1,97 @@
+package io.github.hectorvent.floci.services.neptune;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class NeptuneQueryHandlerTest {
+
+    private NeptuneService service;
+    private NeptuneQueryHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        service = mock(NeptuneService.class);
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        when(config.defaultAvailabilityZone()).thenReturn("us-east-1a");
+        handler = new NeptuneQueryHandler(service, config);
+    }
+
+    @Test
+    void unhandledExceptionRendersXmlInternalFailure() {
+        when(service.createDbCluster(any(), any(), anyBoolean(), any(), any()))
+                .thenThrow(new RuntimeException("Docker daemon connection failed"));
+
+        MultivaluedMap<String, String> p = new MultivaluedHashMap<>();
+        p.add("DBClusterIdentifier", "mycluster");
+
+        Response response = handler.handle("CreateDBCluster", p);
+        assertEquals(500, response.getStatus());
+        assertEquals("application/xml", response.getMediaType().toString());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<ErrorResponse xmlns=\"http://rds.amazonaws.com/doc/2014-10-31/\">"), body);
+        assertTrue(body.contains("<Type>Receiver</Type>"), body);
+        assertTrue(body.contains("<Code>InternalFailure</Code>"), body);
+        assertTrue(body.contains("<Message>Unexpected error: Docker daemon connection failed</Message>"), body);
+    }
+
+    @Test
+    void unhandledExceptionInCreateDbInstanceRendersXmlInternalFailure() {
+        when(service.createDbInstance(any(), any(), any(), any(), anyBoolean(), any(), any()))
+                .thenThrow(new RuntimeException("Container startup timed out"));
+
+        MultivaluedMap<String, String> p = new MultivaluedHashMap<>();
+        p.add("DBInstanceIdentifier", "myinstance");
+        p.add("DBClusterIdentifier", "mycluster");
+
+        Response response = handler.handle("CreateDBInstance", p);
+        assertEquals(500, response.getStatus());
+        assertEquals("application/xml", response.getMediaType().toString());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<ErrorResponse xmlns=\"http://rds.amazonaws.com/doc/2014-10-31/\">"), body);
+        assertTrue(body.contains("<Type>Receiver</Type>"), body);
+        assertTrue(body.contains("<Code>InternalFailure</Code>"), body);
+        assertTrue(body.contains("<Message>Unexpected error: Container startup timed out</Message>"), body);
+    }
+
+    @Test
+    void awsExceptionRendersXmlError() {
+        when(service.getDbCluster("missing"))
+                .thenThrow(new AwsException("DBClusterNotFoundFault", "DBCluster missing not found.", 404));
+
+        MultivaluedMap<String, String> p = new MultivaluedHashMap<>();
+        p.add("DBClusterIdentifier", "missing");
+
+        Response response = handler.handle("DescribeDBClusters", p);
+        assertEquals(404, response.getStatus());
+        assertEquals("application/xml", response.getMediaType().toString());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>DBClusterNotFoundFault</Code>"), body);
+        assertTrue(body.contains("<Type>Sender</Type>"), body);
+    }
+
+    @Test
+    void unsupportedOperationReturnsQueryError() {
+        Response response = handler.handle("NoSuchAction", new MultivaluedHashMap<>());
+        assertEquals(400, response.getStatus());
+        assertEquals("application/xml", response.getMediaType().toString());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<Code>UnsupportedOperation</Code>"), body);
+        assertTrue(body.contains("<Type>Sender</Type>"), body);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -2385,4 +2385,27 @@ class RdsQueryHandlerTest {
                 isNull(), isNull(), captor.capture());
         assertEquals(new DbInstanceSettings(null, null, 3, "01:00-01:30", null, true), captor.getValue());
     }
+
+    @Test
+    void unhandledExceptionRendersXmlInternalFailure() {
+        when(service.createDbInstance(any(), any(), any(), any(), any(), any(),
+                any(), anyInt(), anyBoolean(), any(), any(), any(), any(), anyBoolean(),
+                anyBoolean(), any(), any(), any(), any(), any(), anyBoolean(), any()))
+                .thenThrow(new RuntimeException("Docker daemon connection failed"));
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBInstanceIdentifier", "mydb");
+        p.add("Engine", "postgres");
+        p.add("DBInstanceClass", "db.t3.micro");
+
+        Response response = handler.handle("CreateDBInstance", p);
+        assertEquals(500, response.getStatus());
+        assertEquals("application/xml", response.getMediaType().toString());
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<ErrorResponse xmlns=\"http://rds.amazonaws.com/doc/2014-10-31/\">"), body);
+        assertTrue(body.contains("<Type>Receiver</Type>"), body);
+        assertTrue(body.contains("<Code>InternalFailure</Code>"), body);
+        assertTrue(body.contains("<Message>Unexpected error: Docker daemon connection failed</Message>"), body);
+    }
 }


### PR DESCRIPTION
## Summary

Format unexpected runtime exceptions in `RdsQueryHandler` and `NeptuneQueryHandler` as XML `ErrorResponse` envelopes (`InternalFailure`) instead of plain-text 500 entities. Also ensure `AwsQueryResponse.error()` uses `<Type>Receiver</Type>` for 5xx status codes, and add unit test coverage for default platform image eviction in `ImageCacheServiceTest`.

Closes #3110

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

- Bug fix: When an unhandled runtime error (such as a Docker daemon error) occurs in RDS or Neptune Query handlers, Floci previously returned an HTTP 500 response with a plain text body `Unexpected error: ...` under `application/xml`. Clients such as the AWS CLI and AWS SDK v3 failed with XML syntax parse errors (`invalid XML received`) rather than parsing the true error message.
- Expected behavior: The server returns a standard Query-protocol XML error envelope with `<Code>InternalFailure</Code>` and `<Type>Receiver</Type>`, allowing SDKs and the AWS CLI to parse the error message cleanly.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
