### PR TITLE
fix(lambda): bound ZIP extraction resources

### DIFF
--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -138,6 +138,7 @@ floci:
       runtime-api-base-port: 12000            # Port range for Lambda Runtime API
       runtime-api-max-port: 12499             # One port per running container = concurrency ceiling
       code-path: ./data/lambda-code           # Where ZIP archives are stored
+      zip-max-entries: 100000                  # Maximum ZIP entries extracted per deployment package
       poll-interval-ms: 1000
       container-idle-timeout-seconds: 300     # Remove idle containers after this
       region-concurrency-limit: 1000          # Concurrent executions ceiling per region
@@ -315,6 +316,7 @@ All keys in this table are declared on `EmulatorConfig` and accept environment v
 | `FLOCI_SERVICES_SES_SMTP_PASS`                     | *(unset)*        | SMTP authentication password                                  |
 | `FLOCI_SERVICES_SES_SMTP_STARTTLS`                 | `DISABLED`       | STARTTLS mode: `DISABLED`, `OPTIONAL`, or `REQUIRED`          |
 | `FLOCI_SERVICES_LAMBDA_HONOUR_ARCHITECTURES`       | `false`          | Select the declared Lambda architecture for Docker image pulls and containers |
+| `FLOCI_SERVICES_LAMBDA_ZIP_MAX_ENTRIES`            | `100000`         | Maximum number of entries accepted in a Lambda ZIP archive |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ENABLED`         | `false`          | Enable bind-mount hot-reload mode (`S3Bucket=hot-reload`)     |
 | `FLOCI_SERVICES_LAMBDA_HOT_RELOAD_ALLOWED_PATHS`   | *(unset)*        | Comma-separated list of host paths allowed as bind-mount roots; unset = any absolute path |
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1885,6 +1885,14 @@ public interface EmulatorConfig {
         @WithDefault("./data/lambda-code")
         String codePath();
 
+        /**
+         * Maximum number of entries accepted in a Lambda ZIP archive.
+         *
+         * Env var: FLOCI_SERVICES_LAMBDA_ZIP_MAX_ENTRIES
+         */
+        @WithDefault("100000")
+        int zipMaxEntries();
+
         @WithDefault("1000")
         long pollIntervalMs();
 

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaLayerService.java
@@ -131,6 +131,11 @@ public class LambdaLayerService {
 
         // Resolve the zip content
         byte[] zipBytes = resolveLayerContent(content);
+        if (content.get("ZipFile") != null
+                && zipBytes.length > ZipExtractor.DIRECT_UPLOAD_MAX_COMPRESSED_BYTES) {
+            throw new AwsException("RequestEntityTooLargeException",
+                    "Request must be smaller than 52428800 bytes.", 413);
+        }
 
         // Determine the next version number
         long nextVersion = layerStore.getLatestVersion(region, layerName) + 1;
@@ -138,7 +143,7 @@ public class LambdaLayerService {
         // Extract the layer zip to disk
         Path layerPath = getLayerCodePath(layerName, nextVersion);
         try {
-            zipExtractor.extractTo(zipBytes, layerPath);
+            zipExtractor.extractTo(zipBytes, layerPath, configuredZipMaxEntries());
         } catch (IOException e) {
             throw new AwsException("InvalidParameterValueException",
                     "Failed to extract layer archive: " + e.getMessage(), 400);
@@ -179,6 +184,16 @@ public class LambdaLayerService {
         layerStore.save(region, layerVersion);
         LOG.infov("Published layer version: {0} v{1} in region {2}", layerName, nextVersion, region);
         return layerVersion;
+    }
+
+    private int configuredZipMaxEntries() {
+        int configured = config.services().lambda().zipMaxEntries();
+        if (configured < 1) {
+            LOG.warnv("Ignoring invalid Lambda ZIP entry limit {0}; using {1}",
+                    configured, ZipExtractor.DEFAULT_MAX_ENTRIES);
+            return ZipExtractor.DEFAULT_MAX_ENTRIES;
+        }
+        return configured;
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -2589,13 +2589,18 @@ public class LambdaService implements ResourceProvider {
     }
 
     private void extractZipCode(LambdaFunction fn, String zipFileBase64, String region) {
-        extractZipCodeBytes(fn, Base64.getDecoder().decode(zipFileBase64), region);
+        byte[] zipBytes = Base64.getDecoder().decode(zipFileBase64);
+        if (zipBytes.length > ZipExtractor.DIRECT_UPLOAD_MAX_COMPRESSED_BYTES) {
+            throw new AwsException("RequestEntityTooLargeException",
+                    "Request must be smaller than 52428800 bytes.", 413);
+        }
+        extractZipCodeBytes(fn, zipBytes, region);
     }
 
     private void extractZipCodeBytes(LambdaFunction fn, byte[] zipBytes, String region) {
         Path codePath = codeStore.getCodePath(ownerAccount(fn), fn.getFunctionName());
         try {
-            zipExtractor.extractTo(zipBytes, codePath);
+            zipExtractor.extractTo(zipBytes, codePath, configuredZipMaxEntries());
             // Publish the new code identity under the same per-function lock publishVersion holds.
             // PublishVersion's CodeSha256 precondition is a check-then-act: it compares the hash and
             // then snapshots the code. Mutating these fields without the lock lets an overlapping
@@ -2656,6 +2661,19 @@ public class LambdaService implements ResourceProvider {
             throw new AwsException("InvalidParameterValueException",
                     "Failed to extract deployment package: " + e.getMessage(), 400);
         }
+    }
+
+    private int configuredZipMaxEntries() {
+        if (config == null || config.services() == null || config.services().lambda() == null) {
+            return ZipExtractor.DEFAULT_MAX_ENTRIES;
+        }
+        int configured = config.services().lambda().zipMaxEntries();
+        if (configured < 1) {
+            LOG.warnv("Ignoring invalid Lambda ZIP entry limit {0}; using {1}",
+                    configured, ZipExtractor.DEFAULT_MAX_ENTRIES);
+            return ZipExtractor.DEFAULT_MAX_ENTRIES;
+        }
+        return configured;
     }
 
     private void storeDeploymentPackage(LambdaFunction fn, byte[] zipBytes, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractor.java
@@ -27,8 +27,25 @@ public class ZipExtractor {
     private static final Logger LOG = Logger.getLogger(ZipExtractor.class);
 
     private static final char BACKSLASH = '\\';
+    public static final long DIRECT_UPLOAD_MAX_COMPRESSED_BYTES = 50L * 1024 * 1024;
+    private static final long S3_MAX_COMPRESSED_BYTES = 250L * 1024 * 1024;
+    static final long MAX_EXPANDED_BYTES = 250L * 1024 * 1024;
+    static final long MAX_ENTRY_BYTES = 250L * 1024 * 1024;
+    public static final int DEFAULT_MAX_ENTRIES = 100_000;
 
     public void extractTo(byte[] zipBytes, Path targetDir) throws IOException {
+        extractTo(zipBytes, targetDir, DEFAULT_MAX_ENTRIES);
+    }
+
+    public void extractTo(byte[] zipBytes, Path targetDir, int maxEntries) throws IOException {
+        if (maxEntries < 1) {
+            throw new IOException("ZIP archive entry limit must be at least 1: " + maxEntries);
+        }
+        if (zipBytes.length > S3_MAX_COMPRESSED_BYTES) {
+            throw new IOException("ZIP archive exceeds the " + S3_MAX_COMPRESSED_BYTES
+                    + " byte compressed limit: " + zipBytes.length);
+        }
+
         // Resolve to absolute path so that normalize() on entry paths stays comparable
         Path absTarget = targetDir.toAbsolutePath().normalize();
         Files.createDirectories(absTarget.getParent());
@@ -65,7 +82,13 @@ public class ZipExtractor {
             Files.write(staged, zipBytes);
             try (ZipFile zip = new ZipFile(staged.toFile())) {
                 var entries = zip.entries();
+                int entryCount = 0;
+                long expandedBytes = 0;
                 while (entries.hasMoreElements()) {
+                    if (++entryCount > maxEntries) {
+                        throw new IOException("ZIP archive contains more than the configured "
+                                + maxEntries + " entries");
+                    }
                     ZipEntry entry = entries.nextElement();
                     String entryName = entry.getName();
 
@@ -91,12 +114,29 @@ public class ZipExtractor {
                         continue;
                     }
 
+                    long declaredSize = entry.getSize();
+                    if (declaredSize > MAX_ENTRY_BYTES) {
+                        throw new IOException("ZIP entry exceeds the " + MAX_ENTRY_BYTES
+                                + " byte limit: " + entryName);
+                    }
+                    long accountedSize = declaredSize >= 0 ? declaredSize : 0;
+                    if (accountedSize > MAX_EXPANDED_BYTES - expandedBytes) {
+                        throw new IOException("ZIP archive exceeds the " + MAX_EXPANDED_BYTES
+                                + " byte expanded limit");
+                    }
+
                     if (entry.isDirectory()) {
                         Files.createDirectories(targetPath);
                     } else {
                         Files.createDirectories(targetPath.getParent());
-                        copyVerified(zip, entry, targetPath);
+                        long copyLimit = declaredSize >= 0
+                                ? Math.min(declaredSize, MAX_EXPANDED_BYTES - expandedBytes)
+                                : MAX_EXPANDED_BYTES - expandedBytes;
+                        long copiedBytes = copyVerified(zip, entry, targetPath,
+                                MAX_ENTRY_BYTES, copyLimit);
+                        accountedSize = declaredSize >= 0 ? declaredSize : copiedBytes;
                     }
+                    expandedBytes += accountedSize;
                 }
             }
             // Extraction succeeded in full: install the new tree.
@@ -197,15 +237,21 @@ public class ZipExtractor {
      * a package corrupted in transit would be deployed silently as garbage code rather than
      * rejected. The message mirrors the JDK's own so existing reports stay recognisable.
      */
-    private static void copyVerified(ZipFile zip, ZipEntry entry, Path targetPath) throws IOException {
+    private static long copyVerified(ZipFile zip, ZipEntry entry, Path targetPath,
+                                     long maxEntryBytes, long remainingExpandedBytes) throws IOException {
         CRC32 checksum = new CRC32();
+        long bytesWritten = 0;
         try (InputStream in = zip.getInputStream(entry);
              OutputStream out = Files.newOutputStream(targetPath)) {
             byte[] buffer = new byte[8192];
             int read;
             while ((read = in.read(buffer)) >= 0) {
+                if (read > maxEntryBytes - bytesWritten || read > remainingExpandedBytes - bytesWritten) {
+                    throw new IOException("ZIP archive exceeds its extraction size limit");
+                }
                 checksum.update(buffer, 0, read);
                 out.write(buffer, 0, read);
+                bytesWritten += read;
             }
         }
         long expected = entry.getCrc();
@@ -214,5 +260,6 @@ public class ZipExtractor {
                     "invalid entry CRC for \"%s\" (expected 0x%08x but got 0x%08x)",
                     entry.getName(), expected, checksum.getValue()));
         }
+        return bytesWritten;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -269,6 +269,7 @@ floci:
       runtime-api-base-port: 12000
       runtime-api-max-port: 12499
       code-path: ./data/lambda-code
+      zip-max-entries: 100000
       poll-interval-ms: 1000
       container-idle-timeout-seconds: 300
       region-concurrency-limit: 1000

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -871,6 +871,11 @@ class LambdaServiceTest {
     // ──────────────────────────── Hot-reload ────────────────────────────
 
     private LambdaService serviceWithHotReload(boolean enabled, List<String> allowedPaths) {
+        return serviceWithHotReload(enabled, allowedPaths, ZipExtractor.DEFAULT_MAX_ENTRIES);
+    }
+
+    private LambdaService serviceWithHotReload(boolean enabled, List<String> allowedPaths,
+                                               int zipMaxEntries) {
         EmulatorConfig cfg = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig svc = mock(EmulatorConfig.ServicesConfig.class);
         EmulatorConfig.LambdaServiceConfig lambdaCfg = mock(EmulatorConfig.LambdaServiceConfig.class);
@@ -881,6 +886,7 @@ class LambdaServiceTest {
         when(lambdaCfg.hotReload()).thenReturn(hr);
         when(lambdaCfg.defaultTimeoutSeconds()).thenReturn(3);
         when(lambdaCfg.defaultMemoryMb()).thenReturn(128);
+        when(lambdaCfg.zipMaxEntries()).thenReturn(zipMaxEntries);
         when(hr.enabled()).thenReturn(enabled);
         when(hr.allowedPaths()).thenReturn(allowedPaths == null ? Optional.empty() : Optional.of(allowedPaths));
 
@@ -890,6 +896,32 @@ class LambdaServiceTest {
         ZipExtractor zipExtractor = new ZipExtractor();
         RegionResolver regionResolver = new RegionResolver(REGION, "000000000000");
         return new LambdaService(store, warmPool, codeStore, zipExtractor, cfg, regionResolver);
+    }
+
+    @Test
+    void createFunctionRejectsConfiguredZipEntryLimit() throws Exception {
+        LambdaService limited = serviceWithHotReload(true, null, 2);
+        Map<String, Object> request = baseRequest("zip-entry-limit");
+        request.put("Code", Map.of("ZipFile", createZipBase64("index.js", "one.js", "two.js")));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> limited.createFunction(REGION, request));
+
+        assertEquals("InvalidParameterValueException", error.getErrorCode());
+        assertTrue(error.getMessage().contains("more than the configured 2 entries"));
+    }
+
+    @Test
+    void createFunctionRejectsOversizedDirectZipUploadWithAwsError() {
+        Map<String, Object> request = baseRequest("oversized-zip");
+        byte[] oversized = new byte[(int) ZipExtractor.DIRECT_UPLOAD_MAX_COMPRESSED_BYTES + 1];
+        request.put("Code", Map.of("ZipFile", Base64.getEncoder().encodeToString(oversized)));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.createFunction(REGION, request));
+
+        assertEquals("RequestEntityTooLargeException", error.getErrorCode());
+        assertEquals(413, error.getHttpStatus());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -34,6 +34,79 @@ class ZipExtractorTest {
         return baos.toByteArray();
     }
 
+    private static byte[] zipWithEntries(String... names) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            for (String name : names) {
+                zos.putNextEntry(new ZipEntry(name));
+                zos.write(name.getBytes(StandardCharsets.UTF_8));
+                zos.closeEntry();
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] zipWithDeclaredSizes(long... sizes) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        List<Integer> offsets = new ArrayList<>();
+        List<byte[]> names = new ArrayList<>();
+        byte[] content = new byte[]{'x'};
+        CRC32 crc = new CRC32();
+        crc.update(content);
+
+        for (int i = 0; i < sizes.length; i++) {
+            byte[] name = ("entry" + i).getBytes(StandardCharsets.UTF_8);
+            offsets.add(out.size());
+            names.add(name);
+            le32(out, 0x04034b50L);
+            le16(out, 20);
+            le16(out, 0);
+            le16(out, 0);
+            le16(out, 0);
+            le16(out, 0);
+            le32(out, crc.getValue());
+            le32(out, content.length);
+            le32(out, sizes[i]);
+            le16(out, name.length);
+            le16(out, 0);
+            out.write(name);
+            out.write(content);
+        }
+
+        int centralOffset = out.size();
+        for (int i = 0; i < sizes.length; i++) {
+            byte[] name = names.get(i);
+            le32(out, 0x02014b50L);
+            le16(out, 20);
+            le16(out, 20);
+            le16(out, 0);
+            le16(out, 0);
+            le16(out, 0);
+            le16(out, 0);
+            le32(out, crc.getValue());
+            le32(out, content.length);
+            le32(out, sizes[i]);
+            le16(out, name.length);
+            le16(out, 0);
+            le16(out, 0);
+            le16(out, 0);
+            le16(out, 0);
+            le32(out, 0);
+            le32(out, offsets.get(i));
+            out.write(name);
+        }
+        int centralSize = out.size() - centralOffset;
+        le32(out, 0x06054b50L);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, sizes.length);
+        le16(out, sizes.length);
+        le32(out, centralSize);
+        le32(out, centralOffset);
+        le16(out, 0);
+        return out.toByteArray();
+    }
+
     @Test
     void extractsBackslashEntriesAsLiteralFilename(@TempDir Path target) throws IOException {
         // PowerShell 5 Compress-Archive writes '\' separators (issue #1198).
@@ -75,6 +148,67 @@ class ZipExtractorTest {
 
         assertFalse(Files.exists(target.getParent().getParent().resolve("evil.sh")),
                 "traversal entry must not escape the target dir");
+    }
+
+    @Test
+    void rejectsArchivesAboveTheConfiguredEntryCount(@TempDir Path target) throws IOException {
+        byte[] zip = zipWithEntries("one.txt", "two.txt", "three.txt");
+
+        IOException thrown = assertThrows(IOException.class,
+                () -> extractor.extractTo(zip, target, 2));
+
+        assertEquals("ZIP archive contains more than the configured 2 entries", thrown.getMessage());
+        assertFalse(Files.exists(target.resolve("one.txt")));
+    }
+
+    @Test
+    void acceptsArchivesAtTheConfiguredEntryCount(@TempDir Path target) throws IOException {
+        byte[] zip = zipWithEntries("one.txt", "two.txt");
+
+        extractor.extractTo(zip, target, 2);
+
+        assertEquals("one.txt", Files.readString(target.resolve("one.txt")));
+        assertEquals("two.txt", Files.readString(target.resolve("two.txt")));
+    }
+
+    @Test
+    void rejectsAnInvalidEntryCountLimit(@TempDir Path target) throws IOException {
+        IOException thrown = assertThrows(IOException.class,
+                () -> extractor.extractTo(zipWith("one.txt", "one"), target, 0));
+
+        assertEquals("ZIP archive entry limit must be at least 1: 0", thrown.getMessage());
+    }
+
+    @Test
+    void rejectsAnEntryAboveTheExpandedEntryLimit(@TempDir Path target) throws IOException {
+        byte[] zip = zipWithDeclaredSizes(ZipExtractor.MAX_ENTRY_BYTES + 1);
+
+        IOException thrown = assertThrows(IOException.class, () -> extractor.extractTo(zip, target));
+
+        assertEquals("ZIP entry exceeds the 262144000 byte limit: entry0", thrown.getMessage());
+        assertFalse(Files.exists(target.resolve("entry0")));
+    }
+
+    @Test
+    void rejectsExpandedContentAboveTheArchiveLimit(@TempDir Path target) throws IOException {
+        byte[] zip = zipWithDeclaredSizes(200L * 1024 * 1024, 200L * 1024 * 1024);
+
+        IOException thrown = assertThrows(IOException.class, () -> extractor.extractTo(zip, target));
+
+        assertEquals("ZIP archive exceeds the 262144000 byte expanded limit", thrown.getMessage());
+        assertFalse(Files.exists(target.resolve("entry0")));
+    }
+
+    @Test
+    void leavesThePreviousExtractionIntactAfterAResourceLimitFailure(@TempDir Path target)
+            throws IOException {
+        extractor.extractTo(zipWith("entry0", "previous"), target);
+
+        assertThrows(IOException.class,
+                () -> extractor.extractTo(
+                        zipWithDeclaredSizes(200L * 1024 * 1024, 200L * 1024 * 1024), target));
+
+        assertEquals("previous", Files.readString(target.resolve("entry0")));
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -228,6 +228,7 @@ class ZipExtractorTest {
     private static void writeLocalHeader(ByteArrayOutputStream out, RawZipEntry entry) {
         boolean hasDescriptor = (entry.flags() & DATA_DESCRIPTOR_FLAG) != 0;
         byte[] name = entry.name().getBytes(StandardCharsets.UTF_8);
+        // Local header: version, flags, method, timestamps, CRC, sizes, and file name.
         le32(out, LOCAL_FILE_HEADER_SIGNATURE);
         le16(out, 20);
         le16(out, entry.flags());
@@ -243,6 +244,7 @@ class ZipExtractorTest {
     }
 
     private static void writeDataDescriptor(ByteArrayOutputStream out, RawZipEntry entry) {
+        // Data descriptor: streamed entries write CRC and sizes after their payload.
         le32(out, DATA_DESCRIPTOR_SIGNATURE);
         le32(out, entry.crc());
         le32(out, entry.payload().length);
@@ -252,6 +254,7 @@ class ZipExtractorTest {
     private static void writeCentralDirectoryHeader(ByteArrayOutputStream out,
                                                     RawZipEntry entry, int localOffset) {
         byte[] name = entry.name().getBytes(StandardCharsets.UTF_8);
+        // Central directory entry: metadata plus the offset of the matching local header.
         le32(out, CENTRAL_DIRECTORY_HEADER_SIGNATURE);
         le16(out, 20);
         le16(out, 20);
@@ -275,6 +278,7 @@ class ZipExtractorTest {
     private static void writeEndOfCentralDirectory(ByteArrayOutputStream out,
                                                    int entryCount, int centralSize,
                                                    int centralOffset) {
+        // End record: entry count and the central directory's size and location.
         le32(out, END_OF_CENTRAL_DIRECTORY_SIGNATURE);
         le16(out, 0);
         le16(out, 0);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/ZipExtractorTest.java
@@ -23,6 +23,17 @@ class ZipExtractorTest {
 
     private final ZipExtractor extractor = new ZipExtractor();
 
+    private static final int LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+    private static final int CENTRAL_DIRECTORY_HEADER_SIGNATURE = 0x02014b50;
+    private static final int END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+    private static final int DATA_DESCRIPTOR_SIGNATURE = 0x08074b50;
+    private static final int DATA_DESCRIPTOR_FLAG = 0x0008;
+
+    /** Entry metadata for fixtures that need to control central-directory declarations. */
+    private record RawZipEntry(String name, int method, int flags, byte[] payload,
+                               long crc, long expandedSize, long descriptorExpandedSize) {
+    }
+
     /** Build a ZIP whose entry names use the given separator, as PowerShell does. */
     private static byte[] zipWith(String entryName, String content) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -47,64 +58,15 @@ class ZipExtractorTest {
     }
 
     private static byte[] zipWithDeclaredSizes(long... sizes) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        List<Integer> offsets = new ArrayList<>();
-        List<byte[]> names = new ArrayList<>();
         byte[] content = new byte[]{'x'};
         CRC32 crc = new CRC32();
         crc.update(content);
-
+        RawZipEntry[] entries = new RawZipEntry[sizes.length];
         for (int i = 0; i < sizes.length; i++) {
-            byte[] name = ("entry" + i).getBytes(StandardCharsets.UTF_8);
-            offsets.add(out.size());
-            names.add(name);
-            le32(out, 0x04034b50L);
-            le16(out, 20);
-            le16(out, 0);
-            le16(out, 0);
-            le16(out, 0);
-            le16(out, 0);
-            le32(out, crc.getValue());
-            le32(out, content.length);
-            le32(out, sizes[i]);
-            le16(out, name.length);
-            le16(out, 0);
-            out.write(name);
-            out.write(content);
+            entries[i] = new RawZipEntry("entry" + i, 0, 0, content,
+                    crc.getValue(), sizes[i], 0);
         }
-
-        int centralOffset = out.size();
-        for (int i = 0; i < sizes.length; i++) {
-            byte[] name = names.get(i);
-            le32(out, 0x02014b50L);
-            le16(out, 20);
-            le16(out, 20);
-            le16(out, 0);
-            le16(out, 0);
-            le16(out, 0);
-            le16(out, 0);
-            le32(out, crc.getValue());
-            le32(out, content.length);
-            le32(out, sizes[i]);
-            le16(out, name.length);
-            le16(out, 0);
-            le16(out, 0);
-            le16(out, 0);
-            le16(out, 0);
-            le32(out, 0);
-            le32(out, offsets.get(i));
-            out.write(name);
-        }
-        int centralSize = out.size() - centralOffset;
-        le32(out, 0x06054b50L);
-        le16(out, 0);
-        le16(out, 0);
-        le16(out, sizes.length);
-        le16(out, sizes.length);
-        le32(out, centralSize);
-        le32(out, centralOffset);
-        le16(out, 0);
-        return out.toByteArray();
+        return rawZip(entries);
     }
 
     @Test
@@ -226,76 +188,101 @@ class ZipExtractorTest {
      * the bytes are assembled by hand.
      */
     private static byte[] streamedZip(StreamedEntry... entries) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        List<int[]> localOffsets = new ArrayList<>();
-        List<byte[]> names = new ArrayList<>();
-        List<long[]> meta = new ArrayList<>();
-
-        for (StreamedEntry entry : entries) {
-            byte[] name = entry.name().getBytes(StandardCharsets.UTF_8);
+        RawZipEntry[] rawEntries = new RawZipEntry[entries.length];
+        for (int i = 0; i < entries.length; i++) {
+            StreamedEntry entry = entries[i];
             byte[] raw = entry.content().getBytes(StandardCharsets.UTF_8);
             byte[] payload = entry.stored() ? raw : deflate(raw);
             CRC32 crc = new CRC32();
             crc.update(raw);
             int method = entry.stored() ? 0 : 8;
+            rawEntries[i] = new RawZipEntry(entry.name(), method, DATA_DESCRIPTOR_FLAG, payload,
+                    crc.getValue(), raw.length, raw.length);
+        }
+        return rawZip(rawEntries);
+    }
 
-            localOffsets.add(new int[]{out.size()});
-            le32(out, 0x04034b50L);          // local file header signature
-            le16(out, 20);                   // version needed
-            le16(out, 0x0008);               // general-purpose bit 3: data descriptor follows
-            le16(out, method);
-            le16(out, 0);                    // mod time
-            le16(out, 0);                    // mod date
-            le32(out, 0);                    // crc-32       — deferred to the descriptor
-            le32(out, 0);                    // compressed   — deferred to the descriptor
-            le32(out, 0);                    // uncompressed — deferred to the descriptor
-            le16(out, name.length);
-            le16(out, 0);                    // extra length
-            out.write(name);
-            out.write(payload);
-            le32(out, 0x08074b50L);          // data descriptor signature
-            le32(out, crc.getValue());
-            le32(out, payload.length);
-            le32(out, raw.length);
+    /** Writes a raw archive so tests can use valid data with deliberately invalid declarations. */
+    private static byte[] rawZip(RawZipEntry... entries) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        List<Integer> localOffsets = new ArrayList<>();
 
-            names.add(name);
-            meta.add(new long[]{crc.getValue(), payload.length, raw.length, method});
+        for (RawZipEntry entry : entries) {
+            localOffsets.add(out.size());
+            writeLocalHeader(out, entry);
+            out.write(entry.payload());
+            if ((entry.flags() & DATA_DESCRIPTOR_FLAG) != 0) {
+                writeDataDescriptor(out, entry);
+            }
         }
 
         int centralOffset = out.size();
         for (int i = 0; i < entries.length; i++) {
-            byte[] name = names.get(i);
-            long[] m = meta.get(i);
-            le32(out, 0x02014b50L);          // central directory header signature
-            le16(out, 20);                   // version made by
-            le16(out, 20);                   // version needed
-            le16(out, 0x0008);               // same descriptor flag as the local header
-            le16(out, (int) m[3]);
-            le16(out, 0);
-            le16(out, 0);
-            le32(out, m[0]);                 // crc-32       — the real value lives here
-            le32(out, m[1]);                 // compressed   — the real value lives here
-            le32(out, m[2]);                 // uncompressed — the real value lives here
-            le16(out, name.length);
-            le16(out, 0);                    // extra length
-            le16(out, 0);                    // comment length
-            le16(out, 0);                    // disk number start
-            le16(out, 0);                    // internal attributes
-            le32(out, 0);                    // external attributes
-            le32(out, localOffsets.get(i)[0]);
-            out.write(name);
+            writeCentralDirectoryHeader(out, entries[i], localOffsets.get(i));
         }
         int centralSize = out.size() - centralOffset;
+        writeEndOfCentralDirectory(out, entries.length, centralSize, centralOffset);
+        return out.toByteArray();
+    }
 
-        le32(out, 0x06054b50L);              // end of central directory signature
-        le16(out, 0);                        // this disk
-        le16(out, 0);                        // disk with central directory
-        le16(out, entries.length);
-        le16(out, entries.length);
+    private static void writeLocalHeader(ByteArrayOutputStream out, RawZipEntry entry) {
+        boolean hasDescriptor = (entry.flags() & DATA_DESCRIPTOR_FLAG) != 0;
+        byte[] name = entry.name().getBytes(StandardCharsets.UTF_8);
+        le32(out, LOCAL_FILE_HEADER_SIGNATURE);
+        le16(out, 20);
+        le16(out, entry.flags());
+        le16(out, entry.method());
+        le16(out, 0);
+        le16(out, 0);
+        le32(out, hasDescriptor ? 0 : entry.crc());
+        le32(out, hasDescriptor ? 0 : entry.payload().length);
+        le32(out, hasDescriptor ? 0 : entry.expandedSize());
+        le16(out, name.length);
+        le16(out, 0);
+        out.writeBytes(name);
+    }
+
+    private static void writeDataDescriptor(ByteArrayOutputStream out, RawZipEntry entry) {
+        le32(out, DATA_DESCRIPTOR_SIGNATURE);
+        le32(out, entry.crc());
+        le32(out, entry.payload().length);
+        le32(out, entry.descriptorExpandedSize());
+    }
+
+    private static void writeCentralDirectoryHeader(ByteArrayOutputStream out,
+                                                    RawZipEntry entry, int localOffset) {
+        byte[] name = entry.name().getBytes(StandardCharsets.UTF_8);
+        le32(out, CENTRAL_DIRECTORY_HEADER_SIGNATURE);
+        le16(out, 20);
+        le16(out, 20);
+        le16(out, entry.flags());
+        le16(out, entry.method());
+        le16(out, 0);
+        le16(out, 0);
+        le32(out, entry.crc());
+        le32(out, entry.payload().length);
+        le32(out, entry.expandedSize());
+        le16(out, name.length);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, 0);
+        le32(out, 0);
+        le32(out, localOffset);
+        out.writeBytes(name);
+    }
+
+    private static void writeEndOfCentralDirectory(ByteArrayOutputStream out,
+                                                   int entryCount, int centralSize,
+                                                   int centralOffset) {
+        le32(out, END_OF_CENTRAL_DIRECTORY_SIGNATURE);
+        le16(out, 0);
+        le16(out, 0);
+        le16(out, entryCount);
+        le16(out, entryCount);
         le32(out, centralSize);
         le32(out, centralOffset);
-        le16(out, 0);                        // comment length
-        return out.toByteArray();
+        le16(out, 0);
     }
 
     private static byte[] deflate(byte[] raw) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -131,6 +131,7 @@ floci:
     lambda:
       enabled: true
       honour-architectures: false
+      zip-max-entries: 100000
       # aws-config-path:
       hot-reload:
         enabled: true


### PR DESCRIPTION
## Summary

Bound Lambda ZIP extraction so compressed packages, expanded content, and entry counts cannot exhaust local disk, inodes, or CPU during function and layer deployment.

The existing package is preserved when extraction fails. The entry-count guard defaults to 100,000 entries and can be changed with `FLOCI_SERVICES_LAMBDA_ZIP_MAX_ENTRIES`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Lambda ZIP extraction previously had no expanded-size or entry-count bound. A small compressed archive could expand into a very large tree or contain enough entries to exhaust local resources.

This change applies AWS-aligned package limits:

- Direct inline ZIP uploads over 50 MiB return `RequestEntityTooLargeException` with HTTP 413.
- ZIP extraction is limited to 250 MiB of cumulative expanded content.
- A single entry is limited to 250 MiB.
- S3-backed archives are bounded at 250 MiB compressed before extraction.
- Failed extraction is staged and discarded, so the previous deployment remains intact.

AWS documents deployment-package size limits but does not define a ZIP entry-count quota. The default of 100,000 entries is therefore a Floci safety bound, not an AWS protocol value. It is high enough for normal Lambda packages while bounding inode use and traversal work for archives containing many tiny files. The `FLOCI_SERVICES_LAMBDA_ZIP_MAX_ENTRIES` setting allows environments with unusually large, trusted package layouts to raise the limit.

Direct oversized uploads use AWS's `RequestEntityTooLargeException`. Expanded-size and entry-count failures use the existing `InvalidParameterValueException` response path.

Focused validation passed:

- `./mvnw test -Dtest=ZipExtractorTest,LambdaServiceTest,LambdaLayerIntegrationTest`
- 113 tests passed

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
