### PR TITLE
fix(lambda): give each published version its own code directory

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -75,6 +75,8 @@ public class LambdaService implements ResourceProvider {
             "arn:(aws[a-zA-Z-]*)?:iam::\\d{12}:role/?[a-zA-Z_0-9+=,.@\\-_/]+");
     private static final Pattern HANDLER_PATTERN = Pattern.compile("\\S+");
     private static final int MAX_HANDLER_LENGTH = 128;
+    /** Shape of the hex SHA-256 directory names {@link CodeStore#getCodePath} creates. */
+    private static final Pattern CONTENT_DIRECTORY = Pattern.compile("[0-9a-f]{64}");
 
     private final LambdaFunctionStore functionStore;
     private final LambdaExecutorService executorService;
@@ -774,9 +776,10 @@ public class LambdaService implements ResourceProvider {
         synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
             warmPool.drainEnvironment(version.get());
             functionStore.deleteVersion(region, name, qualifier);
-            // The snapshot shares $LATEST's code directory, so this only reclaims once no
-            // remaining version references it.
+            // Reclaims a directory (legacy or content-addressed) only once no remaining
+            // version, including $LATEST, still references it.
             reclaimLegacyCodeDirectoryIfUnused(name);
+            reclaimUnusedCodeVersionDirectories(region, fn);
         }
         LOG.infov("Deleted version {0} of Lambda function: {1}", qualifier, name);
     }
@@ -838,6 +841,58 @@ public class LambdaService implements ResourceProvider {
                         && legacyPath.equals(other.getCodeLocalPath()));
         if (!stillLive) {
             codeStore.deleteLegacy(functionName);
+        }
+    }
+
+    /**
+     * Deletes content-addressed code directories under a function that no version — including
+     * the just-extracted {@code $LATEST} still in memory, not yet persisted by the caller — still
+     * references by {@code codeLocalPath}. Content-addressing (see {@link CodeStore#getCodePath
+     * (String, String, String)}) means every deploy that changes the code creates a new
+     * directory rather than overwriting one a published version relies on, so without this a
+     * function accumulates one directory per historical deploy forever. Must run under the same
+     * per-function lock as {@link #publishVersion}, otherwise a version could be published
+     * between this method's scan and its delete, referencing a directory about to be removed.
+     *
+     * <p>Only directories named like a content hash are ever considered, which is what keeps two
+     * other things in that same directory safe. ZipExtractor stages and retires trees under
+     * {@code <hash>.floci-staging-<uuid>} / {@code <hash>.floci-previous-<uuid>} SIBLINGS of its
+     * target, so they land here too — and extraction runs outside the lock below, meaning a
+     * concurrent deploy of the same function can have one live mid-flight. Pre-content-addressing
+     * functions are the other case: their code sits directly in this directory, so its
+     * subdirectories are that older layout's own files (a {@code node_modules}, say), still named
+     * by a version published before the upgrade. Matching hash-shaped names only leaves both
+     * alone; the cost is that the superseded layout lingers until the function is deleted.
+     */
+    private void reclaimUnusedCodeVersionDirectories(String region, LambdaFunction fn) {
+        Path functionDir = codeStore.getCodePath(ownerAccount(fn), fn.getFunctionName())
+                .toAbsolutePath().normalize();
+        if (!Files.isDirectory(functionDir)) {
+            return;
+        }
+        Set<String> referenced = new java.util.HashSet<>();
+        referenced.add(functionDir.relativize(Path.of(fn.getCodeLocalPath()).toAbsolutePath().normalize()).toString());
+        for (LambdaFunction version : functionStore.listVersions(region, fn.getFunctionName())) {
+            String path = version.getCodeLocalPath();
+            if (path == null) {
+                continue;
+            }
+            Path normalized = Path.of(path).toAbsolutePath().normalize();
+            if (normalized.startsWith(functionDir)) {
+                referenced.add(functionDir.relativize(normalized).toString());
+            }
+        }
+        try (var children = Files.list(functionDir)) {
+            for (Path child : children.toList()) {
+                String name = child.getFileName().toString();
+                if (CONTENT_DIRECTORY.matcher(name).matches()
+                        && !referenced.contains(name)
+                        && Files.isDirectory(child)) {
+                    codeStore.deleteContentDirectory(child, fn.getFunctionName());
+                }
+            }
+        } catch (IOException e) {
+            LOG.warnv("Failed to scan code directory for {0}: {1}", fn.getFunctionName(), e.getMessage());
         }
     }
 
@@ -1962,15 +2017,24 @@ public class LambdaService implements ResourceProvider {
     }
 
     private void extractZipCodeBytes(LambdaFunction fn, byte[] zipBytes, String region) {
-        Path codePath = codeStore.getCodePath(ownerAccount(fn), fn.getFunctionName());
+        // Hashed up front so the extraction target itself is content-addressed: a version's
+        // codeLocalPath then names the directory for the exact bytes it was published with,
+        // and a later redeploy of $LATEST lands in a different directory (a different hash)
+        // instead of overwriting the one a published version still points at (#2958).
+        byte[] digest;
+        try {
+            digest = java.security.MessageDigest.getInstance("SHA-256").digest(zipBytes);
+        } catch (java.security.NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is not available", e);
+        }
+        String codeSha256 = Base64.getEncoder().encodeToString(digest);
+        Path codePath = codeStore.getCodePath(ownerAccount(fn), fn.getFunctionName(),
+                java.util.HexFormat.of().formatHex(digest));
         try {
             zipExtractor.extractTo(zipBytes, codePath);
             fn.setCodeLocalPath(codePath.toAbsolutePath().normalize().toString());
             fn.setCodeSizeBytes(zipBytes.length);
-            try {
-                byte[] digest = java.security.MessageDigest.getInstance("SHA-256").digest(zipBytes);
-                fn.setCodeSha256(Base64.getEncoder().encodeToString(digest));
-            } catch (java.security.NoSuchAlgorithmException ignored) {}
+            fn.setCodeSha256(codeSha256);
 
             // For file-based runtimes, verify handler file exists (skip Java and .NET which use different handler formats)
             if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java") && !fn.getRuntime().startsWith("dotnet")) {
@@ -2006,6 +2070,7 @@ public class LambdaService implements ResourceProvider {
             // and the actual delete.
             synchronized (lockForConcurrencyOp(fn.getFunctionArn())) {
                 reclaimLegacyCodeDirectoryIfUnused(fn.getFunctionName());
+                reclaimUnusedCodeVersionDirectories(region, fn);
             }
         } catch (AwsException e) {
             throw e;

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
@@ -16,6 +16,11 @@ import java.util.Comparator;
  * the account-prefixed S3 key {@code LambdaService.codeObjectKey} uses for the same
  * deployment package. Without the account segment two accounts' same-named functions in
  * one region share a single extraction directory and overwrite each other's code.
+ *
+ * <p>That per-function directory holds one subdirectory per distinct deployment package
+ * rather than the code itself, keyed by content hash — see {@link #getCodePath(String,
+ * String, String)}. Code deployed before that layout still sits directly in the function
+ * directory, which is why callers must not assume every child is a build.
  */
 @ApplicationScoped
 public class CodeStore {
@@ -35,6 +40,19 @@ public class CodeStore {
 
     public Path getCodePath(String accountId, String functionName) {
         return baseDir.resolve(sanitizeName(accountId)).resolve(sanitizeName(functionName));
+    }
+
+    /**
+     * Content-addressed path for one specific build of a function's code, keyed by the hex
+     * SHA-256 of its deployment package. A published version's {@code codeLocalPath} names the
+     * directory for the exact code it was published with, so a later {@code UpdateFunctionCode}
+     * against {@code $LATEST} extracts into a *different* directory (a different hash) instead
+     * of overwriting the one a published version still points at (#2958). Identical deployment
+     * packages resolve to the same directory, so redeploying unchanged code reuses storage
+     * rather than duplicating it.
+     */
+    public Path getCodePath(String accountId, String functionName, String codeHashHex) {
+        return getCodePath(accountId, functionName).resolve(sanitizeName(codeHashHex));
     }
 
     /**
@@ -58,6 +76,19 @@ public class CodeStore {
      */
     public void deleteLegacy(String functionName) {
         deleteDirectory(getLegacyCodePath(functionName), functionName);
+    }
+
+    /**
+     * Removes one content-addressed build directory (see {@link #getCodePath(String, String,
+     * String)}) that no version references any more. Refuses anything outside {@link #baseDir}
+     * so a caller cannot be tricked into deleting an unrelated directory.
+     */
+    public void deleteContentDirectory(Path path, String functionName) {
+        if (!path.toAbsolutePath().normalize().startsWith(baseDir.toAbsolutePath().normalize())) {
+            LOG.warnv("Refusing to delete directory outside the code store: {0}", path);
+            return;
+        }
+        deleteDirectory(path, functionName);
     }
 
     private void deleteDirectory(Path path, String functionName) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -580,6 +580,103 @@ class LambdaServiceTest {
     }
 
     @Test
+    void publishedVersionCodeDirectorySurvivesLatestRedeploy() throws Exception {
+        // Regression test for #2958: CodeStore.getCodePath had no version component, so every
+        // version shared $LATEST's on-disk directory. publishVersion only copied the
+        // codeLocalPath *pointer*, so a later UpdateFunctionCode rewrote the directory a
+        // published version's pointer named — the version's own metadata (CodeSha256) still
+        // reported the original hash while the bytes behind it silently became a different build.
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "immutable-version-fn",
+                "Runtime", "nodejs20.x",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "index.handler",
+                "Code", Map.of("ZipFile", createZipBase64WithContent("v1"))
+        ));
+        service.createFunction(REGION, req);
+        LambdaFunction version = service.publishVersion(REGION, "immutable-version-fn", null);
+        String versionCodePath = version.getCodeLocalPath();
+        String versionCodeSha256 = version.getCodeSha256();
+        assertEquals("v1", java.nio.file.Files.readString(Path.of(versionCodePath, "index.js")));
+
+        service.updateFunctionCode(REGION, "immutable-version-fn",
+                Map.of("ZipFile", createZipBase64WithContent("v2")));
+
+        // The version's own metadata never changed...
+        assertEquals(versionCodeSha256, version.getCodeSha256());
+        // ...and now the directory it names agrees with that metadata too: still v1's bytes,
+        // not $LATEST's new ones.
+        assertEquals("v1", java.nio.file.Files.readString(Path.of(versionCodePath, "index.js")));
+
+        LambdaFunction latest = service.getFunction(REGION, "immutable-version-fn");
+        assertNotEquals(versionCodePath, latest.getCodeLocalPath(),
+                "$LATEST must extract to a directory of its own, not the version's");
+        assertEquals("v2", java.nio.file.Files.readString(Path.of(latest.getCodeLocalPath(), "index.js")));
+    }
+
+    @Test
+    void redeployingLatestWithoutPublishingReclaimsTheSupersededContentDirectory() throws Exception {
+        // Content-addressing (one directory per distinct deployment package) means a function
+        // that is redeployed repeatedly without ever publishing a version would otherwise
+        // accumulate one directory per historical deploy forever. Nothing referenced the old
+        // build once $LATEST moves on, so it must be cleaned up rather than leaked.
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "churn-fn",
+                "Runtime", "nodejs20.x",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "index.handler",
+                "Code", Map.of("ZipFile", createZipBase64WithContent("v1"))
+        ));
+        service.createFunction(REGION, req);
+        String v1Path = service.getFunction(REGION, "churn-fn").getCodeLocalPath();
+
+        service.updateFunctionCode(REGION, "churn-fn", Map.of("ZipFile", createZipBase64WithContent("v2")));
+
+        assertFalse(java.nio.file.Files.exists(Path.of(v1Path)),
+                "no version references v1's build any more, so its directory should be reclaimed");
+    }
+
+    @Test
+    void reclaimLeavesThePreContentAddressingLayoutAlone() throws Exception {
+        // A function deployed before content-addressing has its code directly in the function
+        // directory, and a version published back then points at that directory itself. The
+        // first redeploy after the upgrade extracts to a hash subdirectory and then reclaims
+        // unreferenced ones — it must not treat that older layout's own subdirectories as
+        // superseded builds, which would strip files out from under that still-live version.
+        CodeStore codeStore = new CodeStore(Path.of("target/test-data/lambda-code"));
+        Map<String, Object> req = new java.util.HashMap<>(Map.of(
+                "FunctionName", "legacy-layout-fn",
+                "Runtime", "nodejs20.x",
+                "Role", "arn:aws:iam::000000000000:role/test-role",
+                "Handler", "index.handler",
+                "Code", Map.of("ZipFile", createZipBase64WithContent("v1"))
+        ));
+        service.createFunction(REGION, req);
+
+        // Recreate the old on-disk shape: code sitting straight in the function directory.
+        Path functionDir = codeStore.getCodePath("000000000000", "legacy-layout-fn");
+        Path preUpgradeSubdir = functionDir.resolve("node_modules");
+        java.nio.file.Files.createDirectories(preUpgradeSubdir);
+        java.nio.file.Files.writeString(preUpgradeSubdir.resolve("dep.js"), "dependency");
+
+        service.updateFunctionCode(REGION, "legacy-layout-fn",
+                Map.of("ZipFile", createZipBase64WithContent("v2")));
+
+        assertTrue(java.nio.file.Files.exists(preUpgradeSubdir.resolve("dep.js")),
+                "the pre-upgrade layout is not a superseded build and must survive the reclaim");
+    }
+
+    private static String createZipBase64WithContent(String content) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write(content.getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    @Test
     void rehydrateConcurrency_restoresReservedFromStore() {
         // Simulate a persisted state: functions already live in the store
         // with reserved values before the limiter is populated.

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVersionIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVersionIntegrationTest.java
@@ -258,14 +258,58 @@ class LambdaVersionIntegrationTest {
         }
     }
 
-    private void createInvocableFunction(String fnName) throws Exception {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-            zos.putNextEntry(new ZipEntry("index.js"));
-            zos.write("exports.handler = async () => ({ ok: true });".getBytes());
-            zos.closeEntry();
+    @Test
+    @Order(10)
+    void publishedVersionKeepsRunningItsOwnCodeAfterLatestIsRedeployed() throws Exception {
+        // Regression test for #2958: a published version is supposed to be an immutable
+        // snapshot of code plus configuration. Before the fix, CodeStore.getCodePath had no
+        // version component, so every version shared $LATEST's on-disk directory; publishing
+        // a version only copied the codeLocalPath *pointer*, and a later UpdateFunctionCode
+        // rewrote the directory that pointer named. A version's metadata (CodeSha256) still
+        // reported the original hash, but invoking it would launch the container with
+        // whatever code $LATEST was last redeployed with.
+        String fnName = "version-immutability";
+        createInvocableFunction(fnName, "v1");
+
+        try {
+            given()
+                .contentType("application/json")
+                .body("{\"Description\": \"first build\"}")
+            .when()
+                .post(BASE_PATH + "/functions/" + fnName + "/versions")
+            .then()
+                .statusCode(201)
+                .body("Version", equalTo("1"));
+
+            // Redeploy $LATEST with different code, the way a normal iterative deploy would.
+            updateFunctionCode(fnName, "v2");
+
+            // The published version must still run the code it was published with. Only the
+            // version-qualified invoke is checked here, not a follow-up $LATEST invoke on the
+            // same function name: the warm pool is keyed by function name alone (#1988, see the
+            // comment on invokePublishedVersion_runsTheVersionsCode above), so a second invoke
+            // on this function could reuse this call's warm container and pass or fail on that
+            // unrelated bug instead of on the one this test targets.
+            given()
+                .contentType("application/json")
+                .body("{}")
+            .when()
+                .post(BASE_PATH + "/functions/" + fnName + ":1/invocations")
+            .then()
+                .statusCode(200)
+                .header("X-Amz-Function-Error", nullValue())
+                .body("build", equalTo("v1"));
+        } finally {
+            given().delete(BASE_PATH + "/functions/" + fnName);
         }
-        String base64Zip = Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private void createInvocableFunction(String fnName) throws Exception {
+        createInvocableFunction(fnName, "v1");
+    }
+
+    private void createInvocableFunction(String fnName, String build) throws Exception {
+        String base64Zip = zipHandler(build);
 
         given()
             .contentType("application/json")
@@ -285,5 +329,29 @@ class LambdaVersionIntegrationTest {
             .post(BASE_PATH + "/functions")
         .then()
             .statusCode(201);
+    }
+
+    private void updateFunctionCode(String fnName, String build) throws Exception {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "ZipFile": "%s"
+                }
+                """.formatted(zipHandler(build)))
+        .when()
+            .put(BASE_PATH + "/functions/" + fnName + "/code")
+        .then()
+            .statusCode(200);
+    }
+
+    private String zipHandler(String build) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            zos.putNextEntry(new ZipEntry("index.js"));
+            zos.write(("exports.handler = async () => ({ ok: true, build: '" + build + "' });").getBytes());
+            zos.closeEntry();
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
@@ -103,6 +103,71 @@ class CodeStoreTest {
         assertFalse(Files.exists(legacyPath));
     }
 
+    @Test
+    void contentAddressedPathsForDifferentHashesAreDistinctSiblings(@TempDir Path baseDir) {
+        // #2958: without a version/content component every deploy shared one directory, so a
+        // published version and a later $LATEST redeploy could not both keep their own code.
+        CodeStore store = new CodeStore(baseDir);
+
+        Path v1 = store.getCodePath(ACCOUNT_A, "fn", "aaaa");
+        Path v2 = store.getCodePath(ACCOUNT_A, "fn", "bbbb");
+
+        assertNotEquals(v1, v2);
+        assertEquals(store.getCodePath(ACCOUNT_A, "fn"), v1.getParent());
+        assertEquals(v1.getParent(), v2.getParent());
+    }
+
+    @Test
+    void sameHashResolvesToTheSameContentAddressedPath(@TempDir Path baseDir) {
+        CodeStore store = new CodeStore(baseDir);
+
+        assertEquals(store.getCodePath(ACCOUNT_A, "fn", "aaaa"), store.getCodePath(ACCOUNT_A, "fn", "aaaa"));
+    }
+
+    @Test
+    void deleteOfTheWholeFunctionRemovesEveryContentAddressedDirectoryUnderIt(
+            @TempDir Path baseDir) throws IOException {
+        CodeStore store = new CodeStore(baseDir);
+        writeHandler(store.getCodePath(ACCOUNT_A, "fn", "aaaa"), "v1");
+        writeHandler(store.getCodePath(ACCOUNT_A, "fn", "bbbb"), "v2");
+
+        store.delete(ACCOUNT_A, "fn");
+
+        assertFalse(Files.exists(store.getCodePath(ACCOUNT_A, "fn")));
+    }
+
+    @Test
+    void deleteContentDirectoryRemovesOnlyThatOneBuild(@TempDir Path baseDir) throws IOException {
+        CodeStore store = new CodeStore(baseDir);
+        Path v1 = store.getCodePath(ACCOUNT_A, "fn", "aaaa");
+        Path v2 = store.getCodePath(ACCOUNT_A, "fn", "bbbb");
+        writeHandler(v1, "v1");
+        writeHandler(v2, "v2");
+
+        store.deleteContentDirectory(v1, "fn");
+
+        assertFalse(Files.exists(v1));
+        assertTrue(Files.exists(v2));
+    }
+
+    @Test
+    void deleteContentDirectoryRefusesAPathOutsideTheBaseDirectory(@TempDir Path baseDir) throws IOException {
+        CodeStore store = new CodeStore(baseDir);
+        Path outside = baseDir.getParent().resolve("outside-" + baseDir.getFileName());
+        writeHandler(outside, "not-ours");
+
+        store.deleteContentDirectory(outside, "fn");
+
+        assertTrue(Files.exists(outside), "must refuse to delete anything outside baseDir");
+        Files.walk(outside).sorted(java.util.Comparator.reverseOrder()).forEach(p -> {
+            try {
+                Files.delete(p);
+            } catch (IOException ignored) {
+                // best-effort cleanup of the temp fixture created outside @TempDir
+            }
+        });
+    }
+
     private void writeHandler(Path codePath, String content) throws IOException {
         Files.createDirectories(codePath);
         Files.writeString(codePath.resolve("index.js"), content);


### PR DESCRIPTION
> @avison9 — you're assigned to #2958 and said you'd take it, so apologies if this duplicates work already in flight. Happy to close this in favour of yours, or to hand over any part of it; the diagnosis in your issue is what this is built on. The reclaim-pass details below are the only part that goes beyond what you'd already worked out.

## Summary

Fixes #2958 — a published Lambda version's metadata was immutable, but the code directory it named was not.

`CodeStore.getCodePath` had no version component, so every version shared one directory with `$LATEST`, and `publishVersion` copied only the `codeLocalPath` *pointer*. A later `UpdateFunctionCode` rewrote the very directory each published version pointed at, leaving a version advertising one `CodeSha256` while the bytes behind it were a different build — and `ContainerLauncher` tar-copies that directory at launch, so a qualified invoke ran `$LATEST`'s code.

**The fix — content-addressing.** The deployment package is hashed up front and extracted to `<account>/<function>/<hex sha256>`. A published version's `codeLocalPath` therefore names the directory for the exact bytes it was published with, and a redeploy of `$LATEST` lands in a *different* directory rather than overwriting it. Identical packages resolve to the same directory, so redeploying unchanged code reuses storage instead of duplicating it. `publishVersion` needs no change: the pointer it copies is now stable by construction.

**Reclaiming superseded builds.** Since a changed deploy no longer overwrites in place, old builds would otherwise accumulate one directory per historical deploy, forever. A reclaim pass (run under the same per-function lock as `publishVersion`, on code update and version delete) drops directories no version still references — including `$LATEST`.

That pass deliberately matches **hash-shaped names only**, which is load-bearing in two ways I hit while building it:

- `ZipExtractor` stages and retires trees as `<hash>.floci-staging-<uuid>` / `<hash>.floci-previous-<uuid>` *siblings* of its target, so they live in the same directory — and extraction runs outside the lock, so a concurrent deploy of the same function can have one live mid-flight. An unfiltered sweep would delete it out from under that deploy.
- A function deployed before this change has its code sitting directly in the function directory, possibly still named by a version published before the upgrade. An unfiltered sweep would strip that live version's subdirectories (its `node_modules`, say) while leaving its loose files — corrupting it. There is a regression test for exactly this, and I confirmed it fails without the filter.

## Test plan

- [x] `LambdaServiceTest.publishedVersionCodeDirectorySurvivesLatestRedeploy` — publish v1, redeploy `$LATEST`, assert the version's directory still holds v1's bytes and `$LATEST` extracted elsewhere. **Verified it fails on the pre-fix code** with `expected: <v1> but was: <v2>`, i.e. it reproduces the reported bug.
- [x] `LambdaServiceTest.redeployingLatestWithoutPublishingReclaimsTheSupersededContentDirectory` — no version references the old build, so it must not leak. Also verified failing pre-fix.
- [x] `LambdaServiceTest.reclaimLeavesThePreContentAddressingLayoutAlone` — migration safety. Verified failing without the hash-shape filter.
- [x] `CodeStoreTest` — distinct hashes are distinct sibling directories, equal hashes coincide, whole-function delete still removes every build under it, and `deleteContentDirectory` removes one build only and refuses paths outside the store.
- [x] Full lambda unit suite green: `CodeStoreTest`, `LambdaServiceTest`, `LambdaAccountScopedCodeTest`, `LambdaServicePersistenceTest` — 83 tests, 0 failures.
- [ ] `LambdaVersionIntegrationTest.publishedVersionKeepsRunningItsOwnCodeAfterLatestIsRedeployed` — added, but **not run locally**: it needs a container runtime and Docker was unavailable on my machine. This is the same measurement gap the issue author flagged, now covered at the disk level by the unit test above. Worth a look from CI.

Note: it asserts only the version-qualified invoke, not a follow-up `$LATEST` invoke on the same function — the warm pool is keyed by function name alone (#1988), so a second invoke could reuse the first's container and make this test pass or fail on that unrelated bug.

Two pre-existing `ZipExtractorTest` failures show up on Windows (`\` is a real path separator there; `setPosixFilePermissions` is unsupported on NTFS). Both are in a file this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvQwz2o9EStW3wFwJJxGyg
