### PR TITLE
refactor(ses): move three single-owner helpers off the SesService facade

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesConfigurationSetService.java
@@ -33,8 +33,9 @@ import java.util.regex.Pattern;
  * <p>The boundary follows the cross-domain seams: option validation that reads OTHER domains stays
  * in the facade (tracking options check a verified domain identity, delivery options check a
  * dedicated IP pool), which validates first (or resolves existence through {@link #get}) and then
- * mutates through {@link #save}. The ARN-dispatched configuration-set tagging lives here; the
- * facade keeps the send-path reads (pause check, event publishing, effective suppression reasons)
+ * mutates through {@link #save}. The ARN-dispatched configuration-set tagging and the send-time
+ * validation ({@link #validateForSending}: existence plus the sending-paused gate) live here; the
+ * facade keeps the remaining send-path reads (event publishing, effective suppression reasons)
  * and the tenant delete-guard around {@link #remove}.
  */
 @ApplicationScoped
@@ -102,6 +103,32 @@ public class SesConfigurationSetService {
     public void remove(String name, String region) {
         configSetStore.delete(configSetKey(region, name));
         LOG.infov("Deleted SES configuration set: {0} in region {1}", name, region);
+    }
+
+    /**
+     * Validate that a non-blank {@code ConfigurationSetName} is usable for a send. Performs
+     * two gates:
+     *   1. Existence: raises {@code ConfigurationSetDoesNotExist} (400) when the set is
+     *      missing in the given region. The V2 REST controller's {@code remapV1Exception}
+     *      translates that into {@code NotFoundException 404}; V1 Query keeps the original.
+     *   2. Sending-enabled: raises {@code ConfigurationSetSendingPausedException} (400)
+     *      when the set's {@code SendingEnabled} flag has been turned off via
+     *      {@code UpdateConfigurationSetSendingEnabled} (v1) /
+     *      {@code PutConfigurationSetSendingOptions} (v2). The V2 controller narrows that
+     *      code to {@code SendingPausedException}; V1 keeps the longer form, matching the
+     *      exact wire shape AWS returns on each surface.
+     * Mirrors AWS SES behaviour: invalid or paused set fails fast instead of silently
+     * storing/relaying the message and skipping event publishing later.
+     */
+    public void validateForSending(String configurationSetName, String region) {
+        if (configurationSetName == null || configurationSetName.isBlank()) {
+            return;
+        }
+        ConfigurationSet cs = get(configurationSetName, region);
+        if (cs.getSendingEnabled() != null && !cs.getSendingEnabled()) {
+            throw new AwsException("ConfigurationSetSendingPausedException",
+                    "Sending is paused for configuration set " + configurationSetName, 400);
+        }
     }
 
     /** The ARN-dispatched tag operations, sharing the store behind {@code CreateConfigurationSet.Tags}. */

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -568,7 +568,7 @@ public class SesController {
                 if (hasName || hasArn) {
                     String resolvedName = hasName
                             ? templateName
-                            : SesService.templateNameFromArn(templateArn);
+                            : SesTemplateService.templateNameFromArn(templateArn);
                     sesService.checkTenantSendAccess(tenantName, fromEmailAddress,
                             configurationSetName, resolvedName, regionResolver.getAccountId(), region);
                     messageId = sesService.sendTemplatedEmail(fromEmailAddress, toAddresses, ccAddresses,
@@ -666,7 +666,7 @@ public class SesController {
             } else {
                 String resolvedName = hasName
                         ? templateName
-                        : SesService.templateNameFromArn(templateArn);
+                        : SesTemplateService.templateNameFromArn(templateArn);
                 gateTemplateName = resolvedName;
                 EmailTemplate stored = sesService.getTemplate(resolvedName, region);
                 subject = stored.getSubject();

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesQueryHandler.java
@@ -555,7 +555,7 @@ public class SesQueryHandler {
             throw new AwsException("InvalidParameterValue",
                     "Template or TemplateArn is required.", 400);
         }
-        String resolvedName = hasName ? templateName : SesService.templateNameFromArn(templateArn);
+        String resolvedName = hasName ? templateName : SesTemplateService.templateNameFromArn(templateArn);
 
         JsonNode templateData = parseTemplateData(templateDataRaw);
         String configurationSetName = getParam(params, "ConfigurationSetName");
@@ -577,7 +577,7 @@ public class SesQueryHandler {
         String rendered = sesService.renderTestTemplate(templateName, templateDataRaw, region);
         // XML 1.0 character data forbids C0 controls except \t \n \r; strip them
         // so SDK clients can parse the response when template data injects \x01 etc.
-        String xmlSafe = SesService.stripXml10InvalidChars(rendered);
+        String xmlSafe = stripXml10InvalidChars(rendered);
         String result = new XmlBuilder().elem("RenderedTemplate", xmlSafe).build();
         return Response.ok(AwsQueryResponse.envelope("TestRenderTemplate", AwsNamespaces.SES, result)).build();
     }
@@ -676,7 +676,7 @@ public class SesQueryHandler {
             throw new AwsException("InvalidParameterValue",
                     "Template or TemplateArn is required.", 400);
         }
-        String resolvedName = hasName ? templateName : SesService.templateNameFromArn(templateArn);
+        String resolvedName = hasName ? templateName : SesTemplateService.templateNameFromArn(templateArn);
         EmailTemplate template = sesService.getTemplate(resolvedName, region);
         JsonNode defaultTemplateData = parseTemplateData(defaultDataRaw);
 
@@ -1189,5 +1189,32 @@ public class SesQueryHandler {
 
     private String getParam(MultivaluedMap<String, String> params, String name) {
         return params.getFirst(name);
+    }
+
+    /** Package-private for the unit test; the sole caller is the TestRenderTemplate XML response above. */
+    static String stripXml10InvalidChars(String s) {
+        if (s == null || s.isEmpty()) {
+            return s;
+        }
+        // XML 1.0 char production: \t \n \r, U+0020-U+D7FF, U+E000-U+FFFD,
+        // U+10000-U+10FFFF. Anything else (C0 controls, U+FFFE/U+FFFF, lone
+        // surrogates) makes the response unparseable by SDK XML parsers.
+        StringBuilder out = new StringBuilder(s.length());
+        int i = 0;
+        while (i < s.length()) {
+            int cp = s.codePointAt(i);
+            if (isXml10Char(cp)) {
+                out.appendCodePoint(cp);
+            }
+            i += Character.charCount(cp);
+        }
+        return out.toString();
+    }
+
+    private static boolean isXml10Char(int cp) {
+        return cp == 0x09 || cp == 0x0A || cp == 0x0D
+                || (cp >= 0x20 && cp <= 0xD7FF)
+                || (cp >= 0xE000 && cp <= 0xFFFD)
+                || (cp >= 0x10000 && cp <= 0x10FFFF);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -218,7 +218,7 @@ public class SesService {
             throw new AwsException("InvalidParameterValue", "At least one destination address is required.", 400);
         }
         String effectiveConfigSet = resolveDefaultConfigurationSet(configurationSetName, source, region);
-        validateConfigurationSet(effectiveConfigSet, region);
+        configSetService.validateForSending(effectiveConfigSet, region);
 
         // Resolve suppression before recording the message so a bad ListManagementOptions (e.g. an
         // unknown contact list) fails the whole send without leaving an orphaned SentEmail record.
@@ -281,7 +281,7 @@ public class SesService {
             throw new AwsException("InvalidParameterValue", "RawMessage.Data is required.", 400);
         }
         String effectiveConfigSet = resolveDefaultConfigurationSet(configurationSetName, source, region);
-        validateConfigurationSet(effectiveConfigSet, region);
+        configSetService.validateForSending(effectiveConfigSet, region);
         boolean hasExplicitDestinations = destinations != null && !destinations.isEmpty();
         boolean sourceOmitted = source == null || source.isBlank();
         boolean willPublishEvents = (effectiveConfigSet != null && !effectiveConfigSet.isBlank())
@@ -305,7 +305,7 @@ public class SesService {
         // explicit FromEmailAddress.
         if (sourceOmitted && (configurationSetName == null || configurationSetName.isBlank())) {
             effectiveConfigSet = resolveDefaultConfigurationSet(configurationSetName, effectiveSource, region);
-            validateConfigurationSet(effectiveConfigSet, region);
+            configSetService.validateForSending(effectiveConfigSet, region);
         }
         List<String> effectiveDestinations = hasExplicitDestinations
                 ? destinations
@@ -358,32 +358,6 @@ public class SesService {
             all.addAll(bcc);
         }
         return all;
-    }
-
-    /**
-     * Validate that a non-blank {@code ConfigurationSetName} is usable for a send. Performs
-     * two gates:
-     *   1. Existence — raises {@code ConfigurationSetDoesNotExist} (400) when the set is
-     *      missing in the given region. The V2 REST controller's {@code remapV1Exception}
-     *      translates that into {@code NotFoundException 404}; V1 Query keeps the original.
-     *   2. Sending-enabled — raises {@code ConfigurationSetSendingPausedException} (400)
-     *      when the set's {@code SendingEnabled} flag has been turned off via
-     *      {@code UpdateConfigurationSetSendingEnabled} (v1) /
-     *      {@code PutConfigurationSetSendingOptions} (v2). The V2 controller narrows that
-     *      code to {@code SendingPausedException}; V1 keeps the longer form, matching the
-     *      exact wire shape AWS returns on each surface.
-     * Mirrors AWS SES behaviour: invalid or paused set fails fast instead of silently
-     * storing/relaying the message and skipping event publishing later.
-     */
-    private void validateConfigurationSet(String configurationSetName, String region) {
-        if (configurationSetName == null || configurationSetName.isBlank()) {
-            return;
-        }
-        ConfigurationSet cs = configSetService.get(configurationSetName, region);
-        if (cs.getSendingEnabled() != null && !cs.getSendingEnabled()) {
-            throw new AwsException("ConfigurationSetSendingPausedException",
-                    "Sending is paused for configuration set " + configurationSetName, 400);
-        }
     }
 
     private void publishSendEvents(String configurationSetName, String messageId, String source,
@@ -1910,32 +1884,6 @@ public class SesService {
         return templateService.renderTestTemplate(templateName, templateDataRaw, region);
     }
 
-    static String stripXml10InvalidChars(String s) {
-        if (s == null || s.isEmpty()) {
-            return s;
-        }
-        // XML 1.0 char production: \t \n \r, U+0020-U+D7FF, U+E000-U+FFFD,
-        // U+10000-U+10FFFF. Anything else (C0 controls, U+FFFE/U+FFFF, lone
-        // surrogates) makes the response unparseable by SDK XML parsers.
-        StringBuilder out = new StringBuilder(s.length());
-        int i = 0;
-        while (i < s.length()) {
-            int cp = s.codePointAt(i);
-            if (isXml10Char(cp)) {
-                out.appendCodePoint(cp);
-            }
-            i += Character.charCount(cp);
-        }
-        return out.toString();
-    }
-
-    private static boolean isXml10Char(int cp) {
-        return cp == 0x09 || cp == 0x0A || cp == 0x0D
-                || (cp >= 0x20 && cp <= 0xD7FF)
-                || (cp >= 0xE000 && cp <= 0xFFFD)
-                || (cp >= 0x10000 && cp <= 0x10FFFF);
-    }
-
     /**
      * Also called by the controller ahead of the tenant send gate: AWS reports an empty inline
      * template before it looks the tenant up (probe-confirmed), so the check must not stay behind
@@ -1983,7 +1931,7 @@ public class SesService {
             throw new AwsException("InvalidParameterValue",
                     "At least one destination entry is required.", 400);
         }
-        validateConfigurationSet(configurationSetName, region);
+        configSetService.validateForSending(configurationSetName, region);
         if (entries.size() > MAX_BULK_DESTINATIONS) {
             throw new AwsException("MessageRejected",
                     "Number of destinations (" + entries.size() + ") exceeds the maximum of "
@@ -2112,28 +2060,4 @@ public class SesService {
         replacement.fields().forEachRemaining(e -> merged.set(e.getKey(), e.getValue()));
         return merged;
     }
-
-    /**
-     * Extracts the template name from an SES template ARN of the form
-     * {@code arn:aws:ses:<region>:<account>:template/<name>}. Region and
-     * account segments are not validated; only the {@code template/<name>}
-     * suffix is required.
-     */
-    public static String templateNameFromArn(String arn) {
-        if (arn == null || arn.isBlank()) {
-            throw new AwsException("InvalidParameterValue", "TemplateArn is required.", 400);
-        }
-        int marker = arn.indexOf(":template/");
-        if (!arn.startsWith("arn:") || marker < 0) {
-            throw new AwsException("InvalidParameterValue",
-                    "TemplateArn is not a valid SES template ARN: " + arn, 400);
-        }
-        String name = arn.substring(marker + ":template/".length());
-        if (name.isEmpty()) {
-            throw new AwsException("InvalidParameterValue",
-                    "TemplateArn is missing a template name: " + arn, 400);
-        }
-        return name;
-    }
-
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesTemplateService.java
@@ -40,9 +40,7 @@ import java.util.regex.Pattern;
  * {@link SecureRandom} (no static instance, so no native-image run-time-init registration).
  *
  * <p>Tag validation is a shared cross-resource concern, so {@code createTemplate} calls
- * {@link SesTags#validate} rather than depending back on the facade. The template ARN parser
- * ({@code SesService.templateNameFromArn}) stays on the facade because external callers reference it
- * statically.
+ * {@link SesTags#validate} rather than depending back on the facade.
  */
 @ApplicationScoped
 public class SesTemplateService {
@@ -170,6 +168,29 @@ public class SesTemplateService {
     private static String templateKey(String region, String templateName) {
         validateTemplateName(templateName);
         return "template::" + region + "::" + templateName;
+    }
+
+    /**
+     * Extracts the template name from an SES template ARN of the form
+     * {@code arn:aws:ses:<region>:<account>:template/<name>}. Region and
+     * account segments are not validated; only the {@code template/<name>}
+     * suffix is required.
+     */
+    public static String templateNameFromArn(String arn) {
+        if (arn == null || arn.isBlank()) {
+            throw new AwsException("InvalidParameterValue", "TemplateArn is required.", 400);
+        }
+        int marker = arn.indexOf(":template/");
+        if (!arn.startsWith("arn:") || marker < 0) {
+            throw new AwsException("InvalidParameterValue",
+                    "TemplateArn is not a valid SES template ARN: " + arn, 400);
+        }
+        String name = arn.substring(marker + ":template/".length());
+        if (name.isEmpty()) {
+            throw new AwsException("InvalidParameterValue",
+                    "TemplateArn is missing a template name: " + arn, 400);
+        }
+        return name;
     }
 
     /** The ARN-dispatched tag operations, sharing the store behind {@code CreateEmailTemplate.Tags}. */

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesServiceTemplateTest.java
@@ -280,7 +280,7 @@ class SesServiceTemplateTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("stripXml10InvalidCharsCases")
     void stripXml10InvalidChars_returnsExpected(String label, String input, String expected) {
-        assertEquals(expected, SesService.stripXml10InvalidChars(input));
+        assertEquals(expected, SesQueryHandler.stripXml10InvalidChars(input));
     }
 
     static Stream<Arguments> stripXml10InvalidCharsCases() {


### PR DESCRIPTION
## Summary

Follow-up to #2356, continuing the post-split cleanup (#2881, #2984, #3030, #3090): moves three
facade helpers whose ownership became unambiguous after the store split, each to its single
natural home:

- `validateConfigurationSet` becomes `SesConfigurationSetService.validateForSending`: its only
  dependency was the configuration-set domain itself (existence plus the sending-paused gate), so
  unlike the cross-domain tracking/delivery validators it needs no callback and moves whole, with
  its v1/v2 exception-remap documentation.
- `templateNameFromArn` moves onto `SesTemplateService` as the same public static; the four static
  call sites in `SesQueryHandler` and `SesController` follow, and the Javadoc sentence that kept it
  on the facade is dropped.
- `stripXml10InvalidChars` (with its private `isXml10Char`) moves into `SesQueryHandler`, its sole
  production caller: sanitizing the v1 `TestRenderTemplate` XML response is a protocol concern,
  not domain logic. It stays package-private for the existing unit test.

No behavior change: wordings, gate order, and the ARN parsing are verbatim.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Pure code motion; no wire-visible change. The full SES suite (1046 tests) plus the native-image
runtime-initialization guard passes unchanged.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added (not applicable: behavior-preserving refactor, existing tests pin the behavior and only their static references moved)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
