### PR TITLE
fix(cloudcontrol): reject ListResources for unsupported resource types instead of returning empty

### DIFF
--- a/docs/services/cloudcontrol.md
+++ b/docs/services/cloudcontrol.md
@@ -34,6 +34,11 @@ Cloud Control.
   which is broader than the read side. A resource created through Cloud Control but
   outside the read-side type list is still readable via `GetResource`, from
   create-time state, but will not appear in `ListResources`.
+- **`ListResources` on an unlisted type**: `TypeName` values outside the list above
+  fail with `UnsupportedActionException` (HTTP 400) instead of returning an empty
+  `ResourceDescriptions`. This applies to any type Floci does not enumerate on the
+  read side, whether or not the type is real in AWS, since Floci has no CloudFormation
+  type registry to tell the two apart.
 - **Delete needs create-time state**: types whose delete depends on attributes
   captured at create time (currently `AWS::EKS::Nodegroup` and `AWS::IAM::Policy`, plus
   any `Custom::*` / `AWS::CloudFormation::CustomResource`) fail `DeleteResource` with a

--- a/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlService.java
@@ -143,9 +143,12 @@ public class CloudControlService {
      */
     private String resourceModel(String region, String typeName, String physicalId, JsonNode desiredState) {
         try {
-            for (ResourceDescription d : listResources(region, typeName)) {
-                if (physicalId.equals(d.identifier())) {
-                    return d.properties();
+            List<ResourceDescription> listed = resourcesForType(region, typeName);
+            if (listed != null) {
+                for (ResourceDescription d : listed) {
+                    if (physicalId.equals(d.identifier())) {
+                        return d.properties();
+                    }
                 }
             }
         } catch (Exception ignored) {
@@ -206,9 +209,12 @@ public class CloudControlService {
 
     /** Cloud Control {@code GetResource}: a single resource from the read side, by identifier. */
     public ResourceDescription getResource(String region, String typeName, String identifier) {
-        for (ResourceDescription d : listResources(region, typeName)) {
-            if (d.identifier().equals(identifier)) {
-                return d;
+        List<ResourceDescription> listed = resourcesForType(region, typeName);
+        if (listed != null) {
+            for (ResourceDescription d : listed) {
+                if (d.identifier().equals(identifier)) {
+                    return d;
+                }
             }
         }
         // CreateResource provisions the whole CFN type set while the read side lists six types, so
@@ -253,7 +259,26 @@ public class CloudControlService {
         }
     }
 
+    /**
+     * Cloud Control {@code ListResources}. A type this read side does not enumerate reports
+     * {@code UnsupportedActionException} rather than an empty list: an empty {@code
+     * ResourceDescriptions} is indistinguishable from "supported type, zero resources", which
+     * defeats a caller sweeping type names to discover inventory. Floci provisions many more types
+     * than {@link #resourcesForType} lists (see {@link #getResource} and {@link #createResource}),
+     * so this is a statement about read-side enumeration support, not about the type existing in
+     * AWS at all.
+     */
     public List<ResourceDescription> listResources(String region, String typeName) {
+        List<ResourceDescription> resources = resourcesForType(region, typeName);
+        if (resources == null) {
+            throw new AwsException("UnsupportedActionException",
+                    "ListResources is not supported for resource type " + typeName + ".", 400);
+        }
+        return resources;
+    }
+
+    /** The types {@link #listResources} and {@link #getResource} can enumerate, or {@code null}. */
+    private List<ResourceDescription> resourcesForType(String region, String typeName) {
         return switch (typeName) {
             case "AWS::S3::Bucket" -> s3Buckets();
             case "AWS::EC2::VPC" -> vpcs(region);
@@ -264,7 +289,7 @@ public class CloudControlService {
             case "AWS::EC2::Instance" -> instances(region);
             case "AWS::EC2::LaunchTemplate" -> launchTemplates(region);
             case "AWS::IAM::InstanceProfile" -> instanceProfiles();
-            default -> List.of();
+            default -> null;
         };
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlIntegrationTest.java
@@ -170,6 +170,33 @@ class CloudControlIntegrationTest {
                 "{\"TypeName\":\"AWS::EC2::VPC\",\"DesiredState\":\"not json\"}");
     }
 
+    @Test
+    void listResourcesRejectsUnsupportedTypesInsteadOfReturningEmpty() {
+        // AWS::SQS::Queue and AWS::Logs::LogGroup are real Cloud Control types that Floci backs
+        // through their own service APIs but does not enumerate on this read side. Returning an
+        // empty ResourceDescriptions for them was indistinguishable from "no queues exist".
+        String ct = "application/x-amz-json-1.0";
+        assertErrorCode(ct, "CloudApiService.ListResources",
+                "{\"TypeName\":\"AWS::SQS::Queue\"}", 400, "UnsupportedActionException");
+        assertErrorCode(ct, "CloudApiService.ListResources",
+                "{\"TypeName\":\"AWS::Logs::LogGroup\"}", 400, "UnsupportedActionException");
+
+        // A type name that does not exist in AWS at all reports the same error: Floci has no
+        // CloudFormation type registry to tell a real-but-unbacked type from an invented one.
+        assertErrorCode(ct, "CloudApiService.ListResources",
+                "{\"TypeName\":\"AWS::NoSuch::Type\"}", 400, "UnsupportedActionException");
+
+        // A supported type is unaffected.
+        given()
+                .config(config().encoderConfig(encoderConfig().encodeContentTypeAs(ct, TEXT)))
+                .contentType(ct)
+                .header("X-Amz-Target", "CloudApiService.ListResources")
+                .body("{\"TypeName\":\"AWS::S3::Bucket\"}")
+                .when().post("/")
+                .then().statusCode(200)
+                .body("TypeName", org.hamcrest.Matchers.equalTo("AWS::S3::Bucket"));
+    }
+
     private void assertErrorCode(String contentType, String target, String body) {
         assertErrorCode(contentType, target, body, 400, "InvalidRequestException");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudcontrol/CloudControlServiceTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.cloudcontrol;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.cloudformation.CloudFormationResourceProvisioner;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.Tag;
@@ -15,6 +16,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -49,5 +51,42 @@ class CloudControlServiceTest {
         assertFalse(properties.contains("ignored-null"));
         assertFalse(properties.contains("ignored-empty"));
         assertFalse(properties.contains("ignored-blank"));
+    }
+
+    @Test
+    void listResourcesRejectsARealButUnbackedTypeInsteadOfReturningEmpty() {
+        CloudControlService service = new CloudControlService(
+                mock(S3Service.class), mock(Ec2Service.class), mock(IamService.class),
+                mock(CloudFormationResourceProvisioner.class), new ObjectMapper());
+
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.listResources("us-east-1", "AWS::SQS::Queue"));
+
+        assertEquals("UnsupportedActionException", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+    }
+
+    @Test
+    void listResourcesRejectsATypeThatDoesNotExistInAwsAtAll() {
+        CloudControlService service = new CloudControlService(
+                mock(S3Service.class), mock(Ec2Service.class), mock(IamService.class),
+                mock(CloudFormationResourceProvisioner.class), new ObjectMapper());
+
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.listResources("us-east-1", "AWS::NoSuch::Type"));
+
+        assertEquals("UnsupportedActionException", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+    }
+
+    @Test
+    void listResourcesStillReturnsASupportedType() {
+        S3Service s3Service = mock(S3Service.class);
+        when(s3Service.listBuckets()).thenReturn(List.of());
+        CloudControlService service = new CloudControlService(
+                s3Service, mock(Ec2Service.class), mock(IamService.class),
+                mock(CloudFormationResourceProvisioner.class), new ObjectMapper());
+
+        assertTrue(service.listResources("us-east-1", "AWS::S3::Bucket").isEmpty());
     }
 }


### PR DESCRIPTION
## Summary

Closes #2043

`CloudControlService.listResources` returned an empty list for any `TypeName`
outside the nine types it enumerates (S3 buckets, EC2 VPCs/subnets/security
groups/instances/launch templates, IAM roles/users/instance profiles). That
empty result was indistinguishable from "supported type, zero resources," so
a real but unbacked type (e.g. `AWS::SQS::Queue`, `AWS::Logs::LogGroup`) and a
type that does not exist in AWS at all both looked like a successful,
resource-free call. Tools that sweep a list of type names to discover
inventory silently missed real resources.

## Approach

Went with a combination of the issue's options 1 and 2:

- `ListResources` now throws `UnsupportedActionException` (HTTP 400) for any
  `TypeName` it does not enumerate, matching real Cloud Control API semantics
  for a resource type that does not support the requested action.
  `TypeNotFoundException` was considered but doesn't fit: it means the type
  isn't in the CloudFormation registry, and Floci has no such registry to
  check against, so it can't distinguish a real-but-unbacked type from an
  invented one. Both get the same error.
- `docs/services/cloudcontrol.md` already documents the supported type list;
  added a note describing the new error behavior.
- `GetResource` and the internal `CreateResource` read-back still work for
  types outside the enumerated list (falling back to create-time state), so
  this only changes `ListResources`'s own contract, not the read side as a
  whole.

Skipped option 3 (extending `ListResources` to cover SQS, CloudWatch Logs,
etc.) as a larger, separately-scoped change.

## Checklist

- [x] `CloudControlServiceTest` and `CloudControlIntegrationTest` pass
      (11/11), including new regression tests for a supported type, a real
      but unbacked type, and a nonexistent type
- [x] `make docs-check` passes