### PR TITLE
fix(rds): support tagging DB proxy target groups

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -840,8 +840,30 @@ public class RdsService implements Resettable, ResourceProvider {
                     putOptionGroupForRegion(resourceId, effectiveRegion, group);
                 });
             }
-            // Valid RDS resource types Floci does not model yet (snapshot, ri, ...) — taggable
-            // on real AWS, so the message states the Floci limitation rather than AWS semantics.
+            case "target-group" -> {
+                DbProxyTargetGroup targetGroup = proxyTargetGroups.scan(k -> true).stream()
+                        .filter(candidate -> effectiveRegion.equals(
+                                regionFromArn(candidate.getTargetGroupArn())))
+                        .filter(candidate -> resourceName.equals(candidate.getTargetGroupArn()))
+                        .findFirst()
+                        .orElseThrow(() -> new AwsException("DBProxyTargetGroupNotFoundFault",
+                                "DB proxy target group " + resourceId + " not found.", 404));
+                targetGroup = findProxyTargetGroup(targetGroup.getDbProxyName(), effectiveRegion)
+                        .filter(candidate -> resourceName.equals(candidate.getTargetGroupArn()))
+                        .orElseThrow(() -> new AwsException("DBProxyTargetGroupNotFoundFault",
+                                "DB proxy target group " + resourceId + " not found.", 404));
+                DbProxyTargetGroup resolvedTargetGroup = targetGroup;
+                yield new TagHandle(targetGroup.getTags(), updated -> {
+                    DbProxyTargetGroup updatedTargetGroup = copyProxyTargetGroup(resolvedTargetGroup);
+                    updatedTargetGroup.setTags(updated);
+                    putTargetGroupForAccount(currentAccountId(),
+                            dbProxyKey(effectiveRegion, resolvedTargetGroup.getDbProxyName()),
+                            updatedTargetGroup);
+                });
+            }
+            // Valid RDS resource types Floci does not model yet (snapshot, ri, es, secgrp, ...):
+            // taggable on real AWS, so the message states the Floci limitation rather than AWS
+            // semantics.
             default -> throw new AwsException("InvalidParameterValue",
                     "Tagging for resource type '" + type + "' is not yet implemented by Floci: " + resourceName, 400);
         };
@@ -4033,6 +4055,7 @@ public class RdsService implements Resettable, ResourceProvider {
         copy.setInitQuery(source.getInitQuery());
         copy.setSessionPinningFilters(source.getSessionPinningFilters());
         copy.setTargets(source.getTargets());
+        copy.setTags(source.getTags());
         return copy;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbProxyTargetGroup.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbProxyTargetGroup.java
@@ -4,7 +4,9 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * The (single, always named {@code "default"}) target group of an {@code AWS::RDS::DBProxy}. Holds
@@ -26,6 +28,7 @@ public class DbProxyTargetGroup {
     private String initQuery;
     private List<String> sessionPinningFilters = new ArrayList<>();
     private List<DbProxyTarget> targets = new ArrayList<>();
+    private Map<String, String> tags = new LinkedHashMap<>();
 
     public DbProxyTargetGroup() {}
 
@@ -73,5 +76,10 @@ public class DbProxyTargetGroup {
     public List<DbProxyTarget> getTargets() { return targets; }
     public void setTargets(List<DbProxyTarget> targets) {
         this.targets = targets != null ? new ArrayList<>(targets) : new ArrayList<>();
+    }
+
+    public Map<String, String> getTags() { return tags; }
+    public void setTags(Map<String, String> tags) {
+        this.tags = tags != null ? new LinkedHashMap<>(tags) : new LinkedHashMap<>();
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -1015,6 +1015,32 @@ class RdsServiceTest {
     }
 
     @Test
+    void dbProxyTargetGroupTagsRoundTripByArn() {
+        rdsService.createDbProxy("app-proxy", "POSTGRESQL", true, false, PROXY_ROLE_ARN,
+                PROXY_SUBNET_IDS, List.of(), PROXY_AUTH, Map.of());
+        String targetGroupArn = rdsService.describeDbProxyTargetGroups("app-proxy")
+                .iterator().next().getTargetGroupArn();
+
+        assertEquals(java.util.Map.of(), rdsService.listTagsForResource(targetGroupArn));
+
+        rdsService.addTagsToResource(targetGroupArn, java.util.Map.of("env", "test"));
+        assertEquals(java.util.Map.of("env", "test"),
+                rdsService.listTagsForResource(targetGroupArn));
+
+        rdsService.removeTagsFromResource(targetGroupArn, java.util.List.of("env"));
+        assertEquals(java.util.Map.of(), rdsService.listTagsForResource(targetGroupArn));
+    }
+
+    @Test
+    void dbProxyTargetGroupTagOperationsRejectMissingTargetGroup() {
+        AwsException exception = assertThrows(AwsException.class, () ->
+                rdsService.listTagsForResource(
+                        "arn:aws:rds:us-east-1:123456789012:target-group:prx-tg-missing"));
+
+        assertEquals("DBProxyTargetGroupNotFoundFault", exception.getErrorCode());
+    }
+
+    @Test
     void tagOperationsRejectUnsupportedResourceArn() {
         // Parameter groups are tagged now, so an absent one is a missing resource rather than a
         // missing feature. A type Floci still does not model keeps the limitation message.


### PR DESCRIPTION
## Summary

RDS's tag resolver (`RdsService.resolveTagHandle`) already covers DB instances, clusters, subnet groups, parameter groups, cluster parameter groups, option groups, and DB proxies, but fell through to "not yet implemented by Floci" for `target-group` ARNs, even though every DB proxy Floci creates gets its own default target group with a real ARN. This adds a `tags` field to `DbProxyTargetGroup` and wires `target-group` ARNs into `AddTagsToResource`/`RemoveTagsFromResource`/`ListTagsForResource`, the same way `db-proxy` ARNs already work.

Snapshot, reserved-instance, and event-subscription ARNs still fall through to the same "not implemented" message, since Floci doesn't model those resources at all yet; tagging them is a separate, larger effort.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

On a live account, `AddTagsToResource` operates on DB proxy target-group ARNs directly (it reports `DBProxyTargetGroupNotFoundFault` when one doesn't exist). Floci instead rejected every target-group ARN with `InvalidParameterValue: Tagging for resource type 'target-group' is not yet implemented by Floci`, even for a target group it had just created. `resolveTagHandle` now resolves the target group the same way it already resolves `db-proxy` ARNs (scan by ARN, confirm ownership through `findProxyTargetGroup`, persist the updated tag map back through the account-scoped store).

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
