### PR TITLE
fix(eventbridge,scheduler): read cron day-of-week as AWS 1-7 SUN-SAT

### DIFF
--- a/docs/services/scheduler.md
+++ b/docs/services/scheduler.md
@@ -29,7 +29,8 @@ background dispatcher fires schedule targets on time. Supported expressions:
   (default UTC) and `ActionAfterCompletion=DELETE`.
 - `rate(N unit)` — repeating fire (`minutes`, `hours`, `days`, `weeks`).
 - `cron(minute hour day-of-month month day-of-week year)` — AWS 6-field cron;
-  honors `ScheduleExpressionTimezone`.
+  honors `ScheduleExpressionTimezone`. Day-of-week is `1-7` or `SUN-SAT`, so
+  `2` is Monday and `cron(30 2 ? * 2#1 *)` is the first Monday of the month.
 
 `State=DISABLED` schedules and schedules outside their `StartDate`/`EndDate`
 window are skipped. The dispatcher ticks every

--- a/src/main/java/io/github/hectorvent/floci/services/eventbridge/ScheduleExpressionParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/eventbridge/ScheduleExpressionParser.java
@@ -29,7 +29,11 @@ public final class ScheduleExpressionParser {
                 .withHours().and()
                 .withDayOfMonth().supportsHash().supportsL().supportsW().supportsQuestionMark().and()
                 .withMonth().and()
-                .withDayOfWeek().supportsHash().supportsL().supportsW().supportsQuestionMark().and()
+                // AWS numbers day-of-week 1-7 as SUN-SAT, not the Unix 0-6 SUN-SAT that cron-utils
+                // defaults to, so Monday is 2. Without this every numeric day fires one day late and
+                // 7 (Saturday) does not parse at all.
+                .withDayOfWeek().withValidRange(1, 7).withMondayDoWValue(2)
+                .supportsHash().supportsL().supportsW().supportsQuestionMark().and()
                 .withYear().optional().and()
                 .instance();
         CRON_PARSER = new CronParser(definition);

--- a/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerExpressionParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/scheduler/SchedulerExpressionParser.java
@@ -52,7 +52,11 @@ public final class SchedulerExpressionParser {
                 .withHours().and()
                 .withDayOfMonth().supportsHash().supportsL().supportsW().supportsQuestionMark().and()
                 .withMonth().and()
-                .withDayOfWeek().supportsHash().supportsL().supportsW().supportsQuestionMark().and()
+                // AWS numbers day-of-week 1-7 as SUN-SAT, not the Unix 0-6 SUN-SAT that cron-utils
+                // defaults to, so Monday is 2. Without this every numeric day fires one day late and
+                // 7 (Saturday) does not parse at all.
+                .withDayOfWeek().withValidRange(1, 7).withMondayDoWValue(2)
+                .supportsHash().supportsL().supportsW().supportsQuestionMark().and()
                 .withYear().optional().and()
                 .instance();
         CRON_PARSER = new CronParser(definition);

--- a/src/test/java/io/github/hectorvent/floci/services/eventbridge/ScheduleExpressionParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/eventbridge/ScheduleExpressionParserTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.eventbridge;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.DayOfWeek;
 import java.time.ZonedDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -123,11 +124,15 @@ class ScheduleExpressionParserTest {
 
     @Test
     void getNextFireTimeWeekdays() {
+        // AWS day-of-week is 1-7 = SUN-SAT, so Monday to Friday is 2-6.
         ZonedDateTime from = ZonedDateTime.parse("2026-03-23T08:00:00Z");
-        ZonedDateTime next = ScheduleExpressionParser.getNextFireTime("cron(0 9-17 * * 1-5 *)", from);
+        ZonedDateTime next = ScheduleExpressionParser.getNextFireTime("cron(0 9-17 * * 2-6 *)", from);
 
         assertNotNull(next);
         assertTrue(next.getHour() >= 9 && next.getHour() <= 17);
+        assertTrue(next.getDayOfWeek().getValue() >= DayOfWeek.MONDAY.getValue()
+                        && next.getDayOfWeek().getValue() <= DayOfWeek.FRIDAY.getValue(),
+                "expected a weekday but got " + next);
     }
 
     @Test
@@ -135,10 +140,52 @@ class ScheduleExpressionParserTest {
         ZonedDateTime from = ZonedDateTime.parse("2026-03-01T02:00:00Z");
         ZonedDateTime next = ScheduleExpressionParser.getNextFireTime("cron(30 2 ? * 2#1 *)", from);
 
-        assertNotNull(next);
-        assertEquals(2, next.getHour());
-        assertEquals(30, next.getMinute());
-        assertEquals(2, next.getDayOfWeek().getValue());
+        assertEquals(ZonedDateTime.parse("2026-03-02T02:30:00Z"), next);
+        assertEquals(DayOfWeek.MONDAY, next.getDayOfWeek());
+    }
+
+    // ──────────────────────────── Day-of-week numbering (AWS 1-7 = SUN-SAT) ────────────────────────────
+
+    /** 2026-03-01 is a Sunday, so it doubles as the day the "from" instant lands on. */
+    private static final ZonedDateTime SUNDAY_2026_03_01_02_00 = ZonedDateTime.parse("2026-03-01T02:00:00Z");
+
+    @Test
+    void dayOfWeekOneIsSunday() {
+        assertEquals(ZonedDateTime.parse("2026-03-01T12:00:00Z"),
+                ScheduleExpressionParser.getNextFireTime("cron(0 12 ? * 1 *)", SUNDAY_2026_03_01_02_00));
+    }
+
+    @Test
+    void dayOfWeekTwoIsMonday() {
+        assertEquals(ZonedDateTime.parse("2026-03-02T12:00:00Z"),
+                ScheduleExpressionParser.getNextFireTime("cron(0 12 ? * 2 *)", SUNDAY_2026_03_01_02_00));
+    }
+
+    @Test
+    void dayOfWeekSevenIsSaturdayAndIsAccepted() {
+        assertEquals(ZonedDateTime.parse("2026-03-07T12:00:00Z"),
+                ScheduleExpressionParser.getNextFireTime("cron(0 12 ? * 7 *)", SUNDAY_2026_03_01_02_00));
+    }
+
+    @Test
+    void dayOfWeekNamesAgreeWithTheirNumbers() {
+        assertEquals(
+                ScheduleExpressionParser.getNextFireTime("cron(0 12 ? * 2 *)", SUNDAY_2026_03_01_02_00),
+                ScheduleExpressionParser.getNextFireTime("cron(0 12 ? * MON *)", SUNDAY_2026_03_01_02_00));
+    }
+
+    @Test
+    void lastWeekdayOfMonthUsesAwsNumbering() {
+        // AWS documents cron(15 10 ? * 6L 2022-2023) as the last Friday of the month.
+        // The last Friday of March 2026 is the 27th.
+        assertEquals(ZonedDateTime.parse("2026-03-27T10:15:00Z"),
+                ScheduleExpressionParser.getNextFireTime("cron(15 10 ? * 6L *)", SUNDAY_2026_03_01_02_00));
+    }
+
+    @Test
+    void dayOfWeekZeroIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ScheduleExpressionParser.getNextFireTime("cron(0 12 ? * 0 *)", SUNDAY_2026_03_01_02_00));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerExpressionParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/scheduler/SchedulerExpressionParserTest.java
@@ -96,4 +96,60 @@ class SchedulerExpressionParserTest {
         assertThrows(IllegalArgumentException.class,
                 () -> SchedulerExpressionParser.nextCronFire("cron(0 10 * * *)", from, null));
     }
+
+    // Day-of-week numbering: AWS is 1-7 = SUN-SAT.
+
+    /** 2026-03-01 is a Sunday, so it doubles as the day the "from" instant lands on. */
+    private static final Instant SUNDAY_2026_03_01_02_00 =
+            ZonedDateTime.of(2026, 3, 1, 2, 0, 0, 0, ZoneOffset.UTC).toInstant();
+
+    private static Instant utc(int day, int hour, int minute) {
+        return ZonedDateTime.of(2026, 3, day, hour, minute, 0, 0, ZoneOffset.UTC).toInstant();
+    }
+
+    @Test
+    void dayOfWeekOneIsSunday() {
+        assertEquals(utc(1, 12, 0),
+                SchedulerExpressionParser.nextCronFire("cron(0 12 ? * 1 *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
+
+    @Test
+    void dayOfWeekTwoIsMonday() {
+        assertEquals(utc(2, 12, 0),
+                SchedulerExpressionParser.nextCronFire("cron(0 12 ? * 2 *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
+
+    @Test
+    void dayOfWeekSevenIsSaturdayAndIsAccepted() {
+        assertEquals(utc(7, 12, 0),
+                SchedulerExpressionParser.nextCronFire("cron(0 12 ? * 7 *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
+
+    @Test
+    void dayOfWeekNamesAgreeWithTheirNumbers() {
+        assertEquals(
+                SchedulerExpressionParser.nextCronFire("cron(0 12 ? * 2 *)", SUNDAY_2026_03_01_02_00, "UTC"),
+                SchedulerExpressionParser.nextCronFire("cron(0 12 ? * MON *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
+
+    @Test
+    void hashSelectsTheNthWeekdayOfTheMonth() {
+        // 2#1 is the first Monday of March 2026, which is the 2nd.
+        assertEquals(utc(2, 2, 30),
+                SchedulerExpressionParser.nextCronFire("cron(30 2 ? * 2#1 *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
+
+    @Test
+    void lastWeekdayOfMonthUsesAwsNumbering() {
+        // AWS documents cron(15 10 ? * 6L 2022-2023) as the last Friday of the month.
+        // The last Friday of March 2026 is the 27th.
+        assertEquals(utc(27, 10, 15),
+                SchedulerExpressionParser.nextCronFire("cron(15 10 ? * 6L *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
+
+    @Test
+    void dayOfWeekZeroIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> SchedulerExpressionParser.nextCronFire("cron(0 12 ? * 0 *)", SUNDAY_2026_03_01_02_00, "UTC"));
+    }
 }


### PR DESCRIPTION
## Summary

Both schedule expression parsers read a numeric cron day-of-week with Unix numbering, 0-6 for SUN-SAT, but AWS numbers that field 1-7 for SUN-SAT. Every numeric day fired one day late, and Saturday could not be expressed at all.

`cron(0 12 ? * 2 *)` is Monday to AWS and fired on Tuesday. AWS's own documented example `cron(15 10 ? * 6L 2022-2023)`, described in the user guide as the last Friday of the month, fired on the last Saturday. `cron(0 12 ? * 7 *)` did not parse at all: cron-utils rejected it with `Value 7 not in range [0, 6]`. Day names were always right, because cron-utils resolves `MON` against its own numbering, so only expressions written with numbers were affected.

The cause is the cron definition in `ScheduleExpressionParser.java:32` (eventbridge) and `SchedulerExpressionParser.java:55` (scheduler). Both called `.withDayOfWeek()` with no range and no Monday value, which leaves cron-utils on its Unix default. Both now use `.withValidRange(1, 7).withMondayDoWValue(2)`, the same shape cron-utils ships for Quartz, whose day-of-week dialect AWS follows. `7` parses as Saturday, and `0` is rejected in line with AWS's documented `1-7` range.

One existing test had the old behavior baked into it. `getNextFireTimeFirstMondayOfMonth` parsed `cron(30 2 ? * 2#1 *)`, named itself for the first Monday, then asserted the fire day was a Tuesday. It now asserts `2026-03-02`, the first Monday of that month. `getNextFireTimeWeekdays` used `1-5`, which is SUN-THU in AWS numbering, so it now uses `2-6` and asserts the fire day really is a weekday.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior was the day-of-week mapping described above: numeric days shifted one day later, and `7` rejected as unparseable.

The field is documented as `1-7 or SUN-SAT` in the EventBridge Scheduler user guide, https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html, which also spells the mapping out for `#`: "3#2 would be the second Tuesday of the month: the 3 refers to Tuesday because it is the third day of each week". EventBridge Rules use the same six-field dialect. I checked this against the published field table and AWS's two worked examples, not against a live account.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Both parsers are pure functions with plain JVM unit tests, so the new coverage went there rather than into an integration test. I ran the affected suites rather than the whole build, because the full `./mvnw test` wants Docker for the Lambda, RDS and ElastiCache containers and there is no daemon on this machine.

`./mvnw test -Dtest='SchedulerExpressionParserTest,ScheduleExpressionParserTest,ScheduleDispatcherTest,SchedulerServiceTest,ScheduleInvokerTest,EventBridgeSchedulerIntegrationTest,EventBridgeServiceTest,EventBridgeInvokerTest,RulePersistenceTest,ReplayDispatcherTest,InputTransformerTest'` gives 253 tests, 0 failures. On the unmodified parsers the 13 new day-of-week tests and the one corrected test fail: 12 assertion failures plus 2 errors, both `Value 7 not in range [0, 6]`. `make docs-check` passes.
