### PR TITLE
fix(rds): populate MasterUserSecret for Aurora clusters with ManageMasterUserPassword

### DIFF
--- a/compatibility-tests/sdk-test-awscli/test/rds.bats
+++ b/compatibility-tests/sdk-test-awscli/test/rds.bats
@@ -5,11 +5,13 @@ setup() {
     load 'test_helper/common-setup'
     DB_ID="bats-rds-$(unique_name)"
     DB_ID_2="bats-rds-2-$(unique_name)"
+    RDS_CLUSTER_ID="bats-rds-cluster-$(unique_name)"
 }
 
 teardown() {
     aws_cmd rds delete-db-instance --db-instance-identifier "$DB_ID" --skip-final-snapshot >/dev/null 2>&1 || true
     aws_cmd rds delete-db-instance --db-instance-identifier "$DB_ID_2" --skip-final-snapshot >/dev/null 2>&1 || true
+    aws_cmd rds delete-db-cluster --db-cluster-identifier "$RDS_CLUSTER_ID" --skip-final-snapshot >/dev/null 2>&1 || true
     if [ -n "${MANAGED_SECRET_ARN:-}" ]; then
         aws_cmd secretsmanager delete-secret --secret-id "$MANAGED_SECRET_ARN" \
             --force-delete-without-recovery >/dev/null 2>&1 || true
@@ -134,6 +136,27 @@ teardown() {
     assert_success
     [ "$(json_get "$output" '.RotationEnabled')" = "true" ]
     [ "$(json_get "$output" '.RotationRules.AutomaticallyAfterDays')" = "7" ]
+}
+
+@test "RDS: Aurora cluster with managed master user password populates MasterUserSecret" {
+    run aws_cmd rds create-db-cluster \
+        --db-cluster-identifier "$RDS_CLUSTER_ID" \
+        --engine aurora-postgresql \
+        --master-username omni_admin \
+        --manage-master-user-password
+    assert_success
+
+    MANAGED_SECRET_ARN=$(json_get "$output" '.DBCluster.MasterUserSecret.SecretArn')
+    [ -n "$MANAGED_SECRET_ARN" ]
+    [ "$(json_get "$output" '.DBCluster.MasterUserSecret.SecretStatus')" = "active" ]
+
+    run aws_cmd rds describe-db-clusters --db-cluster-identifier "$RDS_CLUSTER_ID"
+    assert_success
+    [ "$(json_get "$output" '.DBClusters[0].MasterUserSecret.SecretArn')" = "$MANAGED_SECRET_ARN" ]
+
+    run aws_cmd secretsmanager describe-secret --secret-id "$MANAGED_SECRET_ARN"
+    assert_success
+    [ "$(json_get "$output" '.OwningService')" = "rds" ]
 }
 
 @test "RDS: describe global clusters returns an empty list" {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsQueryHandler.java
@@ -453,6 +453,8 @@ public class RdsQueryHandler {
         String dbSubnetGroupName = params.getFirst("DBSubnetGroupName");
         String availabilityZone = params.getFirst("AvailabilityZone");
         boolean multiAz = "true".equalsIgnoreCase(params.getFirst("MultiAZ"));
+        boolean manageMasterUserPassword = "true".equalsIgnoreCase(params.getFirst("ManageMasterUserPassword"));
+        String masterUserSecretKmsKeyId = params.getFirst("MasterUserSecretKmsKeyId");
 
         if (engineVersion == null) {
             engineVersion = defaultEngineVersion(engine);
@@ -466,7 +468,8 @@ public class RdsQueryHandler {
             DbCluster cluster = service.createDbCluster(id, engine, engineVersion, masterUsername,
                     masterPassword, databaseName, iamEnabled, paramGroupName,
                     dbSubnetGroupName, availabilityZone, multiAz, region,
-                    serverlessV2Min, serverlessV2Max, serverlessV2SecondsUntilAutoPause);
+                    serverlessV2Min, serverlessV2Max, serverlessV2SecondsUntilAutoPause,
+                    manageMasterUserPassword, masterUserSecretKmsKeyId);
             String result = dbClusterXml(cluster);
             return Response.ok(AwsQueryResponse.envelope("CreateDBCluster", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -568,13 +571,17 @@ public class RdsQueryHandler {
         String newPassword = params.getFirst("MasterUserPassword");
         String iamStr = params.getFirst("EnableIAMDatabaseAuthentication");
         Boolean iamEnabled = iamStr != null ? Boolean.parseBoolean(iamStr) : null;
+        String manageStr = params.getFirst("ManageMasterUserPassword");
+        Boolean manageMasterUserPassword = manageStr != null ? Boolean.parseBoolean(manageStr) : null;
+        String masterUserSecretKmsKeyId = params.getFirst("MasterUserSecretKmsKeyId");
         try {
             Double serverlessV2Min = parseDoubleParam(params, "ServerlessV2ScalingConfiguration.MinCapacity");
             Double serverlessV2Max = parseDoubleParam(params, "ServerlessV2ScalingConfiguration.MaxCapacity");
             Integer serverlessV2SecondsUntilAutoPause = parseIntegerParam(
                     params, "ServerlessV2ScalingConfiguration.SecondsUntilAutoPause");
             DbCluster cluster = service.modifyDbCluster(id, newPassword, iamEnabled,
-                    serverlessV2Min, serverlessV2Max, serverlessV2SecondsUntilAutoPause, region);
+                    serverlessV2Min, serverlessV2Max, serverlessV2SecondsUntilAutoPause,
+                    manageMasterUserPassword, masterUserSecretKmsKeyId, region);
             String result = dbClusterXml(cluster);
             return Response.ok(AwsQueryResponse.envelope("ModifyDBCluster", AwsNamespaces.RDS, result)).build();
         } catch (AwsException e) {
@@ -1466,6 +1473,15 @@ public class RdsQueryHandler {
            .elem("DBSubnetGroup", c.getDbSubnetGroupName() != null ? c.getDbSubnetGroupName() : "default")
            .elem("DbClusterResourceId", c.getDbClusterResourceId())
            .elem("DBClusterArn", c.getDbClusterArn());
+        if (c.getMasterUserSecretArn() != null && !c.getMasterUserSecretArn().isBlank()) {
+            xml.start("MasterUserSecret")
+                    .elem("SecretArn", c.getMasterUserSecretArn())
+                    .elem("SecretStatus", c.getMasterUserSecretStatus() == null ? "active" : c.getMasterUserSecretStatus());
+            if (c.getMasterUserSecretKmsKeyId() != null && !c.getMasterUserSecretKmsKeyId().isBlank()) {
+                xml.elem("KmsKeyId", c.getMasterUserSecretKmsKeyId());
+            }
+            xml.end("MasterUserSecret");
+        }
         if (c.getServerlessV2MinCapacity() != null || c.getServerlessV2MaxCapacity() != null) {
             xml.start("ServerlessV2ScalingConfiguration");
             if (c.getServerlessV2MinCapacity() != null) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -1026,6 +1026,19 @@ public class RdsService implements Resettable, ResourceProvider {
         cluster.setMasterUserSecretKmsKeyId(null);
     }
 
+    /**
+     * Applies a new KMS key to a cluster's existing managed master user secret. AWS re-encrypts the
+     * secret in place on {@code ModifyDBCluster}; silently keeping the old key would make the call
+     * report a success it did not perform.
+     */
+    private void rekeyManagedMasterUserSecret(DbCluster cluster, String kmsKeyId, String region) {
+        if (secretsManagerService == null) {
+            return;
+        }
+        secretsManagerService.updateSecret(cluster.getMasterUserSecretArn(), null, kmsKeyId, region);
+        cluster.setMasterUserSecretKmsKeyId(kmsKeyId);
+    }
+
     private static String managedMasterSecretString(DbCluster cluster) {
         try {
             return JSON.writeValueAsString(Map.of(
@@ -1573,23 +1586,32 @@ public class RdsService implements Resettable, ResourceProvider {
             attachManagedMasterUserSecret(cluster, effectiveRegion, masterUserSecretKmsKeyId);
         }
 
-        if (!mock) {
-            String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
-            final String accountId = accountIdFromArn(cluster.getDbClusterArn());
-            final String clusterRegion = regionFromArn(cluster.getDbClusterArn());
-            proxyManager.startProxy(rdsResourceRelayKey(cluster.getDbClusterArn(), id),
-                    engine, iamEnabled, proxyPort,
-                    cluster.getContainerHost(), cluster.getContainerPort(),
-                    cluster.getEndpoint().address(),
-                    effectiveMasterUser, masterPassword, databaseName,
-                    (user, pw) -> validateDbClusterPasswordForScope(
-                            accountId, clusterRegion, id, user, pw));
-        }
+        try {
+            if (!mock) {
+                String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
+                final String accountId = accountIdFromArn(cluster.getDbClusterArn());
+                final String clusterRegion = regionFromArn(cluster.getDbClusterArn());
+                proxyManager.startProxy(rdsResourceRelayKey(cluster.getDbClusterArn(), id),
+                        engine, iamEnabled, proxyPort,
+                        cluster.getContainerHost(), cluster.getContainerPort(),
+                        cluster.getEndpoint().address(),
+                        effectiveMasterUser, masterPassword, databaseName,
+                        (user, pw) -> validateDbClusterPasswordForScope(
+                                accountId, clusterRegion, id, user, pw));
+            }
 
-        cluster.setServerlessV2MinCapacity(serverlessV2MinCapacity);
-        cluster.setServerlessV2MaxCapacity(serverlessV2MaxCapacity);
-        cluster.setServerlessV2SecondsUntilAutoPause(effectiveAutoPauseSeconds);
-        putClusterForScope(currentAccountId(), effectiveRegion, id, cluster);
+            cluster.setServerlessV2MinCapacity(serverlessV2MinCapacity);
+            cluster.setServerlessV2MaxCapacity(serverlessV2MaxCapacity);
+            cluster.setServerlessV2SecondsUntilAutoPause(effectiveAutoPauseSeconds);
+            putClusterForScope(currentAccountId(), effectiveRegion, id, cluster);
+        } catch (RuntimeException e) {
+            // The cluster is not persisted, so DeleteDBCluster cannot reach the secret we just
+            // created: roll it back here rather than leave an orphaned RDS-owned secret.
+            if (manageMasterUserPassword) {
+                detachManagedMasterUserSecret(cluster, effectiveRegion);
+            }
+            throw e;
+        }
         LOG.infov("DB cluster {0} created (mock={1}), engine={2}, endpoint={3}:{4}",
                 id, String.valueOf(mock), engine, endpoint.address(), String.valueOf(endpoint.port()));
         return cluster;
@@ -1810,6 +1832,10 @@ public class RdsService implements Resettable, ResourceProvider {
             attachManagedMasterUserSecret(cluster, effectiveRegion, masterUserSecretKmsKeyId);
         } else if (Boolean.FALSE.equals(manageMasterUserPassword) && cluster.getMasterUserSecretArn() != null) {
             detachManagedMasterUserSecret(cluster, effectiveRegion);
+        } else if (cluster.getMasterUserSecretArn() != null
+                && masterUserSecretKmsKeyId != null
+                && !masterUserSecretKmsKeyId.equals(cluster.getMasterUserSecretKmsKeyId())) {
+            rekeyManagedMasterUserSecret(cluster, masterUserSecretKmsKeyId, effectiveRegion);
         }
         if (modifiesServerlessV2Scaling) {
             cluster.setServerlessV2MinCapacity(effectiveMinCapacity);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -882,6 +882,17 @@ public class RdsService implements Resettable, ResourceProvider {
                     LOG.debugv(e, "Could not mark master user secret {0} as service-managed", secretArn);
                 }
             }
+            for (DbCluster cluster : allClusters()) {
+                String secretArn = cluster.getMasterUserSecretArn();
+                if (secretArn == null) {
+                    continue;
+                }
+                try {
+                    secretsManagerService.markOwnedByService(secretArn, MANAGED_SECRET_OWNING_SERVICE);
+                } catch (RuntimeException e) {
+                    LOG.debugv(e, "Could not mark master user secret {0} as service-managed", secretArn);
+                }
+            }
         } catch (RuntimeException e) {
             LOG.warnv(e, "Skipped the master user secret ownership backfill");
         }
@@ -965,6 +976,68 @@ public class RdsService implements Resettable, ResourceProvider {
                     "port", instance.getEndpoint().port(),
                     "dbname", instance.getDbName() == null ? "" : instance.getDbName(),
                     "dbInstanceIdentifier", instance.getDbInstanceIdentifier()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Unable to serialize RDS master user secret", e);
+        }
+    }
+
+    private void attachManagedMasterUserSecret(DbCluster cluster, String region, String kmsKeyId) {
+        if (secretsManagerService == null) {
+            throw new AwsException("InvalidParameterCombination",
+                    "ManageMasterUserPassword requires Secrets Manager support.", 400);
+        }
+        String secretName = "rds!" + cluster.getDbClusterResourceId();
+        // RDS owns the secret it manages: it rotates the master password itself, so the secret
+        // carries no rotation Lambda. AWS marks that with OwningService and these two tags.
+        List<Secret.Tag> tags = List.of(
+                new Secret.Tag("aws:rds:primaryDBClusterArn", cluster.getDbClusterArn()),
+                new Secret.Tag("aws:secretsmanager:owningService", MANAGED_SECRET_OWNING_SERVICE));
+        Secret secret = secretsManagerService.createSecret(
+                secretName,
+                managedMasterSecretString(cluster),
+                null,
+                "Managed RDS master user secret for " + cluster.getDbClusterIdentifier(),
+                kmsKeyId,
+                tags,
+                MANAGED_SECRET_OWNING_SERVICE,
+                region);
+        cluster.setMasterUserSecretArn(secret.getArn());
+        cluster.setMasterUserSecretStatus("active");
+        cluster.setMasterUserSecretKmsKeyId(kmsKeyId);
+    }
+
+    /**
+     * Deletes the Secrets Manager secret RDS manages for a cluster's master user and clears the
+     * reference. A missing or already-deleted secret is tolerated: the cluster is being torn down or
+     * switched back to a caller-supplied password either way.
+     */
+    private void detachManagedMasterUserSecret(DbCluster cluster, String region) {
+        String secretArn = cluster.getMasterUserSecretArn();
+        if (secretArn == null || secretsManagerService == null) {
+            return;
+        }
+        try {
+            secretsManagerService.deleteSecret(secretArn, null, true, region);
+        } catch (RuntimeException e) {
+            LOG.debugv(e, "Managed master user secret {0} could not be deleted", secretArn);
+        }
+        cluster.setMasterUserSecretArn(null);
+        cluster.setMasterUserSecretStatus(null);
+        cluster.setMasterUserSecretKmsKeyId(null);
+    }
+
+    private static String managedMasterSecretString(DbCluster cluster) {
+        try {
+            return JSON.writeValueAsString(Map.of(
+                    "username", cluster.getMasterUsername(),
+                    "password", cluster.getMasterPassword(),
+                    "engine", cluster.getEngineIdentifier() != null && !cluster.getEngineIdentifier().isBlank()
+                            ? cluster.getEngineIdentifier().toLowerCase()
+                            : cluster.getEngine().name().toLowerCase(),
+                    "host", cluster.getEndpoint().address(),
+                    "port", cluster.getEndpoint().port(),
+                    "dbname", cluster.getDatabaseName() == null ? "" : cluster.getDatabaseName(),
+                    "dbClusterIdentifier", cluster.getDbClusterIdentifier()));
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Unable to serialize RDS master user secret", e);
         }
@@ -1402,6 +1475,20 @@ public class RdsService implements Resettable, ResourceProvider {
                                      String availabilityZone, boolean multiAz, String region,
                                      Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
                                      Integer serverlessV2SecondsUntilAutoPause) {
+        return createDbCluster(id, engineParam, engineVersion, masterUsername, masterPassword,
+                databaseName, iamEnabled, paramGroupName, dbSubnetGroupName, availabilityZone,
+                multiAz, region, serverlessV2MinCapacity, serverlessV2MaxCapacity,
+                serverlessV2SecondsUntilAutoPause, false, null);
+    }
+
+    public DbCluster createDbCluster(String id, String engineParam, String engineVersion,
+                                     String masterUsername, String masterPassword,
+                                     String databaseName, boolean iamEnabled,
+                                     String paramGroupName, String dbSubnetGroupName,
+                                     String availabilityZone, boolean multiAz, String region,
+                                     Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
+                                     Integer serverlessV2SecondsUntilAutoPause,
+                                     boolean manageMasterUserPassword, String masterUserSecretKmsKeyId) {
         String provisioningKey = "cluster:" + currentAccountId() + ":"
                 + dbResourceKey(effectiveRegion(region), id);
         if (!provisioningIds.add(provisioningKey)) {
@@ -1412,7 +1499,7 @@ public class RdsService implements Resettable, ResourceProvider {
             return doCreateDbCluster(id, engineParam, engineVersion, masterUsername, masterPassword,
                     databaseName, iamEnabled, paramGroupName, dbSubnetGroupName, availabilityZone,
                     multiAz, region, serverlessV2MinCapacity, serverlessV2MaxCapacity,
-                    serverlessV2SecondsUntilAutoPause);
+                    serverlessV2SecondsUntilAutoPause, manageMasterUserPassword, masterUserSecretKmsKeyId);
         } finally {
             provisioningIds.remove(provisioningKey);
         }
@@ -1424,7 +1511,8 @@ public class RdsService implements Resettable, ResourceProvider {
                                         String paramGroupName, String dbSubnetGroupName,
                                         String availabilityZone, boolean multiAz, String region,
                                         Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
-                                        Integer serverlessV2SecondsUntilAutoPause) {
+                                        Integer serverlessV2SecondsUntilAutoPause,
+                                        boolean manageMasterUserPassword, String masterUserSecretKmsKeyId) {
         String effectiveRegion = effectiveRegion(region);
         String clusterResourceId = "cluster-" + java.util.UUID.randomUUID().toString()
                 .replace("-", "").substring(0, 24).toUpperCase();
@@ -1448,6 +1536,9 @@ public class RdsService implements Resettable, ResourceProvider {
         // Always reserve a unique port (even in mock) so endpoints stay distinct and usedPorts
         // is consistent; mock mode only skips starting the container and auth proxy.
         int proxyPort = allocateProxyPort();
+        if (manageMasterUserPassword && (masterPassword == null || masterPassword.isBlank())) {
+            masterPassword = generatedMasterPassword();
+        }
         DbEndpoint endpoint = mock ? new DbEndpoint("localhost", proxyPort) : proxyEndpoint(proxyPort);
         DbCluster cluster = new DbCluster(id, engine, engineVersion, masterUsername, masterPassword,
                 databaseName, DbInstanceStatus.AVAILABLE, endpoint, endpoint,
@@ -1477,6 +1568,10 @@ public class RdsService implements Resettable, ResourceProvider {
 
         cluster.setDbClusterResourceId(clusterResourceId);
         cluster.setDbClusterArn(clusterArn);
+
+        if (manageMasterUserPassword) {
+            attachManagedMasterUserSecret(cluster, effectiveRegion, masterUserSecretKmsKeyId);
+        }
 
         if (!mock) {
             String effectiveMasterUser = masterUsername != null ? masterUsername : "root";
@@ -1651,9 +1746,18 @@ public class RdsService implements Resettable, ResourceProvider {
         return modifyDbCluster(id, newPassword, iamEnabled, null, null, null, region);
     }
 
-    public synchronized DbCluster modifyDbCluster(String id, String newPassword, Boolean iamEnabled,
+    public DbCluster modifyDbCluster(String id, String newPassword, Boolean iamEnabled,
                                      Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
                                      Integer serverlessV2SecondsUntilAutoPause, String region) {
+        return modifyDbCluster(id, newPassword, iamEnabled, serverlessV2MinCapacity,
+                serverlessV2MaxCapacity, serverlessV2SecondsUntilAutoPause, null, null, region);
+    }
+
+    public synchronized DbCluster modifyDbCluster(String id, String newPassword, Boolean iamEnabled,
+                                     Double serverlessV2MinCapacity, Double serverlessV2MaxCapacity,
+                                     Integer serverlessV2SecondsUntilAutoPause,
+                                     Boolean manageMasterUserPassword, String masterUserSecretKmsKeyId,
+                                     String region) {
         String effectiveRegion = effectiveRegion(region);
         DbCluster cluster = getDbCluster(id, effectiveRegion);
         boolean modifiesServerlessV2Scaling = serverlessV2MinCapacity != null
@@ -1698,6 +1802,14 @@ public class RdsService implements Resettable, ResourceProvider {
         }
         if (iamEnabled != null) {
             cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
+        }
+        if (Boolean.TRUE.equals(manageMasterUserPassword) && cluster.getMasterUserSecretArn() == null) {
+            if (cluster.getMasterPassword() == null || cluster.getMasterPassword().isBlank()) {
+                cluster.setMasterPassword(generatedMasterPassword());
+            }
+            attachManagedMasterUserSecret(cluster, effectiveRegion, masterUserSecretKmsKeyId);
+        } else if (Boolean.FALSE.equals(manageMasterUserPassword) && cluster.getMasterUserSecretArn() != null) {
+            detachManagedMasterUserSecret(cluster, effectiveRegion);
         }
         if (modifiesServerlessV2Scaling) {
             cluster.setServerlessV2MinCapacity(effectiveMinCapacity);
@@ -1751,6 +1863,8 @@ public class RdsService implements Resettable, ResourceProvider {
             throw new AwsException("InvalidDBClusterStateFault",
                     "DB cluster " + id + " is registered with a DB proxy target group.", 400);
         }
+
+        detachManagedMasterUserSecret(cluster, effectiveRegion);
 
         cluster.setStatus(DbInstanceStatus.DELETING);
         putClusterForScope(currentAccountId(), effectiveRegion, id, cluster);

--- a/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/model/DbCluster.java
@@ -31,6 +31,9 @@ public class DbCluster {
     private Map<String, String> subnetAvailabilityZones = new LinkedHashMap<>();
     private String dbClusterResourceId;
     private String dbClusterArn;
+    private String masterUserSecretArn;
+    private String masterUserSecretStatus;
+    private String masterUserSecretKmsKeyId;
     private Instant createdAt;
     private int proxyPort;
     private Map<String, String> tags = new LinkedHashMap<>();
@@ -137,6 +140,17 @@ public class DbCluster {
 
     public String getDbClusterArn() { return dbClusterArn; }
     public void setDbClusterArn(String dbClusterArn) { this.dbClusterArn = dbClusterArn; }
+
+    public String getMasterUserSecretArn() { return masterUserSecretArn; }
+    public void setMasterUserSecretArn(String masterUserSecretArn) { this.masterUserSecretArn = masterUserSecretArn; }
+
+    public String getMasterUserSecretStatus() { return masterUserSecretStatus; }
+    public void setMasterUserSecretStatus(String masterUserSecretStatus) { this.masterUserSecretStatus = masterUserSecretStatus; }
+
+    public String getMasterUserSecretKmsKeyId() { return masterUserSecretKmsKeyId; }
+    public void setMasterUserSecretKmsKeyId(String masterUserSecretKmsKeyId) {
+        this.masterUserSecretKmsKeyId = masterUserSecretKmsKeyId;
+    }
 
     public Instant getCreatedAt() { return createdAt; }
     public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsQueryHandlerTest.java
@@ -255,7 +255,7 @@ class RdsQueryHandlerTest {
         when(service.listDbClusters(null, "us-west-2")).thenReturn(List.of());
         when(service.getDbCluster("mycluster", "us-west-2")).thenReturn(cluster);
         when(service.modifyDbCluster("mycluster", null, null,
-                null, null, null, "us-west-2"))
+                null, null, null, null, null, "us-west-2"))
                 .thenReturn(cluster);
 
         handler.handle("DescribeDBInstances", params(), "us-west-2");
@@ -281,7 +281,73 @@ class RdsQueryHandlerTest {
         verify(service).getDbCluster("mycluster", "us-west-2");
         verify(service).deleteDbCluster("mycluster", "us-west-2");
         verify(service).modifyDbCluster("mycluster", null, null,
-                null, null, null, "us-west-2");
+                null, null, null, null, null, "us-west-2");
+    }
+
+    @Test
+    void createDbClusterPassesManagedMasterUserSecretOptions() {
+        DbCluster cluster = makeCluster("mycluster");
+        cluster.setMasterUserSecretArn("arn:aws:secretsmanager:us-east-1:000000000000:secret:rds!cluster-ABC");
+        cluster.setMasterUserSecretStatus("active");
+        cluster.setMasterUserSecretKmsKeyId("kms-key-1");
+        when(service.createDbCluster(eq("mycluster"), eq("aurora-postgresql"), any(),
+                eq("omni_admin"), isNull(), eq("omni"), eq(false), isNull(),
+                isNull(), isNull(), eq(false), any(),
+                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1")))
+                .thenReturn(cluster);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBClusterIdentifier", "mycluster");
+        p.add("Engine", "aurora-postgresql");
+        p.add("MasterUsername", "omni_admin");
+        p.add("DatabaseName", "omni");
+        p.add("ManageMasterUserPassword", "true");
+        p.add("MasterUserSecretKmsKeyId", "kms-key-1");
+        Response response = handler.handle("CreateDBCluster", p);
+
+        String body = (String) response.getEntity();
+        assertTrue(body.contains("<MasterUserSecret>"));
+        assertTrue(body.contains("<SecretArn>arn:aws:secretsmanager:us-east-1:000000000000:secret:rds!cluster-ABC</SecretArn>"));
+        assertTrue(body.contains("<SecretStatus>active</SecretStatus>"));
+        assertTrue(body.contains("<KmsKeyId>kms-key-1</KmsKeyId>"));
+        verify(service).createDbCluster(eq("mycluster"), eq("aurora-postgresql"), any(),
+                eq("omni_admin"), isNull(), eq("omni"), eq(false), isNull(),
+                isNull(), isNull(), eq(false), any(),
+                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1"));
+    }
+
+    @Test
+    void createDbClusterWithoutManagedSecretOmitsMasterUserSecretElement() {
+        DbCluster cluster = makeCluster("mycluster");
+        when(service.createDbCluster(any(), any(), any(), any(), any(), any(), anyBoolean(), any(),
+                any(), any(), anyBoolean(), any(), any(), any(), any(), eq(false), isNull()))
+                .thenReturn(cluster);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBClusterIdentifier", "mycluster");
+        p.add("Engine", "aurora-postgresql");
+        p.add("MasterUsername", "admin");
+        Response response = handler.handle("CreateDBCluster", p);
+
+        String body = (String) response.getEntity();
+        assertFalse(body.contains("<MasterUserSecret>"));
+    }
+
+    @Test
+    void modifyDbClusterPassesManagedMasterUserSecretOptions() {
+        DbCluster cluster = makeCluster("mycluster");
+        when(service.modifyDbCluster(eq("mycluster"), isNull(), isNull(),
+                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1"), any()))
+                .thenReturn(cluster);
+
+        MultivaluedMap<String, String> p = params();
+        p.add("DBClusterIdentifier", "mycluster");
+        p.add("ManageMasterUserPassword", "true");
+        p.add("MasterUserSecretKmsKeyId", "kms-key-1");
+        handler.handle("ModifyDBCluster", p);
+
+        verify(service).modifyDbCluster(eq("mycluster"), isNull(), isNull(),
+                isNull(), isNull(), isNull(), eq(true), eq("kms-key-1"), any());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -592,6 +592,54 @@ class RdsServiceTest {
     }
 
     @Test
+    void createDbClusterRollsBackManagedSecretWhenProxyStartupFails() {
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        String secretArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-RB";
+        secret.setArn(secretArn);
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        doThrow(new IllegalStateException("proxy down"))
+                .when(proxyManager).startProxy(any(), any(), anyBoolean(), anyInt(), any(), anyInt(),
+                        any(), any(), any(), any(), any());
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        assertThrows(IllegalStateException.class, () -> service.createDbCluster(
+                "cluster1", "aurora-postgresql", "16.3",
+                "admin", null, "omni", false, null, null, null, false, "us-east-1",
+                null, null, null, true, null));
+
+        verify(secretsManager).deleteSecret(eq(secretArn), any(), anyBoolean(), eq("us-east-1"));
+    }
+
+    @Test
+    void modifyDbClusterRekeysExistingManagedSecret() {
+        when(config.services().rds().mock()).thenReturn(true);
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        String secretArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-RK";
+        secret.setArn(secretArn);
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq("kms-key-1"), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+        service.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", null, "omni", false, null, null, null, false, "us-east-1",
+                null, null, null, true, "kms-key-1");
+
+        DbCluster cluster = service.modifyDbCluster("cluster1", null, null,
+                null, null, null, true, "kms-key-2", "us-east-1");
+
+        assertEquals("kms-key-2", cluster.getMasterUserSecretKmsKeyId());
+        verify(secretsManager).updateSecret(eq(secretArn), any(), eq("kms-key-2"), eq("us-east-1"));
+    }
+
+    @Test
     void modifyDbClusterEnablingManagedMasterPasswordCreatesSecret() {
         when(config.services().rds().mock()).thenReturn(true);
         SecretsManagerService secretsManager = mock(SecretsManagerService.class);

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -551,6 +551,115 @@ class RdsServiceTest {
     }
 
     @Test
+    void createDbClusterWithManagedMasterPasswordCreatesSecret() {
+        when(config.services().rds().mock()).thenReturn(true);
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        secret.setArn("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-ABC");
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq("kms-key-1"), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+
+        DbCluster cluster = service.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "omni_admin", null, "omni", false, null, null, null, false, "us-east-1",
+                0.5, 1.0, null, true, "kms-key-1");
+
+        assertEquals("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-ABC",
+                cluster.getMasterUserSecretArn());
+        assertEquals("active", cluster.getMasterUserSecretStatus());
+        assertEquals("kms-key-1", cluster.getMasterUserSecretKmsKeyId());
+        assertNotNull(cluster.getMasterPassword());
+        assertTrue(cluster.getMasterPassword().startsWith("floci-"));
+
+        ArgumentCaptor<String> secretName = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> secretString = ArgumentCaptor.forClass(String.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<List<Secret.Tag>> secretTags = ArgumentCaptor.forClass(List.class);
+        verify(secretsManager).createSecret(secretName.capture(), secretString.capture(), eq(null), any(),
+                eq("kms-key-1"), secretTags.capture(), eq("rds"), eq("us-east-1"));
+        assertTrue(secretName.getValue().startsWith("rds!cluster-"));
+        assertTrue(secretString.getValue().contains("\"username\":\"omni_admin\""));
+        assertTrue(secretString.getValue().contains("\"password\":\"" + cluster.getMasterPassword() + "\""));
+        assertTrue(secretString.getValue().contains("\"dbClusterIdentifier\":\"cluster1\""));
+
+        assertTrue(secretTags.getValue().contains(
+                new Secret.Tag("aws:secretsmanager:owningService", "rds")));
+        assertTrue(secretTags.getValue().contains(
+                new Secret.Tag("aws:rds:primaryDBClusterArn", cluster.getDbClusterArn())));
+    }
+
+    @Test
+    void modifyDbClusterEnablingManagedMasterPasswordCreatesSecret() {
+        when(config.services().rds().mock()).thenReturn(true);
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        secret.setArn("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-MOD");
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+        service.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", "password", "omni", false, null);
+
+        DbCluster cluster = service.modifyDbCluster("cluster1", null, null,
+                null, null, null, true, null, "us-east-1");
+
+        assertEquals("arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-MOD",
+                cluster.getMasterUserSecretArn());
+        assertEquals("active", cluster.getMasterUserSecretStatus());
+        verify(secretsManager).createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1"));
+    }
+
+    @Test
+    void deleteDbClusterDeletesManagedMasterUserSecret() {
+        when(config.services().rds().mock()).thenReturn(true);
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        String secretArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-DEL";
+        secret.setArn(secretArn);
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+        service.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", null, "omni", false, null, null, null, false, "us-east-1",
+                null, null, null, true, null);
+
+        service.deleteDbCluster("cluster1", "us-east-1");
+
+        verify(secretsManager).deleteSecret(eq(secretArn), any(), eq(true), eq("us-east-1"));
+    }
+
+    @Test
+    void backfillMarksMasterUserSecretsOfPersistedClusters() {
+        when(config.services().rds().mock()).thenReturn(true);
+        SecretsManagerService secretsManager = mock(SecretsManagerService.class);
+        Secret secret = new Secret();
+        String secretArn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!cluster-BF";
+        secret.setArn(secretArn);
+        when(secretsManager.createSecret(any(), any(), eq(null), any(), eq(null), any(), eq("rds"), eq("us-east-1")))
+                .thenReturn(secret);
+        RdsService service = newService(containerManager, proxyManager,
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(),
+                secretsManager);
+        service.createDbCluster("cluster1", "aurora-postgresql", "16.3",
+                "admin", null, "omni", false, null, null, null, false, "us-east-1",
+                null, null, null, true, null);
+
+        service.backfillManagedSecretOwnership();
+
+        verify(secretsManager).markOwnedByService(secretArn, "rds");
+    }
+
+    @Test
     void backfillMarksMasterUserSecretsOfPersistedInstances() {
         SecretsManagerService secretsManager = mock(SecretsManagerService.class);
         Secret secret = new Secret();


### PR DESCRIPTION
## Summary

`CreateDBCluster` never parsed `ManageMasterUserPassword`, so an `aws_rds_cluster` (Aurora) created with `manage_master_user_password = true` always came back with an empty `master_user_secret`, and any Terraform reference to `master_user_secret[0].secret_arn` failed with `Invalid index`. The instance path already generates the RDS-managed secret (see #2376); only the cluster path was missing it.

This mirrors the instance behavior on the cluster path:

- `CreateDBCluster` / `ModifyDBCluster` parse `ManageMasterUserPassword` and `MasterUserSecretKmsKeyId`, generate the master password when none is supplied, and create a Secrets Manager secret named `rds!<clusterResourceId>` with `OwningService=rds` and the `aws:rds:primaryDBClusterArn` / `aws:secretsmanager:owningService` tags.
- `DescribeDBClusters` and the other cluster responses render `<MasterUserSecret>` (`SecretArn`, `SecretStatus`, optional `KmsKeyId`).
- `ModifyDBCluster` attaches the secret when the option is turned on and deletes it when turned off with a caller-supplied password.
- `DeleteDBCluster` deletes the managed secret.
- The startup ownership backfill now also marks persisted clusters' secrets.

Note: the issue speculated this shared a root cause with #1918 (engine-enum collapse). It does not. The cluster create/modify handlers simply never read the option.

Closes #3061

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: for `aws_rds_cluster` with `manage_master_user_password = true`, `DescribeDBClusters` returned no `MasterUserSecret` member, so `master_user_secret` was an empty list. Real RDS generates a Secrets Manager secret for the master user and populates `MasterUserSecret` on the cluster, exactly as it does for `aws_db_instance`.

Verified against the reproduction in #3061 (Terraform `hashicorp/aws` ~> 5.0) and with a new AWS CLI bats case (`aws rds create-db-cluster --engine aurora-postgresql --manage-master-user-password`, then `describe-db-clusters` and `secretsmanager describe-secret`).

## Checklist

- [x] `./mvnw test` passes locally (`RdsServiceTest`, `RdsQueryHandlerTest`, `RdsCfnProvisionerTest`: 447 tests green; 2 pre-existing `RdsContainerManagerTest` host-path failures unrelated, fail on a clean `main` too)
- [x] New or updated integration test added (`RdsServiceTest` +4, `RdsQueryHandlerTest` +3, `rds.bats` +1)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

