### PR TITLE
fix(elbv2): bound Lambda and target body sizes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -478,13 +478,13 @@ public class ElbV2DataPlane {
             if (Boolean.TRUE.equals(isBase64)) {
                 decodedBody = Base64.getDecoder().decode(String.valueOf(responseBody));
                 if (decodedBody.length > MAX_LAMBDA_BODY_BYTES) {
-                    req.response().setStatusCode(460).end();
+                    req.response().setStatusCode(502).end();
                     return;
                 }
             } else {
                 textBody = String.valueOf(responseBody);
                 if (textBody.getBytes(StandardCharsets.UTF_8).length > MAX_LAMBDA_BODY_BYTES) {
-                    req.response().setStatusCode(460).end();
+                    req.response().setStatusCode(502).end();
                     return;
                 }
             }

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -650,7 +650,10 @@ public class ElbV2DataPlane {
                     clientReq.send(req);
                     req.resume();
                 })
-                .onFailure(err -> req.response().setStatusCode(503).end("Service unavailable"));
+                .onFailure(err -> {
+                    req.resume();
+                    req.response().setStatusCode(503).end("Service unavailable");
+                });
     }
 
     private void executeRedirect(io.vertx.core.http.HttpServerRequest req, Action action) {

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -470,12 +470,31 @@ public class ElbV2DataPlane {
         Map<String, Object> lambdaResp = objectMapper.readValue(result.getPayload(),
                 new TypeReference<Map<String, Object>>() {});
 
+        Object responseBody = lambdaResp.get("body");
+        Boolean isBase64 = (Boolean) lambdaResp.get("isBase64Encoded");
+        byte[] decodedBody = null;
+        String textBody = null;
+        if (responseBody != null) {
+            if (Boolean.TRUE.equals(isBase64)) {
+                decodedBody = Base64.getDecoder().decode(String.valueOf(responseBody));
+                if (decodedBody.length > MAX_LAMBDA_BODY_BYTES) {
+                    req.response().setStatusCode(460).end();
+                    return;
+                }
+            } else {
+                textBody = String.valueOf(responseBody);
+                if (textBody.getBytes(StandardCharsets.UTF_8).length > MAX_LAMBDA_BODY_BYTES) {
+                    req.response().setStatusCode(460).end();
+                    return;
+                }
+            }
+        }
+
         int statusCode = 200;
         Object sc = lambdaResp.get("statusCode");
         if (sc != null) {
             statusCode = ((Number) sc).intValue();
         }
-
         req.response().setStatusCode(statusCode);
 
         Object headers = lambdaResp.get("headers");
@@ -496,24 +515,12 @@ public class ElbV2DataPlane {
             }
         }
 
-        Object responseBody = lambdaResp.get("body");
-        Boolean isBase64 = (Boolean) lambdaResp.get("isBase64Encoded");
         if (responseBody == null) {
             req.response().end();
-        } else if (Boolean.TRUE.equals(isBase64)) {
-            byte[] decoded = Base64.getDecoder().decode(String.valueOf(responseBody));
-            if (decoded.length > MAX_LAMBDA_BODY_BYTES) {
-                req.response().setStatusCode(460).end();
-                return;
-            }
-            req.response().end(Buffer.buffer(decoded));
+        } else if (decodedBody != null) {
+            req.response().end(Buffer.buffer(decodedBody));
         } else {
-            String body = String.valueOf(responseBody);
-            if (body.getBytes(StandardCharsets.UTF_8).length > MAX_LAMBDA_BODY_BYTES) {
-                req.response().setStatusCode(460).end();
-                return;
-            }
-            req.response().end(body);
+            req.response().end(textBody);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elbv2/ElbV2DataPlane.java
@@ -28,6 +28,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -35,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -49,6 +51,7 @@ public class ElbV2DataPlane {
             "connection", "keep-alive", "transfer-encoding", "upgrade", "te", "trailers", "proxy-authorization", "proxy-authenticate"
     );
     private static final String PRESERVE_HOST_HEADER_ATTRIBUTE = "routing.http.preserve_host_header.enabled";
+    private static final int MAX_LAMBDA_BODY_BYTES = 1024 * 1024;
 
     @Inject
     Vertx vertx;
@@ -400,27 +403,57 @@ public class ElbV2DataPlane {
     }
 
     private void invokeLambdaTarget(io.vertx.core.http.HttpServerRequest req, String functionArn, String region) {
-        req.bodyHandler(body -> {
-            Map<String, Object> event = buildAlbEvent(req, body);
-            // Lambda invocation is synchronous and may take seconds while a cold container
-            // boots and polls the Runtime API. The Runtime API itself runs on Vert.x event
-            // loops, so blocking the listener's event loop here would deadlock the runtime
-            // and the function would time out. Offload to a worker thread, same as WebSocket.
-            // ordered=false so independent ALB requests run in parallel on the worker pool.
-            vertx.<InvokeResult>executeBlocking(() -> {
-                byte[] payload = objectMapper.writeValueAsBytes(event);
-                return lambdaService.invoke(region, functionArn, payload, InvocationType.RequestResponse);
-            }, false).onSuccess(result -> {
-                try {
-                    writeLambdaResponse(req, result);
-                } catch (Exception e) {
-                    LOG.errorf(e, "Error writing Lambda response for %s", functionArn);
-                    req.response().setStatusCode(502).end("Lambda invocation error");
-                }
-            }).onFailure(e -> {
-                LOG.errorf(e, "Error invoking Lambda target %s", functionArn);
+        if (req.isEnded()) {
+            invokeLambdaWithBody(req, functionArn, region, Buffer.buffer());
+            return;
+        }
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        AtomicBoolean rejected = new AtomicBoolean();
+        req.handler(chunk -> {
+            if (rejected.get()) {
+                return;
+            }
+            if (body.size() > MAX_LAMBDA_BODY_BYTES - chunk.length()) {
+                rejected.set(true);
+                req.response().setStatusCode(413).end();
+                return;
+            }
+            body.writeBytes(chunk.getBytes());
+        });
+        req.exceptionHandler(error -> {
+            if (rejected.compareAndSet(false, true)) {
+                req.response().setStatusCode(502).end("Request body error");
+            }
+        });
+        req.endHandler(ignored -> {
+            if (rejected.get()) {
+                return;
+            }
+            invokeLambdaWithBody(req, functionArn, region, Buffer.buffer(body.toByteArray()));
+        });
+    }
+
+    private void invokeLambdaWithBody(io.vertx.core.http.HttpServerRequest req, String functionArn,
+                                      String region, Buffer body) {
+        Map<String, Object> event = buildAlbEvent(req, body);
+        // Lambda invocation is synchronous and may take seconds while a cold container
+        // boots and polls the Runtime API. The Runtime API itself runs on Vert.x event
+        // loops, so blocking the listener's event loop here would deadlock the runtime
+        // and the function would time out. Offload to a worker thread, same as WebSocket.
+        // ordered=false so independent ALB requests run in parallel on the worker pool.
+        vertx.<InvokeResult>executeBlocking(() -> {
+            byte[] payload = objectMapper.writeValueAsBytes(event);
+            return lambdaService.invoke(region, functionArn, payload, InvocationType.RequestResponse);
+        }, false).onSuccess(result -> {
+            try {
+                writeLambdaResponse(req, result);
+            } catch (Exception e) {
+                LOG.errorf(e, "Error writing Lambda response for %s", functionArn);
                 req.response().setStatusCode(502).end("Lambda invocation error");
-            });
+            }
+        }).onFailure(e -> {
+            LOG.errorf(e, "Error invoking Lambda target %s", functionArn);
+            req.response().setStatusCode(502).end("Lambda invocation error");
         });
     }
 
@@ -434,7 +467,6 @@ public class ElbV2DataPlane {
             req.response().setStatusCode(200).end();
             return;
         }
-
         Map<String, Object> lambdaResp = objectMapper.readValue(result.getPayload(),
                 new TypeReference<Map<String, Object>>() {});
 
@@ -470,9 +502,18 @@ public class ElbV2DataPlane {
             req.response().end();
         } else if (Boolean.TRUE.equals(isBase64)) {
             byte[] decoded = Base64.getDecoder().decode(String.valueOf(responseBody));
+            if (decoded.length > MAX_LAMBDA_BODY_BYTES) {
+                req.response().setStatusCode(460).end();
+                return;
+            }
             req.response().end(Buffer.buffer(decoded));
         } else {
-            req.response().end(String.valueOf(responseBody));
+            String body = String.valueOf(responseBody);
+            if (body.getBytes(StandardCharsets.UTF_8).length > MAX_LAMBDA_BODY_BYTES) {
+                req.response().setStatusCode(460).end();
+                return;
+            }
+            req.response().end(body);
         }
     }
 
@@ -547,38 +588,62 @@ public class ElbV2DataPlane {
 
     private void proxyRequest(io.vertx.core.http.HttpServerRequest req, String host, int port,
                               boolean preserveHostHeader) {
-        req.bodyHandler(body -> {
-            RequestOptions opts = new RequestOptions()
-                    .setHost(host)
-                    .setPort(port)
-                    .setURI(req.uri())
-                    .setMethod(req.method());
-            proxyClient.request(opts)
-                    .onSuccess(clientReq -> {
-                        req.headers().forEach(entry -> {
+        req.pause();
+        RequestOptions opts = new RequestOptions()
+                .setHost(host)
+                .setPort(port)
+                .setURI(req.uri())
+                .setMethod(req.method());
+        proxyClient.request(opts)
+                .onSuccess(clientReq -> {
+                    req.headers().forEach(entry -> {
+                        if (!HOP_BY_HOP_HEADERS.contains(entry.getKey().toLowerCase())) {
+                            clientReq.putHeader(entry.getKey(), entry.getValue());
+                        }
+                    });
+                    if (!preserveHostHeader) {
+                        clientReq.putHeader("Host", host + ":" + port);
+                    }
+                    AtomicBoolean responseStarted = new AtomicBoolean();
+                    AtomicBoolean requestFailed = new AtomicBoolean();
+                    clientReq.response().onSuccess(resp -> {
+                        if (requestFailed.get()) {
+                            return;
+                        }
+                        responseStarted.set(true);
+                        req.response().setStatusCode(resp.statusCode());
+                        resp.headers().forEach(entry -> {
                             if (!HOP_BY_HOP_HEADERS.contains(entry.getKey().toLowerCase())) {
-                                clientReq.putHeader(entry.getKey(), entry.getValue());
+                                req.response().putHeader(entry.getKey(), entry.getValue());
                             }
                         });
-                        if (!preserveHostHeader) {
-                            clientReq.putHeader("Host", host + ":" + port);
+                        if (resp.getHeader("Content-Length") == null) {
+                            req.response().setChunked(true);
                         }
-                        clientReq.send(body)
-                                .onSuccess(resp -> {
-                                    req.response().setStatusCode(resp.statusCode());
-                                    resp.headers().forEach(entry -> {
-                                        if (!HOP_BY_HOP_HEADERS.contains(entry.getKey().toLowerCase())) {
-                                            req.response().putHeader(entry.getKey(), entry.getValue());
-                                        }
-                                    });
-                                    resp.body()
-                                            .onSuccess(req.response()::end)
-                                            .onFailure(err -> req.response().setStatusCode(502).end("Body error"));
-                                })
-                                .onFailure(err -> req.response().setStatusCode(502).end("Bad gateway"));
-                    })
-                    .onFailure(err -> req.response().setStatusCode(503).end("Service unavailable"));
-        });
+                        resp.pipeTo(req.response());
+                        resp.exceptionHandler(error -> {
+                            if (req.response().headWritten()) {
+                                req.response().close();
+                            } else {
+                                req.response().setStatusCode(502).end("Body error");
+                            }
+                        });
+                    }).onFailure(error -> {
+                        vertx.runOnContext(ignored -> {
+                            if (requestFailed.compareAndSet(false, true)) {
+                                if (responseStarted.get() || req.response().headWritten()) {
+                                    req.response().close();
+                                } else {
+                                    req.response().setStatusCode(502).end("Bad gateway");
+                                }
+                            }
+                        });
+                    });
+
+                    clientReq.send(req);
+                    req.resume();
+                })
+                .onFailure(err -> req.response().setStatusCode(503).end("Service unavailable"));
     }
 
     private void executeRedirect(io.vertx.core.http.HttpServerRequest req, Action action) {

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -266,7 +266,7 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
             .when()
                 .get("/response-oversized");
 
-        response.then().statusCode(460);
+        response.then().statusCode(502);
         assertNotEquals("1048577", response.getHeader("Content-Length"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -17,6 +17,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -60,7 +61,16 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
         try (ZipOutputStream zos = new ZipOutputStream(baos)) {
             zos.putNextEntry(new ZipEntry("index.py"));
             zos.write((
+                "invocations = 0\n" +
                 "def handler(event, context):\n" +
+                "    global invocations\n" +
+                "    invocations += 1\n" +
+                "    if event.get(\"path\") == \"/invocation-count\":\n" +
+                "        return {\"statusCode\": 200, \"body\": str(invocations)}\n" +
+                "    if event.get(\"path\") == \"/response-at-limit\":\n" +
+                "        return {\"statusCode\": 200, \"body\": \"x\" * (1024 * 1024)}\n" +
+                "    if event.get(\"path\") == \"/response-oversized\":\n" +
+                "        return {\"statusCode\": 200, \"body\": \"x\" * (1024 * 1024 + 1)}\n" +
                 "    return {\"statusCode\": 200, \"body\": \"ok\"}\n"
             ).getBytes(StandardCharsets.UTF_8));
             zos.closeEntry();
@@ -178,6 +188,84 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
             .then()
                 .statusCode(200)
                 .body(equalTo("ok"));
+    }
+
+    @Test
+    @Order(6)
+    void requestBodyAtOneMiBIsAccepted() {
+        byte[] exactLimit = new byte[1024 * 1024];
+
+        given()
+                .baseUri("http://" + lbDnsName)
+                .port(LISTENER_PORT)
+                .contentType("application/octet-stream")
+                .body(exactLimit)
+            .when()
+                .post("/exact")
+            .then()
+                .statusCode(200)
+                .body(equalTo("ok"));
+    }
+
+    @Test
+    @Order(7)
+    void oversizedRequestBodyIsRejectedBeforeLambdaInvocation() {
+        byte[] oversized = new byte[1024 * 1024 + 1];
+        int invocationCountBefore = Integer.parseInt(given()
+                .baseUri("http://" + lbDnsName)
+                .port(LISTENER_PORT)
+            .when()
+                .get("/invocation-count")
+            .then()
+                .statusCode(200)
+                .extract()
+                .asString());
+
+        given()
+                .baseUri("http://" + lbDnsName)
+                .port(LISTENER_PORT)
+                .contentType("application/octet-stream")
+                .body(oversized)
+            .when()
+                .post("/oversized")
+            .then()
+                .statusCode(413);
+
+        int invocationCountAfter = Integer.parseInt(given()
+                .baseUri("http://" + lbDnsName)
+                .port(LISTENER_PORT)
+            .when()
+                .get("/invocation-count")
+            .then()
+                .statusCode(200)
+                .extract()
+                .asString());
+        assertEquals(invocationCountBefore + 1, invocationCountAfter);
+    }
+
+    @Test
+    @Order(8)
+    void lambdaResponseBodyAtOneMiBIsAccepted() {
+        given()
+                .baseUri("http://" + lbDnsName)
+                .port(LISTENER_PORT)
+            .when()
+                .get("/response-at-limit")
+            .then()
+                .statusCode(200)
+                .body(org.hamcrest.Matchers.hasLength(1024 * 1024));
+    }
+
+    @Test
+    @Order(9)
+    void oversizedLambdaResponseIsRejected() {
+        given()
+                .baseUri("http://" + lbDnsName)
+                .port(LISTENER_PORT)
+            .when()
+                .get("/response-oversized")
+            .then()
+                .statusCode(460);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2LambdaTargetDataPlaneIntegrationTest.java
@@ -18,6 +18,7 @@ import java.util.zip.ZipOutputStream;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -70,7 +71,7 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
                 "    if event.get(\"path\") == \"/response-at-limit\":\n" +
                 "        return {\"statusCode\": 200, \"body\": \"x\" * (1024 * 1024)}\n" +
                 "    if event.get(\"path\") == \"/response-oversized\":\n" +
-                "        return {\"statusCode\": 200, \"body\": \"x\" * (1024 * 1024 + 1)}\n" +
+                "        return {\"statusCode\": 200, \"headers\": {\"Content-Length\": \"1048577\"}, \"body\": \"x\" * (1024 * 1024 + 1)}\n" +
                 "    return {\"statusCode\": 200, \"body\": \"ok\"}\n"
             ).getBytes(StandardCharsets.UTF_8));
             zos.closeEntry();
@@ -259,13 +260,14 @@ class ElbV2LambdaTargetDataPlaneIntegrationTest {
     @Test
     @Order(9)
     void oversizedLambdaResponseIsRejected() {
-        given()
+        Response response = given()
                 .baseUri("http://" + lbDnsName)
                 .port(LISTENER_PORT)
             .when()
-                .get("/response-oversized")
-            .then()
-                .statusCode(460);
+                .get("/response-oversized");
+
+        response.then().statusCode(460);
+        assertNotEquals("1048577", response.getHeader("Content-Length"));
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2PreserveHostHeaderIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2PreserveHostHeaderIntegrationTest.java
@@ -12,6 +12,13 @@ import io.vertx.core.http.RequestOptions;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -85,6 +92,79 @@ class ElbV2PreserveHostHeaderIntegrationTest {
             deleteLoadBalancer(loadBalancerArn);
             backend.close().toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
         }
+    }
+
+    @Test
+    void drainsRequestWhenTargetConnectionFails() throws Exception {
+        HttpServer backend = vertx.createHttpServer()
+                .requestHandler(request -> request.response().end("healthy"))
+                .listen(0, "127.0.0.1")
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+
+        String loadBalancerArn = null;
+        String targetGroupArn = null;
+        String listenerArn = null;
+        int failedPort;
+        try (ServerSocket reservation = new ServerSocket(0)) {
+            failedPort = reservation.getLocalPort();
+        }
+        try {
+            loadBalancerArn = createLoadBalancer();
+            targetGroupArn = createTargetGroup(backend.actualPort());
+            registerTargets(targetGroupArn, failedPort, backend.actualPort());
+            listenerArn = createListener(loadBalancerArn, targetGroupArn);
+
+            String host = loadBalancerDnsName(loadBalancerArn);
+            try (Socket socket = new Socket("127.0.0.1", LISTENER_PORT)) {
+                socket.setSoTimeout(2_000);
+                OutputStream output = socket.getOutputStream();
+                output.write(("POST /failed HTTP/1.1\r\n"
+                        + "Host: " + host + "\r\n"
+                        + "Content-Length: 11\r\n"
+                        + "Connection: keep-alive\r\n\r\n"
+                        + "hello world").getBytes(StandardCharsets.ISO_8859_1));
+                output.flush();
+
+                BufferedReader input = new BufferedReader(
+                        new InputStreamReader(socket.getInputStream(), StandardCharsets.ISO_8859_1));
+                assertEquals(503, readStatus(input));
+
+                output.write(("GET /healthy HTTP/1.1\r\n"
+                        + "Host: " + host + "\r\n"
+                        + "Connection: close\r\n\r\n").getBytes(StandardCharsets.ISO_8859_1));
+                output.flush();
+
+                assertEquals(200, readStatus(input));
+            }
+        } finally {
+            deleteListener(listenerArn);
+            deleteTargetGroup(targetGroupArn);
+            deleteLoadBalancer(loadBalancerArn);
+            backend.close().toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
+        }
+    }
+
+    private static int readStatus(BufferedReader input) throws IOException {
+        String statusLine = input.readLine();
+        if (statusLine == null) {
+            throw new IOException("Response ended before the status line");
+        }
+        int contentLength = 0;
+        String header;
+        while (!(header = input.readLine()).isEmpty()) {
+            int separator = header.indexOf(':');
+            if (separator > 0 && "content-length".equalsIgnoreCase(header.substring(0, separator))) {
+                contentLength = Integer.parseInt(header.substring(separator + 1).trim());
+            }
+        }
+        for (int i = 0; i < contentLength; i++) {
+            if (input.read() == -1) {
+                throw new IOException("Response ended before the body");
+            }
+        }
+        return Integer.parseInt(statusLine.split(" ", 3)[1]);
     }
 
     private void assertStreamsRequestAndResponse(String loadBalancerArn) throws Exception {
@@ -162,6 +242,21 @@ class ElbV2PreserveHostHeaderIntegrationTest {
                 .formParam("TargetGroupArn", targetGroupArn)
                 .formParam("Targets.member.1.Id", "127.0.0.1")
                 .formParam("Targets.member.1.Port", backendPort)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+    }
+
+    private static void registerTargets(String targetGroupArn, int failedPort, int backendPort) {
+        given()
+                .formParam("Action", "RegisterTargets")
+                .formParam("TargetGroupArn", targetGroupArn)
+                .formParam("Targets.member.1.Id", "127.0.0.1")
+                .formParam("Targets.member.1.Port", failedPort)
+                .formParam("Targets.member.2.Id", "127.0.0.1")
+                .formParam("Targets.member.2.Port", backendPort)
                 .header("Authorization", AUTH)
             .when()
                 .post("/")

--- a/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2PreserveHostHeaderIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elbv2/ElbV2PreserveHostHeaderIntegrationTest.java
@@ -3,19 +3,25 @@ package io.github.hectorvent.floci.services.elbv2;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpServer;
+import io.vertx.core.http.RequestOptions;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @QuarkusTest
 @TestProfile(ElbV2PreserveHostHeaderIntegrationTest.RealElbV2DataPlaneProfile.class)
@@ -39,7 +45,20 @@ class ElbV2PreserveHostHeaderIntegrationTest {
     @Test
     void preservesHostHeaderWhenLoadBalancerAttributeIsEnabled() throws Exception {
         HttpServer backend = vertx.createHttpServer()
-                .requestHandler(request -> request.response().end(request.getHeader("Host")))
+                .requestHandler(request -> {
+                    if ("/stream".equals(request.path())) {
+                        request.body().onSuccess(body -> {
+                            request.response()
+                                    .putHeader("X-Received-Content-Length",
+                                            String.valueOf(request.getHeader("Content-Length")))
+                                    .setChunked(true);
+                            request.response().write("stream-");
+                            request.response().end(body.toString());
+                        });
+                    } else {
+                        request.response().end(request.getHeader("Host"));
+                    }
+                })
                 .listen(0, "127.0.0.1")
                 .toCompletionStage()
                 .toCompletableFuture()
@@ -54,6 +73,7 @@ class ElbV2PreserveHostHeaderIntegrationTest {
             registerTarget(targetGroupArn, backend.actualPort());
             listenerArn = createListener(loadBalancerArn, targetGroupArn);
 
+            assertStreamsRequestAndResponse(loadBalancerArn);
             assertForwardedHost("127.0.0.1:" + backend.actualPort());
 
             enableHostHeaderPreservation(loadBalancerArn);
@@ -65,6 +85,31 @@ class ElbV2PreserveHostHeaderIntegrationTest {
             deleteLoadBalancer(loadBalancerArn);
             backend.close().toCompletionStage().toCompletableFuture().get(2, TimeUnit.SECONDS);
         }
+    }
+
+    private void assertStreamsRequestAndResponse(String loadBalancerArn) throws Exception {
+        HttpClientRequest request = vertx.createHttpClient()
+                .request(new RequestOptions()
+                        .setHost(loadBalancerDnsName(loadBalancerArn))
+                        .setPort(LISTENER_PORT)
+                        .setMethod(io.vertx.core.http.HttpMethod.POST)
+                        .setURI("/stream"))
+                .toCompletionStage()
+                .toCompletableFuture()
+                .get(2, TimeUnit.SECONDS);
+        CompletableFuture<Buffer> bodyFuture = new CompletableFuture<>();
+        CompletableFuture<HttpClientResponse> responseFuture = request.response()
+                .onSuccess(response -> response.bodyHandler(bodyFuture::complete))
+                .toCompletionStage()
+                .toCompletableFuture();
+        request.putHeader("Content-Length", "11");
+        request.write(Buffer.buffer("hello "));
+        request.end(Buffer.buffer("world"));
+
+        HttpClientResponse response = responseFuture.get(2, TimeUnit.SECONDS);
+        assertEquals(200, response.statusCode());
+        assertEquals("11", response.getHeader("X-Received-Content-Length"));
+        assertEquals("stream-hello world", bodyFuture.get(2, TimeUnit.SECONDS).toString());
     }
 
     private static String createLoadBalancer() {
@@ -79,6 +124,19 @@ class ElbV2PreserveHostHeaderIntegrationTest {
                 .statusCode(200)
                 .extract()
                 .path("CreateLoadBalancerResponse.CreateLoadBalancerResult.LoadBalancers.member.LoadBalancerArn");
+    }
+
+    private static String loadBalancerDnsName(String loadBalancerArn) {
+        return given()
+                .formParam("Action", "DescribeLoadBalancers")
+                .formParam("LoadBalancerArns.member.1", loadBalancerArn)
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .extract()
+                .path("DescribeLoadBalancersResponse.DescribeLoadBalancersResult.LoadBalancers.member.DNSName");
     }
 
     private static String createTargetGroup(int backendPort) {


### PR DESCRIPTION
## Summary

Enforce the AWS 1 MiB body limit for ELBv2 Lambda targets without invoking Lambda for oversized requests. Preserve known Content-Length values for ordinary targets and stream unknown-length traffic.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Oversized Lambda request bodies return HTTP 413 before invocation. Oversized Lambda response bodies return HTTP 502, matching AWS behavior. Bodies at exactly 1 MiB are accepted. Ordinary target requests retain a known Content-Length and unknown-length responses remain streamed.

Focused integration tests cover the exact limit, overflow behavior, Lambda invocation count, response header handling, and multi-chunk streaming.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)