### PR TITLE
feat(iot): MQTT over WebSocket at /mqtt

### DIFF
--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -134,6 +134,23 @@ services:
 
 The value is a hostname or `host:port`, never a URL, and is returned as is for every endpoint type: AWS hands out one hostname per type (`iot:Data-ATS`, `iot:Data`, `iot:Jobs`, `iot:CredentialProvider`), Floci answers all four with this one. The name is added to the generated server certificate, like `FLOCI_HOSTNAME`, so devices verify it on 8883 and 443; a name under `localhost.floci.io` resolves to `127.0.0.1` on its own, any other needs a DNS or `/etc/hosts` entry. Floci does not detect published ports itself: unset, or set to an empty value, `DescribeEndpoint` keeps returning `host:4566`, so the plain `-p 4566:4566` setup keeps working for IoT Data clients.
 
+### MQTT over WebSocket
+
+The broker is also reachable as MQTT over WebSocket at `/mqtt` on Floci's HTTP and HTTPS ports
+(`ws://<host>:4566/mqtt`, `wss://<host>:4566/mqtt`), the path AWS IoT serves on 443 for browser
+clients, the AWS IoT Device SDK's WebSocket transport and secure tunnelling. With the `443:443`
+mapping above (or `443:4566`) the AWS URL `wss://<endpoint>:443/mqtt` works unchanged. The handshake echoes
+the `mqtt` subprotocol and uses the same certificate as HTTPS, so hostnames learned at runtime
+apply to it too. Frames are piped to the plaintext MQTT listener, so every broker feature behaves
+the same on both transports. There is no separate port or setting for it; disabling the broker
+(`FLOCI_SERVICES_IOT_MQTT_ENABLED=false`) makes `/mqtt` answer 503 to an upgrade, and a plain
+request to `/mqtt` gets the usual 404.
+
+No client certificate is requested on this path. On AWS it authenticates by SigV4 (signed query
+string on the upgrade URL) or by a custom authorizer (`<clientId>?x-amz-customauthorizer-name=<name>`
+as the MQTT username with a token as the password); Floci accepts such a CONNECT as is and does
+not evaluate the signature or the authorizer yet.
+
 ## Reserved Topics
 
 AWS IoT reserved topics such as `$aws/things/{thingName}/shadow/update` are service control topics, not ordinary application topics. Floci should handle these publishes by invoking IoT shadow behavior and then publishing the AWS-compatible response topics through the broker.

--- a/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/HttpOptionsCustomizer.java
@@ -4,6 +4,8 @@ import io.quarkus.vertx.http.HttpServerOptionsCustomizer;
 import io.vertx.core.http.HttpServerOptions;
 import jakarta.enterprise.context.ApplicationScoped;
 
+import java.util.List;
+
 /**
  * Customizes Vert.x HTTP server options for Floci's requirements.
  *
@@ -19,6 +21,8 @@ import jakarta.enterprise.context.ApplicationScoped;
  *       defaults to 64 KB per frame, which causes Netty to silently reject larger
  *       frames before the application-level size check in
  *       {@code WebSocketHandler} can fire.</li>
+ *   <li>Echoes the MQTT WebSocket subprotocol names, so MQTT over WebSocket clients
+ *       complete their handshake on {@code /mqtt}.</li>
  * </ul>
  *
  * The overall request body size is still bounded by
@@ -41,17 +45,29 @@ public class HttpOptionsCustomizer implements HttpServerOptionsCustomizer {
      */
     private static final int MAX_WS_MESSAGE_SIZE = 256 * 1024;
 
+    /**
+     * Subprotocol names an MQTT over WebSocket client offers in {@code Sec-WebSocket-Protocol}
+     * (AWS IoT documents {@code mqtt}; the others are the names Vert.x MQTT accepts). Vert.x only
+     * echoes a name from this list, and Paho and the AWS Device SDKs refuse a handshake whose
+     * response does not echo one. Netty completes a handshake that asks for any other name without
+     * the header, so API Gateway WebSocket clients are unaffected.
+     */
+    static final List<String> MQTT_WEBSOCKET_SUBPROTOCOLS = List.of("mqtt", "mqttv3.1", "mqttv3.1.1");
+
     @Override
     public void customizeHttpServer(HttpServerOptions options) {
-        options.setMaxFormAttributeSize(-1);
-        options.setMaxWebSocketFrameSize(MAX_WS_FRAME_SIZE);
-        options.setMaxWebSocketMessageSize(MAX_WS_MESSAGE_SIZE);
+        customize(options);
     }
 
     @Override
     public void customizeHttpsServer(HttpServerOptions options) {
+        customize(options);
+    }
+
+    private static void customize(HttpServerOptions options) {
         options.setMaxFormAttributeSize(-1);
         options.setMaxWebSocketFrameSize(MAX_WS_FRAME_SIZE);
         options.setMaxWebSocketMessageSize(MAX_WS_MESSAGE_SIZE);
+        options.setWebSocketSubProtocols(MQTT_WEBSOCKET_SUBPROTOCOLS);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketBridge.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketBridge.java
@@ -1,0 +1,138 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.ServerWebSocket;
+import io.vertx.core.net.NetClient;
+import io.vertx.core.net.NetSocket;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+/**
+ * Serves MQTT over WebSocket at {@code /mqtt} on the HTTP and HTTPS ports, the path and port AWS
+ * IoT uses for browser clients, the Device SDK's WebSocket transport and secure tunnelling. Frames
+ * are piped byte for byte to the broker's plaintext listener, so every broker feature and every
+ * authorization rule applies without a second code path. No client certificate is involved: on
+ * AWS this path authenticates by SigV4 or a custom authorizer, and the broker stays permissive
+ * for it.
+ *
+ * <p>Everything for one session runs on the event loop of the WebSocket's connection, the
+ * broker socket included, so the handlers below never race each other.
+ */
+@ApplicationScoped
+public class IotMqttWebSocketBridge {
+
+    static final String PATH = "/mqtt";
+    private static final Logger LOG = Logger.getLogger(IotMqttWebSocketBridge.class);
+    private static final short CLOSE_UNSUPPORTED_DATA = 1003;
+    private static final short CLOSE_INTERNAL_ERROR = 1011;
+
+    private final EmulatorConfig config;
+    private final Vertx vertx;
+    private final NetClient client;
+    private final IotMqttBrokerService broker;
+
+    @Inject
+    public IotMqttWebSocketBridge(EmulatorConfig config, Vertx vertx, IotMqttBrokerService broker) {
+        this.config = config;
+        this.vertx = vertx;
+        this.client = vertx.createNetClient();
+        this.broker = broker;
+    }
+
+    void init(@Observes Router router) {
+        router.route(PATH).handler(this::upgrade);
+    }
+
+    private void upgrade(RoutingContext ctx) {
+        if (!"websocket".equalsIgnoreCase(ctx.request().getHeader("Upgrade"))) {
+            ctx.next();
+            return;
+        }
+        vertx.executeBlocking(() -> {
+            broker.startIfEnabled();
+            return broker.isRunning();
+        }).onSuccess(running -> {
+            if (!running) {
+                ctx.response().setStatusCode(503).end();
+                return;
+            }
+            ctx.request().toWebSocket()
+                    .onSuccess(this::pipeToBroker)
+                    .onFailure(error -> rejectUpgrade(ctx, error));
+        }).onFailure(error -> {
+            LOG.warnv("MQTT WebSocket upgrade refused, the broker did not start: {0}", error.getMessage());
+            ctx.response().setStatusCode(503).end();
+        });
+    }
+
+    private static void rejectUpgrade(RoutingContext ctx, Throwable error) {
+        LOG.debugv("MQTT WebSocket upgrade failed: {0}", error.getMessage());
+        if (!ctx.response().ended()) {
+            ctx.response().setStatusCode(400).end();
+        }
+    }
+
+    private void pipeToBroker(ServerWebSocket ws) {
+        ws.pause();
+        int port = config.services().iot().mqtt().port();
+        String host = brokerHost();
+        client.connect(port, host)
+                .onSuccess(socket -> {
+                    if (ws.isClosed()) {
+                        socket.close();
+                        return;
+                    }
+                    wire(ws, socket);
+                    ws.resume();
+                })
+                .onFailure(error -> {
+                    LOG.warnv("MQTT WebSocket bridge could not reach the broker on {0}:{1}: {2}",
+                            host, port, error.getMessage());
+                    ws.close(CLOSE_INTERNAL_ERROR, "MQTT broker unavailable");
+                });
+    }
+
+    private static void wire(ServerWebSocket ws, NetSocket socket) {
+        ws.frameHandler(frame -> {
+            if (frame.isText()) {
+                ws.close(CLOSE_UNSUPPORTED_DATA, "MQTT over WebSocket is binary");
+            }
+        });
+        ws.handler(bytes -> {
+            if (ws.isClosed()) {
+                return;
+            }
+            socket.write(bytes);
+            if (socket.writeQueueFull()) {
+                ws.pause();
+                socket.drainHandler(ignored -> ws.resume());
+            }
+        });
+        ws.closeHandler(ignored -> socket.close());
+        ws.exceptionHandler(error -> socket.close());
+
+        socket.handler(bytes -> {
+            if (ws.isClosed()) {
+                return;
+            }
+            ws.writeBinaryMessage(bytes);
+            if (ws.writeQueueFull()) {
+                socket.pause();
+                ws.drainHandler(ignored -> socket.resume());
+            }
+        });
+        socket.closeHandler(ignored -> ws.close());
+        socket.exceptionHandler(error -> ws.close(CLOSE_INTERNAL_ERROR, "MQTT broker connection failed"));
+    }
+
+    /** The broker binds {@code 0.0.0.0} by default, which is not a connect target; loopback is. */
+    private String brokerHost() {
+        String host = config.services().iot().mqtt().host();
+        return "0.0.0.0".equals(host) ? "127.0.0.1" : host;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketBridge.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketBridge.java
@@ -102,15 +102,17 @@ public class IotMqttWebSocketBridge {
 
     private static void wire(ServerWebSocket ws, NetSocket socket) {
         ws.frameHandler(frame -> {
-            if (frame.isText()) {
-                ws.close(CLOSE_UNSUPPORTED_DATA, "MQTT over WebSocket is binary");
-            }
-        });
-        ws.handler(bytes -> {
             if (ws.isClosed()) {
                 return;
             }
-            socket.write(bytes);
+            if (frame.isText()) {
+                ws.close(CLOSE_UNSUPPORTED_DATA, "MQTT over WebSocket is binary");
+                return;
+            }
+            if (!frame.isBinary() && !frame.isContinuation()) {
+                return;
+            }
+            socket.write(frame.binaryData());
             if (socket.writeQueueFull()) {
                 ws.pause();
                 socket.drainHandler(ignored -> ws.resume());

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketBridge.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketBridge.java
@@ -53,10 +53,13 @@ public class IotMqttWebSocketBridge {
             ctx.next();
             return;
         }
+        // startIfEnabled blocks on the listen, and ordered blocking tasks queue behind every other
+        // blocking task of this event loop (a Lambda invocation, say); the start is idempotent and
+        // synchronized, so the handshake need not wait its turn.
         vertx.executeBlocking(() -> {
             broker.startIfEnabled();
             return broker.isRunning();
-        }).onSuccess(running -> {
+        }, false).onSuccess(running -> {
             if (!running) {
                 ctx.response().setStatusCode(503).end();
                 return;

--- a/src/test/java/io/github/hectorvent/floci/config/IotMqttWebSocketProxyIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/IotMqttWebSocketProxyIntegrationTest.java
@@ -1,0 +1,250 @@
+package io.github.hectorvent.floci.config;
+
+import io.github.hectorvent.floci.services.iot.IotMqttWebSocketIntegrationTest;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.Vertx;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SSLHandshakeException;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocket;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The deployment claims behind {@code wss://<endpoint>:443/mqtt}: in production one port fronts
+ * both Quarkus servers through {@link TlsProxyServer}, which sniffs the first byte, and a custom
+ * domain learned at runtime is served by the same HTTPS listener. Neither is proven by tests that
+ * dial the Quarkus test ports directly.
+ */
+@QuarkusTest
+@TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
+class IotMqttWebSocketProxyIntegrationTest {
+
+    static final String LEARNED_HOST = "iot.example.localhost.floci.io";
+    private static final byte[] CONNACK_ACCEPTED = {0x20, 0x02, 0x00, 0x00};
+
+    @ConfigProperty(name = "quarkus.http.test-ssl-port", defaultValue = "0")
+    int testSslPort;
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
+    int testHttpPort;
+
+    @Inject
+    Vertx vertx;
+
+    @Inject
+    TlsCertificateManager certificateManager;
+
+    private TlsProxyServer proxy;
+
+    @AfterEach
+    void stopProxy() {
+        if (proxy != null) {
+            proxy.stop();
+        }
+    }
+
+    @Test
+    void wssAndWsShareOnePortThroughTheTlsProxy() throws Exception {
+        int publicPort = startProxy();
+        String topic = "proxy/" + System.nanoTime();
+        byte[] payload = "through the proxy".getBytes(StandardCharsets.UTF_8);
+
+        try (PahoClient subscriber = PahoClient.connect("wss://127.0.0.1:" + publicPort + "/mqtt", "proxy-wss-" + System.nanoTime())) {
+            subscriber.client.subscribe(topic, 1);
+            try (PahoClient publisher = PahoClient.connect("ws://127.0.0.1:" + publicPort + "/mqtt", "proxy-ws-" + System.nanoTime())) {
+                publisher.client.publish(topic, payload, 1, false);
+            }
+            assertArrayEquals(payload, subscriber.take(), "a TLS ClientHello and a plain GET on the same port both reach /mqtt");
+        }
+    }
+
+    @Test
+    void learnedHostnameServesMqttOverWssOnceEnsureHostRan() throws Exception {
+        assertThrows(SSLHandshakeException.class, () -> upgradeAs(LEARNED_HOST),
+                "precondition: the boot leaf covers one label under localhost.floci.io, not two");
+
+        certificateManager.ensureHost(LEARNED_HOST);
+
+        assertArrayEquals(CONNACK_ACCEPTED, upgradeAs(LEARNED_HOST),
+                "after ensureHost a client verifying the learned name gets an MQTT session on /mqtt");
+    }
+
+    private int startProxy() throws Exception {
+        int publicPort;
+        try (ServerSocket probe = new ServerSocket(0)) {
+            publicPort = probe.getLocalPort();
+        }
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.TlsConfig tls = mock(EmulatorConfig.TlsConfig.class);
+        when(config.port()).thenReturn(publicPort);
+        when(config.tls()).thenReturn(tls);
+        when(tls.enabled()).thenReturn(true);
+        when(tls.awsHttpsPort()).thenReturn(0);
+        proxy = new TlsProxyServer(vertx, config, testHttpPort, testSslPort);
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (true) {
+            try (Socket probe = new Socket("127.0.0.1", publicPort)) {
+                return publicPort;
+            } catch (IOException notYet) {
+                assertTrue(System.nanoTime() < deadline, "the proxy never bound " + publicPort);
+                Thread.sleep(50);
+            }
+        }
+    }
+
+    /**
+     * Dials 127.0.0.1 the way a client that resolved {@code host} would: the TLS layer is given the
+     * name, so SNI and HTTPS endpoint identification apply to it, trusting only the Floci CA. Then a hand-written upgrade with
+     * that Host, one masked binary frame carrying an MQTT CONNECT, and the CONNACK frame back.
+     */
+    private byte[] upgradeAs(String host) throws Exception {
+        Socket plain = new Socket();
+        plain.connect(new InetSocketAddress("127.0.0.1", testSslPort), 5000);
+        try (SSLSocket socket = (SSLSocket) IotMqttWebSocketIntegrationTest.trustOnlyFlociCa().getSocketFactory()
+                .createSocket(plain, host, testSslPort, true)) {
+            socket.setSoTimeout(10_000);
+            SSLParameters parameters = socket.getSSLParameters();
+            parameters.setServerNames(List.of(new SNIHostName(host)));
+            parameters.setEndpointIdentificationAlgorithm("HTTPS");
+            socket.setSSLParameters(parameters);
+            socket.startHandshake();
+
+            OutputStream out = socket.getOutputStream();
+            out.write(("GET /mqtt HTTP/1.1\r\nHost: " + host + ":" + testSslPort + "\r\nUpgrade: websocket\r\n"
+                    + "Connection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n"
+                    + "Sec-WebSocket-Protocol: mqtt\r\n\r\n").getBytes(StandardCharsets.US_ASCII));
+            out.flush();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+            String status = reader.readLine();
+            assertNotNull(status);
+            assertTrue(status.startsWith("HTTP/1.1 101"), status);
+            boolean echoed = false;
+            for (String line = reader.readLine(); line != null && !line.isEmpty(); line = reader.readLine()) {
+                echoed |= line.equalsIgnoreCase("sec-websocket-protocol: mqtt");
+            }
+            assertTrue(echoed, "the learned host echoes the mqtt subprotocol");
+
+            out.write(maskedBinaryFrame(connectPacket("learned-" + System.nanoTime())));
+            out.flush();
+            return readBinaryFramePayload(socket.getInputStream());
+        }
+    }
+
+    private static byte[] connectPacket(String clientId) {
+        byte[] id = clientId.getBytes(StandardCharsets.UTF_8);
+        byte[] variable = new byte[10 + 2 + id.length];
+        System.arraycopy(new byte[] {0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C}, 0, variable, 0, 10);
+        variable[10] = (byte) (id.length >> 8);
+        variable[11] = (byte) id.length;
+        System.arraycopy(id, 0, variable, 12, id.length);
+        byte[] packet = new byte[2 + variable.length];
+        packet[0] = 0x10;
+        packet[1] = (byte) variable.length;
+        System.arraycopy(variable, 0, packet, 2, variable.length);
+        return packet;
+    }
+
+    /** RFC 6455 client frames are masked; payloads here are under 126 bytes. */
+    private static byte[] maskedBinaryFrame(byte[] payload) {
+        byte[] mask = {0x12, 0x34, 0x56, 0x78};
+        byte[] frame = new byte[6 + payload.length];
+        frame[0] = (byte) 0x82;
+        frame[1] = (byte) (0x80 | payload.length);
+        System.arraycopy(mask, 0, frame, 2, 4);
+        for (int i = 0; i < payload.length; i++) {
+            frame[6 + i] = (byte) (payload[i] ^ mask[i % 4]);
+        }
+        return frame;
+    }
+
+    private static byte[] readBinaryFramePayload(InputStream in) throws IOException {
+        int first = in.read();
+        int second = in.read();
+        assertEquals(0x82, first, "a final binary frame");
+        int length = second & 0x7F;
+        byte[] payload = in.readNBytes(length);
+        assertEquals(length, payload.length);
+        return payload;
+    }
+
+    private static final class PahoClient implements AutoCloseable {
+        final MqttClient client;
+        private final BlockingQueue<byte[]> payloads = new LinkedBlockingQueue<>();
+
+        private PahoClient(MqttClient client) {
+            this.client = client;
+        }
+
+        static PahoClient connect(String url, String clientId) throws Exception {
+            MqttClient client = new MqttClient(url, clientId, new MemoryPersistence());
+            PahoClient paho = new PahoClient(client);
+            client.setCallback(new MqttCallback() {
+                @Override
+                public void connectionLost(Throwable cause) {
+                }
+
+                @Override
+                public void messageArrived(String topic, MqttMessage message) {
+                    paho.payloads.add(message.getPayload());
+                }
+
+                @Override
+                public void deliveryComplete(IMqttDeliveryToken token) {
+                }
+            });
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setConnectionTimeout(10);
+            if (url.startsWith("wss://")) {
+                options.setSocketFactory(IotMqttWebSocketIntegrationTest.trustOnlyFlociCa().getSocketFactory());
+            }
+            client.connect(options);
+            return paho;
+        }
+
+        byte[] take() throws InterruptedException {
+            byte[] payload = payloads.poll(10, TimeUnit.SECONDS);
+            assertNotNull(payload, "no publish received within 10s");
+            return payload;
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (client.isConnected()) {
+                client.disconnect();
+            }
+            client.close();
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttDisabledIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttDisabledIntegrationTest.java
@@ -3,12 +3,21 @@ package io.github.hectorvent.floci.services.iot;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @QuarkusTest
@@ -17,6 +26,9 @@ class IotMqttDisabledIntegrationTest {
 
     private static final int PORT = 18830;
 
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
+    int testHttpPort;
+
     @Test
     void disabledMqttDoesNotOpenConfiguredPort() {
         assertThrows(Exception.class, () -> {
@@ -24,6 +36,17 @@ class IotMqttDisabledIntegrationTest {
                 socket.connect(new InetSocketAddress("127.0.0.1", PORT), 250);
             }
         });
+    }
+
+    @Test
+    void disabledMqttRefusesTheWebSocketUpgrade() {
+        ExecutionException failure = assertThrows(ExecutionException.class, () -> HttpClient.newHttpClient()
+                .newWebSocketBuilder()
+                .subprotocols("mqtt")
+                .buildAsync(URI.create("ws://127.0.0.1:" + testHttpPort + "/mqtt"), new WebSocket.Listener() { })
+                .get(10, TimeUnit.SECONDS));
+        WebSocketHandshakeException handshake = assertInstanceOf(WebSocketHandshakeException.class, failure.getCause());
+        assertEquals(503, handshake.getResponse().statusCode());
     }
 
     public static final class DisabledMqttProfile implements QuarkusTestProfile {

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketContractIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketContractIntegrationTest.java
@@ -15,6 +15,7 @@ import org.eclipse.paho.mqttv5.client.MqttCallback;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -54,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
 class IotMqttWebSocketContractIntegrationTest {
 
+    private static final Logger LOG = Logger.getLogger(IotMqttWebSocketContractIntegrationTest.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final int PLAIN_PORT = IotMqttWebSocketIntegrationTest.PLAIN_PORT;
     @ConfigProperty(name = "quarkus.http.test-ssl-port", defaultValue = "0")
@@ -243,8 +245,8 @@ class IotMqttWebSocketContractIntegrationTest {
             message.setQos(2);
             try {
                 client.client.publish("contract/qos2/" + System.nanoTime(), message);
-            } catch (MqttException expected) {
-                // Paho may report the drop while waiting for PUBREC; the assertion below is the contract.
+            } catch (MqttException dropWhileWaitingForPubrec) {
+                LOG.debugv("QoS 2 publish reported the disconnect: {0}", dropWhileWaitingForPubrec.getMessage());
             }
             assertTrue(client.lost.await(10, TimeUnit.SECONDS), "AWS IoT disconnects a client that publishes QoS 2");
         }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketContractIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketContractIntegrationTest.java
@@ -113,6 +113,33 @@ class IotMqttWebSocketContractIntegrationTest {
     }
 
     @Test
+    void unrelatedSubprotocolOnAnotherPathStillConnects() throws Exception {
+        String apiId = given()
+                .contentType("application/json")
+                .body("{\"name\":\"ws-subprotocol-probe\",\"protocolType\":\"WEBSOCKET\",\"routeSelectionExpression\":\"$request.body.action\"}")
+        .when()
+                .post("/v2/apis")
+        .then()
+                .statusCode(201)
+                .extract().path("apiId");
+        given()
+                .contentType("application/json")
+                .body("{\"stageName\":\"probe\"}")
+        .when()
+                .post("/v2/apis/" + apiId + "/stages")
+        .then()
+                .statusCode(201);
+
+        WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                .subprotocols("graphql-ws")
+                .buildAsync(URI.create("ws://127.0.0.1:" + testHttpPort + "/ws/" + apiId + "/probe"), new WebSocket.Listener() { })
+                .get(10, TimeUnit.SECONDS);
+
+        assertEquals("", socket.getSubprotocol(), "the server lists only MQTT names, so it echoes none and still upgrades");
+        socket.abort();
+    }
+
+    @Test
     void webSocketPingIsAnsweredWithPong() throws Exception {
         CompletableFuture<byte[]> pong = new CompletableFuture<>();
         WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketContractIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketContractIntegrationTest.java
@@ -1,0 +1,448 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttCallback;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The AWS IoT contract for {@code /mqtt} at two levels. The handshake: only a GET with WebSocket
+ * version 13 upgrades, the offered subprotocol is echoed, control frames work. The session: once
+ * the bytes reach the broker it behaves as on AWS (client id takeover, retained messages, QoS 2
+ * refused, shadow topics, rules, MQTT 5), whichever transport the peer uses. Frame boundaries are
+ * covered by {@link IotMqttWebSocketFramingIntegrationTest}.
+ */
+@QuarkusTest
+@TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
+class IotMqttWebSocketContractIntegrationTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final int PLAIN_PORT = IotMqttWebSocketIntegrationTest.PLAIN_PORT;
+    @ConfigProperty(name = "quarkus.http.test-ssl-port", defaultValue = "0")
+    int testSslPort;
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
+    int testHttpPort;
+
+    // ==================== Handshake ====================
+
+    @Test
+    void onlyGetUpgrades() throws Exception {
+        assertEquals(405, rawUpgradeStatus("POST", "13"));
+    }
+
+    @Test
+    void unsupportedWebSocketVersionIsUpgradeRequired() throws Exception {
+        assertEquals(426, rawUpgradeStatus("GET", "99"));
+    }
+
+    @Test
+    void nonUpgradeRequestsFallThroughToTheRestOfTheServer() throws Exception {
+        HttpClient http = HttpClient.newHttpClient();
+        for (String method : List.of("POST", "PUT", "DELETE", "HEAD")) {
+            HttpResponse<String> response = http.send(
+                    HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + testHttpPort + "/mqtt"))
+                            .method(method, HttpRequest.BodyPublishers.noBody())
+                            .build(),
+                    HttpResponse.BodyHandlers.ofString());
+            assertNotEquals(101, response.statusCode(), method);
+            assertTrue(response.statusCode() < 500, method + " answered " + response.statusCode());
+        }
+    }
+
+    @Test
+    void eachMqttSubprotocolNameIsEchoed() throws Exception {
+        for (String name : List.of("mqtt", "mqttv3.1", "mqttv3.1.1")) {
+            WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                    .subprotocols(name)
+                    .buildAsync(URI.create(ws()), new WebSocket.Listener() { })
+                    .get(10, TimeUnit.SECONDS);
+            assertEquals(name, socket.getSubprotocol());
+            socket.abort();
+        }
+    }
+
+    @Test
+    void firstOfferedSupportedSubprotocolWins() throws Exception {
+        WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                .subprotocols("graphql-ws", "mqttv3.1.1", "mqtt")
+                .buildAsync(URI.create(ws()), new WebSocket.Listener() { })
+                .get(10, TimeUnit.SECONDS);
+        assertEquals("mqttv3.1.1", socket.getSubprotocol());
+        socket.abort();
+    }
+
+    @Test
+    void webSocketPingIsAnsweredWithPong() throws Exception {
+        CompletableFuture<byte[]> pong = new CompletableFuture<>();
+        WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                .subprotocols("mqtt")
+                .buildAsync(URI.create(ws()), new WebSocket.Listener() {
+                    @Override
+                    public CompletionStage<?> onPong(WebSocket webSocket, ByteBuffer message) {
+                        byte[] bytes = new byte[message.remaining()];
+                        message.get(bytes);
+                        pong.complete(bytes);
+                        return null;
+                    }
+                })
+                .get(10, TimeUnit.SECONDS);
+        byte[] probe = "keepalive".getBytes(StandardCharsets.UTF_8);
+
+        socket.sendPing(ByteBuffer.wrap(probe)).get(10, TimeUnit.SECONDS);
+
+        assertArrayEquals(probe, pong.get(10, TimeUnit.SECONDS));
+        socket.abort();
+    }
+
+    // ==================== Broker semantics over the bridge ====================
+
+    @Test
+    void mqtt5ClientWorksOverWss() throws Exception {
+        String topic = "contract/mqtt5/" + System.nanoTime();
+        byte[] payload = "mqtt5 over wss".getBytes(StandardCharsets.UTF_8);
+        BlockingQueue<byte[]> received = new LinkedBlockingQueue<>();
+
+        org.eclipse.paho.mqttv5.client.MqttClient client = new org.eclipse.paho.mqttv5.client.MqttClient(
+                wss(), "ws-v5-" + System.nanoTime(), null);
+        client.setCallback(new MqttCallback() {
+            @Override
+            public void disconnected(MqttDisconnectResponse disconnectResponse) {
+            }
+
+            @Override
+            public void mqttErrorOccurred(org.eclipse.paho.mqttv5.common.MqttException exception) {
+            }
+
+            @Override
+            public void messageArrived(String topic, org.eclipse.paho.mqttv5.common.MqttMessage message) {
+                received.add(message.getPayload());
+            }
+
+            @Override
+            public void deliveryComplete(IMqttToken token) {
+            }
+
+            @Override
+            public void connectComplete(boolean reconnect, String serverURI) {
+            }
+
+            @Override
+            public void authPacketArrived(int reasonCode, MqttProperties properties) {
+            }
+        });
+        MqttConnectionOptions options = new MqttConnectionOptions();
+        options.setSocketFactory(IotMqttWebSocketIntegrationTest.trustOnlyFlociCa().getSocketFactory());
+        client.connect(options);
+        try {
+            assertTrue(client.isConnected());
+            client.subscribe(topic, 1);
+            client.publish(topic, payload, 1, false);
+            byte[] delivered = received.poll(10, TimeUnit.SECONDS);
+            assertNotNull(delivered, "no MQTT 5 publish received within 10s");
+            assertArrayEquals(payload, delivered);
+        } finally {
+            client.disconnect();
+            client.close();
+        }
+    }
+
+    @Test
+    void sameClientIdOverWebSocketTakesOverTheTcpSession() throws Exception {
+        String clientId = "takeover-" + System.nanoTime();
+        CountDownLatch tcpLost = new CountDownLatch(1);
+        MqttClient tcp = new MqttClient("tcp://127.0.0.1:" + PLAIN_PORT, clientId, new MemoryPersistence());
+        tcp.setCallback(new org.eclipse.paho.client.mqttv3.MqttCallback() {
+            @Override
+            public void connectionLost(Throwable cause) {
+                tcpLost.countDown();
+            }
+
+            @Override
+            public void messageArrived(String topic, MqttMessage message) {
+            }
+
+            @Override
+            public void deliveryComplete(org.eclipse.paho.client.mqttv3.IMqttDeliveryToken token) {
+            }
+        });
+        tcp.connect();
+        try {
+            MqttClient ws = new MqttClient(ws(), clientId, new MemoryPersistence());
+            ws.connect();
+            try {
+                assertTrue(ws.isConnected());
+                assertTrue(tcpLost.await(10, TimeUnit.SECONDS), "AWS drops the older session with the same client id");
+            } finally {
+                ws.disconnect();
+                ws.close();
+            }
+        } finally {
+            tcp.close();
+        }
+    }
+
+    @Test
+    void retainedMessagePublishedOverTcpReachesALaterWebSocketSubscriber() throws Exception {
+        String topic = "contract/retained/" + System.nanoTime();
+        byte[] payload = "kept".getBytes(StandardCharsets.UTF_8);
+        MqttClient tcp = new MqttClient("tcp://127.0.0.1:" + PLAIN_PORT, "retain-pub-" + System.nanoTime(), new MemoryPersistence());
+        tcp.connect();
+        tcp.publish(topic, payload, 1, true);
+        tcp.disconnect();
+        tcp.close();
+
+        try (PahoWs subscriber = PahoWs.connect(wss(), "retain-sub-" + System.nanoTime())) {
+            subscriber.client.subscribe(topic, 1);
+            assertArrayEquals(payload, subscriber.take());
+        }
+    }
+
+    @Test
+    void qos2PublishIsDisconnectedAsOnAws() throws Exception {
+        try (PahoWs client = PahoWs.connect(ws(), "qos2-" + System.nanoTime())) {
+            MqttMessage message = new MqttMessage("exactly once".getBytes(StandardCharsets.UTF_8));
+            message.setQos(2);
+            try {
+                client.client.publish("contract/qos2/" + System.nanoTime(), message);
+            } catch (MqttException expected) {
+                // Paho may report the drop while waiting for PUBREC; the assertion below is the contract.
+            }
+            assertTrue(client.lost.await(10, TimeUnit.SECONDS), "AWS IoT disconnects a client that publishes QoS 2");
+        }
+    }
+
+    @Test
+    void shadowTopicsWorkOverWebSocket() throws Exception {
+        String thing = "wsThing" + System.nanoTime();
+        try (PahoWs client = PahoWs.connect(wss(), "shadow-" + System.nanoTime())) {
+            client.client.subscribe("$aws/things/" + thing + "/shadow/update/accepted", 1);
+            client.client.publish("$aws/things/" + thing + "/shadow/update",
+                    "{\"state\":{\"desired\":{\"led\":\"on\"}},\"clientToken\":\"ws-token\"}".getBytes(StandardCharsets.UTF_8), 1, false);
+
+            JsonNode accepted = OBJECT_MAPPER.readTree(client.take());
+            assertEquals("on", accepted.path("state").path("desired").path("led").asText());
+            assertEquals("ws-token", accepted.path("clientToken").asText());
+        }
+    }
+
+    @Test
+    void topicRuleFiresForAWebSocketPublish() throws Exception {
+        String source = "contract/rule/source/" + System.nanoTime();
+        String target = "contract/rule/target/" + System.nanoTime();
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "topicRulePayload": {
+                    "sql": "SELECT * FROM '%s'",
+                    "actions": [
+                      {
+                        "republish": {
+                          "roleArn": "arn:aws:iam::000000000000:role/iot-rule-role",
+                          "topic": "%s"
+                        }
+                      }
+                    ]
+                  }
+                }
+                """.formatted(source, target))
+        .when()
+            .put("/rules/wsRepublish" + System.nanoTime())
+        .then()
+            .statusCode(200);
+
+        try (PahoWs subscriber = PahoWs.connect(wss(), "rule-sub-" + System.nanoTime())) {
+            subscriber.client.subscribe(target, 1);
+            try (PahoWs publisher = PahoWs.connect(wss(), "rule-pub-" + System.nanoTime())) {
+                publisher.client.publish(source, "{\"v\":1}".getBytes(StandardCharsets.UTF_8), 1, false);
+            }
+            assertArrayEquals("{\"v\":1}".getBytes(StandardCharsets.UTF_8), subscriber.take());
+        }
+    }
+
+    @Test
+    void mqttKeepAlivePingsCrossTheBridge() throws Exception {
+        MqttClient client = new MqttClient(ws(), "keepalive-" + System.nanoTime(), new MemoryPersistence());
+        MqttConnectOptions options = new MqttConnectOptions();
+        options.setKeepAliveInterval(1);
+        client.connect(options);
+        try {
+            Thread.sleep(3500);
+            assertTrue(client.isConnected(), "PINGREQ and PINGRESP keep a quiet session alive");
+        } finally {
+            client.disconnect();
+            client.close();
+        }
+    }
+
+    @Test
+    void connectionApisSeeTheWebSocketSession() throws Exception {
+        String clientId = "ws-api-" + System.nanoTime();
+        String topic = "contract/api/" + System.nanoTime();
+        byte[] payload = "direct".getBytes(StandardCharsets.UTF_8);
+
+        try (PahoWs client = PahoWs.connect(wss(), clientId)) {
+            client.client.subscribe(topic, 0);
+
+            given()
+                .queryParam("includeSocketInformation", true)
+            .when()
+                .get("/connections/{clientId}", clientId)
+            .then()
+                .statusCode(200)
+                .body("clientId", equalTo(clientId))
+                .body("connected", equalTo(true))
+                .body("sourceIp", equalTo("127.0.0.1"));
+
+            given()
+            .when()
+                .get("/connections/{clientId}/subscriptions", clientId)
+            .then()
+                .statusCode(200)
+                .body("subscriptions[0].topicFilter", equalTo(topic));
+
+            given()
+                .queryParam("topic", topic)
+                .body(payload)
+            .when()
+                .post("/connections/{clientId}/messages", clientId)
+            .then()
+                .statusCode(200);
+            assertArrayEquals(payload, client.take());
+
+            given()
+                .queryParam("cleanSession", true)
+            .when()
+                .delete("/connections/{clientId}", clientId)
+            .then()
+                .statusCode(200);
+            assertTrue(client.lost.await(10, TimeUnit.SECONDS), "DeleteConnection reaches a WebSocket session");
+        }
+    }
+
+    // ==================== helpers ====================
+
+    private String ws() {
+        return "ws://127.0.0.1:" + testHttpPort + "/mqtt";
+    }
+
+    private String wss() {
+        return "wss://127.0.0.1:" + testSslPort + "/mqtt";
+    }
+
+    /**
+     * The status line of a hand-written upgrade request. The JDK HttpClient refuses to send the
+     * Upgrade header itself, so this goes over a plain socket.
+     */
+    private int rawUpgradeStatus(String method, String version) throws Exception {
+        try (Socket socket = new Socket("127.0.0.1", testHttpPort)) {
+            socket.setSoTimeout(10_000);
+            String request = method + " /mqtt HTTP/1.1\r\n"
+                    + "Host: 127.0.0.1:" + testHttpPort + "\r\n"
+                    + "Upgrade: websocket\r\n"
+                    + "Connection: Upgrade\r\n"
+                    + "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                    + "Sec-WebSocket-Version: " + version + "\r\n"
+                    + "Sec-WebSocket-Protocol: mqtt\r\n"
+                    + "\r\n";
+            socket.getOutputStream().write(request.getBytes(StandardCharsets.US_ASCII));
+            socket.getOutputStream().flush();
+            String statusLine = new BufferedReader(new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII)).readLine();
+            assertNotNull(statusLine, "no status line");
+            assertTrue(statusLine.startsWith("HTTP/1.1 "), statusLine);
+            return Integer.parseInt(statusLine.substring(9, 12));
+        }
+    }
+
+    /** Paho 3.1.1 client over the bridge with a payload queue and a connection-lost latch. */
+    private static final class PahoWs implements AutoCloseable {
+        final MqttClient client;
+        final CountDownLatch lost = new CountDownLatch(1);
+        private final BlockingQueue<byte[]> payloads = new LinkedBlockingQueue<>();
+
+        private PahoWs(MqttClient client) {
+            this.client = client;
+        }
+
+        static PahoWs connect(String url, String clientId) throws Exception {
+            MqttClient client = new MqttClient(url, clientId, new MemoryPersistence());
+            PahoWs paho = new PahoWs(client);
+            client.setCallback(new org.eclipse.paho.client.mqttv3.MqttCallback() {
+                @Override
+                public void connectionLost(Throwable cause) {
+                    paho.lost.countDown();
+                }
+
+                @Override
+                public void messageArrived(String topic, MqttMessage message) {
+                    paho.payloads.add(message.getPayload());
+                }
+
+                @Override
+                public void deliveryComplete(org.eclipse.paho.client.mqttv3.IMqttDeliveryToken token) {
+                }
+            });
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setCleanSession(true);
+            options.setConnectionTimeout(10);
+            if (url.startsWith("wss://")) {
+                options.setSocketFactory(IotMqttWebSocketIntegrationTest.trustOnlyFlociCa().getSocketFactory());
+            }
+            client.connect(options);
+            return paho;
+        }
+
+        byte[] take() throws InterruptedException {
+            byte[] payload = payloads.poll(10, TimeUnit.SECONDS);
+            assertNotNull(payload, "no publish received within 10s");
+            return payload;
+        }
+
+        @Override
+        public void close() throws MqttException {
+            if (client.isConnected()) {
+                client.disconnect();
+            }
+            client.close();
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketFramingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketFramingIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.iot;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -36,6 +38,9 @@ class IotMqttWebSocketFramingIntegrationTest {
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
     int testHttpPort;
+
+    @Inject
+    IotMqttBrokerService broker;
 
     @Test
     void connectSplitAcrossTwoFramesStillGetsConnack() throws Exception {
@@ -62,6 +67,43 @@ class IotMqttWebSocketFramingIntegrationTest {
             assertArrayEquals(CONNACK_ACCEPTED, raw.take(4));
             assertArrayEquals(new byte[] {(byte) 0x90, 0x03, 0x00, 0x07, 0x01}, raw.take(5), "SUBACK for id 7 granting QoS 1");
         }
+    }
+
+    @Test
+    void textFrameAfterConnectClosesWithUnsupportedDataAndFreesTheBrokerSession() throws Exception {
+        String clientId = "text-mid-" + System.nanoTime();
+        try (RawWs raw = RawWs.open(ws())) {
+            raw.socket.sendBinary(ByteBuffer.wrap(connectPacket(clientId)), true).get(10, TimeUnit.SECONDS);
+            assertArrayEquals(CONNACK_ACCEPTED, raw.take(4));
+            assertTrue(broker.getConnection(clientId).isPresent(), "precondition: a live broker session");
+
+            raw.socket.sendText("{\"not\":\"mqtt\"}", true).get(10, TimeUnit.SECONDS);
+
+            assertTrue(raw.closed.await(10, TimeUnit.SECONDS));
+            assertEquals(1003, raw.closeCode.get(10, TimeUnit.SECONDS), "MQTT over WebSocket is binary only");
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            while (broker.getConnection(clientId).isPresent() && System.nanoTime() < deadline) {
+                Thread.sleep(20);
+            }
+            assertTrue(broker.getConnection(clientId).isEmpty(), "the broker side is closed with the WebSocket");
+        }
+    }
+
+    @Test
+    void abruptTcpDropWithoutACloseFrameFreesTheBrokerSession() throws Exception {
+        String clientId = "abrupt-" + System.nanoTime();
+        RawWs raw = RawWs.open(ws());
+        raw.socket.sendBinary(ByteBuffer.wrap(connectPacket(clientId)), true).get(10, TimeUnit.SECONDS);
+        assertArrayEquals(CONNACK_ACCEPTED, raw.take(4));
+        assertTrue(broker.getConnection(clientId).isPresent(), "precondition: a live broker session");
+
+        raw.socket.abort();
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (broker.getConnection(clientId).isPresent() && System.nanoTime() < deadline) {
+            Thread.sleep(20);
+        }
+        assertTrue(broker.getConnection(clientId).isEmpty(), "a vanished client frees the broker session without an MQTT DISCONNECT");
     }
 
     @Test
@@ -138,6 +180,7 @@ class IotMqttWebSocketFramingIntegrationTest {
     private static final class RawWs implements AutoCloseable {
         final WebSocket socket;
         final CountDownLatch closed = new CountDownLatch(1);
+        final CompletableFuture<Integer> closeCode = new CompletableFuture<>();
         private final ByteArrayOutputStream received = new ByteArrayOutputStream();
 
         private RawWs(WebSocket socket) {
@@ -162,7 +205,9 @@ class IotMqttWebSocketFramingIntegrationTest {
 
                 @Override
                 public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
-                    ready.join().closed.countDown();
+                    RawWs raw = ready.join();
+                    raw.closeCode.complete(statusCode);
+                    raw.closed.countDown();
                     return null;
                 }
 

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketFramingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketFramingIntegrationTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.iot;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
@@ -30,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
 class IotMqttWebSocketFramingIntegrationTest {
 
+    private static final Logger LOG = Logger.getLogger(IotMqttWebSocketFramingIntegrationTest.class);
     private static final byte[] CONNACK_ACCEPTED = {0x20, 0x02, 0x00, 0x00};
 
     @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
@@ -83,6 +85,7 @@ class IotMqttWebSocketFramingIntegrationTest {
             } catch (ExecutionException serverClosedMidWrite) {
                 // The frame header already says 300 KB, so the server may drop the connection before
                 // the client has finished writing it; the latch below is the assertion either way.
+                LOG.debugv("oversized frame write ended early: {0}", serverClosedMidWrite.getCause());
             }
 
             assertTrue(raw.closed.await(10, TimeUnit.SECONDS), "a 300 KB frame is over the 256 KB limit");

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketFramingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketFramingIntegrationTest.java
@@ -1,0 +1,202 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * MQTT 3.1.1 section 6: control packets are sent in binary WebSocket frames, and a frame may carry
+ * several or partial packets, so the receiver must not assume packets align with frame boundaries.
+ * These tests speak raw bytes through the JDK WebSocket to prove the bridge keeps the stream intact,
+ * and that a broken stream or an oversized frame ends the session rather than hanging it.
+ */
+@QuarkusTest
+@TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
+class IotMqttWebSocketFramingIntegrationTest {
+
+    private static final byte[] CONNACK_ACCEPTED = {0x20, 0x02, 0x00, 0x00};
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
+    int testHttpPort;
+
+    @Test
+    void connectSplitAcrossTwoFramesStillGetsConnack() throws Exception {
+        try (RawWs raw = RawWs.open(ws())) {
+            byte[] connect = connectPacket("split-" + System.nanoTime());
+            int cut = connect.length / 2;
+
+            raw.socket.sendBinary(ByteBuffer.wrap(connect, 0, cut), false).get(10, TimeUnit.SECONDS);
+            raw.socket.sendBinary(ByteBuffer.wrap(connect, cut, connect.length - cut), true).get(10, TimeUnit.SECONDS);
+
+            assertArrayEquals(CONNACK_ACCEPTED, raw.take(4));
+        }
+    }
+
+    @Test
+    void twoPacketsInOneFrameAreBothAnswered() throws Exception {
+        try (RawWs raw = RawWs.open(ws())) {
+            ByteArrayOutputStream frame = new ByteArrayOutputStream();
+            frame.write(connectPacket("packed-" + System.nanoTime()));
+            frame.write(subscribePacket(7, "contract/packed/" + System.nanoTime()));
+
+            raw.socket.sendBinary(ByteBuffer.wrap(frame.toByteArray()), true).get(10, TimeUnit.SECONDS);
+
+            assertArrayEquals(CONNACK_ACCEPTED, raw.take(4));
+            assertArrayEquals(new byte[] {(byte) 0x90, 0x03, 0x00, 0x07, 0x01}, raw.take(5), "SUBACK for id 7 granting QoS 1");
+        }
+    }
+
+    @Test
+    void garbageBytesCloseTheSession() throws Exception {
+        try (RawWs raw = RawWs.open(ws())) {
+            raw.socket.sendBinary(ByteBuffer.wrap(new byte[] {(byte) 0xFF, (byte) 0xFF, (byte) 0xFF, 0x00}), true)
+                    .get(10, TimeUnit.SECONDS);
+
+            assertTrue(raw.closed.await(10, TimeUnit.SECONDS), "the broker refuses the packet and the WebSocket follows");
+        }
+    }
+
+    @Test
+    void frameAboveTheTransportLimitClosesTheSession() throws Exception {
+        try (RawWs raw = RawWs.open(ws())) {
+            raw.socket.sendBinary(ByteBuffer.wrap(connectPacket("huge-" + System.nanoTime())), true).get(10, TimeUnit.SECONDS);
+            assertArrayEquals(CONNACK_ACCEPTED, raw.take(4));
+
+            try {
+                raw.socket.sendBinary(ByteBuffer.wrap(new byte[300 * 1024]), true).get(10, TimeUnit.SECONDS);
+            } catch (ExecutionException serverClosedMidWrite) {
+                // The frame header already says 300 KB, so the server may drop the connection before
+                // the client has finished writing it; the latch below is the assertion either way.
+            }
+
+            assertTrue(raw.closed.await(10, TimeUnit.SECONDS), "a 300 KB frame is over the 256 KB limit");
+        }
+    }
+
+    private String ws() {
+        return "ws://127.0.0.1:" + testHttpPort + "/mqtt";
+    }
+
+    /** MQTT 3.1.1 CONNECT, clean session, keep alive 60, no will, no credentials. */
+    private static byte[] connectPacket(String clientId) throws Exception {
+        ByteArrayOutputStream variable = new ByteArrayOutputStream();
+        variable.write(new byte[] {0x00, 0x04, 'M', 'Q', 'T', 'T', 0x04, 0x02, 0x00, 0x3C});
+        writeString(variable, clientId);
+        return packet(0x10, variable.toByteArray());
+    }
+
+    /** MQTT 3.1.1 SUBSCRIBE for one topic filter at QoS 1. */
+    private static byte[] subscribePacket(int packetId, String topicFilter) throws Exception {
+        ByteArrayOutputStream variable = new ByteArrayOutputStream();
+        variable.write(packetId >> 8);
+        variable.write(packetId & 0xFF);
+        writeString(variable, topicFilter);
+        variable.write(0x01);
+        return packet(0x82, variable.toByteArray());
+    }
+
+    private static void writeString(ByteArrayOutputStream out, String value) throws Exception {
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        out.write(bytes.length >> 8);
+        out.write(bytes.length & 0xFF);
+        out.write(bytes);
+    }
+
+    private static byte[] packet(int fixedHeader, byte[] body) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        out.write(fixedHeader);
+        int remaining = body.length;
+        do {
+            int digit = remaining % 128;
+            remaining /= 128;
+            out.write(remaining > 0 ? digit | 0x80 : digit);
+        } while (remaining > 0);
+        out.write(body);
+        return out.toByteArray();
+    }
+
+    /** A raw JDK WebSocket that collects the server's bytes and notices the close. */
+    private static final class RawWs implements AutoCloseable {
+        final WebSocket socket;
+        final CountDownLatch closed = new CountDownLatch(1);
+        private final ByteArrayOutputStream received = new ByteArrayOutputStream();
+
+        private RawWs(WebSocket socket) {
+            this.socket = socket;
+        }
+
+        static RawWs open(String url) throws Exception {
+            CompletableFuture<RawWs> ready = new CompletableFuture<>();
+            WebSocket.Listener listener = new WebSocket.Listener() {
+                @Override
+                public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+                    RawWs raw = ready.join();
+                    synchronized (raw.received) {
+                        while (data.hasRemaining()) {
+                            raw.received.write(data.get());
+                        }
+                        raw.received.notifyAll();
+                    }
+                    webSocket.request(1);
+                    return null;
+                }
+
+                @Override
+                public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+                    ready.join().closed.countDown();
+                    return null;
+                }
+
+                @Override
+                public void onError(WebSocket webSocket, Throwable error) {
+                    ready.join().closed.countDown();
+                }
+            };
+            WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                    .subprotocols("mqtt")
+                    .buildAsync(URI.create(url), listener)
+                    .get(10, TimeUnit.SECONDS);
+            RawWs raw = new RawWs(socket);
+            ready.complete(raw);
+            return raw;
+        }
+
+        byte[] take(int count) throws InterruptedException {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+            synchronized (received) {
+                while (received.size() < count) {
+                    long left = deadline - System.nanoTime();
+                    assertTrue(left > 0, "expected " + count + " bytes, got " + received.size());
+                    received.wait(Math.max(1, left / 1_000_000));
+                }
+                byte[] all = received.toByteArray();
+                byte[] head = new byte[count];
+                System.arraycopy(all, 0, head, 0, count);
+                received.reset();
+                received.write(all, count, all.length - count);
+                return head;
+            }
+        }
+
+        @Override
+        public void close() {
+            socket.abort();
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
@@ -302,7 +302,7 @@ class IotMqttWebSocketIntegrationTest {
         return handshake.getResponse().statusCode();
     }
 
-    private static SSLContext trustOnlyFlociCa() throws Exception {
+    static SSLContext trustOnlyFlociCa() throws Exception {
         KeyStore trust = KeyStore.getInstance(KeyStore.getDefaultType());
         trust.load(null, null);
         trust.setCertificateEntry("floci", FlociCertificateAuthority.loadOrCreate(TLS_DIR).certificate());

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
@@ -58,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @QuarkusTest
 @TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
-class IotMqttWebSocketIntegrationTest {
+public class IotMqttWebSocketIntegrationTest {
 
     static final Path DATA_DIR = Path.of("target", "floci-iot-mqtt-ws-test").toAbsolutePath();
     static final Path TLS_DIR = DATA_DIR.resolve("tls");
@@ -208,7 +208,7 @@ class IotMqttWebSocketIntegrationTest {
     @Test
     void burstOfPublishesArrivesCompleteAndInOrder() throws Exception {
         String topic = "ws/burst/" + System.nanoTime();
-        int count = 200;
+        int count = 1000;
         byte[] filler = new byte[4096];
 
         try (WsClient subscriber = WsClient.connect(wss("/mqtt"), "ws-burst-sub-" + System.nanoTime(), null, null)) {
@@ -273,6 +273,26 @@ class IotMqttWebSocketIntegrationTest {
     }
 
     @Test
+    void connectDisconnectChurnLeavesNoBrokerSessionBehind() throws Exception {
+        List<String> clientIds = new ArrayList<>();
+        for (int i = 0; i < 30; i++) {
+            String clientId = "churn-" + i + "-" + System.nanoTime();
+            clientIds.add(clientId);
+            String url = i % 2 == 0 ? ws("/mqtt") : wss("/mqtt");
+            try (WsClient client = WsClient.connect(url, clientId, null, null)) {
+                assertTrue(client.isConnected());
+            }
+        }
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        for (String clientId : clientIds) {
+            while (broker.getConnection(clientId).isPresent() && System.nanoTime() < deadline) {
+                Thread.sleep(20);
+            }
+            assertTrue(broker.getConnection(clientId).isEmpty(), clientId + " still has a broker session");
+        }
+    }
+
+    @Test
     void plaintextTcpListenerStillWorks() throws Exception {
         MqttClient client = new MqttClient("tcp://127.0.0.1:" + PLAIN_PORT, "tcp-" + System.nanoTime(), new MemoryPersistence());
         client.connect();
@@ -303,7 +323,7 @@ class IotMqttWebSocketIntegrationTest {
         return handshake.getResponse().statusCode();
     }
 
-    static SSLContext trustOnlyFlociCa() throws Exception {
+    public static SSLContext trustOnlyFlociCa() throws Exception {
         KeyStore trust = KeyStore.getInstance(KeyStore.getDefaultType());
         trust.load(null, null);
         trust.setCertificateEntry("floci", FlociCertificateAuthority.loadOrCreate(TLS_DIR).certificate());

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
@@ -1,0 +1,430 @@
+package io.github.hectorvent.floci.services.iot;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.CertificateMetadata;
+import io.github.hectorvent.floci.config.FlociCertificateAuthority;
+import io.github.hectorvent.floci.services.acm.model.KeyAlgorithm;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.Test;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Clients reach the broker as MQTT over WebSocket at {@code /mqtt} on the HTTP and HTTPS ports,
+ * the way AWS IoT serves {@code wss://<endpoint>:443/mqtt}: the {@code mqtt} subprotocol is
+ * echoed, the HTTPS certificate is the one every other Floci API serves, and the session behaves
+ * like one on the plaintext TCP listener because that is where the frames end up.
+ */
+@QuarkusTest
+@TestProfile(IotMqttWebSocketIntegrationTest.Profile.class)
+class IotMqttWebSocketIntegrationTest {
+
+    static final Path DATA_DIR = Path.of("target", "floci-iot-mqtt-ws-test").toAbsolutePath();
+    static final Path TLS_DIR = DATA_DIR.resolve("tls");
+    static final int PLAIN_PORT = 18836;
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final short CLOSE_UNSUPPORTED_DATA = 1003;
+
+    @ConfigProperty(name = "quarkus.http.test-ssl-port", defaultValue = "0")
+    int testSslPort;
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
+    int testHttpPort;
+
+    @Inject
+    IotMqttBrokerService broker;
+
+    @Test
+    void connectSubscribePublishOverWssTrustingOnlyTheFlociCa() throws Exception {
+        String topic = "ws/roundtrip/" + System.nanoTime();
+        byte[] payload = "over websocket".getBytes(StandardCharsets.UTF_8);
+
+        try (WsClient subscriber = WsClient.connect(wss("/mqtt"), "ws-sub-" + System.nanoTime(), null, null)) {
+            subscriber.subscribe(topic);
+            try (WsClient publisher = WsClient.connect(wss("/mqtt"), "ws-pub-" + System.nanoTime(), null, null)) {
+                publisher.publish(topic, payload, 1);
+            }
+            assertArrayEquals(payload, subscriber.takePayload());
+        }
+    }
+
+    @Test
+    void plainWebSocketWorksOnTheHttpPort() throws Exception {
+        String topic = "ws/plain/" + System.nanoTime();
+        byte[] payload = "plain websocket".getBytes(StandardCharsets.UTF_8);
+
+        try (WsClient client = WsClient.connect(ws("/mqtt"), "ws-plain-" + System.nanoTime(), null, null)) {
+            assertTrue(client.isConnected());
+            client.subscribe(topic);
+            client.publish(topic, payload, 0);
+            assertArrayEquals(payload, client.takePayload());
+        }
+    }
+
+    @Test
+    void webSocketAndTcpClientsShareTheBroker() throws Exception {
+        String topic = "ws/shared/" + System.nanoTime();
+        byte[] payload = "from tcp".getBytes(StandardCharsets.UTF_8);
+
+        try (WsClient subscriber = WsClient.connect(wss("/mqtt"), "ws-shared-" + System.nanoTime(), null, null)) {
+            subscriber.subscribe(topic);
+            MqttClient tcp = new MqttClient("tcp://127.0.0.1:" + PLAIN_PORT, "tcp-pub-" + System.nanoTime(), new MemoryPersistence());
+            tcp.connect();
+            tcp.publish(topic, payload, 1, false);
+            tcp.disconnect();
+            tcp.close();
+            assertArrayEquals(payload, subscriber.takePayload());
+        }
+    }
+
+    @Test
+    void customAuthorizerStyleConnectIsAccepted() throws Exception {
+        String clientId = "tunnel-" + System.nanoTime();
+        String username = clientId + "?x-amz-customauthorizer-name=my-authorizer";
+        try (WsClient client = WsClient.connect(wss("/mqtt"), clientId, username, "token-" + System.nanoTime())) {
+            assertTrue(client.isConnected());
+        }
+    }
+
+    @Test
+    void sigV4QueryStringOnTheMqttPathIsAccepted() throws Exception {
+        String query = "?X-Amz-Algorithm=AWS4-HMAC-SHA256"
+                + "&X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20260906%2Fus-east-1%2Fiotdevicegateway%2Faws4_request"
+                + "&X-Amz-Date=20260906T120000Z&X-Amz-SignedHeaders=host"
+                + "&X-Amz-Signature=0000000000000000000000000000000000000000000000000000000000000000";
+        try (WsClient client = WsClient.connect(wss("/mqtt" + query), "ws-sigv4-" + System.nanoTime(), null, null)) {
+            assertTrue(client.isConnected());
+        }
+    }
+
+    @Test
+    void wrongPathIsNotAnMqttEndpoint() {
+        assertEquals(404, handshakeStatus("/not-mqtt"));
+        assertEquals(404, handshakeStatus("/mqtt/extra"));
+    }
+
+    @Test
+    void plainGetOnTheMqttPathIsNotAnUpgrade() throws Exception {
+        HttpResponse<String> response = HttpClient.newHttpClient().send(
+                HttpRequest.newBuilder(URI.create("http://127.0.0.1:" + testHttpPort + "/mqtt")).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(404, response.statusCode());
+    }
+
+    @Test
+    void textFrameClosesTheSessionAsUnsupportedData() throws Exception {
+        CompletableFuture<Integer> closeCode = new CompletableFuture<>();
+        WebSocket socket = HttpClient.newHttpClient().newWebSocketBuilder()
+                .subprotocols("mqtt")
+                .buildAsync(URI.create(ws("/mqtt")), new WebSocket.Listener() {
+                    @Override
+                    public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+                        closeCode.complete(statusCode);
+                        return null;
+                    }
+
+                    @Override
+                    public void onError(WebSocket webSocket, Throwable error) {
+                        closeCode.completeExceptionally(error);
+                    }
+                })
+                .get(10, TimeUnit.SECONDS);
+        assertEquals("mqtt", socket.getSubprotocol());
+
+        socket.sendText("not an mqtt packet", true).get(10, TimeUnit.SECONDS);
+
+        assertEquals(CLOSE_UNSUPPORTED_DATA, closeCode.get(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void brokerSideDisconnectDropsTheWebSocket() throws Exception {
+        String clientId = "ws-dropped-" + System.nanoTime();
+        try (WsClient client = WsClient.connect(ws("/mqtt"), clientId, null, null)) {
+            assertTrue(broker.getConnection(clientId).isPresent(), "the bridged session is a broker session");
+
+            assertTrue(broker.disconnectClient(clientId, true));
+
+            assertTrue(client.awaitConnectionLost(10, TimeUnit.SECONDS), "closing the broker side closes the WebSocket");
+        }
+    }
+
+    @Test
+    void clientDisconnectFreesTheBrokerSession() throws Exception {
+        String clientId = "ws-leaving-" + System.nanoTime();
+        WsClient client = WsClient.connect(ws("/mqtt"), clientId, null, null);
+        assertTrue(broker.getConnection(clientId).isPresent());
+
+        client.close();
+
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (broker.getConnection(clientId).isPresent() && System.nanoTime() < deadline) {
+            Thread.sleep(20);
+        }
+        assertTrue(broker.getConnection(clientId).isEmpty(), "the broker session is gone once the WebSocket closes");
+    }
+
+    @Test
+    void burstOfPublishesArrivesCompleteAndInOrder() throws Exception {
+        String topic = "ws/burst/" + System.nanoTime();
+        int count = 200;
+        byte[] filler = new byte[4096];
+
+        try (WsClient subscriber = WsClient.connect(wss("/mqtt"), "ws-burst-sub-" + System.nanoTime(), null, null)) {
+            subscriber.subscribe(topic);
+            try (WsClient publisher = WsClient.connect(wss("/mqtt"), "ws-burst-pub-" + System.nanoTime(), null, null)) {
+                for (int i = 0; i < count; i++) {
+                    byte[] payload = ByteBuffer.allocate(4 + filler.length).putInt(i).put(filler).array();
+                    publisher.publish(topic, payload, 0);
+                }
+                for (int i = 0; i < count; i++) {
+                    byte[] payload = subscriber.takePayload();
+                    assertEquals(4 + filler.length, payload.length);
+                    assertEquals(i, ByteBuffer.wrap(payload).getInt(), "publishes keep their order across the bridge");
+                }
+            }
+        }
+    }
+
+    @Test
+    void manyConcurrentWebSocketClientsEachReceiveThePublish() throws Exception {
+        String topic = "ws/fanout/" + System.nanoTime();
+        byte[] payload = "to everyone".getBytes(StandardCharsets.UTF_8);
+        int clients = 16;
+        List<WsClient> subscribers = new ArrayList<>();
+        try {
+            CountDownLatch connected = new CountDownLatch(clients);
+            List<Thread> threads = new ArrayList<>();
+            List<Throwable> failures = new java.util.concurrent.CopyOnWriteArrayList<>();
+            for (int i = 0; i < clients; i++) {
+                String clientId = "ws-fanout-" + i + "-" + System.nanoTime();
+                Thread thread = new Thread(() -> {
+                    try {
+                        WsClient subscriber = WsClient.connect(wss("/mqtt"), clientId, null, null);
+                        subscriber.subscribe(topic);
+                        synchronized (subscribers) {
+                            subscribers.add(subscriber);
+                        }
+                    } catch (Exception e) {
+                        failures.add(e);
+                    } finally {
+                        connected.countDown();
+                    }
+                });
+                threads.add(thread);
+                thread.start();
+            }
+            assertTrue(connected.await(30, TimeUnit.SECONDS));
+            assertTrue(failures.isEmpty(), "every concurrent handshake succeeds: " + failures);
+            assertEquals(clients, subscribers.size());
+
+            try (WsClient publisher = WsClient.connect(ws("/mqtt"), "ws-fanout-pub-" + System.nanoTime(), null, null)) {
+                publisher.publish(topic, payload, 1);
+            }
+            for (WsClient subscriber : subscribers) {
+                assertArrayEquals(payload, subscriber.takePayload());
+            }
+        } finally {
+            for (WsClient subscriber : subscribers) {
+                subscriber.close();
+            }
+        }
+    }
+
+    @Test
+    void plaintextTcpListenerStillWorks() throws Exception {
+        MqttClient client = new MqttClient("tcp://127.0.0.1:" + PLAIN_PORT, "tcp-" + System.nanoTime(), new MemoryPersistence());
+        client.connect();
+        assertTrue(client.isConnected());
+        client.disconnect();
+        client.close();
+    }
+
+    private String ws(String pathAndQuery) {
+        return "ws://127.0.0.1:" + testHttpPort + pathAndQuery;
+    }
+
+    private String wss(String pathAndQuery) {
+        return "wss://127.0.0.1:" + testSslPort + pathAndQuery;
+    }
+
+    /**
+     * The status of a failed handshake, sent the way Paho sends it (with the mqtt subprotocol), so
+     * a 404 proves the server routes on the path and not on the subprotocol.
+     */
+    private int handshakeStatus(String path) {
+        ExecutionException failure = assertThrows(ExecutionException.class, () -> HttpClient.newHttpClient()
+                .newWebSocketBuilder()
+                .subprotocols("mqtt")
+                .buildAsync(URI.create(ws(path)), new WebSocket.Listener() { })
+                .get(10, TimeUnit.SECONDS));
+        WebSocketHandshakeException handshake = assertInstanceOf(WebSocketHandshakeException.class, failure.getCause());
+        return handshake.getResponse().statusCode();
+    }
+
+    private static SSLContext trustOnlyFlociCa() throws Exception {
+        KeyStore trust = KeyStore.getInstance(KeyStore.getDefaultType());
+        trust.load(null, null);
+        trust.setCertificateEntry("floci", FlociCertificateAuthority.loadOrCreate(TLS_DIR).certificate());
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(trust);
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(null, tmf.getTrustManagers(), null);
+        return ctx;
+    }
+
+    private static final class WsClient implements AutoCloseable {
+        private final MqttClient client;
+        private final BlockingQueue<byte[]> payloads = new LinkedBlockingQueue<>();
+        private final CountDownLatch connectionLost = new CountDownLatch(1);
+
+        private WsClient(MqttClient client) {
+            this.client = client;
+        }
+
+        static WsClient connect(String url, String clientId, String username, String password) throws Exception {
+            MqttClient client = new MqttClient(url, clientId, new MemoryPersistence());
+            WsClient wsClient = new WsClient(client);
+            client.setCallback(new MqttCallback() {
+                @Override
+                public void connectionLost(Throwable cause) {
+                    wsClient.connectionLost.countDown();
+                }
+
+                @Override
+                public void messageArrived(String topic, MqttMessage message) {
+                    wsClient.payloads.add(message.getPayload());
+                }
+
+                @Override
+                public void deliveryComplete(IMqttDeliveryToken token) {
+                }
+            });
+            MqttConnectOptions options = new MqttConnectOptions();
+            options.setCleanSession(true);
+            options.setConnectionTimeout(10);
+            if (url.startsWith("wss://")) {
+                options.setSocketFactory(trustOnlyFlociCa().getSocketFactory());
+            }
+            if (username != null) {
+                options.setUserName(username);
+                options.setPassword(password.toCharArray());
+            }
+            client.connect(options);
+            return wsClient;
+        }
+
+        boolean isConnected() {
+            return client.isConnected();
+        }
+
+        void subscribe(String topic) throws MqttException {
+            client.subscribe(topic, 1);
+        }
+
+        void publish(String topic, byte[] payload, int qos) throws MqttException {
+            client.publish(topic, payload, qos, false);
+        }
+
+        byte[] takePayload() throws InterruptedException {
+            byte[] payload = payloads.poll(10, TimeUnit.SECONDS);
+            assertNotNull(payload, "no publish received over WebSocket within 10s");
+            return payload;
+        }
+
+        boolean awaitConnectionLost(long timeout, TimeUnit unit) throws InterruptedException {
+            return connectionLost.await(timeout, unit);
+        }
+
+        @Override
+        public void close() throws MqttException {
+            if (client.isConnected()) {
+                client.disconnect();
+            }
+            client.close();
+        }
+    }
+
+    /**
+     * TLS on with a CA-issued leaf on disk, exactly what TlsConfigSource produces in production.
+     * TlsConfigSource reads system properties, not profile overrides, so the profile lays the files
+     * down and points the TLS registry at them. The broker's plaintext listener is the bridge's
+     * target.
+     */
+    public static final class Profile implements QuarkusTestProfile {
+
+        static {
+            try {
+                Files.createDirectories(TLS_DIR);
+                for (String name : List.of("floci-server.crt", "floci-server.key", "floci-server.metadata.json")) {
+                    Files.deleteIfExists(TLS_DIR.resolve(name));
+                }
+                FlociCertificateAuthority ca = FlociCertificateAuthority.loadOrCreate(TLS_DIR);
+                List<String> sans = List.of("localhost", "127.0.0.1", "*.localhost.floci.io");
+                var leaf = ca.issueServerCertificate("localhost", sans, KeyAlgorithm.RSA_2048, null);
+                Files.writeString(TLS_DIR.resolve("floci-server.crt"), leaf.certificatePem());
+                Files.writeString(TLS_DIR.resolve("floci-server.key"), leaf.privateKeyPem());
+                Files.writeString(TLS_DIR.resolve("floci-server.metadata.json"),
+                        OBJECT_MAPPER.writeValueAsString(CertificateMetadata.create(sans, "dev")));
+            } catch (IOException e) {
+                throw new IllegalStateException("could not prepare the TLS fixtures", e);
+            }
+        }
+
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.ofEntries(
+                    Map.entry("floci.tls.enabled", "true"),
+                    Map.entry("floci.tls.self-signed", "true"),
+                    Map.entry("floci.tls.aws-https-port", "0"),
+                    Map.entry("floci.storage.persistent-path", DATA_DIR.toString()),
+                    Map.entry("quarkus.tls.key-store.pem.0.cert", TLS_DIR.resolve("floci-server.crt").toString()),
+                    Map.entry("quarkus.tls.key-store.pem.0.key", TLS_DIR.resolve("floci-server.key").toString()),
+                    Map.entry("quarkus.http.insecure-requests", "enabled"),
+                    Map.entry("floci.services.iot.mqtt.enabled", "true"),
+                    Map.entry("floci.services.iot.mqtt.auto-start", "true"),
+                    Map.entry("floci.services.iot.mqtt.host", "127.0.0.1"),
+                    Map.entry("floci.services.iot.mqtt.port", Integer.toString(PLAIN_PORT)));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketIntegrationTest.java
@@ -63,6 +63,7 @@ class IotMqttWebSocketIntegrationTest {
     static final Path DATA_DIR = Path.of("target", "floci-iot-mqtt-ws-test").toAbsolutePath();
     static final Path TLS_DIR = DATA_DIR.resolve("tls");
     static final int PLAIN_PORT = 18836;
+    static final int TLS_PORT = 18837;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final short CLOSE_UNSUPPORTED_DATA = 1003;
 
@@ -424,7 +425,8 @@ class IotMqttWebSocketIntegrationTest {
                     Map.entry("floci.services.iot.mqtt.enabled", "true"),
                     Map.entry("floci.services.iot.mqtt.auto-start", "true"),
                     Map.entry("floci.services.iot.mqtt.host", "127.0.0.1"),
-                    Map.entry("floci.services.iot.mqtt.port", Integer.toString(PLAIN_PORT)));
+                    Map.entry("floci.services.iot.mqtt.port", Integer.toString(PLAIN_PORT)),
+                    Map.entry("floci.services.iot.mqtt.tls-port", Integer.toString(TLS_PORT)));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketLazyStartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketLazyStartIntegrationTest.java
@@ -110,7 +110,9 @@ class IotMqttWebSocketLazyStartIntegrationTest {
         broker.stop();
         awaitPortClosed();
         assertFalse(broker.isRunning());
-        first.close();
+        // Paho may not have noticed the drop yet and refuses a plain close while it thinks it is
+        // connected; the forced close does not wait for that.
+        first.close(true);
 
         MqttClient second = new MqttClient(ws(), "lazy-second-" + System.nanoTime(), new MemoryPersistence());
         second.connect();

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketLazyStartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketLazyStartIntegrationTest.java
@@ -1,0 +1,158 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * With the default {@code auto-start=false} the broker is not listening until something needs
+ * it. A WebSocket upgrade on {@code /mqtt} is one of those things: the first one starts the
+ * broker, concurrent first ones all get a session, and an upgrade after a stop starts it again.
+ */
+@QuarkusTest
+@TestProfile(IotMqttWebSocketLazyStartIntegrationTest.Profile.class)
+class IotMqttWebSocketLazyStartIntegrationTest {
+
+    private static final int PORT = 18838;
+
+    @ConfigProperty(name = "quarkus.http.test-port", defaultValue = "0")
+    int testHttpPort;
+
+    @Inject
+    IotMqttBrokerService broker;
+
+    @BeforeEach
+    void stopBroker() throws InterruptedException {
+        broker.stop();
+        awaitPortClosed();
+    }
+
+    @Test
+    void firstUpgradeStartsTheBroker() throws Exception {
+        assertFalse(broker.isRunning(), "precondition: nothing has started the broker");
+
+        MqttClient client = new MqttClient(ws(), "lazy-" + System.nanoTime(), new MemoryPersistence());
+        client.connect();
+        try {
+            assertTrue(client.isConnected());
+            assertTrue(broker.isRunning(), "the upgrade started the broker");
+            try (Socket tcp = new Socket()) {
+                tcp.connect(new InetSocketAddress("127.0.0.1", PORT), 1000);
+            }
+        } finally {
+            client.disconnect();
+            client.close();
+        }
+    }
+
+    @Test
+    void concurrentFirstUpgradesAllGetASession() throws Exception {
+        int clients = 8;
+        List<MqttClient> connected = new CopyOnWriteArrayList<>();
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        CountDownLatch done = new CountDownLatch(clients);
+        List<Thread> threads = new ArrayList<>();
+        for (int i = 0; i < clients; i++) {
+            String clientId = "lazy-burst-" + i + "-" + System.nanoTime();
+            Thread thread = new Thread(() -> {
+                try {
+                    MqttClient client = new MqttClient(ws(), clientId, new MemoryPersistence());
+                    client.connect();
+                    connected.add(client);
+                } catch (Exception e) {
+                    failures.add(e);
+                } finally {
+                    done.countDown();
+                }
+            });
+            threads.add(thread);
+            thread.start();
+        }
+        assertTrue(done.await(30, TimeUnit.SECONDS));
+        try {
+            assertTrue(failures.isEmpty(), "every concurrent first upgrade succeeds: " + failures);
+            for (MqttClient client : connected) {
+                assertTrue(client.isConnected());
+            }
+        } finally {
+            for (MqttClient client : connected) {
+                client.disconnect();
+                client.close();
+            }
+        }
+    }
+
+    @Test
+    void upgradeAfterAStopStartsTheBrokerAgain() throws Exception {
+        MqttClient first = new MqttClient(ws(), "lazy-first-" + System.nanoTime(), new MemoryPersistence());
+        first.connect();
+        assertTrue(broker.isRunning());
+
+        broker.stop();
+        awaitPortClosed();
+        assertFalse(broker.isRunning());
+        first.close();
+
+        MqttClient second = new MqttClient(ws(), "lazy-second-" + System.nanoTime(), new MemoryPersistence());
+        second.connect();
+        try {
+            assertTrue(second.isConnected());
+            assertTrue(broker.isRunning(), "the next upgrade started the broker again");
+        } finally {
+            second.disconnect();
+            second.close();
+        }
+    }
+
+    private String ws() {
+        return "ws://127.0.0.1:" + testHttpPort + "/mqtt";
+    }
+
+    /** The close future can resolve before the OS releases the port; wait until it refuses. */
+    private static void awaitPortClosed() throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (System.currentTimeMillis() < deadline) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress("127.0.0.1", PORT), 100);
+            } catch (Exception refused) {
+                return;
+            }
+            Thread.sleep(50);
+        }
+        assertThrows(Exception.class, () -> {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress("127.0.0.1", PORT), 100);
+            }
+        }, "the broker port is still accepting after stop()");
+    }
+
+    public static final class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "floci.services.iot.mqtt.enabled", "true",
+                    "floci.services.iot.mqtt.auto-start", "false",
+                    "floci.services.iot.mqtt.host", "127.0.0.1",
+                    "floci.services.iot.mqtt.port", Integer.toString(PORT));
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketLazyStartIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttWebSocketLazyStartIntegrationTest.java
@@ -5,7 +5,10 @@ import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
 import jakarta.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
 import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,15 +107,29 @@ class IotMqttWebSocketLazyStartIntegrationTest {
     @Test
     void upgradeAfterAStopStartsTheBrokerAgain() throws Exception {
         MqttClient first = new MqttClient(ws(), "lazy-first-" + System.nanoTime(), new MemoryPersistence());
+        CountDownLatch firstLost = new CountDownLatch(1);
+        first.setCallback(new MqttCallback() {
+            @Override
+            public void connectionLost(Throwable cause) {
+                firstLost.countDown();
+            }
+
+            @Override
+            public void messageArrived(String topic, MqttMessage message) {
+            }
+
+            @Override
+            public void deliveryComplete(IMqttDeliveryToken token) {
+            }
+        });
         first.connect();
         assertTrue(broker.isRunning());
 
         broker.stop();
         awaitPortClosed();
         assertFalse(broker.isRunning());
-        // Paho may not have noticed the drop yet and refuses a plain close while it thinks it is
-        // connected; the forced close does not wait for that.
-        first.close(true);
+        assertTrue(firstLost.await(10, TimeUnit.SECONDS), "stopping the broker drops the WebSocket session");
+        first.close();
 
         MqttClient second = new MqttClient(ws(), "lazy-second-" + System.nanoTime(), new MemoryPersistence());
         second.connect();


### PR DESCRIPTION
## Summary

The MQTT broker is now reachable as MQTT over WebSocket at `/mqtt` on Floci's HTTP and HTTPS ports.

Before this change a client dialing `wss://<host>:443/mqtt`, the URL AWS IoT gives browsers, the AWS IoT Device SDK's WebSocket transport and secure tunnelling, found no MQTT at Floci. A `443:4566` port mapping landed on the Quarkus HTTP server, which answered 404, and the client kept retrying.

Now a WebSocket upgrade on `/mqtt` is piped, byte for byte, to the broker's plaintext MQTT listener. The session is a normal broker session, so subscribe, publish, retained messages, shadow topics and rules all behave exactly as they do over TCP. Because it rides the Quarkus servers, `wss://` gets the same certificate as HTTPS (including hostnames learned at runtime) and works on the documented `443:4566` mapping. No new port, listener, config key or environment variable.

Two small things around it:

- `HttpOptionsCustomizer` now echoes the `mqtt`, `mqttv3.1` and `mqttv3.1.1` subprotocols on both servers. AWS documents `sec-websocket-protocol: mqtt` on the upgrade, and Paho and the AWS Device SDKs refuse a handshake whose response does not echo it. Netty completes a handshake that asks for any other name without the header, so API Gateway WebSocket clients are unaffected (their tests are in the run).
- With the broker disabled (`FLOCI_SERVICES_IOT_MQTT_ENABLED=false`) an upgrade on `/mqtt` gets 503. A plain request to `/mqtt` falls through to the usual 404.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| Endpoint | `GET /mqtt` WebSocket upgrade on the HTTPS port (`wss://`) | ✅ | Same certificate as HTTPS. Works on `443:4566`. |
| Endpoint | `GET /mqtt` WebSocket upgrade on the HTTP port (`ws://`) | ✅ | AWS has no plaintext variant; Floci serves both, like every other API. |
| Endpoint | `Sec-WebSocket-Protocol` echo (`mqtt`, `mqttv3.1`, `mqttv3.1.1`) | ✅ | |
| Endpoint | Any other path, or a non-upgrade request on `/mqtt` | ✅ | 404, as before. |
| Session | Connect, subscribe, publish, QoS 0 and 1, retained, shadow and rules | ✅ | The frames reach the plaintext listener, one code path. |
| Session | Binary frames only; a text frame closes the socket with 1003 | ✅ | MQTT 3.1.1 section 6 and AWS. |
| Session | Close in either direction closes the other side | ✅ | `DeleteConnection` and a broker stop drop the WebSocket; a vanished client frees the broker session. |
| Session | Back-pressure both ways | ✅ | Pause and resume on the Vert.x write queues. |
| Session | Lazy broker start (`auto-start=false`) on the first upgrade | ✅ | Off the event loop. |
| Auth | SigV4 signed URL (`/mqtt?X-Amz-Algorithm=...`) | 🟡 | Accepted, signature not checked. The broker is permissive today. |
| Auth | Custom authorizer (`<clientId>?x-amz-customauthorizer-name=<name>` username, token password) | 🟡 | Accepted as is, authorizer not evaluated. Documented. |
| Auth | Custom authorizer through upgrade headers or query parameters | 🟡 | Accepted, ignored. |
| Auth | X.509 client certificate | ❌ | Not on this path on AWS either (SigV4 or custom authorizer only). |

## Files

- `IotMqttWebSocketBridge` (new): the `/mqtt` route and the pipe to the broker listener.
- `HttpOptionsCustomizer`: the subprotocol echo.
- `IotMqttWebSocketIntegrationTest` (new, 14 cases): Paho over `wss://` trusting only the Floci CA, `ws://`, TCP and WebSocket clients on one topic, the custom authorizer and SigV4 URL shapes, wrong path and plain GET are 404, text frame closes with 1003, close propagation in both directions, a 1000 message burst arrives complete and in order, 16 concurrent clients, 30 connect and disconnect cycles leave no broker session behind, the TCP listener untouched.
- `IotMqttWebSocketContractIntegrationTest` (new, 15 cases): the handshake as AWS serves it (only GET upgrades, 405 otherwise; an unsupported WebSocket version is 426; each of the three subprotocol names is echoed and the first supported offer wins; a client offering only an unrelated subprotocol on an API Gateway WebSocket path still connects with none echoed; WebSocket ping gets pong; other methods fall through) and the session as on AWS (MQTT 5 over `wss://`, a second connection with the same client id takes over the first across transports, a retained message published over TCP reaches a later WebSocket subscriber, a QoS 2 publish is disconnected, shadow topics and topic rules work from a WebSocket publish, MQTT keep-alive pings cross the bridge, and the IoT Data connection APIs see, message and delete a WebSocket session).
- `IotMqttWebSocketFramingIntegrationTest` (new, 6 cases, raw bytes over the JDK WebSocket): MQTT 3.1.1 section 6 says packets need not align with frame boundaries, so a CONNECT split over two frames still gets a CONNACK and CONNECT plus SUBSCRIBE in one frame get CONNACK then SUBACK; garbage bytes and a frame over the transport limit end the session instead of hanging it; a text frame after a live CONNECT closes with 1003 and frees the broker session, and so does an abrupt TCP drop with no close frame.
- `IotMqttWebSocketProxyIntegrationTest` (new, 2 cases): `ws://` and `wss://` on one port through `TlsProxyServer`, which is the real `443:4566` path; and a hostname learned through `ensureHost` is refused by a client verifying that name before, and serves an MQTT session on `/mqtt` after.
- `IotMqttWebSocketLazyStartIntegrationTest` (new, 3 cases, `auto-start=false`): the first upgrade starts the broker, eight simultaneous first upgrades all get a session, and an upgrade after a broker stop starts it again.
- `IotMqttDisabledIntegrationTest`: 503 with the broker off.
- `docs/services/iot.md`: "MQTT over WebSocket" subsection.

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Docs / chore

## Checklist

* [x] `./mvnw test` passes locally. One full run: 13591 tests, the only failures were local noise (a Docker platform test on an arm64 Mac, the shared `/tmp` TLS fixture of another worktree, and two classes that passed on their own after a concurrent compile had disturbed them). `make docs-check` passes.
* [x] New or updated integration test added
* [x] Commit messages follow Conventional Commits


