### PR TITLE
feat(securityhub): add organization configuration operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Floci supports local emulation for application services, data services, eventing
 | Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Redshift Data API, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
 | Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
 | Messaging and transfer | SES, Kinesis, MSK, Amazon MQ, Transfer Family, IoT Core, Amazon Connect |
-| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, Amazon Inspector, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, AWS Account Management, IAM Access Analyzer, IAM Identity Center (SSO Admin), Identity Store, Amazon Macie, Amazon Detective, Control Catalog, Control Tower, Service Catalog |
+| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, Amazon Inspector, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, AWS Account Management, IAM Access Analyzer, IAM Identity Center (SSO Admin), Identity Store, Amazon Macie, Amazon Detective, Security Hub, Control Catalog, Control Tower, Service Catalog |
 | Cost and billing | AWS Budgets, Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |
 | Resilience, backup, and config | AWS FIS, AWS Backup, AWS Config, AppConfig, AppConfigData, CloudFormation, Cloud Control API |
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -267,6 +267,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>inspector2</artifactId>
         </dependency>
+        <!-- AWS Security Hub client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>securityhub</artifactId>
+        </dependency>
         <!-- AWS Account Management client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -39,6 +39,7 @@ import software.amazon.awssdk.services.budgets.BudgetsClient;
 import software.amazon.awssdk.services.macie2.Macie2Client;
 import software.amazon.awssdk.services.controlcatalog.ControlCatalogClient;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
+import software.amazon.awssdk.services.securityhub.SecurityHubClient;
 import software.amazon.awssdk.services.detective.DetectiveClient;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
@@ -367,6 +368,14 @@ public final class TestFixtures {
 
     public static Inspector2Client inspector2Client(String accountId) {
         return Inspector2Client.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))
+                .build();
+    }
+
+    public static SecurityHubClient securityHubClient(String accountId) {
+        return SecurityHubClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.floci.test;
 
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
@@ -14,6 +15,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("Security Hub organization configuration")
 class SecurityHubOrganizationConfigurationTest {
+    private static final Logger LOG = Logger.getLogger(SecurityHubOrganizationConfigurationTest.class);
     private static final String MANAGEMENT_ACCOUNT = "test";
 
     @Test
@@ -98,8 +100,8 @@ class SecurityHubOrganizationConfigurationTest {
     private static void ensureOrganization(OrganizationsClient organizations) {
         try {
             organizations.createOrganization(request -> request.featureSet("ALL"));
-        } catch (AlreadyInOrganizationException ignored) {
-            // The compatibility suite may already have created the default-account organization.
+        } catch (AlreadyInOrganizationException e) {
+            LOG.debugf(e, "Default compatibility account already belongs to an AWS organization");
         }
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
@@ -1,0 +1,91 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.securityhub.SecurityHubClient;
+import software.amazon.awssdk.services.securityhub.model.Policy;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@DisplayName("Security Hub organization configuration")
+class SecurityHubOrganizationConfigurationTest {
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+    private static final String ADMIN_ACCOUNT = "111111111111";
+    private static final String MEMBER_ACCOUNT = "333333333333";
+
+    @Test
+    void organizationConfigurationUsesAwsSdk() {
+        assumeFalse(TestFixtures.isRealAws(), "Avoids changing Security Hub organization settings in real AWS");
+
+        try (SecurityHubClient management = TestFixtures.securityHubClient(MANAGEMENT_ACCOUNT);
+             SecurityHubClient administrator = TestFixtures.securityHubClient(ADMIN_ACCOUNT)) {
+            assertThat(management.listOrganizationAdminAccounts(request -> {}).adminAccounts()).isEmpty();
+
+            var enabledAdmin = management.enableOrganizationAdminAccount(request -> request
+                    .adminAccountId(ADMIN_ACCOUNT));
+            assertThat(enabledAdmin.adminAccountId()).isEqualTo(ADMIN_ACCOUNT);
+            assertThat(enabledAdmin.featureAsString()).isEqualTo("SecurityHub");
+
+            var administrators = management.listOrganizationAdminAccounts(request -> {});
+            assertThat(administrators.featureAsString()).isEqualTo("SecurityHub");
+            assertThat(administrators.adminAccounts())
+                    .singleElement()
+                    .satisfies(account -> {
+                        assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT);
+                        assertThat(account.statusAsString()).isEqualTo("ENABLED");
+                    });
+
+            assertThat(administrator.describeHub(request -> {}).hubArn()).isNotBlank();
+            administrator.updateSecurityHubConfiguration(request -> request
+                    .autoEnableControls(false)
+                    .controlFindingGenerator("STANDARD_CONTROL"));
+            var hub = administrator.describeHub(request -> {});
+            assertThat(hub.autoEnableControls()).isFalse();
+            assertThat(hub.controlFindingGeneratorAsString()).isEqualTo("STANDARD_CONTROL");
+
+            administrator.updateOrganizationConfiguration(request -> request
+                    .autoEnable(false)
+                    .autoEnableStandards("NONE")
+                    .organizationConfiguration(configuration -> configuration.configurationType("CENTRAL")));
+
+            var organization = administrator.describeOrganizationConfiguration(request -> {});
+            assertThat(organization.autoEnable()).isFalse();
+            assertThat(organization.autoEnableStandardsAsString()).isEqualTo("NONE");
+            assertThat(organization.organizationConfiguration().configurationTypeAsString()).isEqualTo("CENTRAL");
+
+            var aggregator = administrator.createFindingAggregator(request -> request.regionLinkingMode("ALL_REGIONS"));
+            assertThat(aggregator.findingAggregatorArn()).isNotBlank();
+
+            var policy = administrator.createConfigurationPolicy(request -> request
+                    .name(TestFixtures.uniqueName("securityhub-policy"))
+                    .configurationPolicy(Policy.fromSecurityHub(securityHub -> securityHub.serviceEnabled(true)))
+                    .tags(Map.of("env", "test")));
+            assertThat(policy.id()).isNotBlank();
+            assertThat(policy.configurationPolicy().securityHub().serviceEnabled()).isTrue();
+
+            assertThat(administrator.listConfigurationPolicies(request -> {}).configurationPolicySummaries())
+                    .anySatisfy(summary -> {
+                        assertThat(summary.id()).isEqualTo(policy.id());
+                        assertThat(summary.serviceEnabled()).isTrue();
+                    });
+
+            var association = administrator.startConfigurationPolicyAssociation(request -> request
+                    .configurationPolicyIdentifier(policy.id())
+                    .target(target -> target.accountId(MEMBER_ACCOUNT)));
+            assertThat(association.targetId()).isEqualTo(MEMBER_ACCOUNT);
+            assertThat(association.configurationPolicyId()).isEqualTo(policy.id());
+
+            administrator.getConfigurationPolicyAssociation(request -> request
+                    .target(target -> target.accountId(MEMBER_ACCOUNT)));
+            var converged = administrator.getConfigurationPolicyAssociation(request -> request
+                    .target(target -> target.accountId(MEMBER_ACCOUNT)));
+            assertThat(converged.associationStatusAsString()).isEqualTo("SUCCESS");
+
+            assertThat(administrator.listTagsForResource(request -> request.resourceArn(policy.arn())).tags())
+                    .containsEntry("env", "test");
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
@@ -23,7 +23,7 @@ class SecurityHubOrganizationConfigurationTest {
         assumeFalse(TestFixtures.isRealAws(), "Avoids changing Security Hub organization settings in real AWS");
 
         try (OrganizationsClient organizations = TestFixtures.organizationsClient()) {
-            ensureOrganization(organizations);
+            boolean createdOrganization = ensureOrganization(organizations);
             String adminAccount = createMemberAccount(organizations, "securityhub-admin");
             String memberAccount = createMemberAccount(organizations, "securityhub-member");
 
@@ -93,15 +93,23 @@ class SecurityHubOrganizationConfigurationTest {
 
                 assertThat(administrator.listTagsForResource(request -> request.resourceArn(policy.arn())).tags())
                         .containsEntry("env", "test");
+            } finally {
+                organizations.removeAccountFromOrganization(request -> request.accountId(memberAccount));
+                organizations.removeAccountFromOrganization(request -> request.accountId(adminAccount));
+                if (createdOrganization) {
+                    organizations.deleteOrganization();
+                }
             }
         }
     }
 
-    private static void ensureOrganization(OrganizationsClient organizations) {
+    private static boolean ensureOrganization(OrganizationsClient organizations) {
         try {
             organizations.createOrganization(request -> request.featureSet("ALL"));
+            return true;
         } catch (AlreadyInOrganizationException e) {
             LOG.debugf(e, "Default compatibility account already belongs to an AWS organization");
+            return false;
         }
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
@@ -94,12 +94,22 @@ class SecurityHubOrganizationConfigurationTest {
                 assertThat(administrator.listTagsForResource(request -> request.resourceArn(policy.arn())).tags())
                         .containsEntry("env", "test");
             } finally {
-                organizations.removeAccountFromOrganization(request -> request.accountId(memberAccount));
-                organizations.removeAccountFromOrganization(request -> request.accountId(adminAccount));
+                cleanup("remove member account", () ->
+                        organizations.removeAccountFromOrganization(request -> request.accountId(memberAccount)));
+                cleanup("remove administrator account", () ->
+                        organizations.removeAccountFromOrganization(request -> request.accountId(adminAccount)));
                 if (createdOrganization) {
-                    organizations.deleteOrganization();
+                    cleanup("delete test organization", organizations::deleteOrganization);
                 }
             }
+        }
+    }
+
+    private static void cleanup(String action, Runnable cleanup) {
+        try {
+            cleanup.run();
+        } catch (RuntimeException e) {
+            LOG.warnf(e, "Security Hub compatibility cleanup failed: %s", action);
         }
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SecurityHubOrganizationConfigurationTest.java
@@ -2,6 +2,8 @@ package com.floci.test;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.organizations.OrganizationsClient;
+import software.amazon.awssdk.services.organizations.model.AlreadyInOrganizationException;
 import software.amazon.awssdk.services.securityhub.SecurityHubClient;
 import software.amazon.awssdk.services.securityhub.model.Policy;
 
@@ -12,80 +14,100 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("Security Hub organization configuration")
 class SecurityHubOrganizationConfigurationTest {
-    private static final String MANAGEMENT_ACCOUNT = "222222222222";
-    private static final String ADMIN_ACCOUNT = "111111111111";
-    private static final String MEMBER_ACCOUNT = "333333333333";
+    private static final String MANAGEMENT_ACCOUNT = "test";
 
     @Test
     void organizationConfigurationUsesAwsSdk() {
         assumeFalse(TestFixtures.isRealAws(), "Avoids changing Security Hub organization settings in real AWS");
 
-        try (SecurityHubClient management = TestFixtures.securityHubClient(MANAGEMENT_ACCOUNT);
-             SecurityHubClient administrator = TestFixtures.securityHubClient(ADMIN_ACCOUNT)) {
-            assertThat(management.listOrganizationAdminAccounts(request -> {}).adminAccounts()).isEmpty();
+        try (OrganizationsClient organizations = TestFixtures.organizationsClient()) {
+            ensureOrganization(organizations);
+            String adminAccount = createMemberAccount(organizations, "securityhub-admin");
+            String memberAccount = createMemberAccount(organizations, "securityhub-member");
 
-            var enabledAdmin = management.enableOrganizationAdminAccount(request -> request
-                    .adminAccountId(ADMIN_ACCOUNT));
-            assertThat(enabledAdmin.adminAccountId()).isEqualTo(ADMIN_ACCOUNT);
-            assertThat(enabledAdmin.featureAsString()).isEqualTo("SecurityHub");
+            try (SecurityHubClient management = TestFixtures.securityHubClient(MANAGEMENT_ACCOUNT);
+                 SecurityHubClient administrator = TestFixtures.securityHubClient(adminAccount)) {
+                assertThat(management.listOrganizationAdminAccounts(request -> {}).adminAccounts()).isEmpty();
 
-            var administrators = management.listOrganizationAdminAccounts(request -> {});
-            assertThat(administrators.featureAsString()).isEqualTo("SecurityHub");
-            assertThat(administrators.adminAccounts())
+                var enabledAdmin = management.enableOrganizationAdminAccount(request -> request
+                        .adminAccountId(adminAccount));
+                assertThat(enabledAdmin.adminAccountId()).isEqualTo(adminAccount);
+                assertThat(enabledAdmin.featureAsString()).isEqualTo("SecurityHub");
+
+                var administrators = management.listOrganizationAdminAccounts(request -> {});
+                assertThat(administrators.featureAsString()).isEqualTo("SecurityHub");
+                assertThat(administrators.adminAccounts())
                     .singleElement()
                     .satisfies(account -> {
-                        assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT);
+                        assertThat(account.accountId()).isEqualTo(adminAccount);
                         assertThat(account.statusAsString()).isEqualTo("ENABLED");
                     });
 
-            assertThat(administrator.describeHub(request -> {}).hubArn()).isNotBlank();
-            administrator.updateSecurityHubConfiguration(request -> request
+                assertThat(administrator.describeHub(request -> {}).hubArn()).isNotBlank();
+                administrator.updateSecurityHubConfiguration(request -> request
                     .autoEnableControls(false)
                     .controlFindingGenerator("STANDARD_CONTROL"));
-            var hub = administrator.describeHub(request -> {});
-            assertThat(hub.autoEnableControls()).isFalse();
-            assertThat(hub.controlFindingGeneratorAsString()).isEqualTo("STANDARD_CONTROL");
+                var hub = administrator.describeHub(request -> {});
+                assertThat(hub.autoEnableControls()).isFalse();
+                assertThat(hub.controlFindingGeneratorAsString()).isEqualTo("STANDARD_CONTROL");
 
-            administrator.updateOrganizationConfiguration(request -> request
+                administrator.updateOrganizationConfiguration(request -> request
                     .autoEnable(false)
                     .autoEnableStandards("NONE")
                     .organizationConfiguration(configuration -> configuration.configurationType("CENTRAL")));
 
-            var organization = administrator.describeOrganizationConfiguration(request -> {});
-            assertThat(organization.autoEnable()).isFalse();
-            assertThat(organization.autoEnableStandardsAsString()).isEqualTo("NONE");
-            assertThat(organization.organizationConfiguration().configurationTypeAsString()).isEqualTo("CENTRAL");
+                var organization = administrator.describeOrganizationConfiguration(request -> {});
+                assertThat(organization.autoEnable()).isFalse();
+                assertThat(organization.autoEnableStandardsAsString()).isEqualTo("NONE");
+                assertThat(organization.organizationConfiguration().configurationTypeAsString()).isEqualTo("CENTRAL");
 
-            var aggregator = administrator.createFindingAggregator(request -> request.regionLinkingMode("ALL_REGIONS"));
-            assertThat(aggregator.findingAggregatorArn()).isNotBlank();
+                var aggregator = administrator.createFindingAggregator(request -> request.regionLinkingMode("ALL_REGIONS"));
+                assertThat(aggregator.findingAggregatorArn()).isNotBlank();
 
-            var policy = administrator.createConfigurationPolicy(request -> request
+                var policy = administrator.createConfigurationPolicy(request -> request
                     .name(TestFixtures.uniqueName("securityhub-policy"))
                     .configurationPolicy(Policy.fromSecurityHub(securityHub -> securityHub.serviceEnabled(true)))
                     .tags(Map.of("env", "test")));
-            assertThat(policy.id()).isNotBlank();
-            assertThat(policy.configurationPolicy().securityHub().serviceEnabled()).isTrue();
+                assertThat(policy.id()).isNotBlank();
+                assertThat(policy.configurationPolicy().securityHub().serviceEnabled()).isTrue();
 
-            assertThat(administrator.listConfigurationPolicies(request -> {}).configurationPolicySummaries())
+                assertThat(administrator.listConfigurationPolicies(request -> {}).configurationPolicySummaries())
                     .anySatisfy(summary -> {
                         assertThat(summary.id()).isEqualTo(policy.id());
                         assertThat(summary.serviceEnabled()).isTrue();
                     });
 
-            var association = administrator.startConfigurationPolicyAssociation(request -> request
+                var association = administrator.startConfigurationPolicyAssociation(request -> request
                     .configurationPolicyIdentifier(policy.id())
-                    .target(target -> target.accountId(MEMBER_ACCOUNT)));
-            assertThat(association.targetId()).isEqualTo(MEMBER_ACCOUNT);
-            assertThat(association.configurationPolicyId()).isEqualTo(policy.id());
+                    .target(target -> target.accountId(memberAccount)));
+                assertThat(association.targetId()).isEqualTo(memberAccount);
+                assertThat(association.configurationPolicyId()).isEqualTo(policy.id());
 
-            administrator.getConfigurationPolicyAssociation(request -> request
-                    .target(target -> target.accountId(MEMBER_ACCOUNT)));
-            var converged = administrator.getConfigurationPolicyAssociation(request -> request
-                    .target(target -> target.accountId(MEMBER_ACCOUNT)));
-            assertThat(converged.associationStatusAsString()).isEqualTo("SUCCESS");
+                administrator.getConfigurationPolicyAssociation(request -> request
+                    .target(target -> target.accountId(memberAccount)));
+                var converged = administrator.getConfigurationPolicyAssociation(request -> request
+                    .target(target -> target.accountId(memberAccount)));
+                assertThat(converged.associationStatusAsString()).isEqualTo("SUCCESS");
 
-            assertThat(administrator.listTagsForResource(request -> request.resourceArn(policy.arn())).tags())
-                    .containsEntry("env", "test");
+                assertThat(administrator.listTagsForResource(request -> request.resourceArn(policy.arn())).tags())
+                        .containsEntry("env", "test");
+            }
         }
+    }
+
+    private static void ensureOrganization(OrganizationsClient organizations) {
+        try {
+            organizations.createOrganization(request -> request.featureSet("ALL"));
+        } catch (AlreadyInOrganizationException ignored) {
+            // The compatibility suite may already have created the default-account organization.
+        }
+    }
+
+    private static String createMemberAccount(OrganizationsClient organizations, String prefix) {
+        String suffix = TestFixtures.uniqueName(prefix);
+        var response = organizations.createAccount(request -> request
+                .accountName(suffix)
+                .email(suffix + "@example.com"));
+        return response.createAccountStatus().accountId();
     }
 }

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -50,7 +50,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Identity Store](identitystore.md) | `POST /` + `X-Amz-Target: AWSIdentityStore.*` | JSON 1.1 | 19 |
 | [Amazon Macie](macie2.md) | `/admin`, `/macie`, `/admin/configuration` | REST JSON | 6 |
 | [Amazon Inspector](inspector2.md) | `/delegatedadminaccounts/*`, `/status/batch/get`, `/enable`, `/organizationconfiguration/*` | REST JSON | 7 |
-| [Security Hub](securityhub.md) | `/organization/*`, `/accounts`, `/findingAggregator/*`, `/configurationPolicy*`, `/tags/*` | REST JSON | 19 |
+| [Security Hub](securityhub.md) | `/organization/*`, `/accounts`, `/findingAggregator/*`, `/configurationPolicy*`, `/tags/*` | REST JSON | 22 |
 | [Amazon Detective](detective.md) | `/orgs/*`, `/graphs/list`, `/graph/*` | REST JSON | 8 |
 | [Amazon Connect](connect.md) | `/instance`, `/instance/{instanceId}/*`, `/tags/*` | REST JSON | 15 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -50,6 +50,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Identity Store](identitystore.md) | `POST /` + `X-Amz-Target: AWSIdentityStore.*` | JSON 1.1 | 19 |
 | [Amazon Macie](macie2.md) | `/admin`, `/macie`, `/admin/configuration` | REST JSON | 6 |
 | [Amazon Inspector](inspector2.md) | `/delegatedadminaccounts/*`, `/status/batch/get`, `/enable`, `/organizationconfiguration/*` | REST JSON | 7 |
+| [Security Hub](securityhub.md) | `/organization/*`, `/accounts`, `/findingAggregator/*`, `/configurationPolicy*`, `/tags/*` | REST JSON | 19 |
 | [Amazon Detective](detective.md) | `/orgs/*`, `/graphs/list`, `/graph/*` | REST JSON | 8 |
 | [Amazon Connect](connect.md) | `/instance`, `/instance/{instanceId}/*`, `/tags/*` | REST JSON | 15 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |

--- a/docs/services/securityhub.md
+++ b/docs/services/securityhub.md
@@ -1,0 +1,21 @@
+# AWS Security Hub
+
+Floci implements the REST JSON organization and central-configuration surfaces used by local security-governance workflows.
+
+## Supported behavior
+
+The supported surface includes delegated administrator management, Security Hub enablement, finding aggregators, organization configuration, configuration policies, policy associations, and resource tag lookup. Delegation is visible in the delegated account so subsequent calls can be signed by that account exactly as they are against AWS.
+
+Finding aggregators support `ALL_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED`, `SPECIFIED_REGIONS`, and `NO_REGIONS`. `GetFindingAggregator` accepts the complete finding-aggregator ARN carried in the greedy AWS REST path.
+
+Central organization configuration models asynchronous convergence. Changing to `CENTRAL` first returns organization status `PENDING`; a subsequent poll converges to `ENABLED`. Configuration-policy association behaves the same way with `PENDING` followed by `SUCCESS`. Disassociation is also represented as a pending transition before the association disappears.
+
+Configuration-policy tags are persisted and returned by `ListTagsForResource` rather than synthesized at read time.
+
+## AWS-compatible failures
+
+Floci validates administrator account IDs, finding-aggregator modes and Region lists, central-configuration input, policy names and documents, target identifiers, tags, and association state. Deterministic failures use the AWS-modeled errors, including `InvalidInputException`, `InvalidAccessException`, `ResourceNotFoundException`, `ResourceConflictException`, and `LimitExceededException`.
+
+AWS also defines provider-side `InternalException` and rate-limit failures. Floci does not inject those failures without a request or local state condition that causes them.
+
+See the [AWS Security Hub API Reference](https://docs.aws.amazon.com/securityhub/1.0/APIReference/Welcome.html).

--- a/docs/services/securityhub.md
+++ b/docs/services/securityhub.md
@@ -1,21 +1,62 @@
 # AWS Security Hub
 
-Floci implements the REST JSON organization and central-configuration surfaces used by local security-governance workflows.
+**Protocol:** REST JSON
+
+**Endpoint:** `http://localhost:4566`
+
+Floci implements the AWS Security Hub CSPM organization and central-configuration surfaces used by local security-governance workflows.
+
+## Supported Actions
+
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `ListOrganizationAdminAccounts` | - |
+| `EnableOrganizationAdminAccount` | - |
+| `DescribeHub` | - |
+| `EnableSecurityHub` | - |
+| `UpdateSecurityHubConfiguration` | - |
+| `ListFindingAggregators` | - |
+| `CreateFindingAggregator` | - |
+| `GetFindingAggregator` | - |
+| `UpdateFindingAggregator` | - |
+| `DescribeOrganizationConfiguration` | - |
+| `UpdateOrganizationConfiguration` | - |
+| `ListConfigurationPolicies` | - |
+| `CreateConfigurationPolicy` | - |
+| `GetConfigurationPolicy` | - |
+| `UpdateConfigurationPolicy` | - |
+| `GetConfigurationPolicyAssociation` | - |
+| `StartConfigurationPolicyAssociation` | - |
+| `StartConfigurationPolicyDisassociation` | - |
+| `ListConfigurationPolicyAssociations` | - |
+| `ListTagsForResource` | - |
+| `TagResource` | - |
+| `UntagResource` | - |
+<!-- floci:actions:end -->
 
 ## Supported behavior
 
-The supported surface includes delegated administrator management, Security Hub enablement, finding aggregators, organization configuration, configuration policies, policy associations, and resource tag lookup. Delegation is visible in the delegated account so subsequent calls can be signed by that account exactly as they are against AWS.
+The supported surface includes Security Hub CSPM enablement and configuration, delegated administrator management, finding aggregators, organization configuration, configuration policies, policy associations, and resource tags.
+
+`EnableOrganizationAdminAccount` supports the AWS `SecurityHub` and `SecurityHubV2` feature values. Legacy `SecurityHub` delegation enables Security Hub CSPM for the delegated administrator in the current Region, matching AWS organization behavior.
 
 Finding aggregators support `ALL_REGIONS`, `ALL_REGIONS_EXCEPT_SPECIFIED`, `SPECIFIED_REGIONS`, and `NO_REGIONS`. `GetFindingAggregator` accepts the complete finding-aggregator ARN carried in the greedy AWS REST path.
 
-Central organization configuration models asynchronous convergence. Changing to `CENTRAL` first returns organization status `PENDING`; a subsequent poll converges to `ENABLED`. Configuration-policy association behaves the same way with `PENDING` followed by `SUCCESS`. Disassociation is also represented as a pending transition before the association disappears.
+Central organization configuration models asynchronous convergence. Changing to `CENTRAL` first reports organization status `PENDING`; a subsequent poll converges to `ENABLED`. Central configuration forces `AutoEnable` to `false` and `AutoEnableStandards` to `NONE`, as AWS does in the home and linked Regions. Configuration-policy association behaves similarly with `PENDING` followed by `SUCCESS`. Disassociation is represented as a pending transition before the association disappears.
 
-Configuration-policy tags are persisted and returned by `ListTagsForResource` rather than synthesized at read time.
+Configuration-policy and hub tags are persisted and returned through the shared Security Hub tagging routes. Tag keys and values use the AWS Security Hub constraints, including the reserved `aws:` prefix restriction.
 
 ## AWS-compatible failures
 
-Floci validates administrator account IDs, finding-aggregator modes and Region lists, central-configuration input, policy names and documents, target identifiers, tags, and association state. Deterministic failures use the AWS-modeled errors, including `InvalidInputException`, `InvalidAccessException`, `ResourceNotFoundException`, `ResourceConflictException`, and `LimitExceededException`.
+Floci validates administrator account IDs and features, finding-aggregator modes and Region lists, central-configuration input, policy names and documents, target identifiers, tags, and association state. Deterministic failures use AWS-modeled errors, including `InvalidInputException`, `InvalidAccessException`, `ResourceNotFoundException`, `ResourceConflictException`, and `LimitExceededException`.
 
 AWS also defines provider-side `InternalException` and rate-limit failures. Floci does not inject those failures without a request or local state condition that causes them.
 
 See the [AWS Security Hub API Reference](https://docs.aws.amazon.com/securityhub/1.0/APIReference/Welcome.html).
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_SECURITYHUB_ENABLED` | `true` | Enable or disable AWS Security Hub CSPM |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
     - AWS Budgets: services/budgets.md
     - Amazon Macie: services/macie2.md
     - Amazon Inspector: services/inspector2.md
+    - Security Hub: services/securityhub.md
     - Amazon Detective: services/detective.md
     - Control Catalog: services/controlcatalog.md
     - Control Tower: services/controltower.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -730,6 +730,7 @@ public interface EmulatorConfig {
         IdentityStoreServiceConfig identitystore();
         BudgetsServiceConfig budgets();
         Inspector2ServiceConfig inspector2();
+        SecurityHubServiceConfig securityhub();
         DetectiveServiceConfig detective();
         ServiceQuotasServiceConfig servicequotas();
         RamServiceConfig ram();
@@ -786,6 +787,11 @@ public interface EmulatorConfig {
     }
 
     interface Inspector2ServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface SecurityHubServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -36,6 +36,7 @@ import io.github.hectorvent.floci.services.macie2.MacieController;
 import io.github.hectorvent.floci.services.account.AccountController;
 import io.github.hectorvent.floci.services.accessanalyzer.AccessAnalyzerController;
 import io.github.hectorvent.floci.services.inspector2.Inspector2Controller;
+import io.github.hectorvent.floci.services.securityhub.SecurityHubController;
 import io.github.hectorvent.floci.services.detective.DetectiveController;
 import io.github.hectorvent.floci.services.aps.ApsController;
 import io.github.hectorvent.floci.services.controlcatalog.ControlCatalogController;
@@ -440,6 +441,9 @@ public class ResolvedServiceCatalog {
                 descriptor("inspector2", "inspector2", config.services().inspector2().enabled(), true,
                         "inspector2", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("inspector2"), Set.of(), Set.of(Inspector2Controller.class)),
+                descriptor("securityhub", "securityhub", config.services().securityhub().enabled(), true,
+                        "securityhub", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("securityhub"), Set.of(), Set.of(SecurityHubController.class)),
                 descriptor("autoscaling", "autoscaling", config.services().autoscaling().enabled(), true,
                         "autoscaling", config.storage().mode(), 5000L, AwsNamespaces.AUTOSCALING, ServiceProtocol.QUERY,
                         protocols(ServiceProtocol.QUERY),

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java
@@ -1,0 +1,263 @@
+package io.github.hectorvent.floci.services.securityhub;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.JsonErrorResponseUtils;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.securityhub.model.SecurityHubAssociation;
+import io.github.hectorvent.floci.services.securityhub.model.SecurityHubState;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PATCH;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.time.Instant;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class SecurityHubController {
+    private final SecurityHubService securityHubService;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public SecurityHubController(SecurityHubService securityHubService,
+                                 RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.securityHubService = securityHubService;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @GET
+    @Path("/organization/admin")
+    public Response listOrganizationAdminAccounts(@Context HttpHeaders headers) {
+        SecurityHubState state = securityHubService.state(region(headers));
+        ObjectNode response = objectMapper.createObjectNode();
+        var accounts = response.putArray("AdminAccounts");
+        if (state.getAdminAccountId() != null) {
+            accounts.addObject().put("AccountId", state.getAdminAccountId()).put("Status", "ENABLED");
+        }
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/organization/admin/enable")
+    public Response enableOrganizationAdminAccount(@Context HttpHeaders headers, String body) {
+        JsonNode request = readTree(body);
+        securityHubService.enableOrganizationAdminAccount(region(headers), request.path("AdminAccountId").asText(null));
+        return empty();
+    }
+
+    @GET
+    @Path("/accounts")
+    public Response describeHub(@Context HttpHeaders headers) {
+        String region = region(headers);
+        securityHubService.requireEnabled(region);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("HubArn", securityHubService.hubArn(region));
+        response.put("AutoEnableControls", true);
+        response.put("ControlFindingGenerator", "SECURITY_CONTROL");
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/accounts")
+    public Response enableSecurityHub(@Context HttpHeaders headers, String body) {
+        securityHubService.enableSecurityHub(region(headers));
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @GET
+    @Path("/findingAggregator/list")
+    public Response listFindingAggregators(@Context HttpHeaders headers) {
+        SecurityHubState state = securityHubService.state(region(headers));
+        ObjectNode response = objectMapper.createObjectNode();
+        var items = response.putArray("FindingAggregators");
+        if (state.getAggregatorArn() != null) {
+            items.addObject().put("FindingAggregatorArn", state.getAggregatorArn());
+        }
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/findingAggregator/create")
+    public Response createFindingAggregator(@Context HttpHeaders headers, String body) {
+        String region = region(headers);
+        return aggregator(securityHubService.createFindingAggregator(region, readTree(body)), region);
+    }
+
+    @GET
+    @Path("/findingAggregator/get/{findingAggregatorArn: .+}")
+    public Response getFindingAggregator(@Context HttpHeaders headers,
+                                         @PathParam("findingAggregatorArn") String findingAggregatorArn) {
+        String region = region(headers);
+        return aggregator(securityHubService.getFindingAggregator(region, findingAggregatorArn), region);
+    }
+
+    @PATCH
+    @Path("/findingAggregator/update")
+    public Response updateFindingAggregator(@Context HttpHeaders headers, String body) {
+        String region = region(headers);
+        SecurityHubState state = securityHubService.updateFindingAggregator(region, readTree(body));
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("FindingAggregatorArn", state.getAggregatorArn());
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/organization/configuration")
+    public Response describeOrganizationConfiguration(@Context HttpHeaders headers) {
+        SecurityHubState state = securityHubService.organizationConfiguration(region(headers));
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("AutoEnable", false);
+        response.put("AutoEnableStandards", "NONE");
+        response.put("MemberAccountLimitReached", false);
+        ObjectNode configuration = response.putObject("OrganizationConfiguration");
+        configuration.put("ConfigurationType", state.getOrganizationConfigurationType());
+        configuration.put("Status", state.getOrganizationConfigurationStatus());
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/organization/configuration")
+    public Response updateOrganizationConfiguration(@Context HttpHeaders headers, String body) {
+        securityHubService.updateOrganizationConfiguration(region(headers), readTree(body));
+        return empty();
+    }
+
+    @GET
+    @Path("/configurationPolicy/list")
+    public Response listConfigurationPolicies(@Context HttpHeaders headers) {
+        String region = region(headers);
+        ObjectNode response = objectMapper.createObjectNode();
+        var items = response.putArray("ConfigurationPolicySummaries");
+        securityHubService.policies(region).forEach(entry -> items.add(policySummary(region, entry.getKey(), entry.getValue())));
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/configurationPolicy/create")
+    public Response createConfigurationPolicy(@Context HttpHeaders headers, String body) {
+        String region = region(headers);
+        JsonNode request = readTree(body);
+        String id = securityHubService.createConfigurationPolicy(region, request);
+        return Response.ok(policyDocument(region, id, request)).build();
+    }
+
+    @GET
+    @Path("/configurationPolicy/get/{id: .+}")
+    public Response getConfigurationPolicy(@Context HttpHeaders headers, @PathParam("id") String id) {
+        String region = region(headers);
+        return Response.ok(policyDocument(region, id, securityHubService.getConfigurationPolicy(region, id))).build();
+    }
+
+    @PATCH
+    @Path("/configurationPolicy/{id: .+}")
+    public Response updateConfigurationPolicy(@Context HttpHeaders headers, @PathParam("id") String id, String body) {
+        String region = region(headers);
+        return Response.ok(policyDocument(region, id,
+                securityHubService.updateConfigurationPolicy(region, id, readTree(body)))).build();
+    }
+
+    @POST
+    @Path("/configurationPolicyAssociation/get")
+    public Response getConfigurationPolicyAssociation(@Context HttpHeaders headers, String body) {
+        String region = region(headers);
+        JsonNode request = readTree(body);
+        return Response.ok(association(securityHubService.association(region, request))).build();
+    }
+
+    @POST
+    @Path("/configurationPolicyAssociation/associate")
+    public Response startConfigurationPolicyAssociation(@Context HttpHeaders headers, String body) {
+        String region = region(headers);
+        JsonNode request = readTree(body);
+        return Response.ok(association(securityHubService.associate(region, request))).build();
+    }
+
+    @POST
+    @Path("/configurationPolicyAssociation/disassociate")
+    public Response startConfigurationPolicyDisassociation(@Context HttpHeaders headers, String body) {
+        securityHubService.disassociate(region(headers), readTree(body));
+        return empty();
+    }
+
+    @POST
+    @Path("/configurationPolicyAssociation/list")
+    public Response listConfigurationPolicyAssociations(@Context HttpHeaders headers, String body) {
+        String region = region(headers);
+        ObjectNode response = objectMapper.createObjectNode();
+        var items = response.putArray("ConfigurationPolicyAssociationSummaries");
+        securityHubService.associations(region).forEach(entry -> items.add(association(entry)));
+        return Response.ok(response).build();
+    }
+
+    @GET
+    @Path("/tags/{resource: .+}")
+    public Response listTagsForResource(@Context HttpHeaders headers, @PathParam("resource") String resource) {
+        ObjectNode response = objectMapper.createObjectNode();
+        ObjectNode tags = response.putObject("Tags");
+        securityHubService.tagsForResource(region(headers), resource).forEach(tags::put);
+        return Response.ok(response).build();
+    }
+
+    private Response aggregator(SecurityHubState state, String region) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("FindingAggregatorArn", state.getAggregatorArn());
+        response.put("FindingAggregationRegion", region);
+        response.put("RegionLinkingMode", state.getRegionLinkingMode());
+        if (state.getRegions() != null) response.set("Regions", state.getRegions());
+        return Response.ok(response).build();
+    }
+
+    private ObjectNode policySummary(String region, String id, JsonNode policy) {
+        int slash = id == null ? -1 : id.lastIndexOf('/');
+        String policyId = slash >= 0 ? id.substring(slash + 1) : id;
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("Arn", securityHubService.policyArn(region, policyId));
+        response.put("Id", policyId);
+        response.put("Name", policy.path("Name").asText());
+        if (policy.hasNonNull("Description")) response.put("Description", policy.path("Description").asText());
+        response.put("UpdatedAt", Instant.now().toString());
+        return response;
+    }
+
+    private ObjectNode policyDocument(String region, String id, JsonNode policy) {
+        ObjectNode response = policySummary(region, id, policy);
+        if (policy.has("ConfigurationPolicy")) response.set("ConfigurationPolicy", policy.get("ConfigurationPolicy"));
+        response.put("CreatedAt", Instant.now().toString());
+        return response;
+    }
+
+    private ObjectNode association(SecurityHubAssociation association) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("AssociationStatus", association.getStatus());
+        if (association.getStatusMessage() != null) {
+            response.put("AssociationStatusMessage", association.getStatusMessage());
+        }
+        response.put("AssociationType", "APPLIED");
+        response.put("ConfigurationPolicyId", association.getPolicyId());
+        response.put("TargetId", association.getTargetId());
+        response.put("TargetType", association.getTargetType());
+        response.put("UpdatedAt", Instant.now().toString());
+        return response;
+    }
+
+    private String region(HttpHeaders headers) { return regionResolver.resolveRegion(headers); }
+    private Response empty() { return Response.ok(objectMapper.createObjectNode()).build(); }
+    private JsonNode readTree(String body) {
+        try { return objectMapper.readTree(body == null || body.isBlank() ? "{}" : body); }
+        catch (Exception e) { throw new WebApplicationException(JsonErrorResponseUtils.createSerializationErrorResponse()); }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java
@@ -3,7 +3,10 @@ package io.github.hectorvent.floci.services.securityhub;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.JsonErrorResponseUtils;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.securityhub.model.SecurityHubAssociation;
 import io.github.hectorvent.floci.services.securityhub.model.SecurityHubState;
@@ -15,6 +18,7 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
@@ -41,13 +45,27 @@ public class SecurityHubController {
 
     @GET
     @Path("/organization/admin")
-    public Response listOrganizationAdminAccounts(@Context HttpHeaders headers) {
+    public Response listOrganizationAdminAccounts(@Context HttpHeaders headers,
+                                                  @QueryParam("Feature") String feature,
+                                                  @QueryParam("MaxResults") String maxResultsValue,
+                                                  @QueryParam("NextToken") String nextToken) {
+        Integer maxResults = Pagination.parseMaxResults(maxResultsValue, "InvalidInputException");
+        if (maxResults != null && maxResults > 10) {
+            throw new AwsException("InvalidInputException", "MaxResults must be between 1 and 10.", 400);
+        }
+        if (nextToken != null && !nextToken.isBlank()) {
+            throw new AwsException("InvalidInputException", "NextToken is invalid.", 400);
+        }
         SecurityHubState state = securityHubService.state(region(headers));
         ObjectNode response = objectMapper.createObjectNode();
         var accounts = response.putArray("AdminAccounts");
-        if (state.getAdminAccountId() != null) {
-            accounts.addObject().put("AccountId", state.getAdminAccountId()).put("Status", "ENABLED");
+        String requestedFeature = securityHubService.normalizeFeature(feature);
+        if (state.getAdminAccountId() != null && requestedFeature.equals(state.getAdminFeature())) {
+            accounts.addObject()
+                    .put("AccountId", state.getAdminAccountId())
+                    .put("Status", "ENABLED");
         }
+        response.put("Feature", requestedFeature);
         return Response.ok(response).build();
     }
 
@@ -55,8 +73,12 @@ public class SecurityHubController {
     @Path("/organization/admin/enable")
     public Response enableOrganizationAdminAccount(@Context HttpHeaders headers, String body) {
         JsonNode request = readTree(body);
-        securityHubService.enableOrganizationAdminAccount(region(headers), request.path("AdminAccountId").asText(null));
-        return empty();
+        SecurityHubState state = securityHubService.enableOrganizationAdminAccount(
+                region(headers), request.path("AdminAccountId").asText(null), request.path("Feature").asText(null));
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("AdminAccountId", state.getAdminAccountId());
+        response.put("Feature", state.getAdminFeature());
+        return Response.ok(response).build();
     }
 
     @GET
@@ -66,21 +88,38 @@ public class SecurityHubController {
         securityHubService.requireEnabled(region);
         ObjectNode response = objectMapper.createObjectNode();
         response.put("HubArn", securityHubService.hubArn(region));
-        response.put("AutoEnableControls", true);
-        response.put("ControlFindingGenerator", "SECURITY_CONTROL");
+        SecurityHubState state = securityHubService.state(region);
+        response.put("AutoEnableControls", state.isAutoEnableControls());
+        response.put("ControlFindingGenerator", state.getControlFindingGenerator());
         return Response.ok(response).build();
     }
 
     @POST
     @Path("/accounts")
     public Response enableSecurityHub(@Context HttpHeaders headers, String body) {
-        securityHubService.enableSecurityHub(region(headers));
-        return Response.ok(objectMapper.createObjectNode()).build();
+        securityHubService.enableSecurityHub(region(headers), readTree(body));
+        return empty();
+    }
+
+    @PATCH
+    @Path("/accounts")
+    public Response updateSecurityHubConfiguration(@Context HttpHeaders headers, String body) {
+        securityHubService.updateSecurityHubConfiguration(region(headers), readTree(body));
+        return empty();
     }
 
     @GET
     @Path("/findingAggregator/list")
-    public Response listFindingAggregators(@Context HttpHeaders headers) {
+    public Response listFindingAggregators(@Context HttpHeaders headers,
+                                           @QueryParam("MaxResults") String maxResultsValue,
+                                           @QueryParam("NextToken") String nextToken) {
+        Integer maxResults = Pagination.parseMaxResults(maxResultsValue, "InvalidInputException");
+        if (maxResults != null && maxResults > 100) {
+            throw new AwsException("InvalidInputException", "MaxResults must be between 1 and 100.", 400);
+        }
+        if (nextToken != null && !nextToken.isBlank()) {
+            throw new AwsException("InvalidInputException", "NextToken is invalid.", 400);
+        }
         SecurityHubState state = securityHubService.state(region(headers));
         ObjectNode response = objectMapper.createObjectNode();
         var items = response.putArray("FindingAggregators");
@@ -120,8 +159,8 @@ public class SecurityHubController {
     public Response describeOrganizationConfiguration(@Context HttpHeaders headers) {
         SecurityHubState state = securityHubService.organizationConfiguration(region(headers));
         ObjectNode response = objectMapper.createObjectNode();
-        response.put("AutoEnable", false);
-        response.put("AutoEnableStandards", "NONE");
+        response.put("AutoEnable", state.isAutoEnable());
+        response.put("AutoEnableStandards", state.getAutoEnableStandards());
         response.put("MemberAccountLimitReached", false);
         ObjectNode configuration = response.putObject("OrganizationConfiguration");
         configuration.put("ConfigurationType", state.getOrganizationConfigurationType());
@@ -138,11 +177,19 @@ public class SecurityHubController {
 
     @GET
     @Path("/configurationPolicy/list")
-    public Response listConfigurationPolicies(@Context HttpHeaders headers) {
+    public Response listConfigurationPolicies(@Context HttpHeaders headers,
+                                              @QueryParam("MaxResults") String maxResultsValue,
+                                              @QueryParam("NextToken") String nextToken) {
         String region = region(headers);
+        Integer maxResults = Pagination.parseMaxResults(maxResultsValue, "InvalidInputException");
+        PaginatedResult<java.util.Map.Entry<String, JsonNode>> page =
+                securityHubService.policyPage(region, maxResults, nextToken);
         ObjectNode response = objectMapper.createObjectNode();
         var items = response.putArray("ConfigurationPolicySummaries");
-        securityHubService.policies(region).forEach(entry -> items.add(policySummary(region, entry.getKey(), entry.getValue())));
+        page.items().forEach(entry -> items.add(policySummary(region, entry.getKey(), entry.getValue())));
+        if (page.nextToken() != null) {
+            response.put("NextToken", page.nextToken());
+        }
         return Response.ok(response).build();
     }
 
@@ -197,18 +244,13 @@ public class SecurityHubController {
     @Path("/configurationPolicyAssociation/list")
     public Response listConfigurationPolicyAssociations(@Context HttpHeaders headers, String body) {
         String region = region(headers);
+        PaginatedResult<SecurityHubAssociation> page = securityHubService.associationPage(region, readTree(body));
         ObjectNode response = objectMapper.createObjectNode();
         var items = response.putArray("ConfigurationPolicyAssociationSummaries");
-        securityHubService.associations(region).forEach(entry -> items.add(association(entry)));
-        return Response.ok(response).build();
-    }
-
-    @GET
-    @Path("/tags/{resource: .+}")
-    public Response listTagsForResource(@Context HttpHeaders headers, @PathParam("resource") String resource) {
-        ObjectNode response = objectMapper.createObjectNode();
-        ObjectNode tags = response.putObject("Tags");
-        securityHubService.tagsForResource(region(headers), resource).forEach(tags::put);
+        page.items().forEach(entry -> items.add(association(entry)));
+        if (page.nextToken() != null) {
+            response.put("NextToken", page.nextToken());
+        }
         return Response.ok(response).build();
     }
 
@@ -217,7 +259,9 @@ public class SecurityHubController {
         response.put("FindingAggregatorArn", state.getAggregatorArn());
         response.put("FindingAggregationRegion", region);
         response.put("RegionLinkingMode", state.getRegionLinkingMode());
-        if (state.getRegions() != null) response.set("Regions", state.getRegions());
+        if (state.getRegions() != null) {
+            response.set("Regions", state.getRegions());
+        }
         return Response.ok(response).build();
     }
 
@@ -228,15 +272,23 @@ public class SecurityHubController {
         response.put("Arn", securityHubService.policyArn(region, policyId));
         response.put("Id", policyId);
         response.put("Name", policy.path("Name").asText());
-        if (policy.hasNonNull("Description")) response.put("Description", policy.path("Description").asText());
-        response.put("UpdatedAt", Instant.now().toString());
+        if (policy.hasNonNull("Description")) {
+            response.put("Description", policy.path("Description").asText());
+        }
+        JsonNode securityHub = policy.path("ConfigurationPolicy").path("SecurityHub");
+        if (securityHub.path("ServiceEnabled").isBoolean()) {
+            response.put("ServiceEnabled", securityHub.path("ServiceEnabled").asBoolean());
+        }
+        response.put("UpdatedAt", policy.path("UpdatedAt").asText(Instant.now().toString()));
         return response;
     }
 
     private ObjectNode policyDocument(String region, String id, JsonNode policy) {
         ObjectNode response = policySummary(region, id, policy);
-        if (policy.has("ConfigurationPolicy")) response.set("ConfigurationPolicy", policy.get("ConfigurationPolicy"));
-        response.put("CreatedAt", Instant.now().toString());
+        if (policy.has("ConfigurationPolicy")) {
+            response.set("ConfigurationPolicy", policy.get("ConfigurationPolicy"));
+        }
+        response.put("CreatedAt", policy.path("CreatedAt").asText(Instant.now().toString()));
         return response;
     }
 
@@ -250,14 +302,23 @@ public class SecurityHubController {
         response.put("ConfigurationPolicyId", association.getPolicyId());
         response.put("TargetId", association.getTargetId());
         response.put("TargetType", association.getTargetType());
-        response.put("UpdatedAt", Instant.now().toString());
+        response.put("UpdatedAt", association.getUpdatedAt());
         return response;
     }
 
-    private String region(HttpHeaders headers) { return regionResolver.resolveRegion(headers); }
-    private Response empty() { return Response.ok(objectMapper.createObjectNode()).build(); }
+    private String region(HttpHeaders headers) {
+        return regionResolver.resolveRegion(headers);
+    }
+
+    private Response empty() {
+        return Response.ok().build();
+    }
+
     private JsonNode readTree(String body) {
-        try { return objectMapper.readTree(body == null || body.isBlank() ? "{}" : body); }
-        catch (Exception e) { throw new WebApplicationException(JsonErrorResponseUtils.createSerializationErrorResponse()); }
+        try {
+            return objectMapper.readTree(body == null || body.isBlank() ? "{}" : body);
+        } catch (Exception e) {
+            throw new WebApplicationException(JsonErrorResponseUtils.createSerializationErrorResponse());
+        }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java
@@ -56,7 +56,7 @@ public class SecurityHubController {
         if (nextToken != null && !nextToken.isBlank()) {
             throw new AwsException("InvalidInputException", "NextToken is invalid.", 400);
         }
-        SecurityHubState state = securityHubService.state(region(headers));
+        SecurityHubState state = securityHubService.organizationAdminState(region(headers));
         ObjectNode response = objectMapper.createObjectNode();
         var accounts = response.putArray("AdminAccounts");
         String requestedFeature = securityHubService.normalizeFeature(feature);

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.PaginatedResult;
+import io.github.hectorvent.floci.core.common.Pagination;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.securityhub.model.SecurityHubAssociation;
@@ -18,7 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @ApplicationScoped
-public class SecurityHubService {
+public class SecurityHubService implements Resettable {
     private static final String SELF_MANAGED = "SELF_MANAGED_SECURITY_HUB";
     private static final List<String> LINKING_MODES = List.of(
             "ALL_REGIONS", "ALL_REGIONS_EXCEPT_SPECIFIED", "SPECIFIED_REGIONS", "NO_REGIONS");
@@ -28,8 +31,12 @@ public class SecurityHubService {
 
     @Inject
     public SecurityHubService(StorageFactory storageFactory, RegionResolver regionResolver) {
-        this.states = storageFactory.create("securityhub", "securityhub-state.json",
-                new TypeReference<Map<String, SecurityHubState>>() {});
+        this(storageFactory.create("securityhub", "securityhub-state.json",
+                new TypeReference<Map<String, SecurityHubState>>() {}), regionResolver);
+    }
+
+    SecurityHubService(AccountAwareStorageBackend<SecurityHubState> states, RegionResolver regionResolver) {
+        this.states = states;
         this.regionResolver = regionResolver;
     }
 
@@ -37,26 +44,67 @@ public class SecurityHubService {
         return states.get(region).orElseGet(SecurityHubState::new);
     }
 
-    public synchronized void enableOrganizationAdminAccount(String region, String adminAccountId) {
+    public synchronized SecurityHubState enableOrganizationAdminAccount(String region, String adminAccountId,
+                                                                        String feature) {
         requireAccountId(adminAccountId, "AdminAccountId");
+        String requestedFeature = normalizeFeature(feature);
         SecurityHubState management = state(region);
         if (management.getAdminAccountId() != null && !management.getAdminAccountId().equals(adminAccountId)) {
             throw conflict("A different Security Hub administrator account is already configured.");
         }
         management.setAdminAccountId(adminAccountId);
+        management.setAdminFeature(requestedFeature);
         save(region, management);
 
         SecurityHubState delegated = states.getForAccount(adminAccountId, region).orElseGet(SecurityHubState::new);
         delegated.setAdminAccountId(adminAccountId);
+        delegated.setAdminFeature(requestedFeature);
+        if ("SecurityHub".equals(requestedFeature)) {
+            delegated.setEnabled(true);
+        }
         states.putForAccount(adminAccountId, region, delegated);
+        return management;
     }
 
-    public synchronized void enableSecurityHub(String region) {
+    public synchronized void enableSecurityHub(String region, JsonNode request) {
         SecurityHubState state = state(region);
         if (state.isEnabled()) {
             throw conflict("Security Hub is already enabled for this account.");
         }
+        String controlFindingGenerator = text(request, "ControlFindingGenerator");
+        if (controlFindingGenerator != null
+                && !"SECURITY_CONTROL".equals(controlFindingGenerator)
+                && !"STANDARD_CONTROL".equals(controlFindingGenerator)) {
+            throw invalid("ControlFindingGenerator must be SECURITY_CONTROL or STANDARD_CONTROL.");
+        }
+        validateTags(request == null ? null : request.get("Tags"));
         state.setEnabled(true);
+        if (controlFindingGenerator != null) {
+            state.setControlFindingGenerator(controlFindingGenerator);
+        }
+        state.setHubTags(readTags(request == null ? null : request.get("Tags")));
+        save(region, state);
+    }
+
+    public synchronized void updateSecurityHubConfiguration(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        JsonNode autoEnableControls = request == null ? null : request.get("AutoEnableControls");
+        if (autoEnableControls != null && !autoEnableControls.isBoolean()) {
+            throw invalid("AutoEnableControls must be a boolean.");
+        }
+        String controlFindingGenerator = text(request, "ControlFindingGenerator");
+        if (controlFindingGenerator != null
+                && !"SECURITY_CONTROL".equals(controlFindingGenerator)
+                && !"STANDARD_CONTROL".equals(controlFindingGenerator)) {
+            throw invalid("ControlFindingGenerator must be SECURITY_CONTROL or STANDARD_CONTROL.");
+        }
+        if (autoEnableControls != null) {
+            state.setAutoEnableControls(autoEnableControls.booleanValue());
+        }
+        if (controlFindingGenerator != null) {
+            state.setControlFindingGenerator(controlFindingGenerator);
+        }
         save(region, state);
     }
 
@@ -64,6 +112,14 @@ public class SecurityHubService {
         if (!state(region).isEnabled()) {
             throw notFound("Security Hub is not enabled for this account.");
         }
+    }
+
+    public String normalizeFeature(String feature) {
+        String requestedFeature = feature == null || feature.isBlank() ? "SecurityHub" : feature;
+        if (!"SecurityHub".equals(requestedFeature) && !"SecurityHubV2".equals(requestedFeature)) {
+            throw invalid("Feature must be SecurityHub or SecurityHubV2.");
+        }
+        return requestedFeature;
     }
 
     public synchronized SecurityHubState createFindingAggregator(String region, JsonNode request) {
@@ -108,12 +164,7 @@ public class SecurityHubService {
     }
 
     public synchronized void updateOrganizationConfiguration(String region, JsonNode request) {
-        requireEnabled(region);
-        SecurityHubState state = state(region);
-        if (state.getAdminAccountId() == null) {
-            throw new AwsException("InvalidAccessException",
-                    "A Security Hub administrator account is required for central configuration.", 401);
-        }
+        SecurityHubState state = requireAdministrator(region);
         JsonNode autoEnable = request.get("AutoEnable");
         if (autoEnable == null || !autoEnable.isBoolean()) {
             throw invalid("AutoEnable is required.");
@@ -134,9 +185,15 @@ public class SecurityHubService {
         }
         state.setOrganizationConfigurationType(desiredType);
         if ("CENTRAL".equals(desiredType)) {
+            state.setAutoEnable(false);
+            state.setAutoEnableStandards("NONE");
             state.setOrganizationConfigurationStatus("PENDING");
             state.setOrganizationConfigurationPendingPollsRemaining(1);
         } else {
+            state.setAutoEnable(autoEnable.booleanValue());
+            if (autoStandards != null) {
+                state.setAutoEnableStandards(autoStandards);
+            }
             state.setOrganizationConfigurationStatus("ENABLED");
             state.setOrganizationConfigurationPendingPollsRemaining(0);
         }
@@ -144,8 +201,7 @@ public class SecurityHubService {
     }
 
     public synchronized SecurityHubState organizationConfiguration(String region) {
-        requireEnabled(region);
-        SecurityHubState state = state(region);
+        SecurityHubState state = requireAdministrator(region);
         if ("PENDING".equals(state.getOrganizationConfigurationStatus())
                 && state.getOrganizationConfigurationPendingPollsRemaining() > 0) {
             SecurityHubState response = copyConfigurationState(state);
@@ -162,12 +218,11 @@ public class SecurityHubService {
     }
 
     public synchronized String createConfigurationPolicy(String region, JsonNode request) {
-        requireEnabled(region);
+        SecurityHubState state = requireAdministrator(region);
         String name = requireText(request, "Name", "InvalidInputException");
         if (name.length() > 128) {
             throw invalid("Name exceeds the maximum length.");
         }
-        SecurityHubState state = state(region);
         boolean duplicate = state.getPolicies().values().stream()
                 .anyMatch(policy -> name.equals(text(policy, "Name")));
         if (duplicate) {
@@ -178,14 +233,18 @@ public class SecurityHubService {
         }
         validateTags(request.get("Tags"));
         String id = UUID.randomUUID().toString();
-        state.getPolicies().put(id, request.deepCopy());
+        ObjectNode stored = (ObjectNode) request.deepCopy();
+        String now = java.time.Instant.now().toString();
+        stored.put("CreatedAt", now);
+        stored.put("UpdatedAt", now);
+        state.getPolicies().put(id, stored);
         save(region, state);
         return id;
     }
 
     public JsonNode getConfigurationPolicy(String region, String identifier) {
         String id = normalizePolicyId(identifier);
-        JsonNode policy = state(region).getPolicies().get(id);
+        JsonNode policy = requireAdministrator(region).getPolicies().get(id);
         if (policy == null) {
             throw notFound("The configuration policy was not found.");
         }
@@ -194,7 +253,7 @@ public class SecurityHubService {
 
     public synchronized JsonNode updateConfigurationPolicy(String region, String identifier, JsonNode request) {
         String id = normalizePolicyId(identifier);
-        SecurityHubState state = state(region);
+        SecurityHubState state = requireAdministrator(region);
         JsonNode current = state.getPolicies().get(id);
         if (current == null) {
             throw notFound("The configuration policy was not found.");
@@ -221,14 +280,14 @@ public class SecurityHubService {
             }
             merged.set("ConfigurationPolicy", request.get("ConfigurationPolicy").deepCopy());
         }
+        merged.put("UpdatedAt", java.time.Instant.now().toString());
         state.getPolicies().put(id, merged);
         save(region, state);
         return merged;
     }
 
     public synchronized SecurityHubAssociation associate(String region, JsonNode request) {
-        requireEnabled(region);
-        SecurityHubState state = state(region);
+        SecurityHubState state = requireAdministrator(region);
         TargetRef target = target(request);
         String policyIdentifier = requireText(request, "ConfigurationPolicyIdentifier", "InvalidInputException");
         String policyId = normalizePolicyId(policyIdentifier);
@@ -248,8 +307,7 @@ public class SecurityHubService {
     }
 
     public synchronized SecurityHubAssociation association(String region, JsonNode request) {
-        requireEnabled(region);
-        SecurityHubState state = state(region);
+        SecurityHubState state = requireAdministrator(region);
         TargetRef target = target(request);
         SecurityHubAssociation association = state.getAssociations().get(target.id());
         if (association == null) {
@@ -268,6 +326,7 @@ public class SecurityHubService {
                 throw notFound("The configuration policy association was not found.");
             }
             association.setStatus("SUCCESS");
+            association.setUpdatedAt(java.time.Instant.now().toString());
             applyPolicyToAccountTarget(region, state, association);
             save(region, state);
         }
@@ -275,8 +334,7 @@ public class SecurityHubService {
     }
 
     public synchronized void disassociate(String region, JsonNode request) {
-        requireEnabled(region);
-        SecurityHubState state = state(region);
+        SecurityHubState state = requireAdministrator(region);
         TargetRef target = target(request);
         String policyIdentifier = requireText(request, "ConfigurationPolicyIdentifier", "InvalidInputException");
         String requestedPolicyId = normalizePolicyId(policyIdentifier);
@@ -288,6 +346,7 @@ public class SecurityHubService {
             throw conflict("The configuration policy association is already being removed.");
         }
         association.setStatus("PENDING");
+        association.setUpdatedAt(java.time.Instant.now().toString());
         association.setPendingPollsRemaining(1);
         association.setDisassociating(true);
         save(region, state);
@@ -310,34 +369,84 @@ public class SecurityHubService {
     }
 
     public List<SecurityHubAssociation> associations(String region) {
-        return state(region).getAssociations().values().stream()
+        return requireAdministrator(region).getAssociations().values().stream()
                 .map(SecurityHubAssociation::copy)
                 .toList();
     }
 
+    public PaginatedResult<SecurityHubAssociation> associationPage(String region, JsonNode request) {
+        JsonNode filters = request == null ? null : request.get("Filters");
+        if (filters != null && !filters.isObject()) {
+            throw invalid("Filters must be an object.");
+        }
+        String policyId = filters == null ? null : text(filters, "ConfigurationPolicyId");
+        String associationType = filters == null ? null : text(filters, "AssociationType");
+        String associationStatus = filters == null ? null : text(filters, "AssociationStatus");
+        if (associationType != null && !"APPLIED".equals(associationType) && !"INHERITED".equals(associationType)) {
+            throw invalid("AssociationType must be APPLIED or INHERITED.");
+        }
+        if (associationStatus != null && !List.of("PENDING", "SUCCESS", "FAILED").contains(associationStatus)) {
+            throw invalid("AssociationStatus must be PENDING, SUCCESS, or FAILED.");
+        }
+        Integer maxResults = integer(request, "MaxResults");
+        String nextToken = text(request, "NextToken");
+        List<SecurityHubAssociation> filtered = associations(region).stream()
+                .filter(item -> policyId == null || normalizePolicyId(policyId).equals(item.getPolicyId()))
+                .filter(item -> associationType == null || "APPLIED".equals(associationType))
+                .filter(item -> associationStatus == null || associationStatus.equals(item.getStatus()))
+                .toList();
+        return Pagination.paginate(filtered,
+                item -> item.getTargetType() + "\u0000" + item.getTargetId(),
+                maxResults, nextToken, 100, 100, "InvalidInputException");
+    }
+
     public List<Map.Entry<String, JsonNode>> policies(String region) {
-        return List.copyOf(state(region).getPolicies().entrySet());
+        return List.copyOf(requireAdministrator(region).getPolicies().entrySet());
+    }
+
+    public PaginatedResult<Map.Entry<String, JsonNode>> policyPage(String region, Integer maxResults,
+                                                                   String nextToken) {
+        return Pagination.paginate(policies(region), Map.Entry::getKey,
+                maxResults, nextToken, 100, 100, "InvalidInputException");
     }
 
     public Map<String, String> tagsForResource(String region, String arn) {
         SecurityHubState state = state(region);
-        JsonNode resource = taggedResource(state, region, arn);
-        if (resource == null) {
-            return Map.of();
+        validateResourceArn(region, arn);
+        if (arn.equals(hubArn(region))) {
+            if (!state.isEnabled()) {
+                throw notFound("The specified Security Hub resource was not found.");
+            }
+            return Map.copyOf(state.getHubTags());
         }
+        JsonNode resource = taggedPolicy(state, region, arn);
         JsonNode tags = resource.get("Tags");
         if (tags == null || !tags.isObject()) {
             return Map.of();
         }
         Map<String, String> result = new LinkedHashMap<>();
         tags.fields().forEachRemaining(entry -> {
-            if (entry.getValue().isTextual()) result.put(entry.getKey(), entry.getValue().textValue());
+            if (entry.getValue().isTextual()) {
+                result.put(entry.getKey(), entry.getValue().textValue());
+            }
         });
         return result;
     }
 
     public synchronized void tagResource(String region, String arn, Map<String, String> tags) {
         SecurityHubState state = state(region);
+        validateResourceArn(region, arn);
+        if (arn.equals(hubArn(region))) {
+            if (!state.isEnabled()) {
+                throw notFound("The specified Security Hub resource was not found.");
+            }
+            Map<String, String> merged = new LinkedHashMap<>(state.getHubTags());
+            merged.putAll(tags);
+            validateTags(merged);
+            state.setHubTags(merged);
+            save(region, state);
+            return;
+        }
         ObjectNode resource = policyResource(state, region, arn);
         ObjectNode current = resource.withObject("Tags");
         tags.forEach(current::put);
@@ -347,25 +456,44 @@ public class SecurityHubService {
 
     public synchronized void untagResource(String region, String arn, List<String> tagKeys) {
         SecurityHubState state = state(region);
+        validateResourceArn(region, arn);
+        if (arn.equals(hubArn(region))) {
+            if (!state.isEnabled()) {
+                throw notFound("The specified Security Hub resource was not found.");
+            }
+            Map<String, String> updated = new LinkedHashMap<>(state.getHubTags());
+            tagKeys.forEach(updated::remove);
+            state.setHubTags(updated);
+            save(region, state);
+            return;
+        }
         ObjectNode resource = policyResource(state, region, arn);
         ObjectNode tags = resource.withObject("Tags");
         tagKeys.forEach(tags::remove);
         save(region, state);
     }
 
-    private JsonNode taggedResource(SecurityHubState state, String region, String arn) {
-        if (arn == null || !arn.startsWith("arn:aws:securityhub:" + region + ":" + regionResolver.getAccountId() + ":")) {
+    private JsonNode taggedPolicy(SecurityHubState state, String region, String arn) {
+        validateResourceArn(region, arn);
+        if (arn.equals(state.getAggregatorArn())) {
             throw notFound("The specified Security Hub resource was not found.");
         }
-        if (arn.equals(hubArn(region)) || arn.equals(state.getAggregatorArn())) return null;
         String id = normalizePolicyId(arn);
         JsonNode policy = state.getPolicies().get(id);
-        if (policy == null) throw notFound("The specified Security Hub resource was not found.");
+        if (policy == null) {
+            throw notFound("The specified Security Hub resource was not found.");
+        }
         return policy;
     }
 
+    private void validateResourceArn(String region, String arn) {
+        if (arn == null || !arn.startsWith("arn:aws:securityhub:" + region + ":" + regionResolver.getAccountId() + ":")) {
+            throw notFound("The specified Security Hub resource was not found.");
+        }
+    }
+
     private ObjectNode policyResource(SecurityHubState state, String region, String arn) {
-        JsonNode resource = taggedResource(state, region, arn);
+        JsonNode resource = taggedPolicy(state, region, arn);
         if (!(resource instanceof ObjectNode object)) {
             throw notFound("The specified Security Hub resource does not support mutable tags in this emulator.");
         }
@@ -384,7 +512,10 @@ public class SecurityHubService {
     private static SecurityHubState copyConfigurationState(SecurityHubState source) {
         SecurityHubState copy = new SecurityHubState();
         copy.setAdminAccountId(source.getAdminAccountId());
+        copy.setAdminFeature(source.getAdminFeature());
         copy.setEnabled(source.isEnabled());
+        copy.setAutoEnable(source.isAutoEnable());
+        copy.setAutoEnableStandards(source.getAutoEnableStandards());
         copy.setOrganizationConfigurationType(source.getOrganizationConfigurationType());
         copy.setOrganizationConfigurationStatus(source.getOrganizationConfigurationStatus());
         return copy;
@@ -419,12 +550,43 @@ public class SecurityHubService {
         if (!tags.isObject() || tags.size() > 50) {
             throw invalid("Tags must be an object with at most 50 entries.");
         }
-        tags.fields().forEachRemaining(entry -> {
-            if (entry.getKey().isBlank() || entry.getKey().length() > 128
-                    || !entry.getValue().isTextual() || entry.getValue().textValue().length() > 256) {
-                throw invalid("Tags contain an invalid key or value.");
-            }
-        });
+        tags.fields().forEachRemaining(entry -> validateTag(entry.getKey(), entry.getValue()));
+    }
+
+    private static void validateTags(Map<String, String> tags) {
+        if (tags.size() > 50) {
+            throw invalid("Tags must contain at most 50 entries.");
+        }
+        tags.forEach((key, value) -> validateTag(
+                key, value == null ? null : new com.fasterxml.jackson.databind.node.TextNode(value)));
+    }
+
+    private static void validateTag(String key, JsonNode value) {
+        if (key == null || key.isBlank() || key.length() > 128 || key.startsWith("aws:")
+                || !key.matches("[a-zA-Z+\\-=._:/]+")
+                || value == null || !value.isTextual() || value.textValue().length() > 256) {
+            throw invalid("Tags contain an invalid key or value.");
+        }
+    }
+
+    private static Map<String, String> readTags(JsonNode tags) {
+        if (tags == null || tags.isNull()) {
+            return new LinkedHashMap<>();
+        }
+        validateTags(tags);
+        Map<String, String> result = new LinkedHashMap<>();
+        tags.fields().forEachRemaining(entry -> result.put(entry.getKey(), entry.getValue().textValue()));
+        return result;
+    }
+
+    private SecurityHubState requireAdministrator(String region) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        if (state.getAdminAccountId() == null || !regionResolver.getAccountId().equals(state.getAdminAccountId())) {
+            throw new AwsException("InvalidAccessException",
+                    "Only the delegated Security Hub administrator account can manage central configuration.", 401);
+        }
+        return state;
     }
 
     private void save(String region, SecurityHubState state) {
@@ -492,6 +654,17 @@ public class SecurityHubService {
         return node != null && node.isTextual() ? node.textValue() : null;
     }
 
+    private static Integer integer(JsonNode input, String field) {
+        JsonNode node = input == null ? null : input.get(field);
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (!node.isIntegralNumber() || !node.canConvertToInt()) {
+            throw invalid(field + " must be an integer.");
+        }
+        return node.intValue();
+    }
+
     private static AwsException invalid(String message) {
         return new AwsException("InvalidInputException", message, 400);
     }
@@ -502,6 +675,11 @@ public class SecurityHubService {
 
     private static AwsException notFound(String message) {
         return new AwsException("ResourceNotFoundException", message, 404);
+    }
+
+    @Override
+    public void clear() {
+        states.clear();
     }
 
     private record TargetRef(String id, String type) {}

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
@@ -50,7 +50,12 @@ public class SecurityHubService implements Resettable {
     }
 
     public SecurityHubState organizationAdminState(String region) {
-        requireCallerManagementAccount();
+        String callerAccountId = regionResolver.getAccountId();
+        String managementAccountId = organizationsService.findManagementAccountForResource(callerAccountId)
+                .orElseThrow(() -> invalidAccess("Only the organization management account can perform this operation."));
+        if (!callerAccountId.equals(managementAccountId)) {
+            throw invalidAccess("Only the organization management account can perform this operation.");
+        }
         return state(region);
     }
 
@@ -754,6 +759,10 @@ public class SecurityHubService implements Resettable {
 
     private static AwsException invalid(String message) {
         return new AwsException("InvalidInputException", message, 400);
+    }
+
+    private static AwsException invalidAccess(String message) {
+        return new AwsException("InvalidAccessException", message, 401);
     }
 
     private static AwsException conflict(String message) {

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
@@ -1,0 +1,508 @@
+package io.github.hectorvent.floci.services.securityhub;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.securityhub.model.SecurityHubAssociation;
+import io.github.hectorvent.floci.services.securityhub.model.SecurityHubState;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@ApplicationScoped
+public class SecurityHubService {
+    private static final String SELF_MANAGED = "SELF_MANAGED_SECURITY_HUB";
+    private static final List<String> LINKING_MODES = List.of(
+            "ALL_REGIONS", "ALL_REGIONS_EXCEPT_SPECIFIED", "SPECIFIED_REGIONS", "NO_REGIONS");
+
+    private final AccountAwareStorageBackend<SecurityHubState> states;
+    private final RegionResolver regionResolver;
+
+    @Inject
+    public SecurityHubService(StorageFactory storageFactory, RegionResolver regionResolver) {
+        this.states = storageFactory.create("securityhub", "securityhub-state.json",
+                new TypeReference<Map<String, SecurityHubState>>() {});
+        this.regionResolver = regionResolver;
+    }
+
+    public SecurityHubState state(String region) {
+        return states.get(region).orElseGet(SecurityHubState::new);
+    }
+
+    public synchronized void enableOrganizationAdminAccount(String region, String adminAccountId) {
+        requireAccountId(adminAccountId, "AdminAccountId");
+        SecurityHubState management = state(region);
+        if (management.getAdminAccountId() != null && !management.getAdminAccountId().equals(adminAccountId)) {
+            throw conflict("A different Security Hub administrator account is already configured.");
+        }
+        management.setAdminAccountId(adminAccountId);
+        save(region, management);
+
+        SecurityHubState delegated = states.getForAccount(adminAccountId, region).orElseGet(SecurityHubState::new);
+        delegated.setAdminAccountId(adminAccountId);
+        states.putForAccount(adminAccountId, region, delegated);
+    }
+
+    public synchronized void enableSecurityHub(String region) {
+        SecurityHubState state = state(region);
+        if (state.isEnabled()) {
+            throw conflict("Security Hub is already enabled for this account.");
+        }
+        state.setEnabled(true);
+        save(region, state);
+    }
+
+    public void requireEnabled(String region) {
+        if (!state(region).isEnabled()) {
+            throw notFound("Security Hub is not enabled for this account.");
+        }
+    }
+
+    public synchronized SecurityHubState createFindingAggregator(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        if (state.getAggregatorArn() != null) {
+            throw new AwsException("LimitExceededException",
+                    "Only one finding aggregator can exist for an account.", 429);
+        }
+        String mode = requireLinkingMode(request);
+        JsonNode regions = validateAggregatorRegions(mode, request.get("Regions"));
+        state.setAggregatorArn("arn:aws:securityhub:" + region + ":" + regionResolver.getAccountId()
+                + ":finding-aggregator/" + UUID.randomUUID());
+        state.setRegionLinkingMode(mode);
+        state.setRegions(regions);
+        save(region, state);
+        return state;
+    }
+
+    public SecurityHubState getFindingAggregator(String region, String findingAggregatorArn) {
+        SecurityHubState state = state(region);
+        if (state.getAggregatorArn() == null || findingAggregatorArn == null
+                || !state.getAggregatorArn().equals(findingAggregatorArn)) {
+            throw notFound("The finding aggregator was not found.");
+        }
+        return state;
+    }
+
+    public synchronized SecurityHubState updateFindingAggregator(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        String arn = requireText(request, "FindingAggregatorArn", "InvalidInputException");
+        if (state.getAggregatorArn() == null || !state.getAggregatorArn().equals(arn)) {
+            throw notFound("The finding aggregator was not found.");
+        }
+        String mode = requireLinkingMode(request);
+        JsonNode regions = validateAggregatorRegions(mode, request.get("Regions"));
+        state.setRegionLinkingMode(mode);
+        state.setRegions(regions);
+        save(region, state);
+        return state;
+    }
+
+    public synchronized void updateOrganizationConfiguration(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        if (state.getAdminAccountId() == null) {
+            throw new AwsException("InvalidAccessException",
+                    "A Security Hub administrator account is required for central configuration.", 401);
+        }
+        JsonNode autoEnable = request.get("AutoEnable");
+        if (autoEnable == null || !autoEnable.isBoolean()) {
+            throw invalid("AutoEnable is required.");
+        }
+        String autoStandards = text(request, "AutoEnableStandards");
+        if (autoStandards != null && !"DEFAULT".equals(autoStandards) && !"NONE".equals(autoStandards)) {
+            throw invalid("AutoEnableStandards must be DEFAULT or NONE.");
+        }
+        JsonNode organizationConfiguration = request.get("OrganizationConfiguration");
+        String type = organizationConfiguration != null && organizationConfiguration.isObject()
+                ? text(organizationConfiguration, "ConfigurationType") : null;
+        if (type != null && !"CENTRAL".equals(type) && !"LOCAL".equals(type)) {
+            throw invalid("ConfigurationType must be CENTRAL or LOCAL.");
+        }
+        String desiredType = type == null ? state.getOrganizationConfigurationType() : type;
+        if (desiredType == null) {
+            desiredType = "LOCAL";
+        }
+        state.setOrganizationConfigurationType(desiredType);
+        if ("CENTRAL".equals(desiredType)) {
+            state.setOrganizationConfigurationStatus("PENDING");
+            state.setOrganizationConfigurationPendingPollsRemaining(1);
+        } else {
+            state.setOrganizationConfigurationStatus("ENABLED");
+            state.setOrganizationConfigurationPendingPollsRemaining(0);
+        }
+        save(region, state);
+    }
+
+    public synchronized SecurityHubState organizationConfiguration(String region) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        if ("PENDING".equals(state.getOrganizationConfigurationStatus())
+                && state.getOrganizationConfigurationPendingPollsRemaining() > 0) {
+            SecurityHubState response = copyConfigurationState(state);
+            state.setOrganizationConfigurationPendingPollsRemaining(
+                    state.getOrganizationConfigurationPendingPollsRemaining() - 1);
+            save(region, state);
+            return response;
+        }
+        if ("PENDING".equals(state.getOrganizationConfigurationStatus())) {
+            state.setOrganizationConfigurationStatus("ENABLED");
+            save(region, state);
+        }
+        return state;
+    }
+
+    public synchronized String createConfigurationPolicy(String region, JsonNode request) {
+        requireEnabled(region);
+        String name = requireText(request, "Name", "InvalidInputException");
+        if (name.length() > 128) {
+            throw invalid("Name exceeds the maximum length.");
+        }
+        SecurityHubState state = state(region);
+        boolean duplicate = state.getPolicies().values().stream()
+                .anyMatch(policy -> name.equals(text(policy, "Name")));
+        if (duplicate) {
+            throw conflict("A configuration policy with the same name already exists.");
+        }
+        if (!request.path("ConfigurationPolicy").isObject()) {
+            throw invalid("ConfigurationPolicy is required.");
+        }
+        validateTags(request.get("Tags"));
+        String id = UUID.randomUUID().toString();
+        state.getPolicies().put(id, request.deepCopy());
+        save(region, state);
+        return id;
+    }
+
+    public JsonNode getConfigurationPolicy(String region, String identifier) {
+        String id = normalizePolicyId(identifier);
+        JsonNode policy = state(region).getPolicies().get(id);
+        if (policy == null) {
+            throw notFound("The configuration policy was not found.");
+        }
+        return policy;
+    }
+
+    public synchronized JsonNode updateConfigurationPolicy(String region, String identifier, JsonNode request) {
+        String id = normalizePolicyId(identifier);
+        SecurityHubState state = state(region);
+        JsonNode current = state.getPolicies().get(id);
+        if (current == null) {
+            throw notFound("The configuration policy was not found.");
+        }
+        String newName = text(request, "Name");
+        if (newName != null) {
+            boolean duplicate = state.getPolicies().entrySet().stream()
+                    .anyMatch(entry -> !entry.getKey().equals(id)
+                            && newName.equals(text(entry.getValue(), "Name")));
+            if (duplicate) {
+                throw conflict("A configuration policy with the same name already exists.");
+            }
+        }
+        ObjectNode merged = (ObjectNode) current.deepCopy();
+        if (newName != null) {
+            merged.put("Name", newName);
+        }
+        if (request.has("Description")) {
+            merged.set("Description", request.get("Description"));
+        }
+        if (request.has("ConfigurationPolicy")) {
+            if (!request.get("ConfigurationPolicy").isObject()) {
+                throw invalid("ConfigurationPolicy must be an object.");
+            }
+            merged.set("ConfigurationPolicy", request.get("ConfigurationPolicy").deepCopy());
+        }
+        state.getPolicies().put(id, merged);
+        save(region, state);
+        return merged;
+    }
+
+    public synchronized SecurityHubAssociation associate(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        TargetRef target = target(request);
+        String policyIdentifier = requireText(request, "ConfigurationPolicyIdentifier", "InvalidInputException");
+        String policyId = normalizePolicyId(policyIdentifier);
+        if (!SELF_MANAGED.equals(policyId) && !state.getPolicies().containsKey(policyId)) {
+            throw notFound("The configuration policy was not found.");
+        }
+        SecurityHubAssociation existing = state.getAssociations().get(target.id());
+        if (existing != null && !existing.isDisassociating()
+                && policyId.equals(existing.getPolicyId())) {
+            throw conflict("The target is already associated with the specified configuration policy.");
+        }
+        SecurityHubAssociation association = new SecurityHubAssociation(
+                target.id(), target.type(), policyId, "PENDING", 1);
+        state.getAssociations().put(target.id(), association);
+        save(region, state);
+        return association.copy();
+    }
+
+    public synchronized SecurityHubAssociation association(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        TargetRef target = target(request);
+        SecurityHubAssociation association = state.getAssociations().get(target.id());
+        if (association == null) {
+            throw notFound("The configuration policy association was not found.");
+        }
+        if ("PENDING".equals(association.getStatus()) && association.getPendingPollsRemaining() > 0) {
+            SecurityHubAssociation response = association.copy();
+            association.setPendingPollsRemaining(association.getPendingPollsRemaining() - 1);
+            save(region, state);
+            return response;
+        }
+        if ("PENDING".equals(association.getStatus())) {
+            if (association.isDisassociating()) {
+                state.getAssociations().remove(target.id());
+                save(region, state);
+                throw notFound("The configuration policy association was not found.");
+            }
+            association.setStatus("SUCCESS");
+            applyPolicyToAccountTarget(region, state, association);
+            save(region, state);
+        }
+        return association.copy();
+    }
+
+    public synchronized void disassociate(String region, JsonNode request) {
+        requireEnabled(region);
+        SecurityHubState state = state(region);
+        TargetRef target = target(request);
+        String policyIdentifier = requireText(request, "ConfigurationPolicyIdentifier", "InvalidInputException");
+        String requestedPolicyId = normalizePolicyId(policyIdentifier);
+        SecurityHubAssociation association = state.getAssociations().get(target.id());
+        if (association == null || !requestedPolicyId.equals(association.getPolicyId())) {
+            throw notFound("The configuration policy association was not found.");
+        }
+        if (association.isDisassociating()) {
+            throw conflict("The configuration policy association is already being removed.");
+        }
+        association.setStatus("PENDING");
+        association.setPendingPollsRemaining(1);
+        association.setDisassociating(true);
+        save(region, state);
+    }
+
+    private void applyPolicyToAccountTarget(String region, SecurityHubState administrator,
+                                            SecurityHubAssociation association) {
+        if (!"ACCOUNT".equals(association.getTargetType()) || SELF_MANAGED.equals(association.getPolicyId())) {
+            return;
+        }
+        JsonNode policy = administrator.getPolicies().get(association.getPolicyId());
+        JsonNode securityHub = policy == null ? null : policy.path("ConfigurationPolicy").path("SecurityHub");
+        if (securityHub == null || !securityHub.isObject() || !securityHub.path("ServiceEnabled").isBoolean()) {
+            return;
+        }
+        SecurityHubState target = states.getForAccount(association.getTargetId(), region)
+                .orElseGet(SecurityHubState::new);
+        target.setEnabled(securityHub.path("ServiceEnabled").asBoolean());
+        states.putForAccount(association.getTargetId(), region, target);
+    }
+
+    public List<SecurityHubAssociation> associations(String region) {
+        return state(region).getAssociations().values().stream()
+                .map(SecurityHubAssociation::copy)
+                .toList();
+    }
+
+    public List<Map.Entry<String, JsonNode>> policies(String region) {
+        return List.copyOf(state(region).getPolicies().entrySet());
+    }
+
+    public Map<String, String> tagsForResource(String region, String arn) {
+        SecurityHubState state = state(region);
+        JsonNode resource = taggedResource(state, region, arn);
+        if (resource == null) {
+            return Map.of();
+        }
+        JsonNode tags = resource.get("Tags");
+        if (tags == null || !tags.isObject()) {
+            return Map.of();
+        }
+        Map<String, String> result = new LinkedHashMap<>();
+        tags.fields().forEachRemaining(entry -> {
+            if (entry.getValue().isTextual()) result.put(entry.getKey(), entry.getValue().textValue());
+        });
+        return result;
+    }
+
+    public synchronized void tagResource(String region, String arn, Map<String, String> tags) {
+        SecurityHubState state = state(region);
+        ObjectNode resource = policyResource(state, region, arn);
+        ObjectNode current = resource.withObject("Tags");
+        tags.forEach(current::put);
+        validateTags(current);
+        save(region, state);
+    }
+
+    public synchronized void untagResource(String region, String arn, List<String> tagKeys) {
+        SecurityHubState state = state(region);
+        ObjectNode resource = policyResource(state, region, arn);
+        ObjectNode tags = resource.withObject("Tags");
+        tagKeys.forEach(tags::remove);
+        save(region, state);
+    }
+
+    private JsonNode taggedResource(SecurityHubState state, String region, String arn) {
+        if (arn == null || !arn.startsWith("arn:aws:securityhub:" + region + ":" + regionResolver.getAccountId() + ":")) {
+            throw notFound("The specified Security Hub resource was not found.");
+        }
+        if (arn.equals(hubArn(region)) || arn.equals(state.getAggregatorArn())) return null;
+        String id = normalizePolicyId(arn);
+        JsonNode policy = state.getPolicies().get(id);
+        if (policy == null) throw notFound("The specified Security Hub resource was not found.");
+        return policy;
+    }
+
+    private ObjectNode policyResource(SecurityHubState state, String region, String arn) {
+        JsonNode resource = taggedResource(state, region, arn);
+        if (!(resource instanceof ObjectNode object)) {
+            throw notFound("The specified Security Hub resource does not support mutable tags in this emulator.");
+        }
+        return object;
+    }
+
+    public String hubArn(String region) {
+        return "arn:aws:securityhub:" + region + ":" + regionResolver.getAccountId() + ":hub/default";
+    }
+
+    public String policyArn(String region, String id) {
+        return "arn:aws:securityhub:" + region + ":" + regionResolver.getAccountId()
+                + ":configuration-policy/" + id;
+    }
+
+    private static SecurityHubState copyConfigurationState(SecurityHubState source) {
+        SecurityHubState copy = new SecurityHubState();
+        copy.setAdminAccountId(source.getAdminAccountId());
+        copy.setEnabled(source.isEnabled());
+        copy.setOrganizationConfigurationType(source.getOrganizationConfigurationType());
+        copy.setOrganizationConfigurationStatus(source.getOrganizationConfigurationStatus());
+        return copy;
+    }
+
+    private static JsonNode validateAggregatorRegions(String mode, JsonNode regions) {
+        if (regions != null && !regions.isArray()) {
+            throw invalid("Regions must be an array.");
+        }
+        if ("SPECIFIED_REGIONS".equals(mode) && (regions == null || regions.isEmpty())) {
+            throw invalid("Regions is required when RegionLinkingMode is SPECIFIED_REGIONS.");
+        }
+        if (("NO_REGIONS".equals(mode) || "ALL_REGIONS".equals(mode))
+                && regions != null && !regions.isEmpty()) {
+            throw invalid("Regions must be empty for the selected RegionLinkingMode.");
+        }
+        return regions == null ? null : regions.deepCopy();
+    }
+
+    private static String requireLinkingMode(JsonNode request) {
+        String mode = requireText(request, "RegionLinkingMode", "InvalidInputException");
+        if (!LINKING_MODES.contains(mode)) {
+            throw invalid("RegionLinkingMode is invalid.");
+        }
+        return mode;
+    }
+
+    private static void validateTags(JsonNode tags) {
+        if (tags == null || tags.isNull()) {
+            return;
+        }
+        if (!tags.isObject() || tags.size() > 50) {
+            throw invalid("Tags must be an object with at most 50 entries.");
+        }
+        tags.fields().forEachRemaining(entry -> {
+            if (entry.getKey().isBlank() || entry.getKey().length() > 128
+                    || !entry.getValue().isTextual() || entry.getValue().textValue().length() > 256) {
+                throw invalid("Tags contain an invalid key or value.");
+            }
+        });
+    }
+
+    private void save(String region, SecurityHubState state) {
+        states.put(region, state);
+    }
+
+    private static String normalizePolicyId(String identifier) {
+        if (identifier == null || identifier.isBlank()) {
+            throw invalid("Identifier is required.");
+        }
+        if (SELF_MANAGED.equals(identifier)) {
+            return SELF_MANAGED;
+        }
+        int slash = identifier.lastIndexOf('/');
+        return slash >= 0 ? identifier.substring(slash + 1) : identifier;
+    }
+
+    private static TargetRef target(JsonNode input) {
+        JsonNode target = input == null ? null : input.get("Target");
+        if (target == null || !target.isObject()) {
+            throw invalid("Target is required.");
+        }
+        TargetRef found = null;
+        for (Map.Entry<String, String> candidate : Map.of(
+                "AccountId", "ACCOUNT", "OrganizationalUnitId", "ORGANIZATIONAL_UNIT", "RootId", "ROOT").entrySet()) {
+            String value = text(target, candidate.getKey());
+            if (value != null) {
+                if (found != null) {
+                    throw invalid("Target must contain exactly one identifier.");
+                }
+                found = new TargetRef(value, candidate.getValue());
+            }
+        }
+        if (found == null) {
+            throw invalid("Target identifier is required.");
+        }
+        if ("ACCOUNT".equals(found.type()) && !found.id().matches("\\d{12}")) {
+            throw invalid("AccountId must be a 12 digit account ID.");
+        }
+        if ("ORGANIZATIONAL_UNIT".equals(found.type()) && !found.id().matches("ou-[a-z0-9]{4,32}-[a-z0-9]{8,32}")) {
+            throw invalid("OrganizationalUnitId is invalid.");
+        }
+        if ("ROOT".equals(found.type()) && !found.id().matches("r-[a-z0-9]{4,32}")) {
+            throw invalid("RootId is invalid.");
+        }
+        return found;
+    }
+
+    private static void requireAccountId(String value, String field) {
+        if (value == null || !value.matches("\\d{12}")) {
+            throw invalid(field + " must be a 12 digit account ID.");
+        }
+    }
+
+    private static String requireText(JsonNode input, String field, String errorCode) {
+        String value = text(input, field);
+        if (value == null || value.isBlank()) {
+            throw new AwsException(errorCode, field + " is required.", 400);
+        }
+        return value;
+    }
+
+    private static String text(JsonNode input, String field) {
+        JsonNode node = input == null ? null : input.get(field);
+        return node != null && node.isTextual() ? node.textValue() : null;
+    }
+
+    private static AwsException invalid(String message) {
+        return new AwsException("InvalidInputException", message, 400);
+    }
+
+    private static AwsException conflict(String message) {
+        return new AwsException("ResourceConflictException", message, 409);
+    }
+
+    private static AwsException notFound(String message) {
+        return new AwsException("ResourceNotFoundException", message, 404);
+    }
+
+    private record TargetRef(String id, String type) {}
+}

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubService.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import io.github.hectorvent.floci.services.securityhub.model.SecurityHubAssociation;
 import io.github.hectorvent.floci.services.securityhub.model.SecurityHubState;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -28,26 +29,36 @@ public class SecurityHubService implements Resettable {
 
     private final AccountAwareStorageBackend<SecurityHubState> states;
     private final RegionResolver regionResolver;
+    private final OrganizationsService organizationsService;
 
     @Inject
-    public SecurityHubService(StorageFactory storageFactory, RegionResolver regionResolver) {
+    public SecurityHubService(StorageFactory storageFactory, RegionResolver regionResolver,
+                              OrganizationsService organizationsService) {
         this(storageFactory.create("securityhub", "securityhub-state.json",
-                new TypeReference<Map<String, SecurityHubState>>() {}), regionResolver);
+                new TypeReference<Map<String, SecurityHubState>>() {}), regionResolver, organizationsService);
     }
 
-    SecurityHubService(AccountAwareStorageBackend<SecurityHubState> states, RegionResolver regionResolver) {
+    SecurityHubService(AccountAwareStorageBackend<SecurityHubState> states, RegionResolver regionResolver,
+                       OrganizationsService organizationsService) {
         this.states = states;
         this.regionResolver = regionResolver;
+        this.organizationsService = organizationsService;
     }
 
     public SecurityHubState state(String region) {
         return states.get(region).orElseGet(SecurityHubState::new);
     }
 
+    public SecurityHubState organizationAdminState(String region) {
+        requireCallerManagementAccount();
+        return state(region);
+    }
+
     public synchronized SecurityHubState enableOrganizationAdminAccount(String region, String adminAccountId,
                                                                         String feature) {
         requireAccountId(adminAccountId, "AdminAccountId");
         String requestedFeature = normalizeFeature(feature);
+        requireOrganizationManagementAccount(adminAccountId);
         SecurityHubState management = state(region);
         if (management.getAdminAccountId() != null && !management.getAdminAccountId().equals(adminAccountId)) {
             throw conflict("A different Security Hub administrator account is already configured.");
@@ -220,17 +231,13 @@ public class SecurityHubService implements Resettable {
     public synchronized String createConfigurationPolicy(String region, JsonNode request) {
         SecurityHubState state = requireAdministrator(region);
         String name = requireText(request, "Name", "InvalidInputException");
-        if (name.length() > 128) {
-            throw invalid("Name exceeds the maximum length.");
-        }
+        validatePolicyName(name);
         boolean duplicate = state.getPolicies().values().stream()
                 .anyMatch(policy -> name.equals(text(policy, "Name")));
         if (duplicate) {
             throw conflict("A configuration policy with the same name already exists.");
         }
-        if (!request.path("ConfigurationPolicy").isObject()) {
-            throw invalid("ConfigurationPolicy is required.");
-        }
+        validateConfigurationPolicy(request.get("ConfigurationPolicy"));
         validateTags(request.get("Tags"));
         String id = UUID.randomUUID().toString();
         ObjectNode stored = (ObjectNode) request.deepCopy();
@@ -260,6 +267,7 @@ public class SecurityHubService implements Resettable {
         }
         String newName = text(request, "Name");
         if (newName != null) {
+            validatePolicyName(newName);
             boolean duplicate = state.getPolicies().entrySet().stream()
                     .anyMatch(entry -> !entry.getKey().equals(id)
                             && newName.equals(text(entry.getValue(), "Name")));
@@ -275,9 +283,7 @@ public class SecurityHubService implements Resettable {
             merged.set("Description", request.get("Description"));
         }
         if (request.has("ConfigurationPolicy")) {
-            if (!request.get("ConfigurationPolicy").isObject()) {
-                throw invalid("ConfigurationPolicy must be an object.");
-            }
+            validateConfigurationPolicy(request.get("ConfigurationPolicy"));
             merged.set("ConfigurationPolicy", request.get("ConfigurationPolicy").deepCopy());
         }
         merged.put("UpdatedAt", java.time.Instant.now().toString());
@@ -288,7 +294,7 @@ public class SecurityHubService implements Resettable {
 
     public synchronized SecurityHubAssociation associate(String region, JsonNode request) {
         SecurityHubState state = requireAdministrator(region);
-        TargetRef target = target(request);
+        TargetRef target = organizationTarget(request);
         String policyIdentifier = requireText(request, "ConfigurationPolicyIdentifier", "InvalidInputException");
         String policyId = normalizePolicyId(policyIdentifier);
         if (!SELF_MANAGED.equals(policyId) && !state.getPolicies().containsKey(policyId)) {
@@ -308,7 +314,7 @@ public class SecurityHubService implements Resettable {
 
     public synchronized SecurityHubAssociation association(String region, JsonNode request) {
         SecurityHubState state = requireAdministrator(region);
-        TargetRef target = target(request);
+        TargetRef target = organizationTarget(request);
         SecurityHubAssociation association = state.getAssociations().get(target.id());
         if (association == null) {
             throw notFound("The configuration policy association was not found.");
@@ -335,7 +341,7 @@ public class SecurityHubService implements Resettable {
 
     public synchronized void disassociate(String region, JsonNode request) {
         SecurityHubState state = requireAdministrator(region);
-        TargetRef target = target(request);
+        TargetRef target = organizationTarget(request);
         String policyIdentifier = requireText(request, "ConfigurationPolicyIdentifier", "InvalidInputException");
         String requestedPolicyId = normalizePolicyId(policyIdentifier);
         SecurityHubAssociation association = state.getAssociations().get(target.id());
@@ -532,6 +538,13 @@ public class SecurityHubService implements Resettable {
                 && regions != null && !regions.isEmpty()) {
             throw invalid("Regions must be empty for the selected RegionLinkingMode.");
         }
+        if (regions != null) {
+            for (JsonNode candidate : regions) {
+                if (!candidate.isTextual() || candidate.textValue().isBlank()) {
+                    throw invalid("Regions must contain non-blank Region identifiers.");
+                }
+            }
+        }
         return regions == null ? null : regions.deepCopy();
     }
 
@@ -602,6 +615,80 @@ public class SecurityHubService implements Resettable {
         }
         int slash = identifier.lastIndexOf('/');
         return slash >= 0 ? identifier.substring(slash + 1) : identifier;
+    }
+
+    private String requireCallerManagementAccount() {
+        String callerAccountId = regionResolver.getAccountId();
+        String managementAccountId = organizationsService.findManagementAccountForResource(callerAccountId)
+                .orElseThrow(() -> new AwsException("AccessDeniedException",
+                        "Only the organization management account can perform this operation.", 403));
+        if (!callerAccountId.equals(managementAccountId)) {
+            throw new AwsException("AccessDeniedException",
+                    "Only the organization management account can perform this operation.", 403);
+        }
+        return managementAccountId;
+    }
+
+    private void requireOrganizationManagementAccount(String targetAccountId) {
+        String managementAccountId = requireCallerManagementAccount();
+        String targetManagementAccountId = organizationsService.findManagementAccountForResource(targetAccountId)
+                .orElseThrow(() -> invalid("AdminAccountId must belong to the caller's AWS organization."));
+        if (!managementAccountId.equals(targetManagementAccountId)) {
+            throw invalid("AdminAccountId must belong to the caller's AWS organization.");
+        }
+    }
+
+    private TargetRef organizationTarget(JsonNode input) {
+        TargetRef target = target(input);
+        String callerAccountId = regionResolver.getAccountId();
+        String managementAccountId = organizationsService.findManagementAccountForResource(callerAccountId)
+                .orElseThrow(() -> new AwsException("InvalidAccessException",
+                        "The delegated administrator must belong to an AWS organization.", 401));
+        String targetManagementAccountId = organizationsService.findManagementAccountForResource(target.id())
+                .orElseThrow(() -> notFound("The specified organization target was not found."));
+        if (!managementAccountId.equals(targetManagementAccountId)) {
+            throw notFound("The specified organization target was not found.");
+        }
+        return target;
+    }
+
+    private static void validatePolicyName(String name) {
+        if (name == null || name.isBlank()) {
+            throw invalid("Name must contain a non-whitespace character.");
+        }
+        if (name.length() > 128) {
+            throw invalid("Name exceeds the maximum length.");
+        }
+    }
+
+    private static void validateConfigurationPolicy(JsonNode configurationPolicy) {
+        if (configurationPolicy == null || !configurationPolicy.isObject()
+                || configurationPolicy.size() != 1 || !configurationPolicy.has("SecurityHub")) {
+            throw invalid("ConfigurationPolicy must contain exactly one SecurityHub policy.");
+        }
+        JsonNode securityHub = configurationPolicy.get("SecurityHub");
+        if (securityHub == null || !securityHub.isObject()) {
+            throw invalid("ConfigurationPolicy.SecurityHub must be an object.");
+        }
+        JsonNode serviceEnabled = securityHub.get("ServiceEnabled");
+        if (serviceEnabled != null && !serviceEnabled.isBoolean()) {
+            throw invalid("ConfigurationPolicy.SecurityHub.ServiceEnabled must be a boolean.");
+        }
+        JsonNode standards = securityHub.get("EnabledStandardIdentifiers");
+        if (standards != null) {
+            if (!standards.isArray()) {
+                throw invalid("EnabledStandardIdentifiers must be an array.");
+            }
+            for (JsonNode standard : standards) {
+                if (!standard.isTextual() || standard.textValue().isBlank()) {
+                    throw invalid("EnabledStandardIdentifiers must contain non-blank strings.");
+                }
+            }
+        }
+        JsonNode controls = securityHub.get("SecurityControlsConfiguration");
+        if (controls != null && !controls.isObject()) {
+            throw invalid("SecurityControlsConfiguration must be an object.");
+        }
     }
 
     private static TargetRef target(JsonNode input) {

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubTagHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubTagHandler.java
@@ -1,0 +1,59 @@
+package io.github.hectorvent.floci.services.securityhub;
+
+import io.github.hectorvent.floci.core.common.TagHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/** AWS Security Hub CSPM tagging on the shared REST /tags/{ResourceArn} path. */
+@ApplicationScoped
+public class SecurityHubTagHandler implements TagHandler {
+    private final SecurityHubService service;
+
+    @Inject
+    public SecurityHubTagHandler(SecurityHubService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String serviceKey() {
+        return "securityhub";
+    }
+
+    @Override
+    public String tagsBodyKey() {
+        return "Tags";
+    }
+
+    @Override
+    public boolean strictTagValidation() {
+        return true;
+    }
+
+    @Override
+    public int tagResourceSuccessStatus() {
+        return 200;
+    }
+
+    @Override
+    public int untagResourceSuccessStatus() {
+        return 200;
+    }
+
+    @Override
+    public Map<String, String> listTags(String region, String arn) {
+        return service.tagsForResource(region, arn);
+    }
+
+    @Override
+    public void tagResource(String region, String arn, Map<String, String> tags) {
+        service.tagResource(region, arn, tags);
+    }
+
+    @Override
+    public void untagResource(String region, String arn, List<String> tagKeys) {
+        service.untagResource(region, arn, tagKeys);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubAssociation.java
@@ -11,6 +11,7 @@ public class SecurityHubAssociation {
     private String policyId;
     private String status;
     private String statusMessage;
+    private String updatedAt;
     private int pendingPollsRemaining;
     private boolean disassociating;
 
@@ -23,6 +24,7 @@ public class SecurityHubAssociation {
         this.targetType = targetType;
         this.policyId = policyId;
         this.status = status;
+        this.updatedAt = java.time.Instant.now().toString();
         this.pendingPollsRemaining = pendingPollsRemaining;
     }
 
@@ -36,6 +38,8 @@ public class SecurityHubAssociation {
     public void setStatus(String status) { this.status = status; }
     public String getStatusMessage() { return statusMessage; }
     public void setStatusMessage(String statusMessage) { this.statusMessage = statusMessage; }
+    public String getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(String updatedAt) { this.updatedAt = updatedAt; }
     public int getPendingPollsRemaining() { return pendingPollsRemaining; }
     public void setPendingPollsRemaining(int pendingPollsRemaining) { this.pendingPollsRemaining = pendingPollsRemaining; }
     public boolean isDisassociating() { return disassociating; }
@@ -45,6 +49,7 @@ public class SecurityHubAssociation {
         SecurityHubAssociation copy = new SecurityHubAssociation(targetId, targetType, policyId, status,
                 pendingPollsRemaining);
         copy.setStatusMessage(statusMessage);
+        copy.setUpdatedAt(updatedAt);
         copy.setDisassociating(disassociating);
         return copy;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubAssociation.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubAssociation.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.services.securityhub.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecurityHubAssociation {
+    private String targetId;
+    private String targetType;
+    private String policyId;
+    private String status;
+    private String statusMessage;
+    private int pendingPollsRemaining;
+    private boolean disassociating;
+
+    public SecurityHubAssociation() {
+    }
+
+    public SecurityHubAssociation(String targetId, String targetType, String policyId,
+                                  String status, int pendingPollsRemaining) {
+        this.targetId = targetId;
+        this.targetType = targetType;
+        this.policyId = policyId;
+        this.status = status;
+        this.pendingPollsRemaining = pendingPollsRemaining;
+    }
+
+    public String getTargetId() { return targetId; }
+    public void setTargetId(String targetId) { this.targetId = targetId; }
+    public String getTargetType() { return targetType; }
+    public void setTargetType(String targetType) { this.targetType = targetType; }
+    public String getPolicyId() { return policyId; }
+    public void setPolicyId(String policyId) { this.policyId = policyId; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getStatusMessage() { return statusMessage; }
+    public void setStatusMessage(String statusMessage) { this.statusMessage = statusMessage; }
+    public int getPendingPollsRemaining() { return pendingPollsRemaining; }
+    public void setPendingPollsRemaining(int pendingPollsRemaining) { this.pendingPollsRemaining = pendingPollsRemaining; }
+    public boolean isDisassociating() { return disassociating; }
+    public void setDisassociating(boolean disassociating) { this.disassociating = disassociating; }
+
+    public SecurityHubAssociation copy() {
+        SecurityHubAssociation copy = new SecurityHubAssociation(targetId, targetType, policyId, status,
+                pendingPollsRemaining);
+        copy.setStatusMessage(statusMessage);
+        copy.setDisassociating(disassociating);
+        return copy;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubState.java
@@ -11,7 +11,13 @@ import java.util.Map;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SecurityHubState {
     private String adminAccountId;
+    private String adminFeature = "SecurityHub";
     private boolean enabled;
+    private boolean autoEnable;
+    private String autoEnableStandards = "DEFAULT";
+    private boolean autoEnableControls = true;
+    private String controlFindingGenerator = "SECURITY_CONTROL";
+    private Map<String, String> hubTags = new LinkedHashMap<>();
     private String aggregatorArn;
     private String regionLinkingMode;
     private JsonNode regions;
@@ -23,8 +29,20 @@ public class SecurityHubState {
 
     public String getAdminAccountId() { return adminAccountId; }
     public void setAdminAccountId(String adminAccountId) { this.adminAccountId = adminAccountId; }
+    public String getAdminFeature() { return adminFeature; }
+    public void setAdminFeature(String adminFeature) { this.adminFeature = adminFeature; }
     public boolean isEnabled() { return enabled; }
     public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public boolean isAutoEnable() { return autoEnable; }
+    public void setAutoEnable(boolean autoEnable) { this.autoEnable = autoEnable; }
+    public String getAutoEnableStandards() { return autoEnableStandards; }
+    public void setAutoEnableStandards(String autoEnableStandards) { this.autoEnableStandards = autoEnableStandards; }
+    public boolean isAutoEnableControls() { return autoEnableControls; }
+    public void setAutoEnableControls(boolean autoEnableControls) { this.autoEnableControls = autoEnableControls; }
+    public String getControlFindingGenerator() { return controlFindingGenerator; }
+    public void setControlFindingGenerator(String controlFindingGenerator) { this.controlFindingGenerator = controlFindingGenerator; }
+    public Map<String, String> getHubTags() { return hubTags; }
+    public void setHubTags(Map<String, String> hubTags) { this.hubTags = hubTags; }
     public String getAggregatorArn() { return aggregatorArn; }
     public void setAggregatorArn(String aggregatorArn) { this.aggregatorArn = aggregatorArn; }
     public String getRegionLinkingMode() { return regionLinkingMode; }

--- a/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/securityhub/model/SecurityHubState.java
@@ -1,0 +1,44 @@
+package io.github.hectorvent.floci.services.securityhub.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SecurityHubState {
+    private String adminAccountId;
+    private boolean enabled;
+    private String aggregatorArn;
+    private String regionLinkingMode;
+    private JsonNode regions;
+    private String organizationConfigurationType = "LOCAL";
+    private String organizationConfigurationStatus = "ENABLED";
+    private int organizationConfigurationPendingPollsRemaining;
+    private Map<String, JsonNode> policies = new LinkedHashMap<>();
+    private Map<String, SecurityHubAssociation> associations = new LinkedHashMap<>();
+
+    public String getAdminAccountId() { return adminAccountId; }
+    public void setAdminAccountId(String adminAccountId) { this.adminAccountId = adminAccountId; }
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getAggregatorArn() { return aggregatorArn; }
+    public void setAggregatorArn(String aggregatorArn) { this.aggregatorArn = aggregatorArn; }
+    public String getRegionLinkingMode() { return regionLinkingMode; }
+    public void setRegionLinkingMode(String regionLinkingMode) { this.regionLinkingMode = regionLinkingMode; }
+    public JsonNode getRegions() { return regions; }
+    public void setRegions(JsonNode regions) { this.regions = regions; }
+    public String getOrganizationConfigurationType() { return organizationConfigurationType; }
+    public void setOrganizationConfigurationType(String value) { organizationConfigurationType = value; }
+    public String getOrganizationConfigurationStatus() { return organizationConfigurationStatus; }
+    public void setOrganizationConfigurationStatus(String value) { organizationConfigurationStatus = value; }
+    public int getOrganizationConfigurationPendingPollsRemaining() { return organizationConfigurationPendingPollsRemaining; }
+    public void setOrganizationConfigurationPendingPollsRemaining(int value) { organizationConfigurationPendingPollsRemaining = value; }
+    public Map<String, JsonNode> getPolicies() { return policies; }
+    public void setPolicies(Map<String, JsonNode> policies) { this.policies = policies; }
+    public Map<String, SecurityHubAssociation> getAssociations() { return associations; }
+    public void setAssociations(Map<String, SecurityHubAssociation> associations) { this.associations = associations; }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -645,6 +645,8 @@ floci:
       enabled: true
     inspector2:
       enabled: true
+    securityhub:
+      enabled: true
     detective:
       enabled: true
     controltower:

--- a/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardDisabledIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardDisabledIntegrationTest.java
@@ -22,10 +22,10 @@ class UnknownServiceScopeGuardDisabledIntegrationTest {
     @Test
     void unsupportedScopeFallsThroughWhenRejectionDisabled() {
         given()
-            .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260707/us-east-1/securityhub"
+            .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260707/us-east-1/account"
                     + "/aws4_request, SignedHeaders=host;x-amz-date, Signature=deadbeef")
         .when()
-            .get("/accounts")
+            .get("/guard-disabled-no-such-bucket")
         .then()
             // Back to the old behaviour: S3's path-style catch-all answers for the bucket
             // named "accounts", instead of the guard's UnknownOperationException.

--- a/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/UnknownServiceScopeGuardIntegrationTest.java
@@ -39,17 +39,6 @@ class UnknownServiceScopeGuardIntegrationTest {
     }
 
     @Test
-    void securityhubScopedRestRequestGetsUnknownOperation() {
-        given()
-            .header("Authorization", authorization("securityhub"))
-        .when()
-            .get("/accounts")
-        .then()
-            .statusCode(404)
-            .body("__type", equalTo("UnknownOperationException"));
-    }
-
-    @Test
     void s3ScopedRequestKeepsS3Behavior() {
         given()
             .header("Authorization", authorization("s3"))

--- a/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
@@ -1,5 +1,7 @@
 package io.github.hectorvent.floci.services.securityhub;
 
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
+import jakarta.inject.Inject;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
 
@@ -10,41 +12,152 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
 class SecurityHubOrganizationIntegrationTest {
-    private static final String MANAGEMENT_AUTH = "AWS4-HMAC-SHA256 Credential=222222222222/20260101/us-east-1/securityhub/aws4_request";
-    private static final String ADMIN_AUTH = "AWS4-HMAC-SHA256 Credential=111111111111/20260101/us-east-1/securityhub/aws4_request";
+
+    @Inject
+    OrganizationsService organizationsService;
 
     @Test
     void organizationAndConfigurationPolicyLifecycle() {
-        given().header("Authorization", MANAGEMENT_AUTH).get("/organization/admin").then().statusCode(200)
+        String management = "920000000001";
+        String administrator = "920000000002";
+        String member = "920000000003";
+        createOrganization(management, administrator, member);
+
+        given().header("Authorization", auth(management)).get("/organization/admin").then().statusCode(200)
                 .body("AdminAccounts", hasSize(0));
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
-                .body("{\"AdminAccountId\":\"111111111111\"}").post("/organization/admin/enable")
+        given().contentType("application/json").header("Authorization", auth(management))
+                .body("{\"AdminAccountId\":\"" + administrator + "\"}").post("/organization/admin/enable")
                 .then().statusCode(200)
-                .body("AdminAccountId", equalTo("111111111111"))
+                .body("AdminAccountId", equalTo(administrator))
                 .body("Feature", equalTo("SecurityHub"));
-        given().header("Authorization", ADMIN_AUTH).get("/accounts").then().statusCode(200)
+        given().header("Authorization", auth(administrator)).get("/accounts").then().statusCode(200)
                 .body("HubArn", notNullValue());
-        String aggregatorArn = given().contentType("application/json").header("Authorization", ADMIN_AUTH)
+        String aggregatorArn = given().contentType("application/json").header("Authorization", auth(administrator))
                 .body("{\"RegionLinkingMode\":\"ALL_REGIONS\"}").post("/findingAggregator/create")
                 .then().statusCode(200).extract().path("FindingAggregatorArn");
-        given().header("Authorization", ADMIN_AUTH).get("/findingAggregator/get/" + aggregatorArn)
+        given().header("Authorization", auth(administrator)).get("/findingAggregator/get/" + aggregatorArn)
                 .then().statusCode(200).body("RegionLinkingMode", equalTo("ALL_REGIONS"));
-        given().contentType("application/json").header("Authorization", ADMIN_AUTH)
-                .body("{\"OrganizationConfiguration\":{\"ConfigurationType\":\"CENTRAL\"},\"AutoEnable\":false,\"AutoEnableStandards\":\"NONE\"}")
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"OrganizationConfiguration\":{\"ConfigurationType\":\"CENTRAL\"},"
+                        + "\"AutoEnable\":false,\"AutoEnableStandards\":\"NONE\"}")
                 .post("/organization/configuration").then().statusCode(200);
-        given().header("Authorization", ADMIN_AUTH).get("/organization/configuration").then().statusCode(200)
+        given().header("Authorization", auth(administrator)).get("/organization/configuration").then().statusCode(200)
                 .body("OrganizationConfiguration.ConfigurationType", equalTo("CENTRAL"));
-        String policyId = given().contentType("application/json").header("Authorization", ADMIN_AUTH)
-                .body("{\"Name\":\"security-policy\",\"ConfigurationPolicy\":{\"SecurityHub\":{\"ServiceEnabled\":true}}}")
+        String policyId = given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Name\":\"security-policy\",\"ConfigurationPolicy\":{"
+                        + "\"SecurityHub\":{\"ServiceEnabled\":true}}}")
                 .post("/configurationPolicy/create").then().statusCode(200).extract().path("Id");
-        given().header("Authorization", ADMIN_AUTH).get("/configurationPolicy/get/" + policyId)
+        given().header("Authorization", auth(administrator)).get("/configurationPolicy/get/" + policyId)
                 .then().statusCode(200).body("Id", equalTo(policyId));
+
+        String association = "{\"ConfigurationPolicyIdentifier\":\"" + policyId
+                + "\",\"Target\":{\"AccountId\":\"" + member + "\"}}";
+        given().contentType("application/json").header("Authorization", auth(administrator)).body(association)
+                .post("/configurationPolicyAssociation/associate").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Target\":{\"AccountId\":\"" + member + "\"}}")
+                .post("/configurationPolicyAssociation/get").then().statusCode(200)
+                .body("AssociationStatus", equalTo("PENDING"));
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Target\":{\"AccountId\":\"" + member + "\"}}")
+                .post("/configurationPolicyAssociation/get").then().statusCode(200)
+                .body("AssociationStatus", equalTo("SUCCESS"));
+        given().header("Authorization", auth(member)).get("/accounts").then().statusCode(200);
+    }
+
+    @Test
+    void organizationBoundariesAreEnforced() {
+        String management = "920000000011";
+        String administrator = "920000000012";
+        String outsider = "930000000013";
+        createOrganization(management, administrator);
+
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"AdminAccountId\":\"" + administrator + "\"}").post("/organization/admin/enable")
+                .then().statusCode(403).body("__type", equalTo("AccessDeniedException"));
+        given().contentType("application/json").header("Authorization", auth(management))
+                .body("{\"AdminAccountId\":\"" + outsider + "\"}").post("/organization/admin/enable")
+                .then().statusCode(400).body("__type", equalTo("InvalidInputException"));
+
+        given().contentType("application/json").header("Authorization", auth(management))
+                .body("{\"AdminAccountId\":\"" + administrator + "\"}").post("/organization/admin/enable")
+                .then().statusCode(200);
+        String policyId = given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Name\":\"bounded-policy\",\"ConfigurationPolicy\":{"
+                        + "\"SecurityHub\":{\"ServiceEnabled\":true}}}")
+                .post("/configurationPolicy/create").then().statusCode(200).extract().path("Id");
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"ConfigurationPolicyIdentifier\":\"" + policyId
+                        + "\",\"Target\":{\"AccountId\":\"" + outsider + "\"}}")
+                .post("/configurationPolicyAssociation/associate").then().statusCode(404)
+                .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    void malformedPoliciesAndInvalidUpdatesAreRejected() {
+        String management = "920000000021";
+        String administrator = "920000000022";
+        createOrganization(management, administrator);
+        designateAdministrator(management, administrator);
+
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Name\":\"bad-policy\",\"ConfigurationPolicy\":{"
+                        + "\"SecurityHub\":{\"ServiceEnabled\":\"yes\"}}}")
+                .post("/configurationPolicy/create").then().statusCode(400)
+                .body("__type", equalTo("InvalidInputException"));
+
+        String policyId = given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Name\":\"valid-policy\",\"ConfigurationPolicy\":{"
+                        + "\"SecurityHub\":{\"ServiceEnabled\":true}}}")
+                .post("/configurationPolicy/create").then().statusCode(200).extract().path("Id");
+        String longName = "a".repeat(129);
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"Name\":\"" + longName + "\"}")
+                .patch("/configurationPolicy/" + policyId).then().statusCode(400)
+                .body("__type", equalTo("InvalidInputException"));
+    }
+
+    @Test
+    void findingAggregatorValidatesRegionElementsButAllowsEmptyExclusionList() {
+        String management = "920000000031";
+        String administrator = "920000000032";
+        createOrganization(management, administrator);
+        designateAdministrator(management, administrator);
+
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"RegionLinkingMode\":\"ALL_REGIONS_EXCEPT_SPECIFIED\",\"Regions\":[123]}")
+                .post("/findingAggregator/create").then().statusCode(400)
+                .body("__type", equalTo("InvalidInputException"));
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"RegionLinkingMode\":\"ALL_REGIONS_EXCEPT_SPECIFIED\"}")
+                .post("/findingAggregator/create").then().statusCode(200)
+                .body("RegionLinkingMode", equalTo("ALL_REGIONS_EXCEPT_SPECIFIED"));
     }
 
     @Test
     void invalidAdminAccountIdReturnsValidationException() {
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
+        given().contentType("application/json").header("Authorization", auth("920000000041"))
                 .body("{\"AdminAccountId\":\"bad\"}").post("/organization/admin/enable")
                 .then().statusCode(400).body("__type", equalTo("InvalidInputException"));
+    }
+
+    private void createOrganization(String managementAccountId, String... members) {
+        organizationsService.createOrganization(managementAccountId, "ALL");
+        for (String member : members) {
+            var handshake = organizationsService.inviteAccountToOrganization(
+                    managementAccountId, member, "ACCOUNT", null);
+            organizationsService.acceptHandshake(member, handshake.getId());
+        }
+    }
+
+    private void designateAdministrator(String managementAccountId, String administratorAccountId) {
+        given().contentType("application/json").header("Authorization", auth(managementAccountId))
+                .body("{\"AdminAccountId\":\"" + administratorAccountId + "\"}")
+                .post("/organization/admin/enable").then().statusCode(200);
+    }
+
+    private static String auth(String accountId) {
+        return "AWS4-HMAC-SHA256 Credential=" + accountId
+                + "/20260101/us-east-1/securityhub/aws4_request";
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
@@ -10,39 +10,40 @@ import static org.hamcrest.Matchers.notNullValue;
 
 @QuarkusTest
 class SecurityHubOrganizationIntegrationTest {
-    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/securityhub/aws4_request";
+    private static final String MANAGEMENT_AUTH = "AWS4-HMAC-SHA256 Credential=222222222222/20260101/us-east-1/securityhub/aws4_request";
+    private static final String ADMIN_AUTH = "AWS4-HMAC-SHA256 Credential=111111111111/20260101/us-east-1/securityhub/aws4_request";
 
     @Test
     void organizationAndConfigurationPolicyLifecycle() {
-        given().header("Authorization", AUTH).get("/organization/admin").then().statusCode(200)
+        given().header("Authorization", MANAGEMENT_AUTH).get("/organization/admin").then().statusCode(200)
                 .body("AdminAccounts", hasSize(0));
-        given().contentType("application/json").header("Authorization", AUTH)
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
                 .body("{\"AdminAccountId\":\"111111111111\"}").post("/organization/admin/enable")
-                .then().statusCode(200);
-        given().contentType("application/json").header("Authorization", AUTH).body("{}")
-                .post("/accounts").then().statusCode(200);
-        given().header("Authorization", AUTH).get("/accounts").then().statusCode(200)
+                .then().statusCode(200)
+                .body("AdminAccountId", equalTo("111111111111"))
+                .body("Feature", equalTo("SecurityHub"));
+        given().header("Authorization", ADMIN_AUTH).get("/accounts").then().statusCode(200)
                 .body("HubArn", notNullValue());
-        String aggregatorArn = given().contentType("application/json").header("Authorization", AUTH)
+        String aggregatorArn = given().contentType("application/json").header("Authorization", ADMIN_AUTH)
                 .body("{\"RegionLinkingMode\":\"ALL_REGIONS\"}").post("/findingAggregator/create")
                 .then().statusCode(200).extract().path("FindingAggregatorArn");
-        given().header("Authorization", AUTH).get("/findingAggregator/get/" + aggregatorArn)
+        given().header("Authorization", ADMIN_AUTH).get("/findingAggregator/get/" + aggregatorArn)
                 .then().statusCode(200).body("RegionLinkingMode", equalTo("ALL_REGIONS"));
-        given().contentType("application/json").header("Authorization", AUTH)
+        given().contentType("application/json").header("Authorization", ADMIN_AUTH)
                 .body("{\"OrganizationConfiguration\":{\"ConfigurationType\":\"CENTRAL\"},\"AutoEnable\":false,\"AutoEnableStandards\":\"NONE\"}")
                 .post("/organization/configuration").then().statusCode(200);
-        given().header("Authorization", AUTH).get("/organization/configuration").then().statusCode(200)
+        given().header("Authorization", ADMIN_AUTH).get("/organization/configuration").then().statusCode(200)
                 .body("OrganizationConfiguration.ConfigurationType", equalTo("CENTRAL"));
-        String policyId = given().contentType("application/json").header("Authorization", AUTH)
+        String policyId = given().contentType("application/json").header("Authorization", ADMIN_AUTH)
                 .body("{\"Name\":\"security-policy\",\"ConfigurationPolicy\":{\"SecurityHub\":{\"ServiceEnabled\":true}}}")
                 .post("/configurationPolicy/create").then().statusCode(200).extract().path("Id");
-        given().header("Authorization", AUTH).get("/configurationPolicy/get/" + policyId)
+        given().header("Authorization", ADMIN_AUTH).get("/configurationPolicy/get/" + policyId)
                 .then().statusCode(200).body("Id", equalTo(policyId));
     }
 
     @Test
     void invalidAdminAccountIdReturnsValidationException() {
-        given().contentType("application/json").header("Authorization", AUTH)
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
                 .body("{\"AdminAccountId\":\"bad\"}").post("/organization/admin/enable")
                 .then().statusCode(400).body("__type", equalTo("InvalidInputException"));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.services.securityhub;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class SecurityHubOrganizationIntegrationTest {
+    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/securityhub/aws4_request";
+
+    @Test
+    void organizationAndConfigurationPolicyLifecycle() {
+        given().header("Authorization", AUTH).get("/organization/admin").then().statusCode(200)
+                .body("AdminAccounts", hasSize(0));
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"AdminAccountId\":\"111111111111\"}").post("/organization/admin/enable")
+                .then().statusCode(200);
+        given().contentType("application/json").header("Authorization", AUTH).body("{}")
+                .post("/accounts").then().statusCode(200);
+        given().header("Authorization", AUTH).get("/accounts").then().statusCode(200)
+                .body("HubArn", notNullValue());
+        String aggregatorArn = given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"RegionLinkingMode\":\"ALL_REGIONS\"}").post("/findingAggregator/create")
+                .then().statusCode(200).extract().path("FindingAggregatorArn");
+        given().header("Authorization", AUTH).get("/findingAggregator/get/" + aggregatorArn)
+                .then().statusCode(200).body("RegionLinkingMode", equalTo("ALL_REGIONS"));
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"OrganizationConfiguration\":{\"ConfigurationType\":\"CENTRAL\"},\"AutoEnable\":false,\"AutoEnableStandards\":\"NONE\"}")
+                .post("/organization/configuration").then().statusCode(200);
+        given().header("Authorization", AUTH).get("/organization/configuration").then().statusCode(200)
+                .body("OrganizationConfiguration.ConfigurationType", equalTo("CENTRAL"));
+        String policyId = given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"Name\":\"security-policy\",\"ConfigurationPolicy\":{\"SecurityHub\":{\"ServiceEnabled\":true}}}")
+                .post("/configurationPolicy/create").then().statusCode(200).extract().path("Id");
+        given().header("Authorization", AUTH).get("/configurationPolicy/get/" + policyId)
+                .then().statusCode(200).body("Id", equalTo(policyId));
+    }
+
+    @Test
+    void invalidAdminAccountIdReturnsValidationException() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"AdminAccountId\":\"bad\"}").post("/organization/admin/enable")
+                .then().statusCode(400).body("__type", equalTo("InvalidInputException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubOrganizationIntegrationTest.java
@@ -75,6 +75,8 @@ class SecurityHubOrganizationIntegrationTest {
         given().contentType("application/json").header("Authorization", auth(administrator))
                 .body("{\"AdminAccountId\":\"" + administrator + "\"}").post("/organization/admin/enable")
                 .then().statusCode(403).body("__type", equalTo("AccessDeniedException"));
+        given().header("Authorization", auth(administrator)).get("/organization/admin")
+                .then().statusCode(401).body("__type", equalTo("InvalidAccessException"));
         given().contentType("application/json").header("Authorization", auth(management))
                 .body("{\"AdminAccountId\":\"" + outsider + "\"}").post("/organization/admin/enable")
                 .then().statusCode(400).body("__type", equalTo("InvalidInputException"));

--- a/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import io.github.hectorvent.floci.services.securityhub.model.SecurityHubState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,8 @@ class SecurityHubServiceTest {
     void setUp() {
         RegionResolver regionResolver = mock(RegionResolver.class);
         when(regionResolver.getAccountId()).thenReturn(ACCOUNT_ID);
-        service = new SecurityHubService(AccountAwareStorageBackend.inMemory(ACCOUNT_ID), regionResolver);
+        service = new SecurityHubService(AccountAwareStorageBackend.inMemory(ACCOUNT_ID), regionResolver,
+                mock(OrganizationsService.class));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/securityhub/SecurityHubServiceTest.java
@@ -1,0 +1,74 @@
+package io.github.hectorvent.floci.services.securityhub;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.services.securityhub.model.SecurityHubState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SecurityHubServiceTest {
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT_ID = "222222222222";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private SecurityHubService service;
+
+    @BeforeEach
+    void setUp() {
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn(ACCOUNT_ID);
+        service = new SecurityHubService(AccountAwareStorageBackend.inMemory(ACCOUNT_ID), regionResolver);
+    }
+
+    @Test
+    void enableSecurityHubPersistsConfigurationAndHubTags() throws Exception {
+        service.enableSecurityHub(REGION, objectMapper.readTree("""
+                {
+                  "ControlFindingGenerator": "STANDARD_CONTROL",
+                  "Tags": {"env": "test"}
+                }
+                """));
+
+        SecurityHubState state = service.state(REGION);
+        assertTrue(state.isEnabled());
+        assertEquals("STANDARD_CONTROL", state.getControlFindingGenerator());
+        assertEquals(Map.of("env", "test"), service.tagsForResource(REGION, service.hubArn(REGION)));
+    }
+
+    @Test
+    void invalidReservedTagPrefixIsRejected() throws Exception {
+        AwsException error = assertThrows(AwsException.class, () -> service.enableSecurityHub(REGION,
+                objectMapper.readTree("{\"Tags\":{\"aws:owner\":\"test\"}}")));
+
+        assertEquals("InvalidInputException", error.getErrorCode());
+    }
+
+    @Test
+    void invalidAdministratorFeatureIsRejected() {
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.enableOrganizationAdminAccount(REGION, "111111111111", "Other"));
+
+        assertEquals("InvalidInputException", error.getErrorCode());
+    }
+
+    @Test
+    void clearRemovesState() throws Exception {
+        service.enableSecurityHub(REGION, objectMapper.readTree("{}"));
+        assertTrue(service.state(REGION).isEnabled());
+
+        service.clear();
+
+        assertFalse(service.state(REGION).isEnabled());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -392,6 +392,8 @@ floci:
       enabled: true
     inspector2:
       enabled: true
+    securityhub:
+      enabled: true
     detective:
       enabled: true
     controltower:

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -224,6 +224,19 @@ services:
     doc: docs/services/route53resolver.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/route53resolver/Route53ResolverJsonHandler.java, mode: switch }
+  - service: securityhub
+    doc: docs/services/securityhub.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/securityhub/SecurityHubController.java, mode: rest }
+      - { path: src/main/java/io/github/hectorvent/floci/core/common/SharedTagsController.java, mode: rest }
+    rename_actions:
+      ListTags: ListTagsForResource
+      TagResourcePost: TagResource
+    exclude_actions:
+      - ListTagsByQuery
+      - TagResourceByBody
+      - TagResourcePut
+      - UntagResourceByQuery
   - service: secretsmanager
     doc: docs/services/secrets-manager.md
     sources:


### PR DESCRIPTION
## Summary

- add AWS Security Hub organization administration and central configuration support
- support delegated admin, hub enable/update, finding aggregators, configuration policies and associations, tagging, pagination, and AWS-modeled validation/errors
- add service, integration, generated docs, and AWS SDK Java v2 compatibility coverage

## AWS Compatibility

Validated against the official AWS Security Hub API reference. The implementation keeps the REST JSON wire contract, modeled errors, pagination semantics, delegated-administrator behavior, central-configuration convergence, and configuration-policy association lifecycle aligned with AWS behavior used by Cloud Launchpad.

Validation on the rebased branch:
- focused Security Hub/config/unknown-scope suite: 16/16 passed
- AWS SDK Java v2 `SecurityHubOrganizationConfigurationTest`: passed against an isolated branch instance
- sdk-test-java `test-compile`: passed
- `make docs-check`: passed
- `git diff --check`: passed

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] New or updated integration test added
- [x] AWS SDK compatibility test added
- [x] Commit messages follow Conventional Commits