### PR TITLE
feat(inspector2): add organization configuration operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Floci supports local emulation for application services, data services, eventing
 | Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Redshift Data API, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
 | Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
 | Messaging and transfer | SES, Kinesis, MSK, Amazon MQ, Transfer Family, IoT Core, Amazon Connect |
-| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, AWS Account Management, IAM Access Analyzer, IAM Identity Center (SSO Admin), Identity Store, Amazon Macie, Amazon Detective, Control Catalog, Control Tower, Service Catalog |
+| Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, Amazon Inspector, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, AWS Account Management, IAM Access Analyzer, IAM Identity Center (SSO Admin), Identity Store, Amazon Macie, Amazon Detective, Control Catalog, Control Tower, Service Catalog |
 | Cost and billing | AWS Budgets, Pricing, Cost Explorer, Cost and Usage Reports, BCM Data Exports |
 | Resilience, backup, and config | AWS FIS, AWS Backup, AWS Config, AppConfig, AppConfigData, CloudFormation, Cloud Control API |
 

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -262,6 +262,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>detective</artifactId>
         </dependency>
+        <!-- Amazon Inspector client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>inspector2</artifactId>
+        </dependency>
         <!-- AWS Account Management client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -38,6 +38,7 @@ import software.amazon.awssdk.services.identitystore.IdentitystoreClient;
 import software.amazon.awssdk.services.budgets.BudgetsClient;
 import software.amazon.awssdk.services.macie2.Macie2Client;
 import software.amazon.awssdk.services.controlcatalog.ControlCatalogClient;
+import software.amazon.awssdk.services.inspector2.Inspector2Client;
 import software.amazon.awssdk.services.detective.DetectiveClient;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
@@ -358,6 +359,14 @@ public final class TestFixtures {
 
     public static DetectiveClient detectiveClient(String accountId) {
         return DetectiveClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))
+                .build();
+    }
+
+    public static Inspector2Client inspector2Client(String accountId) {
+        return Inspector2Client.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
@@ -5,60 +5,98 @@ import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
 import software.amazon.awssdk.services.inspector2.model.AutoEnable;
 import software.amazon.awssdk.services.inspector2.model.ResourceScanType;
+import software.amazon.awssdk.services.organizations.OrganizationsClient;
+import software.amazon.awssdk.services.organizations.model.AlreadyInOrganizationException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("Amazon Inspector organization configuration")
 class Inspector2OrganizationConfigurationTest {
-    private static final String MANAGEMENT_ACCOUNT = "222222222222";
-    private static final String ADMIN_ACCOUNT = "111111111111";
+    private static final String MANAGEMENT_ACCOUNT = "test";
 
     @Test
     void organizationConfigurationUsesAwsSdk() {
         assumeFalse(TestFixtures.isRealAws(), "Avoids changing Amazon Inspector organization settings in real AWS");
 
-        try (Inspector2Client management = TestFixtures.inspector2Client(MANAGEMENT_ACCOUNT);
-             Inspector2Client administrator = TestFixtures.inspector2Client(ADMIN_ACCOUNT)) {
-            assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts()).isEmpty();
+        try (OrganizationsClient organizations = TestFixtures.organizationsClient()) {
+            ensureOrganization(organizations);
+            String adminAccount = createMemberAccount(organizations, "inspector-admin");
+            String memberAccount = createMemberAccount(organizations, "inspector-member");
 
-            var enabled = management.enableDelegatedAdminAccount(request -> request
-                    .delegatedAdminAccountId(ADMIN_ACCOUNT));
-            assertThat(enabled.delegatedAdminAccountId()).isEqualTo(ADMIN_ACCOUNT);
+            try (Inspector2Client management = TestFixtures.inspector2Client(MANAGEMENT_ACCOUNT);
+                 Inspector2Client administrator = TestFixtures.inspector2Client(adminAccount)) {
+                assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts()).isEmpty();
 
-            assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts())
-                    .singleElement()
-                    .satisfies(account -> {
-                        assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT);
-                        assertThat(account.statusAsString()).isEqualTo("ENABLED");
-                    });
+                var enabled = management.enableDelegatedAdminAccount(request -> request
+                        .delegatedAdminAccountId(adminAccount));
+                assertThat(enabled.delegatedAdminAccountId()).isEqualTo(adminAccount);
 
-            administrator.enable(request -> request
-                    .accountIds(ADMIN_ACCOUNT)
-                    .resourceTypes(ResourceScanType.EC2, ResourceScanType.ECR, ResourceScanType.CODE_REPOSITORY));
+                assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts())
+                        .singleElement()
+                        .satisfies(account -> {
+                            assertThat(account.accountId()).isEqualTo(adminAccount);
+                            assertThat(account.statusAsString()).isEqualTo("ENABLED");
+                        });
 
-            var status = administrator.batchGetAccountStatus(request -> {});
-            assertThat(status.accounts()).singleElement()
-                    .satisfies(account -> assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT));
+                var enableMember = administrator.enable(request -> request
+                        .accountIds(memberAccount)
+                        .resourceTypes(ResourceScanType.EC2));
+                assertThat(enableMember.accounts()).singleElement().satisfies(account -> {
+                    assertThat(account.accountId()).isEqualTo(memberAccount);
+                    assertThat(account.resourceStatus().ec2AsString()).isEqualTo("ENABLING");
+                    assertThat(account.resourceStatus().ecrAsString()).isEqualTo("DISABLED");
+                });
 
-            var updated = administrator.updateOrganizationConfiguration(request -> request
-                    .autoEnable(AutoEnable.builder()
-                            .ec2(true)
-                            .ecr(true)
-                            .lambda(false)
-                            .lambdaCode(false)
-                            .codeRepository(true)
-                            .build()));
-            assertThat(updated.autoEnable().ec2()).isTrue();
-            assertThat(updated.autoEnable().ecr()).isTrue();
-            assertThat(updated.autoEnable().codeRepository()).isTrue();
+                var firstStatus = administrator.batchGetAccountStatus(request -> request.accountIds(memberAccount));
+                assertThat(firstStatus.accounts()).singleElement().satisfies(account -> {
+                    assertThat(account.accountId()).isEqualTo(memberAccount);
+                    assertThat(account.state().statusAsString()).isEqualTo("ENABLING");
+                    assertThat(account.resourceState().ec2().statusAsString()).isEqualTo("ENABLING");
+                    assertThat(account.resourceState().ecr().statusAsString()).isEqualTo("DISABLED");
+                });
+                var converged = administrator.batchGetAccountStatus(request -> request.accountIds(memberAccount));
+                assertThat(converged.accounts()).singleElement().satisfies(account -> {
+                    assertThat(account.state().statusAsString()).isEqualTo("ENABLED");
+                    assertThat(account.resourceState().ec2().statusAsString()).isEqualTo("ENABLED");
+                    assertThat(account.resourceState().ecr().statusAsString()).isEqualTo("DISABLED");
+                });
 
-            var described = administrator.describeOrganizationConfiguration(request -> {});
-            assertThat(described.autoEnable().codeRepository()).isTrue();
+                var updated = administrator.updateOrganizationConfiguration(request -> request
+                        .autoEnable(AutoEnable.builder()
+                                .ec2(true)
+                                .ecr(true)
+                                .lambda(false)
+                                .lambdaCode(false)
+                                .codeRepository(true)
+                                .build()));
+                assertThat(updated.autoEnable().ec2()).isTrue();
+                assertThat(updated.autoEnable().ecr()).isTrue();
+                assertThat(updated.autoEnable().codeRepository()).isTrue();
 
-            var disabled = management.disableDelegatedAdminAccount(request -> request
-                    .delegatedAdminAccountId(ADMIN_ACCOUNT));
-            assertThat(disabled.delegatedAdminAccountId()).isEqualTo(ADMIN_ACCOUNT);
+                var described = administrator.describeOrganizationConfiguration(request -> {});
+                assertThat(described.autoEnable().codeRepository()).isTrue();
+
+                var disabled = management.disableDelegatedAdminAccount(request -> request
+                        .delegatedAdminAccountId(adminAccount));
+                assertThat(disabled.delegatedAdminAccountId()).isEqualTo(adminAccount);
+            }
         }
+    }
+
+    private static void ensureOrganization(OrganizationsClient organizations) {
+        try {
+            organizations.createOrganization(request -> request.featureSet("ALL"));
+        } catch (AlreadyInOrganizationException ignored) {
+            // The compatibility suite may already have created the default-account organization.
+        }
+    }
+
+    private static String createMemberAccount(OrganizationsClient organizations, String prefix) {
+        String suffix = TestFixtures.uniqueName(prefix);
+        var response = organizations.createAccount(request -> request
+                .accountName(suffix)
+                .email(suffix + "@example.com"));
+        return response.createAccountStatus().accountId();
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.floci.test;
 
+import org.jboss.logging.Logger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
@@ -13,6 +14,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 @DisplayName("Amazon Inspector organization configuration")
 class Inspector2OrganizationConfigurationTest {
+    private static final Logger LOG = Logger.getLogger(Inspector2OrganizationConfigurationTest.class);
     private static final String MANAGEMENT_ACCOUNT = "test";
 
     @Test
@@ -87,8 +89,8 @@ class Inspector2OrganizationConfigurationTest {
     private static void ensureOrganization(OrganizationsClient organizations) {
         try {
             organizations.createOrganization(request -> request.featureSet("ALL"));
-        } catch (AlreadyInOrganizationException ignored) {
-            // The compatibility suite may already have created the default-account organization.
+        } catch (AlreadyInOrganizationException e) {
+            LOG.debugf(e, "Default compatibility account already belongs to an AWS organization");
         }
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
@@ -22,75 +22,128 @@ class Inspector2OrganizationConfigurationTest {
         assumeFalse(TestFixtures.isRealAws(), "Avoids changing Amazon Inspector organization settings in real AWS");
 
         try (OrganizationsClient organizations = TestFixtures.organizationsClient()) {
-            ensureOrganization(organizations);
-            String adminAccount = createMemberAccount(organizations, "inspector-admin");
-            String memberAccount = createMemberAccount(organizations, "inspector-member");
+            boolean createdOrganization = ensureOrganization(organizations);
+            String adminAccount = null;
+            String memberAccount = null;
+            boolean delegatedAdminEnabled = false;
 
-            try (Inspector2Client management = TestFixtures.inspector2Client(MANAGEMENT_ACCOUNT);
-                 Inspector2Client administrator = TestFixtures.inspector2Client(adminAccount)) {
-                assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts()).isEmpty();
+            try {
+                adminAccount = createMemberAccount(organizations, "inspector-admin");
+                memberAccount = createMemberAccount(organizations, "inspector-member");
+                String delegatedAdminAccount = adminAccount;
+                String inspectedMemberAccount = memberAccount;
 
-                var enabled = management.enableDelegatedAdminAccount(request -> request
-                        .delegatedAdminAccountId(adminAccount));
-                assertThat(enabled.delegatedAdminAccountId()).isEqualTo(adminAccount);
+                try (Inspector2Client management = TestFixtures.inspector2Client(MANAGEMENT_ACCOUNT);
+                     Inspector2Client administrator = TestFixtures.inspector2Client(delegatedAdminAccount)) {
+                    assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts()).isEmpty();
 
-                assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts())
-                        .singleElement()
-                        .satisfies(account -> {
-                            assertThat(account.accountId()).isEqualTo(adminAccount);
-                            assertThat(account.statusAsString()).isEqualTo("ENABLED");
-                        });
+                    var enabled = management.enableDelegatedAdminAccount(request -> request
+                            .delegatedAdminAccountId(delegatedAdminAccount));
+                    delegatedAdminEnabled = true;
+                    assertThat(enabled.delegatedAdminAccountId()).isEqualTo(delegatedAdminAccount);
 
-                var enableMember = administrator.enable(request -> request
-                        .accountIds(memberAccount)
-                        .resourceTypes(ResourceScanType.EC2));
-                assertThat(enableMember.accounts()).singleElement().satisfies(account -> {
-                    assertThat(account.accountId()).isEqualTo(memberAccount);
-                    assertThat(account.resourceStatus().ec2AsString()).isEqualTo("ENABLING");
-                    assertThat(account.resourceStatus().ecrAsString()).isEqualTo("DISABLED");
-                });
+                    assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts())
+                            .singleElement()
+                            .satisfies(account -> {
+                                assertThat(account.accountId()).isEqualTo(delegatedAdminAccount);
+                                assertThat(account.statusAsString()).isEqualTo("ENABLED");
+                            });
 
-                var firstStatus = administrator.batchGetAccountStatus(request -> request.accountIds(memberAccount));
-                assertThat(firstStatus.accounts()).singleElement().satisfies(account -> {
-                    assertThat(account.accountId()).isEqualTo(memberAccount);
-                    assertThat(account.state().statusAsString()).isEqualTo("ENABLING");
-                    assertThat(account.resourceState().ec2().statusAsString()).isEqualTo("ENABLING");
-                    assertThat(account.resourceState().ecr().statusAsString()).isEqualTo("DISABLED");
-                });
-                var converged = administrator.batchGetAccountStatus(request -> request.accountIds(memberAccount));
-                assertThat(converged.accounts()).singleElement().satisfies(account -> {
-                    assertThat(account.state().statusAsString()).isEqualTo("ENABLED");
-                    assertThat(account.resourceState().ec2().statusAsString()).isEqualTo("ENABLED");
-                    assertThat(account.resourceState().ecr().statusAsString()).isEqualTo("DISABLED");
-                });
+                    var enableMember = administrator.enable(request -> request
+                            .accountIds(inspectedMemberAccount)
+                            .resourceTypes(ResourceScanType.EC2));
+                    assertThat(enableMember.accounts()).singleElement().satisfies(account -> {
+                        assertThat(account.accountId()).isEqualTo(inspectedMemberAccount);
+                        assertThat(account.resourceStatus().ec2AsString()).isEqualTo("ENABLING");
+                        assertThat(account.resourceStatus().ecrAsString()).isEqualTo("DISABLED");
+                    });
 
-                var updated = administrator.updateOrganizationConfiguration(request -> request
-                        .autoEnable(AutoEnable.builder()
-                                .ec2(true)
-                                .ecr(true)
-                                .lambda(false)
-                                .lambdaCode(false)
-                                .codeRepository(true)
-                                .build()));
-                assertThat(updated.autoEnable().ec2()).isTrue();
-                assertThat(updated.autoEnable().ecr()).isTrue();
-                assertThat(updated.autoEnable().codeRepository()).isTrue();
+                    var firstStatus = administrator.batchGetAccountStatus(
+                            request -> request.accountIds(inspectedMemberAccount));
+                    assertThat(firstStatus.accounts()).singleElement().satisfies(account -> {
+                        assertThat(account.accountId()).isEqualTo(inspectedMemberAccount);
+                        assertThat(account.state().statusAsString()).isEqualTo("ENABLING");
+                        assertThat(account.resourceState().ec2().statusAsString()).isEqualTo("ENABLING");
+                        assertThat(account.resourceState().ecr().statusAsString()).isEqualTo("DISABLED");
+                    });
+                    var converged = administrator.batchGetAccountStatus(
+                            request -> request.accountIds(inspectedMemberAccount));
+                    assertThat(converged.accounts()).singleElement().satisfies(account -> {
+                        assertThat(account.state().statusAsString()).isEqualTo("ENABLED");
+                        assertThat(account.resourceState().ec2().statusAsString()).isEqualTo("ENABLED");
+                        assertThat(account.resourceState().ecr().statusAsString()).isEqualTo("DISABLED");
+                    });
 
-                var described = administrator.describeOrganizationConfiguration(request -> {});
-                assertThat(described.autoEnable().codeRepository()).isTrue();
+                    var updated = administrator.updateOrganizationConfiguration(request -> request
+                            .autoEnable(AutoEnable.builder()
+                                    .ec2(true)
+                                    .ecr(true)
+                                    .lambda(false)
+                                    .lambdaCode(false)
+                                    .codeRepository(true)
+                                    .build()));
+                    assertThat(updated.autoEnable().ec2()).isTrue();
+                    assertThat(updated.autoEnable().ecr()).isTrue();
+                    assertThat(updated.autoEnable().codeRepository()).isTrue();
 
-                var disabled = management.disableDelegatedAdminAccount(request -> request
-                        .delegatedAdminAccountId(adminAccount));
-                assertThat(disabled.delegatedAdminAccountId()).isEqualTo(adminAccount);
+                    var described = administrator.describeOrganizationConfiguration(request -> {});
+                    assertThat(described.autoEnable().codeRepository()).isTrue();
+
+                    var disabled = management.disableDelegatedAdminAccount(request -> request
+                            .delegatedAdminAccountId(delegatedAdminAccount));
+                    delegatedAdminEnabled = false;
+                    assertThat(disabled.delegatedAdminAccountId()).isEqualTo(delegatedAdminAccount);
+                }
+            } finally {
+                if (delegatedAdminEnabled) {
+                    disableDelegatedAdminBestEffort(adminAccount);
+                }
+                removeAccountBestEffort(organizations, memberAccount);
+                removeAccountBestEffort(organizations, adminAccount);
+                if (createdOrganization) {
+                    deleteOrganizationBestEffort(organizations);
+                }
             }
         }
     }
 
-    private static void ensureOrganization(OrganizationsClient organizations) {
+    private static boolean ensureOrganization(OrganizationsClient organizations) {
         try {
             organizations.createOrganization(request -> request.featureSet("ALL"));
+            return true;
         } catch (AlreadyInOrganizationException e) {
             LOG.debugf(e, "Default compatibility account already belongs to an AWS organization");
+            return false;
+        }
+    }
+
+    private static void disableDelegatedAdminBestEffort(String accountId) {
+        if (accountId == null) {
+            return;
+        }
+        try (Inspector2Client management = TestFixtures.inspector2Client(MANAGEMENT_ACCOUNT)) {
+            management.disableDelegatedAdminAccount(request -> request.delegatedAdminAccountId(accountId));
+        } catch (RuntimeException e) {
+            LOG.warnf(e, "Inspector2 compatibility cleanup could not disable delegated administrator %s", accountId);
+        }
+    }
+
+    private static void removeAccountBestEffort(OrganizationsClient organizations, String accountId) {
+        if (accountId == null) {
+            return;
+        }
+        try {
+            organizations.removeAccountFromOrganization(request -> request.accountId(accountId));
+        } catch (RuntimeException e) {
+            LOG.warnf(e, "Inspector2 compatibility cleanup could not remove account %s", accountId);
+        }
+    }
+
+    private static void deleteOrganizationBestEffort(OrganizationsClient organizations) {
+        try {
+            organizations.deleteOrganization();
+        } catch (RuntimeException e) {
+            LOG.warnf(e, "Inspector2 compatibility cleanup could not delete the temporary organization");
         }
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Inspector2OrganizationConfigurationTest.java
@@ -1,0 +1,64 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.inspector2.Inspector2Client;
+import software.amazon.awssdk.services.inspector2.model.AutoEnable;
+import software.amazon.awssdk.services.inspector2.model.ResourceScanType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@DisplayName("Amazon Inspector organization configuration")
+class Inspector2OrganizationConfigurationTest {
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+    private static final String ADMIN_ACCOUNT = "111111111111";
+
+    @Test
+    void organizationConfigurationUsesAwsSdk() {
+        assumeFalse(TestFixtures.isRealAws(), "Avoids changing Amazon Inspector organization settings in real AWS");
+
+        try (Inspector2Client management = TestFixtures.inspector2Client(MANAGEMENT_ACCOUNT);
+             Inspector2Client administrator = TestFixtures.inspector2Client(ADMIN_ACCOUNT)) {
+            assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts()).isEmpty();
+
+            var enabled = management.enableDelegatedAdminAccount(request -> request
+                    .delegatedAdminAccountId(ADMIN_ACCOUNT));
+            assertThat(enabled.delegatedAdminAccountId()).isEqualTo(ADMIN_ACCOUNT);
+
+            assertThat(management.listDelegatedAdminAccounts(request -> {}).delegatedAdminAccounts())
+                    .singleElement()
+                    .satisfies(account -> {
+                        assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT);
+                        assertThat(account.statusAsString()).isEqualTo("ENABLED");
+                    });
+
+            administrator.enable(request -> request
+                    .accountIds(ADMIN_ACCOUNT)
+                    .resourceTypes(ResourceScanType.EC2, ResourceScanType.ECR, ResourceScanType.CODE_REPOSITORY));
+
+            var status = administrator.batchGetAccountStatus(request -> {});
+            assertThat(status.accounts()).singleElement()
+                    .satisfies(account -> assertThat(account.accountId()).isEqualTo(ADMIN_ACCOUNT));
+
+            var updated = administrator.updateOrganizationConfiguration(request -> request
+                    .autoEnable(AutoEnable.builder()
+                            .ec2(true)
+                            .ecr(true)
+                            .lambda(false)
+                            .lambdaCode(false)
+                            .codeRepository(true)
+                            .build()));
+            assertThat(updated.autoEnable().ec2()).isTrue();
+            assertThat(updated.autoEnable().ecr()).isTrue();
+            assertThat(updated.autoEnable().codeRepository()).isTrue();
+
+            var described = administrator.describeOrganizationConfiguration(request -> {});
+            assertThat(described.autoEnable().codeRepository()).isTrue();
+
+            var disabled = management.disableDelegatedAdminAccount(request -> request
+                    .delegatedAdminAccountId(ADMIN_ACCOUNT));
+            assertThat(disabled.delegatedAdminAccountId()).isEqualTo(ADMIN_ACCOUNT);
+        }
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -49,6 +49,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [IAM Identity Center (SSO Admin)](ssoadmin.md) | `POST /` + `X-Amz-Target: SWBExternalService.*` | JSON 1.1 | 13 |
 | [Identity Store](identitystore.md) | `POST /` + `X-Amz-Target: AWSIdentityStore.*` | JSON 1.1 | 19 |
 | [Amazon Macie](macie2.md) | `/admin`, `/macie`, `/admin/configuration` | REST JSON | 6 |
+| [Amazon Inspector](inspector2.md) | `/delegatedadminaccounts/*`, `/status/batch/get`, `/enable`, `/organizationconfiguration/*` | REST JSON | 6 |
 | [Amazon Detective](detective.md) | `/orgs/*`, `/graphs/list`, `/graph/*` | REST JSON | 8 |
 | [Amazon Connect](connect.md) | `/instance`, `/instance/{instanceId}/*`, `/tags/*` | REST JSON | 15 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -49,7 +49,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [IAM Identity Center (SSO Admin)](ssoadmin.md) | `POST /` + `X-Amz-Target: SWBExternalService.*` | JSON 1.1 | 13 |
 | [Identity Store](identitystore.md) | `POST /` + `X-Amz-Target: AWSIdentityStore.*` | JSON 1.1 | 19 |
 | [Amazon Macie](macie2.md) | `/admin`, `/macie`, `/admin/configuration` | REST JSON | 6 |
-| [Amazon Inspector](inspector2.md) | `/delegatedadminaccounts/*`, `/status/batch/get`, `/enable`, `/organizationconfiguration/*` | REST JSON | 6 |
+| [Amazon Inspector](inspector2.md) | `/delegatedadminaccounts/*`, `/status/batch/get`, `/enable`, `/organizationconfiguration/*` | REST JSON | 7 |
 | [Amazon Detective](detective.md) | `/orgs/*`, `/graphs/list`, `/graph/*` | REST JSON | 8 |
 | [Amazon Connect](connect.md) | `/instance`, `/instance/{instanceId}/*`, `/tags/*` | REST JSON | 15 |
 | [ElastiCache](elasticache.md) | `POST /` with `Action=` param + TCP proxy | Query + RESP | 8 |

--- a/docs/services/inspector2.md
+++ b/docs/services/inspector2.md
@@ -1,0 +1,13 @@
+# Amazon Inspector
+
+Floci implements the REST JSON Inspector organization operations used by local security-governance workflows.
+
+## Supported behavior
+
+The supported surface includes delegated administrator management, `BatchGetAccountStatus`, Inspector enablement, and organization auto-enable configuration. Delegation is reflected into the delegated account and reports Inspector as enabled there, matching the delegated-administrator workflow.
+
+Explicit enablement uses the AWS account-state values `ENABLING` and `ENABLED`. Organization auto-enable validates the `ec2`, `ecr`, `lambda`, and `lambdaCode` fields. Missing delegation where it is required returns `AccessDeniedException`; invalid account IDs, resource types, and request shapes return `ValidationException`; conflicting delegated-administrator state returns `ConflictException`.
+
+AWS also models internal and throttling failures. Floci does not synthesize provider-side failures without a local triggering condition.
+
+See the [Amazon Inspector API Reference](https://docs.aws.amazon.com/inspector/v2/APIReference/Welcome.html).

--- a/docs/services/inspector2.md
+++ b/docs/services/inspector2.md
@@ -1,13 +1,43 @@
 # Amazon Inspector
 
-Floci implements the REST JSON Inspector organization operations used by local security-governance workflows.
+**Protocol:** REST JSON
+
+**Endpoint:** `http://localhost:4566`
+
+Floci implements the Amazon Inspector organization operations used by local security-governance workflows.
+
+## Supported Actions
+
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `ListDelegatedAdminAccounts` | - |
+| `EnableDelegatedAdminAccount` | - |
+| `DisableDelegatedAdminAccount` | - |
+| `BatchGetAccountStatus` | - |
+| `Enable` | - |
+| `UpdateOrganizationConfiguration` | - |
+| `DescribeOrganizationConfiguration` | - |
+<!-- floci:actions:end -->
 
 ## Supported behavior
 
-The supported surface includes delegated administrator management, `BatchGetAccountStatus`, Inspector enablement, and organization auto-enable configuration. Delegation is reflected into the delegated account and reports Inspector as enabled there, matching the delegated-administrator workflow.
+The supported surface includes delegated administrator management, `BatchGetAccountStatus`, Inspector enablement, and organization auto-enable configuration. Delegation is reflected into the delegated account so organization configuration can be managed through credentials for that administrator account.
 
-Explicit enablement uses the AWS account-state values `ENABLING` and `ENABLED`. Organization auto-enable validates the `ec2`, `ecr`, `lambda`, and `lambdaCode` fields. Missing delegation where it is required returns `AccessDeniedException`; invalid account IDs, resource types, and request shapes return `ValidationException`; conflicting delegated-administrator state returns `ConflictException`.
+`BatchGetAccountStatus` accepts an omitted or empty `accountIds` list and resolves it to the caller account. Explicit enablement supports `EC2`, `ECR`, `LAMBDA`, `LAMBDA_CODE`, and `CODE_REPOSITORY`, with the documented request-size limits. Explicit enablement uses the account-state values `ENABLING` and `ENABLED` so SDK and deployment waiters can converge.
+
+Organization auto-enable supports `ec2`, `ecr`, `lambda`, `lambdaCode`, and `codeRepository`. Only the delegated administrator account can update or describe organization configuration.
+
+## AWS-compatible failures
+
+Invalid account IDs, resource types, pagination input, and request shapes return `ValidationException`. Conflicting delegated-administrator state returns `ConflictException`. Organization configuration from a non-administrator account returns `AccessDeniedException`, and disabling an administrator that is not configured returns `ResourceNotFoundException`.
 
 AWS also models internal and throttling failures. Floci does not synthesize provider-side failures without a local triggering condition.
 
 See the [Amazon Inspector API Reference](https://docs.aws.amazon.com/inspector/v2/APIReference/Welcome.html).
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_INSPECTOR2_ENABLED` | `true` | Enable or disable Amazon Inspector |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
     - Identity Store: services/identitystore.md
     - AWS Budgets: services/budgets.md
     - Amazon Macie: services/macie2.md
+    - Amazon Inspector: services/inspector2.md
     - Amazon Detective: services/detective.md
     - Control Catalog: services/controlcatalog.md
     - Control Tower: services/controltower.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -729,6 +729,7 @@ public interface EmulatorConfig {
         AccessAnalyzerServiceConfig accessanalyzer();
         IdentityStoreServiceConfig identitystore();
         BudgetsServiceConfig budgets();
+        Inspector2ServiceConfig inspector2();
         DetectiveServiceConfig detective();
         ServiceQuotasServiceConfig servicequotas();
         RamServiceConfig ram();
@@ -780,6 +781,11 @@ public interface EmulatorConfig {
     }
 
     interface BudgetsServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+    }
+
+    interface Inspector2ServiceConfig {
         @WithDefault("true")
         boolean enabled();
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -35,6 +35,7 @@ import io.github.hectorvent.floci.services.guardduty.GuardDutyController;
 import io.github.hectorvent.floci.services.macie2.MacieController;
 import io.github.hectorvent.floci.services.account.AccountController;
 import io.github.hectorvent.floci.services.accessanalyzer.AccessAnalyzerController;
+import io.github.hectorvent.floci.services.inspector2.Inspector2Controller;
 import io.github.hectorvent.floci.services.detective.DetectiveController;
 import io.github.hectorvent.floci.services.aps.ApsController;
 import io.github.hectorvent.floci.services.controlcatalog.ControlCatalogController;
@@ -436,6 +437,9 @@ public class ResolvedServiceCatalog {
                 descriptor("detective", "detective", config.services().detective().enabled(), true,
                         "detective", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("detective"), Set.of(), Set.of(DetectiveController.class)),
+                descriptor("inspector2", "inspector2", config.services().inspector2().enabled(), true,
+                        "inspector2", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
+                        protocols(ServiceProtocol.REST_JSON), Set.of(), Set.of("inspector2"), Set.of(), Set.of(Inspector2Controller.class)),
                 descriptor("autoscaling", "autoscaling", config.services().autoscaling().enabled(), true,
                         "autoscaling", config.storage().mode(), 5000L, AwsNamespaces.AUTOSCALING, ServiceProtocol.QUERY,
                         protocols(ServiceProtocol.QUERY),

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.JsonErrorResponseUtils;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.RequestContext;
 import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.Consumes;
@@ -24,17 +25,30 @@ public class Inspector2Controller {
     private final Inspector2Service service;
     private final RegionResolver regionResolver;
     private final ObjectMapper objectMapper;
+    private final RequestContext requestContext;
 
     @Inject
-    public Inspector2Controller(Inspector2Service service, RegionResolver regionResolver, ObjectMapper objectMapper) {
+    public Inspector2Controller(Inspector2Service service, RegionResolver regionResolver, ObjectMapper objectMapper,
+                                RequestContext requestContext) {
         this.service = service;
         this.regionResolver = regionResolver;
         this.objectMapper = objectMapper;
+        this.requestContext = requestContext;
     }
 
     @POST
     @Path("/delegatedadminaccounts/list")
     public Response listDelegatedAdminAccounts(@Context HttpHeaders headers, String body) {
+        JsonNode request = parse(body);
+        if (request.has("maxResults")) {
+            JsonNode maxResults = request.get("maxResults");
+            if (!maxResults.canConvertToInt() || maxResults.intValue() < 1 || maxResults.intValue() > 5) {
+                throw new AwsException("ValidationException", "maxResults must be between 1 and 5.", 400);
+            }
+        }
+        if (request.hasNonNull("nextToken") && !request.path("nextToken").asText().isBlank()) {
+            throw new AwsException("ValidationException", "nextToken is invalid.", 400);
+        }
         InspectorState state = service.state(region(headers));
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("delegatedAdminAccounts");
@@ -56,27 +70,47 @@ public class Inspector2Controller {
     }
 
     @POST
+    @Path("/delegatedadminaccounts/disable")
+    public Response disableDelegatedAdminAccount(@Context HttpHeaders headers, String body) {
+        JsonNode request = parse(body);
+        String accountId = request.path("delegatedAdminAccountId").asText(null);
+        service.disableDelegatedAdmin(region(headers), accountId);
+        var response = objectMapper.createObjectNode();
+        response.put("delegatedAdminAccountId", accountId);
+        return Response.ok(response).build();
+    }
+
+    @POST
     @Path("/status/batch/get")
     public Response batchGetAccountStatus(@Context HttpHeaders headers, String body) {
         JsonNode request = parse(body);
         JsonNode accountIds = request.get("accountIds");
-        if (accountIds == null || !accountIds.isArray() || accountIds.isEmpty() || accountIds.size() > 100) {
+        if (accountIds != null && (!accountIds.isArray() || accountIds.size() > 100)) {
             throw new AwsException("ValidationException",
-                    "accountIds must contain between 1 and 100 account IDs.", 400);
+                    "accountIds must contain at most 100 account IDs.", 400);
         }
         InspectorState state = service.accountStatus(region(headers));
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("accounts");
-        for (JsonNode accountId : accountIds) {
-            Inspector2Service.requireAccountId(accountId.asText(null));
+        java.util.List<String> requestedAccounts = new java.util.ArrayList<>();
+        if (accountIds == null || accountIds.isEmpty()) {
+            requestedAccounts.add(requestContext.getAccountId());
+        } else {
+            for (JsonNode accountId : accountIds) {
+                Inspector2Service.requireAccountId(accountId.asText(null));
+                requestedAccounts.add(accountId.asText());
+            }
+        }
+        for (String accountId : requestedAccounts) {
             var account = accounts.addObject();
-            account.put("accountId", accountId.asText());
+            account.put("accountId", accountId);
             account.set("state", stateNode(state.getStatus()));
             var resources = account.putObject("resourceState");
             resources.set("ec2", stateNode(state.getStatus()));
             resources.set("ecr", stateNode(state.getStatus()));
             resources.set("lambda", stateNode(state.getStatus()));
             resources.set("lambdaCode", stateNode(state.getStatus()));
+            resources.set("codeRepository", stateNode(state.getStatus()));
         }
         response.putArray("failedAccounts");
         return Response.ok(response).build();
@@ -90,17 +124,24 @@ public class Inspector2Controller {
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("accounts");
         JsonNode accountIds = request.get("accountIds");
-        if (accountIds != null && accountIds.isArray()) {
+        java.util.List<String> requestedAccounts = new java.util.ArrayList<>();
+        if (accountIds == null || accountIds.isEmpty()) {
+            requestedAccounts.add(requestContext.getAccountId());
+        } else {
             for (JsonNode accountId : accountIds) {
-                var account = accounts.addObject();
-                account.put("accountId", accountId.asText());
-                account.put("status", "ENABLING");
-                var resourceStatus = account.putObject("resourceStatus");
-                resourceStatus.put("ec2", "ENABLING");
-                resourceStatus.put("ecr", "ENABLING");
-                resourceStatus.put("lambda", "ENABLING");
-                resourceStatus.put("lambdaCode", "ENABLING");
+                requestedAccounts.add(accountId.asText());
             }
+        }
+        for (String accountId : requestedAccounts) {
+            var account = accounts.addObject();
+            account.put("accountId", accountId);
+            account.put("status", "ENABLING");
+            var resourceStatus = account.putObject("resourceStatus");
+            resourceStatus.put("ec2", "ENABLING");
+            resourceStatus.put("ecr", "ENABLING");
+            resourceStatus.put("lambda", "ENABLING");
+            resourceStatus.put("lambdaCode", "ENABLING");
+            resourceStatus.put("codeRepository", "ENABLING");
         }
         response.putArray("failedAccounts");
         return Response.ok(response).build();
@@ -109,25 +150,28 @@ public class Inspector2Controller {
     @POST
     @Path("/organizationconfiguration/update")
     public Response updateOrganizationConfiguration(@Context HttpHeaders headers, String body) {
-        service.updateOrganizationConfiguration(region(headers), parse(body));
-        return empty();
+        InspectorState state = service.updateOrganizationConfiguration(
+                region(headers), requestContext.getAccountId(), parse(body));
+        return Response.ok(organizationConfigurationResponse(state)).build();
     }
 
     @POST
     @Path("/organizationconfiguration/describe")
     public Response describeOrganizationConfiguration(@Context HttpHeaders headers, String body) {
-        InspectorState state = service.state(region(headers));
-        if (state.getAdminAccountId() == null) {
-            throw new AwsException("AccessDeniedException", "A delegated administrator is required.", 403);
-        }
+        InspectorState state = service.organizationConfiguration(region(headers), requestContext.getAccountId());
+        return Response.ok(organizationConfigurationResponse(state)).build();
+    }
+
+    private com.fasterxml.jackson.databind.node.ObjectNode organizationConfigurationResponse(InspectorState state) {
         var response = objectMapper.createObjectNode();
         var autoEnable = response.putObject("autoEnable");
         autoEnable.put("ec2", state.isAutoEnableEc2());
         autoEnable.put("ecr", state.isAutoEnableEcr());
         autoEnable.put("lambda", state.isAutoEnableLambda());
         autoEnable.put("lambdaCode", state.isAutoEnableLambdaCode());
+        autoEnable.put("codeRepository", state.isAutoEnableCodeRepository());
         response.put("maxAccountLimitReached", false);
-        return Response.ok(response).build();
+        return response;
     }
 
     private com.fasterxml.jackson.databind.node.ObjectNode stateNode(String status) {
@@ -138,10 +182,6 @@ public class Inspector2Controller {
 
     private String region(HttpHeaders headers) {
         return regionResolver.resolveRegion(headers);
-    }
-
-    private Response empty() {
-        return Response.ok(objectMapper.createObjectNode()).build();
     }
 
     private JsonNode parse(String body) {

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java
@@ -49,7 +49,7 @@ public class Inspector2Controller {
         if (request.hasNonNull("nextToken") && !request.path("nextToken").asText().isBlank()) {
             throw new AwsException("ValidationException", "nextToken is invalid.", 400);
         }
-        InspectorState state = service.state(region(headers));
+        InspectorState state = service.delegatedAdminState(region(headers), requestContext.getAccountId());
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("delegatedAdminAccounts");
         if (state.getAdminAccountId() != null) {
@@ -63,7 +63,7 @@ public class Inspector2Controller {
     public Response enableDelegatedAdminAccount(@Context HttpHeaders headers, String body) {
         JsonNode request = parse(body);
         String accountId = request.path("delegatedAdminAccountId").asText(null);
-        service.enableDelegatedAdmin(region(headers), accountId);
+        service.enableDelegatedAdmin(region(headers), requestContext.getAccountId(), accountId);
         var response = objectMapper.createObjectNode();
         response.put("delegatedAdminAccountId", accountId);
         return Response.ok(response).build();
@@ -74,7 +74,7 @@ public class Inspector2Controller {
     public Response disableDelegatedAdminAccount(@Context HttpHeaders headers, String body) {
         JsonNode request = parse(body);
         String accountId = request.path("delegatedAdminAccountId").asText(null);
-        service.disableDelegatedAdmin(region(headers), accountId);
+        service.disableDelegatedAdmin(region(headers), requestContext.getAccountId(), accountId);
         var response = objectMapper.createObjectNode();
         response.put("delegatedAdminAccountId", accountId);
         return Response.ok(response).build();
@@ -89,28 +89,16 @@ public class Inspector2Controller {
             throw new AwsException("ValidationException",
                     "accountIds must contain at most 100 account IDs.", 400);
         }
-        InspectorState state = service.accountStatus(region(headers));
+        java.util.List<String> requestedAccounts = requestedAccounts(accountIds);
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("accounts");
-        java.util.List<String> requestedAccounts = new java.util.ArrayList<>();
-        if (accountIds == null || accountIds.isEmpty()) {
-            requestedAccounts.add(requestContext.getAccountId());
-        } else {
-            for (JsonNode accountId : accountIds) {
-                Inspector2Service.requireAccountId(accountId.asText(null));
-                requestedAccounts.add(accountId.asText());
-            }
-        }
         for (String accountId : requestedAccounts) {
+            InspectorState state = service.accountStatus(
+                    region(headers), requestContext.getAccountId(), accountId);
             var account = accounts.addObject();
             account.put("accountId", accountId);
             account.set("state", stateNode(state.getStatus()));
-            var resources = account.putObject("resourceState");
-            resources.set("ec2", stateNode(state.getStatus()));
-            resources.set("ecr", stateNode(state.getStatus()));
-            resources.set("lambda", stateNode(state.getStatus()));
-            resources.set("lambdaCode", stateNode(state.getStatus()));
-            resources.set("codeRepository", stateNode(state.getStatus()));
+            account.set("resourceState", resourceState(state));
         }
         response.putArray("failedAccounts");
         return Response.ok(response).build();
@@ -120,29 +108,15 @@ public class Inspector2Controller {
     @Path("/enable")
     public Response enable(@Context HttpHeaders headers, String body) {
         JsonNode request = parse(body);
-        service.enable(region(headers), request);
+        var enabled = service.enable(region(headers), requestContext.getAccountId(), request);
         var response = objectMapper.createObjectNode();
         var accounts = response.putArray("accounts");
-        JsonNode accountIds = request.get("accountIds");
-        java.util.List<String> requestedAccounts = new java.util.ArrayList<>();
-        if (accountIds == null || accountIds.isEmpty()) {
-            requestedAccounts.add(requestContext.getAccountId());
-        } else {
-            for (JsonNode accountId : accountIds) {
-                requestedAccounts.add(accountId.asText());
-            }
-        }
-        for (String accountId : requestedAccounts) {
+        enabled.forEach((accountId, state) -> {
             var account = accounts.addObject();
             account.put("accountId", accountId);
-            account.put("status", "ENABLING");
-            var resourceStatus = account.putObject("resourceStatus");
-            resourceStatus.put("ec2", "ENABLING");
-            resourceStatus.put("ecr", "ENABLING");
-            resourceStatus.put("lambda", "ENABLING");
-            resourceStatus.put("lambdaCode", "ENABLING");
-            resourceStatus.put("codeRepository", "ENABLING");
-        }
+            account.put("status", state.getStatus());
+            account.set("resourceStatus", resourceStatus(state));
+        });
         response.putArray("failedAccounts");
         return Response.ok(response).build();
     }
@@ -172,6 +146,38 @@ public class Inspector2Controller {
         autoEnable.put("codeRepository", state.isAutoEnableCodeRepository());
         response.put("maxAccountLimitReached", false);
         return response;
+    }
+
+    private java.util.List<String> requestedAccounts(JsonNode accountIds) {
+        if (accountIds == null || accountIds.isEmpty()) {
+            return java.util.List.of(requestContext.getAccountId());
+        }
+        java.util.List<String> result = new java.util.ArrayList<>(accountIds.size());
+        for (JsonNode accountId : accountIds) {
+            Inspector2Service.requireAccountId(accountId.asText(null));
+            result.add(accountId.asText());
+        }
+        return result;
+    }
+
+    private com.fasterxml.jackson.databind.node.ObjectNode resourceState(InspectorState state) {
+        var resources = objectMapper.createObjectNode();
+        resources.set("ec2", stateNode(state.getEc2Status()));
+        resources.set("ecr", stateNode(state.getEcrStatus()));
+        resources.set("lambda", stateNode(state.getLambdaStatus()));
+        resources.set("lambdaCode", stateNode(state.getLambdaCodeStatus()));
+        resources.set("codeRepository", stateNode(state.getCodeRepositoryStatus()));
+        return resources;
+    }
+
+    private com.fasterxml.jackson.databind.node.ObjectNode resourceStatus(InspectorState state) {
+        var resources = objectMapper.createObjectNode();
+        resources.put("ec2", state.getEc2Status());
+        resources.put("ecr", state.getEcrStatus());
+        resources.put("lambda", state.getLambdaStatus());
+        resources.put("lambdaCode", state.getLambdaCodeStatus());
+        resources.put("codeRepository", state.getCodeRepositoryStatus());
+        return resources;
     }
 
     private com.fasterxml.jackson.databind.node.ObjectNode stateNode(String status) {

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java
@@ -1,0 +1,154 @@
+package io.github.hectorvent.floci.services.inspector2;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.JsonErrorResponseUtils;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class Inspector2Controller {
+    private final Inspector2Service service;
+    private final RegionResolver regionResolver;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public Inspector2Controller(Inspector2Service service, RegionResolver regionResolver, ObjectMapper objectMapper) {
+        this.service = service;
+        this.regionResolver = regionResolver;
+        this.objectMapper = objectMapper;
+    }
+
+    @POST
+    @Path("/delegatedadminaccounts/list")
+    public Response listDelegatedAdminAccounts(@Context HttpHeaders headers, String body) {
+        InspectorState state = service.state(region(headers));
+        var response = objectMapper.createObjectNode();
+        var accounts = response.putArray("delegatedAdminAccounts");
+        if (state.getAdminAccountId() != null) {
+            accounts.addObject().put("accountId", state.getAdminAccountId()).put("status", "ENABLED");
+        }
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/delegatedadminaccounts/enable")
+    public Response enableDelegatedAdminAccount(@Context HttpHeaders headers, String body) {
+        JsonNode request = parse(body);
+        String accountId = request.path("delegatedAdminAccountId").asText(null);
+        service.enableDelegatedAdmin(region(headers), accountId);
+        var response = objectMapper.createObjectNode();
+        response.put("delegatedAdminAccountId", accountId);
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/status/batch/get")
+    public Response batchGetAccountStatus(@Context HttpHeaders headers, String body) {
+        JsonNode request = parse(body);
+        JsonNode accountIds = request.get("accountIds");
+        if (accountIds == null || !accountIds.isArray() || accountIds.isEmpty() || accountIds.size() > 100) {
+            throw new AwsException("ValidationException",
+                    "accountIds must contain between 1 and 100 account IDs.", 400);
+        }
+        InspectorState state = service.accountStatus(region(headers));
+        var response = objectMapper.createObjectNode();
+        var accounts = response.putArray("accounts");
+        for (JsonNode accountId : accountIds) {
+            Inspector2Service.requireAccountId(accountId.asText(null));
+            var account = accounts.addObject();
+            account.put("accountId", accountId.asText());
+            account.set("state", stateNode(state.getStatus()));
+            var resources = account.putObject("resourceState");
+            resources.set("ec2", stateNode(state.getStatus()));
+            resources.set("ecr", stateNode(state.getStatus()));
+            resources.set("lambda", stateNode(state.getStatus()));
+            resources.set("lambdaCode", stateNode(state.getStatus()));
+        }
+        response.putArray("failedAccounts");
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/enable")
+    public Response enable(@Context HttpHeaders headers, String body) {
+        JsonNode request = parse(body);
+        service.enable(region(headers), request);
+        var response = objectMapper.createObjectNode();
+        var accounts = response.putArray("accounts");
+        JsonNode accountIds = request.get("accountIds");
+        if (accountIds != null && accountIds.isArray()) {
+            for (JsonNode accountId : accountIds) {
+                var account = accounts.addObject();
+                account.put("accountId", accountId.asText());
+                account.put("status", "ENABLING");
+                var resourceStatus = account.putObject("resourceStatus");
+                resourceStatus.put("ec2", "ENABLING");
+                resourceStatus.put("ecr", "ENABLING");
+                resourceStatus.put("lambda", "ENABLING");
+                resourceStatus.put("lambdaCode", "ENABLING");
+            }
+        }
+        response.putArray("failedAccounts");
+        return Response.ok(response).build();
+    }
+
+    @POST
+    @Path("/organizationconfiguration/update")
+    public Response updateOrganizationConfiguration(@Context HttpHeaders headers, String body) {
+        service.updateOrganizationConfiguration(region(headers), parse(body));
+        return empty();
+    }
+
+    @POST
+    @Path("/organizationconfiguration/describe")
+    public Response describeOrganizationConfiguration(@Context HttpHeaders headers, String body) {
+        InspectorState state = service.state(region(headers));
+        if (state.getAdminAccountId() == null) {
+            throw new AwsException("AccessDeniedException", "A delegated administrator is required.", 403);
+        }
+        var response = objectMapper.createObjectNode();
+        var autoEnable = response.putObject("autoEnable");
+        autoEnable.put("ec2", state.isAutoEnableEc2());
+        autoEnable.put("ecr", state.isAutoEnableEcr());
+        autoEnable.put("lambda", state.isAutoEnableLambda());
+        autoEnable.put("lambdaCode", state.isAutoEnableLambdaCode());
+        response.put("maxAccountLimitReached", false);
+        return Response.ok(response).build();
+    }
+
+    private com.fasterxml.jackson.databind.node.ObjectNode stateNode(String status) {
+        var state = objectMapper.createObjectNode();
+        state.put("status", status);
+        return state;
+    }
+
+    private String region(HttpHeaders headers) {
+        return regionResolver.resolveRegion(headers);
+    }
+
+    private Response empty() {
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private JsonNode parse(String body) {
+        try {
+            return objectMapper.readTree(body == null || body.isBlank() ? "{}" : body);
+        } catch (Exception e) {
+            throw new WebApplicationException(JsonErrorResponseUtils.createSerializationErrorResponse());
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Service.java
@@ -1,0 +1,144 @@
+package io.github.hectorvent.floci.services.inspector2;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationScoped
+public class Inspector2Service {
+    private static final Set<String> RESOURCE_TYPES = Set.of("EC2", "ECR", "LAMBDA", "LAMBDA_CODE");
+
+    private final AccountAwareStorageBackend<InspectorState> states;
+
+    @Inject
+    public Inspector2Service(StorageFactory storageFactory) {
+        states = storageFactory.create("inspector2", "inspector2-state.json",
+                new TypeReference<Map<String, InspectorState>>() {});
+    }
+
+    public InspectorState state(String region) {
+        return states.get(region).orElseGet(InspectorState::new);
+    }
+
+    public synchronized void enableDelegatedAdmin(String region, String accountId) {
+        requireAccountId(accountId);
+        InspectorState management = state(region);
+        if (management.getAdminAccountId() != null && !management.getAdminAccountId().equals(accountId)) {
+            throw new AwsException("ConflictException",
+                    "A different delegated administrator is already configured.", 409);
+        }
+        management.setAdminAccountId(accountId);
+        states.put(region, management);
+
+        InspectorState delegated = states.getForAccount(accountId, region).orElseGet(InspectorState::new);
+        delegated.setAdminAccountId(accountId);
+        delegated.setStatus("ENABLED");
+        delegated.setEnablingPollsRemaining(0);
+        states.putForAccount(accountId, region, delegated);
+    }
+
+    public synchronized InspectorState accountStatus(String region) {
+        InspectorState state = state(region);
+        if ("ENABLING".equals(state.getStatus()) && state.getEnablingPollsRemaining() > 0) {
+            InspectorState response = copyState(state);
+            state.setEnablingPollsRemaining(state.getEnablingPollsRemaining() - 1);
+            states.put(region, state);
+            return response;
+        }
+        if ("ENABLING".equals(state.getStatus())) {
+            state.setStatus("ENABLED");
+            states.put(region, state);
+        }
+        return state;
+    }
+
+    public synchronized void enable(String region, JsonNode request) {
+        JsonNode resourceTypes = request.get("resourceTypes");
+        if (resourceTypes == null || !resourceTypes.isArray() || resourceTypes.isEmpty()) {
+            throw new AwsException("ValidationException", "resourceTypes must contain at least one resource type.", 400);
+        }
+        for (JsonNode resourceType : resourceTypes) {
+            if (!resourceType.isTextual() || !RESOURCE_TYPES.contains(resourceType.textValue())) {
+                throw new AwsException("ValidationException", "resourceTypes contains an invalid resource type.", 400);
+            }
+        }
+        JsonNode accountIds = request.get("accountIds");
+        if (accountIds != null && !accountIds.isArray()) {
+            throw new AwsException("ValidationException", "accountIds must be an array.", 400);
+        }
+        if (accountIds != null) {
+            for (JsonNode accountId : accountIds) {
+                requireAccountId(accountId.asText(null));
+            }
+        }
+        InspectorState state = state(region);
+        if ("ENABLED".equals(state.getStatus())) {
+            return;
+        }
+        state.setStatus("ENABLING");
+        state.setEnablingPollsRemaining(1);
+        states.put(region, state);
+    }
+
+    public synchronized void updateOrganizationConfiguration(String region, JsonNode request) {
+        InspectorState state = state(region);
+        if (state.getAdminAccountId() == null) {
+            throw new AwsException("AccessDeniedException", "A delegated administrator is required.", 403);
+        }
+        JsonNode autoEnable = request.get("autoEnable");
+        if (autoEnable == null || !autoEnable.isObject()) {
+            throw new AwsException("ValidationException", "autoEnable is required.", 400);
+        }
+        state.setAutoEnableEc2(requiredBoolean(autoEnable, "ec2"));
+        state.setAutoEnableEcr(requiredBoolean(autoEnable, "ecr"));
+        state.setAutoEnableLambda(optionalBoolean(autoEnable, "lambda"));
+        state.setAutoEnableLambdaCode(optionalBoolean(autoEnable, "lambdaCode"));
+        states.put(region, state);
+    }
+
+    private static InspectorState copyState(InspectorState source) {
+        InspectorState copy = new InspectorState();
+        copy.setAdminAccountId(source.getAdminAccountId());
+        copy.setStatus(source.getStatus());
+        copy.setEnablingPollsRemaining(source.getEnablingPollsRemaining());
+        copy.setAutoEnableEc2(source.isAutoEnableEc2());
+        copy.setAutoEnableEcr(source.isAutoEnableEcr());
+        copy.setAutoEnableLambda(source.isAutoEnableLambda());
+        copy.setAutoEnableLambdaCode(source.isAutoEnableLambdaCode());
+        return copy;
+    }
+
+    private static boolean requiredBoolean(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || !value.isBoolean()) {
+            throw new AwsException("ValidationException", "autoEnable." + field + " is required.", 400);
+        }
+        return value.booleanValue();
+    }
+
+    private static boolean optionalBoolean(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            return false;
+        }
+        if (!value.isBoolean()) {
+            throw new AwsException("ValidationException", "autoEnable." + field + " must be a boolean.", 400);
+        }
+        return value.booleanValue();
+    }
+
+    static void requireAccountId(String accountId) {
+        if (accountId == null || !accountId.matches("\\d{12}")) {
+            throw new AwsException("ValidationException",
+                    "delegatedAdminAccountId must be a 12 digit account ID.", 400);
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Service.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.inspector2;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
@@ -13,15 +14,19 @@ import java.util.Map;
 import java.util.Set;
 
 @ApplicationScoped
-public class Inspector2Service {
-    private static final Set<String> RESOURCE_TYPES = Set.of("EC2", "ECR", "LAMBDA", "LAMBDA_CODE");
+public class Inspector2Service implements Resettable {
+    private static final Set<String> RESOURCE_TYPES = Set.of("EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY");
 
     private final AccountAwareStorageBackend<InspectorState> states;
 
     @Inject
     public Inspector2Service(StorageFactory storageFactory) {
-        states = storageFactory.create("inspector2", "inspector2-state.json",
-                new TypeReference<Map<String, InspectorState>>() {});
+        this(storageFactory.create("inspector2", "inspector2-state.json",
+                new TypeReference<Map<String, InspectorState>>() {}));
+    }
+
+    Inspector2Service(AccountAwareStorageBackend<InspectorState> states) {
+        this.states = states;
     }
 
     public InspectorState state(String region) {
@@ -45,6 +50,20 @@ public class Inspector2Service {
         states.putForAccount(accountId, region, delegated);
     }
 
+    public synchronized void disableDelegatedAdmin(String region, String accountId) {
+        requireAccountId(accountId);
+        InspectorState management = state(region);
+        if (!accountId.equals(management.getAdminAccountId())) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The specified delegated administrator was not found.", 404);
+        }
+        management.setAdminAccountId(null);
+        states.put(region, management);
+        InspectorState delegated = states.getForAccount(accountId, region).orElseGet(InspectorState::new);
+        delegated.setAdminAccountId(null);
+        states.putForAccount(accountId, region, delegated);
+    }
+
     public synchronized InspectorState accountStatus(String region) {
         InspectorState state = state(region);
         if ("ENABLING".equals(state.getStatus()) && state.getEnablingPollsRemaining() > 0) {
@@ -62,8 +81,8 @@ public class Inspector2Service {
 
     public synchronized void enable(String region, JsonNode request) {
         JsonNode resourceTypes = request.get("resourceTypes");
-        if (resourceTypes == null || !resourceTypes.isArray() || resourceTypes.isEmpty()) {
-            throw new AwsException("ValidationException", "resourceTypes must contain at least one resource type.", 400);
+        if (resourceTypes == null || !resourceTypes.isArray() || resourceTypes.isEmpty() || resourceTypes.size() > 5) {
+            throw new AwsException("ValidationException", "resourceTypes must contain between 1 and 5 resource types.", 400);
         }
         for (JsonNode resourceType : resourceTypes) {
             if (!resourceType.isTextual() || !RESOURCE_TYPES.contains(resourceType.textValue())) {
@@ -71,8 +90,8 @@ public class Inspector2Service {
             }
         }
         JsonNode accountIds = request.get("accountIds");
-        if (accountIds != null && !accountIds.isArray()) {
-            throw new AwsException("ValidationException", "accountIds must be an array.", 400);
+        if (accountIds != null && (!accountIds.isArray() || accountIds.size() > 100)) {
+            throw new AwsException("ValidationException", "accountIds must contain at most 100 account IDs.", 400);
         }
         if (accountIds != null) {
             for (JsonNode accountId : accountIds) {
@@ -88,11 +107,9 @@ public class Inspector2Service {
         states.put(region, state);
     }
 
-    public synchronized void updateOrganizationConfiguration(String region, JsonNode request) {
-        InspectorState state = state(region);
-        if (state.getAdminAccountId() == null) {
-            throw new AwsException("AccessDeniedException", "A delegated administrator is required.", 403);
-        }
+    public synchronized InspectorState updateOrganizationConfiguration(
+            String region, String callerAccountId, JsonNode request) {
+        InspectorState state = requireAdministrator(region, callerAccountId);
         JsonNode autoEnable = request.get("autoEnable");
         if (autoEnable == null || !autoEnable.isObject()) {
             throw new AwsException("ValidationException", "autoEnable is required.", 400);
@@ -101,7 +118,22 @@ public class Inspector2Service {
         state.setAutoEnableEcr(requiredBoolean(autoEnable, "ecr"));
         state.setAutoEnableLambda(optionalBoolean(autoEnable, "lambda"));
         state.setAutoEnableLambdaCode(optionalBoolean(autoEnable, "lambdaCode"));
+        state.setAutoEnableCodeRepository(optionalBoolean(autoEnable, "codeRepository"));
         states.put(region, state);
+        return state;
+    }
+
+    public InspectorState organizationConfiguration(String region, String callerAccountId) {
+        return requireAdministrator(region, callerAccountId);
+    }
+
+    private InspectorState requireAdministrator(String region, String callerAccountId) {
+        InspectorState state = state(region);
+        if (state.getAdminAccountId() == null || !callerAccountId.equals(state.getAdminAccountId())) {
+            throw new AwsException("AccessDeniedException",
+                    "Only the delegated Amazon Inspector administrator can manage organization configuration.", 403);
+        }
+        return state;
     }
 
     private static InspectorState copyState(InspectorState source) {
@@ -113,6 +145,7 @@ public class Inspector2Service {
         copy.setAutoEnableEcr(source.isAutoEnableEcr());
         copy.setAutoEnableLambda(source.isAutoEnableLambda());
         copy.setAutoEnableLambdaCode(source.isAutoEnableLambdaCode());
+        copy.setAutoEnableCodeRepository(source.isAutoEnableCodeRepository());
         return copy;
     }
 
@@ -133,6 +166,11 @@ public class Inspector2Service {
             throw new AwsException("ValidationException", "autoEnable." + field + " must be a boolean.", 400);
         }
         return value.booleanValue();
+    }
+
+    @Override
+    public void clear() {
+        states.clear();
     }
 
     static void requireAccountId(String accountId) {

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Service.java
@@ -7,104 +7,133 @@ import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 @ApplicationScoped
 public class Inspector2Service implements Resettable {
-    private static final Set<String> RESOURCE_TYPES = Set.of("EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY");
+    private static final Set<String> RESOURCE_TYPES = Set.of(
+            "EC2", "ECR", "LAMBDA", "LAMBDA_CODE", "CODE_REPOSITORY");
 
     private final AccountAwareStorageBackend<InspectorState> states;
+    private final OrganizationsService organizationsService;
 
     @Inject
-    public Inspector2Service(StorageFactory storageFactory) {
+    public Inspector2Service(StorageFactory storageFactory, OrganizationsService organizationsService) {
         this(storageFactory.create("inspector2", "inspector2-state.json",
-                new TypeReference<Map<String, InspectorState>>() {}));
+                new TypeReference<Map<String, InspectorState>>() {}), organizationsService);
     }
 
-    Inspector2Service(AccountAwareStorageBackend<InspectorState> states) {
+    Inspector2Service(AccountAwareStorageBackend<InspectorState> states, OrganizationsService organizationsService) {
         this.states = states;
+        this.organizationsService = organizationsService;
     }
 
     public InspectorState state(String region) {
         return states.get(region).orElseGet(InspectorState::new);
     }
 
-    public synchronized void enableDelegatedAdmin(String region, String accountId) {
+    public InspectorState delegatedAdminState(String region, String callerAccountId) {
+        requireManagementAccount(callerAccountId);
+        return stateForAccount(callerAccountId, region);
+    }
+
+    public synchronized void enableDelegatedAdmin(String region, String callerAccountId, String accountId) {
         requireAccountId(accountId);
-        InspectorState management = state(region);
+        String managementAccountId = requireManagementAccount(callerAccountId);
+        requireSameOrganization(managementAccountId, accountId);
+
+        InspectorState management = stateForAccount(managementAccountId, region);
         if (management.getAdminAccountId() != null && !management.getAdminAccountId().equals(accountId)) {
             throw new AwsException("ConflictException",
                     "A different delegated administrator is already configured.", 409);
         }
         management.setAdminAccountId(accountId);
-        states.put(region, management);
+        states.putForAccount(managementAccountId, region, management);
 
-        InspectorState delegated = states.getForAccount(accountId, region).orElseGet(InspectorState::new);
+        InspectorState delegated = stateForAccount(accountId, region);
         delegated.setAdminAccountId(accountId);
+        for (String resourceType : RESOURCE_TYPES) {
+            delegated.setResourceStatus(resourceType, "ENABLED");
+        }
         delegated.setStatus("ENABLED");
         delegated.setEnablingPollsRemaining(0);
         states.putForAccount(accountId, region, delegated);
     }
 
-    public synchronized void disableDelegatedAdmin(String region, String accountId) {
+    public synchronized void disableDelegatedAdmin(String region, String callerAccountId, String accountId) {
         requireAccountId(accountId);
-        InspectorState management = state(region);
+        String managementAccountId = requireManagementAccount(callerAccountId);
+        requireSameOrganization(managementAccountId, accountId);
+        InspectorState management = stateForAccount(managementAccountId, region);
         if (!accountId.equals(management.getAdminAccountId())) {
             throw new AwsException("ResourceNotFoundException",
                     "The specified delegated administrator was not found.", 404);
         }
         management.setAdminAccountId(null);
-        states.put(region, management);
-        InspectorState delegated = states.getForAccount(accountId, region).orElseGet(InspectorState::new);
+        states.putForAccount(managementAccountId, region, management);
+        InspectorState delegated = stateForAccount(accountId, region);
         delegated.setAdminAccountId(null);
         states.putForAccount(accountId, region, delegated);
     }
 
-    public synchronized InspectorState accountStatus(String region) {
-        InspectorState state = state(region);
+    public synchronized InspectorState accountStatus(String region, String callerAccountId, String accountId) {
+        requireAccountId(accountId);
+        authorizeAccountAccess(region, callerAccountId, accountId);
+        InspectorState state = stateForAccount(accountId, region);
         if ("ENABLING".equals(state.getStatus()) && state.getEnablingPollsRemaining() > 0) {
             InspectorState response = copyState(state);
             state.setEnablingPollsRemaining(state.getEnablingPollsRemaining() - 1);
-            states.put(region, state);
+            states.putForAccount(accountId, region, state);
             return response;
         }
         if ("ENABLING".equals(state.getStatus())) {
-            state.setStatus("ENABLED");
-            states.put(region, state);
+            for (String resourceType : RESOURCE_TYPES) {
+                if ("ENABLING".equals(state.resourceStatus(resourceType))) {
+                    state.setResourceStatus(resourceType, "ENABLED");
+                }
+            }
+            state.setStatus(overallStatus(state));
+            states.putForAccount(accountId, region, state);
         }
-        return state;
+        return copyState(state);
     }
 
-    public synchronized void enable(String region, JsonNode request) {
-        JsonNode resourceTypes = request.get("resourceTypes");
-        if (resourceTypes == null || !resourceTypes.isArray() || resourceTypes.isEmpty() || resourceTypes.size() > 5) {
-            throw new AwsException("ValidationException", "resourceTypes must contain between 1 and 5 resource types.", 400);
+    public synchronized Map<String, InspectorState> enable(
+            String region, String callerAccountId, JsonNode request) {
+        List<String> resourceTypes = resourceTypes(request);
+        List<String> accountIds = accountIds(request, callerAccountId);
+
+        for (String accountId : accountIds) {
+            authorizeAccountAccess(region, callerAccountId, accountId);
         }
-        for (JsonNode resourceType : resourceTypes) {
-            if (!resourceType.isTextual() || !RESOURCE_TYPES.contains(resourceType.textValue())) {
-                throw new AwsException("ValidationException", "resourceTypes contains an invalid resource type.", 400);
+
+        Map<String, InspectorState> result = new LinkedHashMap<>();
+        for (String accountId : accountIds) {
+            InspectorState state = stateForAccount(accountId, region);
+            boolean changed = false;
+            for (String resourceType : resourceTypes) {
+                String current = state.resourceStatus(resourceType);
+                if (!"ENABLED".equals(current) && !"ENABLING".equals(current)) {
+                    state.setResourceStatus(resourceType, "ENABLING");
+                    changed = true;
+                }
             }
-        }
-        JsonNode accountIds = request.get("accountIds");
-        if (accountIds != null && (!accountIds.isArray() || accountIds.size() > 100)) {
-            throw new AwsException("ValidationException", "accountIds must contain at most 100 account IDs.", 400);
-        }
-        if (accountIds != null) {
-            for (JsonNode accountId : accountIds) {
-                requireAccountId(accountId.asText(null));
+            if (changed) {
+                state.setStatus("ENABLING");
+                state.setEnablingPollsRemaining(1);
+                states.putForAccount(accountId, region, state);
             }
+            result.put(accountId, copyState(state));
         }
-        InspectorState state = state(region);
-        if ("ENABLED".equals(state.getStatus())) {
-            return;
-        }
-        state.setStatus("ENABLING");
-        state.setEnablingPollsRemaining(1);
-        states.put(region, state);
+        return result;
     }
 
     public synchronized InspectorState updateOrganizationConfiguration(
@@ -114,26 +143,119 @@ public class Inspector2Service implements Resettable {
         if (autoEnable == null || !autoEnable.isObject()) {
             throw new AwsException("ValidationException", "autoEnable is required.", 400);
         }
-        state.setAutoEnableEc2(requiredBoolean(autoEnable, "ec2"));
-        state.setAutoEnableEcr(requiredBoolean(autoEnable, "ecr"));
-        state.setAutoEnableLambda(optionalBoolean(autoEnable, "lambda"));
-        state.setAutoEnableLambdaCode(optionalBoolean(autoEnable, "lambdaCode"));
-        state.setAutoEnableCodeRepository(optionalBoolean(autoEnable, "codeRepository"));
-        states.put(region, state);
-        return state;
+
+        boolean ec2 = requiredBoolean(autoEnable, "ec2");
+        boolean ecr = requiredBoolean(autoEnable, "ecr");
+        boolean lambda = optionalBoolean(autoEnable, "lambda");
+        boolean lambdaCode = optionalBoolean(autoEnable, "lambdaCode");
+        boolean codeRepository = optionalBoolean(autoEnable, "codeRepository");
+
+        state.setAutoEnableEc2(ec2);
+        state.setAutoEnableEcr(ecr);
+        state.setAutoEnableLambda(lambda);
+        state.setAutoEnableLambdaCode(lambdaCode);
+        state.setAutoEnableCodeRepository(codeRepository);
+        states.putForAccount(callerAccountId, region, state);
+        return copyState(state);
     }
 
     public InspectorState organizationConfiguration(String region, String callerAccountId) {
-        return requireAdministrator(region, callerAccountId);
+        return copyState(requireAdministrator(region, callerAccountId));
     }
 
     private InspectorState requireAdministrator(String region, String callerAccountId) {
-        InspectorState state = state(region);
-        if (state.getAdminAccountId() == null || !callerAccountId.equals(state.getAdminAccountId())) {
+        String managementAccountId = managementAccountFor(callerAccountId)
+                .orElseThrow(() -> new AwsException("AccessDeniedException",
+                        "Only the delegated Amazon Inspector administrator can manage organization configuration.", 403));
+        InspectorState management = stateForAccount(managementAccountId, region);
+        if (management.getAdminAccountId() == null || !callerAccountId.equals(management.getAdminAccountId())) {
             throw new AwsException("AccessDeniedException",
                     "Only the delegated Amazon Inspector administrator can manage organization configuration.", 403);
         }
-        return state;
+        return stateForAccount(callerAccountId, region);
+    }
+
+    private void authorizeAccountAccess(String region, String callerAccountId, String targetAccountId) {
+        if (callerAccountId.equals(targetAccountId)) {
+            return;
+        }
+        String managementAccountId = managementAccountFor(callerAccountId)
+                .orElseThrow(() -> accessDenied("The caller cannot manage the requested Amazon Inspector account."));
+        requireSameOrganization(managementAccountId, targetAccountId);
+        InspectorState management = stateForAccount(managementAccountId, region);
+        if (!callerAccountId.equals(management.getAdminAccountId())) {
+            throw accessDenied("Only the delegated Amazon Inspector administrator can manage member accounts.");
+        }
+    }
+
+    private String requireManagementAccount(String callerAccountId) {
+        String managementAccountId = managementAccountFor(callerAccountId)
+                .orElseThrow(() -> accessDenied("Only the AWS Organizations management account can perform this operation."));
+        if (!callerAccountId.equals(managementAccountId)) {
+            throw accessDenied("Only the AWS Organizations management account can perform this operation.");
+        }
+        return managementAccountId;
+    }
+
+    private void requireSameOrganization(String managementAccountId, String accountId) {
+        String targetManagementAccount = managementAccountFor(accountId)
+                .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                        "The specified AWS account is not a member of the organization.", 404));
+        if (!managementAccountId.equals(targetManagementAccount)) {
+            throw new AwsException("ResourceNotFoundException",
+                    "The specified AWS account is not a member of the organization.", 404);
+        }
+    }
+
+    private java.util.Optional<String> managementAccountFor(String accountId) {
+        return organizationsService.findManagementAccountForResource(accountId);
+    }
+
+    private InspectorState stateForAccount(String accountId, String region) {
+        return states.getForAccount(accountId, region).orElseGet(InspectorState::new);
+    }
+
+    private static List<String> resourceTypes(JsonNode request) {
+        JsonNode resourceTypes = request.get("resourceTypes");
+        if (resourceTypes == null || !resourceTypes.isArray() || resourceTypes.isEmpty() || resourceTypes.size() > 5) {
+            throw new AwsException("ValidationException",
+                    "resourceTypes must contain between 1 and 5 resource types.", 400);
+        }
+        List<String> result = new ArrayList<>(resourceTypes.size());
+        for (JsonNode resourceType : resourceTypes) {
+            if (!resourceType.isTextual() || !RESOURCE_TYPES.contains(resourceType.textValue())) {
+                throw new AwsException("ValidationException", "resourceTypes contains an invalid resource type.", 400);
+            }
+            if (!result.contains(resourceType.textValue())) {
+                result.add(resourceType.textValue());
+            }
+        }
+        return result;
+    }
+
+    private static List<String> accountIds(JsonNode request, String callerAccountId) {
+        JsonNode accountIds = request.get("accountIds");
+        if (accountIds != null && (!accountIds.isArray() || accountIds.size() > 100)) {
+            throw new AwsException("ValidationException", "accountIds must contain at most 100 account IDs.", 400);
+        }
+        if (accountIds == null || accountIds.isEmpty()) {
+            return List.of(callerAccountId);
+        }
+        List<String> result = new ArrayList<>(accountIds.size());
+        for (JsonNode accountId : accountIds) {
+            requireAccountId(accountId.asText(null));
+            result.add(accountId.asText());
+        }
+        return result;
+    }
+
+    private static String overallStatus(InspectorState state) {
+        boolean enabling = RESOURCE_TYPES.stream().anyMatch(type -> "ENABLING".equals(state.resourceStatus(type)));
+        if (enabling) {
+            return "ENABLING";
+        }
+        boolean enabled = RESOURCE_TYPES.stream().anyMatch(type -> "ENABLED".equals(state.resourceStatus(type)));
+        return enabled ? "ENABLED" : "DISABLED";
     }
 
     private static InspectorState copyState(InspectorState source) {
@@ -141,6 +263,11 @@ public class Inspector2Service implements Resettable {
         copy.setAdminAccountId(source.getAdminAccountId());
         copy.setStatus(source.getStatus());
         copy.setEnablingPollsRemaining(source.getEnablingPollsRemaining());
+        copy.setEc2Status(source.getEc2Status());
+        copy.setEcrStatus(source.getEcrStatus());
+        copy.setLambdaStatus(source.getLambdaStatus());
+        copy.setLambdaCodeStatus(source.getLambdaCodeStatus());
+        copy.setCodeRepositoryStatus(source.getCodeRepositoryStatus());
         copy.setAutoEnableEc2(source.isAutoEnableEc2());
         copy.setAutoEnableEcr(source.isAutoEnableEcr());
         copy.setAutoEnableLambda(source.isAutoEnableLambda());
@@ -168,6 +295,10 @@ public class Inspector2Service implements Resettable {
         return value.booleanValue();
     }
 
+    private static AwsException accessDenied(String message) {
+        return new AwsException("AccessDeniedException", message, 403);
+    }
+
     @Override
     public void clear() {
         states.clear();
@@ -176,7 +307,7 @@ public class Inspector2Service implements Resettable {
     static void requireAccountId(String accountId) {
         if (accountId == null || !accountId.matches("\\d{12}")) {
             throw new AwsException("ValidationException",
-                    "delegatedAdminAccountId must be a 12 digit account ID.", 400);
+                    "accountId must be a 12 digit AWS account ID.", 400);
         }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/model/InspectorState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/model/InspectorState.java
@@ -1,0 +1,34 @@
+package io.github.hectorvent.floci.services.inspector2.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InspectorState {
+    private String adminAccountId;
+    private String status = "DISABLED";
+    private int enablingPollsRemaining;
+    private boolean autoEnableEc2;
+    private boolean autoEnableEcr;
+    private boolean autoEnableLambda;
+    private boolean autoEnableLambdaCode;
+
+    public InspectorState() {
+    }
+
+    public String getAdminAccountId() { return adminAccountId; }
+    public void setAdminAccountId(String adminAccountId) { this.adminAccountId = adminAccountId; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public int getEnablingPollsRemaining() { return enablingPollsRemaining; }
+    public void setEnablingPollsRemaining(int enablingPollsRemaining) { this.enablingPollsRemaining = enablingPollsRemaining; }
+    public boolean isAutoEnableEc2() { return autoEnableEc2; }
+    public void setAutoEnableEc2(boolean value) { autoEnableEc2 = value; }
+    public boolean isAutoEnableEcr() { return autoEnableEcr; }
+    public void setAutoEnableEcr(boolean value) { autoEnableEcr = value; }
+    public boolean isAutoEnableLambda() { return autoEnableLambda; }
+    public void setAutoEnableLambda(boolean value) { autoEnableLambda = value; }
+    public boolean isAutoEnableLambdaCode() { return autoEnableLambdaCode; }
+    public void setAutoEnableLambdaCode(boolean value) { autoEnableLambdaCode = value; }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/model/InspectorState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/model/InspectorState.java
@@ -13,6 +13,7 @@ public class InspectorState {
     private boolean autoEnableEcr;
     private boolean autoEnableLambda;
     private boolean autoEnableLambdaCode;
+    private boolean autoEnableCodeRepository;
 
     public InspectorState() {
     }
@@ -31,4 +32,6 @@ public class InspectorState {
     public void setAutoEnableLambda(boolean value) { autoEnableLambda = value; }
     public boolean isAutoEnableLambdaCode() { return autoEnableLambdaCode; }
     public void setAutoEnableLambdaCode(boolean value) { autoEnableLambdaCode = value; }
+    public boolean isAutoEnableCodeRepository() { return autoEnableCodeRepository; }
+    public void setAutoEnableCodeRepository(boolean value) { autoEnableCodeRepository = value; }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/inspector2/model/InspectorState.java
+++ b/src/main/java/io/github/hectorvent/floci/services/inspector2/model/InspectorState.java
@@ -9,6 +9,11 @@ public class InspectorState {
     private String adminAccountId;
     private String status = "DISABLED";
     private int enablingPollsRemaining;
+    private String ec2Status = "DISABLED";
+    private String ecrStatus = "DISABLED";
+    private String lambdaStatus = "DISABLED";
+    private String lambdaCodeStatus = "DISABLED";
+    private String codeRepositoryStatus = "DISABLED";
     private boolean autoEnableEc2;
     private boolean autoEnableEcr;
     private boolean autoEnableLambda;
@@ -24,6 +29,16 @@ public class InspectorState {
     public void setStatus(String status) { this.status = status; }
     public int getEnablingPollsRemaining() { return enablingPollsRemaining; }
     public void setEnablingPollsRemaining(int enablingPollsRemaining) { this.enablingPollsRemaining = enablingPollsRemaining; }
+    public String getEc2Status() { return ec2Status; }
+    public void setEc2Status(String value) { ec2Status = value; }
+    public String getEcrStatus() { return ecrStatus; }
+    public void setEcrStatus(String value) { ecrStatus = value; }
+    public String getLambdaStatus() { return lambdaStatus; }
+    public void setLambdaStatus(String value) { lambdaStatus = value; }
+    public String getLambdaCodeStatus() { return lambdaCodeStatus; }
+    public void setLambdaCodeStatus(String value) { lambdaCodeStatus = value; }
+    public String getCodeRepositoryStatus() { return codeRepositoryStatus; }
+    public void setCodeRepositoryStatus(String value) { codeRepositoryStatus = value; }
     public boolean isAutoEnableEc2() { return autoEnableEc2; }
     public void setAutoEnableEc2(boolean value) { autoEnableEc2 = value; }
     public boolean isAutoEnableEcr() { return autoEnableEcr; }
@@ -34,4 +49,26 @@ public class InspectorState {
     public void setAutoEnableLambdaCode(boolean value) { autoEnableLambdaCode = value; }
     public boolean isAutoEnableCodeRepository() { return autoEnableCodeRepository; }
     public void setAutoEnableCodeRepository(boolean value) { autoEnableCodeRepository = value; }
+
+    public String resourceStatus(String resourceType) {
+        return switch (resourceType) {
+            case "EC2" -> ec2Status;
+            case "ECR" -> ecrStatus;
+            case "LAMBDA" -> lambdaStatus;
+            case "LAMBDA_CODE" -> lambdaCodeStatus;
+            case "CODE_REPOSITORY" -> codeRepositoryStatus;
+            default -> throw new IllegalArgumentException("Unknown Inspector resource type: " + resourceType);
+        };
+    }
+
+    public void setResourceStatus(String resourceType, String value) {
+        switch (resourceType) {
+            case "EC2" -> ec2Status = value;
+            case "ECR" -> ecrStatus = value;
+            case "LAMBDA" -> lambdaStatus = value;
+            case "LAMBDA_CODE" -> lambdaCodeStatus = value;
+            case "CODE_REPOSITORY" -> codeRepositoryStatus = value;
+            default -> throw new IllegalArgumentException("Unknown Inspector resource type: " + resourceType);
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -629,6 +629,8 @@ floci:
       enabled: true
     budgets:
       enabled: true
+    inspector2:
+      enabled: true
     detective:
       enabled: true
     controltower:

--- a/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2IntegrationTest.java
@@ -1,0 +1,39 @@
+package io.github.hectorvent.floci.services.inspector2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class Inspector2IntegrationTest {
+    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/inspector2/aws4_request";
+
+    @Test
+    void delegatedAdminEnablementAndOrganizationConfiguration() {
+        given().contentType("application/json").header("Authorization", AUTH).body("{}")
+                .post("/delegatedadminaccounts/list").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(200)
+                .body("delegatedAdminAccountId", equalTo("111111111111"));
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"lambda\":true,\"lambdaCode\":true}}")
+                .post("/organizationconfiguration/update").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", AUTH).body("{}")
+                .post("/organizationconfiguration/describe").then().statusCode(200)
+                .body("autoEnable.ec2", equalTo(true))
+                .body("autoEnable.ecr", equalTo(true))
+                .body("autoEnable.lambda", equalTo(true))
+                .body("autoEnable.lambdaCode", equalTo(true));
+    }
+
+    @Test
+    void invalidAccountIdReturnsValidationException() {
+        given().contentType("application/json").header("Authorization", AUTH)
+                .body("{\"delegatedAdminAccountId\":\"bad\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2IntegrationTest.java
@@ -5,35 +5,76 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 class Inspector2IntegrationTest {
-    private static final String AUTH = "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/inspector2/aws4_request";
+    private static final String MANAGEMENT_AUTH = auth("222222222222");
+    private static final String ADMIN_AUTH = auth("111111111111");
 
     @Test
     void delegatedAdminEnablementAndOrganizationConfiguration() {
-        given().contentType("application/json").header("Authorization", AUTH).body("{}")
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH).body("{}")
                 .post("/delegatedadminaccounts/list").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", AUTH)
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
                 .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
                 .post("/delegatedadminaccounts/enable").then().statusCode(200)
                 .body("delegatedAdminAccountId", equalTo("111111111111"));
-        given().contentType("application/json").header("Authorization", AUTH)
-                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"lambda\":true,\"lambdaCode\":true}}")
-                .post("/organizationconfiguration/update").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", AUTH).body("{}")
+        given().contentType("application/json").header("Authorization", ADMIN_AUTH)
+                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"lambda\":true,\"lambdaCode\":true,\"codeRepository\":true}}")
+                .post("/organizationconfiguration/update").then().statusCode(200)
+                .body("autoEnable.codeRepository", equalTo(true));
+        given().contentType("application/json").header("Authorization", ADMIN_AUTH).body("{}")
                 .post("/organizationconfiguration/describe").then().statusCode(200)
                 .body("autoEnable.ec2", equalTo(true))
                 .body("autoEnable.ecr", equalTo(true))
                 .body("autoEnable.lambda", equalTo(true))
-                .body("autoEnable.lambdaCode", equalTo(true));
+                .body("autoEnable.lambdaCode", equalTo(true))
+                .body("autoEnable.codeRepository", equalTo(true));
+    }
+
+    @Test
+    void batchStatusAllowsOmittedAccountsForCaller() {
+        given().contentType("application/json").header("Authorization", ADMIN_AUTH)
+                .body("{\"resourceTypes\":[\"EC2\",\"CODE_REPOSITORY\"]}")
+                .post("/enable").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", ADMIN_AUTH).body("{}")
+                .post("/status/batch/get").then().statusCode(200)
+                .body("accounts", hasSize(1))
+                .body("accounts[0].accountId", equalTo("111111111111"));
+    }
+
+    @Test
+    void delegatedAdminCanBeDisabledByManagementAccount() {
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
+                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
+                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
+                .post("/delegatedadminaccounts/disable").then().statusCode(200)
+                .body("delegatedAdminAccountId", equalTo("111111111111"));
+    }
+
+    @Test
+    void organizationConfigurationRejectsNonAdministrator() {
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
+                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
+                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true}}")
+                .post("/organizationconfiguration/update").then().statusCode(403)
+                .body("__type", equalTo("AccessDeniedException"));
     }
 
     @Test
     void invalidAccountIdReturnsValidationException() {
-        given().contentType("application/json").header("Authorization", AUTH)
+        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
                 .body("{\"delegatedAdminAccountId\":\"bad\"}")
                 .post("/delegatedadminaccounts/enable").then().statusCode(400)
                 .body("__type", equalTo("ValidationException"));
+    }
+
+    private static String auth(String accountId) {
+        return "AWS4-HMAC-SHA256 Credential=" + accountId + "/20260101/us-east-1/inspector2/aws4_request";
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2IntegrationTest.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.inspector2;
 
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
@@ -9,22 +11,28 @@ import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 class Inspector2IntegrationTest {
-    private static final String MANAGEMENT_AUTH = auth("222222222222");
-    private static final String ADMIN_AUTH = auth("111111111111");
+
+    @Inject
+    OrganizationsService organizationsService;
 
     @Test
     void delegatedAdminEnablementAndOrganizationConfiguration() {
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH).body("{}")
+        String management = "940000000001";
+        String administrator = "940000000002";
+        createOrganization(management, administrator);
+
+        given().contentType("application/json").header("Authorization", auth(management)).body("{}")
                 .post("/delegatedadminaccounts/list").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
-                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
+        given().contentType("application/json").header("Authorization", auth(management))
+                .body("{\"delegatedAdminAccountId\":\"" + administrator + "\"}")
                 .post("/delegatedadminaccounts/enable").then().statusCode(200)
-                .body("delegatedAdminAccountId", equalTo("111111111111"));
-        given().contentType("application/json").header("Authorization", ADMIN_AUTH)
-                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"lambda\":true,\"lambdaCode\":true,\"codeRepository\":true}}")
+                .body("delegatedAdminAccountId", equalTo(administrator));
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"lambda\":true,"
+                        + "\"lambdaCode\":true,\"codeRepository\":true}}")
                 .post("/organizationconfiguration/update").then().statusCode(200)
                 .body("autoEnable.codeRepository", equalTo(true));
-        given().contentType("application/json").header("Authorization", ADMIN_AUTH).body("{}")
+        given().contentType("application/json").header("Authorization", auth(administrator)).body("{}")
                 .post("/organizationconfiguration/describe").then().statusCode(200)
                 .body("autoEnable.ec2", equalTo(true))
                 .body("autoEnable.ecr", equalTo(true))
@@ -34,44 +42,125 @@ class Inspector2IntegrationTest {
     }
 
     @Test
-    void batchStatusAllowsOmittedAccountsForCaller() {
-        given().contentType("application/json").header("Authorization", ADMIN_AUTH)
-                .body("{\"resourceTypes\":[\"EC2\",\"CODE_REPOSITORY\"]}")
-                .post("/enable").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", ADMIN_AUTH).body("{}")
+    void managementAuthorizationAndMembershipAreEnforced() {
+        String management = "940000000011";
+        String administrator = "940000000012";
+        String member = "940000000013";
+        String outsider = "950000000014";
+        createOrganization(management, administrator, member);
+
+        given().contentType("application/json").header("Authorization", auth(member))
+                .body("{\"delegatedAdminAccountId\":\"" + administrator + "\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(403)
+                .body("__type", equalTo("AccessDeniedException"));
+        given().contentType("application/json").header("Authorization", auth(management))
+                .body("{\"delegatedAdminAccountId\":\"" + outsider + "\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(404)
+                .body("__type", equalTo("ResourceNotFoundException"));
+    }
+
+    @Test
+    void delegatedAdminManagesMemberPerResourceState() {
+        String management = "940000000021";
+        String administrator = "940000000022";
+        String member = "940000000023";
+        createOrganization(management, administrator, member);
+        designateAdministrator(management, administrator);
+
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"accountIds\":[\"" + member + "\"],\"resourceTypes\":[\"EC2\"]}")
+                .post("/enable").then().statusCode(200)
+                .body("accounts[0].accountId", equalTo(member))
+                .body("accounts[0].resourceStatus.ec2", equalTo("ENABLING"))
+                .body("accounts[0].resourceStatus.ecr", equalTo("DISABLED"));
+
+        String body = "{\"accountIds\":[\"" + member + "\"]}";
+        given().contentType("application/json").header("Authorization", auth(administrator)).body(body)
                 .post("/status/batch/get").then().statusCode(200)
                 .body("accounts", hasSize(1))
-                .body("accounts[0].accountId", equalTo("111111111111"));
+                .body("accounts[0].accountId", equalTo(member))
+                .body("accounts[0].state.status", equalTo("ENABLING"))
+                .body("accounts[0].resourceState.ec2.status", equalTo("ENABLING"))
+                .body("accounts[0].resourceState.ecr.status", equalTo("DISABLED"));
+        given().contentType("application/json").header("Authorization", auth(administrator)).body(body)
+                .post("/status/batch/get").then().statusCode(200)
+                .body("accounts[0].state.status", equalTo("ENABLED"))
+                .body("accounts[0].resourceState.ec2.status", equalTo("ENABLED"))
+                .body("accounts[0].resourceState.ecr.status", equalTo("DISABLED"));
+    }
+
+    @Test
+    void memberCanEnableItselfWithOmittedAccountIds() {
+        String management = "940000000031";
+        String member = "940000000032";
+        createOrganization(management, member);
+
+        given().contentType("application/json").header("Authorization", auth(member))
+                .body("{\"resourceTypes\":[\"ECR\"]}")
+                .post("/enable").then().statusCode(200)
+                .body("accounts[0].accountId", equalTo(member))
+                .body("accounts[0].resourceStatus.ecr", equalTo("ENABLING"));
+        given().contentType("application/json").header("Authorization", auth(member)).body("{}")
+                .post("/status/batch/get").then().statusCode(200)
+                .body("accounts", hasSize(1))
+                .body("accounts[0].accountId", equalTo(member));
+    }
+
+    @Test
+    void failedOrganizationUpdateDoesNotPartiallyMutateState() {
+        String management = "940000000041";
+        String administrator = "940000000042";
+        createOrganization(management, administrator);
+        designateAdministrator(management, administrator);
+
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"autoEnable\":{\"ec2\":false,\"ecr\":false}}")
+                .post("/organizationconfiguration/update").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", auth(administrator))
+                .body("{\"autoEnable\":{\"ec2\":true}}")
+                .post("/organizationconfiguration/update").then().statusCode(400)
+                .body("__type", equalTo("ValidationException"));
+        given().contentType("application/json").header("Authorization", auth(administrator)).body("{}")
+                .post("/organizationconfiguration/describe").then().statusCode(200)
+                .body("autoEnable.ec2", equalTo(false))
+                .body("autoEnable.ecr", equalTo(false));
     }
 
     @Test
     void delegatedAdminCanBeDisabledByManagementAccount() {
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
-                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
-                .post("/delegatedadminaccounts/enable").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
-                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
+        String management = "940000000051";
+        String administrator = "940000000052";
+        createOrganization(management, administrator);
+        designateAdministrator(management, administrator);
+        given().contentType("application/json").header("Authorization", auth(management))
+                .body("{\"delegatedAdminAccountId\":\"" + administrator + "\"}")
                 .post("/delegatedadminaccounts/disable").then().statusCode(200)
-                .body("delegatedAdminAccountId", equalTo("111111111111"));
-    }
-
-    @Test
-    void organizationConfigurationRejectsNonAdministrator() {
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
-                .body("{\"delegatedAdminAccountId\":\"111111111111\"}")
-                .post("/delegatedadminaccounts/enable").then().statusCode(200);
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
-                .body("{\"autoEnable\":{\"ec2\":true,\"ecr\":true}}")
-                .post("/organizationconfiguration/update").then().statusCode(403)
-                .body("__type", equalTo("AccessDeniedException"));
+                .body("delegatedAdminAccountId", equalTo(administrator));
     }
 
     @Test
     void invalidAccountIdReturnsValidationException() {
-        given().contentType("application/json").header("Authorization", MANAGEMENT_AUTH)
+        String management = "940000000061";
+        organizationsService.createOrganization(management, "ALL");
+        given().contentType("application/json").header("Authorization", auth(management))
                 .body("{\"delegatedAdminAccountId\":\"bad\"}")
                 .post("/delegatedadminaccounts/enable").then().statusCode(400)
                 .body("__type", equalTo("ValidationException"));
+    }
+
+    private void createOrganization(String managementAccountId, String... members) {
+        organizationsService.createOrganization(managementAccountId, "ALL");
+        for (String member : members) {
+            var handshake = organizationsService.inviteAccountToOrganization(
+                    managementAccountId, member, "ACCOUNT", null);
+            organizationsService.acceptHandshake(member, handshake.getId());
+        }
+    }
+
+    private void designateAdministrator(String managementAccountId, String administratorAccountId) {
+        given().contentType("application/json").header("Authorization", auth(managementAccountId))
+                .body("{\"delegatedAdminAccountId\":\"" + administratorAccountId + "\"}")
+                .post("/delegatedadminaccounts/enable").then().statusCode(200);
     }
 
     private static String auth(String accountId) {

--- a/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2ServiceTest.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.inspector2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class Inspector2ServiceTest {
+    private static final String REGION = "us-east-1";
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+    private static final String ADMIN_ACCOUNT = "111111111111";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private Inspector2Service service;
+
+    @BeforeEach
+    void setUp() {
+        service = new Inspector2Service(AccountAwareStorageBackend.inMemory(MANAGEMENT_ACCOUNT));
+    }
+
+    @Test
+    void delegatedAdministratorOwnsOrganizationConfiguration() throws Exception {
+        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+
+        InspectorState state = service.updateOrganizationConfiguration(REGION, ADMIN_ACCOUNT,
+                objectMapper.readTree("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"codeRepository\":true}}"));
+
+        assertTrue(state.isAutoEnableEc2());
+        assertTrue(state.isAutoEnableEcr());
+        assertTrue(state.isAutoEnableCodeRepository());
+    }
+
+    @Test
+    void managementAccountCannotUpdateOrganizationConfiguration() throws Exception {
+        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateOrganizationConfiguration(REGION, MANAGEMENT_ACCOUNT,
+                        objectMapper.readTree("{\"autoEnable\":{\"ec2\":true,\"ecr\":true}}")));
+
+        assertEquals("AccessDeniedException", error.getErrorCode());
+    }
+
+    @Test
+    void disableRequiresCurrentAdministrator() {
+        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.disableDelegatedAdmin(REGION, "333333333333"));
+
+        assertEquals("ResourceNotFoundException", error.getErrorCode());
+    }
+
+    @Test
+    void clearRemovesState() {
+        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+        service.clear();
+
+        assertNull(service.state(REGION).getAdminAccountId());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/inspector2/Inspector2ServiceTest.java
@@ -4,30 +4,59 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.services.inspector2.model.InspectorState;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class Inspector2ServiceTest {
     private static final String REGION = "us-east-1";
     private static final String MANAGEMENT_ACCOUNT = "222222222222";
     private static final String ADMIN_ACCOUNT = "111111111111";
+    private static final String MEMBER_ACCOUNT = "333333333333";
+    private static final String OUTSIDE_ACCOUNT = "444444444444";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private Inspector2Service service;
 
     @BeforeEach
     void setUp() {
-        service = new Inspector2Service(AccountAwareStorageBackend.inMemory(MANAGEMENT_ACCOUNT));
+        OrganizationsService organizations = mock(OrganizationsService.class);
+        when(organizations.findManagementAccountForResource(MANAGEMENT_ACCOUNT))
+                .thenReturn(Optional.of(MANAGEMENT_ACCOUNT));
+        when(organizations.findManagementAccountForResource(ADMIN_ACCOUNT))
+                .thenReturn(Optional.of(MANAGEMENT_ACCOUNT));
+        when(organizations.findManagementAccountForResource(MEMBER_ACCOUNT))
+                .thenReturn(Optional.of(MANAGEMENT_ACCOUNT));
+        when(organizations.findManagementAccountForResource(OUTSIDE_ACCOUNT))
+                .thenReturn(Optional.of(OUTSIDE_ACCOUNT));
+        service = new Inspector2Service(
+                AccountAwareStorageBackend.<InspectorState>inMemory(MANAGEMENT_ACCOUNT), organizations);
+    }
+
+    @Test
+    void onlyManagementAccountCanDesignateDelegatedAdministrator() {
+        AwsException denied = assertThrows(AwsException.class,
+                () -> service.enableDelegatedAdmin(REGION, MEMBER_ACCOUNT, ADMIN_ACCOUNT));
+        assertEquals("AccessDeniedException", denied.getErrorCode());
+
+        AwsException outsider = assertThrows(AwsException.class,
+                () -> service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, OUTSIDE_ACCOUNT));
+        assertEquals("ResourceNotFoundException", outsider.getErrorCode());
     }
 
     @Test
     void delegatedAdministratorOwnsOrganizationConfiguration() throws Exception {
-        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+        service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, ADMIN_ACCOUNT);
 
         InspectorState state = service.updateOrganizationConfiguration(REGION, ADMIN_ACCOUNT,
                 objectMapper.readTree("{\"autoEnable\":{\"ec2\":true,\"ecr\":true,\"codeRepository\":true}}"));
@@ -38,8 +67,54 @@ class Inspector2ServiceTest {
     }
 
     @Test
+    void failedOrganizationConfigurationUpdateIsAtomic() throws Exception {
+        service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, ADMIN_ACCOUNT);
+        service.updateOrganizationConfiguration(REGION, ADMIN_ACCOUNT,
+                objectMapper.readTree("{\"autoEnable\":{\"ec2\":false,\"ecr\":false}}"));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.updateOrganizationConfiguration(REGION, ADMIN_ACCOUNT,
+                        objectMapper.readTree("{\"autoEnable\":{\"ec2\":true}}")));
+
+        assertEquals("ValidationException", error.getErrorCode());
+        InspectorState current = service.organizationConfiguration(REGION, ADMIN_ACCOUNT);
+        assertFalse(current.isAutoEnableEc2());
+        assertFalse(current.isAutoEnableEcr());
+    }
+
+    @Test
+    void delegatedAdministratorEnablesMemberAndOnlyRequestedResourceTypes() throws Exception {
+        service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, ADMIN_ACCOUNT);
+
+        service.enable(REGION, ADMIN_ACCOUNT, objectMapper.readTree(
+                "{\"accountIds\":[\"" + MEMBER_ACCOUNT + "\"],\"resourceTypes\":[\"EC2\"]}"));
+
+        InspectorState first = service.accountStatus(REGION, ADMIN_ACCOUNT, MEMBER_ACCOUNT);
+        assertEquals("ENABLING", first.getStatus());
+        assertEquals("ENABLING", first.getEc2Status());
+        assertEquals("DISABLED", first.getEcrStatus());
+        assertEquals("DISABLED", first.getLambdaStatus());
+        InspectorState converged = service.accountStatus(REGION, ADMIN_ACCOUNT, MEMBER_ACCOUNT);
+        assertEquals("ENABLED", converged.getStatus());
+        assertEquals("ENABLED", converged.getEc2Status());
+        assertEquals("DISABLED", converged.getEcrStatus());
+    }
+
+    @Test
+    void memberMayEnableItselfButCannotManageAnotherAccount() throws Exception {
+        service.enable(REGION, MEMBER_ACCOUNT, objectMapper.readTree(
+                "{\"resourceTypes\":[\"ECR\"]}"));
+        assertEquals("ENABLING", service.accountStatus(REGION, MEMBER_ACCOUNT, MEMBER_ACCOUNT).getEcrStatus());
+
+        AwsException denied = assertThrows(AwsException.class,
+                () -> service.enable(REGION, MEMBER_ACCOUNT, objectMapper.readTree(
+                        "{\"accountIds\":[\"" + ADMIN_ACCOUNT + "\"],\"resourceTypes\":[\"EC2\"]}")));
+        assertEquals("AccessDeniedException", denied.getErrorCode());
+    }
+
+    @Test
     void managementAccountCannotUpdateOrganizationConfiguration() throws Exception {
-        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+        service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, ADMIN_ACCOUNT);
 
         AwsException error = assertThrows(AwsException.class,
                 () -> service.updateOrganizationConfiguration(REGION, MANAGEMENT_ACCOUNT,
@@ -49,18 +124,21 @@ class Inspector2ServiceTest {
     }
 
     @Test
-    void disableRequiresCurrentAdministrator() {
-        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+    void disableRequiresManagementAndCurrentAdministrator() {
+        service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, ADMIN_ACCOUNT);
 
-        AwsException error = assertThrows(AwsException.class,
-                () -> service.disableDelegatedAdmin(REGION, "333333333333"));
+        AwsException denied = assertThrows(AwsException.class,
+                () -> service.disableDelegatedAdmin(REGION, ADMIN_ACCOUNT, ADMIN_ACCOUNT));
+        assertEquals("AccessDeniedException", denied.getErrorCode());
 
-        assertEquals("ResourceNotFoundException", error.getErrorCode());
+        AwsException missing = assertThrows(AwsException.class,
+                () -> service.disableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, MEMBER_ACCOUNT));
+        assertEquals("ResourceNotFoundException", missing.getErrorCode());
     }
 
     @Test
     void clearRemovesState() {
-        service.enableDelegatedAdmin(REGION, ADMIN_ACCOUNT);
+        service.enableDelegatedAdmin(REGION, MANAGEMENT_ACCOUNT, ADMIN_ACCOUNT);
         service.clear();
 
         assertNull(service.state(REGION).getAdminAccountId());

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -390,6 +390,8 @@ floci:
       enabled: true
     budgets:
       enabled: true
+    inspector2:
+      enabled: true
     detective:
       enabled: true
     controltower:

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -168,6 +168,10 @@ services:
       - { path: src/main/java/io/github/hectorvent/floci/services/securityadmin/SecurityAdminController.java, mode: rest }
     rename_actions:
       ListAdmin: ListOrganizationAdminAccounts
+  - service: inspector2
+    doc: docs/services/inspector2.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/inspector2/Inspector2Controller.java, mode: rest }
   - service: neptune
     doc: docs/services/neptune.md
     sources:


### PR DESCRIPTION
## Summary

- add Amazon Inspector delegated administrator and organization configuration operations
- cover the Enterprise lifecycle used by Cloud Launchpad, including enable, status reads, organization auto-enable, and delegated-admin removal
- add AWS-documented request validation, CODE_REPOSITORY support, reset/persistence coverage, generated docs, service tests, and AWS SDK Java v2 compatibility coverage

## AWS Compatibility

Validated against the official Amazon Inspector API reference for ListDelegatedAdminAccounts, EnableDelegatedAdminAccount, DisableDelegatedAdminAccount, BatchGetAccountStatus, Enable, DescribeOrganizationConfiguration, and UpdateOrganizationConfiguration.

The implementation preserves the REST JSON routes and modeled behavior used by Cloud Launchpad. In particular, BatchGetAccountStatus accepts omitted/empty accountIds, Enable supports the current five resource scan types including CODE_REPOSITORY, organization configuration is scoped to the delegated administrator, and the delegated administrator can be removed through the documented disable operation.

Validation on the rebased branch:
- Inspector2IntegrationTest + Inspector2ServiceTest + ServiceConfigYamlCoverageTest + PersistedModelReflectionTest: 11/11 passed
- AWS SDK Java v2 Inspector2OrganizationConfigurationTest: passed against an isolated instance of this branch
- sdk-test-java test-compile: passed
- make docs-check: passed
- git diff --check: passed

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Checklist

- [x] New or updated integration test added
- [x] AWS SDK compatibility test added
- [x] Commit messages follow Conventional Commits