### PR TITLE
feat(sfn):  publish history events for Parallel branches and Map iterations

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsExecutionHistoryTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StepFunctionsExecutionHistoryTest.java
@@ -126,6 +126,149 @@ class StepFunctionsExecutionHistoryTest {
         }
     }
 
+    /**
+     * Issue #2868: the states inside a Parallel branch and an inline Map iteration publish into the
+     * execution's history, chained through previousEventId to the Started event that opened them.
+     * The SDK reads each event's details under the field named for its type, which is what this
+     * test pins. Shapes verified against real AWS in us-east-1.
+     */
+    @Test
+    void parallelBranchesAndMapIterationsPublishTheirEvents() throws Exception {
+        var smDef = """
+                {
+                  "StartAt": "P",
+                  "States": {
+                    "P": {
+                      "Type": "Parallel",
+                      "Branches": [
+                        {"StartAt": "A1", "States": {"A1": {"Type": "Pass", "End": true}}}
+                      ],
+                      "Next": "M"
+                    },
+                    "M": {
+                      "Type": "Map",
+                      "ItemsPath": "$[0].items",
+                      "MaxConcurrency": 1,
+                      "ItemProcessor": {
+                        "ProcessorConfig": {"Mode": "INLINE"},
+                        "StartAt": "I1",
+                        "States": {"I1": {"Type": "Pass", "End": true}}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """;
+
+        var smArn = sfn.createStateMachine(b -> b
+                .name(TestFixtures.uniqueName("sfn-history-branches-sm"))
+                .definition(smDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            var execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(smArn)
+                    .input("{\"items\": [1, 2]}")).executionArn();
+
+            var execution = pollUntilDone(execArn);
+            assertThat(execution.status()).isEqualTo(ExecutionStatus.SUCCEEDED);
+
+            var events = sfn.getExecutionHistory(b -> b
+                    .executionArn(execArn)
+                    .includeExecutionData(true)).events();
+
+            var types = events.stream().map(HistoryEvent::type).toList();
+            assertThat(types).containsExactly(
+                    HistoryEventType.EXECUTION_STARTED,
+                    HistoryEventType.PARALLEL_STATE_ENTERED,
+                    HistoryEventType.PARALLEL_STATE_STARTED,
+                    HistoryEventType.PASS_STATE_ENTERED,
+                    HistoryEventType.PASS_STATE_EXITED,
+                    HistoryEventType.PARALLEL_STATE_SUCCEEDED,
+                    HistoryEventType.PARALLEL_STATE_EXITED,
+                    HistoryEventType.MAP_STATE_ENTERED,
+                    HistoryEventType.MAP_STATE_STARTED,
+                    HistoryEventType.MAP_ITERATION_STARTED,
+                    HistoryEventType.PASS_STATE_ENTERED,
+                    HistoryEventType.PASS_STATE_EXITED,
+                    HistoryEventType.MAP_ITERATION_SUCCEEDED,
+                    HistoryEventType.MAP_ITERATION_STARTED,
+                    HistoryEventType.PASS_STATE_ENTERED,
+                    HistoryEventType.PASS_STATE_EXITED,
+                    HistoryEventType.MAP_ITERATION_SUCCEEDED,
+                    HistoryEventType.MAP_STATE_SUCCEEDED,
+                    HistoryEventType.MAP_STATE_EXITED,
+                    HistoryEventType.EXECUTION_SUCCEEDED);
+
+            var expectedPreviousEventIds = List.of(0L, 0L, 2L, 3L, 4L, 5L, 5L, 7L, 8L, 9L, 10L, 11L, 12L,
+                    9L, 14L, 15L, 16L, 17L, 17L, 19L);
+            for (var i = 0; i < events.size(); i++) {
+                var event = events.get(i);
+                assertThat(event.id()).isEqualTo(i + 1L);
+                assertThat(event.previousEventId()).as("previousEventId of event %d", i + 1)
+                        .isEqualTo(expectedPreviousEventIds.get(i));
+            }
+
+            assertThat(events.get(8).mapStateStartedEventDetails().length()).isEqualTo(2);
+            assertThat(events.get(9).mapIterationStartedEventDetails().name()).isEqualTo("M");
+            assertThat(events.get(9).mapIterationStartedEventDetails().index()).isEqualTo(0);
+            assertThat(events.get(16).mapIterationSucceededEventDetails().name()).isEqualTo("M");
+            assertThat(events.get(16).mapIterationSucceededEventDetails().index()).isEqualTo(1);
+            assertThat(events.get(18).stateExitedEventDetails().output()).isEqualTo("[1,2]");
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(smArn)); } catch (Exception ignored) {}
+        }
+    }
+
+    /** Issue #2868: the cause of a failure inside a branch names the branch state, as on AWS. */
+    @Test
+    void failureInsideABranchNamesTheBranchStateInItsCause() throws Exception {
+        var smDef = """
+                {
+                  "StartAt": "P",
+                  "States": {
+                    "P": {
+                      "Type": "Parallel",
+                      "Branches": [
+                        {"StartAt": "Fast", "States": {"Fast": {"Type": "Pass", "Parameters": {"m.$": "$.nope"}, "End": true}}}
+                      ],
+                      "End": true
+                    }
+                  }
+                }
+                """;
+
+        var smArn = sfn.createStateMachine(b -> b
+                .name(TestFixtures.uniqueName("sfn-history-branch-failure-sm"))
+                .definition(smDef)
+                .roleArn(ROLE_ARN)).stateMachineArn();
+
+        try {
+            var execArn = sfn.startExecution(b -> b
+                    .stateMachineArn(smArn)
+                    .input("{\"x\":\"a\"}")).executionArn();
+
+            var execution = pollUntilDone(execArn);
+            assertThat(execution.status()).isEqualTo(ExecutionStatus.FAILED);
+            assertThat(execution.error()).isEqualTo("States.Runtime");
+            assertThat(execution.cause()).isEqualTo(
+                    "An error occurred while executing the state 'Fast' (entered at the event id #4). "
+                    + "The JSONPath '$.nope' specified for the field 'm.$' could not be found in the input '{\"x\":\"a\"}'");
+
+            var events = sfn.getExecutionHistory(b -> b.executionArn(execArn)).events();
+            assertThat(events.stream().map(HistoryEvent::type).toList()).containsExactly(
+                    HistoryEventType.EXECUTION_STARTED,
+                    HistoryEventType.PARALLEL_STATE_ENTERED,
+                    HistoryEventType.PARALLEL_STATE_STARTED,
+                    HistoryEventType.PASS_STATE_ENTERED,
+                    HistoryEventType.EXECUTION_FAILED);
+            assertThat(events.get(3).stateEnteredEventDetails().name()).isEqualTo("Fast");
+            assertThat(events.get(4).executionFailedEventDetails().cause()).isEqualTo(execution.cause());
+        } finally {
+            try { sfn.deleteStateMachine(b -> b.stateMachineArn(smArn)); } catch (Exception ignored) {}
+        }
+    }
+
     private DescribeExecutionResponse pollUntilDone(String execArn) throws InterruptedException {
         for (var i = 0; i < 120; i++) {
             var resp = sfn.describeExecution(b -> b.executionArn(execArn));

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -62,9 +62,32 @@ A `Retry` re-entry emits its own Scheduled, Started, and Failed triple for each 
 mocked Task (`SFN_MOCK_CONFIG`) emits the same events as a real one, because Step Functions
 Local does the same.
 
-Every event's `previousEventId` points to the id of the event right before it. The one
-exception is the first state's `*StateEntered` event. Its `previousEventId` is `0`. That
-matches `ExecutionStarted`, which is always `id: 1, previousEventId: 0`.
+Every event's `previousEventId` points to the id of the event right before it on the same
+chain of states. The one exception is the first state's `*StateEntered` event. Its
+`previousEventId` is `0`. That matches `ExecutionStarted`, which is always
+`id: 1, previousEventId: 0`.
+
+### Parallel branches and Map iterations
+
+The states inside a `Parallel` branch or an inline `Map` iteration publish their events into
+the parent execution's history, as on AWS. A `Parallel` records `ParallelStateStarted`,
+`ParallelStateSucceeded` and `ParallelStateFailed`. An inline `Map` records `MapStateStarted`,
+`MapIterationStarted`, `MapIterationSucceeded`, `MapIterationFailed`, `MapStateSucceeded` and
+`MapStateFailed`. A Distributed `Map` records `MapRunStarted`, `MapRunSucceeded` and
+`MapRunFailed` instead. Its items are child executions and publish nothing into the parent
+history. A `Task` whose failure ends its branch also records `TaskStateAborted`.
+
+Branches and iterations run concurrently, so the order in which their events interleave differs
+from run to run. Each branch chains its own events through `previousEventId`, and that chain is
+the same every time.
+
+### The cause of a failure
+
+The `cause` of a failure the interpreter raises starts with
+`An error occurred while executing the state '<name>' (entered at the event id #<n>). `, as on
+AWS. The prefix is added once, at the innermost state. A `Fail` state's `Cause` and a cause a
+task's resource answered with pass through unchanged. A `Choice` that matches no rule and has
+no `Default`, and a payload template path that matches nothing, fail with `States.Runtime`.
 
 `inputDetails` appears on `ExecutionStarted`, on `stateEnteredEventDetails`, and on
 `LambdaFunctionScheduled`/`ActivityScheduled`. `outputDetails` appears on
@@ -76,9 +99,13 @@ When the request sets `includeExecutionData` to false, the details objects stay 
 `taskScheduledEventDetails.parameters`. This matches AWS.
 
 A few gaps remain. `TaskStarted`, `LambdaFunctionStarted`, and `ActivityStarted` fire at
-scheduling time, not when a worker actually picks up the task. Events inside a `Parallel` or
-`Map` branch are not recorded in the parent execution's history. `TaskSubmitted`, which real
-AWS emits for `.sync` and `.waitForTaskToken` integrations, is not emitted yet.
+scheduling time, not when a worker actually picks up the task. `TaskSubmitted`, which real
+AWS emits for `.sync` and `.waitForTaskToken` integrations, is not emitted yet. A JSONata
+failure does not emit the `EvaluationFailed` event AWS records before `ExecutionFailed`. When a
+branch fails, AWS records `*StateAborted` and `MapIterationAborted` events for the states its
+sibling branches were in; Floci cancels the siblings without recording them. A Distributed
+`Map` whose item fails reports the item's own error rather than AWS's
+`States.ExceedToleratedFailureThreshold`, and emits `MapRunFailed` with that error.
 
 ## Map concurrency
 
@@ -187,9 +214,8 @@ index: `Output`, `Output/a/b[0]`, `Assign/x`, `Arguments/MessageGroupId`, `Choic
 `Choices[1]/Output/v`, `Choices[0]/Assign/x`, `Catch[1]/Output/v`. A `Choice` stops at the first rule
 that matches, so an undefined condition in a later rule is never evaluated.
 
-One deviation. AWS prefixes the cause of a real execution with
-`An error occurred while executing the state '<name>' (entered at the event id #<n>).`; Floci
-returns the cause without it, which is the form AWS's own `TestState` returns.
+The cause of a real execution carries the state prefix described under
+[The cause of a failure](#the-cause-of-a-failure).
 
 ## JSONata functions
 

--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -88,6 +88,8 @@ The `cause` of a failure the interpreter raises starts with
 AWS. The prefix is added once, at the innermost state. A `Fail` state's `Cause` and a cause a
 task's resource answered with pass through unchanged. A `Choice` that matches no rule and has
 no `Default`, and a payload template path that matches nothing, fail with `States.Runtime`.
+A JSONata expression that fails also records an `EvaluationFailed` event with `error`, `cause`,
+`location` and `state`, once per attempt.
 
 `inputDetails` appears on `ExecutionStarted`, on `stateEnteredEventDetails`, and on
 `LambdaFunctionScheduled`/`ActivityScheduled`. `outputDetails` appears on
@@ -100,8 +102,7 @@ When the request sets `includeExecutionData` to false, the details objects stay 
 
 A few gaps remain. `TaskStarted`, `LambdaFunctionStarted`, and `ActivityStarted` fire at
 scheduling time, not when a worker actually picks up the task. `TaskSubmitted`, which real
-AWS emits for `.sync` and `.waitForTaskToken` integrations, is not emitted yet. A JSONata
-failure does not emit the `EvaluationFailed` event AWS records before `ExecutionFailed`. When a
+AWS emits for `.sync` and `.waitForTaskToken` integrations, is not emitted yet. When a
 branch fails, AWS records `*StateAborted` and `MapIterationAborted` events for the states its
 sibling branches were in; Floci cancels the siblings without recording them. A Distributed
 `Map` whose item fails reports the item's own error rather than AWS's

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -125,6 +125,10 @@ public class AslExecutor {
     private static final String HISTORY_EVENT_LIMIT_CAUSE =
             "The execution reached the maximum number of history events (" + MAX_HISTORY_EVENTS + ").";
 
+    /** AWS wording, verified against us-east-1. */
+    private static final String NO_NEXT_STATE_CAUSE =
+            "Failed to transition out of the state. The state does not point to a next state.";
+
     private static final int INLINE_MAP_MAX_CONCURRENCY = 40;
     private static final int DISTRIBUTED_MAP_MAX_CONCURRENCY = 10_000;
 
@@ -379,11 +383,7 @@ public class AslExecutor {
 
     private void doExecute(StateMachine sm, Execution exec, List<HistoryEvent> history,
                            BiConsumer<Execution, List<HistoryEvent>> onUpdate) {
-        // Shared with every Parallel branch and every inline Map iteration of this execution: the
-        // 25,000-event limit is the execution's, not the thread's. It starts where the history
-        // already is, because ExecutionStarted is an event of this execution too.
-        AtomicLong producedEventCount = new AtomicLong(history.size());
-        var firstState = true;
+        var chain = HistoryChain.of(history);
         try {
             JsonNode definition = objectMapper.readTree(sm.getDefinition());
             JsonNode states = definition.path("States");
@@ -411,73 +411,30 @@ public class AslExecutor {
                     throw new RuntimeException("State not found: " + currentStateName);
                 }
 
-                String type = stateDef.path("Type").asText();
-                publishStateEnteredEvent(history, producedEventCount, stateEnteredEventType(type),
-                        firstState ? 0L : history.size(),
-                        Map.of("name", currentStateName, "input", currentInput.toString(),
-                               "inputDetails", Map.of("truncated", false)));
-                firstState = false;
-
-                // Update per-state context fields
-                updateStateContext(execContext, currentStateName);
-
-                var jsonata = isJsonata(stateDef, topLevelQueryLanguage);
+                StateResult stateResult;
                 try {
-                    var stateResult = executeStateWithRetry(currentStateName, type, stateDef, currentInput,
-                            history, producedEventCount, sm, jsonata, topLevelQueryLanguage, execContext,
-                            variables, executionDeadlineNanos);
-                    publishEvent(history, producedEventCount, stateExitedEventType(type),
-                            Map.of("name", currentStateName, "output", stateResult.output().toString(),
-                                   "outputDetails", Map.of("truncated", false)));
-
-                    currentInput = stateResult.output();
-                    currentStateName = stateResult.nextState();
-
-                    if ("Succeed".equals(type) || stateDef.path("End").asBoolean(false)) {
-                        currentStateName = null;
-                    }
+                    stateResult = runState(chain, currentStateName, stateDef, currentInput, sm,
+                            topLevelQueryLanguage, execContext, variables, executionDeadlineNanos);
                 } catch (FailStateException e) {
-                    StateResult caught = null;
-                    FailStateException failure = e;
-                    try {
-                        caught = handleCatch(stateDef, currentInput, e, jsonata, execContext, variables);
-                    } catch (FailStateException catchClauseFailure) {
-                        // A matching Catch clause carries its own Assign and Output, and an
-                        // expression there can fail. AWS reports that failure, not the error the
-                        // clause was catching, and no later clause catches it.
-                        failure = catchClauseFailure;
-                    }
-                    if (caught != null) {
-                        publishEvent(history, producedEventCount, stateExitedEventType(type),
-                                Map.of("name", currentStateName, "output", caught.output().toString(),
-                                       "outputDetails", Map.of("truncated", false)));
-                        currentInput = caught.output();
-                        currentStateName = caught.nextState();
-                        continue;
-                    }
-                    failExecution(exec, history, failure);
+                    failExecution(exec, chain, e);
                     onUpdate.accept(exec, history);
                     return;
                 }
+                currentInput = stateResult.output();
+                currentStateName = stateResult.nextState();
             }
 
-            succeedExecution(exec, history, currentInput);
+            succeedExecution(exec, chain, currentInput);
             onUpdate.accept(exec, history);
 
         } catch (ExecutionTimedOutException e) {
-            timeOutExecution(exec, history);
-            onUpdate.accept(exec, history);
-        } catch (FailStateException e) {
-            // A state's own failure is handled inside the loop, where its Catch clauses apply. What
-            // reaches here is a failure raised while recording a state's entered event, outside the
-            // per-state try: the execution hit the history-event limit.
-            failExecution(exec, history, e);
+            timeOutExecution(exec, chain);
             onUpdate.accept(exec, history);
         } catch (Exception e) {
             LOG.warnv("ASL execution failed for {0}: {1}", exec.getExecutionArn(), e.getMessage());
             // This path previously set only the status, leaving error and cause null forever on an
             // execution DescribeExecution reports as FAILED.
-            failExecution(exec, history, "States.Runtime",
+            failExecution(exec, chain, "States.Runtime",
                     e.getMessage() != null ? e.getMessage() : "Unknown error");
             onUpdate.accept(exec, history);
         } catch (Error e) {
@@ -487,11 +444,56 @@ public class AslExecutor {
             // and the rethrow keeps the Error itself from being swallowed here. The cause carries
             // toString() rather than getMessage(), because an Error's message is often null and
             // the type name is the whole diagnostic.
-            failExecution(exec, history, "States.Runtime", e.toString());
+            failExecution(exec, chain, "States.Runtime", e.toString());
             onUpdate.accept(exec, history);
             throw e;
         } finally {
             activeMocks.remove(exec.getExecutionArn());
+        }
+    }
+
+    private StateResult runState(HistoryChain chain, String name, JsonNode stateDef, JsonNode input,
+                                 StateMachine sm, String topLevelQueryLanguage, JsonNode context,
+                                 ObjectNode variables, long executionDeadlineNanos) throws Exception {
+        var type = stateDef.path("Type").asText();
+        var enteredEventId = chain.publish(stateEnteredEventType(type),
+                Map.of("name", name, "input", input.toString(), "inputDetails", Map.of("truncated", false)));
+        updateStateContext(context, name);
+        var jsonata = isJsonata(stateDef, topLevelQueryLanguage);
+        StateResult result;
+        try {
+            result = executeStateWithRetry(name, type, stateDef, input, chain, sm, jsonata,
+                    topLevelQueryLanguage, context, variables, executionDeadlineNanos);
+            if ("Succeed".equals(type) || stateDef.path("End").asBoolean(false)) {
+                result = new StateResult(result.output(), null);
+            }
+        } catch (FailStateException e) {
+            var failure = e.attributedTo(name, enteredEventId);
+            publishStateFailedEvent(chain, type, failure);
+            try {
+                result = handleCatch(stateDef, input, failure, jsonata, context, variables);
+            } catch (FailStateException catchClauseFailure) {
+                // AWS reports a failure inside the Catch clause itself, and no later clause catches it.
+                throw catchClauseFailure.attributedTo(name, enteredEventId);
+            }
+            if (result == null) {
+                if (chain.isBranch() && "Task".equals(type) && !failure.isRuntimeError()) {
+                    // AWS records this after TaskFailed when the failure ends the branch.
+                    chain.publishAside("TaskStateAborted", null);
+                }
+                throw failure;
+            }
+        }
+        chain.publish(stateExitedEventType(type),
+                Map.of("name", name, "output", result.output().toString(),
+                       "outputDetails", Map.of("truncated", false)));
+        return result;
+    }
+
+    /** AWS records no *StateFailed event for States.Runtime. */
+    private void publishStateFailedEvent(HistoryChain chain, String type, FailStateException failure) {
+        if (("Parallel".equals(type) || "Map".equals(type)) && !failure.isRuntimeError()) {
+            chain.publish(type + "StateFailed", null);
         }
     }
 
@@ -508,16 +510,16 @@ public class AslExecutor {
      * caller's Catch handling, preserving Retry-before-Catch order.
      */
     private StateResult executeStateWithRetry(String name, String type, JsonNode stateDef, JsonNode input,
-                                              List<HistoryEvent> history, AtomicLong producedEventCount,
-                                              StateMachine sm, boolean jsonata, String topLevelQueryLanguage,
-                                              JsonNode context, ObjectNode variables,
-                                              long executionDeadlineNanos) throws Exception {
+                                              HistoryChain chain, StateMachine sm, boolean jsonata,
+                                              String topLevelQueryLanguage, JsonNode context,
+                                              ObjectNode variables, long executionDeadlineNanos)
+            throws Exception {
         var retriers = stateDef.path("Retry");
         var attemptsPerRetrier = new HashMap<Integer, Integer>();
         var attempt = 0;
         while (true) {
             try {
-                return executeState(name, type, stateDef, input, history, producedEventCount, sm, jsonata,
+                return executeState(name, type, stateDef, input, chain, sm, jsonata,
                         topLevelQueryLanguage, context, variables, attempt, executionDeadlineNanos);
             } catch (FailStateException e) {
                 var retrierIndex = findMatchingRetrier(retriers, e);
@@ -586,21 +588,20 @@ public class AslExecutor {
     }
 
     private StateResult executeState(String name, String type, JsonNode stateDef, JsonNode input,
-                                     List<HistoryEvent> history, AtomicLong producedEventCount,
-                                     StateMachine sm, boolean jsonata, String topLevelQueryLanguage,
-                                     JsonNode context, ObjectNode variables, int attempt,
-                                     long executionDeadlineNanos) throws Exception {
+                                     HistoryChain chain, StateMachine sm, boolean jsonata,
+                                     String topLevelQueryLanguage, JsonNode context, ObjectNode variables,
+                                     int attempt, long executionDeadlineNanos) throws Exception {
         return switch (type) {
             case "Pass" -> executePassState(stateDef, input, jsonata, context, variables);
-            case "Task" -> executeTaskState(name, stateDef, input, history, producedEventCount, sm,
+            case "Task" -> executeTaskState(name, stateDef, input, chain, sm,
                     jsonata, context, variables, attempt, executionDeadlineNanos);
             case "Choice" -> executeChoiceState(stateDef, input, jsonata, context, variables);
             case "Wait" -> executeWaitState(stateDef, input, jsonata, context, variables, executionDeadlineNanos);
             case "Succeed" -> executeSucceedState(stateDef, input, jsonata, context, variables);
             case "Fail" -> executeFail(stateDef, input, jsonata, context, variables);
-            case "Parallel" -> executeParallelState(name, stateDef, input, producedEventCount, sm, jsonata,
+            case "Parallel" -> executeParallelState(name, stateDef, input, chain, sm, jsonata,
                     topLevelQueryLanguage, context, variables, executionDeadlineNanos);
-            case "Map" -> executeMapState(name, stateDef, input, producedEventCount, sm, jsonata,
+            case "Map" -> executeMapState(name, stateDef, input, chain, sm, jsonata,
                     topLevelQueryLanguage, context, variables, executionDeadlineNanos);
             default -> new StateResult(input, stateDef.path("Next").asText(null));
         };
@@ -632,9 +633,8 @@ public class AslExecutor {
     }
 
     private StateResult executeTaskState(String stateName, JsonNode stateDef, JsonNode input,
-                                         List<HistoryEvent> history, AtomicLong producedEventCount,
-                                         StateMachine sm, boolean jsonata, JsonNode context,
-                                         ObjectNode variables, int attempt,
+                                         HistoryChain chain, StateMachine sm, boolean jsonata,
+                                         JsonNode context, ObjectNode variables, int attempt,
                                          long executionDeadlineNanos) throws Exception {
         var resource = stateDef.path("Resource").asText();
         var isWaitForToken = resource.endsWith(".waitForTaskToken");
@@ -648,11 +648,9 @@ public class AslExecutor {
         var needsToken = mockedSteps == null && (isWaitForToken || isActivity);
 
         String taskToken = null;
-        CompletableFuture<JsonNode> tokenFuture = null;
         if (needsToken) {
             taskToken = UUID.randomUUID().toString();
             ((ObjectNode) context.get("Task")).put("Token", taskToken);
-            tokenFuture = sfnService.get().registerPendingToken(taskToken);
         }
 
         JsonNode effectiveInput;
@@ -670,11 +668,13 @@ public class AslExecutor {
             }
         }
 
+        // Registered after the input template resolved, so a template failure leaves no token behind.
+        var tokenFuture = needsToken ? sfnService.get().registerPendingToken(taskToken) : null;
         var profile = taskEventProfile(resource, isActivity);
         JsonNode taskResult;
         try {
-            addTaskScheduledEvent(history, producedEventCount, profile, stateDef, effectiveInput, sm);
-            addTaskStartedEvent(history, producedEventCount, profile);
+            addTaskScheduledEvent(chain, profile, stateDef, effectiveInput, sm);
+            addTaskStartedEvent(chain, profile);
             try {
                 taskResult = mockedSteps != null
                         ? mockedTaskResult(mockedSteps, stateName, attempt)
@@ -690,14 +690,18 @@ public class AslExecutor {
                 // ActivityScheduled, ExecutionTimedOut, with no TaskFailed and no TaskTimedOut.
                 throw e;
             } catch (TaskTimedOutException e) {
-                addTaskTimedOutEvent(history, producedEventCount, profile);
+                addTaskTimedOutEvent(chain, profile);
+                throw e;
+            } catch (InterruptedException e) {
+                // The task of a branch that was cut. AWS records nothing for it.
                 throw e;
             } catch (Exception e) {
                 var failure = e instanceof FailStateException f ? f : null;
-                addTaskFailedEvent(history, producedEventCount, profile,
+                addTaskFailedEvent(chain, profile,
                         failure != null && failure.error != null ? failure.error : "States.Runtime",
                         failure != null ? failure.cause : e.getMessage());
-                throw e;
+                // AWS does not prefix a cause the resource answered with.
+                throw failure != null ? failure.withFinalCause() : e;
             }
         } catch (Exception e) {
             // A token registered above is normally discarded by awaitToken's own finally. Anything
@@ -709,7 +713,7 @@ public class AslExecutor {
             }
             throw e;
         }
-        addTaskSucceededEvent(history, producedEventCount, profile, taskResult);
+        addTaskSucceededEvent(chain, profile, taskResult);
 
         if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, taskResult, context, variables);
@@ -1897,7 +1901,7 @@ public class AslExecutor {
                 JsonNode output = applyJsonataAssignAndOutput(stateDef, "", statesVar, input, variables);
                 return new StateResult(output, defaultState);
             }
-            throw new FailStateException("States.NoChoiceMatched", "No choice rule matched and no default state");
+            throw new FailStateException("States.Runtime", NO_NEXT_STATE_CAUSE);
         }
 
         JsonNode choices = stateDef.path("Choices");
@@ -1911,7 +1915,7 @@ public class AslExecutor {
         if (defaultState != null) {
             return new StateResult(input, defaultState);
         }
-        throw new FailStateException("States.NoChoiceMatched", "No choice rule matched and no default state");
+        throw new FailStateException("States.Runtime", NO_NEXT_STATE_CAUSE);
     }
 
     private boolean evaluateCondition(JsonNode rule, JsonNode input) throws Exception {
@@ -2002,15 +2006,18 @@ public class AslExecutor {
                 cause = jsonataEvaluator.evaluateField(cause, "Cause", statesVar, variables).asText();
             }
         }
-        throw new FailStateException(error, cause);
+        // AWS does not prefix a Fail state's Cause.
+        throw new FailStateException(error, cause, true);
     }
 
     private StateResult executeParallelState(String name, JsonNode stateDef, JsonNode input,
-                                              AtomicLong producedEventCount, StateMachine sm, boolean jsonata,
+                                              HistoryChain chain, StateMachine sm, boolean jsonata,
                                               String topLevelQueryLanguage, JsonNode context,
                                               ObjectNode variables, long executionDeadlineNanos)
             throws Exception {
         JsonNode branches = stateDef.path("Branches");
+        chain.publish("ParallelStateStarted", null);
+        var branchChains = new ArrayList<HistoryChain>();
         List<Future<JsonNode>> futures = new ArrayList<>();
 
         for (JsonNode branch : branches) {
@@ -2023,6 +2030,8 @@ public class AslExecutor {
             // Each branch also gets its own copy of the context object so State.RetryCount and
             // Task.Token writes cannot race across concurrent branches.
             var branchContext = ((ObjectNode) context).deepCopy();
+            var branchChain = chain.fork();
+            branchChains.add(branchChain);
 
             // Run each branch on its own worker thread under the execution's account: the request
             // scope is thread-bound, so without this a branch's Task integrations would resolve to
@@ -2031,7 +2040,7 @@ public class AslExecutor {
             // this Parallel's: the ASL specification calls the two independent, so what travels
             // into the branch is topLevelQueryLanguage. https://states-language.net/spec.html
             futures.add(executor.submit(() -> callUnderExecutionAccount(sm,
-                    () -> executeBranch(startAt, branchStates, capturedInput, producedEventCount, sm,
+                    () -> executeBranch(startAt, branchStates, capturedInput, branchChain, sm,
                             topLevelQueryLanguage, branchContext, branchVariables))));
         }
 
@@ -2044,6 +2053,7 @@ public class AslExecutor {
         long joinDeadlineNanos = Math.min(stateDeadlineNanos, executionDeadlineNanos);
 
         ArrayNode results = objectMapper.createArrayNode();
+        var joined = 0;
         try {
             for (Future<JsonNode> future : futures) {
                 long remainingNanos = joinDeadlineNanos - System.nanoTime();
@@ -2055,13 +2065,15 @@ public class AslExecutor {
                 } catch (java.util.concurrent.TimeoutException e) {
                     throw parallelJoinExpired(stateDeadlineNanos, timeoutSeconds);
                 }
+                joined++;
             }
         } catch (InterruptedException e) {
-            futures.forEach(future -> future.cancel(true));
+            abandon(branchChains, futures);
             Thread.currentThread().interrupt();
             throw e;
         } catch (ExecutionException e) {
-            futures.forEach(future -> future.cancel(true));
+            abandon(branchChains, futures);
+            chain.continueFrom(branchChains.get(joined).lastEventId());
             // Unwrap so a branch's FailStateException reaches the Parallel state's own Retry and
             // Catch handling instead of surfacing as States.Runtime, and so an Error reaches the
             // execution-level handler as itself rather than as an ExecutionException wrapper. The
@@ -2076,9 +2088,12 @@ public class AslExecutor {
             }
             throw e;
         } catch (Exception | Error e) {
-            futures.forEach(future -> future.cancel(true));
+            abandon(branchChains, futures);
             throw e;
         }
+
+        chain.continueAfter(branchChains);
+        chain.publishAside("ParallelStateSucceeded", null);
 
         if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, results, context, variables);
@@ -2094,6 +2109,11 @@ public class AslExecutor {
         return new StateResult(output, stateDef.path("Next").asText(null));
     }
 
+    private static void abandon(List<HistoryChain> chains, List<? extends Future<?>> futures) {
+        chains.forEach(HistoryChain::abandon);
+        futures.forEach(future -> future.cancel(true));
+    }
+
     /**
      * Names the clock that ended a Parallel's join. The state's own {@code TimeoutSeconds} fails
      * the state, so its Retry and Catch still apply; the state machine's budget ends the whole
@@ -2104,11 +2124,11 @@ public class AslExecutor {
             return new ExecutionTimedOutException();
         }
         return new FailStateException("States.Timeout",
-                "Parallel state timed out after " + timeoutSeconds + " seconds");
+                "Parallel state timed out after " + timeoutSeconds + " seconds", true);
     }
 
     private StateResult executeMapState(String name, JsonNode stateDef, JsonNode input,
-                                         AtomicLong producedEventCount, StateMachine sm, boolean jsonata,
+                                         HistoryChain chain, StateMachine sm, boolean jsonata,
                                          String topLevelQueryLanguage, JsonNode context,
                                          ObjectNode variables, long executionDeadlineNanos)
             throws Exception {
@@ -2151,7 +2171,19 @@ public class AslExecutor {
         int effectiveConcurrency = effectiveMapConcurrency(
                 itemCount, requestedConcurrency, distributed);
 
+        chain.publish("MapStateStarted", Map.of("length", itemCount));
+        MapRunIdentity mapRun = null;
+        if (distributed) {
+            mapRun = newMapRunIdentity(stateDef, sm, context);
+            chain.publish("MapRunStarted", Map.of("mapRunArn", mapRun.arn()));
+        }
+        var iterationChains = new ArrayList<HistoryChain>(itemCount);
+        for (var i = 0; i < itemCount; i++) {
+            iterationChains.add(distributed ? HistoryChain.ofChildExecution() : chain.fork());
+        }
+
         java.util.function.IntFunction<Callable<JsonNode>> makeTask = (i) -> () -> {
+            var iterationChain = iterationChains.get(i);
             JsonNode item = items.get(i);
             ObjectNode iterContext = ((ObjectNode) context).deepCopy();
             ObjectNode mapCtx = objectMapper.createObjectNode();
@@ -2166,27 +2198,36 @@ public class AslExecutor {
             mapCtx.set("Item", mapItem);
             iterContext.set("Map", mapCtx);
 
-            JsonNode iterInput = item;
-            if (itemTransform != null) {
-                // $ in ItemSelector resolves against the Map state's effective input, not the item.
-                iterInput = resolveParameters(itemTransform, mapInput, iterContext);
-            }
-            // Each iteration gets an isolated copy of the current variables; assignments inside an
-            // iteration are scoped to that iteration and do not leak back to the parent scope. An
-            // isolated copy per worker also keeps concurrent iterations from racing on shared state.
             long startMs = hasResultWriter ? System.currentTimeMillis() : 0L;
-            if (hasResultWriter) {
-                childInputsByIndex[i] = iterInput;
+            JsonNode branchOutput;
+            try {
+                if (!distributed) {
+                    iterationChain.publish("MapIterationStarted", Map.of("name", name, "index", i));
+                }
+                JsonNode iterInput = item;
+                if (itemTransform != null) {
+                    // $ in ItemSelector resolves against the Map state's effective input, not the item.
+                    iterInput = resolveParameters(itemTransform, mapInput, iterContext);
+                }
+                if (hasResultWriter) {
+                    childInputsByIndex[i] = iterInput;
+                }
+                // Each iteration gets an isolated copy of the current variables; assignments inside an
+                // iteration are scoped to that iteration and do not leak back to the parent scope. An
+                // isolated copy per worker also keeps concurrent iterations from racing on shared state.
+                // Same rule as the Parallel branches above: an ItemProcessor state declaring no
+                // QueryLanguage runs as the state machine's, never as this Map's.
+                branchOutput = executeBranch(startAt, iteratorStates, iterInput, iterationChain, sm,
+                        topLevelQueryLanguage, iterContext, variables.deepCopy());
+            } catch (FailStateException e) {
+                if (!distributed && !e.isRuntimeError()) {
+                    iterationChain.publishAside("MapIterationFailed", Map.of("name", name, "index", i));
+                }
+                throw new IterationFailure(i, e);
             }
-            // A Distributed Map runs each item as a child execution, and a child execution has a
-            // history of its own: the item's events count against its own limit, not the parent's.
-            // An inline Map's iterations are part of this execution and count here.
-            AtomicLong childExecutionEventCount = distributed ? new AtomicLong() : producedEventCount;
-            // Same rule as the Parallel branches above: an ItemProcessor state declaring no
-            // QueryLanguage runs as the state machine's, never as this Map's.
-            JsonNode branchOutput = executeBranch(startAt, iteratorStates, iterInput,
-                    childExecutionEventCount, sm, topLevelQueryLanguage, iterContext,
-                    variables.deepCopy());
+            if (!distributed) {
+                iterationChain.publish("MapIterationSucceeded", Map.of("name", name, "index", i));
+            }
             if (hasResultWriter) {
                 childTimingsByIndex[i] = new long[]{startMs, System.currentTimeMillis()};
             }
@@ -2204,6 +2245,16 @@ public class AslExecutor {
                 // The only deadline the scheduler is given is the state machine's budget, so its
                 // expiry ends the execution rather than failing the Map state.
                 throw new ExecutionTimedOutException();
+            } catch (IterationFailure e) {
+                // A Distributed Map's chain stays at MapRunStarted, as on AWS.
+                if (!distributed) {
+                    chain.continueFrom(iterationChains.get(e.index).lastEventId());
+                } else {
+                    publishMapRunFailedEvent(chain, e.failure);
+                }
+                throw e.failure;
+            } finally {
+                iterationChains.forEach(HistoryChain::abandon);
             }
             results.addAll(itemOutputs);
         }
@@ -2216,10 +2267,23 @@ public class AslExecutor {
                 childInputs.add(childInputsByIndex[i]);
                 childTimings.add(childTimingsByIndex[i]);
             }
-            mapResult = applyResultWriter(name, stateDef, mapInput, results, childInputs, childTimings,
-                    sm, context, jsonata, variables);
+            try {
+                mapResult = applyResultWriter(name, stateDef, mapInput, results, childInputs, childTimings,
+                        sm, context, jsonata, variables, mapRun);
+            } catch (FailStateException e) {
+                // A ResultWriter failure fails the Map run on AWS.
+                publishMapRunFailedEvent(chain, e);
+                throw e;
+            }
             recordMapRun(mapResult, context, childTimings, requestedConcurrency);
         }
+
+        if (distributed) {
+            chain.publishAside("MapRunSucceeded", null);
+        } else {
+            chain.continueAfter(iterationChains);
+        }
+        chain.publishAside("MapStateSucceeded", null);
 
         if (jsonata) {
             JsonNode output = applyJsonataOutput(stateDef, input, mapResult, context, variables);
@@ -2331,13 +2395,29 @@ public class AslExecutor {
                                ArrayNode results, ArrayNode childInputs, List<long[]> childTimings,
                                StateMachine sm, JsonNode context, boolean jsonata) throws Exception {
         return applyResultWriter(mapStateName, stateDef, input, results, childInputs, childTimings,
-                sm, context, jsonata, objectMapper.createObjectNode());
+                sm, context, jsonata, objectMapper.createObjectNode(), newMapRunIdentity(stateDef, sm, context));
+    }
+
+    private record MapRunIdentity(String label, String id, String arn) {
+    }
+
+    private MapRunIdentity newMapRunIdentity(JsonNode stateDef, StateMachine sm, JsonNode context) {
+        var region = extractRegionFromArn(sm.getStateMachineArn());
+        var account = AwsArnUtils.accountOrDefault(sm.getStateMachineArn(), null);
+        var smName = context.path("StateMachine").path("Name").asText(sm.getName());
+        var label = stateDef.path("Label").asText(null);
+        if (label == null || label.isBlank()) {
+            label = UUID.randomUUID().toString();
+        }
+        var id = UUID.randomUUID().toString();
+        return new MapRunIdentity(label, id, "arn:aws:states:" + region + ":" + account + ":mapRun:"
+                + smName + "/" + label + ":" + id);
     }
 
     private JsonNode applyResultWriter(String mapStateName, JsonNode stateDef, JsonNode input,
                                        ArrayNode results, ArrayNode childInputs, List<long[]> childTimings,
                                        StateMachine sm, JsonNode context, boolean jsonata,
-                                       ObjectNode variables) throws Exception {
+                                       ObjectNode variables, MapRunIdentity mapRun) throws Exception {
         JsonNode writer = stateDef.get("ResultWriter");
         JsonNode writerConfig = writer.path("WriterConfig");
         boolean export = writer.hasNonNull("Resource");
@@ -2350,13 +2430,9 @@ public class AslExecutor {
         String region = extractRegionFromArn(sm.getStateMachineArn());
         String account = AwsArnUtils.accountOrDefault(sm.getStateMachineArn(), null);
         String smName = context.path("StateMachine").path("Name").asText(sm.getName());
-        String mapRunLabel = stateDef.path("Label").asText(null);
-        if (mapRunLabel == null || mapRunLabel.isBlank()) {
-            mapRunLabel = UUID.randomUUID().toString();
-        }
 
         JsonNode formatted = formatMapResults(transformation, results, childInputs, childTimings,
-                region, account, smName, mapRunLabel);
+                region, account, smName, mapRun.label());
 
         if (!export) {
             // WriterConfig only: return the formatted results to the next state (no S3 write).
@@ -2414,11 +2490,9 @@ public class AslExecutor {
                                 + "as the state machine");
             }
 
-            // AWS includes the Map label (or an automatically generated label) before the run id.
             // The run id alone keys the exported result set under the user-supplied S3 prefix.
-            String mapRunId = UUID.randomUUID().toString();
-            String mapRunArn = "arn:aws:states:" + region + ":" + account + ":mapRun:"
-                    + smName + "/" + mapRunLabel + ":" + mapRunId;
+            var mapRunId = mapRun.id();
+            var mapRunArn = mapRun.arn();
             String base = prefix.isEmpty()
                     ? mapRunId + "/"
                     : prefix + (prefix.endsWith("/") ? "" : "/") + mapRunId + "/";
@@ -2638,16 +2712,12 @@ public class AslExecutor {
     }
 
     /**
-     * Runs the states of one Parallel branch or one Map iteration. floci does not publish their
-     * events, but they are events of the execution all the same, so each one is counted against its
-     * history-event limit: a branch that never reaches a terminal state ends the whole execution at
-     * event 25,000, exactly as one in the top-level flow does. A null history is what tells the
-     * states below they are running inside a branch.
+     * Runs the states of one Parallel branch or one Map iteration. Their events count against the
+     * execution's history-event limit, as on AWS.
      */
-    private JsonNode executeBranch(String startAt, JsonNode states, JsonNode input,
-                                    AtomicLong producedEventCount, StateMachine sm,
-                                    String topLevelQueryLanguage, JsonNode context,
-                                    ObjectNode variables) throws Exception {
+    private JsonNode executeBranch(String startAt, JsonNode states, JsonNode input, HistoryChain chain,
+                                   StateMachine sm, String topLevelQueryLanguage, JsonNode context,
+                                   ObjectNode variables) throws Exception {
         JsonNode currentInput = input;
         String currentState = startAt;
 
@@ -2659,31 +2729,13 @@ public class AslExecutor {
             if (stateDef.isMissingNode()) {
                 throw new RuntimeException("State not found: " + currentState);
             }
-            String type = stateDef.path("Type").asText();
-            boolean stateJsonata = isJsonata(stateDef, topLevelQueryLanguage);
-            updateStateContext(context, currentState);
-            countTowardsHistoryEventLimit(producedEventCount);
-            StateResult result;
-            try {
-                // A Parallel or Map branch runs on its own thread and is not cut mid-state by the
-                // execution's TimeoutSeconds: the state loop that resumes once the branch returns
-                // is where the budget is enforced.
-                result = executeStateWithRetry(currentState, type, stateDef, currentInput,
-                        null, producedEventCount, sm, stateJsonata, topLevelQueryLanguage, context,
-                        variables, Long.MAX_VALUE);
-            } catch (FailStateException e) {
-                StateResult caught = handleCatch(stateDef, currentInput, e, stateJsonata, context, variables);
-                if (caught == null) {
-                    throw e;
-                }
-                result = caught;
-            }
-            countTowardsHistoryEventLimit(producedEventCount);
+            // A Parallel or Map branch runs on its own thread and is not cut mid-state by the
+            // execution's TimeoutSeconds: the state loop that resumes once the branch returns
+            // is where the budget is enforced.
+            var result = runState(chain, currentState, stateDef, currentInput, sm, topLevelQueryLanguage,
+                    context, variables, Long.MAX_VALUE);
             currentInput = result.output();
             currentState = result.nextState();
-            if ("Succeed".equals(type) || stateDef.path("End").asBoolean(false)) {
-                currentState = null;
-            }
         }
         return currentInput;
     }
@@ -3913,63 +3965,7 @@ public class AslExecutor {
      */
     static void countTowardsHistoryEventLimit(AtomicLong producedEventCount) {
         if (producedEventCount.incrementAndGet() >= MAX_HISTORY_EVENTS) {
-            throw new FailStateException("States.Runtime", HISTORY_EVENT_LIMIT_CAUSE);
-        }
-    }
-
-    /**
-     * Records an event the state machine produced: counted against the history-event limit, then
-     * published.
-     *
-     * <p>{@code history} is null inside a Parallel branch or a Map iteration. Their states are
-     * states of this execution and their events count against its limit, but floci does not publish
-     * them, so there is nothing to build for them beyond the count.
-     */
-    private void publishEvent(List<HistoryEvent> history, AtomicLong producedEventCount, String type,
-                              Map<String, Object> details) {
-        countTowardsHistoryEventLimit(producedEventCount);
-        if (history == null) {
-            return;
-        }
-        appendEvent(history, type, history.size(), details);
-    }
-
-    /**
-     * Records a state's Entered event with the previousEventId the top-level flow works out: AWS
-     * leaves the Entered event of the state an execution starts in unchained, at previousEventId 0,
-     * rather than pointing it at the ExecutionStarted event before it. Only the top-level flow
-     * publishes these, so its history is never null.
-     */
-    private void publishStateEnteredEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
-                                          String type, long previousEventId,
-                                          Map<String, Object> details) {
-        countTowardsHistoryEventLimit(producedEventCount);
-        appendEvent(history, type, previousEventId, details);
-    }
-
-    /**
-     * Records the event that ends the execution. It does not count towards the history-event limit:
-     * an execution always gets to say how it ended, in the slot {@link #publishEvent} leaves free.
-     */
-    private void publishTerminalEvent(List<HistoryEvent> history, String type, Map<String, Object> details) {
-        appendEvent(history, type, history.size(), details);
-    }
-
-    /**
-     * Appends an event and numbers it from the end of the history: the published history is the one
-     * authority for an event's id, so an event's id is its position in the list. Held under the
-     * history's own monitor, because StopExecution appends the terminal event of an aborted
-     * execution from another thread and seals the history against anything after it.
-     */
-    private void appendEvent(List<HistoryEvent> history, String type, long previousEventId,
-                             Map<String, Object> details) {
-        synchronized (history) {
-            var event = new HistoryEvent();
-            event.setId(history.size() + 1L);
-            event.setPreviousEventId(previousEventId);
-            event.setType(type);
-            event.setDetails(details);
-            history.add(event);
+            throw new FailStateException("States.Runtime", HISTORY_EVENT_LIMIT_CAUSE, true);
         }
     }
 
@@ -3993,9 +3989,8 @@ public class AslExecutor {
         return new TaskEventProfile("Task", resource, resource);
     }
 
-    private void addTaskScheduledEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
-                                       TaskEventProfile profile, JsonNode stateDef, JsonNode effectiveInput,
-                                       StateMachine sm) {
+    private void addTaskScheduledEvent(HistoryChain chain, TaskEventProfile profile, JsonNode stateDef,
+                                       JsonNode effectiveInput, StateMachine sm) {
         var details = new LinkedHashMap<String, Object>();
         if (profile.resourceType() != null) {
             details.put("resourceType", profile.resourceType());
@@ -4014,34 +4009,31 @@ public class AslExecutor {
         if (stateDef.path("HeartbeatSeconds").isNumber()) {
             details.put("heartbeatInSeconds", stateDef.path("HeartbeatSeconds").asLong());
         }
-        publishEvent(history, producedEventCount, profile.prefix() + "Scheduled", details);
+        chain.publish(profile.prefix() + "Scheduled", details);
     }
 
-    private void addTaskStartedEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
-                                     TaskEventProfile profile) {
+    private void addTaskStartedEvent(HistoryChain chain, TaskEventProfile profile) {
         if ("Task".equals(profile.prefix())) {
-            publishEvent(history, producedEventCount, profile.prefix() + "Started",
+            chain.publish(profile.prefix() + "Started",
                     Map.of("resourceType", profile.resourceType(), "resource", profile.resource()));
         } else {
-            publishEvent(history, producedEventCount, profile.prefix() + "Started", null);
+            chain.publish(profile.prefix() + "Started", null);
         }
     }
 
-    private void addTaskSucceededEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
-                                       TaskEventProfile profile, JsonNode taskResult) {
+    private void addTaskSucceededEvent(HistoryChain chain, TaskEventProfile profile, JsonNode taskResult) {
         var output = taskResult.toString();
         if ("Task".equals(profile.prefix())) {
-            publishEvent(history, producedEventCount, profile.prefix() + "Succeeded",
+            chain.publish(profile.prefix() + "Succeeded",
                     Map.of("resourceType", profile.resourceType(), "resource", profile.resource(),
                            "output", output, "outputDetails", Map.of("truncated", false)));
         } else {
-            publishEvent(history, producedEventCount, profile.prefix() + "Succeeded",
+            chain.publish(profile.prefix() + "Succeeded",
                     Map.of("output", output, "outputDetails", Map.of("truncated", false)));
         }
     }
 
-    private void addTaskFailedEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
-                                    TaskEventProfile profile, String error, String cause) {
+    private void addTaskFailedEvent(HistoryChain chain, TaskEventProfile profile, String error, String cause) {
         var details = new LinkedHashMap<String, Object>();
         if ("Task".equals(profile.prefix())) {
             details.put("resourceType", profile.resourceType());
@@ -4053,26 +4045,25 @@ public class AslExecutor {
         if (cause != null) {
             details.put("cause", cause);
         }
-        publishEvent(history, producedEventCount, profile.prefix() + "Failed", details);
+        chain.publish(profile.prefix() + "Failed", details);
     }
 
     /**
      * The event a Task leaves when one of its clocks runs out. It names {@code States.Timeout} for
      * both {@code TimeoutSeconds} and {@code HeartbeatSeconds}, and carries no cause.
      */
-    private void addTaskTimedOutEvent(List<HistoryEvent> history, AtomicLong producedEventCount,
-                                      TaskEventProfile profile) {
+    private void addTaskTimedOutEvent(HistoryChain chain, TaskEventProfile profile) {
         var details = new LinkedHashMap<String, Object>();
         if ("Task".equals(profile.prefix())) {
             details.put("resourceType", profile.resourceType());
             details.put("resource", profile.resource());
         }
         details.put("error", "States.Timeout");
-        publishEvent(history, producedEventCount, profile.prefix() + "TimedOut", details);
+        chain.publish(profile.prefix() + "TimedOut", details);
     }
 
-    private void failExecution(Execution exec, List<HistoryEvent> history, FailStateException e) {
-        failExecution(exec, history, e.error != null ? e.error : "States.Runtime", e.cause);
+    private void failExecution(Execution exec, HistoryChain chain, FailStateException e) {
+        failExecution(exec, chain, e.error != null ? e.error : "States.Runtime", e.cause);
     }
 
     /**
@@ -4084,7 +4075,7 @@ public class AslExecutor {
      * ExecutionFailed event leave the key out rather than reporting it empty. Only a task that ran
      * out of its TimeoutSeconds or HeartbeatSeconds budget arrives here without one.
      */
-    private void failExecution(Execution exec, List<HistoryEvent> history, String error, String cause) {
+    private void failExecution(Execution exec, HistoryChain chain, String error, String cause) {
         synchronized (exec) {
             if (abortedByCaller(exec)) {
                 return;
@@ -4094,12 +4085,26 @@ public class AslExecutor {
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
             exec.setStatus("FAILED");
         }
+        chain.end("ExecutionFailed", failureDetails(error, cause));
+    }
+
+    private static void publishMapRunFailedEvent(HistoryChain chain, FailStateException failure) {
+        if (!failure.isRuntimeError()) {
+            chain.publish("MapRunFailed", failureDetails(failure));
+        }
+    }
+
+    private static Map<String, Object> failureDetails(FailStateException failure) {
+        return failureDetails(failure.error, failure.cause);
+    }
+
+    private static Map<String, Object> failureDetails(String error, String cause) {
         var details = new LinkedHashMap<String, Object>();
         details.put("error", error);
         if (cause != null) {
             details.put("cause", cause);
         }
-        publishTerminalEvent(history, "ExecutionFailed", details);
+        return details;
     }
 
     /**
@@ -4109,7 +4114,7 @@ public class AslExecutor {
      * it cut. The event is appended rather than published, because it is what ends the execution
      * and the history-event limit leaves the last slot free for exactly that.
      */
-    private void timeOutExecution(Execution exec, List<HistoryEvent> history) {
+    private void timeOutExecution(Execution exec, HistoryChain chain) {
         synchronized (exec) {
             if (abortedByCaller(exec)) {
                 return;
@@ -4117,7 +4122,7 @@ public class AslExecutor {
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
             exec.setStatus("TIMED_OUT");
         }
-        appendEvent(history, "ExecutionTimedOut", 0L, Map.of("error", "States.Timeout"));
+        chain.end("ExecutionTimedOut", 0L, Map.of("error", "States.Timeout"));
     }
 
     /**
@@ -4127,7 +4132,7 @@ public class AslExecutor {
      * live Execution, so a client polling for SUCCEEDED between setStatus and setOutput would read
      * a terminal execution with a null output, which real Step Functions never returns.
      */
-    private void succeedExecution(Execution exec, List<HistoryEvent> history, JsonNode output) {
+    private void succeedExecution(Execution exec, HistoryChain chain, JsonNode output) {
         synchronized (exec) {
             if (abortedByCaller(exec)) {
                 return;
@@ -4136,7 +4141,7 @@ public class AslExecutor {
             exec.setStopDate(System.currentTimeMillis() / 1000.0);
             exec.setStatus("SUCCEEDED");
         }
-        publishTerminalEvent(history, "ExecutionSucceeded",
+        chain.end("ExecutionSucceeded",
                 Map.of("output", output.toString(), "outputDetails", Map.of("truncated", false)));
     }
 
@@ -4255,13 +4260,45 @@ public class AslExecutor {
     }
 
     static class FailStateException extends RuntimeException {
+        static final String ATTRIBUTION_PREFIX = "An error occurred while executing the state '%s' (entered at the event id #%d). ";
+
         final String error;
         final String cause;
+        private final boolean causeFinal;
 
         FailStateException(String error, String cause) {
+            this(error, cause, false);
+        }
+
+        /**
+         * A Fail state's Cause and a cause a resource answered with are final. AWS prefixes every
+         * other cause with the state name, once, at the innermost state.
+         */
+        FailStateException(String error, String cause, boolean causeFinal) {
             super(error + ": " + cause);
             this.error = error;
             this.cause = cause;
+            this.causeFinal = causeFinal;
+        }
+
+        /** States.Runtime skips Retry, Catch and the *StateFailed event on AWS. */
+        boolean isRuntimeError() {
+            return error == null || "States.Runtime".equals(error);
+        }
+
+        FailStateException attributedTo(String stateName, long enteredEventId) {
+            if (causeFinal || cause == null) {
+                return this;
+            }
+            return new FailStateException(error,
+                    ATTRIBUTION_PREFIX.formatted(stateName, enteredEventId) + cause, true);
+        }
+
+        FailStateException withFinalCause() {
+            if (causeFinal || cause == null) {
+                return this;
+            }
+            return new FailStateException(error, cause, true);
         }
 
         /**
@@ -4271,6 +4308,17 @@ public class AslExecutor {
          */
         boolean isNamedBy(String errorName) {
             return errorName.equals(error);
+        }
+    }
+
+    private static final class IterationFailure extends RuntimeException {
+        final int index;
+        final FailStateException failure;
+
+        IterationFailure(int index, FailStateException failure) {
+            super(failure.getMessage(), failure, false, false);
+            this.index = index;
+            this.failure = failure;
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -462,19 +462,24 @@ public class AslExecutor {
         var jsonata = isJsonata(stateDef, topLevelQueryLanguage);
         StateResult result;
         try {
-            result = executeStateWithRetry(name, type, stateDef, input, chain, sm, jsonata,
+            result = executeStateWithRetry(name, enteredEventId, type, stateDef, input, chain, sm, jsonata,
                     topLevelQueryLanguage, context, variables, executionDeadlineNanos);
             if ("Succeed".equals(type) || stateDef.path("End").asBoolean(false)) {
                 result = new StateResult(result.output(), null);
             }
-        } catch (FailStateException e) {
-            var failure = e.attributedTo(name, enteredEventId);
+        } catch (FailStateException failure) {
+            var beforeFailed = chain.lastEventId();
             publishStateFailedEvent(chain, type, failure);
             try {
                 result = handleCatch(stateDef, input, failure, jsonata, context, variables);
             } catch (FailStateException catchClauseFailure) {
-                // AWS reports a failure inside the Catch clause itself, and no later clause catches it.
-                throw catchClauseFailure.attributedTo(name, enteredEventId);
+                // AWS reports a failure inside the Catch clause itself, and no later clause catches
+                // it. The clause's EvaluationFailed is recorded from before the state's Failed event.
+                var clauseFailure = catchClauseFailure.attributedTo(name, enteredEventId);
+                chain.continueFrom(beforeFailed);
+                publishEvaluationFailedEvent(chain, name, clauseFailure);
+                publishStateFailedEvent(chain, type, clauseFailure);
+                throw clauseFailure;
             }
             if (result == null) {
                 if (chain.isBranch() && "Task".equals(type) && !failure.isRuntimeError()) {
@@ -497,6 +502,19 @@ public class AslExecutor {
         }
     }
 
+    /** Recorded once per attempt, before Retry and Catch, as on AWS. */
+    private void publishEvaluationFailedEvent(HistoryChain chain, String stateName, FailStateException failure) {
+        if (!"States.QueryEvaluationError".equals(failure.error)) {
+            return;
+        }
+        var details = failureDetails(failure);
+        if (failure.location != null) {
+            details.put("location", failure.location);
+        }
+        details.put("state", stateName);
+        chain.publish("EvaluationFailed", details);
+    }
+
     private void registerMocks(Execution exec, MockedTestCase mockedTestCase) {
         if (mockedTestCase != null) {
             activeMocks.put(exec.getExecutionArn(), mockedTestCase);
@@ -509,8 +527,8 @@ public class AslExecutor {
      * used up. Errors that no retrier matches (or that exhaust their retrier) propagate to the
      * caller's Catch handling, preserving Retry-before-Catch order.
      */
-    private StateResult executeStateWithRetry(String name, String type, JsonNode stateDef, JsonNode input,
-                                              HistoryChain chain, StateMachine sm, boolean jsonata,
+    private StateResult executeStateWithRetry(String name, long enteredEventId, String type, JsonNode stateDef,
+                                              JsonNode input, HistoryChain chain, StateMachine sm, boolean jsonata,
                                               String topLevelQueryLanguage, JsonNode context,
                                               ObjectNode variables, long executionDeadlineNanos)
             throws Exception {
@@ -521,7 +539,11 @@ public class AslExecutor {
             try {
                 return executeState(name, type, stateDef, input, chain, sm, jsonata,
                         topLevelQueryLanguage, context, variables, attempt, executionDeadlineNanos);
-            } catch (FailStateException e) {
+            } catch (FailStateException raised) {
+                var e = raised.attributedTo(name, enteredEventId);
+                if (!raised.hasFinalCause()) {
+                    publishEvaluationFailedEvent(chain, name, e);
+                }
                 var retrierIndex = findMatchingRetrier(retriers, e);
                 if (retrierIndex < 0) {
                     throw e;
@@ -2319,7 +2341,7 @@ public class AslExecutor {
         if (!value.isIntegralNumber() || value.bigIntegerValue().signum() < 0) {
             throw new FailStateException(
                     jsonataExpression ? "States.QueryEvaluationError" : "States.Runtime",
-                    "MaxConcurrency must resolve to a non-negative integer");
+                    "MaxConcurrency must resolve to a non-negative integer", "MaxConcurrency");
         }
         return value.bigIntegerValue().compareTo(java.math.BigInteger.valueOf(Integer.MAX_VALUE)) > 0
                 ? Integer.MAX_VALUE
@@ -2456,7 +2478,7 @@ public class AslExecutor {
                 throw new FailStateException(
                         jsonata ? "States.QueryEvaluationError" : "States.ResultWriterFailed",
                         "ResultWriter " + (jsonata ? "Arguments" : "Parameters")
-                                + " must resolve to an object");
+                                + " must resolve to an object", "ResultWriter/Arguments");
             }
             JsonNode bucketNode = loc.get("Bucket");
             if (bucketNode == null) {
@@ -2466,7 +2488,7 @@ public class AslExecutor {
             if (!bucketNode.isTextual()) {
                 throw new FailStateException(
                         jsonata ? "States.QueryEvaluationError" : "States.ResultWriterFailed",
-                        "ResultWriter Bucket must resolve to a string");
+                        "ResultWriter Bucket must resolve to a string", "ResultWriter/Arguments/Bucket");
             }
             String bucket = bucketNode.asText();
             if (bucket.isBlank()) {
@@ -2477,7 +2499,7 @@ public class AslExecutor {
             if (prefixNode != null && !prefixNode.isTextual()) {
                 throw new FailStateException(
                         jsonata ? "States.QueryEvaluationError" : "States.ResultWriterFailed",
-                        "ResultWriter Prefix must resolve to a string");
+                        "ResultWriter Prefix must resolve to a string", "ResultWriter/Arguments/Prefix");
             }
             String prefix = prefixNode == null ? "" : prefixNode.asText();
 
@@ -4264,21 +4286,36 @@ public class AslExecutor {
 
         final String error;
         final String cause;
+        /** The field of the failed JSONata expression, as the cause names it. */
+        final String location;
         private final boolean causeFinal;
 
         FailStateException(String error, String cause) {
             this(error, cause, false);
         }
 
+        FailStateException(String error, String cause, boolean causeFinal) {
+            this(error, cause, causeFinal, null);
+        }
+
+        FailStateException(String error, String cause, String location) {
+            this(error, cause, false, location);
+        }
+
         /**
          * A Fail state's Cause and a cause a resource answered with are final. AWS prefixes every
          * other cause with the state name, once, at the innermost state.
          */
-        FailStateException(String error, String cause, boolean causeFinal) {
+        private FailStateException(String error, String cause, boolean causeFinal, String location) {
             super(error + ": " + cause);
             this.error = error;
             this.cause = cause;
             this.causeFinal = causeFinal;
+            this.location = location;
+        }
+
+        boolean hasFinalCause() {
+            return causeFinal || cause == null;
         }
 
         /** States.Runtime skips Retry, Catch and the *StateFailed event on AWS. */
@@ -4287,18 +4324,18 @@ public class AslExecutor {
         }
 
         FailStateException attributedTo(String stateName, long enteredEventId) {
-            if (causeFinal || cause == null) {
+            if (hasFinalCause()) {
                 return this;
             }
             return new FailStateException(error,
-                    ATTRIBUTION_PREFIX.formatted(stateName, enteredEventId) + cause, true);
+                    ATTRIBUTION_PREFIX.formatted(stateName, enteredEventId) + cause, true, location);
         }
 
         FailStateException withFinalCause() {
-            if (causeFinal || cause == null) {
+            if (hasFinalCause()) {
                 return this;
             }
-            return new FailStateException(error, cause, true);
+            return new FailStateException(error, cause, true, location);
         }
 
         /**

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -94,6 +94,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -2195,10 +2196,14 @@ public class AslExecutor {
 
         chain.publish("MapStateStarted", Map.of("length", itemCount));
         MapRunIdentity mapRun = null;
+        MapRun mapRunRecord = null;
         if (distributed) {
             mapRun = newMapRunIdentity(stateDef, sm, context);
+            mapRunRecord = newMapRun(mapRun, context, itemCount, requestedConcurrency);
             chain.publish("MapRunStarted", Map.of("mapRunArn", mapRun.arn()));
         }
+        var succeededItems = new AtomicInteger();
+        var failedItems = new AtomicInteger();
         var iterationChains = new ArrayList<HistoryChain>(itemCount);
         for (var i = 0; i < itemCount; i++) {
             iterationChains.add(distributed ? HistoryChain.ofChildExecution() : chain.fork());
@@ -2242,11 +2247,13 @@ public class AslExecutor {
                 branchOutput = executeBranch(startAt, iteratorStates, iterInput, iterationChain, sm,
                         topLevelQueryLanguage, iterContext, variables.deepCopy());
             } catch (FailStateException e) {
+                failedItems.incrementAndGet();
                 if (!distributed && !e.isRuntimeError()) {
                     iterationChain.publishAside("MapIterationFailed", Map.of("name", name, "index", i));
                 }
                 throw new IterationFailure(i, e);
             }
+            succeededItems.incrementAndGet();
             if (!distributed) {
                 iterationChain.publish("MapIterationSucceeded", Map.of("name", name, "index", i));
             }
@@ -2273,6 +2280,7 @@ public class AslExecutor {
                     chain.continueFrom(iterationChains.get(e.index).lastEventId());
                 } else {
                     publishMapRunFailedEvent(chain, e.failure);
+                    recordMapRun(mapRunRecord, "FAILED", succeededItems.get(), failedItems.get());
                 }
                 throw e.failure;
             } finally {
@@ -2295,12 +2303,13 @@ public class AslExecutor {
             } catch (FailStateException e) {
                 // A ResultWriter failure fails the Map run on AWS.
                 publishMapRunFailedEvent(chain, e);
+                recordMapRun(mapRunRecord, "FAILED", succeededItems.get(), failedItems.get());
                 throw e;
             }
-            recordMapRun(mapResult, context, childTimings, requestedConcurrency);
         }
 
         if (distributed) {
+            recordMapRun(mapRunRecord, "SUCCEEDED", succeededItems.get(), failedItems.get());
             chain.publishAside("MapRunSucceeded", null);
         } else {
             chain.continueAfter(iterationChains);
@@ -2368,28 +2377,26 @@ public class AslExecutor {
      * a Map run's window on the export rather than on the last item. A run over no items starts and
      * stops at that same instant.
      */
-    private void recordMapRun(JsonNode mapResult, JsonNode context, List<long[]> childTimings,
-                              int requestedConcurrency) {
-        String mapRunArn = mapResult.path("MapRunArn").asText(null);
-        if (mapRunArn == null) {
-            return;
-        }
-        long stop = System.currentTimeMillis();
-        long start = stop;
-        for (long[] timing : childTimings) {
-            start = Math.min(start, timing[0]);
-        }
-
-        MapRun mapRun = new MapRun();
-        mapRun.setMapRunArn(mapRunArn);
+    private static MapRun newMapRun(MapRunIdentity identity, JsonNode context, int itemCount,
+                                    int requestedConcurrency) {
+        var mapRun = new MapRun();
+        mapRun.setMapRunArn(identity.arn());
         mapRun.setExecutionArn(context.path("Execution").path("Id").asText(null));
-        mapRun.setStartDate(start / 1000.0);
-        mapRun.setStopDate(stop / 1000.0);
-        mapRun.setItemCount(childTimings.size());
+        mapRun.setStartDate(System.currentTimeMillis() / 1000.0);
+        mapRun.setItemCount(itemCount);
         // ASL spells an unbounded Map as MaxConcurrency 0, or by omitting it; DescribeMapRun
         // reports that same run as Integer.MAX_VALUE.
         mapRun.setMaxConcurrency(
                 requestedConcurrency == 0 ? Integer.MAX_VALUE : requestedConcurrency);
+        return mapRun;
+    }
+
+    /** Kept for every Distributed Map, so the mapRunArn in the history resolves through DescribeMapRun. */
+    private void recordMapRun(MapRun mapRun, String status, int succeededItems, int failedItems) {
+        mapRun.setStopDate(System.currentTimeMillis() / 1000.0);
+        mapRun.setStatus(status);
+        mapRun.setSucceededCount(succeededItems);
+        mapRun.setFailedCount(failedItems);
         sfnService.get().recordMapRun(mapRun);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/HistoryChain.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/HistoryChain.java
@@ -87,8 +87,7 @@ final class HistoryChain {
         if (isAbandoned()) {
             return 0L;
         }
-        AslExecutor.countTowardsHistoryEventLimit(producedEventCount);
-        long id = append(type, lastEventId, details);
+        long id = append(type, lastEventId, details, true);
         if (id > 0) {
             lastEventId = id;
             tailEventId = id;
@@ -104,8 +103,7 @@ final class HistoryChain {
         if (isAbandoned()) {
             return;
         }
-        AslExecutor.countTowardsHistoryEventLimit(producedEventCount);
-        long id = append(type, tailEventId, details);
+        long id = append(type, tailEventId, details, true);
         if (id > 0) {
             tailEventId = id;
         }
@@ -119,23 +117,33 @@ final class HistoryChain {
     /** ExecutionTimedOut points at 0. */
     void end(String type, long previousEventId, Map<String, Object> details) {
         synchronized (history) {
-            append(type, previousEventId, details);
+            append(type, previousEventId, details, false);
             ended.set(true);
         }
     }
 
-    /** Synchronized on the history because StopExecution appends the terminal event from another thread. */
-    private long append(String type, long previousEventId, Map<String, Object> details) {
+    /**
+     * Synchronized on the history because StopExecution appends the terminal event from another
+     * thread. An event counts towards the limit only once the history is known to take it.
+     */
+    private long append(String type, long previousEventId, Map<String, Object> details, boolean counted) {
         synchronized (history) {
             if (ended.get()) {
                 return 0L;
+            }
+            if (counted) {
+                AslExecutor.countTowardsHistoryEventLimit(producedEventCount);
             }
             var event = new HistoryEvent();
             event.setId(history.size() + 1L);
             event.setPreviousEventId(previousEventId);
             event.setType(type);
             event.setDetails(details);
-            return history.add(event) ? event.getId() : 0L;
+            if (!history.add(event)) {
+                ended.set(true);
+                return 0L;
+            }
+            return event.getId();
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/HistoryChain.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/HistoryChain.java
@@ -1,0 +1,161 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+
+import java.util.AbstractList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * One {@code previousEventId} chain of an execution's history: the top-level state loop, a Parallel
+ * branch, or a Map iteration. All chains share the execution's history and event limit.
+ */
+final class HistoryChain {
+
+    private final List<HistoryEvent> history;
+    private final AtomicLong producedEventCount;
+    private final AtomicBoolean ended;
+    private final HistoryChain parent;
+    private volatile boolean abandoned;
+    private long lastEventId;
+    private long tailEventId;
+
+    private HistoryChain(List<HistoryEvent> history, AtomicLong producedEventCount, AtomicBoolean ended,
+                         HistoryChain parent, long lastEventId) {
+        this.history = history;
+        this.producedEventCount = producedEventCount;
+        this.ended = ended;
+        this.parent = parent;
+        this.lastEventId = lastEventId;
+        this.tailEventId = lastEventId;
+    }
+
+    /** Starts at 0, not at ExecutionStarted. AWS leaves the first state's Entered event unchained. */
+    static HistoryChain of(List<HistoryEvent> history) {
+        return new HistoryChain(history, new AtomicLong(history.size()), new AtomicBoolean(), null, 0L);
+    }
+
+    /** A Distributed Map item is a child execution. Its events are counted, not kept. */
+    static HistoryChain ofChildExecution() {
+        return new HistoryChain(new CountOnlyHistory(), new AtomicLong(), new AtomicBoolean(), null, 0L);
+    }
+
+    HistoryChain fork() {
+        return new HistoryChain(history, producedEventCount, ended, this, lastEventId);
+    }
+
+    boolean isBranch() {
+        return parent != null;
+    }
+
+    long lastEventId() {
+        return lastEventId;
+    }
+
+    void continueFrom(long eventId) {
+        lastEventId = eventId;
+        tailEventId = eventId;
+    }
+
+    void continueAfter(Collection<HistoryChain> chains) {
+        var last = lastEventId;
+        for (HistoryChain chain : chains) {
+            last = Math.max(last, chain.lastEventId);
+        }
+        continueFrom(last);
+    }
+
+    /** AWS records nothing of a branch it cut. */
+    void abandon() {
+        abandoned = true;
+    }
+
+    private boolean isAbandoned() {
+        for (var chain = this; chain != null; chain = chain.parent) {
+            if (chain.abandoned) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Returns the event id, or 0 once the execution has ended. */
+    long publish(String type, Map<String, Object> details) {
+        if (isAbandoned()) {
+            return 0L;
+        }
+        AslExecutor.countTowardsHistoryEventLimit(producedEventCount);
+        long id = append(type, lastEventId, details);
+        if (id > 0) {
+            lastEventId = id;
+            tailEventId = id;
+        }
+        return id;
+    }
+
+    /**
+     * The event does not become the chain's tail. AWS records {@code *StateSucceeded},
+     * {@code MapRunSucceeded}, {@code MapIterationFailed} and {@code TaskStateAborted} this way.
+     */
+    void publishAside(String type, Map<String, Object> details) {
+        if (isAbandoned()) {
+            return;
+        }
+        AslExecutor.countTowardsHistoryEventLimit(producedEventCount);
+        long id = append(type, tailEventId, details);
+        if (id > 0) {
+            tailEventId = id;
+        }
+    }
+
+    /** The terminal event does not count towards the limit, and nothing is recorded after it. */
+    void end(String type, Map<String, Object> details) {
+        end(type, tailEventId, details);
+    }
+
+    /** ExecutionTimedOut points at 0. */
+    void end(String type, long previousEventId, Map<String, Object> details) {
+        synchronized (history) {
+            append(type, previousEventId, details);
+            ended.set(true);
+        }
+    }
+
+    /** Synchronized on the history because StopExecution appends the terminal event from another thread. */
+    private long append(String type, long previousEventId, Map<String, Object> details) {
+        synchronized (history) {
+            if (ended.get()) {
+                return 0L;
+            }
+            var event = new HistoryEvent();
+            event.setId(history.size() + 1L);
+            event.setPreviousEventId(previousEventId);
+            event.setType(type);
+            event.setDetails(details);
+            return history.add(event) ? event.getId() : 0L;
+        }
+    }
+
+    private static final class CountOnlyHistory extends AbstractList<HistoryEvent> {
+        private int size;
+
+        @Override
+        public boolean add(HistoryEvent event) {
+            size++;
+            return true;
+        }
+
+        @Override
+        public HistoryEvent get(int index) {
+            throw new IndexOutOfBoundsException(index);
+        }
+
+        @Override
+        public int size() {
+            return size;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/JsonataEvaluator.java
@@ -477,12 +477,13 @@ public class JsonataEvaluator {
         } catch (QueryEvaluationFailure failure) {
             throw new FailStateException(failure.error,
                     "The JSONata expression '" + expr + "' specified for the field '" + field
-                            + "' threw an error during evaluation" + failure.sentenceSeparator + failure.cause);
+                            + "' threw an error during evaluation" + failure.sentenceSeparator + failure.cause,
+                    field);
         }
         if (value.isMissingNode()) {
             throw new FailStateException("States.QueryEvaluationError",
                     "The JSONata expression '" + expr + "' specified for the field '" + field
-                            + "' returned nothing (undefined).");
+                            + "' returned nothing (undefined).", field);
         }
         return value;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -367,7 +368,12 @@ public class StepFunctionsJsonHandler {
         var arn = request.path("executionArn").asText();
         var includeExecutionData = request.path("includeExecutionData").asBoolean(true);
 
-        List<HistoryEvent> events = service.getExecutionHistory(arn);
+        var live = service.getExecutionHistory(arn);
+        List<HistoryEvent> events;
+        // Branch and iteration threads append under the history's own monitor while a client reads.
+        synchronized (live) {
+            events = new ArrayList<>(live);
+        }
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode array = response.putArray("events");
         for (HistoryEvent e : events) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonHandler.java
@@ -302,37 +302,38 @@ public class StepFunctionsJsonHandler {
      * {@code arn:aws:states:::aws-sdk:sfn:describeMapRun} Task integration renders the same node in
      * PascalCase, so this is the one place the response is described.
      *
-     * <p>A retained run is one whose every item succeeded, because a Map fails on the first item
-     * that fails. That fixes {@code status}, both zero tolerances and {@code redriveCount}:
-     * {@code redriveDate} is absent until a run is redriven, and no run here ever is.
+     * <p>Both tolerances and {@code redriveCount} are zero because Floci implements neither, and
+     * {@code redriveDate} is absent until a run is redriven, which no run here ever is.
      */
     static ObjectNode describeMapRunResponse(ObjectMapper objectMapper, MapRun mapRun) {
         ObjectNode response = objectMapper.createObjectNode();
         response.put("mapRunArn", mapRun.getMapRunArn());
         response.put("executionArn", mapRun.getExecutionArn());
-        response.put("status", "SUCCEEDED");
+        response.put("status", mapRun.getStatus());
         response.put("startDate", mapRun.getStartDate());
         response.put("stopDate", mapRun.getStopDate());
         response.put("maxConcurrency", mapRun.getMaxConcurrency());
         response.put("toleratedFailurePercentage", 0.0);
         response.put("toleratedFailureCount", 0);
-        putMapRunCounts(response.putObject("itemCounts"), mapRun.getItemCount());
+        putMapRunCounts(response.putObject("itemCounts"), mapRun);
         // One child execution per item: ItemBatcher is not applied, so no execution covers a batch.
-        putMapRunCounts(response.putObject("executionCounts"), mapRun.getItemCount());
+        putMapRunCounts(response.putObject("executionCounts"), mapRun);
         response.put("redriveCount", 0);
         return response;
     }
 
-    /** The ten counters of a run whose every item succeeded and was written to the result set. */
-    private static void putMapRunCounts(ObjectNode counts, int items) {
+    /** A failed item's result counts as written, as on AWS. */
+    private static void putMapRunCounts(ObjectNode counts, MapRun mapRun) {
+        var succeeded = mapRun.getSucceededCount();
+        var failed = mapRun.getFailedCount();
         counts.put("pending", 0);
         counts.put("running", 0);
-        counts.put("succeeded", items);
-        counts.put("failed", 0);
+        counts.put("succeeded", succeeded);
+        counts.put("failed", failed);
         counts.put("timedOut", 0);
-        counts.put("aborted", 0);
-        counts.put("total", items);
-        counts.put("resultsWritten", items);
+        counts.put("aborted", mapRun.getItemCount() - succeeded - failed);
+        counts.put("total", mapRun.getItemCount());
+        counts.put("resultsWritten", succeeded + failed);
         counts.put("failuresNotRedrivable", 0);
         counts.put("pendingRedrive", 0);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/model/MapRun.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/model/MapRun.java
@@ -4,23 +4,24 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 /**
- * A distributed Map run that has finished, keyed by its Map run ARN.
- *
- * <p>A Map fails on the first item that fails, so a run only reaches the {@code ResultWriter} that
- * mints its ARN once every item has succeeded. That is why a run carries a single {@code itemCount}
- * rather than the ten counters {@code DescribeMapRun} reports: the other nine are zero, and
- * {@code succeeded}, {@code total} and {@code resultsWritten} are all this count.
+ * A distributed Map run that has finished, keyed by its Map run ARN. It is kept on success and on
+ * failure, so the {@code mapRunArn} of a {@code MapRunStarted} event resolves through
+ * {@code DescribeMapRun}. A Map cancels the remaining items on the first failure, so a failed run
+ * reports those as aborted.
  */
 @RegisterForReflection
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class MapRun {
     private String mapRunArn;
+    private String status;
     /** The execution of the state machine whose Map state opened this run. */
     private String executionArn;
     private double startDate;
     private double stopDate;
-    /** Items processed by the run, which is also the number of child executions it ran. */
+    /** Items of the run, which is also the number of child executions it ran. */
     private int itemCount;
+    private int succeededCount;
+    private int failedCount;
     /** The Map's declared MaxConcurrency, with an unbounded Map held as Integer.MAX_VALUE. */
     private int maxConcurrency;
 
@@ -38,6 +39,13 @@ public class MapRun {
 
     public int getItemCount() { return itemCount; }
     public void setItemCount(int itemCount) { this.itemCount = itemCount; }
+    /** A run recorded before the status was kept is one whose every item succeeded. */
+    public String getStatus() { return status == null ? "SUCCEEDED" : status; }
+    public void setStatus(String status) { this.status = status; }
+    public int getSucceededCount() { return status == null ? itemCount : succeededCount; }
+    public void setSucceededCount(int succeededCount) { this.succeededCount = succeededCount; }
+    public int getFailedCount() { return failedCount; }
+    public void setFailedCount(int failedCount) { this.failedCount = failedCount; }
 
     public int getMaxConcurrency() { return maxConcurrency; }
     public void setMaxConcurrency(int maxConcurrency) { this.maxConcurrency = maxConcurrency; }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
@@ -1,0 +1,542 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.MockedResponseStep;
+import io.github.hectorvent.floci.services.stepfunctions.model.MockedTestCase;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import io.quarkus.test.junit.QuarkusTest;
+import io.vertx.mutiny.core.Vertx;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * The history events of the states inside a Parallel branch or a Map iteration, and the cause a
+ * failure inside one reports. Every shape here was read off real Step Functions in us-east-1 for
+ * issue #2868: the event families a Parallel and a Map publish around their branches, how
+ * {@code previousEventId} chains a branch's events to each other and to the state that started
+ * them, which failures leave a {@code *StateFailed} event, and the
+ * {@code An error occurred while executing the state ...} prefix a cause carries.
+ *
+ * <p>Branches run concurrently, so the order in which their events interleave is not asserted.
+ * What is asserted is what a reader needs to follow each branch: the chain.
+ */
+@QuarkusTest
+class AslExecutorBranchHistoryEventsTest {
+
+    private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "000000000000";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private AslExecutor executor;
+
+    @Inject
+    Vertx vertx;
+
+    @BeforeEach
+    void setUp() {
+        executor = new AslExecutor(
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
+                mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
+                mock(S3Service.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsService.class),
+                mock(io.github.hectorvent.floci.services.ecs.EcsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerService.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
+                objectMapper,
+                new JsonataEvaluator(objectMapper),
+                mock(Instance.class), mock(EmulatorConfig.class), vertx,
+                mock(io.github.hectorvent.floci.core.common.CustomResourceLiveness.class));
+    }
+
+    @Test
+    void parallelBranchesPublishTheirStatesOnChainsOfTheirOwn() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"A1","States":{"A1":{"Type":"Pass","Next":"A2"},"A2":{"Type":"Pass","End":true}}},
+                    {"StartAt":"B1","States":{"B1":{"Type":"Pass","Next":"B2"},"B2":{"Type":"Pass","End":true}}}
+                  ],"Next":"After"},
+                  "After":{"Type":"Pass","End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals("SUCCEEDED", status(history), typesOf(history).toString());
+        assertEquals(16, history.size(), typesOf(history).toString());
+        assertIdsAreConsecutive(history);
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted"),
+                typesOf(history.subList(0, 3)));
+        assertEquals(List.of("ParallelStateSucceeded", "ParallelStateExited", "PassStateEntered",
+                        "PassStateExited", "ExecutionSucceeded"),
+                typesOf(history.subList(11, 16)));
+
+        var started = eventOfType(history, "ParallelStateStarted");
+        assertEquals(2L, started.getPreviousEventId());
+        assertNull(started.getDetails());
+        // Each branch's first state starts from ParallelStateStarted, and the branch chains on from
+        // there: A1 exited points at A1 entered, A2 entered at A1 exited.
+        for (String branch : List.of("A", "B")) {
+            var firstEntered = stateEvent(history, "PassStateEntered", branch + "1");
+            var firstExited = stateEvent(history, "PassStateExited", branch + "1");
+            var secondEntered = stateEvent(history, "PassStateEntered", branch + "2");
+            var secondExited = stateEvent(history, "PassStateExited", branch + "2");
+            assertEquals(started.getId(), firstEntered.getPreviousEventId());
+            assertEquals(firstEntered.getId(), firstExited.getPreviousEventId());
+            assertEquals(firstExited.getId(), secondEntered.getPreviousEventId());
+            assertEquals(secondEntered.getId(), secondExited.getPreviousEventId());
+        }
+        // The Parallel continues from the last event a branch published. ParallelStateSucceeded
+        // points at it and is passed by: ParallelStateExited points at it too.
+        long lastBranchEvent = history.get(10).getId();
+        var succeeded = eventOfType(history, "ParallelStateSucceeded");
+        var exited = eventOfType(history, "ParallelStateExited");
+        assertEquals(lastBranchEvent, succeeded.getPreviousEventId());
+        assertNull(succeeded.getDetails());
+        assertEquals(lastBranchEvent, exited.getPreviousEventId());
+        assertEquals("[{\"x\":\"a\"},{\"x\":\"a\"}]", exited.getDetails().get("output"));
+        assertEquals(exited.getId(), stateEvent(history, "PassStateEntered", "After").getPreviousEventId());
+    }
+
+    /** The shape reported in issue #2868, with the branch that never fails left out. */
+    @Test
+    void runtimeErrorInABranchNamesTheBranchStateAndItsEnteredEvent() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Fast","States":{"Fast":{"Type":"Pass","Parameters":{"m.$":"$.nope"},"End":true}}}
+                  ],"End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "PassStateEntered", "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L), previousEventIdsOf(history));
+        var failed = history.get(4);
+        assertEquals("States.Runtime", failed.getDetails().get("error"));
+        assertEquals("An error occurred while executing the state 'Fast' (entered at the event id #4). "
+                + "The JSONPath '$.nope' specified for the field 'm.$' could not be found in the input '{\"x\":\"a\"}'",
+                failed.getDetails().get("cause"));
+    }
+
+    @Test
+    void failStateInABranchPassesItsCauseThroughAndLeavesAParallelStateFailedEvent() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Boom","States":{"Boom":{"Type":"Fail","Error":"MyError","Cause":"my cause"}}}
+                  ],"End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "FailStateEntered", "ParallelStateFailed", "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L), previousEventIdsOf(history));
+        assertNull(history.get(4).getDetails());
+        assertEquals(Map.of("error", "MyError", "cause", "my cause"), history.get(5).getDetails());
+    }
+
+    @Test
+    void caughtBranchFailureExitsTheParallelWithTheErrorOutput() {
+        var history = run("""
+                {"QueryLanguage":"JSONata","StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Undef","States":{"Undef":{"Type":"Pass","Output":{"v":"{% $states.input.missing %}"},"End":true}}}
+                  ],"Catch":[{"ErrorEquals":["States.ALL"],"Next":"Handled"}],"End":true},
+                  "Handled":{"Type":"Pass","End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "PassStateEntered", "ParallelStateFailed", "ParallelStateExited", "PassStateEntered",
+                "PassStateExited", "ExecutionSucceeded"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L, 7L, 8L), previousEventIdsOf(history));
+        var cause = "An error occurred while executing the state 'Undef' (entered at the event id #4). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
+                + "returned nothing (undefined).";
+        var errorOutput = "{\"Error\":\"States.QueryEvaluationError\",\"Cause\":\"" + cause.replace("\"", "\\\"") + "\"}";
+        assertEquals(errorOutput, history.get(5).getDetails().get("output"));
+        assertEquals(errorOutput, history.get(8).getDetails().get("output"));
+    }
+
+    @Test
+    void retriedParallelStartsAgainAndFailsOnceItsRetryIsUsedUp() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Boom","States":{"Boom":{"Type":"Fail","Error":"MyError","Cause":"my cause"}}}
+                  ],"Retry":[{"ErrorEquals":["States.ALL"],"MaxAttempts":1,"IntervalSeconds":0}],"End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "FailStateEntered", "ParallelStateStarted", "FailStateEntered", "ParallelStateFailed",
+                "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L, 7L), previousEventIdsOf(history));
+    }
+
+    @Test
+    void parallelOwnFailureIsAttributedToTheParallelAfterItsBranchesSucceeded() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Ok","States":{"Ok":{"Type":"Pass","End":true}}}
+                  ],"ResultSelector":{"m.$":"$.nope"},"End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "PassStateEntered", "PassStateExited", "ParallelStateSucceeded", "ExecutionFailed"),
+                typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L), previousEventIdsOf(history));
+        assertEquals("An error occurred while executing the state 'P' (entered at the event id #2). "
+                + "The JSONPath '$.nope' specified for the field 'm.$' could not be found in the input '[{\"x\":\"a\"}]'",
+                history.get(6).getDetails().get("cause"));
+    }
+
+    @Test
+    void taskFailureEndingABranchIsRecordedAsAbortedAndPassesItsCauseThrough() {
+        var mocks = new MockedTestCase("branch-history-test", "Case", Map.of("Send", List.of(
+                new MockedResponseStep(0, 0, null, "SQS.QueueDoesNotExistException", "The specified queue does not exist."))));
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Send","States":{"Send":{"Type":"Task","Resource":"arn:aws:states:::sqs:sendMessage",
+                      "Parameters":{"QueueUrl":"https://sqs.us-east-1.amazonaws.com/000000000000/missing","MessageBody":"hi"},"End":true}}}
+                  ],"Catch":[{"ErrorEquals":["States.ALL"],"Next":"Handled"}],"End":true},
+                  "Handled":{"Type":"Pass","End":true}}}
+                """, "{\"x\":\"a\"}", mocks);
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "TaskStateEntered", "TaskScheduled", "TaskStarted", "TaskFailed", "TaskStateAborted",
+                "ParallelStateFailed", "ParallelStateExited", "PassStateEntered", "PassStateExited",
+                "ExecutionSucceeded"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L, 7L, 7L, 9L, 10L, 11L, 12L), previousEventIdsOf(history));
+        assertNull(history.get(7).getDetails());
+        assertEquals("{\"Error\":\"SQS.QueueDoesNotExistException\",\"Cause\":\"The specified queue does not exist.\"}",
+                history.get(9).getDetails().get("output"));
+    }
+
+    @Test
+    void mapIterationsPublishTheirStatesUnderIterationEvents() {
+        var history = run("""
+                {"StartAt":"M","States":{
+                  "M":{"Type":"Map","ItemsPath":"$.items","ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},
+                    "StartAt":"I1","States":{"I1":{"Type":"Pass","Next":"I2"},"I2":{"Type":"Pass","End":true}}},
+                  "Next":"After"},
+                  "After":{"Type":"Pass","End":true}}}
+                """, "{\"items\":[1,2]}");
+
+        assertEquals("SUCCEEDED", status(history), typesOf(history).toString());
+        assertEquals(20, history.size(), typesOf(history).toString());
+        assertIdsAreConsecutive(history);
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted"), typesOf(history.subList(0, 3)));
+        var started = history.get(2);
+        assertEquals(2L, started.getPreviousEventId());
+        assertEquals(Map.of("length", 2), started.getDetails());
+
+        for (int index = 0; index < 2; index++) {
+            var iterationStarted = iterationEvent(history, "MapIterationStarted", index);
+            var iterationSucceeded = iterationEvent(history, "MapIterationSucceeded", index);
+            var input = String.valueOf(index + 1);
+            var firstEntered = stateEventWithInput(history, "PassStateEntered", "I1", input);
+            var firstExited = stateEventWithOutput(history, "PassStateExited", "I1", input);
+            var secondEntered = stateEventWithInput(history, "PassStateEntered", "I2", input);
+            var secondExited = stateEventWithOutput(history, "PassStateExited", "I2", input);
+            assertEquals(Map.of("name", "M", "index", index), iterationStarted.getDetails());
+            assertEquals(started.getId(), iterationStarted.getPreviousEventId());
+            assertEquals(iterationStarted.getId(), firstEntered.getPreviousEventId());
+            assertEquals(firstEntered.getId(), firstExited.getPreviousEventId());
+            assertEquals(firstExited.getId(), secondEntered.getPreviousEventId());
+            assertEquals(secondEntered.getId(), secondExited.getPreviousEventId());
+            assertEquals(secondExited.getId(), iterationSucceeded.getPreviousEventId());
+            assertEquals(Map.of("name", "M", "index", index), iterationSucceeded.getDetails());
+        }
+        assertEquals(List.of("MapStateSucceeded", "MapStateExited", "PassStateEntered", "PassStateExited",
+                "ExecutionSucceeded"), typesOf(history.subList(15, 20)));
+        long lastIterationEvent = history.get(14).getId();
+        assertEquals("MapIterationSucceeded", history.get(14).getType());
+        assertEquals(lastIterationEvent, history.get(15).getPreviousEventId());
+        assertNull(history.get(15).getDetails());
+        assertEquals(lastIterationEvent, history.get(16).getPreviousEventId());
+        assertEquals("[1,2]", history.get(16).getDetails().get("output"));
+    }
+
+    @Test
+    void mapOverNoItemsExitsFromItsStartedEvent() {
+        var history = run("""
+                {"StartAt":"M","States":{
+                  "M":{"Type":"Map","ItemsPath":"$.items",
+                    "ItemProcessor":{"StartAt":"I","States":{"I":{"Type":"Pass","End":true}}},"End":true}}}
+                """, "{\"items\":[]}");
+
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted", "MapStateSucceeded",
+                "MapStateExited", "ExecutionSucceeded"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 3L, 5L), previousEventIdsOf(history));
+    }
+
+    @Test
+    void runtimeErrorInABranchTaskLeavesNoAbortedEvent() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Send","States":{"Send":{"Type":"Task","Resource":"arn:aws:states:::sqs:sendMessage",
+                      "Parameters":{"QueueUrl.$":"$.nope","MessageBody":"hi"},"End":true}}}
+                  ],"End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "TaskStateEntered", "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L), previousEventIdsOf(history));
+    }
+
+    @Test
+    void mapIterationFailureLeavesIterationAndStateFailedEventsBehind() {
+        var history = run("""
+                {"QueryLanguage":"JSONata","StartAt":"M","States":{
+                  "M":{"Type":"Map","Items":"{% $states.input.items %}","MaxConcurrency":1,
+                    "ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"Undef",
+                      "States":{"Undef":{"Type":"Pass","Output":{"v":"{% $states.input.missing %}"},"End":true}}},
+                  "End":true}}}
+                """, "{\"items\":[1,2]}");
+
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted", "MapIterationStarted",
+                "PassStateEntered", "MapIterationFailed", "MapStateFailed", "ExecutionFailed"), typesOf(history));
+        // MapIterationFailed points at the iteration's last event and is passed by: MapStateFailed
+        // points at that same event.
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 5L, 7L), previousEventIdsOf(history));
+        assertEquals(Map.of("name", "M", "index", 0), history.get(5).getDetails());
+        assertNull(history.get(6).getDetails());
+        assertEquals("An error occurred while executing the state 'Undef' (entered at the event id #5). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
+                + "returned nothing (undefined).", history.get(7).getDetails().get("cause"));
+    }
+
+    @Test
+    void runtimeErrorInAMapIterationLeavesNoFailedEvents() {
+        var history = run("""
+                {"StartAt":"M","States":{
+                  "M":{"Type":"Map","ItemsPath":"$.items","MaxConcurrency":1,
+                    "ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"Fast",
+                      "States":{"Fast":{"Type":"Pass","Parameters":{"m.$":"$.nope"},"End":true}}},
+                  "End":true}}}
+                """, "{\"items\":[1,2]}");
+
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted", "MapIterationStarted",
+                "PassStateEntered", "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L), previousEventIdsOf(history));
+        assertEquals("An error occurred while executing the state 'Fast' (entered at the event id #5). "
+                + "The JSONPath '$.nope' specified for the field 'm.$' could not be found in the input '1'",
+                history.get(5).getDetails().get("cause"));
+    }
+
+    @Test
+    void distributedMapNamesItsRunAndPublishesNoItemEvents() {
+        var history = run("""
+                {"StartAt":"D","States":{
+                  "D":{"Type":"Map","ItemsPath":"$.items","ItemProcessor":{
+                    "ProcessorConfig":{"Mode":"DISTRIBUTED","ExecutionType":"STANDARD"},
+                    "StartAt":"I1","States":{"I1":{"Type":"Pass","End":true}}},
+                  "End":true}}}
+                """, "{\"items\":[1,2]}");
+
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted", "MapRunStarted",
+                "MapRunSucceeded", "MapStateSucceeded", "MapStateExited", "ExecutionSucceeded"), typesOf(history));
+        // The parent chain stays at MapRunStarted: MapStateExited points at it, past both Succeeded events.
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 4L, 7L), previousEventIdsOf(history));
+        var mapRunArn = (String) history.get(3).getDetails().get("mapRunArn");
+        assertTrue(mapRunArn.startsWith("arn:aws:states:us-east-1:000000000000:mapRun:branch-history-test/"), mapRunArn);
+        assertEquals("[1,2]", history.get(6).getDetails().get("output"));
+    }
+
+    @Test
+    void nestedMapInsideAParallelBranchChainsToTheBranch() {
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"M","States":{"M":{"Type":"Map","ItemsPath":"$.items","ItemProcessor":{
+                      "ProcessorConfig":{"Mode":"INLINE"},"StartAt":"I1","States":{"I1":{"Type":"Pass","End":true}}},
+                      "End":true}}},
+                    {"StartAt":"B1","States":{"B1":{"Type":"Pass","End":true}}}
+                  ],"End":true}}}
+                """, "{\"items\":[1,2]}");
+
+        assertEquals("SUCCEEDED", status(history), typesOf(history).toString());
+        assertEquals(20, history.size(), typesOf(history).toString());
+        assertIdsAreConsecutive(history);
+        var parallelStarted = eventOfType(history, "ParallelStateStarted");
+        var mapEntered = eventOfType(history, "MapStateEntered");
+        var mapStarted = eventOfType(history, "MapStateStarted");
+        var mapSucceeded = eventOfType(history, "MapStateSucceeded");
+        var mapExited = eventOfType(history, "MapStateExited");
+        assertEquals(parallelStarted.getId(), mapEntered.getPreviousEventId());
+        assertEquals(parallelStarted.getId(), stateEvent(history, "PassStateEntered", "B1").getPreviousEventId());
+        assertEquals(mapEntered.getId(), mapStarted.getPreviousEventId());
+        for (int index = 0; index < 2; index++) {
+            assertEquals(mapStarted.getId(), iterationEvent(history, "MapIterationStarted", index).getPreviousEventId());
+        }
+        long lastIterationEvent = Math.max(iterationEvent(history, "MapIterationSucceeded", 0).getId(),
+                iterationEvent(history, "MapIterationSucceeded", 1).getId());
+        assertEquals(lastIterationEvent, mapSucceeded.getPreviousEventId());
+        assertEquals(lastIterationEvent, mapExited.getPreviousEventId());
+        var parallelExited = eventOfType(history, "ParallelStateExited");
+        long lastBranchEvent = Math.max(mapExited.getId(), stateEvent(history, "PassStateExited", "B1").getId());
+        assertEquals(lastBranchEvent, eventOfType(history, "ParallelStateSucceeded").getPreviousEventId());
+        assertEquals(lastBranchEvent, parallelExited.getPreviousEventId());
+        assertEquals("ExecutionSucceeded", history.get(19).getType());
+    }
+
+    @Test
+    void choiceWithNoMatchingRuleAndNoDefaultFailsAsAwsDoes() {
+        var history = run("""
+                {"StartAt":"C","States":{
+                  "C":{"Type":"Choice","Choices":[{"Variable":"$.x","StringEquals":"never","Next":"Done"}]},
+                  "Done":{"Type":"Pass","End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ChoiceStateEntered", "ExecutionFailed"), typesOf(history));
+        assertEquals(Map.of("error", "States.Runtime",
+                "cause", "An error occurred while executing the state 'C' (entered at the event id #2). "
+                        + "Failed to transition out of the state. The state does not point to a next state."),
+                history.get(2).getDetails());
+    }
+
+    @Test
+    void catchInsideABranchTakesItsNextEvenOnAnEndState() {
+        var mocks = new MockedTestCase("branch-history-test", "Case", Map.of("Send", List.of(
+                new MockedResponseStep(0, 0, null, "MyError", "boom"))));
+        var history = run("""
+                {"StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Send","States":{
+                      "Send":{"Type":"Task","Resource":"arn:aws:states:::sqs:sendMessage",
+                        "Parameters":{"QueueUrl":"https://sqs.us-east-1.amazonaws.com/000000000000/q","MessageBody":"hi"},
+                        "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Recover"}],"End":true},
+                      "Recover":{"Type":"Pass","Result":{"recovered":true},"End":true}}}
+                  ],"End":true}}}
+                """, "{}", mocks);
+
+        assertEquals("SUCCEEDED", status(history), typesOf(history).toString());
+        assertEquals("[{\"recovered\":true}]", eventOfType(history, "ExecutionSucceeded").getDetails().get("output"));
+        assertFalse(typesOf(history).contains("TaskStateAborted"));
+    }
+
+    private static String status(List<HistoryEvent> history) {
+        var last = history.get(history.size() - 1).getType();
+        return switch (last) {
+            case "ExecutionSucceeded" -> "SUCCEEDED";
+            case "ExecutionFailed" -> "FAILED";
+            default -> last;
+        };
+    }
+
+    private static List<String> typesOf(List<HistoryEvent> history) {
+        return history.stream().map(HistoryEvent::getType).toList();
+    }
+
+    private static List<Long> previousEventIdsOf(List<HistoryEvent> history) {
+        return history.stream().map(HistoryEvent::getPreviousEventId).toList();
+    }
+
+    private static void assertIdsAreConsecutive(List<HistoryEvent> history) {
+        for (var i = 0; i < history.size(); i++) {
+            assertEquals(i + 1L, history.get(i).getId(), "unexpected id at index " + i);
+        }
+        var referenced = history.stream().map(HistoryEvent::getPreviousEventId).collect(Collectors.toSet());
+        referenced.remove(0L);
+        assertTrue(referenced.stream().allMatch(id -> id < history.size()),
+                "previousEventId points past the history: " + Set.copyOf(referenced));
+    }
+
+    private static HistoryEvent eventOfType(List<HistoryEvent> history, String type) {
+        return history.stream()
+                .filter(event -> type.equals(event.getType()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("history has no " + type + " event: " + typesOf(history)));
+    }
+
+    private static HistoryEvent stateEvent(List<HistoryEvent> history, String type, String name) {
+        return history.stream()
+                .filter(event -> type.equals(event.getType()) && name.equals(event.getDetails().get("name")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("history has no " + type + " for " + name + ": " + typesOf(history)));
+    }
+
+    private static HistoryEvent stateEventWithInput(List<HistoryEvent> history, String type, String name, String input) {
+        return history.stream()
+                .filter(event -> type.equals(event.getType()) && name.equals(event.getDetails().get("name"))
+                        && input.equals(event.getDetails().get("input")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("history has no " + type + " for " + name + " with input "
+                        + input + ": " + typesOf(history)));
+    }
+
+    private static HistoryEvent stateEventWithOutput(List<HistoryEvent> history, String type, String name, String output) {
+        return history.stream()
+                .filter(event -> type.equals(event.getType()) && name.equals(event.getDetails().get("name"))
+                        && output.equals(event.getDetails().get("output")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("history has no " + type + " for " + name + " with output "
+                        + output + ": " + typesOf(history)));
+    }
+
+    private static HistoryEvent iterationEvent(List<HistoryEvent> history, String type, int index) {
+        return history.stream()
+                .filter(event -> type.equals(event.getType()) && Integer.valueOf(index).equals(event.getDetails().get("index")))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("history has no " + type + " for index " + index + ": " + typesOf(history)));
+    }
+
+    private List<HistoryEvent> run(String definition, String input) {
+        return run(definition, input, null);
+    }
+
+    /** Runs the definition the way StartExecution does: the history already holds ExecutionStarted as event 1. */
+    private List<HistoryEvent> run(String definition, String input, MockedTestCase mocks) {
+        var stateMachine = new StateMachine();
+        stateMachine.setName("branch-history-test");
+        stateMachine.setStateMachineArn("arn:aws:states:%s:%s:stateMachine:branch-history-test".formatted(REGION, ACCOUNT));
+        stateMachine.setRoleArn("arn:aws:iam::%s:role/test-role".formatted(ACCOUNT));
+        stateMachine.setDefinition(definition);
+
+        var execution = new Execution();
+        execution.setName("branch-history-execution");
+        execution.setExecutionArn(
+                "arn:aws:states:%s:%s:execution:branch-history-test:branch-history-execution".formatted(REGION, ACCOUNT));
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput(input);
+
+        var history = new ArrayList<HistoryEvent>();
+        var started = new HistoryEvent();
+        started.setId(1L);
+        started.setPreviousEventId(0L);
+        started.setType("ExecutionStarted");
+        started.setDetails(Map.of("input", input, "inputDetails", Map.of("truncated", false)));
+        history.add(started);
+
+        executor.executeSync(stateMachine, execution, history, mocks, (updated, events) -> {
+        });
+        return history;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
@@ -171,15 +171,17 @@ class AslExecutorBranchHistoryEventsTest {
                 """, "{\"x\":\"a\"}");
 
         assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
-                "PassStateEntered", "ParallelStateFailed", "ParallelStateExited", "PassStateEntered",
-                "PassStateExited", "ExecutionSucceeded"), typesOf(history));
-        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L, 7L, 8L), previousEventIdsOf(history));
+                "PassStateEntered", "EvaluationFailed", "ParallelStateFailed", "ParallelStateExited",
+                "PassStateEntered", "PassStateExited", "ExecutionSucceeded"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L), previousEventIdsOf(history));
         var cause = "An error occurred while executing the state 'Undef' (entered at the event id #4). "
                 + "The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
                 + "returned nothing (undefined).";
+        assertEquals(Map.of("error", "States.QueryEvaluationError", "cause", cause, "location", "Output/v",
+                "state", "Undef"), history.get(4).getDetails());
         var errorOutput = "{\"Error\":\"States.QueryEvaluationError\",\"Cause\":\"" + cause.replace("\"", "\\\"") + "\"}";
-        assertEquals(errorOutput, history.get(5).getDetails().get("output"));
-        assertEquals(errorOutput, history.get(8).getDetails().get("output"));
+        assertEquals(errorOutput, history.get(6).getDetails().get("output"));
+        assertEquals(errorOutput, history.get(9).getDetails().get("output"));
     }
 
     @Test
@@ -322,15 +324,18 @@ class AslExecutorBranchHistoryEventsTest {
                 """, "{\"items\":[1,2]}");
 
         assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted", "MapIterationStarted",
-                "PassStateEntered", "MapIterationFailed", "MapStateFailed", "ExecutionFailed"), typesOf(history));
+                "PassStateEntered", "EvaluationFailed", "MapIterationFailed", "MapStateFailed", "ExecutionFailed"),
+                typesOf(history));
         // MapIterationFailed points at the iteration's last event and is passed by: MapStateFailed
         // points at that same event.
-        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 5L, 7L), previousEventIdsOf(history));
-        assertEquals(Map.of("name", "M", "index", 0), history.get(5).getDetails());
-        assertNull(history.get(6).getDetails());
-        assertEquals("An error occurred while executing the state 'Undef' (entered at the event id #5). "
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 5L, 6L, 6L, 8L), previousEventIdsOf(history));
+        var cause = "An error occurred while executing the state 'Undef' (entered at the event id #5). "
                 + "The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
-                + "returned nothing (undefined).", history.get(7).getDetails().get("cause"));
+                + "returned nothing (undefined).";
+        assertEquals("Undef", history.get(5).getDetails().get("state"));
+        assertEquals(Map.of("name", "M", "index", 0), history.get(6).getDetails());
+        assertNull(history.get(7).getDetails());
+        assertEquals(cause, history.get(8).getDetails().get("cause"));
     }
 
     @Test
@@ -405,6 +410,70 @@ class AslExecutorBranchHistoryEventsTest {
         assertEquals(lastBranchEvent, eventOfType(history, "ParallelStateSucceeded").getPreviousEventId());
         assertEquals(lastBranchEvent, parallelExited.getPreviousEventId());
         assertEquals("ExecutionSucceeded", history.get(19).getType());
+    }
+
+    @Test
+    void jsonataFailureRecordsAnEvaluationFailedEventPerAttempt() {
+        var history = run("""
+                {"QueryLanguage":"JSONata","StartAt":"Send","States":{
+                  "Send":{"Type":"Task","Resource":"arn:aws:states:::sqs:sendMessage",
+                    "Arguments":{"QueueUrl":"https://sqs.us-east-1.amazonaws.com/000000000000/q","MessageBody":"{% $states.input.missing %}"},
+                    "Retry":[{"ErrorEquals":["States.ALL"],"MaxAttempts":1,"IntervalSeconds":0}],"End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "TaskStateEntered", "EvaluationFailed", "EvaluationFailed",
+                "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L), previousEventIdsOf(history));
+        var cause = "An error occurred while executing the state 'Send' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Arguments/MessageBody' "
+                + "returned nothing (undefined).";
+        var expected = Map.of("error", "States.QueryEvaluationError", "cause", cause,
+                "location", "Arguments/MessageBody", "state", "Send");
+        assertEquals(expected, history.get(2).getDetails());
+        assertEquals(expected, history.get(3).getDetails());
+        assertEquals(Map.of("error", "States.QueryEvaluationError", "cause", cause), history.get(4).getDetails());
+    }
+
+    @Test
+    void mapItemsExpressionFailureIsRecordedBeforeTheMapStarts() {
+        var history = run("""
+                {"QueryLanguage":"JSONata","StartAt":"Fan","States":{
+                  "Fan":{"Type":"Map","Items":"{% $states.input.missing %}",
+                    "ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},"StartAt":"I","States":{"I":{"Type":"Pass","End":true}}},
+                    "End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "EvaluationFailed", "MapStateFailed",
+                "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L), previousEventIdsOf(history));
+        assertEquals("Items", history.get(2).getDetails().get("location"));
+    }
+
+    /**
+     * A Catch clause whose own Output fails. AWS records the clause's EvaluationFailed from where the
+     * state stood before its first Failed event, then fails the state a second time.
+     */
+    @Test
+    void catchClauseOutputFailureIsRecordedFromBeforeTheStateFailedEvent() {
+        var history = run("""
+                {"QueryLanguage":"JSONata","StartAt":"P","States":{
+                  "P":{"Type":"Parallel","Branches":[
+                    {"StartAt":"Boom","States":{"Boom":{"Type":"Fail","Error":"MyError","Cause":"my cause"}}}
+                  ],"Catch":[{"ErrorEquals":["Other"],"Next":"Done"},
+                             {"ErrorEquals":["States.ALL"],"Output":{"v":"{% $states.input.missing %}"},"Next":"Done"}],
+                  "End":true},
+                  "Done":{"Type":"Pass","End":true}}}
+                """, "{\"x\":\"a\"}");
+
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted", "FailStateEntered",
+                "ParallelStateFailed", "EvaluationFailed", "ParallelStateFailed", "ExecutionFailed"), typesOf(history));
+        assertEquals(List.of(0L, 0L, 2L, 3L, 4L, 4L, 6L, 7L), previousEventIdsOf(history));
+        var cause = "An error occurred while executing the state 'P' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Catch[1]/Output/v' "
+                + "returned nothing (undefined).";
+        assertEquals(Map.of("error", "States.QueryEvaluationError", "cause", cause,
+                "location", "Catch[1]/Output/v", "state", "P"), history.get(5).getDetails());
+        assertEquals(Map.of("error", "States.QueryEvaluationError", "cause", cause), history.get(7).getDetails());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * The history events of the states inside a Parallel branch or a Map iteration, and the cause a
@@ -57,6 +58,8 @@ class AslExecutorBranchHistoryEventsTest {
 
     @BeforeEach
     void setUp() {
+        Instance<StepFunctionsService> sfnService = mock(Instance.class);
+        when(sfnService.get()).thenReturn(mock(StepFunctionsService.class));
         executor = new AslExecutor(
                 mock(LambdaExecutorService.class),
                 mock(LambdaFunctionStore.class),
@@ -73,7 +76,7 @@ class AslExecutorBranchHistoryEventsTest {
                 mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
                 objectMapper,
                 new JsonataEvaluator(objectMapper),
-                mock(Instance.class), mock(EmulatorConfig.class), vertx,
+                sfnService, mock(EmulatorConfig.class), vertx,
                 mock(io.github.hectorvent.floci.core.common.CustomResourceLiveness.class));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Guards the bound AWS puts on a running execution: a state machine that never reaches a terminal
@@ -183,6 +184,8 @@ class AslExecutorHistoryEventLimitTest {
 
     @BeforeEach
     void setUp() {
+        Instance<StepFunctionsService> sfnService = mock(Instance.class);
+        when(sfnService.get()).thenReturn(mock(StepFunctionsService.class));
         executor = new AslExecutor(
                 mock(LambdaExecutorService.class),
                 mock(LambdaFunctionStore.class),
@@ -199,7 +202,7 @@ class AslExecutorHistoryEventLimitTest {
                 mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
                 objectMapper,
                 new JsonataEvaluator(objectMapper),
-                mock(Instance.class), mock(EmulatorConfig.class), vertx, null);
+                sfnService, mock(EmulatorConfig.class), vertx, null);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
@@ -238,17 +238,20 @@ class AslExecutorHistoryEventLimitTest {
     }
 
     /**
-     * The branch produced the events that ran the execution out of them, and floci publishes none
-     * of them. What the caller reads back is the four events the top-level flow did produce, ending
-     * in the failure: an unbroken chain, not four events numbered as if 25,000 had happened.
+     * The branch produced the events that ran the execution out of them, and they are published
+     * into the execution's history like any other: what the caller reads back is one history,
+     * numbered without a gap and ending in the failure.
      */
     @Test
     void aParallelBranchLeavesThePublishedHistoryUnbroken() {
         run(RUNAWAY_PARALLEL_BRANCH);
 
         assertEquals(List.of("PassStateEntered", "PassStateExited", "ParallelStateEntered",
-                             "ExecutionFailed"),
-                history.stream().map(HistoryEvent::getType).toList());
+                             "ParallelStateStarted", "ChoiceStateEntered"),
+                history.subList(0, 5).stream().map(HistoryEvent::getType).toList());
+        HistoryEvent last = history.get(history.size() - 1);
+        assertEquals("ExecutionFailed", last.getType());
+        assertEquals(25_000, history.size());
         for (int index = 0; index < history.size(); index++) {
             assertEquals(index + 1L, history.get(index).getId(), "unexpected id at index " + index);
             assertEquals((long) index, history.get(index).getPreviousEventId(),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicMissingArgumentTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicMissingArgumentTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -162,6 +163,14 @@ class AslExecutorIntrinsicMissingArgumentTest {
         assertEquals("The function 'States.Format('{}', $.items[5])' had the following error: "
                 + "The JsonPath argument for the field '$.items[5]' could not be found in the "
                 + "input '{\"items\":[1,2]}'", failure.cause);
+    }
+
+    /** The plain form of the same path is not a miss. AWS resolves it to null and the execution succeeds. */
+    @Test
+    void plainReferencePastTheEndOfAnArrayResolvesToNull() throws Exception {
+        var resolved = resolve("{\"v.$\":\"$.items[5]\"}", "{\"items\":[1,2]}");
+
+        assertTrue(resolved.path("v").isNull());
     }
 
     /** Reading a field off the absent element fails alike. */

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -281,6 +281,7 @@ class AslExecutorTaskHistoryEventsTest {
                     "Iterate": {
                       "Type": "Map",
                       "ItemsPath": "$[0].items",
+                      "MaxConcurrency": 1,
                       "ItemProcessor": {
                         "StartAt": "ItemStep",
                         "States": {"ItemStep": {"Type": "Pass", "End": true}}
@@ -293,10 +294,23 @@ class AslExecutorTaskHistoryEventsTest {
 
         assertEquals("SUCCEEDED", execution.getStatus(), "history: " + typesOf(history));
         assertEquals(
-                List.of("ParallelStateEntered", "ParallelStateExited",
-                        "MapStateEntered", "MapStateExited", "ExecutionSucceeded"),
+                List.of("ParallelStateEntered", "ParallelStateStarted",
+                        "PassStateEntered", "PassStateExited", "PassStateEntered", "PassStateExited",
+                        "ParallelStateSucceeded", "ParallelStateExited",
+                        "MapStateEntered", "MapStateStarted",
+                        "MapIterationStarted", "PassStateEntered", "PassStateExited", "MapIterationSucceeded",
+                        "MapIterationStarted", "PassStateEntered", "PassStateExited", "MapIterationSucceeded",
+                        "MapStateSucceeded", "MapStateExited", "ExecutionSucceeded"),
                 typesOf(history));
-        assertChain(history);
+        // The branch and the iterations chain to the Started event that opened them, and a
+        // Succeeded event is passed by: the Exited event after it points where it pointed.
+        assertEquals(
+                List.of(0L, 1L, 2L, 3L, 4L, 5L, 6L, 6L,
+                        8L, 9L, 10L, 11L, 12L, 13L, 10L, 15L, 16L, 17L, 18L, 18L, 20L),
+                history.stream().map(HistoryEvent::getPreviousEventId).toList());
+        for (var i = 0; i < history.size(); i++) {
+            assertEquals(i + 1L, history.get(i).getId(), "unexpected id at index " + i);
+        }
     }
 
     private static List<String> typesOf(List<HistoryEvent> history) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/HistoryChainTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/HistoryChainTest.java
@@ -1,0 +1,48 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HistoryChainTest {
+
+    /** The history-event limit of AslExecutor. A counted event past it fails the execution. */
+    private static final int MAX_HISTORY_EVENTS = 25_000;
+
+    @Test
+    void publishingAfterTheExecutionEndedRecordsNothingAndDoesNotCountTowardsTheLimit() {
+        List<HistoryEvent> history = new ArrayList<>();
+        var chain = HistoryChain.of(history);
+        chain.end("ExecutionSucceeded", Map.of());
+
+        assertDoesNotThrow(() -> {
+            for (var i = 0; i < MAX_HISTORY_EVENTS; i++) {
+                assertEquals(0L, chain.publish("PassStateEntered", null));
+                chain.publishAside("PassStateSucceeded", null);
+            }
+        });
+        assertEquals(1, history.size());
+    }
+
+    @Test
+    void publishingIntoAHistorySealedByStopExecutionStopsCountingAsWell() {
+        var history = new StepFunctionsService.ExecutionHistory();
+        var chain = HistoryChain.of(history);
+        var branch = chain.fork();
+        history.sealWith("ExecutionAborted", Map.of());
+
+        assertDoesNotThrow(() -> {
+            for (var i = 0; i < MAX_HISTORY_EVENTS; i++) {
+                assertEquals(0L, chain.publish("PassStateEntered", null));
+                assertEquals(0L, branch.publish("PassStateEntered", null));
+            }
+        });
+        assertEquals(1, history.size());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsDescribeMapRunIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsDescribeMapRunIntegrationTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.fail;
  * the {@code arn:aws:states:::aws-sdk:sfn:describeMapRun} Task integration.
  *
  * <p>Every asserted value was measured against us-east-1 with a distributed Map run of the same
- * shape. A Map run only becomes describable once its {@code ResultWriter} has minted the Map run
- * ARN and returned it in the Map result, which is also the only way an ASL author obtains it.
+ * shape. Every run is describable through the {@code mapRunArn} of its {@code MapRunStarted}
+ * event. A run with a {@code ResultWriter} also returns that ARN in the Map result.
  */
 @QuarkusTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -240,6 +240,44 @@ class StepFunctionsDescribeMapRunIntegrationTest {
         assertEquals(0, response.jsonPath().getInt(set + ".pendingRedrive"));
     }
 
+    @Test
+    @Order(10)
+    void describeMapRunResolvesTheArnOfAMapWithoutResultWriter() throws Exception {
+        var smArn = createStateMachine("describe-map-run-no-writer", distributedMapWithoutWriter(
+                "[1, 2]", "Keep", "{\"Keep\": {\"Type\": \"Pass\", \"End\": true}}"));
+        var execArn = startExecution(smArn, "{}");
+        var describe = waitForTerminalState(execArn);
+        assertEquals("SUCCEEDED", describe.jsonPath().getString("status"),
+                "cause: " + describe.jsonPath().getString("cause"));
+
+        var mapRunArn = mapRunArnFromHistory(execArn);
+        var response = describeMapRun(mapRunArn);
+        response.then().statusCode(200);
+        assertEquals(mapRunArn, response.jsonPath().getString("mapRunArn"));
+        assertEquals(execArn, response.jsonPath().getString("executionArn"));
+        assertEquals("SUCCEEDED", response.jsonPath().getString("status"));
+        assertCounters(response, "itemCounts", 2);
+        assertCounters(response, "executionCounts", 2);
+    }
+
+    @Test
+    @Order(11)
+    void describeMapRunReportsARunWhoseItemFailed() throws Exception {
+        var smArn = createStateMachine("describe-map-run-failed", distributedMapWithoutWriter(
+                "[1]", "Boom", "{\"Boom\": {\"Type\": \"Fail\", \"Error\": \"Boom\", \"Cause\": \"item failed\"}}"));
+        var execArn = startExecution(smArn, "{}");
+        assertEquals("FAILED", waitForTerminalState(execArn).jsonPath().getString("status"));
+
+        var response = describeMapRun(mapRunArnFromHistory(execArn));
+        response.then().statusCode(200);
+        assertEquals("FAILED", response.jsonPath().getString("status"));
+        assertEquals(0, response.jsonPath().getInt("itemCounts.succeeded"));
+        assertEquals(1, response.jsonPath().getInt("itemCounts.failed"));
+        assertEquals(0, response.jsonPath().getInt("itemCounts.aborted"));
+        assertEquals(1, response.jsonPath().getInt("itemCounts.total"));
+        assertEquals(1, response.jsonPath().getInt("itemCounts.resultsWritten"));
+    }
+
     private static void assertTaskCounters(JsonNode counts, int items) {
         assertEquals(0, counts.path("Pending").asInt());
         assertEquals(0, counts.path("Running").asInt());
@@ -282,6 +320,44 @@ class StepFunctionsDescribeMapRunIntegrationTest {
                 .replace("CONCURRENCY",
                         maxConcurrency == null ? "" : "\"MaxConcurrency\": " + maxConcurrency + ",")
                 .replace("BUCKET", bucket);
+    }
+
+    private static String distributedMapWithoutWriter(String items, String startAt, String states) {
+        return """
+                {
+                  "QueryLanguage": "JSONata",
+                  "StartAt": "Fan",
+                  "States": {
+                    "Fan": {
+                      "Type": "Map",
+                      "End": true,
+                      "Items": ITEMS,
+                      "ItemProcessor": {
+                        "ProcessorConfig": {"Mode": "DISTRIBUTED", "ExecutionType": "STANDARD"},
+                        "StartAt": "START_AT",
+                        "States": STATES
+                      }
+                    }
+                  }
+                }
+                """.replace("ITEMS", items).replace("START_AT", startAt).replace("STATES", states);
+    }
+
+    private static String mapRunArnFromHistory(String execArn) throws Exception {
+        var history = given()
+                .header("X-Amz-Target", "AWSStepFunctions.GetExecutionHistory")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(execArn))
+                .when().post("/");
+        history.then().statusCode(200);
+        for (JsonNode event : mapper.readTree(history.asString()).path("events")) {
+            if ("MapRunStarted".equals(event.path("type").asText())) {
+                return event.path("mapRunStartedEventDetails").path("mapRunArn").asText();
+            }
+        }
+        return fail("no MapRunStarted event in the history of " + execArn);
     }
 
     private static Response describeMapRun(String mapRunArn) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsExecutionHistoryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsExecutionHistoryIntegrationTest.java
@@ -220,6 +220,136 @@ class StepFunctionsExecutionHistoryIntegrationTest {
         }
     }
 
+    /**
+     * The events of the states inside a Parallel branch and a Map iteration reach the caller through
+     * GetExecutionHistory under the details field the SDK names for each event type. Shapes read
+     * off real Step Functions in us-east-1 for issue #2868.
+     */
+    @Test
+    void getExecutionHistory_publishesParallelBranchAndMapIterationEvents() throws Exception {
+        String definition = """
+                {
+                  "StartAt": "P",
+                  "States": {
+                    "P": {
+                      "Type": "Parallel",
+                      "Branches": [
+                        {"StartAt": "A1", "States": {"A1": {"Type": "Pass", "End": true}}}
+                      ],
+                      "Next": "M"
+                    },
+                    "M": {
+                      "Type": "Map",
+                      "ItemsPath": "$[0].items",
+                      "MaxConcurrency": 1,
+                      "ItemProcessor": {
+                        "ProcessorConfig": {"Mode": "INLINE"},
+                        "StartAt": "I1",
+                        "States": {"I1": {"Type": "Pass", "End": true}}
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """;
+
+        String stateMachineArn = createStateMachine("execution-history-branches-test", definition);
+        String executionArn = startExecution(stateMachineArn, "{\"items\": [1, 2]}");
+        waitForExecution(executionArn);
+
+        var events = MAPPER.readTree(getExecutionHistory(executionArn).body().asString()).path("events");
+        var types = new ArrayList<String>();
+        events.forEach(event -> types.add(event.path("type").asText()));
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "PassStateEntered", "PassStateExited", "ParallelStateSucceeded", "ParallelStateExited",
+                "MapStateEntered", "MapStateStarted",
+                "MapIterationStarted", "PassStateEntered", "PassStateExited", "MapIterationSucceeded",
+                "MapIterationStarted", "PassStateEntered", "PassStateExited", "MapIterationSucceeded",
+                "MapStateSucceeded", "MapStateExited", "ExecutionSucceeded"), types);
+        var expectedPreviousEventIds = List.of(0L, 0L, 2L, 3L, 4L, 5L, 5L, 7L, 8L, 9L, 10L, 11L, 12L,
+                9L, 14L, 15L, 16L, 17L, 17L, 19L);
+        for (var i = 0; i < events.size(); i++) {
+            assertEquals(i + 1L, events.get(i).path("id").asLong());
+            assertEquals(expectedPreviousEventIds.get(i), events.get(i).path("previousEventId").asLong(),
+                    "previousEventId of event " + (i + 1) + " in " + events);
+        }
+        assertFalse(events.get(2).has("parallelStateStartedEventDetails"));
+        assertEquals(2, events.get(8).path("mapStateStartedEventDetails").path("length").asInt());
+        assertEquals("M", events.get(9).path("mapIterationStartedEventDetails").path("name").asText());
+        assertEquals(0, events.get(9).path("mapIterationStartedEventDetails").path("index").asInt());
+        assertEquals("M", events.get(16).path("mapIterationSucceededEventDetails").path("name").asText());
+        assertEquals(1, events.get(16).path("mapIterationSucceededEventDetails").path("index").asInt());
+        assertEquals("[1,2]", events.get(18).path("stateExitedEventDetails").path("output").asText());
+    }
+
+    /** The shape reported in issue #2868, verified against us-east-1. */
+    @Test
+    void getExecutionHistory_namesTheBranchStateAFailureBelongsTo() throws Exception {
+        String definition = """
+                {
+                  "StartAt": "P",
+                  "States": {
+                    "P": {
+                      "Type": "Parallel",
+                      "Branches": [
+                        {"StartAt": "Fast", "States": {"Fast": {"Type": "Pass", "Parameters": {"m.$": "$.nope"}, "End": true}}}
+                      ],
+                      "End": true
+                    }
+                  }
+                }
+                """;
+
+        String stateMachineArn = createStateMachine("execution-history-branch-failure-test", definition);
+        String executionArn = startExecution(stateMachineArn, "{\"x\": \"a\"}");
+        var cause = "An error occurred while executing the state 'Fast' (entered at the event id #4). "
+                + "The JSONPath '$.nope' specified for the field 'm.$' could not be found in the input '{\"x\":\"a\"}'";
+        await().atMost(Duration.ofSeconds(5)).pollInterval(Duration.ofMillis(100)).untilAsserted(() -> {
+            var described = describeExecution(executionArn);
+            assertEquals("FAILED", described.jsonPath().getString("status"), described.body().asString());
+            assertEquals("States.Runtime", described.jsonPath().getString("error"));
+            assertEquals(cause, described.jsonPath().getString("cause"));
+        });
+
+        var events = MAPPER.readTree(getExecutionHistory(executionArn).body().asString()).path("events");
+        var types = new ArrayList<String>();
+        events.forEach(event -> types.add(event.path("type").asText()));
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                "PassStateEntered", "ExecutionFailed"), types);
+        assertEquals("Fast", events.get(3).path("stateEnteredEventDetails").path("name").asText());
+        assertEquals(cause, events.get(4).path("executionFailedEventDetails").path("cause").asText());
+        assertEquals(4L, events.get(4).path("previousEventId").asLong());
+    }
+
+    private Response getExecutionHistory(String executionArn) {
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.GetExecutionHistory")
+                .contentType(SFN_CONTENT_TYPE)
+                .body(String.format("""
+                        {
+                            "executionArn": "%s",
+                            "includeExecutionData": true
+                        }
+                        """, executionArn))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response;
+    }
+
+    private Response describeExecution(String executionArn) {
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.DescribeExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body(String.format("""
+                        { "executionArn": "%s" }
+                        """, executionArn))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response;
+    }
+
     private static String createQueue(String queueName) {
         var response = given()
                 .header("X-Amz-Target", "AmazonSQS.CreateQueue")
@@ -272,6 +402,22 @@ class StepFunctionsExecutionHistoryIntegrationTest {
                             "stateMachineArn": "%s"
                         }
                         """, stateMachineArn))
+                .when()
+                .post("/");
+        response.then().statusCode(200);
+        return response.jsonPath().getString("executionArn");
+    }
+
+    private String startExecution(String stateMachineArn, String input) {
+        Response response = given()
+                .header("X-Amz-Target", "AWSStepFunctions.StartExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body(String.format("""
+                        {
+                            "stateMachineArn": "%s",
+                            "input": %s
+                        }
+                        """, stateMachineArn, quote(input)))
                 .when()
                 .post("/");
         response.then().statusCode(200);

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsIntrinsicMissingArgumentIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsIntrinsicMissingArgumentIntegrationTest.java
@@ -39,7 +39,8 @@ class StepFunctionsIntrinsicMissingArgumentIntegrationTest {
 
         assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
         assertEquals("States.Runtime", describe.jsonPath().getString("error"));
-        assertEquals("The function 'States.Format('{}', $.nope)' had the following error: "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The function 'States.Format('{}', $.nope)' had the following error: "
                 + "The JsonPath argument for the field '$.nope' could not be found in the input "
                 + "'{\"other\":1}'",
                 describe.jsonPath().getString("cause"));
@@ -58,7 +59,8 @@ class StepFunctionsIntrinsicMissingArgumentIntegrationTest {
         var describe = run("nested-intrinsic", definition, "{\"other\":1}");
 
         assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
-        assertEquals("The function 'States.Format('{}', States.Format('{}', $.nope))' had the "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The function 'States.Format('{}', States.Format('{}', $.nope))' had the "
                 + "following error: The JsonPath argument for the field '$.nope' could not be "
                 + "found in the input '{\"other\":1}'",
                 describe.jsonPath().getString("cause"));
@@ -79,7 +81,8 @@ class StepFunctionsIntrinsicMissingArgumentIntegrationTest {
         var describe = run("intrinsic-index-out-of-range", definition, "{\"items\":[1,2]}");
 
         assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
-        assertEquals("The function 'States.Format('{}', $.items[5])' had the following error: "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The function 'States.Format('{}', $.items[5])' had the following error: "
                 + "The JsonPath argument for the field '$.items[5]' could not be found in the "
                 + "input '{\"items\":[1,2]}'",
                 describe.jsonPath().getString("cause"));
@@ -101,7 +104,8 @@ class StepFunctionsIntrinsicMissingArgumentIntegrationTest {
 
         assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
         assertEquals("States.Runtime", describe.jsonPath().getString("error"));
-        assertEquals("The function 'States.Format('{}', $.nope)' had the following error: "
+        assertEquals("An error occurred while executing the state 'M' (entered at the event id #2). "
+                + "The function 'States.Format('{}', $.nope)' had the following error: "
                 + "The JsonPath argument for the field '$.nope' could not be found in the input "
                 + "'{\"items\":[1,2]}'",
                 describe.jsonPath().getString("cause"));

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataFunctionsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataFunctionsIntegrationTest.java
@@ -247,7 +247,8 @@ class StepFunctionsJsonataFunctionsIntegrationTest {
         Response resp = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", resp.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$sum(['a'])' specified for the field 'Output/v' threw an error "
+        assertEquals("An error occurred while executing the state 'Sum' (entered at the event id #2). "
+                + "The JSONata expression '$sum(['a'])' specified for the field 'Output/v' threw an error "
                 + "during evaluation. T0412: Argument [\"a\"] must be an array of \"numbers\"",
                 resp.jsonPath().getString("cause"));
     }
@@ -277,7 +278,8 @@ class StepFunctionsJsonataFunctionsIntegrationTest {
         Response resp = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", resp.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$abs(\"x\")' specified for the field 'Output/v' threw an error "
+        assertEquals("An error occurred while executing the state 'Abs' (entered at the event id #2). "
+                + "The JSONata expression '$abs(\"x\")' specified for the field 'Output/v' threw an error "
                 + "during evaluation. T0410: Argument 1 of function \"abs\" does not match function signature",
                 resp.jsonPath().getString("cause"));
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsJsonataIntegrationTest.java
@@ -619,7 +619,8 @@ class StepFunctionsJsonataIntegrationTest {
 
         assertEquals("FAILED", failure.jsonPath().getString("status"));
         assertEquals("States.ItemReaderFailed", failure.jsonPath().getString("error"));
-        assertEquals("The provided ReaderConfig.ItemsPointer does not match any valid path in the JSON structure.",
+        assertEquals("An error occurred while executing the state 'ProcessWorkers' (entered at the event id #2). "
+                + "The provided ReaderConfig.ItemsPointer does not match any valid path in the JSON structure.",
                 failure.jsonPath().getString("cause"));
     }
 
@@ -672,7 +673,8 @@ class StepFunctionsJsonataIntegrationTest {
 
         assertEquals("FAILED", failure.jsonPath().getString("status"));
         assertEquals("States.ItemReaderFailed", failure.jsonPath().getString("error"));
-        assertEquals("Attempting to map over non-iterable node.", failure.jsonPath().getString("cause"));
+        assertEquals("An error occurred while executing the state 'ProcessWorkers' (entered at the event id #2). "
+                + "Attempting to map over non-iterable node.", failure.jsonPath().getString("cause"));
     }
 
     @Test
@@ -770,7 +772,8 @@ class StepFunctionsJsonataIntegrationTest {
 
         assertEquals("FAILED", failure.jsonPath().getString("status"));
         assertEquals("States.Runtime", failure.jsonPath().getString("error"));
-        assertEquals("The ItemReader, ItemBatcher and ResultWriter fields are not supported for INLINE maps",
+        assertEquals("An error occurred while executing the state 'ProcessWorkers' (entered at the event id #2). "
+                + "The ItemReader, ItemBatcher and ResultWriter fields are not supported for INLINE maps",
                 failure.jsonPath().getString("cause"));
     }
 
@@ -1295,7 +1298,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
+        assertEquals("An error occurred while executing the state 'Transform' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Output/v' "
                 + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
 
         String catching = definition.replace("\"End\": true",
@@ -1390,7 +1394,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Assign/x' "
+        assertEquals("An error occurred while executing the state 'Bind' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Assign/x' "
                 + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1421,7 +1426,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+        assertEquals("An error occurred while executing the state 'Send' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field "
                 + "'Arguments/MessageGroupId' returned nothing (undefined).",
                 failure.jsonPath().getString("cause"));
     }
@@ -1454,7 +1460,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field "
                 + "'Choices[1]/Condition' returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1516,7 +1523,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field "
                 + "'Choices[1]/Output/v' returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1546,7 +1554,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field "
                 + "'Choices[0]/Assign/x' returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1586,7 +1595,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+        assertEquals("An error occurred while executing the state 'Boom' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field "
                 + "'Catch[1]/Output/v' returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1608,7 +1618,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Seconds' "
+        assertEquals("An error occurred while executing the state 'Pause' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Seconds' "
                 + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1631,14 +1642,16 @@ class StepFunctionsJsonataIntegrationTest {
                 createStateMachine("jsonata-fail-error-returned-nothing-test",
                         definition.formatted("{% $states.input.missing %}", "boom")), "{}"));
         assertEquals("States.QueryEvaluationError", errorFailure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Error' "
+        assertEquals("An error occurred while executing the state 'Stop' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Error' "
                 + "returned nothing (undefined).", errorFailure.jsonPath().getString("cause"));
 
         Response causeFailure = waitForExecutionFailure(startExecution(
                 createStateMachine("jsonata-fail-cause-returned-nothing-test",
                         definition.formatted("Boom", "{% $states.input.missing %}")), "{}"));
         assertEquals("States.QueryEvaluationError", causeFailure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Cause' "
+        assertEquals("An error occurred while executing the state 'Stop' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Cause' "
                 + "returned nothing (undefined).", causeFailure.jsonPath().getString("cause"));
     }
 
@@ -1667,7 +1680,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Items' "
+        assertEquals("An error occurred while executing the state 'Fan' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Items' "
                 + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1698,7 +1712,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field "
+        assertEquals("An error occurred while executing the state 'Fan' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field "
                 + "'MaxConcurrency' returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 
@@ -1758,7 +1773,8 @@ class StepFunctionsJsonataIntegrationTest {
         Response failure = waitForExecutionFailure(startExecution(smArn, "{}"));
 
         assertEquals("States.QueryEvaluationError", failure.jsonPath().getString("error"));
-        assertEquals("The JSONata expression '$states.input.missing' specified for the field 'Output' "
+        assertEquals("An error occurred while executing the state 'Transform' (entered at the event id #2). "
+                + "The JSONata expression '$states.input.missing' specified for the field 'Output' "
                 + "returned nothing (undefined).", failure.jsonPath().getString("cause"));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsTimeoutSecondsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsTimeoutSecondsIntegrationTest.java
@@ -117,7 +117,9 @@ class StepFunctionsTimeoutSecondsIntegrationTest {
         assertTrue(elapsedMillis < 3_000,
                 "the branch's 3-second Wait outlasted the 1-second budget: " + elapsedMillis + " ms");
         JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
-        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ExecutionTimedOut"),
+        // The branch's Wait was entered and never exited: the budget cut it.
+        assertEquals(List.of("ExecutionStarted", "ParallelStateEntered", "ParallelStateStarted",
+                        "WaitStateEntered", "ExecutionTimedOut"),
                 eventTypes(events), "history was " + events);
     }
 
@@ -224,8 +226,14 @@ class StepFunctionsTimeoutSecondsIntegrationTest {
         assertTrue(elapsedMillis < 5_000,
                 "the iterations' 10-second Wait outlasted the 1-second budget: " + elapsedMillis + " ms");
         JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
-        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "ExecutionTimedOut"),
-                eventTypes(events), "history was " + events);
+        // Both iterations entered their Wait and neither exited it. They run concurrently, so
+        // the order their events interleave in is theirs to choose.
+        List<String> types = eventTypes(events);
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted"), types.subList(0, 3),
+                "history was " + events);
+        assertEquals(List.of("MapIterationStarted", "MapIterationStarted", "WaitStateEntered", "WaitStateEntered"),
+                types.subList(3, 7).stream().sorted().toList(), "history was " + events);
+        assertEquals(List.of("ExecutionTimedOut"), types.subList(7, types.size()), "history was " + events);
     }
 
     @Test
@@ -259,7 +267,8 @@ class StepFunctionsTimeoutSecondsIntegrationTest {
         assertTrue(elapsedMillis < 5_000,
                 "the single iteration's 10-second Wait outlasted the 1-second budget: " + elapsedMillis + " ms");
         JsonNode events = mapper.readTree(getExecutionHistory(execArn).body().asString()).path("events");
-        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "ExecutionTimedOut"),
+        assertEquals(List.of("ExecutionStarted", "MapStateEntered", "MapStateStarted", "MapIterationStarted",
+                        "WaitStateEntered", "ExecutionTimedOut"),
                 eventTypes(events), "history was " + events);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsUnresolvableJsonPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsUnresolvableJsonPathIntegrationTest.java
@@ -38,7 +38,8 @@ class StepFunctionsUnresolvableJsonPathIntegrationTest {
 
         assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
         assertEquals("States.Runtime", describe.jsonPath().getString("error"));
-        assertEquals("The JSONPath '$.nope.deep' specified for the field 'missing.$' could not "
+        assertEquals("An error occurred while executing the state 'Pick' (entered at the event id #2). "
+                + "The JSONPath '$.nope.deep' specified for the field 'missing.$' could not "
                 + "be found in the input '{\"other\":1}'",
                 describe.jsonPath().getString("cause"));
     }
@@ -92,7 +93,8 @@ class StepFunctionsUnresolvableJsonPathIntegrationTest {
 
         assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
         assertEquals("States.Runtime", describe.jsonPath().getString("error"));
-        assertEquals("The JSONPath '$.nope' specified for the field 'missing.$' could not be "
+        assertEquals("An error occurred while executing the state 'M' (entered at the event id #2). "
+                + "The JSONPath '$.nope' specified for the field 'missing.$' could not be "
                 + "found in the input '[1,2]'",
                 describe.jsonPath().getString("cause"));
     }


### PR DESCRIPTION
## Summary

Closes #2868

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

API surfaces are verified with real AWS in us-east-1.

- Events inside Parallel branches and inline Map iterations are now recorded in the parent execution's history.
- More event types are supported
- previousEventId chaining matches AWS. Each branch has its own chain. *StateSucceeded, MapRunSucceeded, MapIterationFailed and TaskStateAborted do not advance it. Interleaving order varies per run, the chain shape does not.
- Distributed Map items are child executions and publish nothing into the parent. Only MapRun* events appear.
- Branch events count toward the 25,000 event history limit.
- Interpreter failures carry the AWS cause prefix An error occurred while executing the state '<name>' (entered at the event id #<n>), added once at the innermost state.
- A Choice with no matching rule and no Default fails with States.Runtime and the AWS message, instead of States.NoChoiceMatched.
- A missing .$ payload template path fails with States.Runtime and the AWS wording. An array index past the end resolves to null
- A failed JSONata expression records EvaluationFailed with error, cause, location and state, once per retry attempt.

Remaining gaps are documented.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

