### PR TITLE
fix(ec2): describe launchable unknown AMI ids in DescribeImages

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -3956,7 +3956,45 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 .collect(Collectors.toList());
         List<Image> images = new ArrayList<>(catalogImages);
         images.addAll(createdImages);
+        addFallbackLaunchableImages(region, images, imageIds, owners, filters);
         return images;
+    }
+
+    // RunInstances launches an unrecognised AMI id by falling back to the catalog default image (see
+    // AmiImageResolver), so an explicitly requested but unknown id is still launchable. IaC providers read
+    // the AMI's root device via DescribeImages before RunInstances, so an empty result there aborts the
+    // create (the aws provider reports "collecting instance settings: empty result"). Mirror the launch-time
+    // fallback so a describe of a launchable id returns a matching image instead of nothing.
+    private void addFallbackLaunchableImages(String region, List<Image> images, List<String> imageIds,
+                                             List<String> owners, Map<String, List<String>> filters) {
+        if (imageIds == null || imageIds.isEmpty()) {
+            return;
+        }
+        Set<String> present = images.stream().map(Image::getImageId).collect(Collectors.toSet());
+        for (String imageId : imageIds) {
+            if (imageId == null || !imageId.startsWith("ami-") || present.contains(imageId)
+                    || imageCatalog.findByIdOrAlias(imageId).isPresent()
+                    || registeredImages.get(key(region, imageId)).isPresent()) {
+                continue;
+            }
+            Image fallback = fallbackLaunchableImage(imageId);
+            if (matchesImageOwners(fallback, owners) && matchesRegisteredImageFilters(fallback, filters)) {
+                images.add(fallback);
+                present.add(imageId);
+            }
+        }
+    }
+
+    private Image fallbackLaunchableImage(String imageId) {
+        Image image = new Image();
+        image.setImageId(imageId);
+        image.setName(imageId);
+        image.setDescription("Floci fallback image for launchable AMI " + imageId);
+        image.setArchitecture("x86_64");
+        image.setOwnerId(AMAZON_OWNER_ID);
+        image.setImageOwnerAlias("amazon");
+        image.setCreationDate("2026-01-01T00:00:00.000Z");
+        return image;
     }
 
     public Image createImage(String region, String instanceId, String name, String description,

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -422,6 +422,30 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void describeImagesResolvesUnknownLaunchableAmiId() {
+        Ec2ImageCatalog imageCatalog = new Ec2ImageCatalog();
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                new AmiImageResolver(imageCatalog), imageCatalog, new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        // RunInstances launches an unknown id via the catalog-default fallback, so DescribeImages has to
+        // resolve it too: the aws provider reads the AMI root device before RunInstances and aborts the
+        // create with "collecting instance settings: empty result" when the describe comes back empty.
+        List<Image> unknown = service.describeImages(
+                "us-east-1", List.of("ami-0c02fb55956c7d316"), List.of(), Map.of());
+        assertEquals(1, unknown.size());
+        assertEquals("ami-0c02fb55956c7d316", unknown.getFirst().getImageId());
+        assertEquals("/dev/xvda", unknown.getFirst().getRootDeviceName());
+
+        // A real catalog id resolves to exactly the catalog image, never a duplicate fallback.
+        List<Image> catalog = service.describeImages(
+                "us-east-1", List.of("ami-0abcdef1234567891"), List.of(), Map.of());
+        assertEquals(1, catalog.size());
+        assertEquals("al2023-ami-2023.0.20230315.0-kernel-6.1-x86_64", catalog.getFirst().getName());
+    }
+
+    @Test
     void describeInstanceTypesUsesExactCatalogMatches() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),


### PR DESCRIPTION
## Summary

DescribeImages now returns an image for any launchable AMI id, so creating an aws.ec2.Instance against Floci with a real-world AMI id works.

Root cause: RunInstances already launches an unrecognised AMI id by falling back to the catalog default image (AmiImageResolver, plus the runInstancesKeepsX8664FallbackForUnknownImageAndType test), but DescribeImages returned an empty set for that same id. IaC providers read the AMI root device via DescribeImages before RunInstances whenever a root_block_device is set, so the empty result aborted the create with "collecting instance settings: empty result". The instance still launches, so a CLI describe-instances afterwards returns it, which is what made this look like a read race on DescribeInstances. It is not. The failing call is DescribeImages, before RunInstances runs.

Fix: DescribeImages builds a describable fallback image (state available, x86_64, /dev/xvda root device) for an explicitly requested, otherwise-unknown ami- id, mirroring the launch-time fallback. List queries with no image ids are unchanged, and a requested id that matches the catalog or a registered image is still served from there.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: DescribeImages returned an empty imagesSet for an explicitly requested `ami-` id that RunInstances would launch via the catalog fallback. The provider reads the AMI root device via DescribeImages before RunInstances when a root_block_device is set, so the empty result aborted instance create with "collecting instance settings: empty result".

Verified against the real pulumi-aws v5 provider (bridged terraform-provider-aws) driving `aws.ec2.Instance` with `ami-0c02fb55956c7d316` (not in the catalog): the create fails with the error above before the fix, and creates then destroys clean after. Floci-side, a new unit test `describeImagesResolvesUnknownLaunchableAmiId` fails on main and passes with the fix; full `Ec2ServiceTest` is green (126 tests).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
