### PR TITLE
fix(ec2): reject a CreateSubnet whose CIDR overlaps an existing subnet

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -3294,6 +3294,7 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         }
         ensureDefaultResources(region);
         getRequiredVpc(region, vpcId);
+        rejectConflictingSubnetCidr(region, vpcId, cidrBlock);
 
         String zoneName = resolveSubnetZoneName(region, availabilityZone, availabilityZoneId);
 
@@ -3323,6 +3324,26 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
             networkAcls.put(key(region, defaultAcl.getNetworkAclId()), defaultAcl);
         }
         return subnet;
+    }
+
+    /**
+     * AWS refuses a subnet whose IPv4 CIDR overlaps another subnet's in the same VPC. CreateSubnet
+     * carries no idempotency token, so this check is also what stops an SDK transport retry after
+     * a lost response from producing a second, unrecorded subnet at the same CIDR. Requests with
+     * no IPv4 CIDR are not checked here.
+     */
+    private void rejectConflictingSubnetCidr(String region, String vpcId, String cidrBlock) {
+        if (!Ipv4Cidrs.isIpv4(cidrBlock)) {
+            return;
+        }
+        boolean conflict = subnets.scan(k -> true).stream()
+                .filter(s -> region.equals(s.getRegion()) && vpcId.equals(s.getVpcId()))
+                .filter(s -> Ipv4Cidrs.isIpv4(s.getCidrBlock()))
+                .anyMatch(s -> Ipv4Cidrs.overlaps(cidrBlock, s.getCidrBlock()));
+        if (conflict) {
+            throw new AwsException("InvalidSubnet.Conflict",
+                    "The CIDR '" + cidrBlock + "' conflicts with another subnet", 400);
+        }
     }
 
     public List<Subnet> describeSubnets(String region, List<String> subnetIds, Map<String, List<String>> filters) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -3294,7 +3294,6 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         }
         ensureDefaultResources(region);
         getRequiredVpc(region, vpcId);
-        rejectConflictingSubnetCidr(region, vpcId, cidrBlock);
 
         String zoneName = resolveSubnetZoneName(region, availabilityZone, availabilityZoneId);
 
@@ -3310,7 +3309,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         subnet.setOwnerId(accountId);
         subnet.setRegion(region);
         subnet.setSubnetArn(AwsArnUtils.Arn.of("ec2", region, accountId, "subnet/" + subnetId).toString());
-        subnets.put(key(region, subnetId), subnet);
+        // The conflict scan and the store must be one step under the VPC's lock, or two
+        // overlapping creates in flight together both pass the scan before either is stored.
+        synchronized (lockFor(key(region, vpcId))) {
+            rejectConflictingSubnetCidr(region, vpcId, cidrBlock);
+            subnets.put(key(region, subnetId), subnet);
+        }
 
         // Every subnet starts associated with its VPC's default NACL. ReplaceNetworkAclAssociation
         // later moves it onto a custom NACL, so this association must exist for that lookup to work.

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ipv4Cidrs.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ipv4Cidrs.java
@@ -26,6 +26,16 @@ final class Ipv4Cidrs {
         return x[0] <= y[1] && y[0] <= x[1];
     }
 
+    /** True when {@code cidr} parses as an IPv4 block, so the other checks can be applied to it. */
+    static boolean isIpv4(String cidr) {
+        try {
+            parse(cidr);
+            return true;
+        } catch (AwsException e) {
+            return false;
+        }
+    }
+
     /**
      * The first /{@code netmask} block inside any of the {@code provisioned}
      * CIDRs (in order) that overlaps none of the {@code occupied} CIDRs, or

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -1105,6 +1105,24 @@ class Ec2IntegrationTest {
 
     @Test
     @Order(21)
+    void createSubnetWithConflictingCidrReturnsInvalidSubnetConflict() {
+        given()
+            .formParam("Action", "CreateSubnet")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.0.1.128/25")
+            .formParam("AvailabilityZone", "us-east-1a")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidSubnet.Conflict"))
+            .body("Response.Errors.Error.Message",
+                    equalTo("The CIDR '10.0.1.128/25' conflicts with another subnet"));
+    }
+
+    @Test
+    @Order(21)
     void describeSubnetById() {
         given()
             .formParam("Action", "DescribeSubnets")

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceConcurrencyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceConcurrencyTest.java
@@ -200,6 +200,34 @@ class Ec2ServiceConcurrencyTest {
         }
     }
 
+    @Test
+    void concurrentOverlappingCreateSubnetsRecordExactlyOne() throws Exception {
+        for (int trial = 0; trial < TRIALS; trial++) {
+            String region = "race-subnet-" + trial;
+            Ec2Service service = newService();
+            String vpcId = service.createVpc(region, "10.0.0.0/16", false).getVpcId();
+
+            AtomicInteger created = new AtomicInteger();
+            AtomicInteger conflicts = new AtomicInteger();
+            runRaceAllowing(i -> {
+                try {
+                    service.createSubnet(region, vpcId, "10.0.1.0/24", null);
+                    created.incrementAndGet();
+                } catch (AwsException e) {
+                    assertEquals("InvalidSubnet.Conflict", e.getErrorCode());
+                    conflicts.incrementAndGet();
+                }
+            });
+
+            assertEquals(1, created.get(), "trial " + trial + ": exactly one create may win the CIDR");
+            assertEquals(N - 1, conflicts.get(), "trial " + trial + ": losers must see InvalidSubnet.Conflict");
+            long stored = service.describeSubnets(region, List.of(), Map.of()).stream()
+                    .filter(s -> vpcId.equals(s.getVpcId()))
+                    .count();
+            assertEquals(1, stored, "trial " + trial + ": one subnet stored at the CIDR");
+        }
+    }
+
     /** Runs N concurrent invocations of the same op; the op absorbs its own expected failures. */
     private static void runRaceAllowing(java.util.function.IntConsumer op) throws Exception {
         ExecutorService pool = Executors.newFixedThreadPool(THREADS);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -257,6 +257,75 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void createSubnetRejectsCidrThatConflictsWithAnExistingSubnetInTheSameVpc() {
+        // CreateSubnet has no idempotency token, so an SDK transport retry after a lost response
+        // resends the identical request. AWS's CIDR conflict check is what turns that resend into
+        // an error instead of a second, unrecorded subnet.
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Vpc vpc = service.createVpc("us-east-1", "10.0.0.0/16", false);
+        service.createSubnet("us-east-1", vpc.getVpcId(), "10.0.1.0/24", "us-east-1a");
+
+        AwsException error = assertThrows(AwsException.class, () -> service.createSubnet(
+                "us-east-1", vpc.getVpcId(), "10.0.1.0/24", "us-east-1a"));
+
+        assertEquals("InvalidSubnet.Conflict", error.getErrorCode());
+        assertEquals("The CIDR '10.0.1.0/24' conflicts with another subnet", error.getMessage());
+        assertEquals(400, error.getHttpStatus());
+        assertEquals(1, service.describeSubnets("us-east-1", List.of(), Map.of()).stream()
+                .filter(s -> vpc.getVpcId().equals(s.getVpcId())).count());
+    }
+
+    @Test
+    void createSubnetRejectsCidrThatPartiallyOverlapsAnExistingSubnet() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Vpc vpc = service.createVpc("us-east-1", "10.0.0.0/16", false);
+        service.createSubnet("us-east-1", vpc.getVpcId(), "10.0.1.0/24", "us-east-1a");
+
+        // 10.0.1.128/25 lies inside 10.0.1.0/24, an overlap rather than a duplicate.
+        AwsException error = assertThrows(AwsException.class, () -> service.createSubnet(
+                "us-east-1", vpc.getVpcId(), "10.0.1.128/25", "us-east-1a"));
+
+        assertEquals("InvalidSubnet.Conflict", error.getErrorCode());
+    }
+
+    @Test
+    void createSubnetAllowsNonOverlappingCidrsInTheSameVpc() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Vpc vpc = service.createVpc("us-east-1", "10.0.0.0/16", false);
+        service.createSubnet("us-east-1", vpc.getVpcId(), "10.0.1.0/24", "us-east-1a");
+
+        Subnet second = service.createSubnet("us-east-1", vpc.getVpcId(), "10.0.2.0/24", "us-east-1b");
+
+        assertEquals("10.0.2.0/24", second.getCidrBlock());
+        assertEquals(2, service.describeSubnets("us-east-1", List.of(), Map.of()).stream()
+                .filter(s -> vpc.getVpcId().equals(s.getVpcId())).count());
+    }
+
+    @Test
+    void createSubnetAllowsConflictingCidrsInDifferentVpcs() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+        Vpc vpcA = service.createVpc("us-east-1", "10.0.0.0/16", false);
+        Vpc vpcB = service.createVpc("us-east-1", "10.0.0.0/16", false);
+        service.createSubnet("us-east-1", vpcA.getVpcId(), "10.0.1.0/24", "us-east-1a");
+
+        Subnet subnetB = service.createSubnet("us-east-1", vpcB.getVpcId(), "10.0.1.0/24", "us-east-1a");
+
+        assertEquals("10.0.1.0/24", subnetB.getCidrBlock());
+    }
+
+    @Test
     void runInstancesStoresArchitectureFromImageCatalog() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ipv4CidrsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ipv4CidrsTest.java
@@ -28,6 +28,15 @@ class Ipv4CidrsTest {
     }
 
     @Test
+    void isIpv4AcceptsParseableBlocksAndRejectsTheRest() {
+        assertTrue(Ipv4Cidrs.isIpv4("10.0.1.0/24"));
+        assertFalse(Ipv4Cidrs.isIpv4(null));
+        assertFalse(Ipv4Cidrs.isIpv4(""));
+        assertFalse(Ipv4Cidrs.isIpv4("10.0.1.0"));
+        assertFalse(Ipv4Cidrs.isIpv4("2600:1f18::/56"));
+    }
+
+    @Test
     void firstFreeBlockSkipsOccupiedSpaceInOrder() {
         assertEquals("10.0.1.0/24",
                 Ipv4Cidrs.firstFreeBlock(List.of("10.0.0.0/16"), List.of("10.0.0.0/24"), 24));


### PR DESCRIPTION
## Summary

Ports lex00/floci#191. `CreateSubnet` now refuses an IPv4 CIDR that overlaps another subnet in the same VPC with `InvalidSubnet.Conflict`, the way AWS does. The overlap test reuses the `Ipv4Cidrs` helper already backing IPAM, with a small `isIpv4` guard so requests without an IPv4 CIDR skip the check. Subnets in other VPCs are not considered.

The reason this matters beyond fidelity is that `CreateSubnet` has no idempotency token. An SDK transport retry after a lost response resends the same request, and without this check Floci recorded a second live subnet at the same CIDR. AWS's conflict check is what turns that resend into an error.

Unit tests in `Ec2ServiceTest` cover an exact duplicate and a partial overlap. Two more show that adjacent blocks in one VPC and the same block in two VPCs still succeed. `Ec2IntegrationTest` asserts the wire error code and message.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior. Floci accepted any number of subnets at the same or an overlapping CIDR inside one VPC. AWS rejects the second one with `InvalidSubnet.Conflict` and the message `The CIDR '10.0.1.0/24' conflicts with another subnet`.

## Checklist

- [x] `./mvnw test` passes locally for `Ec2ServiceTest`, `Ipv4CidrsTest` and `Ec2IntegrationTest`
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
