### PR TITLE
fix(ec2): carry DeliverLogsPermissionArn through CreateFlowLogs and DescribeFlowLogs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2FlowLogCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2FlowLogCfnProvisioner.java
@@ -63,6 +63,7 @@ public class Ec2FlowLogCfnProvisioner implements CfnResourceProvisioner {
                 ctx.resolveOptional(props, "TrafficType"),
                 ctx.resolveOptional(props, "LogDestinationType"),
                 ctx.resolveOptional(props, "LogDestination"),
+                ctx.resolveOptional(props, "DeliverLogsPermissionArn"),
                 ctx.resolveOptional(props, "LogFormat"),
                 props != null && props.hasNonNull("MaxAggregationInterval")
                         ? props.get("MaxAggregationInterval").asInt()
@@ -92,6 +93,8 @@ public class Ec2FlowLogCfnProvisioner implements CfnResourceProvisioner {
                 orDefault(ctx.resolveOptional(props, "LogDestinationType"), DEFAULT_LOG_DESTINATION_TYPE));
         rejectIfChanged("LogDestination", existing.getLogDestination(),
                 ctx.resolveOptional(props, "LogDestination"));
+        rejectIfChanged("DeliverLogsPermissionArn", existing.getDeliverLogsPermissionArn(),
+                ctx.resolveOptional(props, "DeliverLogsPermissionArn"));
         rejectIfChanged("LogFormat", existing.getLogFormat(), ctx.resolveOptional(props, "LogFormat"));
         int requestedInterval = props != null && props.hasNonNull("MaxAggregationInterval")
                 ? props.get("MaxAggregationInterval").asInt()

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -1417,6 +1417,7 @@ public class Ec2QueryHandler {
         if (logDestination == null) {
             logDestination = p.getFirst("LogDestinationArn");
         }
+        String deliverLogsPermissionArn = p.getFirst("DeliverLogsPermissionArn");
         String logFormat = p.getFirst("LogFormat");
         int maxAgg = parseIntParam(p, "MaxAggregationInterval", 600);
 
@@ -1434,7 +1435,7 @@ public class Ec2QueryHandler {
                 .start("flowLogIdSet");
         for (String resourceId : resourceIds) {
             FlowLog fl = flowLogService.createFlowLog(region, resourceId, resourceType, trafficType,
-                    logDestinationType, logDestination, logFormat, maxAgg);
+                    logDestinationType, logDestination, deliverLogsPermissionArn, logFormat, maxAgg);
             xml.elem("item", fl.getFlowLogId());
         }
         xml.end("flowLogIdSet")
@@ -1460,6 +1461,7 @@ public class Ec2QueryHandler {
                     .elem("trafficType", fl.getTrafficType())
                     .elem("logDestinationType", fl.getLogDestinationType())
                     .elem("logDestination", fl.getLogDestination())
+                    .elem("deliverLogsPermissionArn", fl.getDeliverLogsPermissionArn())
                     .elem("flowLogStatus", fl.getFlowLogStatus())
                     .elem("deliverLogsStatus", fl.getDeliverLogsStatus())
                     .elem("maxAggregationInterval", String.valueOf(fl.getMaxAggregationInterval()))

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/FlowLogService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/FlowLogService.java
@@ -117,7 +117,8 @@ public class FlowLogService {
 
     public FlowLog createFlowLog(String region, String resourceId, String resourceType,
                                  String trafficType, String logDestinationType,
-                                 String logDestination, String logFormat, int maxAggregationInterval) {
+                                 String logDestination, String deliverLogsPermissionArn,
+                                 String logFormat, int maxAggregationInterval) {
         FlowLog fl = new FlowLog();
         fl.setFlowLogId("fl-" + randomHex(17));
         fl.setResourceId(resourceId);
@@ -125,6 +126,7 @@ public class FlowLogService {
         fl.setTrafficType(trafficType != null ? trafficType : "ALL");
         fl.setLogDestinationType(logDestinationType != null ? logDestinationType : "s3");
         fl.setLogDestination(logDestination);
+        fl.setDeliverLogsPermissionArn(deliverLogsPermissionArn);
         fl.setBucketName(bucketFromArn(logDestination));
         fl.setLogFormat(logFormat);
         fl.setMaxAggregationInterval(maxAggregationInterval);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/model/FlowLog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/model/FlowLog.java
@@ -25,6 +25,7 @@ public class FlowLog {
     private String trafficType;      // ALL | ACCEPT | REJECT
     private String logDestinationType; // s3 | cloud-watch-logs
     private String logDestination;   // S3 bucket ARN, e.g. arn:aws:s3:::flow-logs-bucket
+    private String deliverLogsPermissionArn; // IAM role ARN used for cloud-watch-logs delivery
     private String bucketName;       // resolved bucket name from the ARN
     private String logFormat;        // optional custom format string (default format used if null)
     private int maxAggregationInterval = 600; // seconds (60 or 600)
@@ -51,6 +52,11 @@ public class FlowLog {
 
     public String getLogDestination() { return logDestination; }
     public void setLogDestination(String logDestination) { this.logDestination = logDestination; }
+
+    public String getDeliverLogsPermissionArn() { return deliverLogsPermissionArn; }
+    public void setDeliverLogsPermissionArn(String deliverLogsPermissionArn) {
+        this.deliverLogsPermissionArn = deliverLogsPermissionArn;
+    }
 
     public String getBucketName() { return bucketName; }
     public void setBucketName(String bucketName) { this.bucketName = bucketName; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2FlowLogCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/Ec2FlowLogCfnProvisionerTest.java
@@ -62,15 +62,17 @@ class Ec2FlowLogCfnProvisionerTest {
     @Test
     void flowLogSetsPhysicalIdAndIdAttribute() {
         when(flowLogs.createFlowLog(eq("us-east-1"), eq("vpc-123"), eq("VPC"), eq("ALL"),
-                eq("s3"), eq("arn:aws:s3:::flow-bucket"), eq("${srcaddr}"), eq(60)))
+                eq("cloud-watch-logs"), eq("arn:aws:logs:us-east-1:000000000000:log-group:flows"),
+                eq("arn:aws:iam::000000000000:role/flow-logs-role"), eq("${srcaddr}"), eq(60)))
                 .thenReturn(flowLog("fl-0abc"));
         StackResource r = resource();
         ObjectNode props = mapper.createObjectNode()
                 .put("ResourceId", "vpc-123")
                 .put("ResourceType", "VPC")
                 .put("TrafficType", "ALL")
-                .put("LogDestinationType", "s3")
-                .put("LogDestination", "arn:aws:s3:::flow-bucket")
+                .put("LogDestinationType", "cloud-watch-logs")
+                .put("LogDestination", "arn:aws:logs:us-east-1:000000000000:log-group:flows")
+                .put("DeliverLogsPermissionArn", "arn:aws:iam::000000000000:role/flow-logs-role")
                 .put("LogFormat", "${srcaddr}")
                 .put("MaxAggregationInterval", 60);
 
@@ -82,12 +84,12 @@ class Ec2FlowLogCfnProvisionerTest {
 
     @Test
     void omittedAggregationIntervalDefaultsToTenMinutes() {
-        when(flowLogs.createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(flowLogs.createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn(flowLog("fl-0def"));
 
         provisioner.provision(resource(), mapper.createObjectNode().put("ResourceId", "vpc-9"), ctx());
 
-        verify(flowLogs).createFlowLog("us-east-1", "vpc-9", null, null, null, null, null, 600);
+        verify(flowLogs).createFlowLog("us-east-1", "vpc-9", null, null, null, null, null, null, 600);
     }
 
     @Test
@@ -104,7 +106,7 @@ class Ec2FlowLogCfnProvisionerTest {
         provisioner.provision(r, mapper.createObjectNode().put("ResourceId", "vpc-123"), ctx());
 
         // A second flow log here outlives the stack: delete only knows the id recorded last.
-        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt());
         assertEquals("fl-0abc", r.getPhysicalId());
         assertEquals("fl-0abc", r.getAttributes().get("Id"));
     }
@@ -123,7 +125,23 @@ class Ec2FlowLogCfnProvisionerTest {
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r,
                 mapper.createObjectNode().put("ResourceId", "vpc-123").put("TrafficType", "REJECT"), ctx()));
         assertEquals("ValidationError", e.getErrorCode());
-        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt());
+    }
+
+    @Test
+    void changingTheDeliverLogsPermissionArnReportsAnUnsupportedReplacement() {
+        StackResource r = resource();
+        r.setPhysicalId("fl-0abc");
+        FlowLog existing = flowLog("fl-0abc");
+        existing.setResourceId("vpc-123");
+        existing.setDeliverLogsPermissionArn("arn:aws:iam::000000000000:role/old-role");
+        when(flowLogs.describeFlowLogs("us-east-1", List.of("fl-0abc"))).thenReturn(List.of(existing));
+
+        AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r,
+                mapper.createObjectNode().put("ResourceId", "vpc-123")
+                        .put("DeliverLogsPermissionArn", "arn:aws:iam::000000000000:role/new-role"), ctx()));
+        assertEquals("ValidationError", e.getErrorCode());
+        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt());
     }
 
     @Test
@@ -141,7 +159,7 @@ class Ec2FlowLogCfnProvisionerTest {
         AwsException e = assertThrows(AwsException.class, () -> provisioner.provision(r,
                 mapper.createObjectNode().put("ResourceId", "vpc-123"), ctx()));
         assertEquals("ValidationError", e.getErrorCode());
-        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt());
     }
 
     @Test
@@ -160,7 +178,7 @@ class Ec2FlowLogCfnProvisionerTest {
         provisioner.provision(r, mapper.createObjectNode().put("ResourceId", "vpc-123"), ctx());
 
         assertEquals("fl-0abc", r.getPhysicalId());
-        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), anyInt());
+        verify(flowLogs, never()).createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt());
     }
 
     @Test
@@ -183,7 +201,7 @@ class Ec2FlowLogCfnProvisionerTest {
         StackResource r = resource();
         r.setPhysicalId("fl-gone");
         when(flowLogs.describeFlowLogs("us-east-1", List.of("fl-gone"))).thenReturn(List.of());
-        when(flowLogs.createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), anyInt()))
+        when(flowLogs.createFlowLog(anyString(), any(), any(), any(), any(), any(), any(), any(), anyInt()))
                 .thenReturn(flowLog("fl-new"));
 
         provisioner.provision(r, mapper.createObjectNode().put("ResourceId", "vpc-123"), ctx());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2FlowLogIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2FlowLogIntegrationTest.java
@@ -25,6 +25,7 @@ class Ec2FlowLogIntegrationTest {
 
     private static String vpcId;
     private static String flowLogId;
+    private static String cloudWatchFlowLogId;
 
     // =========================================================================
     // Fixture: a VPC to attach the flow log to
@@ -119,6 +120,54 @@ class Ec2FlowLogIntegrationTest {
 
     @Test
     @Order(13)
+    void createFlowLogsWithACloudWatchDestinationKeepsTheDeliverLogsPermissionArn() {
+        // Terraform reads aws_flow_log.iam_role_arn back from DescribeFlowLogs. A dropped ARN
+        // reads as empty and every later plan proposes replacing the flow log.
+        cloudWatchFlowLogId = given()
+            .formParam("Action", "CreateFlowLogs")
+            .formParam("ResourceType", "VPC")
+            .formParam("ResourceId.1", vpcId)
+            .formParam("TrafficType", "ALL")
+            .formParam("LogDestinationType", "cloud-watch-logs")
+            .formParam("LogDestination", "arn:aws:logs:us-east-1:000000000000:log-group:/aws/vpc/flow-logs")
+            .formParam("DeliverLogsPermissionArn", "arn:aws:iam::000000000000:role/flow-logs-role")
+            .formParam("MaxAggregationInterval", "600")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("CreateFlowLogsResponse.flowLogIdSet.item[0]", startsWith("fl-"))
+            .extract().path("CreateFlowLogsResponse.flowLogIdSet.item[0]");
+
+        given()
+            .formParam("Action", "DescribeFlowLogs")
+            .formParam("FlowLogId.1", cloudWatchFlowLogId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].flowLogId", equalTo(cloudWatchFlowLogId))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].logDestinationType", equalTo("cloud-watch-logs"))
+            .body("DescribeFlowLogsResponse.flowLogSet.item[0].deliverLogsPermissionArn",
+                    equalTo("arn:aws:iam::000000000000:role/flow-logs-role"));
+
+        given()
+            .formParam("Action", "DeleteFlowLogs")
+            .formParam("FlowLogId.1", cloudWatchFlowLogId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml");
+    }
+
+    @Test
+    @Order(14)
     void deleteFlowLogs() {
         given()
             .formParam("Action", "DeleteFlowLogs")

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/FlowLogServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/FlowLogServiceTest.java
@@ -33,7 +33,7 @@ class FlowLogServiceTest {
     @Test
     void deleteFlowLogsIsScopedToTheRequestRegion() {
         FlowLog fl = flowLogService.createFlowLog("us-east-1", "vpc-123", "VPC", "ALL",
-                "s3", "arn:aws:s3:::flow-bucket", null, 600);
+                "s3", "arn:aws:s3:::flow-bucket", null, null, 600);
 
         List<String> otherRegion = flowLogService.deleteFlowLogs("eu-west-1", List.of(fl.getFlowLogId()));
 
@@ -44,6 +44,17 @@ class FlowLogServiceTest {
 
         assertEquals(List.of(fl.getFlowLogId()), sameRegion);
         assertTrue(flowLogService.describeFlowLogs("us-east-1", List.of()).isEmpty());
+    }
+
+    @Test
+    void createFlowLogKeepsTheDeliverLogsPermissionArn() {
+        FlowLog fl = flowLogService.createFlowLog("us-east-1", "vpc-123", "VPC", "ALL",
+                "cloud-watch-logs", "arn:aws:logs:us-east-1:000000000000:log-group:flows",
+                "arn:aws:iam::000000000000:role/flow-logs-role", null, 600);
+
+        FlowLog described = flowLogService.describeFlowLogs("us-east-1", List.of(fl.getFlowLogId())).get(0);
+
+        assertEquals("arn:aws:iam::000000000000:role/flow-logs-role", described.getDeliverLogsPermissionArn());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Ports lex00/floci#96.

A flow log with a CloudWatch Logs destination delivers through the IAM role given as `DeliverLogsPermissionArn`. Floci dropped the value on `CreateFlowLogs` and never returned it from `DescribeFlowLogs`. Terraform reads `aws_flow_log.iam_role_arn` back from describe, so it always came back empty and every plan proposed replacing the flow log, even right after an apply that passed a real ARN.

The Query handler and the `AWS::EC2::FlowLog` provisioner now pass the value into `FlowLogService.createFlowLog`, and `DescribeFlowLogs` returns it as `deliverLogsPermissionArn`. The provisioner treats a changed ARN on update the way it treats the other createOnly properties, since AWS replaces the flow log for it.

Tests cover the Query round trip through a real create and describe. The provisioner test checks the pass-through and the update rejection.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior. `DescribeFlowLogs` omitted `deliverLogsPermissionArn` for a flow log created with one. AWS returns it whenever the flow log was created with the parameter.

## Checklist

- [x] `./mvnw test` passes locally for the flow log service and provisioner tests plus the EC2 flow log integration test
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
