### PR TITLE
feat(ssm): answer the public Amazon Linux AMI parameters

### DIFF
--- a/docs/services/ssm.md
+++ b/docs/services/ssm.md
@@ -91,6 +91,18 @@ aws ssm send-command --endpoint-url $AWS_ENDPOINT_URL \
   --parameters commands='["echo hello"]'
 ```
 
+## Public AMI Parameters
+
+AWS publishes AMI id lookup parameters under `/aws/service/ami-amazon-linux-latest/` in every
+account, and Terraform modules read them without any setup. Floci answers the documented Amazon
+Linux 2 and Amazon Linux 2023 names from its EC2 image catalog, so `GetParameter`, `GetParameters`
+and `GetParametersByPath` resolve them to the catalog's AMI ids. As on AWS they are read-only and
+belong to no account, so they do not appear in `DescribeParameters`.
+
+```bash
+aws ssm get-parameter --name /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+```
+
 ## Parameter Types
 
 All AWS parameter types are accepted: `String`, `StringList`, `SecureString`.

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ImageCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2ImageCatalog.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ec2;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,22 @@ public class Ec2ImageCatalog {
         return Optional.ofNullable(loaded().imagesByIdOrAlias.get(imageId));
     }
 
+    /**
+     * Looks up the image published under one of AWS's public SSM parameter names, such as
+     * {@code /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64}.
+     */
+    public Optional<CatalogImage> findByPublicParameterName(String parameterName) {
+        if (parameterName == null || parameterName.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(loaded().imagesByPublicParameterName.get(parameterName));
+    }
+
+    /** Every public SSM parameter name the catalog answers, in catalog order. */
+    public List<String> publicParameterNames() {
+        return List.copyOf(loaded().imagesByPublicParameterName.keySet());
+    }
+
     private Loaded loaded() {
         Loaded result = loaded;
         if (result == null) {
@@ -67,6 +84,7 @@ public class Ec2ImageCatalog {
         private final String defaultDockerImage;
         private final List<CatalogImage> images;
         private final Map<String, CatalogImage> imagesByIdOrAlias;
+        private final Map<String, CatalogImage> imagesByPublicParameterName;
 
         Loaded(Catalog catalog) {
             this.defaultDockerImage = require(catalog.defaultDockerImage, "defaultDockerImage");
@@ -75,6 +93,7 @@ public class Ec2ImageCatalog {
                 throw new IllegalStateException("EC2 image catalog has no images: " + CATALOG_RESOURCE_NAME);
             }
             this.imagesByIdOrAlias = indexImages(this.images);
+            this.imagesByPublicParameterName = indexPublicParameterNames(this.images);
         }
     }
 
@@ -107,6 +126,20 @@ public class Ec2ImageCatalog {
         return Map.copyOf(index);
     }
 
+    private static Map<String, CatalogImage> indexPublicParameterNames(List<CatalogImage> images) {
+        Map<String, CatalogImage> index = new LinkedHashMap<>();
+        for (CatalogImage image : images) {
+            for (String parameterName : image.publicParameterNames()) {
+                CatalogImage previous = index.putIfAbsent(parameterName, image);
+                if (previous != null) {
+                    throw new IllegalStateException(
+                            "Duplicate EC2 image catalog public parameter name: " + parameterName);
+                }
+            }
+        }
+        return Collections.unmodifiableMap(index);
+    }
+
     private static void addIndexEntry(Map<String, CatalogImage> index, String imageIdOrAlias, CatalogImage image) {
         CatalogImage previous = index.putIfAbsent(imageIdOrAlias, image);
         if (previous != null) {
@@ -133,6 +166,7 @@ public class Ec2ImageCatalog {
     public static final class CatalogImage {
         public String imageId;
         public List<String> aliases = List.of();
+        public List<String> publicParameterNames = List.of();
         public String dockerImage;
         public String name;
         public String description;
@@ -158,6 +192,14 @@ public class Ec2ImageCatalog {
 
         public List<String> aliases() {
             return aliases == null ? List.of() : List.copyOf(aliases);
+        }
+
+        /**
+         * The public SSM parameter names AWS publishes this image under. AWS seeds them in every
+         * account with no setup, so SSM answers a read of one of these names from the catalog.
+         */
+        public List<String> publicParameterNames() {
+            return publicParameterNames == null ? List.of() : List.copyOf(publicParameterNames);
         }
 
         public List<String> idsAndAliases() {

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
@@ -195,13 +195,17 @@ public class SsmService implements ResourceProvider {
     }
 
     /**
-     * AWS reserves the {@code aws} and {@code ssm} prefixes, with or without a leading slash
-     * and regardless of case, so an account can never write over a public parameter.
+     * AWS reserves the {@code aws} and {@code ssm} namespaces, with or without a leading slash
+     * and regardless of case, so an account can never write over a public parameter. The rule
+     * keys on the first path segment rather than a bare prefix, so a name such as
+     * {@code ssm-auto-stack-Param-ABC}, which CloudFormation generates for a stack whose name
+     * starts with ssm, is still accepted.
      */
     private static void rejectReservedName(String name) {
         String bare = name == null ? "" : name.startsWith("/") ? name.substring(1) : name;
         String lower = bare.toLowerCase(Locale.ROOT);
-        if (lower.startsWith("aws") || lower.startsWith("ssm")) {
+        if (lower.equals("aws") || lower.equals("ssm")
+                || lower.startsWith("aws/") || lower.startsWith("ssm/")) {
             throw new AwsException("ValidationException",
                     "Parameter name: can't be prefixed with \"aws\" or \"ssm\" (case-insensitive). "
                             + "If formed as a path, it can consist of sub-paths divided by slash symbol; "

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
@@ -6,6 +6,7 @@ import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.ec2.Ec2ImageCatalog;
 import io.github.hectorvent.floci.services.ssm.model.Parameter;
 import io.github.hectorvent.floci.services.ssm.model.ParameterHistory;
 import io.github.hectorvent.floci.services.ssm.model.PatchBaselineIdentity;
@@ -31,6 +32,8 @@ public class SsmService implements ResourceProvider {
 
     private static final Logger LOG = Logger.getLogger(SsmService.class);
 
+    private static final String PUBLIC_PARAMETER_PREFIX = "/aws/service/";
+
     /**
      * Account-default values for the service settings floci models. AWS rejects
      * unknown setting ids with ServiceSettingNotFound; so do we.
@@ -50,9 +53,11 @@ public class SsmService implements ResourceProvider {
     private final StorageBackend<String, SsmAssociation> associationStore;
     private final int maxParameterHistory;
     private final RegionResolver regionResolver;
+    private final Ec2ImageCatalog imageCatalog;
 
     @Inject
-    public SsmService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver) {
+    public SsmService(StorageFactory storageFactory, EmulatorConfig config, RegionResolver regionResolver,
+                      Ec2ImageCatalog imageCatalog) {
         this(
                 storageFactory.create("ssm", "ssm-parameters.json",
                         new TypeReference<>() {
@@ -73,7 +78,8 @@ public class SsmService implements ResourceProvider {
                         new TypeReference<>() {
                         }),
                 config.services().ssm().maxParameterHistory(),
-                regionResolver
+                regionResolver,
+                imageCatalog
         );
     }
 
@@ -117,6 +123,22 @@ public class SsmService implements ResourceProvider {
                StorageBackend<String, ServiceSetting> serviceSettingStore,
                StorageBackend<String, SsmAssociation> associationStore,
                int maxParameterHistory, RegionResolver regionResolver) {
+        this(parameterStore, historyStore, documentPermissionStore, documentStore,
+                serviceSettingStore, associationStore, maxParameterHistory, regionResolver, null);
+    }
+
+    /**
+     * Package-private constructor for testing without CDI. A null image catalog means no
+     * public parameters are answered.
+     */
+    SsmService(StorageBackend<String, Parameter> parameterStore,
+               StorageBackend<String, List<ParameterHistory>> historyStore,
+               StorageBackend<String, List<String>> documentPermissionStore,
+               StorageBackend<String, SsmDocument> documentStore,
+               StorageBackend<String, ServiceSetting> serviceSettingStore,
+               StorageBackend<String, SsmAssociation> associationStore,
+               int maxParameterHistory, RegionResolver regionResolver,
+               Ec2ImageCatalog imageCatalog) {
         this.parameterStore = parameterStore;
         this.historyStore = historyStore;
         this.documentPermissionStore = documentPermissionStore;
@@ -125,6 +147,7 @@ public class SsmService implements ResourceProvider {
         this.associationStore = associationStore;
         this.maxParameterHistory = maxParameterHistory;
         this.regionResolver = regionResolver;
+        this.imageCatalog = imageCatalog;
     }
 
     /**
@@ -157,8 +180,7 @@ public class SsmService implements ResourceProvider {
     }
 
     public Parameter getParameter(String name, String region) {
-        String storageKey = regionKey(region, name);
-        return parameterStore.get(storageKey)
+        return findParameter(name, region)
                 .orElseThrow(() -> new AwsException("ParameterNotFound",
                         "Parameter " + name + " not found.", 400));
     }
@@ -166,29 +188,67 @@ public class SsmService implements ResourceProvider {
     public List<Parameter> getParameters(List<String> names, String region) {
         List<Parameter> result = new ArrayList<>();
         for (String name : names) {
-            parameterStore.get(regionKey(region, name)).ifPresent(result::add);
+            findParameter(name, region).ifPresent(result::add);
         }
         return result;
+    }
+
+    private Optional<Parameter> findParameter(String name, String region) {
+        Optional<Parameter> stored = parameterStore.get(regionKey(region, name));
+        if (stored.isPresent()) {
+            return stored;
+        }
+        return publicParameter(name, region);
+    }
+
+    /**
+     * AWS publishes read-only AMI id parameters under {@code /aws/service/} in every account
+     * with no setup, so a read of one of those names is answered from the EC2 image catalog.
+     * Nothing is written: like on AWS the parameter is not the account's own, so it never
+     * shows up in DescribeParameters or GetParameterHistory. Any other name under the prefix
+     * is still ParameterNotFound.
+     */
+    private Optional<Parameter> publicParameter(String name, String region) {
+        if (imageCatalog == null || name == null || !name.startsWith(PUBLIC_PARAMETER_PREFIX)) {
+            return Optional.empty();
+        }
+        return imageCatalog.findByPublicParameterName(name).map(image -> {
+            Parameter parameter = new Parameter(name, image.imageId, "String");
+            parameter.setArn("arn:aws:ssm:" + region + "::parameter" + name);
+            parameter.setLastModifiedDate(Instant.parse(image.creationDate));
+            return parameter;
+        });
     }
 
     public List<Parameter> getParametersByPath(String path, boolean recursive, String region) {
         String normalizedPath = path.endsWith("/") ? path : path + "/";
         String prefix = region + "::";
 
-        return parameterStore.scan(key -> {
+        List<Parameter> result = new ArrayList<>(parameterStore.scan(key -> {
             if (!key.startsWith(prefix)) {
                 return false;
             }
-            String paramName = key.substring(prefix.length());
-            if (!paramName.startsWith(normalizedPath)) {
-                return false;
+            return underPath(key.substring(prefix.length()), normalizedPath, recursive);
+        }));
+        if (imageCatalog != null && normalizedPath.startsWith(PUBLIC_PARAMETER_PREFIX)) {
+            for (String name : imageCatalog.publicParameterNames()) {
+                if (underPath(name, normalizedPath, recursive)
+                        && parameterStore.get(regionKey(region, name)).isEmpty()) {
+                    publicParameter(name, region).ifPresent(result::add);
+                }
             }
-            if (recursive) {
-                return true;
-            }
-            String remainder = paramName.substring(normalizedPath.length());
-            return !remainder.contains("/");
-        });
+        }
+        return result;
+    }
+
+    private static boolean underPath(String paramName, String normalizedPath, boolean recursive) {
+        if (!paramName.startsWith(normalizedPath)) {
+            return false;
+        }
+        if (recursive) {
+            return true;
+        }
+        return !paramName.substring(normalizedPath.length()).contains("/");
     }
 
     public void deleteParameter(String name, String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmService.java
@@ -155,6 +155,7 @@ public class SsmService implements ResourceProvider {
      * Returns the version number.
      */
     public long putParameter(String name, String value, String type, String description, boolean overwrite, String region) {
+        rejectReservedName(name);
         String storageKey = regionKey(region, name);
         Parameter existing = parameterStore.get(storageKey).orElse(null);
 
@@ -191,6 +192,22 @@ public class SsmService implements ResourceProvider {
             findParameter(name, region).ifPresent(result::add);
         }
         return result;
+    }
+
+    /**
+     * AWS reserves the {@code aws} and {@code ssm} prefixes, with or without a leading slash
+     * and regardless of case, so an account can never write over a public parameter.
+     */
+    private static void rejectReservedName(String name) {
+        String bare = name == null ? "" : name.startsWith("/") ? name.substring(1) : name;
+        String lower = bare.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("aws") || lower.startsWith("ssm")) {
+            throw new AwsException("ValidationException",
+                    "Parameter name: can't be prefixed with \"aws\" or \"ssm\" (case-insensitive). "
+                            + "If formed as a path, it can consist of sub-paths divided by slash symbol; "
+                            + "each sub-path can be formed as a mix of letters, numbers and the following "
+                            + "3 symbols .-_", 400);
+        }
     }
 
     private Optional<Parameter> findParameter(String name, String region) {
@@ -230,10 +247,11 @@ public class SsmService implements ResourceProvider {
             }
             return underPath(key.substring(prefix.length()), normalizedPath, recursive);
         }));
-        if (imageCatalog != null && normalizedPath.startsWith(PUBLIC_PARAMETER_PREFIX)) {
+        if (imageCatalog != null) {
+            // The public names answer to the same path and Recursive rules as stored ones, so a
+            // recursive query on an ancestor such as /aws lists them too.
             for (String name : imageCatalog.publicParameterNames()) {
-                if (underPath(name, normalizedPath, recursive)
-                        && parameterStore.get(regionKey(region, name)).isEmpty()) {
+                if (underPath(name, normalizedPath, recursive)) {
                     publicParameter(name, region).ifPresent(result::add);
                 }
             }

--- a/src/main/resources/ec2/image-catalog.yaml
+++ b/src/main/resources/ec2/image-catalog.yaml
@@ -4,6 +4,10 @@ images:
   - imageId: ami-0abcdef1234567890
     aliases:
       - ami-amazonlinux2
+    publicParameterNames:
+      - /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2
+      - /aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-ebs
+      - /aws/service/ami-amazon-linux-latest/amzn2-ami-kernel-5.10-hvm-x86_64-gp2
     dockerImage: public.ecr.aws/amazonlinux/amazonlinux:2
     name: amzn2-ami-hvm-2.0.20230404.0-x86_64-gp2
     description: Amazon Linux 2 AMI
@@ -15,6 +19,10 @@ images:
   - imageId: ami-0abcdef1234567891
     aliases:
       - ami-amazonlinux2023
+    publicParameterNames:
+      - /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+      - /aws/service/ami-amazon-linux-latest/al2023-ami-minimal-kernel-default-x86_64
+      - /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64
     dockerImage: public.ecr.aws/amazonlinux/amazonlinux:2023
     name: al2023-ami-2023.0.20230315.0-kernel-6.1-x86_64
     description: Amazon Linux 2023 AMI

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -1365,6 +1365,20 @@ class SsmIntegrationTest {
             .body("__type", equalTo("ValidationException"))
             .body("message", containsString("can't be prefixed with \"aws\" or \"ssm\""));
 
+        // Only the aws and ssm path segments are reserved, so a CloudFormation-generated name
+        // for a stack called ssm-auto-stack still writes.
+        given()
+            .header("X-Amz-Target", "AmazonSSM.PutParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Name": "ssm-auto-stack-Param-ABC123", "Value": "ok", "Type": "String" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Version", equalTo(1));
+
         given()
             .header("X-Amz-Target", "AmazonSSM.GetParameter")
             .contentType(SSM_CONTENT_TYPE)

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -1286,6 +1286,64 @@ class SsmIntegrationTest {
             .body("AccountIds", empty());
     }
 
+    @Test
+    @Order(15)
+    void publicAmiParametersResolveWithoutSetup() {
+        String al2023 = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64";
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Name": "%s" }
+                """.formatted(al2023))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameter.Name", equalTo(al2023))
+            .body("Parameter.Value", equalTo("ami-0abcdef1234567891"))
+            .body("Parameter.Type", equalTo("String"))
+            .body("Parameter.Version", equalTo(1))
+            .body("Parameter.ARN", equalTo("arn:aws:ssm:us-east-1::parameter" + al2023));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameters")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Names": ["%s", "/aws/service/ami-amazon-linux-latest/no-such-variant"] }
+                """.formatted(al2023))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameters.Name", contains(al2023))
+            .body("InvalidParameters", contains("/aws/service/ami-amazon-linux-latest/no-such-variant"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParametersByPath")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Path": "/aws/service/ami-amazon-linux-latest" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameters.Name", hasItems(al2023,
+                    "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2"));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.DescribeParameters")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameters.Name", not(hasItem(al2023)));
+    }
+
     private static void createSharableDocument(String name) {
         given()
             .header("X-Amz-Target", "AmazonSSM.CreateDocument")

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmIntegrationTest.java
@@ -1344,6 +1344,40 @@ class SsmIntegrationTest {
             .body("Parameters.Name", not(hasItem(al2023)));
     }
 
+    @Test
+    @Order(16)
+    void putParameterRejectsReservedPrefixes() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.PutParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64",
+                    "Value": "ami-mine",
+                    "Type": "String",
+                    "Overwrite": true
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", containsString("can't be prefixed with \"aws\" or \"ssm\""));
+
+        given()
+            .header("X-Amz-Target", "AmazonSSM.GetParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                { "Name": "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64" }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Parameter.Value", equalTo("ami-0abcdef1234567891"));
+    }
+
     private static void createSharableDocument(String name) {
         given()
             .header("X-Amz-Target", "AmazonSSM.CreateDocument")

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmServicePublicAmiParameterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmServicePublicAmiParameterTest.java
@@ -1,0 +1,107 @@
+package io.github.hectorvent.floci.services.ssm;
+
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.services.ec2.Ec2ImageCatalog;
+import io.github.hectorvent.floci.services.ssm.model.Parameter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * AWS seeds AMI id lookup parameters under {@code /aws/service/} in every account with no
+ * setup, and Terraform modules read them unconditionally, so a read of one of the documented
+ * names must resolve here too.
+ */
+class SsmServicePublicAmiParameterTest {
+
+    private static final String REGION = "eu-west-1";
+    private static final String AL2023_DEFAULT =
+            "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64";
+    private static final String AMZN2_DEFAULT =
+            "/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2";
+
+    private SsmService ssmService;
+
+    @BeforeEach
+    void setUp() {
+        ssmService = new SsmService(
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                new InMemoryStorage<>(), new InMemoryStorage<>(), new InMemoryStorage<>(),
+                5, new RegionResolver(REGION, "000000000000"), new Ec2ImageCatalog());
+    }
+
+    @Test
+    void resolvesTheDocumentedAl2023DefaultFromTheImageCatalog() {
+        Parameter param = ssmService.getParameter(AL2023_DEFAULT, REGION);
+
+        assertEquals("ami-0abcdef1234567891", param.getValue());
+        assertEquals("String", param.getType());
+        assertEquals(1, param.getVersion());
+        assertEquals("arn:aws:ssm:eu-west-1::parameter" + AL2023_DEFAULT, param.getArn());
+        assertEquals(Instant.parse("2023-03-15T00:00:00.000Z"), param.getLastModifiedDate());
+    }
+
+    @Test
+    void resolvesTheDocumentedAmzn2DefaultFromTheImageCatalog() {
+        assertEquals("ami-0abcdef1234567890", ssmService.getParameter(AMZN2_DEFAULT, REGION).getValue());
+    }
+
+    @Test
+    void getParametersAnswersPublicNamesAlongsideStoredOnes() {
+        ssmService.putParameter("/app/ami", "ami-custom", "String", null, false, REGION);
+
+        List<Parameter> params = ssmService.getParameters(
+                List.of("/app/ami", AL2023_DEFAULT, "/app/missing"), REGION);
+
+        assertEquals(List.of("/app/ami", AL2023_DEFAULT), params.stream().map(Parameter::getName).toList());
+    }
+
+    @Test
+    void getParametersByPathListsThePublicFamily() {
+        List<Parameter> params = ssmService.getParametersByPath(
+                "/aws/service/ami-amazon-linux-latest", false, REGION);
+
+        List<String> names = params.stream().map(Parameter::getName).toList();
+        assertTrue(names.contains(AL2023_DEFAULT), names.toString());
+        assertTrue(names.contains(AMZN2_DEFAULT), names.toString());
+        assertTrue(ssmService.getParametersByPath("/aws/service", false, REGION).isEmpty());
+        assertEquals(names.size(), ssmService.getParametersByPath("/aws/service", true, REGION).size());
+    }
+
+    @Test
+    void publicParametersAreNotTheAccountsOwn() {
+        ssmService.getParameter(AL2023_DEFAULT, REGION);
+
+        assertTrue(ssmService.describeParameters(REGION).isEmpty());
+        assertThrows(AwsException.class, () -> ssmService.getParameterHistory(AL2023_DEFAULT, REGION));
+    }
+
+    @Test
+    void anUnknownNameUnderTheSamePrefixStillFails() {
+        AwsException ex = assertThrows(AwsException.class, () -> ssmService.getParameter(
+                "/aws/service/ami-amazon-linux-latest/no-such-variant-x86_64", REGION));
+        assertEquals("ParameterNotFound", ex.getErrorCode());
+    }
+
+    @Test
+    void anUnrelatedUnknownNameStillFails() {
+        AwsException ex = assertThrows(AwsException.class, () ->
+                ssmService.getParameter("/app/does-not-exist", REGION));
+        assertEquals("ParameterNotFound", ex.getErrorCode());
+    }
+
+    @Test
+    void withoutACatalogNothingIsSeeded() {
+        SsmService bare = new SsmService(new InMemoryStorage<>(), new InMemoryStorage<>(), 5);
+
+        assertThrows(AwsException.class, () -> bare.getParameter(AL2023_DEFAULT, REGION));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmServicePublicAmiParameterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmServicePublicAmiParameterTest.java
@@ -77,6 +77,31 @@ class SsmServicePublicAmiParameterTest {
     }
 
     @Test
+    void ancestorQueriesFollowTheSamePathRules() {
+        List<String> recursive = ssmService.getParametersByPath("/aws", true, REGION)
+                .stream().map(Parameter::getName).toList();
+
+        assertTrue(recursive.contains(AL2023_DEFAULT), recursive.toString());
+        assertTrue(ssmService.getParametersByPath("/aws", false, REGION).isEmpty());
+        assertTrue(ssmService.getParametersByPath("/aws/service", false, REGION).isEmpty());
+        assertTrue(ssmService.getParametersByPath("/aws/service", true, REGION)
+                .stream().map(Parameter::getName).toList().contains(AMZN2_DEFAULT));
+    }
+
+    @Test
+    void putParameterRejectsTheReservedPrefixesSoPublicNamesCannotBeShadowed() {
+        for (String name : List.of(AL2023_DEFAULT, "/aws/custom", "aws-custom", "/AWS/custom",
+                "/ssm/custom", "SsmThing")) {
+            AwsException ex = assertThrows(AwsException.class, () ->
+                    ssmService.putParameter(name, "ami-mine", "String", null, true, REGION), name);
+            assertEquals("ValidationException", ex.getErrorCode(), name);
+            assertEquals(400, ex.getHttpStatus(), name);
+        }
+        assertEquals("ami-0abcdef1234567891", ssmService.getParameter(AL2023_DEFAULT, REGION).getValue());
+        assertEquals(1, ssmService.putParameter("/awesome/param", "ok", "String", null, false, REGION));
+    }
+
+    @Test
     void publicParametersAreNotTheAccountsOwn() {
         ssmService.getParameter(AL2023_DEFAULT, REGION);
 

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmServicePublicAmiParameterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmServicePublicAmiParameterTest.java
@@ -90,15 +90,19 @@ class SsmServicePublicAmiParameterTest {
 
     @Test
     void putParameterRejectsTheReservedPrefixesSoPublicNamesCannotBeShadowed() {
-        for (String name : List.of(AL2023_DEFAULT, "/aws/custom", "aws-custom", "/AWS/custom",
-                "/ssm/custom", "SsmThing")) {
+        for (String name : List.of(AL2023_DEFAULT, "/aws/custom", "aws/custom", "/AWS/custom",
+                "/ssm/custom", "SSM/x", "/aws", "ssm")) {
             AwsException ex = assertThrows(AwsException.class, () ->
                     ssmService.putParameter(name, "ami-mine", "String", null, true, REGION), name);
             assertEquals("ValidationException", ex.getErrorCode(), name);
             assertEquals(400, ex.getHttpStatus(), name);
         }
         assertEquals("ami-0abcdef1234567891", ssmService.getParameter(AL2023_DEFAULT, REGION).getValue());
-        assertEquals(1, ssmService.putParameter("/awesome/param", "ok", "String", null, false, REGION));
+        // Only the aws and ssm path segments are reserved. CloudFormation names an
+        // AWS::SSM::Parameter after its stack, so a stack called ssm-auto-stack must still work.
+        for (String name : List.of("/awesome/param", "awsfoo", "ssm-thing", "ssm-auto-stack-Param-ABC")) {
+            assertEquals(1, ssmService.putParameter(name, "ok", "String", null, false, REGION), name);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Ports the SSM half of lex00/floci#116. AWS seeds AMI id lookup parameters under `/aws/service/ami-amazon-linux-latest/` in every account with no setup, and terraform-aws-modules/terraform-aws-ec2-instance reads one of them unconditionally through `data "aws_ssm_parameter"`. On Floci that read returned `ParameterNotFound`, which failed the module's cold deploy even when the caller passed an explicit AMI.

`GetParameter`, `GetParameters` and `GetParametersByPath` now resolve the documented Amazon Linux 2 and Amazon Linux 2023 names from the EC2 image catalog. Each catalog entry lists the public names it is published under. The answer is therefore the same AMI id that `DescribeImages` already returns. The parameter is synthesized on read rather than written, since on AWS it belongs to no account. Its ARN carries the empty account field AWS uses for public parameters, and it stays out of `DescribeParameters` and the history. Any other name under the prefix is still `ParameterNotFound`.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified against the AWS docs for public parameters and the SSM JSON 1.1 wire shape the existing integration test uses. A unit test covers the catalog lookup and the read-only semantics, and `SsmIntegrationTest` gains a case through the protocol for all three read actions plus the `DescribeParameters` exclusion.

## Checklist

- [x] `./mvnw test` passes locally for `Ssm*` and `Ec2ImageCatalog*` with 158 tests
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
