### PR TITLE
fix(autoscaling): round-trip launch configuration InstanceMonitoring and BlockDeviceMappings

### DIFF
--- a/docs/services/autoscaling.md
+++ b/docs/services/autoscaling.md
@@ -16,7 +16,7 @@ Floci implements the EC2 Auto Scaling API — stored-state management for launch
 
 | Operation | Notes |
 |---|---|
-| `CreateLaunchConfiguration` | Stores template: `ImageId`, `InstanceType`, `KeyName`, `SecurityGroups`, `UserData`, `IamInstanceProfile` |
+| `CreateLaunchConfiguration` | Stores template: `ImageId`, `InstanceType`, `KeyName`, `SecurityGroups`, `UserData`, `IamInstanceProfile`, `InstanceMonitoring`, `BlockDeviceMappings` |
 | `DescribeLaunchConfigurations` | Filtered by name list; returns all if no filter |
 | `DeleteLaunchConfiguration` | Removes the named launch configuration |
 

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -117,7 +117,9 @@ public class AutoScalingQueryHandler {
                 memberList(p, "SecurityGroups"),
                 p.getFirst("UserData"),
                 p.getFirst("IamInstanceProfile"),
-                nullableBoolParam(p, "AssociatePublicIpAddress"));
+                nullableBoolParam(p, "AssociatePublicIpAddress"),
+                nullableBoolParam(p, "InstanceMonitoring.Enabled"),
+                parseLaunchConfigurationBlockDeviceMappings(p));
         String xml = new XmlBuilder()
                 .start("CreateLaunchConfigurationResponse", NS)
                   .raw(AwsQueryResponse.responseMetadata())
@@ -150,7 +152,15 @@ public class AutoScalingQueryHandler {
             if (lc.getIamInstanceProfile() != null) { xml.elem("IamInstanceProfile", lc.getIamInstanceProfile()); }
             xml.start("SecurityGroups");
             for (String sg : lc.getSecurityGroups()) { xml.elem("member", sg); }
-            xml.end("SecurityGroups").end("member");
+            xml.end("SecurityGroups");
+            // AWS always returns both structures. A record from before these fields were
+            // stored reads back AWS's default of enabled and an empty mapping list.
+            xml.start("InstanceMonitoring")
+               .elem("Enabled", String.valueOf(
+                       lc.getInstanceMonitoringEnabled() != null ? lc.getInstanceMonitoringEnabled() : Boolean.TRUE))
+               .end("InstanceMonitoring");
+            writeLaunchConfigurationBlockDeviceMappings(xml, lc.getBlockDeviceMappings());
+            xml.end("member");
         }
         xml.end("LaunchConfigurations")
            .end("DescribeLaunchConfigurationsResult")
@@ -1396,6 +1406,101 @@ public class AutoScalingQueryHandler {
         String val = p.getFirst(key);
         if (val == null || val.isBlank()) { return null; }
         return Boolean.parseBoolean(val);
+    }
+
+    private List<LaunchConfigurationBlockDeviceMapping> parseLaunchConfigurationBlockDeviceMappings(
+            MultivaluedMap<String, String> p) {
+        List<LaunchConfigurationBlockDeviceMapping> mappings = new ArrayList<>();
+        for (int i = 1; ; i++) {
+            String prefix = "BlockDeviceMappings.member." + i;
+            String deviceName = p.getFirst(prefix + ".DeviceName");
+            String virtualName = p.getFirst(prefix + ".VirtualName");
+            String noDevice = p.getFirst(prefix + ".NoDevice");
+            String snapshotId = p.getFirst(prefix + ".Ebs.SnapshotId");
+            String volumeSize = p.getFirst(prefix + ".Ebs.VolumeSize");
+            String volumeType = p.getFirst(prefix + ".Ebs.VolumeType");
+            String deleteOnTermination = p.getFirst(prefix + ".Ebs.DeleteOnTermination");
+            String iops = p.getFirst(prefix + ".Ebs.Iops");
+            String throughput = p.getFirst(prefix + ".Ebs.Throughput");
+            String encrypted = p.getFirst(prefix + ".Ebs.Encrypted");
+            boolean hasEbs = snapshotId != null || volumeSize != null || volumeType != null
+                    || deleteOnTermination != null || iops != null || throughput != null || encrypted != null;
+            if (deviceName == null && virtualName == null && noDevice == null && !hasEbs) {
+                break;
+            }
+            if (deviceName == null || deviceName.isBlank()) {
+                throw new AwsException("ValidationError",
+                        "1 validation error detected: Value null at '" + prefix
+                                + ".DeviceName' failed to satisfy constraint: Member must not be null", 400);
+            }
+            LaunchConfigurationBlockDeviceMapping mapping = new LaunchConfigurationBlockDeviceMapping();
+            mapping.setDeviceName(deviceName);
+            mapping.setVirtualName(virtualName);
+            mapping.setNoDevice(parseOptionalBoolean(noDevice, prefix + ".NoDevice"));
+            if (hasEbs) {
+                LaunchConfigurationBlockDeviceMapping.Ebs ebs = new LaunchConfigurationBlockDeviceMapping.Ebs();
+                ebs.setSnapshotId(snapshotId);
+                ebs.setVolumeSize(parseOptionalInt(volumeSize, prefix + ".Ebs.VolumeSize"));
+                ebs.setVolumeType(volumeType);
+                ebs.setDeleteOnTermination(parseOptionalBoolean(deleteOnTermination, prefix + ".Ebs.DeleteOnTermination"));
+                ebs.setIops(parseOptionalInt(iops, prefix + ".Ebs.Iops"));
+                ebs.setThroughput(parseOptionalInt(throughput, prefix + ".Ebs.Throughput"));
+                ebs.setEncrypted(parseOptionalBoolean(encrypted, prefix + ".Ebs.Encrypted"));
+                mapping.setEbs(ebs);
+            }
+            mappings.add(mapping);
+        }
+        return mappings;
+    }
+
+    private Integer parseOptionalInt(String value, String name) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            throw new AwsException("ValidationError", name + " must be an integer.", 400);
+        }
+    }
+
+    private Boolean parseOptionalBoolean(String value, String name) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+            return Boolean.parseBoolean(value);
+        }
+        throw new AwsException("ValidationError", name + " must be true or false.", 400);
+    }
+
+    // AWS returns an empty list when the launch configuration carries no mappings, so the
+    // element is always present.
+    private void writeLaunchConfigurationBlockDeviceMappings(
+            XmlBuilder xml, List<LaunchConfigurationBlockDeviceMapping> mappings) {
+        xml.start("BlockDeviceMappings");
+        for (LaunchConfigurationBlockDeviceMapping mapping : mappings != null ? mappings : List.<LaunchConfigurationBlockDeviceMapping>of()) {
+            xml.start("member");
+            if (mapping.getVirtualName() != null) { xml.elem("VirtualName", mapping.getVirtualName()); }
+            if (mapping.getDeviceName() != null) { xml.elem("DeviceName", mapping.getDeviceName()); }
+            if (mapping.getNoDevice() != null) { xml.elem("NoDevice", String.valueOf(mapping.getNoDevice())); }
+            LaunchConfigurationBlockDeviceMapping.Ebs ebs = mapping.getEbs();
+            if (ebs != null) {
+                xml.start("Ebs");
+                if (ebs.getSnapshotId() != null) { xml.elem("SnapshotId", ebs.getSnapshotId()); }
+                if (ebs.getVolumeSize() != null) { xml.elem("VolumeSize", String.valueOf(ebs.getVolumeSize())); }
+                if (ebs.getVolumeType() != null) { xml.elem("VolumeType", ebs.getVolumeType()); }
+                if (ebs.getDeleteOnTermination() != null) {
+                    xml.elem("DeleteOnTermination", String.valueOf(ebs.getDeleteOnTermination()));
+                }
+                if (ebs.getIops() != null) { xml.elem("Iops", String.valueOf(ebs.getIops())); }
+                if (ebs.getThroughput() != null) { xml.elem("Throughput", String.valueOf(ebs.getThroughput())); }
+                if (ebs.getEncrypted() != null) { xml.elem("Encrypted", String.valueOf(ebs.getEncrypted())); }
+                xml.end("Ebs");
+            }
+            xml.end("member");
+        }
+        xml.end("BlockDeviceMappings");
     }
 
     /** A required boolean member must be present and exactly "true"/"false" — never silently coerced to false. */

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingService.java
@@ -80,6 +80,17 @@ public class AutoScalingService {
                                                           List<String> securityGroups, String userData,
                                                           String iamInstanceProfile,
                                                           Boolean associatePublicIpAddress) {
+        return createLaunchConfiguration(region, name, instanceId, imageId, instanceType, keyName,
+                securityGroups, userData, iamInstanceProfile, associatePublicIpAddress, null, List.of());
+    }
+
+    public LaunchConfiguration createLaunchConfiguration(String region, String name, String instanceId,
+                                                          String imageId, String instanceType, String keyName,
+                                                          List<String> securityGroups, String userData,
+                                                          String iamInstanceProfile,
+                                                          Boolean associatePublicIpAddress,
+                                                          Boolean instanceMonitoringEnabled,
+                                                          List<LaunchConfigurationBlockDeviceMapping> blockDeviceMappings) {
         String key = lcKey(region, name);
         if (launchConfigs.containsKey(key)) {
             throw new AwsException("AlreadyExists",
@@ -131,6 +142,10 @@ public class AutoScalingService {
         lc.setUserData(userData);
         lc.setIamInstanceProfile(iamInstanceProfile);
         lc.setAssociatePublicIpAddress(associatePublicIpAddress);
+        // AWS documents InstanceMonitoring as enabled by default and always returns the
+        // structure from Describe, unlike AssociatePublicIpAddress whose absence is meaningful.
+        lc.setInstanceMonitoringEnabled(instanceMonitoringEnabled != null ? instanceMonitoringEnabled : Boolean.TRUE);
+        lc.setBlockDeviceMappings(blockDeviceMappings != null ? new ArrayList<>(blockDeviceMappings) : new ArrayList<>());
         lc.setCreatedTime(Instant.now());
         lc.setRegion(region);
         launchConfigs.put(key, lc);

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LaunchConfiguration.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LaunchConfiguration.java
@@ -22,6 +22,11 @@ public class LaunchConfiguration {
     // Nullable on purpose: AWS treats an absent flag as "fall back to the
     // subnet's MapPublicIpOnLaunch" and an explicit false as an override.
     private Boolean associatePublicIpAddress;
+    // Set on create to the caller's value or AWS's documented default of true. Left without
+    // a field default so a record persisted before the field existed reads back as unset
+    // rather than as monitored.
+    private Boolean instanceMonitoringEnabled;
+    private List<LaunchConfigurationBlockDeviceMapping> blockDeviceMappings = new ArrayList<>();
     private Instant createdTime;
     private String region;
 
@@ -53,6 +58,12 @@ public class LaunchConfiguration {
 
     public Boolean getAssociatePublicIpAddress() { return associatePublicIpAddress; }
     public void setAssociatePublicIpAddress(Boolean v) { this.associatePublicIpAddress = v; }
+
+    public Boolean getInstanceMonitoringEnabled() { return instanceMonitoringEnabled; }
+    public void setInstanceMonitoringEnabled(Boolean v) { this.instanceMonitoringEnabled = v; }
+
+    public List<LaunchConfigurationBlockDeviceMapping> getBlockDeviceMappings() { return blockDeviceMappings; }
+    public void setBlockDeviceMappings(List<LaunchConfigurationBlockDeviceMapping> v) { this.blockDeviceMappings = v; }
 
     public Instant getCreatedTime() { return createdTime; }
     public void setCreatedTime(Instant v) { this.createdTime = v; }

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LaunchConfigurationBlockDeviceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/model/LaunchConfigurationBlockDeviceMapping.java
@@ -1,0 +1,69 @@
+package io.github.hectorvent.floci.services.autoscaling.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+/**
+ * One entry of a launch configuration's {@code BlockDeviceMappings}. The shape follows the
+ * Auto Scaling API rather than EC2's, which has no {@code Throughput}, {@code Iops},
+ * {@code VirtualName} or {@code NoDevice} on its launch-time mapping.
+ */
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class LaunchConfigurationBlockDeviceMapping {
+
+    private String deviceName;
+    private String virtualName;
+    private Boolean noDevice;
+    private Ebs ebs;
+
+    public LaunchConfigurationBlockDeviceMapping() {}
+
+    public String getDeviceName() { return deviceName; }
+    public void setDeviceName(String v) { this.deviceName = v; }
+
+    public String getVirtualName() { return virtualName; }
+    public void setVirtualName(String v) { this.virtualName = v; }
+
+    public Boolean getNoDevice() { return noDevice; }
+    public void setNoDevice(Boolean v) { this.noDevice = v; }
+
+    public Ebs getEbs() { return ebs; }
+    public void setEbs(Ebs v) { this.ebs = v; }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Ebs {
+
+        private String snapshotId;
+        private Integer volumeSize;
+        private String volumeType;
+        private Boolean deleteOnTermination;
+        private Integer iops;
+        private Integer throughput;
+        private Boolean encrypted;
+
+        public Ebs() {}
+
+        public String getSnapshotId() { return snapshotId; }
+        public void setSnapshotId(String v) { this.snapshotId = v; }
+
+        public Integer getVolumeSize() { return volumeSize; }
+        public void setVolumeSize(Integer v) { this.volumeSize = v; }
+
+        public String getVolumeType() { return volumeType; }
+        public void setVolumeType(String v) { this.volumeType = v; }
+
+        public Boolean getDeleteOnTermination() { return deleteOnTermination; }
+        public void setDeleteOnTermination(Boolean v) { this.deleteOnTermination = v; }
+
+        public Integer getIops() { return iops; }
+        public void setIops(Integer v) { this.iops = v; }
+
+        public Integer getThroughput() { return throughput; }
+        public void setThroughput(Integer v) { this.throughput = v; }
+
+        public Boolean getEncrypted() { return encrypted; }
+        public void setEncrypted(Boolean v) { this.encrypted = v; }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -62,6 +62,94 @@ class AutoScalingIntegrationTest {
                 .body(containsString("t3.micro"));
     }
 
+    // AWS always returns InstanceMonitoring and BlockDeviceMappings from
+    // DescribeLaunchConfigurations. Omitting them made the Terraform provider read
+    // enable_monitoring as false and root_block_device as empty, which forced a
+    // replacement on every plan.
+    @Test
+    @Order(42)
+    void launchConfigurationRoundTripsMonitoringAndBlockDeviceMappings() {
+        given()
+                .formParam("Action", "CreateLaunchConfiguration")
+                .formParam("LaunchConfigurationName", "my-lc-with-root-device")
+                .formParam("ImageId", "ami-12345678")
+                .formParam("InstanceType", "t3.micro")
+                .formParam("InstanceMonitoring.Enabled", "false")
+                .formParam("BlockDeviceMappings.member.1.DeviceName", "/dev/xvda")
+                .formParam("BlockDeviceMappings.member.1.Ebs.VolumeSize", "100")
+                .formParam("BlockDeviceMappings.member.1.Ebs.VolumeType", "gp3")
+                .formParam("BlockDeviceMappings.member.1.Ebs.Throughput", "125")
+                .formParam("BlockDeviceMappings.member.1.Ebs.DeleteOnTermination", "true")
+                .formParam("BlockDeviceMappings.member.2.DeviceName", "/dev/sdb")
+                .formParam("BlockDeviceMappings.member.2.VirtualName", "ephemeral0")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("CreateLaunchConfigurationResponse"));
+
+        given()
+                .formParam("Action", "DescribeLaunchConfigurations")
+                .formParam("LaunchConfigurationNames.member.1", "my-lc-with-root-device")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<InstanceMonitoring><Enabled>false</Enabled></InstanceMonitoring>"))
+                .body(containsString("<DeviceName>/dev/xvda</DeviceName>"))
+                .body(containsString("<VolumeSize>100</VolumeSize>"))
+                .body(containsString("<VolumeType>gp3</VolumeType>"))
+                .body(containsString("<Throughput>125</Throughput>"))
+                .body(containsString("<DeleteOnTermination>true</DeleteOnTermination>"))
+                .body(containsString("<VirtualName>ephemeral0</VirtualName>"));
+    }
+
+    @Test
+    @Order(43)
+    void launchConfigurationDefaultsMonitoringToEnabledAndMappingsToEmpty() {
+        given()
+                .formParam("Action", "CreateLaunchConfiguration")
+                .formParam("LaunchConfigurationName", "my-lc-defaults")
+                .formParam("ImageId", "ami-12345678")
+                .formParam("InstanceType", "t3.micro")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+
+        given()
+                .formParam("Action", "DescribeLaunchConfigurations")
+                .formParam("LaunchConfigurationNames.member.1", "my-lc-defaults")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200)
+                .body(containsString("<InstanceMonitoring><Enabled>true</Enabled></InstanceMonitoring>"))
+                .body(containsString("<BlockDeviceMappings></BlockDeviceMappings>"));
+    }
+
+    @Test
+    @Order(44)
+    void launchConfigurationRejectsAMappingWithoutADeviceName() {
+        given()
+                .formParam("Action", "CreateLaunchConfiguration")
+                .formParam("LaunchConfigurationName", "my-lc-bad-mapping")
+                .formParam("ImageId", "ami-12345678")
+                .formParam("InstanceType", "t3.micro")
+                .formParam("BlockDeviceMappings.member.1.Ebs.VolumeSize", "100")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("ValidationError"))
+                .body(containsString("BlockDeviceMappings.member.1.DeviceName"));
+    }
+
     // ── Auto Scaling Groups ───────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingServiceTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.autoscaling.model.AsgInstance;
 import io.github.hectorvent.floci.services.autoscaling.model.InstanceRefresh;
+import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfigurationBlockDeviceMapping;
 import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
 import io.github.hectorvent.floci.services.ec2.model.GroupIdentifier;
@@ -203,6 +204,55 @@ class AutoScalingServiceTest {
                 launchConfiguration.getIamInstanceProfile());
         assertEquals(launchConfiguration,
                 service.describeLaunchConfigurations(REGION, List.of("lc-from-instance")).getFirst());
+    }
+
+    @Test
+    void createLaunchConfigurationDefaultsInstanceMonitoringToEnabled() {
+        var lc = service.createLaunchConfiguration(REGION, "lc-default-monitoring", null,
+                "ami-12345678", "t3.micro", null, List.of(), null, null, null);
+
+        assertEquals(Boolean.TRUE, lc.getInstanceMonitoringEnabled());
+        assertEquals(List.of(), lc.getBlockDeviceMappings());
+        assertEquals(Boolean.TRUE,
+                service.describeLaunchConfigurations(REGION, List.of("lc-default-monitoring"))
+                        .getFirst().getInstanceMonitoringEnabled());
+    }
+
+    @Test
+    void createLaunchConfigurationKeepsAnExplicitInstanceMonitoringOverride() {
+        var lc = service.createLaunchConfiguration(REGION, "lc-monitoring-off", null,
+                "ami-12345678", "t3.micro", null, List.of(), null, null, null, Boolean.FALSE, List.of());
+
+        assertEquals(Boolean.FALSE, lc.getInstanceMonitoringEnabled());
+        assertEquals(Boolean.FALSE,
+                service.describeLaunchConfigurations(REGION, List.of("lc-monitoring-off"))
+                        .getFirst().getInstanceMonitoringEnabled());
+    }
+
+    @Test
+    void createLaunchConfigurationRoundTripsBlockDeviceMappings() {
+        var ebs = new LaunchConfigurationBlockDeviceMapping.Ebs();
+        ebs.setVolumeSize(100);
+        ebs.setVolumeType("gp3");
+        ebs.setIops(3000);
+        ebs.setThroughput(125);
+        ebs.setDeleteOnTermination(true);
+        var mapping = new LaunchConfigurationBlockDeviceMapping();
+        mapping.setDeviceName("/dev/xvda");
+        mapping.setEbs(ebs);
+
+        service.createLaunchConfiguration(REGION, "lc-with-root-device", null,
+                "ami-12345678", "t3.micro", null, List.of(), null, null, null, null, List.of(mapping));
+
+        var stored = service.describeLaunchConfigurations(REGION, List.of("lc-with-root-device"))
+                .getFirst().getBlockDeviceMappings();
+        assertEquals(1, stored.size());
+        assertEquals("/dev/xvda", stored.getFirst().getDeviceName());
+        assertEquals(100, stored.getFirst().getEbs().getVolumeSize());
+        assertEquals("gp3", stored.getFirst().getEbs().getVolumeType());
+        assertEquals(3000, stored.getFirst().getEbs().getIops());
+        assertEquals(125, stored.getFirst().getEbs().getThroughput());
+        assertEquals(Boolean.TRUE, stored.getFirst().getEbs().getDeleteOnTermination());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Ports lex00/floci#132. `CreateLaunchConfiguration` dropped `InstanceMonitoring.Enabled` and `BlockDeviceMappings` on the floor, and `DescribeLaunchConfigurations` never returned either structure.

Both now round-trip. The mapping carries the Auto Scaling shape, so `Ebs` includes `Iops` and `Throughput` alongside `VirtualName` and `NoDevice`, which EC2's launch-time mapping model lacks. That is why the type lives in the autoscaling package rather than reusing EC2's. A mapping without a `DeviceName` fails with `ValidationError`. Describe always returns both elements, with monitoring defaulting to enabled and mappings to an empty list, since a record persisted before this change has neither stored.

Unit tests cover the default and an explicit override, plus the stored mapping. Integration tests assert the XML on the wire for a populated launch configuration and for one created with neither field.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior. AWS documents `InstanceMonitoring` as enabled by default and always returns it from Describe together with `BlockDeviceMappings`. Omitting both made the Terraform provider read `enable_monitoring` as false and `root_block_device` as empty, which forced a replacement on every plan.

## Checklist

- [x] `./mvnw test` passes locally for `AutoScalingServiceTest` and `AutoScalingIntegrationTest`
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
