### PR TITLE
chore(deps): update to Quarkus 3.39.2 and refresh pinned libraries

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -181,7 +181,12 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Build native executable
-        run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2,-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -216,7 +221,12 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Build native executable
-        run: ./mvnw clean package -Dnative -DskipTests -B
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: ./mvnw clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -162,7 +162,12 @@ jobs:
           restore-keys: maven-${{ runner.os }}-
 
       - name: Build native executable (quick build)
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob"
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-Ob,-H:-AOTSingleCallsiteInline"
 
       # Quarkus always writes GraalVM's build-output JSON next to the native source jar. Surfacing
       # it here gives every PR a size record for both architectures: code area, image heap, total

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,7 +80,12 @@ jobs:
         run: mvn versions:set -DnewVersion="nightly-${{ needs.prepare.outputs.version }}" -DgenerateBackupPoms=false -q
 
       - name: Build native executable
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2,-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -132,7 +137,12 @@ jobs:
         run: mvn versions:set -DnewVersion="nightly-${{ needs.prepare.outputs.version }}" -DgenerateBackupPoms=false -q
 
       - name: Build native executable
-        run: mvn clean package -Dnative -DskipTests -B
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build native executable
-        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2"
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-march=x86-64-v2,-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -76,7 +81,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build native executable
-        run: mvn clean package -Dnative -DskipTests -B
+        # Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+        # REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+        # single call site of a very large method; inlined, the method outgrows the aarch64
+        # conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+        # The flag only exists on Mandrel, so it is passed here rather than in application.yml.
+        run: mvn clean package -Dnative -DskipTests -B -Dquarkus.native.additional-build-args-append="-H:-AOTSingleCallsiteInline"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,21 @@
                 <artifactId>proto-google-common-protos</artifactId>
                 <version>2.49.0</version>
             </dependency>
+            <!-- Matched to httpclient5 5.5.1 (its own declared core). The Quarkus 3.38+ BOM manages
+                 httpcore5 5.4, whose SocketConfig defaults turn on TCP keep-alive with a keep-idle of 5 s;
+                 httpclient5 then sets that extended option through reflection on docker-java's UnixSocket,
+                 which is unregistered in the native image, and every Docker call fails with
+                 "Failure setting extended socket option". docker-java is the only consumer of httpcore5. -->
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5</artifactId>
+                <version>5.3.6</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents.core5</groupId>
+                <artifactId>httpcore5-h2</artifactId>
+                <version>5.3.6</version>
+            </dependency>
             <dependency>
                 <groupId>com.h2database</groupId>
                 <artifactId>h2-mvstore</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,11 +15,11 @@
     <properties>
         <maven.compiler.release>25</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <quarkus.platform.version>3.37.4</quarkus.platform.version>
-        <jackson.version>2.22.1</jackson.version>
+        <quarkus.platform.version>3.39.2</quarkus.platform.version>
+        <jackson.version>2.22.2</jackson.version>
         <apicurio.version>2.6.13.Final</apicurio.version>
         <everit.json.schema.version>1.14.6</everit.json.schema.version>
-        <wire.version>6.4.5</wire.version>
+        <wire.version>6.4.7</wire.version>
     </properties>
 
     <dependencyManagement>
@@ -186,6 +186,8 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
+            <!-- Held at 5.5.x: 5.6 adds commons-compress content decoding, and its XZ codec
+                 needs org.tukaani:xz at native link time (GraalVM link-at-build-time). -->
             <version>5.5.1</version>
         </dependency>
         <!-- Explicit overrides for Quarkus BOM which pins these at 3.7.0;
@@ -216,7 +218,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.85</version>
+            <version>1.85.2</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -242,7 +244,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>26.0</version>
+            <version>26.1</version>
         </dependency>
 
         <!-- JSON Schema validation (API Gateway request validation) -->
@@ -256,7 +258,7 @@
         <dependency>
             <groupId>io.swagger.parser.v3</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>2.1.45</version>
+            <version>2.1.48</version>
         </dependency>
 
         <!-- Glue Schema Registry: Apicurio format utilities (parsing, canonicalization, compatibility) -->
@@ -355,7 +357,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.25.3</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -392,7 +394,7 @@
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
-            <version>6.2.0</version>
+            <version>6.2.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -417,7 +419,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.15.0</version>
+                <version>3.16.0</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
                 </configuration>
@@ -425,7 +427,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.6</version>
+                <version>3.6.0</version>
                 <configuration>
                     <!-- The suite's end-of-run live set exceeds the 4g default heap of
                          16g CI runners; a full GC near the end reclaims almost nothing. -->


### PR DESCRIPTION
## Summary

Supersedes #2906 (dependabot group at Quarkus 3.38.3, native build red).

Quarkus platform 3.37.4 -> 3.39.2 (BOM and plugin), Jackson 2.22.2, wire 6.4.7, bcprov 1.85.2, graphql-java 26.1, swagger-parser 2.1.48, assertj 3.27.7, neo4j-java-driver 6.2.1, maven-compiler-plugin 3.16.0, maven-surefire-plugin 3.6.0. Vert.x 4.5.33, Netty 4.1.137, REST Assured 6.0.1 and the Kubernetes client move with the BOM.

Two pins are kept deliberately, each with a comment in the pom:

- **httpclient5 stays at 5.5.1.** 5.6 adds transparent content decoding through commons-compress (`CommonsCompressCodecFactory`), and its XZ codec references `org.tukaani.xz.XZInputStream`, which is not on the classpath. GraalVM reports it at link time through docker-java's `FrameReader`, so the native image does not build. The Quarkus 3.39 BOM manages 5.6.3, so the explicit pin is what keeps it out. Later options: add `org.tukaani:xz`, or exclude the decoder.
- **protobuf-java 3.25.9 and proto-google-common-protos 2.49.0 stay** for apicurio 2.6.13. Newer common-protos are built against protobuf 4.33+ (`com.google.protobuf.GeneratedFile`), the mixed-classpath native failure that blocks #2906 and blocked #2083 before it. apicurio 3.x is the real fix and is its own change.

Also left for their own changes: h2 2.5 (MVStore is the persistence format), json-schema-validator 3.x (API change), pre-releases (wire 7 RC, assertj 4 M1, httpclient5 5.7 alpha), and kafka-clients, which #3160 removes.

Migration notes for 3.38 and 3.39 checked: Host header validation now defaults on when `quarkus.http.host` is localhost (Floci binds 0.0.0.0); 3.39 only changes Quarkus Data, unused here. One new warning to look at separately: Quarkus reports `quarkus.native.resources.excludes` as unsupported with GraalVM 25 reachability metadata, so the snappy exclusion list in `application.yml` may already be a no-op on the Mandrel 25 builder.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No emulated surface changes. The native binary was booted after the build and answered STS `GetCallerIdentity` on the Query protocol.

## Checklist

- [x] `./mvnw test` passes locally: full suite 14190 tests, 0 failures, 1 environmental error (`ContainerPlatformDockerIntegrationTest` wants a linux/amd64 busybox on an arm64 host). The unsharded fork hit the 6g heap after 1160 of 1294 classes, so the remaining 188 classes ran separately: 3479 tests, 2 failures in `RuntimeApiServerTest` that reproduce on unmodified main (`extensionShutdown_racedAgainstStop_isNeverOrphaned` 2/2, `quiesceAtomicallyClearsInFlightWithStopped` flaky). Native image: `-Dnative -Ob` on GraalVM 25.0.3 aarch64 builds in under two minutes.
- [ ] New or updated integration test added: dependency-only change, no behaviour to pin.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
