### PR TITLE
fix(ec2): add network capacity to instance type responses

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -216,9 +216,32 @@ class Ec2Tests {
         assertThat(resp.instanceTypes()).allSatisfy(instanceType -> {
             assertThat(instanceType.networkInfo()).isNotNull();
             assertThat(instanceType.networkInfo().encryptionInTransitSupported()).isNotNull();
+            assertThat(instanceType.networkInfo().defaultNetworkCardIndex()).isNotNull();
+            assertThat(instanceType.networkInfo().networkCards()).isNotEmpty();
+            assertThat(instanceType.networkInfo().ipv4AddressesPerInterface()).isNotNull();
         });
         assertThat(resp.instanceTypes()).allMatch(instanceType ->
                 !instanceType.networkInfo().encryptionInTransitSupported());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("DescribeInstanceTypes - network card capacity metadata")
+    void describeInstanceTypeNetworkCardCapacityMetadata() {
+        DescribeInstanceTypesResponse resp = ec2.describeInstanceTypes(DescribeInstanceTypesRequest.builder()
+                .instanceTypes(InstanceType.M5_LARGE, InstanceType.fromValue("t4g.medium"))
+                .build());
+
+        assertThat(resp.instanceTypes()).hasSize(2);
+        assertThat(resp.instanceTypes()).allSatisfy(instanceType -> {
+            NetworkInfo networkInfo = instanceType.networkInfo();
+            assertThat(networkInfo.defaultNetworkCardIndex()).isEqualTo(0);
+            assertThat(networkInfo.ipv4AddressesPerInterface()).isEqualTo(10);
+            assertThat(networkInfo.networkCards()).hasSize(1);
+            NetworkCardInfo networkCard = networkInfo.networkCards().get(0);
+            assertThat(networkCard.networkCardIndex()).isEqualTo(0);
+            assertThat(networkCard.maximumNetworkInterfaces()).isEqualTo(3);
+        });
     }
 
     @Test

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -233,14 +233,35 @@ class Ec2Tests {
                 .build());
 
         assertThat(resp.instanceTypes()).hasSize(2);
-        assertThat(resp.instanceTypes()).allSatisfy(instanceType -> {
-            NetworkInfo networkInfo = instanceType.networkInfo();
-            assertThat(networkInfo.defaultNetworkCardIndex()).isEqualTo(0);
-            assertThat(networkInfo.ipv4AddressesPerInterface()).isEqualTo(10);
-            assertThat(networkInfo.networkCards()).hasSize(1);
-            NetworkCardInfo networkCard = networkInfo.networkCards().get(0);
-            assertThat(networkCard.networkCardIndex()).isEqualTo(0);
-            assertThat(networkCard.maximumNetworkInterfaces()).isEqualTo(3);
+        assertThat(resp.instanceTypes()).anySatisfy(instanceType -> {
+            assertThat(instanceType.instanceType()).isEqualTo(InstanceType.M5_LARGE);
+            assertThat(instanceType.networkInfo().defaultNetworkCardIndex()).isEqualTo(0);
+            assertThat(instanceType.networkInfo().ipv4AddressesPerInterface()).isEqualTo(10);
+            assertThat(instanceType.networkInfo().networkCards()).singleElement().satisfies(networkCard -> {
+                assertThat(networkCard.networkCardIndex()).isEqualTo(0);
+                assertThat(networkCard.maximumNetworkInterfaces()).isEqualTo(3);
+            });
+        });
+        assertThat(resp.instanceTypes()).anySatisfy(instanceType -> {
+            assertThat(instanceType.instanceTypeAsString()).isEqualTo("t4g.medium");
+            assertThat(instanceType.networkInfo().defaultNetworkCardIndex()).isEqualTo(0);
+            assertThat(instanceType.networkInfo().ipv4AddressesPerInterface()).isEqualTo(6);
+            assertThat(instanceType.networkInfo().networkCards()).singleElement().satisfies(networkCard -> {
+                assertThat(networkCard.networkCardIndex()).isEqualTo(0);
+                assertThat(networkCard.maximumNetworkInterfaces()).isEqualTo(3);
+            });
+        });
+
+        DescribeInstanceTypesResponse largerArmResponse = ec2.describeInstanceTypes(DescribeInstanceTypesRequest.builder()
+                .instanceTypes(InstanceType.fromValue("m8gd.2xlarge"))
+                .build());
+        assertThat(largerArmResponse.instanceTypes()).singleElement().satisfies(instanceType -> {
+            assertThat(instanceType.networkInfo().defaultNetworkCardIndex()).isEqualTo(0);
+            assertThat(instanceType.networkInfo().ipv4AddressesPerInterface()).isEqualTo(15);
+            assertThat(instanceType.networkInfo().networkCards()).singleElement().satisfies(networkCard -> {
+                assertThat(networkCard.networkCardIndex()).isEqualTo(0);
+                assertThat(networkCard.maximumNetworkInterfaces()).isEqualTo(4);
+            });
         });
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalog.java
@@ -8,10 +8,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @ApplicationScoped
 public class Ec2InstanceTypeCatalog {
@@ -97,12 +99,40 @@ public class Ec2InstanceTypeCatalog {
                 throw new IllegalStateException(
                         "EC2 instance type catalog entry is missing encryptionInTransitSupported: " + name);
             }
+            validateNetworkInfo(instanceType, name);
             CatalogInstanceType previous = index.putIfAbsent(name, instanceType);
             if (previous != null) {
                 throw new IllegalStateException("Duplicate EC2 instance type catalog entry: " + name);
             }
         }
         return Map.copyOf(index);
+    }
+
+    private static void validateNetworkInfo(CatalogInstanceType instanceType, String name) {
+        if (instanceType.defaultNetworkCardIndex == null || instanceType.defaultNetworkCardIndex < 0) {
+            throw new IllegalStateException("EC2 instance type catalog entry has invalid defaultNetworkCardIndex: " + name);
+        }
+        if (instanceType.ipv4AddressesPerInterface == null || instanceType.ipv4AddressesPerInterface <= 0) {
+            throw new IllegalStateException("EC2 instance type catalog entry has invalid ipv4AddressesPerInterface: " + name);
+        }
+        if (instanceType.networkCards == null || instanceType.networkCards.isEmpty()) {
+            throw new IllegalStateException("EC2 instance type catalog entry is missing networkCards: " + name);
+        }
+        if (instanceType.defaultNetworkCardIndex >= instanceType.networkCards.size()) {
+            throw new IllegalStateException("EC2 instance type catalog entry has defaultNetworkCardIndex outside networkCards: " + name);
+        }
+        Set<Integer> cardIndexes = new HashSet<>();
+        for (int position = 0; position < instanceType.networkCards.size(); position++) {
+            CatalogNetworkCard card = instanceType.networkCards.get(position);
+            if (card == null || card.networkCardIndex == null || card.networkCardIndex != position
+                    || !cardIndexes.add(card.networkCardIndex)) {
+                throw new IllegalStateException("EC2 instance type catalog entry has invalid networkCardIndex: " + name);
+            }
+            if (card.maximumNetworkInterfaces == null || card.maximumNetworkInterfaces <= 0) {
+                throw new IllegalStateException(
+                        "EC2 instance type catalog entry has invalid maximumNetworkInterfaces: " + name);
+            }
+        }
     }
 
     private static String require(String value, String field) {
@@ -128,6 +158,9 @@ public class Ec2InstanceTypeCatalog {
         public List<String> supportedArchitectures = List.of();
         public Boolean currentGeneration;
         public Boolean encryptionInTransitSupported;
+        public Integer defaultNetworkCardIndex;
+        public Integer ipv4AddressesPerInterface;
+        public List<CatalogNetworkCard> networkCards = List.of();
 
         public Map<String, Object> toResponseMap() {
             Map<String, Object> type = new LinkedHashMap<>();
@@ -140,8 +173,27 @@ public class Ec2InstanceTypeCatalog {
             type.put("currentGeneration", currentGeneration == null || currentGeneration);
             Map<String, Object> networkInfo = new LinkedHashMap<>();
             networkInfo.put("encryptionInTransitSupported", encryptionInTransitSupported);
+            networkInfo.put("defaultNetworkCardIndex", defaultNetworkCardIndex);
+            networkInfo.put("ipv4AddressesPerInterface", ipv4AddressesPerInterface);
+            networkInfo.put("networkCards", networkCards.stream()
+                    .map(CatalogNetworkCard::toResponseMap)
+                    .toList());
             type.put("networkInfo", networkInfo);
             return type;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @RegisterForReflection
+    public static final class CatalogNetworkCard {
+        public Integer networkCardIndex;
+        public Integer maximumNetworkInterfaces;
+
+        public Map<String, Object> toResponseMap() {
+            Map<String, Object> card = new LinkedHashMap<>();
+            card.put("networkCardIndex", networkCardIndex);
+            card.put("maximumNetworkInterfaces", maximumNetworkInterfaces);
+            return card;
         }
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -3765,6 +3765,16 @@ public class Ec2QueryHandler {
             xml.start("networkInfo")
                     .elem("encryptionInTransitSupported",
                             String.valueOf(networkInfo.get("encryptionInTransitSupported")))
+                    .elem("defaultNetworkCardIndex", (Integer) networkInfo.get("defaultNetworkCardIndex"))
+                    .elem("ipv4AddressesPerInterface", (Integer) networkInfo.get("ipv4AddressesPerInterface"))
+                    .start("networkCards");
+            for (Map<String, Object> card : (List<Map<String, Object>>) networkInfo.get("networkCards")) {
+                xml.start("item")
+                        .elem("networkCardIndex", (Integer) card.get("networkCardIndex"))
+                        .elem("maximumNetworkInterfaces", (Integer) card.get("maximumNetworkInterfaces"))
+                        .end("item");
+            }
+            xml.end("networkCards")
                     .end("networkInfo")
                     .end("item");
         }

--- a/src/main/resources/ec2/instance-type-catalog.yaml
+++ b/src/main/resources/ec2/instance-type-catalog.yaml
@@ -196,7 +196,7 @@ instanceTypes:
     currentGeneration: true
     encryptionInTransitSupported: false
     defaultNetworkCardIndex: 0
-    ipv4AddressesPerInterface: 10
+    ipv4AddressesPerInterface: 15
     networkCards:
       - networkCardIndex: 0
-        maximumNetworkInterfaces: 3
+        maximumNetworkInterfaces: 4

--- a/src/main/resources/ec2/instance-type-catalog.yaml
+++ b/src/main/resources/ec2/instance-type-catalog.yaml
@@ -6,6 +6,11 @@ instanceTypes:
       - x86_64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 2
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 2
 
   - instanceType: t3.micro
     vcpu: 2
@@ -14,6 +19,11 @@ instanceTypes:
       - x86_64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 2
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 2
 
   - instanceType: t3.small
     vcpu: 2
@@ -22,6 +32,11 @@ instanceTypes:
       - x86_64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 4
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: t3.medium
     vcpu: 2
@@ -30,6 +45,11 @@ instanceTypes:
       - x86_64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 6
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: m5.large
     vcpu: 2
@@ -38,6 +58,11 @@ instanceTypes:
       - x86_64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 10
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: t4g.micro
     vcpu: 2
@@ -46,6 +71,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 2
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 2
 
   - instanceType: t4g.small
     vcpu: 2
@@ -54,6 +84,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 4
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: t4g.medium
     vcpu: 2
@@ -62,6 +97,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 6
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: m6gd.large
     vcpu: 2
@@ -71,6 +111,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 10
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: m6gd.2xlarge
     vcpu: 8
@@ -80,6 +125,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 15
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 4
 
   - instanceType: m7gd.large
     vcpu: 2
@@ -89,6 +139,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 10
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: m7gd.2xlarge
     vcpu: 8
@@ -98,6 +153,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 15
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 4
 
   - instanceType: m8gd.medium
     vcpu: 1
@@ -107,6 +167,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 4
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 2
 
   - instanceType: m8gd.large
     vcpu: 2
@@ -116,6 +181,11 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 10
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3
 
   - instanceType: m8gd.2xlarge
     vcpu: 8
@@ -125,3 +195,8 @@ instanceTypes:
       - arm64
     currentGeneration: true
     encryptionInTransitSupported: false
+    defaultNetworkCardIndex: 0
+    ipv4AddressesPerInterface: 10
+    networkCards:
+      - networkCardIndex: 0
+        maximumNetworkInterfaces: 3

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalogTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalogTest.java
@@ -83,6 +83,12 @@ class Ec2InstanceTypeCatalogTest {
         assertEquals(0, m5Large.defaultNetworkCardIndex);
         assertEquals(10, m5Large.ipv4AddressesPerInterface);
         assertEquals(3, m5Large.networkCards.get(0).maximumNetworkInterfaces);
+
+        Ec2InstanceTypeCatalog.CatalogInstanceType m8gd2xlarge =
+                instanceTypeCatalog.find("m8gd.2xlarge").orElseThrow();
+        assertEquals(0, m8gd2xlarge.defaultNetworkCardIndex);
+        assertEquals(15, m8gd2xlarge.ipv4AddressesPerInterface);
+        assertEquals(4, m8gd2xlarge.networkCards.get(0).maximumNetworkInterfaces);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalogTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalogTest.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.services.ec2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -62,6 +63,48 @@ class Ec2InstanceTypeCatalogTest {
 
         assertFalse(instanceTypeCatalog.find("m5.large").orElseThrow().encryptionInTransitSupported);
         assertFalse(instanceTypeCatalog.find("t4g.medium").orElseThrow().encryptionInTransitSupported);
+    }
+
+    @Test
+    void catalogEntriesIncludeUsableNetworkCapacityMetadata() {
+        instanceTypeCatalog.instanceTypes().forEach(instanceType -> {
+            assertNotNull(instanceType.defaultNetworkCardIndex, instanceType.instanceType);
+            assertNotNull(instanceType.ipv4AddressesPerInterface, instanceType.instanceType);
+            assertNotNull(instanceType.networkCards, instanceType.instanceType);
+            assertTrue(instanceType.defaultNetworkCardIndex >= 0);
+            assertTrue(instanceType.defaultNetworkCardIndex < instanceType.networkCards.size());
+            assertTrue(instanceType.ipv4AddressesPerInterface > 0);
+            assertEquals(instanceType.defaultNetworkCardIndex,
+                    instanceType.networkCards.get(instanceType.defaultNetworkCardIndex).networkCardIndex);
+            assertTrue(instanceType.networkCards.get(instanceType.defaultNetworkCardIndex).maximumNetworkInterfaces > 0);
+        });
+
+        Ec2InstanceTypeCatalog.CatalogInstanceType m5Large = instanceTypeCatalog.find("m5.large").orElseThrow();
+        assertEquals(0, m5Large.defaultNetworkCardIndex);
+        assertEquals(10, m5Large.ipv4AddressesPerInterface);
+        assertEquals(3, m5Large.networkCards.get(0).maximumNetworkInterfaces);
+    }
+
+    @Test
+    void catalogRejectsIncompleteNetworkCapacityMetadata() {
+        Ec2InstanceTypeCatalog.CatalogInstanceType type = new Ec2InstanceTypeCatalog.CatalogInstanceType();
+        type.instanceType = "test.type";
+        type.vcpu = 1;
+        type.memoryMib = 1024;
+        type.supportedArchitectures = List.of("x86_64");
+        type.encryptionInTransitSupported = false;
+        type.defaultNetworkCardIndex = 0;
+        type.ipv4AddressesPerInterface = 10;
+        Ec2InstanceTypeCatalog.CatalogNetworkCard card = new Ec2InstanceTypeCatalog.CatalogNetworkCard();
+        card.networkCardIndex = 0;
+        type.networkCards = List.of(card);
+
+        Ec2InstanceTypeCatalog.Catalog catalog = new Ec2InstanceTypeCatalog.Catalog();
+        catalog.instanceTypes = List.of(type);
+
+        IllegalStateException error = assertThrows(IllegalStateException.class,
+                () -> new Ec2InstanceTypeCatalog(catalog));
+        assertTrue(error.getMessage().contains("maximumNetworkInterfaces"));
     }
 
     private void assertLargeGravitonType(String name) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2IntegrationTest.java
@@ -794,6 +794,14 @@ class Ec2IntegrationTest {
             .body("DescribeInstanceTypesResponse.instanceTypeSet.item.instanceStorageInfo.totalSizeInGB", equalTo("474"))
             .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.encryptionInTransitSupported",
                     equalTo("false"))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.defaultNetworkCardIndex",
+                    equalTo("0"))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.ipv4AddressesPerInterface",
+                    equalTo("15"))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.networkCards.item.networkCardIndex",
+                    equalTo("0"))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.networkCards.item.maximumNetworkInterfaces",
+                    equalTo("4"))
             .body("DescribeInstanceTypesResponse.instanceTypeSet.item.processorInfo.supportedArchitectures.item",
                     equalTo("arm64"));
     }
@@ -825,6 +833,14 @@ class Ec2IntegrationTest {
                     everyItem(equalTo("118")))
             .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.encryptionInTransitSupported",
                     everyItem(equalTo("false")))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.defaultNetworkCardIndex",
+                    everyItem(equalTo("0")))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.ipv4AddressesPerInterface",
+                    everyItem(equalTo("10")))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.networkCards.item.networkCardIndex",
+                    everyItem(equalTo("0")))
+            .body("DescribeInstanceTypesResponse.instanceTypeSet.item.networkInfo.networkCards.item.maximumNetworkInterfaces",
+                    everyItem(equalTo("3")))
             .body("DescribeInstanceTypesResponse.instanceTypeSet.item.processorInfo.supportedArchitectures.item",
                     everyItem(equalTo("arm64")));
     }


### PR DESCRIPTION
## Summary

Fixes #3178 by completing the EC2 `DescribeInstanceTypes` network metadata needed by AWS SDK consumers and Karpenter.

The catalog now includes `NetworkInfo.DefaultNetworkCardIndex`, `NetworkInfo.NetworkCards` with per-card `NetworkCardIndex` and `MaximumNetworkInterfaces`, and `NetworkInfo.Ipv4AddressesPerInterface`. The EC2 Query response serializes these fields with the AWS XML names. Catalog validation rejects missing, inconsistent, or non-positive capacity metadata.

The seeded values cover all current catalog entries and match the corresponding Karpenter VPC limits for the supported types, including both x86_64 and arm64 entries.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`DescribeInstanceTypes` previously omitted the network-card and IPv4 capacity fields required by AWS SDK consumers and Karpenter. The `m8gd.2xlarge` entry also used the `m8gd.large` limits. The response now emits AWS-compatible field names and per-type values. Verified with AWS SDK for Java 2.52.0 compatibility tests.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
