### PR TITLE
fix(sns): honor FifoThroughputScope=MessageGroup on FIFO topics

### DIFF
--- a/docs/services/sns.md
+++ b/docs/services/sns.md
@@ -114,6 +114,9 @@ When the topic forwards to an SQS FIFO queue, set the matching queue attributes
 (`DeduplicationScope=messageGroup` and `FifoThroughputLimit=perMessageGroupId`), otherwise the
 queue deduplicates topic-wide on the way in.
 
+CloudFormation carries both settings through: `AWS::SNS::Topic` forwards `FifoThroughputScope` and
+`ContentBasedDeduplication`, and a FIFO topic left unnamed gets a generated name ending in `.fifo`.
+
 ## Control Tower managed topic
 
 AWS Control Tower creates the regional

--- a/docs/services/sns.md
+++ b/docs/services/sns.md
@@ -88,6 +88,32 @@ Supported subscription protocols:
 - `http` / `https` — posts to an HTTP endpoint
 - `application` — fans out to a mobile push platform endpoint (see [Mobile push](#mobile-push-mock))
 
+## FIFO topics
+
+A topic whose name ends in `.fifo` is a FIFO topic. `Publish` and `PublishBatch` require a
+`MessageGroupId`, and a message is deduplicated against its `MessageDeduplicationId` for five
+minutes. Set `ContentBasedDeduplication` on the topic to derive that id from the message body.
+
+The `FifoThroughputScope` attribute decides how wide that deduplication reaches:
+
+| Value | Deduplication scope |
+|---|---|
+| `Topic` (default) | Across the whole topic: the same `MessageDeduplicationId` is a duplicate no matter which message group it arrives under |
+| `MessageGroup` | Within a single message group: the same `MessageDeduplicationId` under two different `MessageGroupId`s is two distinct messages |
+
+`MessageGroup` is what a fan-out that reuses one deduplication id per group needs, for example
+publishing the same event to a topic once per tenant with the tenant as the message group.
+
+```bash
+aws sns create-topic --name events.fifo \
+  --attributes FifoTopic=true,FifoThroughputScope=MessageGroup \
+  --endpoint-url $AWS_ENDPOINT_URL
+```
+
+When the topic forwards to an SQS FIFO queue, set the matching queue attributes
+(`DeduplicationScope=messageGroup` and `FifoThroughputLimit=perMessageGroupId`), otherwise the
+queue deduplicates topic-wide on the way in.
+
 ## Control Tower managed topic
 
 AWS Control Tower creates the regional

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisioner.java
@@ -20,6 +20,7 @@ public class SnsCfnProvisioner implements CfnResourceProvisioner {
     private static final String SUBSCRIPTION = "AWS::SNS::Subscription";
     private static final String TOPIC_POLICY = "AWS::SNS::TopicPolicy";
     private static final int TOPIC_NAME_MAX_LENGTH = 256;
+    private static final String FIFO_SUFFIX = ".fifo";
 
     private final SnsService snsService;
 
@@ -46,22 +47,44 @@ public class SnsCfnProvisioner implements CfnResourceProvisioner {
     private void provisionTopic(StackResource r, JsonNode props, ProvisionContext ctx) {
         String topicName = ctx.resolveOptional(props, "TopicName");
         String contentBasedDedupFlag = ctx.resolveOptional(props, "ContentBasedDeduplication");
+        String throughputScope = ctx.resolveOptional(props, "FifoThroughputScope");
+        // SnsService reads FifoTopic off the .fifo suffix, so the flag only has to steer the
+        // generated name. It is createOnly, which is why a prior name whose suffix no longer
+        // matches belongs to a replacing update and gives way to a fresh name.
+        boolean fifo = "true".equalsIgnoreCase(ctx.resolveOptional(props, "FifoTopic"));
         if (topicName == null || topicName.isBlank()) {
             // ctx.stablePhysicalName does not fit here: the physical id is the topic ARN, so the
             // prior name comes from the attribute recorded at create time. Reusing it keeps an
             // unnamed topic (and its subscriptions) across updates instead of orphaning it.
             String priorName = r.getAttributes().get("TopicName");
-            topicName = priorName != null && !priorName.isBlank()
-                    ? priorName
-                    : ctx.generatePhysicalName(r.getLogicalId(), TOPIC_NAME_MAX_LENGTH, false);
+            if (priorName != null && !priorName.isBlank() && priorName.endsWith(FIFO_SUFFIX) == fifo) {
+                topicName = priorName;
+            } else if (fifo) {
+                // Like real CloudFormation, a generated FIFO topic name ends in .fifo, which is
+                // also what makes SnsService treat the topic as FIFO at all.
+                topicName = ctx.generatePhysicalName(r.getLogicalId(),
+                        TOPIC_NAME_MAX_LENGTH - FIFO_SUFFIX.length(), false) + FIFO_SUFFIX;
+            } else {
+                topicName = ctx.generatePhysicalName(r.getLogicalId(), TOPIC_NAME_MAX_LENGTH, false);
+            }
         }
 
         Map<String, String> attributes = new HashMap<>();
         if (contentBasedDedupFlag != null && !contentBasedDedupFlag.isBlank()) {
             attributes.put("ContentBasedDeduplication", contentBasedDedupFlag);
         }
+        if (throughputScope != null && !throughputScope.isBlank()) {
+            attributes.put("FifoThroughputScope", throughputScope);
+        }
 
         var topic = snsService.createTopic(topicName, attributes, Map.of(), ctx.region());
+        // createTopic hands an existing topic back untouched, so on UpdateStack the mutable
+        // attributes have to be written explicitly. The createOnly ones, TopicName and FifoTopic,
+        // are settled by the naming above.
+        if (ctx.isUpdate()) {
+            attributes.forEach((name, value) ->
+                    snsService.setTopicAttributes(topic.getTopicArn(), name, value, ctx.region()));
+        }
         // Ref returns the topic ARN, which is why the physical id is the ARN and not the name.
         r.setPhysicalId(topic.getTopicArn());
         // TopicArn is the attribute aws-sns-topic.json declares read-only. Arn is kept alongside it

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisioner.java
@@ -48,20 +48,27 @@ public class SnsCfnProvisioner implements CfnResourceProvisioner {
         String topicName = ctx.resolveOptional(props, "TopicName");
         String contentBasedDedupFlag = ctx.resolveOptional(props, "ContentBasedDeduplication");
         String throughputScope = ctx.resolveOptional(props, "FifoThroughputScope");
-        // SnsService reads FifoTopic off the .fifo suffix, so the flag only has to steer the
-        // generated name. It is createOnly, which is why a prior name whose suffix no longer
-        // matches belongs to a replacing update and gives way to a fresh name.
-        boolean fifo = "true".equalsIgnoreCase(ctx.resolveOptional(props, "FifoTopic"));
+        // The .fifo suffix is what makes SnsService treat a topic as FIFO, so an explicitly named
+        // one is FIFO with or without the flag, which only has to steer a generated name.
+        boolean fifo = "true".equalsIgnoreCase(ctx.resolveOptional(props, "FifoTopic"))
+                || (topicName != null && topicName.endsWith(FIFO_SUFFIX));
+        String priorName = r.getAttributes().get("TopicName");
+        // FifoTopic is createOnly and carried by the name, so a flip needs a replacement. Nothing
+        // cleans up the displaced topic or its subscriptions, so refuse it, as SqsCfnProvisioner
+        // does for FifoQueue.
+        if (ctx.isUpdate() && priorName != null && !priorName.isBlank()
+                && priorName.endsWith(FIFO_SUFFIX) != fifo) {
+            throw new AwsException("ValidationError",
+                    "Updating FifoTopic requires resource replacement, which is not supported.", 400);
+        }
         if (topicName == null || topicName.isBlank()) {
             // ctx.stablePhysicalName does not fit here: the physical id is the topic ARN, so the
             // prior name comes from the attribute recorded at create time. Reusing it keeps an
             // unnamed topic (and its subscriptions) across updates instead of orphaning it.
-            String priorName = r.getAttributes().get("TopicName");
-            if (priorName != null && !priorName.isBlank() && priorName.endsWith(FIFO_SUFFIX) == fifo) {
+            if (priorName != null && !priorName.isBlank()) {
                 topicName = priorName;
             } else if (fifo) {
-                // Like real CloudFormation, a generated FIFO topic name ends in .fifo, which is
-                // also what makes SnsService treat the topic as FIFO at all.
+                // Like real CloudFormation, a generated FIFO name ends in .fifo.
                 topicName = ctx.generatePhysicalName(r.getLogicalId(),
                         TOPIC_NAME_MAX_LENGTH - FIFO_SUFFIX.length(), false) + FIFO_SUFFIX;
             } else {
@@ -78,11 +85,15 @@ public class SnsCfnProvisioner implements CfnResourceProvisioner {
         }
 
         var topic = snsService.createTopic(topicName, attributes, Map.of(), ctx.region());
-        // createTopic hands an existing topic back untouched, so on UpdateStack the mutable
-        // attributes have to be written explicitly. The createOnly ones, TopicName and FifoTopic,
-        // are settled by the naming above.
+        // createTopic leaves an existing topic untouched, so an update writes the mutable
+        // attributes itself. A property the template dropped is reset, not left standing.
         if (ctx.isUpdate()) {
-            attributes.forEach((name, value) ->
+            Map<String, String> desired = new HashMap<>(attributes);
+            if (fifo) {
+                desired.putIfAbsent("ContentBasedDeduplication", "false");
+                desired.putIfAbsent("FifoThroughputScope", "Topic");
+            }
+            desired.forEach((name, value) ->
                     snsService.setTopicAttributes(topic.getTopicArn(), name, value, ctx.region()));
         }
         // Ref returns the topic ARN, which is why the physical id is the ARN and not the name.

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -1265,11 +1265,12 @@ public class SnsService implements Resettable, ResourceProvider {
 
     private boolean isDuplicate(String topicArn, String messageGroupId, String deduplicationId,
                                 boolean groupScoped) {
-        // Length-prefixed rather than delimited: nothing validates the characters in either id,
-        // so a delimiter inside one could make two different pairs share a key.
+        // The scope is part of the key: the attribute can change inside the deduplication window,
+        // and a topic-scoped id must never land on a group-scoped entry. The group is
+        // length-prefixed because nothing validates the characters in either id.
         String scopedId = groupScoped
-                ? messageGroupId.length() + "#" + messageGroupId + deduplicationId
-                : deduplicationId;
+                ? "group:" + messageGroupId.length() + ":" + messageGroupId + deduplicationId
+                : "topic:" + deduplicationId;
         String cacheKey = topicArn + ":" + scopedId;
         Instant now = Instant.now();
         Instant existing = fifoDeduplicationCache.get(cacheKey);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -1256,10 +1256,8 @@ public class SnsService implements Resettable, ResourceProvider {
     }
 
     /**
-     * A FIFO topic with {@code FifoThroughputScope=MessageGroup} deduplicates within each message
-     * group rather than across the whole topic, so the same {@code MessageDeduplicationId} sent
-     * under two different {@code MessageGroupId}s is two distinct messages. {@code Topic} is the
-     * AWS default and keeps the scope topic-wide.
+     * {@code MessageGroup} narrows deduplication to a single message group. {@code Topic}, the AWS
+     * default, keeps it topic-wide.
      */
     private static boolean isGroupScopedDeduplication(Topic topic) {
         return "MessageGroup".equalsIgnoreCase(topic.getAttributes().get("FifoThroughputScope"));
@@ -1267,9 +1265,11 @@ public class SnsService implements Resettable, ResourceProvider {
 
     private boolean isDuplicate(String topicArn, String messageGroupId, String deduplicationId,
                                 boolean groupScoped) {
-        // NUL delimits the group from the dedup id. SNS allows neither to contain it, so a
-        // group-scoped key can never collide with a topic-scoped one.
-        String scopedId = groupScoped ? messageGroupId + "\0" + deduplicationId : deduplicationId;
+        // Length-prefixed rather than delimited: nothing validates the characters in either id,
+        // so a delimiter inside one could make two different pairs share a key.
+        String scopedId = groupScoped
+                ? messageGroupId.length() + "#" + messageGroupId + deduplicationId
+                : deduplicationId;
         String cacheKey = topicArn + ":" + scopedId;
         Instant now = Instant.now();
         Instant existing = fifoDeduplicationCache.get(cacheKey);

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsService.java
@@ -435,7 +435,8 @@ public class SnsService implements Resettable, ResourceProvider {
             if (dedupId == null && "true".equals(topic.getAttributes().get("ContentBasedDeduplication"))) {
                 dedupId = sha256(message);
             }
-            if (dedupId != null && isDuplicate(effectiveArn, dedupId)) {
+            if (dedupId != null && isDuplicate(effectiveArn, messageGroupId, dedupId,
+                    isGroupScopedDeduplication(topic))) {
                 LOG.debugv("FIFO dedup: skipping duplicate for topic {0}, dedupId {1}", effectiveArn, dedupId);
                 return UUID.randomUUID().toString();
             }
@@ -841,6 +842,7 @@ public class SnsService implements Resettable, ResourceProvider {
         }
 
         boolean isFifo = "true".equals(topic.getAttributes().get("FifoTopic"));
+        boolean groupScopedDedup = isGroupScopedDeduplication(topic);
         List<String[]> successful = new ArrayList<>();
         List<String[]> failed = new ArrayList<>();
         for (Map<String, Object> entry : entries) {
@@ -871,7 +873,8 @@ public class SnsService implements Resettable, ResourceProvider {
             if (isFifo && messageDeduplicationId == null && "true".equals(topic.getAttributes().get("ContentBasedDeduplication"))) {
                 messageDeduplicationId = sha256(message);
             }
-            if (isFifo && messageDeduplicationId != null && isDuplicate(topicArn, messageDeduplicationId)) {
+            if (isFifo && messageDeduplicationId != null && isDuplicate(topicArn, messageGroupId,
+                    messageDeduplicationId, groupScopedDedup)) {
                 successful.add(new String[]{id, UUID.randomUUID().toString()});
                 continue;
             }
@@ -1252,8 +1255,22 @@ public class SnsService implements Resettable, ResourceProvider {
         return true;
     }
 
-    private boolean isDuplicate(String topicArn, String deduplicationId) {
-        String cacheKey = topicArn + ":" + deduplicationId;
+    /**
+     * A FIFO topic with {@code FifoThroughputScope=MessageGroup} deduplicates within each message
+     * group rather than across the whole topic, so the same {@code MessageDeduplicationId} sent
+     * under two different {@code MessageGroupId}s is two distinct messages. {@code Topic} is the
+     * AWS default and keeps the scope topic-wide.
+     */
+    private static boolean isGroupScopedDeduplication(Topic topic) {
+        return "MessageGroup".equalsIgnoreCase(topic.getAttributes().get("FifoThroughputScope"));
+    }
+
+    private boolean isDuplicate(String topicArn, String messageGroupId, String deduplicationId,
+                                boolean groupScoped) {
+        // NUL delimits the group from the dedup id. SNS allows neither to contain it, so a
+        // group-scoped key can never collide with a topic-scoped one.
+        String scopedId = groupScoped ? messageGroupId + "\0" + deduplicationId : deduplicationId;
+        String cacheKey = topicArn + ":" + scopedId;
         Instant now = Instant.now();
         Instant existing = fifoDeduplicationCache.get(cacheKey);
         if (existing != null && existing.plus(FIFO_DEDUP_WINDOW).isAfter(now)) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SnsFifoThroughputScopeCfnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SnsFifoThroughputScopeCfnIntegrationTest.java
@@ -13,10 +13,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
- * Provisions a FIFO topic fanning out to a FIFO queue, the shape a template takes when it publishes
- * one event per message group. Asserts that {@code FifoThroughputScope} reaches the topic from the
- * template, that {@code MessageGroup} scopes deduplication per group end to end, and that an
- * UpdateStack widening it back to {@code Topic} takes effect on the topic that already exists.
+ * A FIFO topic fanning out to a FIFO queue, the shape a template takes to publish one event per
+ * message group: the scope reaches the topic, per-group dedup holds end to end, and an UpdateStack
+ * back to {@code Topic} takes effect on the topic that already exists.
  */
 @QuarkusTest
 class SnsFifoThroughputScopeCfnIntegrationTest {
@@ -29,11 +28,7 @@ class SnsFifoThroughputScopeCfnIntegrationTest {
             "AWS4-HMAC-SHA256 Credential=test/20260905/us-east-1/sqs/aws4_request";
     private static final String STACK = "sns-fifo-scope-cfn-it";
 
-    /**
-     * The queue deduplicates per group as well, so a message the topic forwards is never dropped a
-     * second time on the way in. Without that the queue's own topic-wide window would mask the
-     * topic's scope and the test would pass for the wrong reason.
-     */
+    /** Per-group dedup on the queue too, so its own topic-wide window cannot mask the topic's. */
     private static final String TEMPLATE = """
         {
           "Parameters": {"Scope": {"Type": "String"}},
@@ -91,8 +86,7 @@ class SnsFifoThroughputScopeCfnIntegrationTest {
         assertTrue(perGroup.contains("per-group-two"),
                 "the second group's message was deduplicated against the first: " + perGroup);
 
-        // A received message stays in flight and holds its group, so clear the queue before the
-        // next pair rather than letting group-1 block on the message just read.
+        // A received message stays in flight and holds its group, so clear the queue first.
         purgeQueue(queueUrl);
 
         cloudFormation("UpdateStack", "Topic");
@@ -188,10 +182,7 @@ class SnsFifoThroughputScopeCfnIntegrationTest {
         .when().post("/").then().statusCode(200);
     }
 
-    /**
-     * A FIFO receive hands back one message group at a time, so read repeatedly and match against
-     * everything that came back instead of a single response.
-     */
+    /** A FIFO receive can return one group at a time, so read repeatedly. */
     private static String drain(String queueUrl) {
         StringBuilder received = new StringBuilder();
         for (int i = 0; i < 6; i++) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/SnsFifoThroughputScopeCfnIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/SnsFifoThroughputScopeCfnIntegrationTest.java
@@ -1,0 +1,217 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.core.common.XmlParser;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Provisions a FIFO topic fanning out to a FIFO queue, the shape a template takes when it publishes
+ * one event per message group. Asserts that {@code FifoThroughputScope} reaches the topic from the
+ * template, that {@code MessageGroup} scopes deduplication per group end to end, and that an
+ * UpdateStack widening it back to {@code Topic} takes effect on the topic that already exists.
+ */
+@QuarkusTest
+class SnsFifoThroughputScopeCfnIntegrationTest {
+
+    private static final String CFN_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260905/us-east-1/cloudformation/aws4_request";
+    private static final String SNS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260905/us-east-1/sns/aws4_request";
+    private static final String SQS_AUTH =
+            "AWS4-HMAC-SHA256 Credential=test/20260905/us-east-1/sqs/aws4_request";
+    private static final String STACK = "sns-fifo-scope-cfn-it";
+
+    /**
+     * The queue deduplicates per group as well, so a message the topic forwards is never dropped a
+     * second time on the way in. Without that the queue's own topic-wide window would mask the
+     * topic's scope and the test would pass for the wrong reason.
+     */
+    private static final String TEMPLATE = """
+        {
+          "Parameters": {"Scope": {"Type": "String"}},
+          "Resources": {
+            "Topic": {
+              "Type": "AWS::SNS::Topic",
+              "Properties": {
+                "TopicName": "sns-fifo-scope-cfn-it.fifo",
+                "FifoTopic": true,
+                "ContentBasedDeduplication": false,
+                "FifoThroughputScope": {"Ref": "Scope"}
+              }
+            },
+            "Queue": {
+              "Type": "AWS::SQS::Queue",
+              "Properties": {
+                "QueueName": "sns-fifo-scope-cfn-it.fifo",
+                "FifoQueue": true,
+                "DeduplicationScope": "messageGroup",
+                "FifoThroughputLimit": "perMessageGroupId"
+              }
+            },
+            "Subscription": {
+              "Type": "AWS::SNS::Subscription",
+              "Properties": {
+                "TopicArn": {"Ref": "Topic"},
+                "Protocol": "sqs",
+                "Endpoint": {"Fn::GetAtt": ["Queue", "Arn"]},
+                "RawMessageDelivery": true
+              }
+            }
+          },
+          "Outputs": {
+            "TopicArn": {"Value": {"Ref": "Topic"}},
+            "QueueUrl": {"Value": {"Ref": "Queue"}}
+          }
+        }
+        """;
+
+    @Test
+    void aTemplateAskingForPerGroupDeduplicationGetsIt() throws InterruptedException {
+        cloudFormation("CreateStack", "MessageGroup");
+        String created = describeStacks("CREATE_COMPLETE");
+        String topicArn = outputValue(created, "TopicArn");
+        String queueUrl = outputValue(created, "QueueUrl");
+
+        assertEquals("MessageGroup", topicAttribute(topicArn, "FifoThroughputScope"),
+                "the template's FifoThroughputScope has to reach the topic");
+
+        // One deduplication id, two message groups. Under MessageGroup scope they are two messages.
+        publish(topicArn, "group-1", "per-group-dedup", "per-group-one");
+        publish(topicArn, "group-2", "per-group-dedup", "per-group-two");
+        String perGroup = drain(queueUrl);
+        assertTrue(perGroup.contains("per-group-one"), perGroup);
+        assertTrue(perGroup.contains("per-group-two"),
+                "the second group's message was deduplicated against the first: " + perGroup);
+
+        // A received message stays in flight and holds its group, so clear the queue before the
+        // next pair rather than letting group-1 block on the message just read.
+        purgeQueue(queueUrl);
+
+        cloudFormation("UpdateStack", "Topic");
+        describeStacks("UPDATE_COMPLETE");
+        assertEquals("Topic", topicAttribute(topicArn, "FifoThroughputScope"),
+                "createTopic hands an existing topic back untouched, so an update has to rewrite it");
+
+        // The same pair against the AWS default scope: the second publish is a topic-wide duplicate.
+        publish(topicArn, "group-1", "topic-wide-dedup", "topic-scope-one");
+        publish(topicArn, "group-2", "topic-wide-dedup", "topic-scope-two");
+        String topicWide = drain(queueUrl);
+        assertTrue(topicWide.contains("topic-scope-one"), topicWide);
+        assertFalse(topicWide.contains("topic-scope-two"),
+                "Topic scope must keep deduplicating across groups: " + topicWide);
+
+        cloudFormation("DeleteStack", null);
+        awaitStackDeleted();
+        topicAttributes(topicArn).statusCode(404);
+    }
+
+    private static void cloudFormation(String action, String scope) {
+        RequestSpecification request = given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", action)
+            .formParam("StackName", STACK);
+        if (scope != null) {
+            request.formParam("TemplateBody", TEMPLATE)
+                   .formParam("Parameters.member.1.ParameterKey", "Scope")
+                   .formParam("Parameters.member.1.ParameterValue", scope);
+        }
+        request.when().post("/").then().statusCode(200);
+    }
+
+    private static String describeStacks(String expectedStatus) {
+        return given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CFN_AUTH)
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", STACK)
+        .when().post("/").then().statusCode(200)
+            .body(org.hamcrest.Matchers.containsString("<StackStatus>" + expectedStatus + "</StackStatus>"))
+            .extract().asString();
+    }
+
+    /** DeleteStack runs asynchronously; a successful delete removes the stack entirely. */
+    private static void awaitStackDeleted() throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            String body = given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", CFN_AUTH)
+                .formParam("Action", "DescribeStacks")
+                .formParam("StackName", STACK)
+            .when().post("/").then().extract().asString();
+            if (body.contains("does not exist")) {
+                return;
+            }
+            if (body.contains("<StackStatus>DELETE_FAILED</StackStatus>")) {
+                fail("stack delete failed: " + body);
+            }
+            Thread.sleep(50);
+        }
+        fail("stack " + STACK + " was not deleted within the timeout");
+    }
+
+    private static String outputValue(String xml, String key) {
+        return XmlParser.extractPairs(xml, "Outputs", "OutputKey", "OutputValue").get(key);
+    }
+
+    private static ValidatableResponse topicAttributes(String topicArn) {
+        return given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", SNS_AUTH)
+            .formParam("Action", "GetTopicAttributes")
+            .formParam("TopicArn", topicArn)
+        .when().post("/").then();
+    }
+
+    private static String topicAttribute(String topicArn, String name) {
+        String xml = topicAttributes(topicArn).statusCode(200).extract().asString();
+        return XmlParser.extractPairs(xml, "entry", "key", "value").get(name);
+    }
+
+    private static void publish(String topicArn, String groupId, String dedupId, String message) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", SNS_AUTH)
+            .formParam("Action", "Publish")
+            .formParam("TopicArn", topicArn)
+            .formParam("Message", message)
+            .formParam("MessageGroupId", groupId)
+            .formParam("MessageDeduplicationId", dedupId)
+        .when().post("/").then().statusCode(200);
+    }
+
+    /**
+     * A FIFO receive hands back one message group at a time, so read repeatedly and match against
+     * everything that came back instead of a single response.
+     */
+    private static String drain(String queueUrl) {
+        StringBuilder received = new StringBuilder();
+        for (int i = 0; i < 6; i++) {
+            received.append(given()
+                .contentType("application/x-www-form-urlencoded")
+                .header("Authorization", SQS_AUTH)
+                .formParam("Action", "ReceiveMessage")
+                .formParam("QueueUrl", queueUrl)
+                .formParam("MaxNumberOfMessages", "10")
+            .when().post("/").then().statusCode(200).extract().asString());
+        }
+        return received.toString();
+    }
+
+    private static void purgeQueue(String queueUrl) {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", SQS_AUTH)
+            .formParam("Action", "PurgeQueue")
+            .formParam("QueueUrl", queueUrl)
+        .when().post("/").then().statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisionerTest.java
@@ -210,26 +210,77 @@ class SnsCfnProvisionerTest {
     }
 
     /**
-     * FifoTopic is createOnly and, in Floci as in CloudFormation, encoded in the name. A prior
-     * generated name that no longer matches the flag therefore belongs to the resource being
-     * replaced, so reusing it would leave the new topic standard.
+     * Replacing would displace a topic nothing cleans up, subscriptions included, so it is refused.
      */
     @Test
-    void aTopicTurningFifoDropsItsPriorStandardName() {
-        ArgumentCaptor<String> name = ArgumentCaptor.forClass(String.class);
-        when(sns.createTopic(name.capture(), anyMap(), anyMap(), anyString())).thenReturn(topic(TOPIC_ARN));
-
+    void aTopicTurningFifoIsRejectedRatherThanReplaced() {
         StackResource r = new StackResource();
         r.setLogicalId("Topic");
         r.setResourceType("AWS::SNS::Topic");
         r.setAttributes(new HashMap<>(Map.of("TopicName", "my-stack-Topic-abc123def456")));
         r.setPhysicalId(TOPIC_ARN);
-        provisioner.provision(r, props("""
+        ProvisionContext update =
+                new ProvisionContext(ctx.engine(), REGION, "000000000000", "my-stack", TOPIC_ARN);
+        JsonNode turningFifo = props("""
                 {"FifoTopic": true}
-                """), new ProvisionContext(ctx.engine(), REGION, "000000000000", "my-stack", TOPIC_ARN));
+                """);
 
-        assertTrue(name.getValue().endsWith(".fifo"));
-        assertFalse(name.getValue().startsWith("my-stack-Topic-abc123def456"));
+        AwsException e = assertThrows(AwsException.class,
+                () -> provisioner.provision(r, turningFifo, update));
+
+        assertEquals("ValidationError", e.getErrorCode());
+        assertTrue(e.getMessage().contains("requires resource replacement"), e.getMessage());
+        verify(sns, never()).createTopic(anyString(), anyMap(), anyMap(), anyString());
+    }
+
+    /** The suffix carries FifoTopic on its own, so this is the same topic, not a mode change. */
+    @Test
+    void anExplicitlyNamedFifoTopicUpdatesWithoutTheFlag() {
+        when(sns.createTopic(eq("events.fifo"), anyMap(), anyMap(), eq(REGION))).thenReturn(topic(TOPIC_ARN));
+
+        provisionUpdate("""
+                {"TopicName": "events.fifo"}
+                """);
+
+        verify(sns).createTopic(eq("events.fifo"), anyMap(), anyMap(), eq(REGION));
+    }
+
+    @Test
+    void anUpdateThatDropsAPropertyResetsItToItsDefault() {
+        when(sns.createTopic(eq("events.fifo"), anyMap(), anyMap(), eq(REGION))).thenReturn(topic(TOPIC_ARN));
+
+        // The template dropped both properties, so both go back to their create-time values.
+        provisionUpdate("""
+                {"TopicName": "events.fifo", "FifoTopic": true}
+                """);
+
+        verify(sns).setTopicAttributes(TOPIC_ARN, "FifoThroughputScope", "Topic", REGION);
+        verify(sns).setTopicAttributes(TOPIC_ARN, "ContentBasedDeduplication", "false", REGION);
+    }
+
+    /** Real SNS rejects both attributes on a standard topic, so an update must not invent them. */
+    @Test
+    void aStandardTopicUpdateWritesNoFifoDefaults() {
+        when(sns.createTopic(eq("events"), anyMap(), anyMap(), eq(REGION))).thenReturn(topic(TOPIC_ARN));
+
+        provisionUpdate("""
+                {"TopicName": "events"}
+                """);
+
+        verify(sns, never()).setTopicAttributes(anyString(), anyString(), anyString(), anyString());
+    }
+
+    /** Provisions an existing topic again, the way UpdateStack re-invokes the provisioner. */
+    private void provisionUpdate(String json) {
+        StackResource r = new StackResource();
+        r.setLogicalId("Topic");
+        r.setResourceType("AWS::SNS::Topic");
+        JsonNode resolved = props(json);
+        String priorName = resolved.path("TopicName").asText(null);
+        r.setAttributes(new HashMap<>(Map.of("TopicName", priorName)));
+        r.setPhysicalId(TOPIC_ARN);
+        provisioner.provision(r, resolved,
+                new ProvisionContext(ctx.engine(), REGION, "000000000000", "my-stack", TOPIC_ARN));
     }
 
     @Test
@@ -246,8 +297,7 @@ class SnsCfnProvisionerTest {
                  "ContentBasedDeduplication": "true"}
                 """), new ProvisionContext(ctx.engine(), REGION, "000000000000", "my-stack", TOPIC_ARN));
 
-        // createTopic hands back the existing topic untouched, so without this an UpdateStack that
-        // changes the scope would be silently dropped.
+        // createTopic returns the existing topic, so without this a changed scope would be lost.
         verify(sns).setTopicAttributes(TOPIC_ARN, "FifoThroughputScope", "MessageGroup", REGION);
         verify(sns).setTopicAttributes(TOPIC_ARN, "ContentBasedDeduplication", "true", REGION);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/SnsCfnProvisionerTest.java
@@ -169,6 +169,90 @@ class SnsCfnProvisionerTest {
     }
 
     @Test
+    void fifoThroughputScopeIsForwardedOnlyWhenSet() {
+        ArgumentCaptor<Map<String, String>> attrs = ArgumentCaptor.forClass(Map.class);
+        when(sns.createTopic(anyString(), attrs.capture(), anyMap(), anyString())).thenReturn(topic(TOPIC_ARN));
+
+        provision("AWS::SNS::Topic", """
+                {"TopicName": "events.fifo", "FifoTopic": true, "FifoThroughputScope": "MessageGroup"}
+                """);
+        assertEquals("MessageGroup", attrs.getValue().get("FifoThroughputScope"));
+        verify(sns, never()).setTopicAttributes(anyString(), anyString(), anyString(), anyString());
+
+        setUp();
+        ArgumentCaptor<Map<String, String>> plain = ArgumentCaptor.forClass(Map.class);
+        when(sns.createTopic(anyString(), plain.capture(), anyMap(), anyString())).thenReturn(topic(TOPIC_ARN));
+        provision("AWS::SNS::Topic", """
+                {"TopicName": "events.fifo", "FifoTopic": true}
+                """);
+        assertFalse(plain.getValue().containsKey("FifoThroughputScope"),
+                "an absent scope must not be sent as an empty attribute");
+    }
+
+    @Test
+    void anUnnamedFifoTopicGetsAGeneratedNameEndingInFifo() {
+        ArgumentCaptor<String> name = ArgumentCaptor.forClass(String.class);
+        when(sns.createTopic(name.capture(), anyMap(), anyMap(), anyString())).thenReturn(topic(TOPIC_ARN));
+
+        provision("AWS::SNS::Topic", """
+                {"FifoTopic": true, "FifoThroughputScope": "MessageGroup"}
+                """);
+        assertTrue(name.getValue().startsWith("my-stack-Topic-"));
+        assertTrue(name.getValue().endsWith(".fifo"),
+                "SnsService reads FifoTopic off the name, so a generated one must carry the suffix");
+
+        setUp();
+        ArgumentCaptor<String> standard = ArgumentCaptor.forClass(String.class);
+        when(sns.createTopic(standard.capture(), anyMap(), anyMap(), anyString())).thenReturn(topic(TOPIC_ARN));
+        provision("AWS::SNS::Topic", "{}");
+        assertFalse(standard.getValue().endsWith(".fifo"),
+                "a standard topic must not be renamed into a FIFO one");
+    }
+
+    /**
+     * FifoTopic is createOnly and, in Floci as in CloudFormation, encoded in the name. A prior
+     * generated name that no longer matches the flag therefore belongs to the resource being
+     * replaced, so reusing it would leave the new topic standard.
+     */
+    @Test
+    void aTopicTurningFifoDropsItsPriorStandardName() {
+        ArgumentCaptor<String> name = ArgumentCaptor.forClass(String.class);
+        when(sns.createTopic(name.capture(), anyMap(), anyMap(), anyString())).thenReturn(topic(TOPIC_ARN));
+
+        StackResource r = new StackResource();
+        r.setLogicalId("Topic");
+        r.setResourceType("AWS::SNS::Topic");
+        r.setAttributes(new HashMap<>(Map.of("TopicName", "my-stack-Topic-abc123def456")));
+        r.setPhysicalId(TOPIC_ARN);
+        provisioner.provision(r, props("""
+                {"FifoTopic": true}
+                """), new ProvisionContext(ctx.engine(), REGION, "000000000000", "my-stack", TOPIC_ARN));
+
+        assertTrue(name.getValue().endsWith(".fifo"));
+        assertFalse(name.getValue().startsWith("my-stack-Topic-abc123def456"));
+    }
+
+    @Test
+    void mutableTopicAttributesAreWrittenOnUpdate() {
+        when(sns.createTopic(eq("events.fifo"), anyMap(), anyMap(), eq(REGION))).thenReturn(topic(TOPIC_ARN));
+
+        StackResource r = new StackResource();
+        r.setLogicalId("Topic");
+        r.setResourceType("AWS::SNS::Topic");
+        r.setAttributes(new HashMap<>(Map.of("TopicName", "events.fifo")));
+        r.setPhysicalId(TOPIC_ARN);
+        provisioner.provision(r, props("""
+                {"TopicName": "events.fifo", "FifoTopic": true, "FifoThroughputScope": "MessageGroup",
+                 "ContentBasedDeduplication": "true"}
+                """), new ProvisionContext(ctx.engine(), REGION, "000000000000", "my-stack", TOPIC_ARN));
+
+        // createTopic hands back the existing topic untouched, so without this an UpdateStack that
+        // changes the scope would be silently dropped.
+        verify(sns).setTopicAttributes(TOPIC_ARN, "FifoThroughputScope", "MessageGroup", REGION);
+        verify(sns).setTopicAttributes(TOPIC_ARN, "ContentBasedDeduplication", "true", REGION);
+    }
+
+    @Test
     void subscriptionRefIsTheSubscriptionArn() {
         when(sns.subscribe(eq(TOPIC_ARN), eq("sqs"), eq("arn:queue"), eq(REGION), anyMap()))
                 .thenReturn(subscription("arn:sub"));

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
@@ -238,6 +238,28 @@ class SnsSqsFanoutFifoDeliveryTest {
     }
 
     @Test
+    void publish_afterThroughputScopeChanges_doesNotHitTheOtherScopesCacheEntry() {
+        // Arrange
+        String queueUrl = createGroupScopedQueue("fifo-scope-switch-queue.fifo");
+        String topicArn = createFifoTopic("fifo-scope-switch-topic.fifo",
+                Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
+                "fifo-scope-switch-queue.fifo");
+
+        // Act: publish group-scoped, then again topic-scoped with a dedup id shaped like the
+        // group-scoped key, inside the deduplication window.
+        snsService.publish(topicArn, null, null, "group-scoped", null, null, "a", "b", REGION);
+        snsService.setTopicAttributes(topicArn, "FifoThroughputScope", "Topic", REGION);
+        snsService.publish(topicArn, null, null, "topic-scoped", null, null, "z", "1#ab", REGION);
+
+        // Assert: the two scopes keep separate cache namespaces, so neither suppresses the other.
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
+        assertEquals(2, messages.size());
+        List<String> bodies = messages.stream().map(Message::getBody).toList();
+        assertTrue(bodies.stream().anyMatch(b -> b.contains("group-scoped")));
+        assertTrue(bodies.stream().anyMatch(b -> b.contains("topic-scoped")));
+    }
+
+    @Test
     void publishBatch_withMessageGroupThroughputScope_deliversSameDedupIdInDifferentGroups() {
         // Arrange
         String queueUrl = createGroupScopedQueue("fifo-batch-group-scope-queue.fifo");

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
@@ -168,16 +168,16 @@ class SnsSqsFanoutFifoDeliveryTest {
 
     @Test
     void publish_withDefaultThroughputScope_dedupsAcrossMessageGroups() {
-        // Arrange — no FifoThroughputScope, so the AWS default (Topic) applies
+        // Arrange: no FifoThroughputScope, so the AWS default (Topic) applies
         String queueUrl = createGroupScopedQueue("fifo-topic-scope-queue.fifo");
         String topicArn = createFifoTopic("fifo-topic-scope-topic.fifo", Map.of("FifoTopic", "true"),
                 "fifo-topic-scope-queue.fifo");
 
-        // Act — same dedup ID under two different message groups
+        // Act: same dedup ID under two different message groups
         snsService.publish(topicArn, null, null, "group-one", null, null, "group-1", "shared-dedup", REGION);
         snsService.publish(topicArn, null, null, "group-two", null, null, "group-2", "shared-dedup", REGION);
 
-        // Assert — deduplication is topic-wide, so the second publish is swallowed
+        // Assert: deduplication is topic-wide, so the second publish is swallowed
         List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
         assertEquals(1, messages.size());
         assertTrue(messages.getFirst().getBody().contains("group-one"));
@@ -191,11 +191,11 @@ class SnsSqsFanoutFifoDeliveryTest {
                 Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
                 "fifo-group-scope-queue.fifo");
 
-        // Act — same dedup ID under two different message groups
+        // Act: same dedup ID under two different message groups
         snsService.publish(topicArn, null, null, "group-one", null, null, "group-1", "shared-dedup", REGION);
         snsService.publish(topicArn, null, null, "group-two", null, null, "group-2", "shared-dedup", REGION);
 
-        // Assert — deduplication is scoped per group, so both are distinct messages
+        // Assert: deduplication is scoped per group, so both are distinct messages
         List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
         assertEquals(2, messages.size());
         List<String> bodies = messages.stream().map(Message::getBody).toList();
@@ -211,11 +211,11 @@ class SnsSqsFanoutFifoDeliveryTest {
                 Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
                 "fifo-group-scope-dup-queue.fifo");
 
-        // Act — same dedup ID twice under the same message group
+        // Act: same dedup ID twice under the same message group
         snsService.publish(topicArn, null, null, "first", null, null, "group-1", "shared-dedup", REGION);
         snsService.publish(topicArn, null, null, "second", null, null, "group-1", "shared-dedup", REGION);
 
-        // Assert — narrowing the scope must not disable deduplication inside a group
+        // Assert: narrowing the scope must not disable deduplication inside a group
         List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
         assertEquals(1, messages.size());
         assertTrue(messages.getFirst().getBody().contains("first"));
@@ -245,7 +245,7 @@ class SnsSqsFanoutFifoDeliveryTest {
                 Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
                 "fifo-batch-group-scope-queue.fifo");
 
-        // Act — one batch, same dedup ID under two different message groups
+        // Act: one batch, same dedup ID under two different message groups
         var entries = List.<Map<String, Object>>of(
                 Map.of("Id", "e1", "Message", "batch-group-one",
                         "MessageGroupId", "group-1", "MessageDeduplicationId", "shared-dedup"),
@@ -264,10 +264,7 @@ class SnsSqsFanoutFifoDeliveryTest {
         assertTrue(bodies.stream().anyMatch(b -> b.contains("batch-group-two")));
     }
 
-    /**
-     * The queue deduplicates per group too, so a message SNS forwards is never dropped again by
-     * SQS on the way in. Without this the queue's own topic-wide dedup would mask the topic's.
-     */
+    /** Per-group dedup on the queue too, so its own topic-wide window cannot mask the topic's. */
     private String createGroupScopedQueue(String queueName) {
         sqsService.createQueue(queueName, Map.of(
                 "FifoQueue", "true",

--- a/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/sns/SnsSqsFanoutFifoDeliveryTest.java
@@ -15,7 +15,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests that SNS FIFO topic delivery correctly passes messageDeduplicationId
- * through to subscribed SQS FIFO queues.
+ * through to subscribed SQS FIFO queues, and that the topic's FifoThroughputScope
+ * decides whether deduplication is topic-wide or per message group.
  */
 class SnsSqsFanoutFifoDeliveryTest {
 
@@ -163,6 +164,124 @@ class SnsSqsFanoutFifoDeliveryTest {
         List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
         assertEquals(1, messages.size());
         assertTrue(messages.get(0).getBody().contains("first"));
+    }
+
+    @Test
+    void publish_withDefaultThroughputScope_dedupsAcrossMessageGroups() {
+        // Arrange — no FifoThroughputScope, so the AWS default (Topic) applies
+        String queueUrl = createGroupScopedQueue("fifo-topic-scope-queue.fifo");
+        String topicArn = createFifoTopic("fifo-topic-scope-topic.fifo", Map.of("FifoTopic", "true"),
+                "fifo-topic-scope-queue.fifo");
+
+        // Act — same dedup ID under two different message groups
+        snsService.publish(topicArn, null, null, "group-one", null, null, "group-1", "shared-dedup", REGION);
+        snsService.publish(topicArn, null, null, "group-two", null, null, "group-2", "shared-dedup", REGION);
+
+        // Assert — deduplication is topic-wide, so the second publish is swallowed
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
+        assertEquals(1, messages.size());
+        assertTrue(messages.getFirst().getBody().contains("group-one"));
+    }
+
+    @Test
+    void publish_withMessageGroupThroughputScope_deliversSameDedupIdInDifferentGroups() {
+        // Arrange
+        String queueUrl = createGroupScopedQueue("fifo-group-scope-queue.fifo");
+        String topicArn = createFifoTopic("fifo-group-scope-topic.fifo",
+                Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
+                "fifo-group-scope-queue.fifo");
+
+        // Act — same dedup ID under two different message groups
+        snsService.publish(topicArn, null, null, "group-one", null, null, "group-1", "shared-dedup", REGION);
+        snsService.publish(topicArn, null, null, "group-two", null, null, "group-2", "shared-dedup", REGION);
+
+        // Assert — deduplication is scoped per group, so both are distinct messages
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
+        assertEquals(2, messages.size());
+        List<String> bodies = messages.stream().map(Message::getBody).toList();
+        assertTrue(bodies.stream().anyMatch(b -> b.contains("group-one")));
+        assertTrue(bodies.stream().anyMatch(b -> b.contains("group-two")));
+    }
+
+    @Test
+    void publish_withMessageGroupThroughputScope_stillDedupsWithinOneGroup() {
+        // Arrange
+        String queueUrl = createGroupScopedQueue("fifo-group-scope-dup-queue.fifo");
+        String topicArn = createFifoTopic("fifo-group-scope-dup-topic.fifo",
+                Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
+                "fifo-group-scope-dup-queue.fifo");
+
+        // Act — same dedup ID twice under the same message group
+        snsService.publish(topicArn, null, null, "first", null, null, "group-1", "shared-dedup", REGION);
+        snsService.publish(topicArn, null, null, "second", null, null, "group-1", "shared-dedup", REGION);
+
+        // Assert — narrowing the scope must not disable deduplication inside a group
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
+        assertEquals(1, messages.size());
+        assertTrue(messages.getFirst().getBody().contains("first"));
+    }
+
+    @Test
+    void publish_withMessageGroupThroughputScope_isCaseInsensitive() {
+        // Arrange
+        String queueUrl = createGroupScopedQueue("fifo-group-scope-case-queue.fifo");
+        String topicArn = createFifoTopic("fifo-group-scope-case-topic.fifo",
+                Map.of("FifoTopic", "true", "FifoThroughputScope", "messagegroup"),
+                "fifo-group-scope-case-queue.fifo");
+
+        // Act
+        snsService.publish(topicArn, null, null, "group-one", null, null, "group-1", "shared-dedup", REGION);
+        snsService.publish(topicArn, null, null, "group-two", null, null, "group-2", "shared-dedup", REGION);
+
+        // Assert
+        assertEquals(2, sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION).size());
+    }
+
+    @Test
+    void publishBatch_withMessageGroupThroughputScope_deliversSameDedupIdInDifferentGroups() {
+        // Arrange
+        String queueUrl = createGroupScopedQueue("fifo-batch-group-scope-queue.fifo");
+        String topicArn = createFifoTopic("fifo-batch-group-scope-topic.fifo",
+                Map.of("FifoTopic", "true", "FifoThroughputScope", "MessageGroup"),
+                "fifo-batch-group-scope-queue.fifo");
+
+        // Act — one batch, same dedup ID under two different message groups
+        var entries = List.<Map<String, Object>>of(
+                Map.of("Id", "e1", "Message", "batch-group-one",
+                        "MessageGroupId", "group-1", "MessageDeduplicationId", "shared-dedup"),
+                Map.of("Id", "e2", "Message", "batch-group-two",
+                        "MessageGroupId", "group-2", "MessageDeduplicationId", "shared-dedup")
+        );
+        var result = snsService.publishBatch(topicArn, entries, REGION);
+
+        // Assert
+        assertEquals(2, result.successful().size());
+        assertEquals(0, result.failed().size());
+        List<Message> messages = sqsService.receiveMessage(queueUrl, 10, 30, 0, REGION);
+        assertEquals(2, messages.size());
+        List<String> bodies = messages.stream().map(Message::getBody).toList();
+        assertTrue(bodies.stream().anyMatch(b -> b.contains("batch-group-one")));
+        assertTrue(bodies.stream().anyMatch(b -> b.contains("batch-group-two")));
+    }
+
+    /**
+     * The queue deduplicates per group too, so a message SNS forwards is never dropped again by
+     * SQS on the way in. Without this the queue's own topic-wide dedup would mask the topic's.
+     */
+    private String createGroupScopedQueue(String queueName) {
+        sqsService.createQueue(queueName, Map.of(
+                "FifoQueue", "true",
+                "DeduplicationScope", "messageGroup",
+                "FifoThroughputLimit", "perMessageGroupId"), REGION);
+        return BASE_URL + "/" + ACCOUNT + "/" + queueName;
+    }
+
+    private String createFifoTopic(String topicName, Map<String, String> attributes, String queueName) {
+        snsService.createTopic(topicName, attributes, null, REGION);
+        String topicArn = "arn:aws:sns:" + REGION + ":" + ACCOUNT + ":" + topicName;
+        snsService.subscribe(topicArn, "sqs",
+                "arn:aws:sqs:" + REGION + ":" + ACCOUNT + ":" + queueName, REGION, Map.of());
+        return topicArn;
     }
 
     @Test


### PR DESCRIPTION
## Summary

An SNS FIFO topic accepted `FifoThroughputScope` and reported it back from `GetTopicAttributes`,
but deduplication stayed topic-wide regardless of the value. The same `MessageDeduplicationId`
published under two different `MessageGroupId`s delivered only the first message, so a fan-out
that reuses one deduplication id per group silently lost every message after the first.

AWS is explicit that this attribute controls the deduplication scope, not just throughput
accounting ([High throughput FIFO topics in Amazon SNS](https://docs.aws.amazon.com/sns/latest/dg/fifo-high-throughput.html)):

> By default Amazon SNS FIFO topics are configured for topic-level deduplication, this is
> controlled by the topic attribute `FifoThroughputScope` set to `Topic` [...] To enable high
> throughput for your Amazon SNS FIFO topic, update the `FifoThroughputScope` attribute to
> `MessageGroup`.

| Same `MessageDeduplicationId`, two different `MessageGroupId`s | Real SNS | Floci before | Floci after |
|---|---|---|---|
| topic `FifoThroughputScope=MessageGroup` | both delivered | only the first | both delivered |
| topic `FifoThroughputScope=Topic` or unset (AWS default) | only the first | only the first | only the first |

Two commits, the service behavior and the CloudFormation path that feeds it:

**`SnsService`** scopes the deduplication cache key to the message group when the topic sets
`FifoThroughputScope=MessageGroup`, on both `Publish` and `PublishBatch`. This mirrors how
`SqsService` already handles `DeduplicationScope=messageGroup`, including the NUL delimiter that
keeps a group-scoped key from colliding with a topic-scoped one. `Topic` stays the default and
keeps the existing behavior.

**`SnsCfnProvisioner`** forwarded only `ContentBasedDeduplication`, so a topic provisioned from a
template never saw the attribute above. It now also:

- forwards `FifoThroughputScope`
- suffixes a generated FIFO topic name with `.fifo`, as CloudFormation does, which is also what
  makes `SnsService` treat the topic as FIFO at all. `FifoTopic` needs no forwarding because
  `SnsService` reads it off that suffix
- treats a prior generated name whose suffix no longer matches the createOnly `FifoTopic` flag as
  belonging to a replaced resource, so it does not reuse it
- rewrites the mutable attributes on `UpdateStack`, which `createTopic` otherwise leaves untouched
  when the topic already exists. That gap applied to `ContentBasedDeduplication` too

One related gap is deliberately left out, happy to follow up: topic attributes are still an
unvalidated bag. An invalid `FifoThroughputScope` value, an unknown attribute name, and
`FifoThroughputScope` on a standard topic are all accepted and echoed back, where real SNS rejects
each one. That is what makes an unimplemented attribute look like a configured one, and it is why
the behavior above read as a caller-side fan-out bug rather than an emulator gap.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `FifoThroughputScope=MessageGroup` was stored and returned but never read, so
deduplication was always topic-wide, and the attribute was dropped entirely on the CloudFormation
path. Verified against the attribute contract in the SNS API model (`CreateTopic` `Attributes`),
which documents exactly two values, `Topic` (default) and `MessageGroup`, and against the
`AWS::SNS::Topic` registry schema, which lists `FifoThroughputScope` as a writable property and
`FifoTopic` and `TopicName` as createOnly.

Reproduced against `floci/floci:1.5.33` and `floci/floci:2.0.1` with `@aws-sdk/client-sns`
3.1077.0 publishing through a FIFO topic to a subscribed SQS FIFO queue: 1 of 2 messages delivered
before, 2 of 2 after.

Value matching is case-insensitive, consistent with how SQS compares `DeduplicationScope`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`SnsSqsFanoutFifoDeliveryTest`, publishing through a real `SqsService` with the subscribed queue on
`DeduplicationScope=messageGroup` so the queue's own topic-wide window cannot mask the topic's:

- `publish_withMessageGroupThroughputScope_deliversSameDedupIdInDifferentGroups`
- `publish_withMessageGroupThroughputScope_stillDedupsWithinOneGroup`
- `publish_withMessageGroupThroughputScope_isCaseInsensitive`
- `publishBatch_withMessageGroupThroughputScope_deliversSameDedupIdInDifferentGroups`
- `publish_withDefaultThroughputScope_dedupsAcrossMessageGroups`, pinning the AWS default

`SnsCfnProvisionerTest` covers the forwarding, the generated `.fifo` name, the replacing update,
and the attribute rewrite on update.

`SnsFifoThroughputScopeCfnIntegrationTest` is the end-to-end case: a stack with a FIFO topic, a
FIFO queue and a raw-delivery subscription, asserting `GetTopicAttributes` reports the scope, that
one deduplication id under two groups delivers both messages, that an `UpdateStack` back to `Topic`
takes effect and then deduplicates across groups again, and that the delete removes the topic.

Each new case fails on the unpatched code (`expected: <2> but was: <1>` for the service, `expected:
<MessageGroup> but was: <null>` for the template path); the two guard cases pass before and after.

`docs/services/sns.md` gains a FIFO topics section documenting both scopes and the CloudFormation
properties, since FIFO behavior was previously undocumented. `make docs-check` is clean.
