### PR TITLE
fix(cloudfront): echo OriginSslProtocols and round-trip legacy cache behavior fields

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
@@ -1934,6 +1934,7 @@ public class CloudFrontController {
                     .elem("HTTPSPort", coc.getOrDefault("HTTPSPort", "443").toString())
                     .elem("OriginProtocolPolicy",
                             coc.getOrDefault("OriginProtocolPolicy", "https-only").toString())
+                    .raw(xmlOriginSslProtocols(coc.get("OriginSslProtocols")))
                     .end("CustomOriginConfig");
         }
 
@@ -1966,13 +1967,19 @@ public class CloudFrontController {
                 .elem("CachePolicyId", dcb.getCachePolicyId())
                 .elem("OriginRequestPolicyId", dcb.getOriginRequestPolicyId())
                 .elem("ResponseHeadersPolicyId", dcb.getResponseHeadersPolicyId())
-                .elem("Compress", dcb.isCompress());
+                .elem("FieldLevelEncryptionId",
+                        dcb.getFieldLevelEncryptionId() != null ? dcb.getFieldLevelEncryptionId() : "")
+                .elem("Compress", dcb.isCompress())
+                .elem("SmoothStreaming", dcb.isSmoothStreaming());
+
+        xml.raw(xmlCacheBehaviorTtls(dcb.getMinTTL(), dcb.getDefaultTTL(), dcb.getMaxTTL()));
 
         xml.raw(xmlTrustedSigners());
         xml.raw(xmlTrustedKeyGroups(
                 dcb.isTrustedKeyGroupsEnabled(), dcb.getTrustedKeyGroups()));
 
         xml.raw(xmlAllowedMethods(dcb.getAllowedMethods(), dcb.getCachedMethods()));
+        xml.raw(xmlCacheBehaviorForwardedValues(dcb.getCachePolicyId(), dcb.getForwardedValues()));
 
         xml.raw(xmlFunctionAssociations(dcb.getFunctionAssociations()));
         xml.raw(xmlLambdaFunctionAssociations(dcb.getLambdaFunctionAssociations()));
@@ -1991,13 +1998,19 @@ public class CloudFrontController {
                 .elem("CachePolicyId", cb.getCachePolicyId())
                 .elem("OriginRequestPolicyId", cb.getOriginRequestPolicyId())
                 .elem("ResponseHeadersPolicyId", cb.getResponseHeadersPolicyId())
-                .elem("Compress", cb.isCompress());
+                .elem("FieldLevelEncryptionId",
+                        cb.getFieldLevelEncryptionId() != null ? cb.getFieldLevelEncryptionId() : "")
+                .elem("Compress", cb.isCompress())
+                .elem("SmoothStreaming", cb.isSmoothStreaming());
+
+        xml.raw(xmlCacheBehaviorTtls(cb.getMinTTL(), cb.getDefaultTTL(), cb.getMaxTTL()));
 
         xml.raw(xmlTrustedSigners());
         xml.raw(xmlTrustedKeyGroups(
                 cb.isTrustedKeyGroupsEnabled(), cb.getTrustedKeyGroups()));
 
         xml.raw(xmlAllowedMethods(cb.getAllowedMethods(), cb.getCachedMethods()));
+        xml.raw(xmlCacheBehaviorForwardedValues(cb.getCachePolicyId(), cb.getForwardedValues()));
 
         xml.raw(xmlFunctionAssociations(cb.getFunctionAssociations()));
         xml.raw(xmlLambdaFunctionAssociations(cb.getLambdaFunctionAssociations()));
@@ -2070,6 +2083,85 @@ public class CloudFrontController {
                 .elem("Quantity", 0)
                 .end("TrustedSigners")
                 .build();
+    }
+
+    // A custom origin must carry OriginSslProtocols. Floci did not echo it, and the Terraform AWS
+    // provider flattens CustomOriginConfig.OriginSslProtocols.Items with no nil guard, so an omitted
+    // element segfaults it on distribution read-back. Round-trip the submitted protocols, defaulting
+    // to the form AWS returns when the client sends none.
+    private String xmlOriginSslProtocols(Object protocols) {
+        List<String> list = stringList(protocols);
+        if (list.isEmpty()) {
+            list = List.of("TLSv1.2");
+        }
+        XmlBuilder xml = new XmlBuilder()
+                .start("OriginSslProtocols")
+                .elem("Quantity", list.size())
+                .start("Items");
+        for (String protocol : list) {
+            xml.elem("SslProtocol", protocol);
+        }
+        return xml.end("Items").end("OriginSslProtocols").build();
+    }
+
+    // DefaultTTL and MaxTTL are optional, and 0 is a meaningful value (the usual "do not cache" with
+    // forwarded_values), so presence has to be tracked separately from the value. Treating 0 as unset
+    // drops an explicit default_ttl = 0 from the read-back and the provider then sees a permanent diff.
+    private String xmlCacheBehaviorTtls(Long minTtl, Long defaultTtl, Long maxTtl) {
+        XmlBuilder xml = new XmlBuilder().elem("MinTTL", minTtl != null ? minTtl : 0L);
+        if (defaultTtl != null) {
+            xml.elem("DefaultTTL", defaultTtl);
+        }
+        if (maxTtl != null) {
+            xml.elem("MaxTTL", maxTtl);
+        }
+        return xml.build();
+    }
+
+    // When a cache behavior uses the legacy (non-cache-policy) form, AWS echoes a full ForwardedValues
+    // object. Floci dropped it, so the provider's read either lost the config or, on newer provider
+    // versions, dereferenced the missing object. Emit the submitted values in the shape AWS returns.
+    private String xmlCacheBehaviorForwardedValues(String cachePolicyId, Map<String, Object> forwardedValues) {
+        if (cachePolicyId != null && !cachePolicyId.isEmpty()) {
+            return "";
+        }
+        boolean queryString = forwardedValues != null
+                && Boolean.TRUE.equals(forwardedValues.get("QueryString"));
+        Object forward = forwardedValues != null ? forwardedValues.get("CookiesForward") : null;
+        XmlBuilder xml = new XmlBuilder()
+                .start("ForwardedValues")
+                .elem("QueryString", queryString)
+                .start("Cookies")
+                .elem("Forward", forward != null ? forward.toString() : "none");
+        xml.raw(xmlForwardedNames("WhitelistedNames", "Name",
+                forwardedValuesList(forwardedValues, "CookieNames")));
+        xml.end("Cookies");
+        xml.raw(xmlForwardedNames("Headers", "Name",
+                forwardedValuesList(forwardedValues, "Headers")));
+        xml.raw(xmlForwardedNames("QueryStringCacheKeys", "Name",
+                forwardedValuesList(forwardedValues, "QueryStringCacheKeys")));
+        return xml.end("ForwardedValues").build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> forwardedValuesList(Map<String, Object> forwardedValues, String key) {
+        Object value = forwardedValues != null ? forwardedValues.get(key) : null;
+        return value instanceof List<?> list ? (List<String>) list : List.of();
+    }
+
+    // Whitelisted cookie names, forwarded headers and query-string cache keys are Quantity/Items pairs.
+    // Echoing a bare Quantity 0 loses whatever the client whitelisted, so the provider reads the lists
+    // back empty and diffs on every plan. AWS omits Items entirely when the quantity is zero.
+    private String xmlForwardedNames(String wrapper, String itemName, List<String> names) {
+        XmlBuilder xml = new XmlBuilder().start(wrapper).elem("Quantity", names.size());
+        if (!names.isEmpty()) {
+            xml.start("Items");
+            for (String name : names) {
+                xml.elem(itemName, name);
+            }
+            xml.end("Items");
+        }
+        return xml.end(wrapper).build();
     }
 
     private String xmlActiveTrustedKeyGroups(DistributionConfig config) {
@@ -2554,9 +2646,11 @@ public class CloudFrontController {
             boolean inOrigin = false;
             boolean inS3OriginConfig = false;
             boolean inCustomOriginConfig = false;
+            boolean inOriginSslProtocols = false;
             Origin current = null;
             Map<String, String> s3Config = null;
             Map<String, Object> customConfig = null;
+            List<String> sslProtocols = null;
             boolean inCustomHeaders = false;
             boolean inCustomHeaderItems = false;
             boolean customHeaderItemsSeen = false;
@@ -2606,6 +2700,17 @@ public class CloudFrontController {
                             if (inOrigin) {
                                 inCustomOriginConfig = true;
                                 customConfig = new LinkedHashMap<>();
+                            }
+                        }
+                        case "OriginSslProtocols" -> {
+                            if (inCustomOriginConfig) {
+                                inOriginSslProtocols = true;
+                                sslProtocols = new ArrayList<>();
+                            }
+                        }
+                        case "SslProtocol" -> {
+                            if (inOriginSslProtocols && sslProtocols != null) {
+                                sslProtocols.add(r.getElementText());
                             }
                         }
                         case "Id" -> {
@@ -2716,6 +2821,13 @@ public class CloudFrontController {
                             }
                             inS3OriginConfig = false;
                             s3Config = null;
+                        }
+                        case "OriginSslProtocols" -> {
+                            if (inCustomOriginConfig && customConfig != null && sslProtocols != null) {
+                                customConfig.put("OriginSslProtocols", sslProtocols);
+                            }
+                            inOriginSslProtocols = false;
+                            sslProtocols = null;
                         }
                         case "CustomOriginConfig" -> {
                             if (inCustomOriginConfig && current != null) {
@@ -2847,6 +2959,40 @@ public class CloudFrontController {
         }
     }
 
+    private static long parseLongOrZero(String value) {
+        if (value == null) {
+            return 0L;
+        }
+        try {
+            return Long.parseLong(value.trim());
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
+    }
+
+    private static Map<String, Object> forwardedValuesModel(
+            Boolean queryString,
+            String cookiesForward,
+            List<String> cookieNames,
+            List<String> headers,
+            List<String> queryStringCacheKeys) {
+        Map<String, Object> forwardedValues = new LinkedHashMap<>();
+        forwardedValues.put("QueryString", queryString != null && queryString);
+        if (cookiesForward != null) {
+            forwardedValues.put("CookiesForward", cookiesForward);
+        }
+        if (cookieNames != null && !cookieNames.isEmpty()) {
+            forwardedValues.put("CookieNames", List.copyOf(cookieNames));
+        }
+        if (headers != null && !headers.isEmpty()) {
+            forwardedValues.put("Headers", List.copyOf(headers));
+        }
+        if (queryStringCacheKeys != null && !queryStringCacheKeys.isEmpty()) {
+            forwardedValues.put("QueryStringCacheKeys", List.copyOf(queryStringCacheKeys));
+        }
+        return forwardedValues;
+    }
+
     private DefaultCacheBehavior parseDefaultCacheBehavior(String body) {
         DefaultCacheBehavior dcb = new DefaultCacheBehavior();
         if (body == null || body.isEmpty()) {
@@ -2864,6 +3010,17 @@ public class CloudFrontController {
             List<String> allowedMethods = new ArrayList<>();
             List<String> cachedMethods = new ArrayList<>();
             List<String> trustedKeyGroups = new ArrayList<>();
+            boolean inForwardedValues = false;
+            boolean inForwardedCookies = false;
+            boolean inForwardedCookieNames = false;
+            boolean inForwardedHeaders = false;
+            boolean inForwardedQueryStringCacheKeys = false;
+            boolean sawForwardedValues = false;
+            Boolean forwardedQueryString = null;
+            String forwardedCookiesForward = null;
+            List<String> forwardedCookieNames = new ArrayList<>();
+            List<String> forwardedHeaders = new ArrayList<>();
+            List<String> forwardedQueryStringCacheKeys = new ArrayList<>();
             boolean inLambdaAssociations = false;
             boolean inFunctionAssociations = false;
             Map<String, Object> currentLambdaAssociation = null;
@@ -2957,6 +3114,41 @@ public class CloudFrontController {
                         case "CachedMethods" -> {
                             if (inAllowedMethods) inCachedMethods = true;
                         }
+                        case "ForwardedValues" -> {
+                            if (inDcb) {
+                                inForwardedValues = true;
+                                sawForwardedValues = true;
+                            }
+                        }
+                        case "Cookies" -> {
+                            if (inForwardedValues) inForwardedCookies = true;
+                        }
+                        case "WhitelistedNames" -> {
+                            if (inForwardedCookies) inForwardedCookieNames = true;
+                        }
+                        case "Headers" -> {
+                            if (inForwardedValues) inForwardedHeaders = true;
+                        }
+                        case "QueryStringCacheKeys" -> {
+                            if (inForwardedValues) inForwardedQueryStringCacheKeys = true;
+                        }
+                        case "Name" -> {
+                            if (inForwardedCookieNames) {
+                                forwardedCookieNames.add(r.getElementText());
+                            } else if (inForwardedHeaders) {
+                                forwardedHeaders.add(r.getElementText());
+                            } else if (inForwardedQueryStringCacheKeys) {
+                                forwardedQueryStringCacheKeys.add(r.getElementText());
+                            }
+                        }
+                        case "QueryString" -> {
+                            if (inForwardedValues && !inForwardedCookies) {
+                                forwardedQueryString = "true".equalsIgnoreCase(r.getElementText());
+                            }
+                        }
+                        case "Forward" -> {
+                            if (inForwardedCookies) forwardedCookiesForward = r.getElementText();
+                        }
                         case "TargetOriginId" -> {
                             if (inDcb) dcb.setTargetOriginId(r.getElementText());
                         }
@@ -2981,6 +3173,18 @@ public class CloudFrontController {
                         case "Compress" -> {
                             if (inDcb) dcb.setCompress("true".equalsIgnoreCase(r.getElementText()));
                         }
+                        case "SmoothStreaming" -> {
+                            if (inDcb) dcb.setSmoothStreaming("true".equalsIgnoreCase(r.getElementText()));
+                        }
+                        case "MinTTL" -> {
+                            if (inDcb) dcb.setMinTTL(parseLongOrZero(r.getElementText()));
+                        }
+                        case "DefaultTTL" -> {
+                            if (inDcb) dcb.setDefaultTTL(parseLongOrZero(r.getElementText()));
+                        }
+                        case "MaxTTL" -> {
+                            if (inDcb) dcb.setMaxTTL(parseLongOrZero(r.getElementText()));
+                        }
                         case "Method" -> {
                             if (inCachedMethods) {
                                 cachedMethods.add(r.getElementText());
@@ -2995,6 +3199,11 @@ public class CloudFrontController {
                     switch (r.getLocalName()) {
                         case "CachedMethods" -> inCachedMethods = false;
                         case "AllowedMethods" -> inAllowedMethods = false;
+                        case "WhitelistedNames" -> inForwardedCookieNames = false;
+                        case "Headers" -> inForwardedHeaders = false;
+                        case "QueryStringCacheKeys" -> inForwardedQueryStringCacheKeys = false;
+                        case "Cookies" -> inForwardedCookies = false;
+                        case "ForwardedValues" -> inForwardedValues = false;
                         case "TrustedKeyGroups" -> inTrustedKeyGroups = false;
                         case "DefaultCacheBehavior" -> inDcb = false;
                         case "LambdaFunctionAssociations" -> inLambdaAssociations = false;
@@ -3022,6 +3231,14 @@ public class CloudFrontController {
             }
             if (!cachedMethods.isEmpty()) {
                 dcb.setCachedMethods(cachedMethods);
+            }
+            if (sawForwardedValues) {
+                dcb.setForwardedValues(forwardedValuesModel(
+                        forwardedQueryString,
+                        forwardedCookiesForward,
+                        forwardedCookieNames,
+                        forwardedHeaders,
+                        forwardedQueryStringCacheKeys));
             }
             if (!trustedKeyGroups.isEmpty()) {
                 dcb.setTrustedKeyGroups(trustedKeyGroups);
@@ -3078,6 +3295,17 @@ public class CloudFrontController {
             List<String> allowedMethods = new ArrayList<>();
             List<String> cachedMethods = new ArrayList<>();
             List<String> trustedKeyGroups = new ArrayList<>();
+            boolean inForwardedValues = false;
+            boolean inForwardedCookies = false;
+            boolean inForwardedCookieNames = false;
+            boolean inForwardedHeaders = false;
+            boolean inForwardedQueryStringCacheKeys = false;
+            boolean sawForwardedValues = false;
+            Boolean forwardedQueryString = null;
+            String forwardedCookiesForward = null;
+            List<String> forwardedCookieNames = new ArrayList<>();
+            List<String> forwardedHeaders = new ArrayList<>();
+            List<String> forwardedQueryStringCacheKeys = new ArrayList<>();
             boolean inLambdaAssociations = false;
             boolean inFunctionAssociations = false;
             Map<String, Object> currentLambdaAssociation = null;
@@ -3103,6 +3331,12 @@ public class CloudFrontController {
                                 allowedMethods = new ArrayList<>();
                                 cachedMethods = new ArrayList<>();
                                 trustedKeyGroups = new ArrayList<>();
+                                sawForwardedValues = false;
+                                forwardedQueryString = null;
+                                forwardedCookiesForward = null;
+                                forwardedCookieNames = new ArrayList<>();
+                                forwardedHeaders = new ArrayList<>();
+                                forwardedQueryStringCacheKeys = new ArrayList<>();
                                 lambdaAssociations = new ArrayList<>();
                                 functionAssociations = new ArrayList<>();
                                 lambdaAssociationsQuantity = null;
@@ -3187,6 +3421,41 @@ public class CloudFrontController {
                         case "CachedMethods" -> {
                             if (inAllowedMethods) inCachedMethods = true;
                         }
+                        case "ForwardedValues" -> {
+                            if (inCacheBehavior) {
+                                inForwardedValues = true;
+                                sawForwardedValues = true;
+                            }
+                        }
+                        case "Cookies" -> {
+                            if (inForwardedValues) inForwardedCookies = true;
+                        }
+                        case "WhitelistedNames" -> {
+                            if (inForwardedCookies) inForwardedCookieNames = true;
+                        }
+                        case "Headers" -> {
+                            if (inForwardedValues) inForwardedHeaders = true;
+                        }
+                        case "QueryStringCacheKeys" -> {
+                            if (inForwardedValues) inForwardedQueryStringCacheKeys = true;
+                        }
+                        case "Name" -> {
+                            if (inForwardedCookieNames) {
+                                forwardedCookieNames.add(r.getElementText());
+                            } else if (inForwardedHeaders) {
+                                forwardedHeaders.add(r.getElementText());
+                            } else if (inForwardedQueryStringCacheKeys) {
+                                forwardedQueryStringCacheKeys.add(r.getElementText());
+                            }
+                        }
+                        case "QueryString" -> {
+                            if (inForwardedValues && !inForwardedCookies) {
+                                forwardedQueryString = "true".equalsIgnoreCase(r.getElementText());
+                            }
+                        }
+                        case "Forward" -> {
+                            if (inForwardedCookies) forwardedCookiesForward = r.getElementText();
+                        }
                         case "PathPattern" -> {
                             if (inCacheBehavior && current != null) current.setPathPattern(r.getElementText());
                         }
@@ -3207,9 +3476,33 @@ public class CloudFrontController {
                             if (inCacheBehavior && current != null)
                                 current.setResponseHeadersPolicyId(r.getElementText());
                         }
+                        case "FieldLevelEncryptionId" -> {
+                            if (inCacheBehavior && current != null)
+                                current.setFieldLevelEncryptionId(r.getElementText());
+                        }
                         case "Compress" -> {
                             if (inCacheBehavior && current != null) {
                                 current.setCompress("true".equalsIgnoreCase(r.getElementText()));
+                            }
+                        }
+                        case "SmoothStreaming" -> {
+                            if (inCacheBehavior && current != null) {
+                                current.setSmoothStreaming("true".equalsIgnoreCase(r.getElementText()));
+                            }
+                        }
+                        case "MinTTL" -> {
+                            if (inCacheBehavior && current != null) {
+                                current.setMinTTL(parseLongOrZero(r.getElementText()));
+                            }
+                        }
+                        case "DefaultTTL" -> {
+                            if (inCacheBehavior && current != null) {
+                                current.setDefaultTTL(parseLongOrZero(r.getElementText()));
+                            }
+                        }
+                        case "MaxTTL" -> {
+                            if (inCacheBehavior && current != null) {
+                                current.setMaxTTL(parseLongOrZero(r.getElementText()));
                             }
                         }
                         case "Method" -> {
@@ -3226,6 +3519,11 @@ public class CloudFrontController {
                     switch (r.getLocalName()) {
                         case "CachedMethods" -> inCachedMethods = false;
                         case "AllowedMethods" -> inAllowedMethods = false;
+                        case "WhitelistedNames" -> inForwardedCookieNames = false;
+                        case "Headers" -> inForwardedHeaders = false;
+                        case "QueryStringCacheKeys" -> inForwardedQueryStringCacheKeys = false;
+                        case "Cookies" -> inForwardedCookies = false;
+                        case "ForwardedValues" -> inForwardedValues = false;
                         case "TrustedKeyGroups" -> inTrustedKeyGroups = false;
                         case "LambdaFunctionAssociations" -> inLambdaAssociations = false;
                         case "FunctionAssociations" -> inFunctionAssociations = false;
@@ -3248,6 +3546,14 @@ public class CloudFrontController {
                                 }
                                 if (!cachedMethods.isEmpty()) {
                                     current.setCachedMethods(cachedMethods);
+                                }
+                                if (sawForwardedValues) {
+                                    current.setForwardedValues(forwardedValuesModel(
+                                            forwardedQueryString,
+                                            forwardedCookiesForward,
+                                            forwardedCookieNames,
+                                            forwardedHeaders,
+                                            forwardedQueryStringCacheKeys));
                                 }
                                 if (!trustedKeyGroups.isEmpty()) {
                                     current.setTrustedKeyGroups(trustedKeyGroups);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CacheBehavior.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/CacheBehavior.java
@@ -21,9 +21,11 @@ public class CacheBehavior {
     private List<Map<String, String>> functionAssociations;
     private List<Map<String, Object>> lambdaFunctionAssociations;
     private boolean compress;
-    private long defaultTTL;
-    private long minTTL;
-    private long maxTTL;
+    private boolean smoothStreaming;
+    private Long defaultTTL;
+    private Long minTTL;
+    private Long maxTTL;
+    private Map<String, Object> forwardedValues;
     // Private-content key group IDs whose public keys may sign requests.
     // Explicit enablement controls signature enforcement.
     private Boolean trustedKeyGroupsEnabled;
@@ -70,14 +72,20 @@ public class CacheBehavior {
     public boolean isCompress() { return compress; }
     public void setCompress(boolean compress) { this.compress = compress; }
 
-    public long getDefaultTTL() { return defaultTTL; }
-    public void setDefaultTTL(long defaultTTL) { this.defaultTTL = defaultTTL; }
+    public boolean isSmoothStreaming() { return smoothStreaming; }
+    public void setSmoothStreaming(boolean smoothStreaming) { this.smoothStreaming = smoothStreaming; }
 
-    public long getMinTTL() { return minTTL; }
-    public void setMinTTL(long minTTL) { this.minTTL = minTTL; }
+    public Map<String, Object> getForwardedValues() { return forwardedValues; }
+    public void setForwardedValues(Map<String, Object> forwardedValues) { this.forwardedValues = forwardedValues; }
 
-    public long getMaxTTL() { return maxTTL; }
-    public void setMaxTTL(long maxTTL) { this.maxTTL = maxTTL; }
+    public Long getDefaultTTL() { return defaultTTL; }
+    public void setDefaultTTL(Long defaultTTL) { this.defaultTTL = defaultTTL; }
+
+    public Long getMinTTL() { return minTTL; }
+    public void setMinTTL(Long minTTL) { this.minTTL = minTTL; }
+
+    public Long getMaxTTL() { return maxTTL; }
+    public void setMaxTTL(Long maxTTL) { this.maxTTL = maxTTL; }
 
     public boolean isTrustedKeyGroupsEnabled() {
         return trustedKeyGroupsEnabled != null

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/DefaultCacheBehavior.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/DefaultCacheBehavior.java
@@ -20,9 +20,11 @@ public class DefaultCacheBehavior {
     private List<Map<String, String>> functionAssociations;
     private List<Map<String, Object>> lambdaFunctionAssociations;
     private boolean compress;
-    private long defaultTTL;
-    private long minTTL;
-    private long maxTTL;
+    private boolean smoothStreaming;
+    private Long defaultTTL;
+    private Long minTTL;
+    private Long maxTTL;
+    private Map<String, Object> forwardedValues;
     // Private-content key group IDs whose public keys may sign requests.
     // Explicit enablement controls signature enforcement.
     private Boolean trustedKeyGroupsEnabled;
@@ -66,14 +68,20 @@ public class DefaultCacheBehavior {
     public boolean isCompress() { return compress; }
     public void setCompress(boolean compress) { this.compress = compress; }
 
-    public long getDefaultTTL() { return defaultTTL; }
-    public void setDefaultTTL(long defaultTTL) { this.defaultTTL = defaultTTL; }
+    public boolean isSmoothStreaming() { return smoothStreaming; }
+    public void setSmoothStreaming(boolean smoothStreaming) { this.smoothStreaming = smoothStreaming; }
 
-    public long getMinTTL() { return minTTL; }
-    public void setMinTTL(long minTTL) { this.minTTL = minTTL; }
+    public Map<String, Object> getForwardedValues() { return forwardedValues; }
+    public void setForwardedValues(Map<String, Object> forwardedValues) { this.forwardedValues = forwardedValues; }
 
-    public long getMaxTTL() { return maxTTL; }
-    public void setMaxTTL(long maxTTL) { this.maxTTL = maxTTL; }
+    public Long getDefaultTTL() { return defaultTTL; }
+    public void setDefaultTTL(Long defaultTTL) { this.defaultTTL = defaultTTL; }
+
+    public Long getMinTTL() { return minTTL; }
+    public void setMinTTL(Long minTTL) { this.minTTL = minTTL; }
+
+    public Long getMaxTTL() { return maxTTL; }
+    public void setMaxTTL(Long maxTTL) { this.maxTTL = maxTTL; }
 
     public boolean isTrustedKeyGroupsEnabled() {
         return trustedKeyGroupsEnabled != null

--- a/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -319,6 +320,218 @@ class CloudFrontControllerTest {
             assertTrue(((String) created.getEntity()).contains("InconsistentQuantities"));
         }
     }
+    @Test
+    void customOriginConfigEchoesOriginSslProtocolsSoTheAwsProviderDoesNotSegfault() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        // A custom origin whose request omits OriginSslProtocols, as the aws provider sends for a
+        // minimal distribution. The provider flattens CustomOriginConfig.OriginSslProtocols.Items with
+        // no nil guard, so an omitted object segfaults it on read-back. AWS always echoes the object.
+        String body = distributionConfigBody("");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-ssl");
+            d.setEtag("etag-ssl");
+            return d;
+        });
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+        when(service.getDistribution("dist-ssl")).thenReturn(captor.getValue());
+
+        try (Response dist = controller.getDistribution("dist-ssl")) {
+            String xml = (String) dist.getEntity();
+            int start = xml.indexOf("<OriginSslProtocols>");
+            assertTrue(start >= 0, "CustomOriginConfig must echo an OriginSslProtocols object");
+            String block = xml.substring(start, xml.indexOf("</OriginSslProtocols>", start));
+            assertTrue(block.contains("<SslProtocol>"),
+                    "OriginSslProtocols must list at least one protocol");
+        }
+    }
+
+    @Test
+    void customOriginConfigRoundTripsSubmittedOriginSslProtocols() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginSslProtocols><Quantity>2</Quantity><Items>"
+                        + "<SslProtocol>TLSv1.1</SslProtocol><SslProtocol>TLSv1.2</SslProtocol>"
+                        + "</Items></OriginSslProtocols></CustomOriginConfig>");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-ssl2");
+            d.setEtag("etag-ssl2");
+            return d;
+        });
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+        when(service.getDistribution("dist-ssl2")).thenReturn(captor.getValue());
+
+        try (Response cfg = controller.getDistributionConfig("dist-ssl2")) {
+            String xml = (String) cfg.getEntity();
+            int start = xml.indexOf("<OriginSslProtocols>");
+            assertTrue(start >= 0);
+            String block = xml.substring(start, xml.indexOf("</OriginSslProtocols>", start));
+            assertTrue(block.contains("<SslProtocol>TLSv1.1</SslProtocol>"), "echoes TLSv1.1");
+            assertTrue(block.contains("<SslProtocol>TLSv1.2</SslProtocol>"), "echoes TLSv1.2");
+        }
+    }
+
+    @Test
+    void defaultCacheBehaviorRoundTripsForwardedValues() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody(
+                "<ForwardedValues><QueryString>true</QueryString>"
+                        + "<Cookies><Forward>all</Forward></Cookies></ForwardedValues>");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-fv");
+            d.setEtag("etag-fv");
+            return d;
+        });
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+        when(service.getDistribution("dist-fv")).thenReturn(captor.getValue());
+
+        try (Response dist = controller.getDistribution("dist-fv")) {
+            String xml = (String) dist.getEntity();
+            int start = xml.indexOf("<ForwardedValues>");
+            assertTrue(start >= 0, "DefaultCacheBehavior must echo a ForwardedValues object");
+            String block = xml.substring(start, xml.indexOf("</ForwardedValues>", start));
+            assertTrue(block.contains("<QueryString>true</QueryString>"), "echoes QueryString");
+            assertTrue(block.contains("<Forward>all</Forward>"), "echoes Cookies.Forward");
+        }
+    }
+
+    @Test
+    void defaultCacheBehaviorRoundTripsAnExplicitZeroDefaultTtl() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        // default_ttl = 0 with forwarded_values is the usual "do not cache". Treating 0 as "unset"
+        // drops it from the read-back, so the provider sees the attribute disappear and diffs forever.
+        String body = distributionConfigBody(
+                "<MinTTL>0</MinTTL><DefaultTTL>0</DefaultTTL><MaxTTL>0</MaxTTL>"
+                        + "<ForwardedValues><QueryString>false</QueryString>"
+                        + "<Cookies><Forward>none</Forward></Cookies></ForwardedValues>");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-ttl0");
+            d.setEtag("etag-ttl0");
+            return d;
+        });
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+        when(service.getDistribution("dist-ttl0")).thenReturn(captor.getValue());
+
+        try (Response dist = controller.getDistribution("dist-ttl0")) {
+            String xml = (String) dist.getEntity();
+            assertTrue(xml.contains("<MinTTL>0</MinTTL>"), "echoes an explicit MinTTL of 0");
+            assertTrue(xml.contains("<DefaultTTL>0</DefaultTTL>"), "echoes an explicit DefaultTTL of 0");
+            assertTrue(xml.contains("<MaxTTL>0</MaxTTL>"), "echoes an explicit MaxTTL of 0");
+        }
+    }
+
+    @Test
+    void defaultCacheBehaviorOmitsTtlsTheClientNeverSubmitted() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody(
+                "<ForwardedValues><QueryString>false</QueryString>"
+                        + "<Cookies><Forward>none</Forward></Cookies></ForwardedValues>");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-ttlabsent");
+            d.setEtag("etag-ttlabsent");
+            return d;
+        });
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+        when(service.getDistribution("dist-ttlabsent")).thenReturn(captor.getValue());
+
+        try (Response dist = controller.getDistribution("dist-ttlabsent")) {
+            String xml = (String) dist.getEntity();
+            assertFalse(xml.contains("<DefaultTTL>"), "an unsubmitted DefaultTTL stays absent");
+            assertFalse(xml.contains("<MaxTTL>"), "an unsubmitted MaxTTL stays absent");
+        }
+    }
+
+    @Test
+    void forwardedValuesRoundTripsHeadersQueryStringCacheKeysAndWhitelistedCookies() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        // Headers, QueryStringCacheKeys and Cookies.WhitelistedNames are Quantity/Items pairs. Echoing
+        // a bare Quantity 0 loses them, so the provider reads the lists back empty and diffs each plan.
+        String body = distributionConfigBody(
+                "<ForwardedValues><QueryString>true</QueryString>"
+                        + "<Cookies><Forward>whitelist</Forward>"
+                        + "<WhitelistedNames><Quantity>2</Quantity><Items>"
+                        + "<Name>session</Name><Name>tracking</Name></Items></WhitelistedNames>"
+                        + "</Cookies>"
+                        + "<Headers><Quantity>2</Quantity><Items>"
+                        + "<Name>Origin</Name><Name>Accept</Name></Items></Headers>"
+                        + "<QueryStringCacheKeys><Quantity>1</Quantity><Items>"
+                        + "<Name>page</Name></Items></QueryStringCacheKeys>"
+                        + "</ForwardedValues>");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-fvnames");
+            d.setEtag("etag-fvnames");
+            return d;
+        });
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+        when(service.getDistribution("dist-fvnames")).thenReturn(captor.getValue());
+
+        try (Response dist = controller.getDistribution("dist-fvnames")) {
+            String xml = (String) dist.getEntity();
+            int start = xml.indexOf("<ForwardedValues>");
+            assertTrue(start >= 0);
+            String block = xml.substring(start, xml.indexOf("</ForwardedValues>", start));
+
+            String cookies = block.substring(
+                    block.indexOf("<Cookies>"), block.indexOf("</Cookies>"));
+            assertEquals(List.of("session", "tracking"), XmlParser.extractAll(cookies, "Name"),
+                    "whitelisted cookie names round-trip inside Cookies");
+
+            String headers = block.substring(
+                    block.indexOf("<Headers>"), block.indexOf("</Headers>"));
+            assertEquals(List.of("Origin", "Accept"), XmlParser.extractAll(headers, "Name"),
+                    "forwarded headers round-trip");
+            assertTrue(headers.contains("<Quantity>2</Quantity>"), "Headers.Quantity matches");
+
+            String keys = block.substring(
+                    block.indexOf("<QueryStringCacheKeys>"), block.indexOf("</QueryStringCacheKeys>"));
+            assertEquals(List.of("page"), XmlParser.extractAll(keys, "Name"),
+                    "query string cache keys round-trip");
+        }
+    }
+
 
     private static String distributionConfigBody(String defaultCacheBehaviorExtra) {
         return """


### PR DESCRIPTION
## Summary

After #3015 echoed TrustedSigners, creating a CloudFront distribution against Floci still crashed the pulumi-aws v5 provider on the read that runs at the end of create. A custom origin's `OriginSslProtocols` was dropped, and the provider flattens `CustomOriginConfig.OriginSslProtocols.Items` with no nil guard, so the missing object segfaults it.

The legacy `forwarded_values` cache-behavior path lost more than that, so this also closes the read-back fidelity gap tracked separately.

Fixes #3208.

### The crash

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]

cloudfront.FlattenCustomOriginConfigSSL(...)  distribution_configuration_structure.go:1053
cloudfront.FlattenCustomOriginConfig(...)     distribution_configuration_structure.go:1019
cloudfront.FlattenOrigin(...)                 distribution_configuration_structure.go:749
cloudfront.FlattenOrigins(...)                distribution_configuration_structure.go:680
cloudfront.flattenDistributionConfig(...)     distribution_configuration_structure.go:153
cloudfront.resourceDistributionRead(...)      distribution.go
cloudfront.resourceDistributionCreate(...)    distribution.go
```

Line 1053 is `return flex.FlattenStringSet(osp.Items)`, where `osp` is the nil `OriginSslProtocols`. Line numbers are from the terraform-provider-aws revision bridged by pulumi-aws v5.43.0. Newer providers panic in the same read for the same reason, they just moved the code.

### The fix

1. `CustomOriginConfig` now echoes `OriginSslProtocols`, round-tripping the submitted protocols and defaulting to `TLSv1.2` when the client sends none.
2. `DefaultTTL` and `MaxTTL` were emitted only when greater than 0, so an explicit `default_ttl = 0` (the usual "do not cache" with `forwarded_values`) read back as absent and drifted on every plan. Presence is now tracked separately from the value: a submitted 0 round-trips, and a TTL the client never sent stays absent.
3. `ForwardedValues` echoed `Headers` and `QueryStringCacheKeys` as a bare `Quantity 0`, and the parser kept only `QueryString` and `Cookies.Forward`, so whitelisted headers, query-string cache keys and cookie names came back empty. All three now round-trip as Quantity/Items pairs, scoped so the shared `Name` element lands in the right block.
4. Both cache behaviors also round-trip `ForwardedValues`, `SmoothStreaming` and `FieldLevelEncryptionId`.

The `CachedMethods` part of this landed separately in #3217, so it is rebased out and main's version is used.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: the `GetDistribution` and `CreateDistribution` responses omitted `CustomOriginConfig.OriginSslProtocols` entirely, emitted `DefaultTTL` / `MaxTTL` only when non-zero, and flattened `ForwardedValues` down to `QueryString` plus `Cookies.Forward` with empty `Headers` and `QueryStringCacheKeys`. Real CloudFront echoes all of these, per the model in [botocore's cloudfront service-2.json](https://github.com/boto/botocore/blob/develop/botocore/data/cloudfront/2020-05-31/service-2.json).

Verified against the real pulumi-aws v5 provider (bridged terraform-provider-aws): a distribution with a custom origin, `defaultTtl = 0` and whitelisted headers and cookies creates, reads back with no segfault, and destroys clean. The same run panics in `flattenDistributionConfig` before the change.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
