### PR TITLE
fix(dynamodb): reject a BETWEEN with reversed bounds at parse time

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -6,7 +6,9 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 
@@ -465,13 +467,24 @@ final class ExpressionEvaluator {
             return;
         }
         var lowType = low.fieldNames().next();
-        if (!lowType.equals(high.fieldNames().next()) || compareAttributeValues(low, high) <= 0) {
+        if (!lowType.equals(high.fieldNames().next()) || compareBoundValues(low, high) <= 0) {
             return;
         }
         throw new AwsException("ValidationException",
                 "Invalid " + exprType + ": The BETWEEN operator requires upper bound to be greater than "
                 + "or equal to lower bound; lower bound operand: " + displayAttributeValue(low)
                 + ", upper bound operand: " + displayAttributeValue(high), 400);
+    }
+
+    // DynamoDB orders strings by their UTF-8 bytes, which differs from Java's UTF-16
+    // ordering above the basic plane: U+E000 sorts before U+10000 on AWS but after it here.
+    private static int compareBoundValues(JsonNode low, JsonNode high) {
+        if (low.has("S") && high.has("S")) {
+            return Arrays.compareUnsigned(
+                    low.get("S").asText().getBytes(StandardCharsets.UTF_8),
+                    high.get("S").asText().getBytes(StandardCharsets.UTF_8));
+        }
+        return compareAttributeValues(low, high);
     }
 
     private static JsonNode placeholderValue(Operand operand, JsonNode values) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -470,8 +470,11 @@ final class ExpressionEvaluator {
         if (!lowType.equals(high.fieldNames().next()) || compareBoundValues(low, high) <= 0) {
             return;
         }
-        throw new AwsException("ValidationException",
-                "Invalid " + exprType + ": The BETWEEN operator requires upper bound to be greater than "
+        // AWS wraps the ConditionExpression form in its validation-error envelope, but reports
+        // the FilterExpression and KeyConditionExpression forms on their own.
+        String envelope = "ConditionExpression".equals(exprType) ? "1 validation error detected: " : "";
+        throw new AwsException("ValidationException", envelope
+                + "Invalid " + exprType + ": The BETWEEN operator requires upper bound to be greater than "
                 + "or equal to lower bound; lower bound operand: " + displayAttributeValue(low)
                 + ", upper bound operand: " + displayAttributeValue(high), 400);
     }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -484,7 +484,21 @@ final class ExpressionEvaluator {
                     low.get("S").asText().getBytes(StandardCharsets.UTF_8),
                     high.get("S").asText().getBytes(StandardCharsets.UTF_8));
         }
+        if (low.has("B") && high.has("B")) {
+            return Arrays.compareUnsigned(decodeBinaryBound(low), decodeBinaryBound(high));
+        }
         return compareAttributeValues(low, high);
+    }
+
+    // A binary value that is not valid base64 never reaches a comparison on AWS: the request
+    // fails to deserialize first, with a 400 SerializationException.
+    private static byte[] decodeBinaryBound(JsonNode bound) {
+        try {
+            return Base64.getDecoder().decode(bound.get("B").asText());
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("SerializationException",
+                    "Unexpected value type in payload", 400);
+        }
     }
 
     private static JsonNode placeholderValue(Operand operand, JsonNode values) {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -451,8 +451,42 @@ final class ExpressionEvaluator {
             case OrExpr o -> o.operands().forEach(x -> validateSemantics(x, exprType, names, values));
             case NotExpr n -> validateSemantics(n.operand(), exprType, names, values);
             case FunctionCallExpr f -> validateFunction(f, exprType, names, values);
+            case BetweenExpr b -> validateBetween(b, exprType, values);
             default -> {}
         }
+    }
+
+    // AWS rejects a BETWEEN whose bounds are the wrong way round when it parses the
+    // expression, rather than letting the condition fail at evaluation time.
+    private static void validateBetween(BetweenExpr between, String exprType, JsonNode values) {
+        var low = placeholderValue(between.low(), values);
+        var high = placeholderValue(between.high(), values);
+        if (low == null || high == null) {
+            return;
+        }
+        var lowType = low.fieldNames().next();
+        if (!lowType.equals(high.fieldNames().next()) || compareAttributeValues(low, high) <= 0) {
+            return;
+        }
+        throw new AwsException("ValidationException",
+                "Invalid " + exprType + ": The BETWEEN operator requires upper bound to be greater than "
+                + "or equal to lower bound; lower bound operand: " + displayAttributeValue(low)
+                + ", upper bound operand: " + displayAttributeValue(high), 400);
+    }
+
+    private static JsonNode placeholderValue(Operand operand, JsonNode values) {
+        if (operand instanceof PlaceholderOperand(String name) && values != null) {
+            var value = values.get(name);
+            if (value != null && value.isObject() && value.fieldNames().hasNext()) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String displayAttributeValue(JsonNode value) {
+        var type = value.fieldNames().next();
+        return "AttributeValue: {" + type + ":" + value.get(type).asText() + "}";
     }
 
     private static void validateFunction(FunctionCallExpr f, String exprType,

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -440,6 +440,35 @@ class DynamoDbIntegrationTest {
             .body("Items[0].total", nullValue());
     }
 
+    // Checked against real DynamoDB (us-east-1, 2026-09-07). A reversed BETWEEN in a
+    // ConditionExpression is a 400 ValidationException, not a ConditionalCheckFailedException,
+    // and AWS wraps the ConditionExpression form in its validation-error envelope.
+    @Test
+    @Order(10)
+    void putItemWithReversedBetweenBoundsReturnsValidationException() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "Item": {"pk": {"S": "between-1"}, "sk": {"S": "a"}},
+                    "ConditionExpression": "#n BETWEEN :hi AND :lo",
+                    "ExpressionAttributeNames": {"#n": "n"},
+                    "ExpressionAttributeValues": {":hi": {"N": "10"}, ":lo": {"N": "1"}}
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("1 validation error detected: Invalid ConditionExpression: "
+                    + "The BETWEEN operator requires upper bound to be greater than or equal to lower "
+                    + "bound; lower bound operand: AttributeValue: {N:10}, upper bound operand: "
+                    + "AttributeValue: {N:1}"));
+    }
+
     @Test
     @Order(10)
     void queryWithSelectSpecificAttributesRequiresProjectionParameters() {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -2,7 +2,6 @@ package io.github.hectorvent.floci.services.dynamodb;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -594,6 +593,33 @@ class ExpressionEvaluatorTest {
                 assertEquals(400, e.getHttpStatus());
                 assertEquals("Invalid ConditionExpression: Syntax error; token: \"" + ch + "\", near: \"a " + ch + " b\"", e.getMessage());
             }
+        }
+
+        @Test
+        void reversedBetweenBoundsAreRejectedAtParseTime() {
+            var mapper = new ObjectMapper();
+            var values = mapper.createObjectNode();
+            values.set(":hi", mapper.createObjectNode().put("N", "10"));
+            values.set(":lo", mapper.createObjectNode().put("N", "1"));
+
+            var e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("n BETWEEN :hi AND :lo",
+                            "ConditionExpression", null, values));
+            assertEquals("ValidationException", e.getErrorCode());
+            assertEquals("Invalid ConditionExpression: The BETWEEN operator requires upper bound to be "
+                    + "greater than or equal to lower bound; lower bound operand: AttributeValue: {N:10}, "
+                    + "upper bound operand: AttributeValue: {N:1}", e.getMessage());
+        }
+
+        @Test
+        void orderedBetweenBoundsAreAccepted() {
+            var mapper = new ObjectMapper();
+            var values = mapper.createObjectNode();
+            values.set(":lo", mapper.createObjectNode().put("N", "1"));
+            values.set(":hi", mapper.createObjectNode().put("N", "10"));
+
+            assertDoesNotThrow(() -> ExpressionEvaluator.validateExpression("n BETWEEN :lo AND :hi",
+                    "ConditionExpression", null, values));
         }
 
         @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -634,6 +634,32 @@ class ExpressionEvaluatorTest {
             assertEquals("ValidationException", e.getErrorCode());
         }
 
+        // Checked against real DynamoDB (us-east-1, 2026-09-07): binary bounds compare by
+        // unsigned bytes, and a bound that is not valid base64 fails the request with a 400
+        // SerializationException before any comparison happens.
+        @Test
+        void binaryBoundsCompareByBytesAndRejectMalformedBase64() {
+            var mapper = new ObjectMapper();
+            var reversed = mapper.createObjectNode();
+            reversed.set(":lo", mapper.createObjectNode().put("B", "/w=="));
+            reversed.set(":hi", mapper.createObjectNode().put("B", "AA=="));
+
+            var e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("n BETWEEN :lo AND :hi",
+                            "ConditionExpression", null, reversed));
+            assertEquals("ValidationException", e.getErrorCode());
+
+            var malformed = mapper.createObjectNode();
+            malformed.set(":lo", mapper.createObjectNode().put("B", "!!!not-base64!!!"));
+            malformed.set(":hi", mapper.createObjectNode().put("B", "@@@@"));
+
+            var serialization = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("n BETWEEN :lo AND :hi",
+                            "ConditionExpression", null, malformed));
+            assertEquals("SerializationException", serialization.getErrorCode());
+            assertEquals(400, serialization.getHttpStatus());
+        }
+
         @Test
         void orderedBetweenBoundsAreAccepted() {
             var mapper = new ObjectMapper();

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -611,6 +611,29 @@ class ExpressionEvaluatorTest {
                     + "upper bound operand: AttributeValue: {N:1}", e.getMessage());
         }
 
+        // Checked against real DynamoDB (us-east-1, 2026-09-07): U+E000 as the lower bound
+        // and U+10000 as the upper bound is accepted, because DynamoDB orders strings by
+        // their UTF-8 bytes. Java's UTF-16 ordering puts them the other way round.
+        @Test
+        void stringBoundsAreOrderedByUtf8Bytes() {
+            var mapper = new ObjectMapper();
+            var values = mapper.createObjectNode();
+            values.set(":lo", mapper.createObjectNode().put("S", "\uE000"));
+            values.set(":hi", mapper.createObjectNode().put("S", "\uD800\uDC00"));
+
+            assertDoesNotThrow(() -> ExpressionEvaluator.validateExpression("n BETWEEN :lo AND :hi",
+                    "ConditionExpression", null, values));
+
+            var reversed = mapper.createObjectNode();
+            reversed.set(":lo", mapper.createObjectNode().put("S", "\uD800\uDC00"));
+            reversed.set(":hi", mapper.createObjectNode().put("S", "\uE000"));
+
+            var e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("n BETWEEN :lo AND :hi",
+                            "ConditionExpression", null, reversed));
+            assertEquals("ValidationException", e.getErrorCode());
+        }
+
         @Test
         void orderedBetweenBoundsAreAccepted() {
             var mapper = new ObjectMapper();

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -606,9 +606,9 @@ class ExpressionEvaluatorTest {
                     ExpressionEvaluator.validateExpression("n BETWEEN :hi AND :lo",
                             "ConditionExpression", null, values));
             assertEquals("ValidationException", e.getErrorCode());
-            assertEquals("Invalid ConditionExpression: The BETWEEN operator requires upper bound to be "
-                    + "greater than or equal to lower bound; lower bound operand: AttributeValue: {N:10}, "
-                    + "upper bound operand: AttributeValue: {N:1}", e.getMessage());
+            assertEquals("1 validation error detected: Invalid ConditionExpression: The BETWEEN operator "
+                    + "requires upper bound to be greater than or equal to lower bound; lower bound operand: "
+                    + "AttributeValue: {N:10}, upper bound operand: AttributeValue: {N:1}", e.getMessage());
         }
 
         // Checked against real DynamoDB (us-east-1, 2026-09-07): U+E000 as the lower bound
@@ -658,6 +658,22 @@ class ExpressionEvaluatorTest {
                             "ConditionExpression", null, malformed));
             assertEquals("SerializationException", serialization.getErrorCode());
             assertEquals(400, serialization.getHttpStatus());
+        }
+
+        // A FilterExpression carries the same text without the envelope on AWS.
+        @Test
+        void filterExpressionReportsTheReversedBoundsWithoutTheEnvelope() {
+            var mapper = new ObjectMapper();
+            var values = mapper.createObjectNode();
+            values.set(":hi", mapper.createObjectNode().put("N", "10"));
+            values.set(":lo", mapper.createObjectNode().put("N", "1"));
+
+            var e = assertThrows(AwsException.class, () ->
+                    ExpressionEvaluator.validateExpression("n BETWEEN :hi AND :lo",
+                            "FilterExpression", null, values));
+            assertEquals("Invalid FilterExpression: The BETWEEN operator requires upper bound to be "
+                    + "greater than or equal to lower bound; lower bound operand: AttributeValue: {N:10}, "
+                    + "upper bound operand: AttributeValue: {N:1}", e.getMessage());
         }
 
         @Test


### PR DESCRIPTION
## Summary

Closes one [TIER 1 case in the dynamodb-conformance suite](https://github.com/paritysuite/dynamodb-conformance/blob/bf21d8294275d88470d7f89b73ba0b640a242a8d/tests/tier1/putItem/conditions.test.ts#L234).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility


A BETWEEN whose lower bound exceeds its upper bound parsed cleanly and then failed the condition at evaluation, so PutItem answered with a ConditionalCheckFailedException. AWS rejects the expression itself with a ValidationException.

The bounds are compared during expression validation, when both resolve to values of the same type.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

