### PR TITLE
feat(redshift-data): emulate the Amazon Redshift Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Floci supports local emulation for application services, data services, eventing
 | Events and workflows | EventBridge, EventBridge Pipes, EventBridge Scheduler, Step Functions, SWF, CloudWatch Logs, CloudWatch Metrics, CloudWatch RUM, Managed Prometheus (AMP) |
 | API and identity | API Gateway REST, API Gateway v2, AppSync, Cognito, ACM, Route53, Route 53 Resolver, Cloud Map |
 | Containers and compute | ECS, EC2, Lightsail, EKS, MWAA, ECR, EFS, CodeBuild, CodeDeploy, CodePipeline, CodeGuru Reviewer, AWS Batch, Auto Scaling, Application Auto Scaling, Elastic Beanstalk, ELB v2, ELB Classic |
-| Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
+| Data, analytics, and AI | Athena, Glue, Lake Formation, EMR, EMR Serverless, Redshift, Redshift Data API, Firehose, Managed Service for Apache Flink, OpenSearch, S3 Tables, S3 Vectors, Textract, Transcribe, Comprehend, Rekognition, Translate, Bedrock Runtime, Bedrock AgentCore |
 | Databases and caching | RDS, RDS Data API, Neptune, DocumentDB, MemoryDB, ElastiCache |
 | Messaging and transfer | SES, Kinesis, MSK, Amazon MQ, Transfer Family, IoT Core, Amazon Connect |
 | Security and governance | AWS Network Firewall, AWS RAM, Service Quotas, WAF v2, GuardDuty, CloudTrail, CloudFront, Resource Groups Tagging API, Resource Explorer 2, CloudHSM v2, Organizations, AWS Account Management, IAM Access Analyzer, IAM Identity Center (SSO Admin), Amazon Macie, Control Tower, Service Catalog |

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -106,6 +106,10 @@
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
+            <artifactId>redshiftdata</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
             <artifactId>sns</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.services.opensearch.OpenSearchClient;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient;
 import software.amazon.awssdk.services.guardduty.GuardDutyClient;
 import software.amazon.awssdk.services.fis.FisClient;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
@@ -1109,6 +1110,14 @@ public final class TestFixtures {
 
     public static RedshiftClient redshiftClient() {
         return RedshiftClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static RedshiftDataClient redshiftDataClient() {
+        return RedshiftDataClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftDataOperationsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftDataOperationsTest.java
@@ -15,17 +15,17 @@ import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultRequ
 import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultResponse;
 import software.amazon.awssdk.services.redshiftdata.model.StatusString;
 
+import org.jboss.logging.Logger;
+
 import java.time.Duration;
 import java.time.Instant;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("Redshift Data API Operations")
 class RedshiftDataOperationsTest {
 
-    private static final Logger LOG = Logger.getLogger(RedshiftDataOperationsTest.class.getName());
+    private static final Logger LOG = Logger.getLogger(RedshiftDataOperationsTest.class);
 
     private static final String USERNAME = "admin";
     private static final String PASSWORD = "password123";
@@ -54,7 +54,7 @@ class RedshiftDataOperationsTest {
             try {
                 redshift.deleteCluster(DeleteClusterRequest.builder().clusterIdentifier(clusterId).build());
             } catch (Exception e) {
-                LOG.log(Level.WARNING, "Failed to clean up Redshift cluster " + clusterId, e);
+                LOG.warnf(e, "Failed to clean up Redshift cluster %s", clusterId);
             }
         }
         if (data != null) {

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftDataOperationsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RedshiftDataOperationsTest.java
@@ -1,0 +1,112 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.redshift.RedshiftClient;
+import software.amazon.awssdk.services.redshift.model.CreateClusterRequest;
+import software.amazon.awssdk.services.redshift.model.DeleteClusterRequest;
+import software.amazon.awssdk.services.redshiftdata.RedshiftDataClient;
+import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementRequest;
+import software.amazon.awssdk.services.redshiftdata.model.DescribeStatementResponse;
+import software.amazon.awssdk.services.redshiftdata.model.ExecuteStatementRequest;
+import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultRequest;
+import software.amazon.awssdk.services.redshiftdata.model.GetStatementResultResponse;
+import software.amazon.awssdk.services.redshiftdata.model.StatusString;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Redshift Data API Operations")
+class RedshiftDataOperationsTest {
+
+    private static final Logger LOG = Logger.getLogger(RedshiftDataOperationsTest.class.getName());
+
+    private static final String USERNAME = "admin";
+    private static final String PASSWORD = "password123";
+    private static final String DATABASE = "dev";
+
+    private static RedshiftClient redshift;
+    private static RedshiftDataClient data;
+    private static String clusterId;
+
+    @BeforeAll
+    static void setup() {
+        redshift = TestFixtures.redshiftClient();
+        data = TestFixtures.redshiftDataClient();
+        clusterId = TestFixtures.uniqueName("rsdata-cluster");
+        redshift.createCluster(CreateClusterRequest.builder()
+                .clusterIdentifier(clusterId)
+                .nodeType("dc2.large")
+                .masterUsername(USERNAME)
+                .masterUserPassword(PASSWORD)
+                .build());
+    }
+
+    @AfterAll
+    static void cleanup() {
+        if (redshift != null && clusterId != null) {
+            try {
+                redshift.deleteCluster(DeleteClusterRequest.builder().clusterIdentifier(clusterId).build());
+            } catch (Exception e) {
+                LOG.log(Level.WARNING, "Failed to clean up Redshift cluster " + clusterId, e);
+            }
+        }
+        if (data != null) {
+            data.close();
+        }
+        if (redshift != null) {
+            redshift.close();
+        }
+    }
+
+    @Test
+    @DisplayName("execute, describe, and get-statement-result round trip")
+    void executeDescribeGetResult() throws Exception {
+        run("CREATE TABLE compat_t (id int, name varchar(20))");
+        String insertId = run("INSERT INTO compat_t VALUES (1, 'a'), (2, 'b')");
+        assertThat(describe(insertId).resultRows()).isEqualTo(2L);
+
+        String selectId = run("SELECT id, name FROM compat_t ORDER BY id");
+        GetStatementResultResponse result = data.getStatementResult(GetStatementResultRequest.builder()
+                .id(selectId)
+                .build());
+
+        assertThat(result.totalNumRows()).isEqualTo(2L);
+        assertThat(result.columnMetadata()).extracting("name").containsExactly("id", "name");
+        assertThat(result.records().get(0).get(0).longValue()).isEqualTo(1L);
+        assertThat(result.records().get(0).get(1).stringValue()).isEqualTo("a");
+    }
+
+    private String run(String sql) throws Exception {
+        String id = data.executeStatement(ExecuteStatementRequest.builder()
+                .clusterIdentifier(clusterId)
+                .dbUser(USERNAME)
+                .database(DATABASE)
+                .sql(sql)
+                .build())
+                .id();
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(30));
+        while (Instant.now().isBefore(deadline)) {
+            DescribeStatementResponse describe = describe(id);
+            StatusString status = describe.status();
+            if (status == StatusString.FINISHED) {
+                return id;
+            }
+            if (status == StatusString.FAILED || status == StatusString.ABORTED) {
+                throw new IllegalStateException("Statement " + id + " ended " + status + ": " + describe.error());
+            }
+            Thread.sleep(250);
+        }
+        throw new IllegalStateException("Statement " + id + " did not finish in time");
+    }
+
+    private DescribeStatementResponse describe(String id) {
+        return data.describeStatement(DescribeStatementRequest.builder().id(id).build());
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -62,6 +62,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 14 |
 | [DocumentDB](docdb.md) | `POST /` with `Action=` param + MongoDB container | Query + MongoDB wire | 8 |
 | [Redshift](redshift.md) | `POST /` with `Action=` param + PostgreSQL container | Query + PostgreSQL wire | 21 |
+| [Redshift Data API](redshift-data.md) | `POST /` + `X-Amz-Target: RedshiftData.*` | JSON 1.1 | 11 |
 | [EMR](emr.md) | `POST /` + `X-Amz-Target: ElasticMapReduce.*` | JSON 1.1 | 24 |
 | [EMR Serverless](emr-serverless.md) | `/applications/*` | REST JSON | 7 |
 | [Data Firehose](firehose.md) | `POST /` + `X-Amz-Target: Firehose_20150804.*` | JSON 1.1 | 6 |

--- a/docs/services/redshift-data.md
+++ b/docs/services/redshift-data.md
@@ -1,0 +1,121 @@
+# Redshift Data API
+
+**Protocol:** JSON 1.1
+**Endpoint:** `POST http://localhost:4566/` with `X-Amz-Target: RedshiftData.<Operation>` and `Content-Type: application/x-amz-json-1.1`
+**Backing data plane:** the PostgreSQL container behind a Redshift cluster created through the Redshift emulator
+
+Floci emulates the Amazon Redshift Data API: the HTTP API that Lambda, Step Functions, and EventBridge use to run SQL on a cluster without opening a PostgreSQL wire connection. Floci resolves the target cluster, connects straight to its container over JDBC, runs the SQL, and stores the statement and its result set in memory so the polling operations (`DescribeStatement`, `GetStatementResult`) can read them back.
+
+For the upstream API shape, see the AWS documentation:
+
+- [Using the Amazon Redshift Data API](https://docs.aws.amazon.com/redshift/latest/mgmt/data-api.html)
+- [`ExecuteStatement`](https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_ExecuteStatement.html)
+- [`BatchExecuteStatement`](https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_BatchExecuteStatement.html)
+- [`DescribeStatement`](https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_DescribeStatement.html)
+- [`GetStatementResult`](https://docs.aws.amazon.com/redshift-data/latest/APIReference/API_GetStatementResult.html)
+
+## Supported Actions
+
+<!-- floci:actions:start -->
+| Action | Description |
+| --- | --- |
+| `ExecuteStatement` | Run one SQL statement synchronously against the cluster container and store the result |
+| `BatchExecuteStatement` | Run `Sqls` in order on one connection in a single transaction |
+| `DescribeStatement` | Return a stored statement's status, timings, row counts, and sub-statements |
+| `GetStatementResult` | Page through a finished statement's rows as typed `Records` |
+| `GetStatementResultV2` | Same rows in the V2 envelope, with `CSVRecords` when the statement used `ResultFormat=CSV` |
+| `ListStatements` | List stored statements newest first, filtered by `StatementName` or `Status` |
+| `CancelStatement` | Mark a non-finished statement `ABORTED`; returns `{ "Status": true }` |
+| `ListDatabases` | List databases on the cluster (`pg_database`) |
+| `ListSchemas` | List schemas, optionally filtered by `SchemaPattern` |
+| `ListTables` | List tables and views, optionally filtered by `SchemaPattern` and `TablePattern` |
+| `DescribeTable` | List a table's columns from `information_schema.columns` |
+<!-- floci:actions:end -->
+
+## Authentication modes
+
+A request identifies its target cluster one of two ways:
+
+- **`ClusterIdentifier` + `DbUser` + `Database`.** The `DbUser` must be the cluster master user. Floci connects directly to the container, so a non-master `DbUser` needs a real PostgreSQL role; until `GetClusterCredentials` is emulated, a non-master `DbUser` returns `ValidationException`.
+- **`SecretArn` + `ClusterIdentifier` + `Database`.** The secret must be a local Secrets Manager secret holding JSON credentials (`username` or `user`, plus `password`). A cross-region `SecretArn` is rejected.
+
+`WorkgroupName` (Amazon Redshift Serverless) is rejected with `ValidationException`. Redshift Serverless is not emulated.
+
+## Compatibility Notes
+
+- **Execution is synchronous.** `ExecuteStatement` runs the SQL and returns only once the statement is terminal. `DescribeStatement` reports `FINISHED` or `FAILED`, or `ABORTED` after a `CancelStatement`. It never reports `SUBMITTED` or `STARTED`, and there is no progression over wall-clock time.
+- **Execution errors are not HTTP errors.** A statement that fails to run is stored with `Status=FAILED` and an `Error` message, and `ExecuteStatement` still returns 200 with the statement `Id`. Callers see the failure through `DescribeStatement`, matching AWS.
+- **Results are in memory.** Statement metadata and result sets are held in a store swept on a 24 hour TTL and are lost when Floci restarts. `ListStatements` returns only what is currently in memory.
+- **`ExecuteStatement` takes one statement.** If the `Sql` contains more than one statement separated by `;`, it is rejected with `ValidationException`. Use `BatchExecuteStatement` for multiple statements.
+- **`BatchExecuteStatement`** runs every entry of `Sqls` in order on one connection in a single transaction: it commits at the end, and on the first failing sub-statement it rolls back and marks the batch `FAILED` with that sub-statement's error. `DescribeStatement` on the parent id returns `SubStatements`, one per entry, each with its own id `<parentId>:<n>`. `GetStatementResult` on the parent id returns the rows of the last sub-statement that produced a result set; on a sub-statement id it returns that sub-statement's rows.
+- **`GetStatementResult` and `GetStatementResultV2`** return the typed `Records` shape. `GetStatementResultV2` also returns `ResultFormat`, and when the statement was run with `ResultFormat=CSV` it returns `Records` as `CSVRecords` strings. A statement that produced no result set (an `INSERT`, `UPDATE`, `DELETE`, or DDL statement) returns `ValidationException` with the message `Statement has no result set`.
+- **Paging.** The page size is 1000 rows. `NextToken` is an opaque base64 row offset; there is no server-side cursor.
+- **`SqlParameters` / `Parameters`** are bound into a `PreparedStatement`. Named `:placeholder` markers are rewritten to positional JDBC bind parameters. Colons inside string literals, quoted identifiers, comments, PostgreSQL `::` casts, and dollar-quoted strings are left untouched. Redshift Data API parameter values are always strings on the wire; PostgreSQL coerces each bound value to the column type.
+- **`CancelStatement`** returns `{ "Status": true }`. In Floci a statement is already terminal by the time it can be cancelled, so `CancelStatement` sets `Status=ABORTED` only when the statement was not already `FINISHED`. An unknown statement id returns `ResourceNotFoundException`.
+- **`WithEvent`** is accepted and ignored: no EventBridge event is published.
+- **`ExecuteSql` and `BatchExecuteSql`** (the deprecated pre-2020 operations) return `ValidationException`.
+- **Type mapping.** JDBC `BOOLEAN` and `BIT` map to `booleanValue`; integer types to `longValue`; floating-point types to `doubleValue`; `NUMERIC` and `DECIMAL` to `stringValue` (as AWS does); binary types to `blobValue`; everything else, including dates, timestamps, uuid, and json, to `stringValue`. A SQL `NULL` maps to `isNull`.
+
+## Configuration
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_REDSHIFT_DATA_ENABLED` | `true` | Enable or disable the Redshift Data API service |
+| `FLOCI_SERVICES_REDSHIFT_DATA_RESULT_TTL_HOURS` | `24` | Hours a finished statement and its result set are kept in memory before the sweep evicts them |
+
+The Redshift Data API also requires the Redshift service itself to be enabled, because it resolves `ClusterIdentifier` values to local Redshift clusters.
+
+## Example
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+
+aws redshift create-cluster \
+  --cluster-identifier wh \
+  --node-type dc2.large \
+  --master-username admin \
+  --master-user-password Secret123 \
+  --endpoint-url "$AWS_ENDPOINT_URL"
+
+STATEMENT_ID=$(aws redshift-data execute-statement \
+  --cluster-identifier wh \
+  --db-user admin \
+  --database dev \
+  --sql "create table t (id int, name varchar(20))" \
+  --query Id --output text \
+  --endpoint-url "$AWS_ENDPOINT_URL")
+
+aws redshift-data describe-statement --id "$STATEMENT_ID" --endpoint-url "$AWS_ENDPOINT_URL"
+
+aws redshift-data execute-statement \
+  --cluster-identifier wh --db-user admin --database dev \
+  --sql "insert into t values (1, 'a'), (2, 'b')" \
+  --endpoint-url "$AWS_ENDPOINT_URL"
+
+SELECT_ID=$(aws redshift-data execute-statement \
+  --cluster-identifier wh --db-user admin --database dev \
+  --sql "select id, name from t order by id" \
+  --query Id --output text \
+  --endpoint-url "$AWS_ENDPOINT_URL")
+
+aws redshift-data get-statement-result --id "$SELECT_ID" --endpoint-url "$AWS_ENDPOINT_URL"
+```
+
+```python
+import boto3
+
+data = boto3.client("redshift-data", endpoint_url="http://localhost:4566")
+
+started = data.execute_statement(
+    ClusterIdentifier="wh", DbUser="admin", Database="dev",
+    Sql="select id, name from t where id = :id",
+    Parameters=[{"name": "id", "value": "2"}],
+)
+statement_id = started["Id"]
+
+while data.describe_statement(Id=statement_id)["Status"] not in ("FINISHED", "FAILED", "ABORTED"):
+    pass
+
+result = data.get_statement_result(Id=statement_id)
+print(result["ColumnMetadata"], result["Records"])
+```

--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -10,6 +10,8 @@ Floci emulates Amazon Redshift by managing a real [PostgreSQL](https://www.postg
 
 The container has **no persistent volume**: if the physical container survives a Floci restart it is adopted and its data is kept, but if the container itself is gone (host reboot, `docker rm`, a pruned dev box) the cluster comes back empty. Use `CreateClusterSnapshot` / `RestoreFromClusterSnapshot` to preserve data explicitly.
 
+For running SQL without a PostgreSQL wire connection (the way Lambda and Step Functions do), see the [Redshift Data API](redshift-data.md).
+
 ## Supported Actions
 
 <!-- floci:actions:start -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,6 +137,7 @@ nav:
     - DocumentDB: services/docdb.md
     - Athena: services/athena.md
     - Redshift: services/redshift.md
+    - Redshift Data API: services/redshift-data.md
     - Data Firehose: services/firehose.md
     - EventBridge: services/eventbridge.md
     - EventBridge Pipes: services/pipes.md

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -631,6 +631,7 @@ public interface EmulatorConfig {
         RdsServiceConfig rds();
         RedshiftServiceConfig redshift();
         RdsDataServiceConfig rdsData();
+        RedshiftDataServiceConfig redshiftData();
         EventBridgeServiceConfig eventbridge();
         CloudMapServiceConfig cloudmap();
         EmrServiceConfig emr();
@@ -1243,6 +1244,14 @@ public interface EmulatorConfig {
 
         @WithDefault("180")
         long transactionTtlSeconds();
+    }
+
+    interface RedshiftDataServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        @WithDefault("24")
+        int resultTtlHours();
     }
 
     interface NeptuneServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import io.github.hectorvent.floci.services.acm.AcmJsonHandler;
 import io.github.hectorvent.floci.services.athena.AthenaJsonHandler;
+import io.github.hectorvent.floci.services.redshiftdata.RedshiftDataJsonHandler;
 import io.github.hectorvent.floci.services.cloudhsmv2.CloudHsmV2JsonHandler;
 import io.github.hectorvent.floci.services.codebuild.CodeBuildJsonHandler;
 import io.github.hectorvent.floci.services.codedeploy.CodeDeployJsonHandler;
@@ -96,6 +97,7 @@ public class AwsJson11Controller {
     private final EcrJsonHandler ecrJsonHandler;
     private final GlueJsonHandler glueJsonHandler;
     private final AthenaJsonHandler athenaJsonHandler;
+    private final RedshiftDataJsonHandler redshiftDataJsonHandler;
     private final FirehoseJsonHandler firehoseJsonHandler;
     private final ResourceGroupsTaggingJsonHandler resourceGroupsTaggingJsonHandler;
     private final CodeBuildJsonHandler codeBuildJsonHandler;
@@ -143,6 +145,7 @@ public class AwsJson11Controller {
                                AcmJsonHandler acmJsonHandler, EcsJsonHandler ecsJsonHandler,
                                EcrJsonHandler ecrJsonHandler, GlueJsonHandler glueJsonHandler,
                                AthenaJsonHandler athenaJsonHandler,
+                               RedshiftDataJsonHandler redshiftDataJsonHandler,
                                FirehoseJsonHandler firehoseJsonHandler,
                                ResourceGroupsTaggingJsonHandler resourceGroupsTaggingJsonHandler,
                                CodeBuildJsonHandler codeBuildJsonHandler,
@@ -194,6 +197,7 @@ public class AwsJson11Controller {
         this.ecrJsonHandler = ecrJsonHandler;
         this.glueJsonHandler = glueJsonHandler;
         this.athenaJsonHandler = athenaJsonHandler;
+        this.redshiftDataJsonHandler = redshiftDataJsonHandler;
         this.firehoseJsonHandler = firehoseJsonHandler;
         this.resourceGroupsTaggingJsonHandler = resourceGroupsTaggingJsonHandler;
         this.codeBuildJsonHandler = codeBuildJsonHandler;
@@ -275,6 +279,7 @@ public class AwsJson11Controller {
                 case "ecr" -> ecrJsonHandler.handle(action, request, region);
                 case "glue" -> glueJsonHandler.handle(action, request, region);
                 case "athena" -> athenaJsonHandler.handle(action, request, region);
+                case "redshift-data" -> redshiftDataJsonHandler.handle(action, request, region);
                 case "firehose" -> firehoseJsonHandler.handle(action, request, region);
                 case "tagging" -> resourceGroupsTaggingJsonHandler.handle(action, request, region);
                 case "codebuild" -> codeBuildJsonHandler.handle(action, request, region, regionResolver.getAccountId());

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -166,7 +166,12 @@ public class ResolvedServiceCatalog {
                         5000L, AwsNamespaces.REDSHIFT, ServiceProtocol.QUERY,
                         protocols(ServiceProtocol.QUERY),
                         Set.of(), Set.of("redshift"), Set.of(), Set.of()),
-                
+                descriptor("redshift-data", "redshift-data",
+                        config.services().redshift().enabled() && config.services().redshiftData().enabled(), true,
+                        null, null, 5000L, null, ServiceProtocol.JSON,
+                        protocols(ServiceProtocol.JSON),
+                        Set.of("RedshiftData."), Set.of("redshift-data"), Set.of(), Set.of()),
+
                 descriptor("events", "eventbridge", config.services().eventbridge().enabled(), true,
                         "eventbridge", config.storage().mode(), 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -168,7 +168,7 @@ public class ResolvedServiceCatalog {
                         Set.of(), Set.of("redshift"), Set.of(), Set.of()),
                 descriptor("redshift-data", "redshift-data",
                         config.services().redshift().enabled() && config.services().redshiftData().enabled(), true,
-                        null, null, 5000L, null, ServiceProtocol.JSON,
+                        "redshift-data", config.storage().mode(), 5000L, null, ServiceProtocol.JSON,
                         protocols(ServiceProtocol.JSON),
                         Set.of("RedshiftData."), Set.of("redshift-data"), Set.of(), Set.of()),
 

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataColumnMetadata.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataColumnMetadata.java
@@ -1,0 +1,56 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * Maps JDBC {@link ResultSetMetaData} onto the Redshift Data API
+ * {@code ColumnMetadata} shape. Every documented field is emitted for each
+ * column; {@code label} matters as much as {@code name} because AWS clients
+ * commonly hydrate rows by the result-set label.
+ */
+final class RedshiftDataColumnMetadata {
+
+    private RedshiftDataColumnMetadata() {
+    }
+
+    static ArrayNode toColumnMetadata(ObjectMapper om, ResultSetMetaData meta) throws SQLException {
+        ArrayNode columns = om.createArrayNode();
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            columns.add(column(om, meta, i));
+        }
+        return columns;
+    }
+
+    private static ObjectNode column(ObjectMapper om, ResultSetMetaData meta, int i) throws SQLException {
+        String name = orEmpty(meta.getColumnName(i));
+        String label = orEmpty(meta.getColumnLabel(i));
+        ObjectNode column = om.createObjectNode();
+        column.put("name", firstNonBlank(name, label));
+        column.put("label", firstNonBlank(label, name));
+        column.put("typeName", orEmpty(meta.getColumnTypeName(i)));
+        column.put("nullable", meta.isNullable(i));
+        column.put("length", meta.getColumnDisplaySize(i));
+        column.put("precision", meta.getPrecision(i));
+        column.put("scale", meta.getScale(i));
+        column.put("isCaseSensitive", meta.isCaseSensitive(i));
+        column.put("isCurrency", meta.isCurrency(i));
+        column.put("isSigned", meta.isSigned(i));
+        column.put("schemaName", orEmpty(meta.getSchemaName(i)));
+        column.put("tableName", orEmpty(meta.getTableName(i)));
+        column.putNull("columnDefault");
+        return column;
+    }
+
+    private static String firstNonBlank(String preferred, String fallback) {
+        return preferred != null && !preferred.isBlank() ? preferred : orEmpty(fallback);
+    }
+
+    private static String orEmpty(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataConnectionFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataConnectionFactory.java
@@ -11,8 +11,13 @@ import java.util.Properties;
 class RedshiftDataConnectionFactory {
 
     Connection open(RedshiftDataResourceResolver.DatabaseTarget target) throws SQLException {
+        // stringtype=unspecified: Redshift Data API parameter values are always strings on the
+        // wire, so every bind goes through PreparedStatement.setString. With the default
+        // (varchar) the driver stamps an explicit type OID and the server refuses
+        // "integer = character varying"; unspecified sends the value untyped and lets the
+        // server infer the column's type from context, matching how AWS binds parameters.
         String url = "jdbc:postgresql://" + target.host() + ":" + target.port() + "/" + target.database()
-                + "?sslmode=disable";
+                + "?sslmode=disable&stringtype=unspecified";
         Properties props = new Properties();
         props.setProperty("user", target.user());
         props.setProperty("password", target.password());

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataConnectionFactory.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataConnectionFactory.java
@@ -1,0 +1,22 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+@ApplicationScoped
+class RedshiftDataConnectionFactory {
+
+    Connection open(RedshiftDataResourceResolver.DatabaseTarget target) throws SQLException {
+        String url = "jdbc:postgresql://" + target.host() + ":" + target.port() + "/" + target.database()
+                + "?sslmode=disable";
+        Properties props = new Properties();
+        props.setProperty("user", target.user());
+        props.setProperty("password", target.password());
+        props.setProperty("connectTimeout", "5");
+        return DriverManager.getConnection(url, props);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataFieldMapper.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataFieldMapper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.jboss.logging.Logger;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -22,6 +23,8 @@ import java.util.List;
  * {@code booleanValue}, {@code blobValue}, or {@code isNull}.
  */
 final class RedshiftDataFieldMapper {
+
+    private static final Logger LOG = Logger.getLogger(RedshiftDataFieldMapper.class);
 
     private RedshiftDataFieldMapper() {
     }
@@ -113,6 +116,8 @@ final class RedshiftDataFieldMapper {
             try {
                 return blob.getBytes(1, Math.toIntExact(blob.length()));
             } catch (SQLException e) {
+                LOG.warnv("Could not read blob value for a Redshift Data API field, returning empty bytes: {0}",
+                        e.getMessage());
                 return new byte[0];
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataFieldMapper.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataFieldMapper.java
@@ -1,0 +1,121 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.sql.Blob;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Maps a JDBC value onto the Redshift Data API {@code Field} union: exactly one
+ * of {@code stringValue}, {@code longValue}, {@code doubleValue},
+ * {@code booleanValue}, {@code blobValue}, or {@code isNull}.
+ */
+final class RedshiftDataFieldMapper {
+
+    private RedshiftDataFieldMapper() {
+    }
+
+    static ObjectNode toField(ObjectMapper om, Object value, int sqlType, boolean wasNull) {
+        ObjectNode field = om.createObjectNode();
+        if (wasNull || value == null) {
+            field.put("isNull", true);
+            return field;
+        }
+        switch (sqlType) {
+            case Types.BIT, Types.BOOLEAN -> field.put("booleanValue", toBoolean(value));
+            case Types.TINYINT, Types.SMALLINT, Types.INTEGER, Types.BIGINT ->
+                    field.put("longValue", coerceNumber(value).longValue());
+            case Types.REAL, Types.FLOAT, Types.DOUBLE ->
+                    field.put("doubleValue", coerceNumber(value).doubleValue());
+            case Types.NUMERIC, Types.DECIMAL -> field.put("stringValue", toPlainString(value));
+            case Types.BINARY, Types.VARBINARY, Types.LONGVARBINARY, Types.BLOB -> field.put("blobValue", toBytes(value));
+            default -> field.put("stringValue", value.toString());
+        }
+        return field;
+    }
+
+    static List<ArrayNode> rows(ObjectMapper om, ResultSet rs) throws SQLException {
+        ResultSetMetaData meta = rs.getMetaData();
+        int columns = meta.getColumnCount();
+        List<ArrayNode> materialised = new ArrayList<>();
+        while (rs.next()) {
+            ArrayNode row = om.createArrayNode();
+            for (int i = 1; i <= columns; i++) {
+                Object value = rs.getObject(i);
+                row.add(toField(om, value, meta.getColumnType(i), rs.wasNull()));
+            }
+            materialised.add(row);
+        }
+        return materialised;
+    }
+
+    static long serializedSize(List<ArrayNode> rows) {
+        long total = 0;
+        for (ArrayNode row : rows) {
+            for (Iterator<JsonNode> it = row.elements(); it.hasNext(); ) {
+                JsonNode field = it.next();
+                if (field.has("stringValue")) {
+                    total += field.get("stringValue").asText().getBytes(StandardCharsets.UTF_8).length;
+                } else if (field.has("blobValue")) {
+                    total += field.get("blobValue").asText().length();
+                } else if (field.has("longValue")) {
+                    total += Long.toString(field.get("longValue").asLong()).length();
+                } else if (field.has("doubleValue")) {
+                    total += Double.toString(field.get("doubleValue").asDouble()).length();
+                } else if (field.has("booleanValue")) {
+                    total += Boolean.toString(field.get("booleanValue").asBoolean()).length();
+                }
+            }
+        }
+        return total;
+    }
+
+    private static boolean toBoolean(Object value) {
+        if (value instanceof Boolean b) {
+            return b;
+        }
+        if (value instanceof Number n) {
+            return n.longValue() != 0;
+        }
+        return Boolean.parseBoolean(value.toString());
+    }
+
+    private static Number coerceNumber(Object value) {
+        if (value instanceof Number n) {
+            return n;
+        }
+        return new BigDecimal(value.toString());
+    }
+
+    private static String toPlainString(Object value) {
+        if (value instanceof BigDecimal d) {
+            return d.toPlainString();
+        }
+        return value.toString();
+    }
+
+    private static byte[] toBytes(Object value) {
+        if (value instanceof byte[] bytes) {
+            return bytes;
+        }
+        if (value instanceof Blob blob) {
+            try {
+                return blob.getBytes(1, Math.toIntExact(blob.length()));
+            } catch (SQLException e) {
+                return new byte[0];
+            }
+        }
+        return value.toString().getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataJsonHandler.java
@@ -1,0 +1,38 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+@ApplicationScoped
+public class RedshiftDataJsonHandler {
+
+    private final RedshiftDataService service;
+
+    @Inject
+    public RedshiftDataJsonHandler(RedshiftDataService service) {
+        this.service = service;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        return switch (action) {
+            case "ExecuteStatement" -> Response.ok(service.executeStatement(request, region)).build();
+            case "BatchExecuteStatement" -> Response.ok(service.batchExecuteStatement(request, region)).build();
+            case "DescribeStatement" -> Response.ok(service.describeStatement(request)).build();
+            case "GetStatementResult" -> Response.ok(service.getStatementResult(request)).build();
+            case "GetStatementResultV2" -> Response.ok(service.getStatementResultV2(request)).build();
+            case "ListStatements" -> Response.ok(service.listStatements(request)).build();
+            case "CancelStatement" -> Response.ok(service.cancelStatement(request)).build();
+            case "ListDatabases" -> Response.ok(service.listDatabases(request, region)).build();
+            case "ListSchemas" -> Response.ok(service.listSchemas(request, region)).build();
+            case "ListTables" -> Response.ok(service.listTables(request, region)).build();
+            case "DescribeTable" -> Response.ok(service.describeTable(request, region)).build();
+            case "ExecuteSql", "BatchExecuteSql" -> throw new AwsException("ValidationException",
+                    action + " is a deprecated operation and is not supported.", 400);
+            default -> throw new AwsException("ValidationException",
+                    "Operation " + action + " is not supported by the Floci Redshift Data API.", 400);
+        };
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolver.java
@@ -1,0 +1,150 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.redshift.RedshiftService;
+import io.github.hectorvent.floci.services.redshift.model.Cluster;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+@ApplicationScoped
+class RedshiftDataResourceResolver {
+
+    private static final Logger LOG = Logger.getLogger(RedshiftDataResourceResolver.class);
+
+    private final RedshiftService redshiftService;
+    private final SecretsManagerService secretsManagerService;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    RedshiftDataResourceResolver(RedshiftService redshiftService,
+                                 SecretsManagerService secretsManagerService,
+                                 ObjectMapper objectMapper) {
+        this.redshiftService = redshiftService;
+        this.secretsManagerService = secretsManagerService;
+        this.objectMapper = objectMapper;
+    }
+
+    DatabaseTarget resolve(JsonNode request, String region) {
+        if (hasText(request, "WorkgroupName")) {
+            throw validation("Redshift Serverless (WorkgroupName) is not emulated by Floci.");
+        }
+        String database = requiredText(request, "Database");
+
+        if (hasText(request, "SecretArn")) {
+            return resolveViaSecret(request, region, database);
+        }
+        return resolveViaDbUser(request, database);
+    }
+
+    private DatabaseTarget resolveViaSecret(JsonNode request, String region, String database) {
+        String secretArn = request.get("SecretArn").asText();
+        try {
+            AwsArnUtils.Arn arn = AwsArnUtils.parse(secretArn);
+            if (region != null && !region.isBlank() && !region.equals(arn.region())) {
+                throw validation("SecretArn is outside the request region.");
+            }
+        } catch (IllegalArgumentException e) {
+            throw validation("SecretArn is not a valid ARN: " + secretArn);
+        }
+        String clusterId = requiredText(request, "ClusterIdentifier");
+        Cluster cluster = cluster(clusterId);
+        SecretVersion secret;
+        try {
+            secret = secretsManagerService.getSecretValue(secretArn, null, null, region);
+        } catch (AwsException e) {
+            throw validation("SecretArn does not resolve to a local secret: " + secretArn);
+        }
+        Credentials creds = parseCredentials(secret.getSecretString());
+        if (creds == null) {
+            throw validation("Secret " + secretArn + " does not contain username and password fields.");
+        }
+        return target(clusterArn(clusterId, region), cluster, database, creds.username(), creds.password());
+    }
+
+    private DatabaseTarget resolveViaDbUser(JsonNode request, String database) {
+        String clusterId = requiredText(request, "ClusterIdentifier");
+        String dbUser = requiredText(request, "DbUser");
+        Cluster cluster = cluster(clusterId);
+        if (!dbUser.equals(cluster.getMasterUsername())) {
+            throw validation("DbUser " + dbUser + " is not the cluster master; create it first or use "
+                    + "GetClusterCredentials (not yet emulated).");
+        }
+        return target(clusterArn(clusterId, null), cluster, database, dbUser, cluster.getMasterPassword());
+    }
+
+    private Cluster cluster(String clusterId) {
+        try {
+            return redshiftService.describeClusters(clusterId).get(0);
+        } catch (AwsException e) {
+            throw validation("Cluster " + clusterId + " was not found.");
+        }
+    }
+
+    private static DatabaseTarget target(String arn, Cluster cluster, String database, String user, String password) {
+        String host = cluster.getContainerHost();
+        int port = cluster.getContainerPort();
+        if (host == null || host.isBlank() || port <= 0) {
+            throw validation("Cluster runtime is not available for Data API execution.");
+        }
+        return new DatabaseTarget(arn, host, port, database, user, password);
+    }
+
+    private Credentials parseCredentials(String secretString) {
+        if (secretString == null || secretString.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode node = objectMapper.readTree(secretString);
+            String username = text(node, "username");
+            if (username == null) {
+                username = text(node, "user");
+            }
+            String password = text(node, "password");
+            if (username != null && password != null) {
+                return new Credentials(username, password);
+            }
+        } catch (Exception e) {
+            LOG.debugv("Could not parse Redshift Data API secret: {0}", e.getMessage());
+        }
+        return null;
+    }
+
+    private static String clusterArn(String clusterId, String region) {
+        String r = (region == null || region.isBlank()) ? "us-east-1" : region;
+        return "arn:aws:redshift:" + r + ":000000000000:cluster:" + clusterId;
+    }
+
+    private static AwsException validation(String message) {
+        return new AwsException("ValidationException", message, 400);
+    }
+
+    private static boolean hasText(JsonNode node, String field) {
+        String value = text(node, field);
+        return value != null && !value.isBlank();
+    }
+
+    private static String requiredText(JsonNode node, String field) {
+        String value = text(node, field);
+        if (value == null || value.isBlank()) {
+            throw validation(field + " is required.");
+        }
+        return value;
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode value = node.get(field);
+        return value == null || value.isNull() ? null : value.asText();
+    }
+
+    record DatabaseTarget(String arn, String host, int port, String database, String user, String password) {
+    }
+
+    private record Credentials(String username, String password) {
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -351,11 +351,13 @@ public class RedshiftDataService implements Resettable {
     public ObjectNode listStatements(JsonNode request) {
         String nameFilter = textOrNull(request, "StatementName");
         String statusFilter = textOrNull(request, "Status");
-        // AWS caps MaxResults at 100 and treats 0 or absent as the default. An unclamped
-        // value of 0 would emit the same NextToken forever, so a follower would loop.
+        // AWS treats 0 or absent as the default and rejects anything above the documented
+        // maximum of 100. Clamping 0 up also stops a follower looping on a static NextToken.
         int maxResults = request.path("MaxResults").asInt(100);
-        if (maxResults <= 0 || maxResults > 100) {
+        if (maxResults <= 0) {
             maxResults = 100;
+        } else if (maxResults > 100) {
+            throw new AwsException("ValidationException", "MaxResults must not exceed 100.", 400);
         }
         int offset = decodeToken(textOrNull(request, "NextToken"));
 

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -61,7 +61,7 @@ public class RedshiftDataService implements Resettable {
         stored.sql = sql;
         stored.sqls = List.of(sql);
         stored.clusterIdentifier = clusterIdentifierOrNull(request);
-        stored.dbUser = textOrNull(request, "DbUser");
+        stored.dbUser = target.user();
         stored.database = target.database();
         stored.resultFormat = request.path("ResultFormat").asText("JSON");
 
@@ -141,8 +141,9 @@ public class RedshiftDataService implements Resettable {
             response.put("Error", stored.error);
         }
         response.put("QueryString", stored.sql);
-        response.put("RedshiftPid", Math.abs(stored.id.hashCode()));
-        response.put("RedshiftQueryId", (long) Math.abs(stored.id.hashCode()));
+        int stableId = stored.id.hashCode() & Integer.MAX_VALUE;
+        response.put("RedshiftPid", stableId);
+        response.put("RedshiftQueryId", (long) stableId);
         response.put("ResultRows", stored.resultRows);
         response.put("ResultSize", stored.resultSize);
         response.put("HasResultSet", stored.hasResultSet);
@@ -226,19 +227,37 @@ public class RedshiftDataService implements Resettable {
             if (field.path("isNull").asBoolean(false)) {
                 continue;
             }
-            if (field.has("stringValue")) {
-                line.append(field.get("stringValue").asText());
-            } else if (field.has("longValue")) {
-                line.append(field.get("longValue").asLong());
-            } else if (field.has("doubleValue")) {
-                line.append(field.get("doubleValue").asDouble());
-            } else if (field.has("booleanValue")) {
-                line.append(field.get("booleanValue").asBoolean());
-            } else if (field.has("blobValue")) {
-                line.append(field.get("blobValue").asText());
-            }
+            line.append(csvCell(fieldText(field)));
         }
         return line.toString();
+    }
+
+    private static String fieldText(JsonNode field) {
+        if (field.has("stringValue")) {
+            return field.get("stringValue").asText();
+        }
+        if (field.has("longValue")) {
+            return Long.toString(field.get("longValue").asLong());
+        }
+        if (field.has("doubleValue")) {
+            return Double.toString(field.get("doubleValue").asDouble());
+        }
+        if (field.has("booleanValue")) {
+            return Boolean.toString(field.get("booleanValue").asBoolean());
+        }
+        if (field.has("blobValue")) {
+            return field.get("blobValue").asText();
+        }
+        return "";
+    }
+
+    // RFC 4180: quote a field that contains a comma, quote, CR, or LF, doubling embedded quotes.
+    private static String csvCell(String value) {
+        if (value.indexOf(',') < 0 && value.indexOf('"') < 0
+                && value.indexOf('\n') < 0 && value.indexOf('\r') < 0) {
+            return value;
+        }
+        return '"' + value.replace("\"", "\"\"") + '"';
     }
 
     // ── BatchExecuteStatement ──────────────────────────────────────────────
@@ -260,7 +279,7 @@ public class RedshiftDataService implements Resettable {
         parent.sql = String.join("; ", sqls);
         parent.sqls = sqls;
         parent.clusterIdentifier = clusterIdentifierOrNull(request);
-        parent.dbUser = textOrNull(request, "DbUser");
+        parent.dbUser = target.user();
         parent.database = target.database();
         parent.resultFormat = request.path("ResultFormat").asText("JSON");
         parent.subStatements = new ArrayList<>();
@@ -375,7 +394,8 @@ public class RedshiftDataService implements Resettable {
 
     public ObjectNode cancelStatement(JsonNode request) {
         RedshiftDataStatementStore.StoredStatement stored = require(request);
-        if (stored.status != RedshiftDataStatementStore.Status.FINISHED) {
+        if (stored.status != RedshiftDataStatementStore.Status.FINISHED
+                && stored.status != RedshiftDataStatementStore.Status.FAILED) {
             stored.status = RedshiftDataStatementStore.Status.ABORTED;
             stored.updatedAt = Instant.now();
         }
@@ -476,6 +496,9 @@ public class RedshiftDataService implements Resettable {
                     col.put("typeName", rs.getString("data_type"));
                     col.put("length", rs.getInt("character_maximum_length"));
                     col.put("nullable", "YES".equalsIgnoreCase(rs.getString("is_nullable")) ? 1 : 0);
+                    // information_schema does not carry these per-column flags. They are
+                    // fixed at emulation-friendly defaults rather than driver-derived as in
+                    // GetStatementResult's ColumnMetadata, which reads a live ResultSetMetaData.
                     col.put("isCaseSensitive", false);
                     col.put("isCurrency", false);
                     col.put("isSigned", true);
@@ -496,10 +519,18 @@ public class RedshiftDataService implements Resettable {
             throw databaseError(e);
         }
 
+        int max = pageSize(request);
+        int offset = decodeToken(textOrNull(request, "NextToken"));
         ObjectNode response = objectMapper.createObjectNode();
         response.put("TableName", table);
         ArrayNode list = response.putArray("ColumnList");
-        columns.forEach(list::add);
+        int end = Math.min(offset + max, columns.size());
+        for (int i = offset; i < end; i++) {
+            list.add(columns.get(i));
+        }
+        if (end < columns.size()) {
+            response.put("NextToken", encodeToken(end));
+        }
         return response;
     }
 
@@ -577,22 +608,9 @@ public class RedshiftDataService implements Resettable {
     }
 
     private static void rejectMultiStatement(String sql) {
-        String trimmed = sql.strip();
-        while (trimmed.endsWith(";")) {
-            trimmed = trimmed.substring(0, trimmed.length() - 1).strip();
-        }
-        boolean inSingle = false;
-        boolean inDouble = false;
-        for (int i = 0; i < trimmed.length(); i++) {
-            char c = trimmed.charAt(i);
-            if (c == '\'' && !inDouble) {
-                inSingle = !inSingle;
-            } else if (c == '"' && !inSingle) {
-                inDouble = !inDouble;
-            } else if (c == ';' && !inSingle && !inDouble) {
-                throw new AwsException("ValidationException",
-                        "A single Sql statement is required; use BatchExecuteStatement for multiple.", 400);
-            }
+        if (RedshiftDataSqlParameters.isMultiStatement(sql)) {
+            throw new AwsException("ValidationException",
+                    "A single Sql statement is required; use BatchExecuteStatement for multiple.", 400);
         }
     }
 
@@ -604,11 +622,16 @@ public class RedshiftDataService implements Resettable {
         if (token == null || token.isBlank()) {
             return 0;
         }
+        int offset;
         try {
-            return Integer.parseInt(new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8));
+            offset = Integer.parseInt(new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8));
         } catch (IllegalArgumentException e) {
             throw new AwsException("ValidationException", "NextToken is not valid.", 400);
         }
+        if (offset < 0) {
+            throw new AwsException("ValidationException", "NextToken is not valid.", 400);
+        }
+        return offset;
     }
 
     private static double epochSeconds(Instant instant) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -384,22 +384,166 @@ public class RedshiftDataService implements Resettable {
         return response;
     }
 
-    // ── Not yet implemented (Task 5) ───────────────────────────────────────
+    // ── Schema introspection ───────────────────────────────────────────────
 
     public ObjectNode listDatabases(JsonNode request, String region) {
-        throw notImplemented("ListDatabases");
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver.resolve(request, region);
+        List<String> names = new ArrayList<>();
+        try (Connection c = connectionFactory.open(target);
+             PreparedStatement ps = c.prepareStatement(
+                     "SELECT datname FROM pg_database WHERE datistemplate = false ORDER BY datname");
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                names.add(rs.getString(1));
+            }
+        } catch (SQLException e) {
+            throw databaseError(e);
+        }
+        return pageStrings(request, "Databases", names);
     }
 
     public ObjectNode listSchemas(JsonNode request, String region) {
-        throw notImplemented("ListSchemas");
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver.resolve(request, region);
+        String pattern = orLike(textOrNull(request, "SchemaPattern"));
+        List<String> names = new ArrayList<>();
+        try (Connection c = connectionFactory.open(target);
+             PreparedStatement ps = c.prepareStatement(
+                     "SELECT schema_name FROM information_schema.schemata "
+                             + "WHERE schema_name LIKE ? ORDER BY schema_name")) {
+            ps.setString(1, pattern);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    names.add(rs.getString(1));
+                }
+            }
+        } catch (SQLException e) {
+            throw databaseError(e);
+        }
+        return pageStrings(request, "Schemas", names);
     }
 
     public ObjectNode listTables(JsonNode request, String region) {
-        throw notImplemented("ListTables");
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver.resolve(request, region);
+        String schemaPattern = orLike(textOrNull(request, "SchemaPattern"));
+        String tablePattern = orLike(textOrNull(request, "TablePattern"));
+        List<ObjectNode> tables = new ArrayList<>();
+        try (Connection c = connectionFactory.open(target);
+             PreparedStatement ps = c.prepareStatement(
+                     "SELECT table_schema, table_name, table_type FROM information_schema.tables "
+                             + "WHERE table_schema LIKE ? AND table_name LIKE ? "
+                             + "ORDER BY table_schema, table_name")) {
+            ps.setString(1, schemaPattern);
+            ps.setString(2, tablePattern);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ObjectNode t = objectMapper.createObjectNode();
+                    t.put("schema", rs.getString(1));
+                    t.put("name", rs.getString(2));
+                    t.put("type", "VIEW".equalsIgnoreCase(rs.getString(3)) ? "VIEW" : "TABLE");
+                    tables.add(t);
+                }
+            }
+        } catch (SQLException e) {
+            throw databaseError(e);
+        }
+        return pageObjects(request, "Tables", tables);
     }
 
     public ObjectNode describeTable(JsonNode request, String region) {
-        throw notImplemented("DescribeTable");
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver.resolve(request, region);
+        String schema = textOrNull(request, "Schema");
+        String table = requiredText(request, "Table");
+        boolean withSchema = schema != null && !schema.isBlank();
+        String sql = "SELECT column_name, data_type, character_maximum_length, is_nullable, "
+                + "numeric_precision, numeric_scale, column_default, table_schema, table_name "
+                + "FROM information_schema.columns WHERE table_name LIKE ? "
+                + (withSchema ? "AND table_schema LIKE ? " : "")
+                + "ORDER BY ordinal_position";
+
+        List<ObjectNode> columns = new ArrayList<>();
+        try (Connection c = connectionFactory.open(target);
+             PreparedStatement ps = c.prepareStatement(sql)) {
+            ps.setString(1, table);
+            if (withSchema) {
+                ps.setString(2, schema);
+            }
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    ObjectNode col = objectMapper.createObjectNode();
+                    String columnName = rs.getString("column_name");
+                    col.put("name", columnName);
+                    col.put("label", columnName);
+                    col.put("typeName", rs.getString("data_type"));
+                    col.put("length", rs.getInt("character_maximum_length"));
+                    col.put("nullable", "YES".equalsIgnoreCase(rs.getString("is_nullable")) ? 1 : 0);
+                    col.put("isCaseSensitive", false);
+                    col.put("isCurrency", false);
+                    col.put("isSigned", true);
+                    col.put("precision", rs.getInt("numeric_precision"));
+                    col.put("scale", rs.getInt("numeric_scale"));
+                    col.put("schemaName", rs.getString("table_schema"));
+                    col.put("tableName", rs.getString("table_name"));
+                    String columnDefault = rs.getString("column_default");
+                    if (columnDefault != null) {
+                        col.put("columnDefault", columnDefault);
+                    } else {
+                        col.putNull("columnDefault");
+                    }
+                    columns.add(col);
+                }
+            }
+        } catch (SQLException e) {
+            throw databaseError(e);
+        }
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("TableName", table);
+        ArrayNode list = response.putArray("ColumnList");
+        columns.forEach(list::add);
+        return response;
+    }
+
+    private ObjectNode pageStrings(JsonNode request, String key, List<String> values) {
+        int max = pageSize(request);
+        int offset = decodeToken(textOrNull(request, "NextToken"));
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode arr = response.putArray(key);
+        int end = Math.min(offset + max, values.size());
+        for (int i = offset; i < end; i++) {
+            arr.add(values.get(i));
+        }
+        if (end < values.size()) {
+            response.put("NextToken", encodeToken(end));
+        }
+        return response;
+    }
+
+    private ObjectNode pageObjects(JsonNode request, String key, List<ObjectNode> values) {
+        int max = pageSize(request);
+        int offset = decodeToken(textOrNull(request, "NextToken"));
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode arr = response.putArray(key);
+        int end = Math.min(offset + max, values.size());
+        for (int i = offset; i < end; i++) {
+            arr.add(values.get(i));
+        }
+        if (end < values.size()) {
+            response.put("NextToken", encodeToken(end));
+        }
+        return response;
+    }
+
+    private static int pageSize(JsonNode request) {
+        int max = request.path("MaxResults").asInt(PAGE_SIZE);
+        return max > 0 ? max : PAGE_SIZE;
+    }
+
+    private static String orLike(String value) {
+        return value == null || value.isBlank() ? "%" : value;
+    }
+
+    private static AwsException databaseError(SQLException e) {
+        return new AwsException("ValidationException", e.getMessage(), 400);
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────
@@ -486,9 +630,5 @@ public class RedshiftDataService implements Resettable {
     private static String textOrNull(JsonNode request, String name) {
         JsonNode node = request.get(name);
         return node == null || node.isNull() ? null : node.asText();
-    }
-
-    private static AwsException notImplemented(String op) {
-        return new AwsException("ValidationException", op + " is not implemented yet.", 400);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -2,14 +2,28 @@ package io.github.hectorvent.floci.services.redshiftdata;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
 @ApplicationScoped
 public class RedshiftDataService implements Resettable {
+
+    private static final int PAGE_SIZE = 1000;
 
     private final RedshiftDataResourceResolver resolver;
     private final RedshiftDataConnectionFactory connectionFactory;
@@ -32,24 +46,203 @@ public class RedshiftDataService implements Resettable {
         store.clear();
     }
 
+    // ── ExecuteStatement ────────────────────────────────────────────────────
+
     public ObjectNode executeStatement(JsonNode request, String region) {
-        throw notImplemented("ExecuteStatement");
+        String sql = requiredText(request, "Sql");
+        rejectMultiStatement(sql);
+        Map<String, String> parameters = RedshiftDataSqlParameters.parseParameters(request, "Parameters");
+
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver.resolve(request, region);
+
+        RedshiftDataStatementStore.StoredStatement stored = newStatement(request);
+        stored.sql = sql;
+        stored.sqls = List.of(sql);
+        stored.clusterIdentifier = clusterIdentifierOrNull(request);
+        stored.dbUser = textOrNull(request, "DbUser");
+        stored.database = target.database();
+        stored.resultFormat = request.path("ResultFormat").asText("JSON");
+
+        runStatement(stored, target, sql, parameters);
+        store.put(stored);
+        return executeResponse(stored);
     }
 
-    public ObjectNode batchExecuteStatement(JsonNode request, String region) {
-        throw notImplemented("BatchExecuteStatement");
+    private void runStatement(RedshiftDataStatementStore.StoredStatement stored,
+                              RedshiftDataResourceResolver.DatabaseTarget target,
+                              String sql, Map<String, String> parameters) {
+        try (Connection connection = connectionFactory.open(target)) {
+            runOnConnection(stored, connection, sql, parameters);
+        } catch (SQLException e) {
+            stored.status = RedshiftDataStatementStore.Status.FAILED;
+            stored.error = e.getMessage();
+        }
+        stored.updatedAt = Instant.now();
     }
+
+    private void runOnConnection(RedshiftDataStatementStore.StoredStatement stored,
+                                 Connection connection, String sql, Map<String, String> parameters)
+            throws SQLException {
+        RedshiftDataSqlParameters.ParsedSql parsed = RedshiftDataSqlParameters.parse(sql);
+        long t0 = System.nanoTime();
+        try (PreparedStatement statement = connection.prepareStatement(parsed.sql())) {
+            RedshiftDataSqlParameters.bind(statement, parsed.parameterOrder(), parameters);
+            boolean hasResultSet = statement.execute();
+            if (hasResultSet) {
+                try (ResultSet rs = statement.getResultSet()) {
+                    stored.columnMetadata = RedshiftDataColumnMetadata.toColumnMetadata(objectMapper, rs.getMetaData());
+                    stored.rows = RedshiftDataFieldMapper.rows(objectMapper, rs);
+                    stored.hasResultSet = true;
+                    stored.resultRows = stored.rows.size();
+                    stored.resultSize = RedshiftDataFieldMapper.serializedSize(stored.rows);
+                }
+            } else {
+                stored.hasResultSet = false;
+                stored.resultRows = Math.max(statement.getUpdateCount(), 0);
+            }
+        }
+        stored.durationNanos = System.nanoTime() - t0;
+        stored.status = RedshiftDataStatementStore.Status.FINISHED;
+    }
+
+    private ObjectNode executeResponse(RedshiftDataStatementStore.StoredStatement stored) {
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("Id", stored.id);
+        if (stored.clusterIdentifier != null) {
+            response.put("ClusterIdentifier", stored.clusterIdentifier);
+        } else {
+            response.putNull("ClusterIdentifier");
+        }
+        response.put("CreatedAt", epochSeconds(stored.createdAt));
+        response.put("Database", stored.database);
+        if (stored.dbUser != null) {
+            response.put("DbUser", stored.dbUser);
+        }
+        response.putArray("DbGroups");
+        response.putNull("WorkgroupName");
+        response.put("HasResultSet", stored.hasResultSet);
+        response.putNull("SessionId");
+        return response;
+    }
+
+    // ── DescribeStatement ───────────────────────────────────────────────────
 
     public ObjectNode describeStatement(JsonNode request) {
-        throw notImplemented("DescribeStatement");
+        RedshiftDataStatementStore.StoredStatement stored = require(request);
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("Id", stored.id);
+        response.put("Status", stored.status.name());
+        response.put("CreatedAt", epochSeconds(stored.createdAt));
+        response.put("UpdatedAt", epochSeconds(stored.updatedAt));
+        response.put("Duration", stored.durationNanos);
+        if (stored.error != null) {
+            response.put("Error", stored.error);
+        }
+        response.put("QueryString", stored.sql);
+        response.put("RedshiftPid", Math.abs(stored.id.hashCode()));
+        response.put("RedshiftQueryId", (long) Math.abs(stored.id.hashCode()));
+        response.put("ResultRows", stored.resultRows);
+        response.put("ResultSize", stored.resultSize);
+        response.put("HasResultSet", stored.hasResultSet);
+        if (stored.clusterIdentifier != null) {
+            response.put("ClusterIdentifier", stored.clusterIdentifier);
+        }
+        response.put("Database", stored.database);
+        if (stored.dbUser != null) {
+            response.put("DbUser", stored.dbUser);
+        }
+        response.putNull("WorkgroupName");
+        response.put("ResultFormat", stored.resultFormat);
+        if (stored.batch && stored.subStatements != null) {
+            ArrayNode subs = response.putArray("SubStatements");
+            for (RedshiftDataStatementStore.StoredStatement sub : stored.subStatements) {
+                ObjectNode s = subs.addObject();
+                s.put("Id", sub.id);
+                s.put("Status", sub.status.name());
+                s.put("QueryString", sub.sql);
+                s.put("Duration", sub.durationNanos);
+                s.put("ResultRows", sub.resultRows);
+                s.put("ResultSize", sub.resultSize);
+                s.put("HasResultSet", sub.hasResultSet);
+                if (sub.error != null) {
+                    s.put("Error", sub.error);
+                }
+            }
+        }
+        return response;
     }
 
+    // ── GetStatementResult / GetStatementResultV2 ───────────────────────────
+
     public ObjectNode getStatementResult(JsonNode request) {
-        throw notImplemented("GetStatementResult");
+        RedshiftDataStatementStore.StoredStatement stored = resultBearing(request);
+        int offset = decodeToken(textOrNull(request, "NextToken"));
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("ColumnMetadata", stored.columnMetadata);
+        ArrayNode records = response.putArray("Records");
+        int end = Math.min(offset + PAGE_SIZE, stored.rows.size());
+        for (int i = offset; i < end; i++) {
+            records.add(stored.rows.get(i));
+        }
+        response.put("TotalNumRows", (long) stored.rows.size());
+        if (end < stored.rows.size()) {
+            response.put("NextToken", encodeToken(end));
+        }
+        return response;
     }
 
     public ObjectNode getStatementResultV2(JsonNode request) {
-        throw notImplemented("GetStatementResultV2");
+        RedshiftDataStatementStore.StoredStatement stored = resultBearing(request);
+        int offset = decodeToken(textOrNull(request, "NextToken"));
+        ObjectNode response = objectMapper.createObjectNode();
+        response.set("ColumnMetadata", stored.columnMetadata);
+        int end = Math.min(offset + PAGE_SIZE, stored.rows.size());
+        boolean csv = "CSV".equalsIgnoreCase(stored.resultFormat);
+        ArrayNode records = response.putArray("Records");
+        for (int i = offset; i < end; i++) {
+            if (csv) {
+                records.addObject().put("CSVRecords", toCsvLine(stored.rows.get(i)));
+            } else {
+                records.add(stored.rows.get(i));
+            }
+        }
+        response.put("ResultFormat", csv ? "CSV" : "JSON");
+        response.put("TotalNumRows", (long) stored.rows.size());
+        if (end < stored.rows.size()) {
+            response.put("NextToken", encodeToken(end));
+        }
+        return response;
+    }
+
+    private static String toCsvLine(ArrayNode row) {
+        StringBuilder line = new StringBuilder();
+        for (int i = 0; i < row.size(); i++) {
+            if (i > 0) {
+                line.append(',');
+            }
+            JsonNode field = row.get(i);
+            if (field.path("isNull").asBoolean(false)) {
+                continue;
+            }
+            if (field.has("stringValue")) {
+                line.append(field.get("stringValue").asText());
+            } else if (field.has("longValue")) {
+                line.append(field.get("longValue").asLong());
+            } else if (field.has("doubleValue")) {
+                line.append(field.get("doubleValue").asDouble());
+            } else if (field.has("booleanValue")) {
+                line.append(field.get("booleanValue").asBoolean());
+            } else if (field.has("blobValue")) {
+                line.append(field.get("blobValue").asText());
+            }
+        }
+        return line.toString();
+    }
+
+    // ── Not yet implemented (Tasks 4 and 5) ────────────────────────────────
+
+    public ObjectNode batchExecuteStatement(JsonNode request, String region) {
+        throw notImplemented("BatchExecuteStatement");
     }
 
     public ObjectNode listStatements(JsonNode request) {
@@ -74,6 +267,92 @@ public class RedshiftDataService implements Resettable {
 
     public ObjectNode describeTable(JsonNode request, String region) {
         throw notImplemented("DescribeTable");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+
+    private RedshiftDataStatementStore.StoredStatement newStatement(JsonNode request) {
+        RedshiftDataStatementStore.StoredStatement stored = new RedshiftDataStatementStore.StoredStatement();
+        stored.id = UUID.randomUUID().toString();
+        stored.statementName = textOrNull(request, "StatementName");
+        Instant now = Instant.now();
+        stored.createdAt = now;
+        stored.updatedAt = now;
+        stored.status = RedshiftDataStatementStore.Status.STARTED;
+        return stored;
+    }
+
+    private RedshiftDataStatementStore.StoredStatement require(JsonNode request) {
+        String id = requiredText(request, "Id");
+        RedshiftDataStatementStore.StoredStatement stored = store.get(id);
+        if (stored == null) {
+            throw new AwsException("ResourceNotFoundException", "Statement " + id + " was not found.", 400);
+        }
+        return stored;
+    }
+
+    private RedshiftDataStatementStore.StoredStatement resultBearing(JsonNode request) {
+        RedshiftDataStatementStore.StoredStatement stored = require(request);
+        if (!stored.hasResultSet || stored.rows == null) {
+            throw new AwsException("ValidationException", "Statement has no result set", 400);
+        }
+        return stored;
+    }
+
+    private static void rejectMultiStatement(String sql) {
+        String trimmed = sql.strip();
+        while (trimmed.endsWith(";")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1).strip();
+        }
+        boolean inSingle = false;
+        boolean inDouble = false;
+        for (int i = 0; i < trimmed.length(); i++) {
+            char c = trimmed.charAt(i);
+            if (c == '\'' && !inDouble) {
+                inSingle = !inSingle;
+            } else if (c == '"' && !inSingle) {
+                inDouble = !inDouble;
+            } else if (c == ';' && !inSingle && !inDouble) {
+                throw new AwsException("ValidationException",
+                        "A single Sql statement is required; use BatchExecuteStatement for multiple.", 400);
+            }
+        }
+    }
+
+    private static String encodeToken(int offset) {
+        return Base64.getEncoder().encodeToString(Integer.toString(offset).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static int decodeToken(String token) {
+        if (token == null || token.isBlank()) {
+            return 0;
+        }
+        try {
+            return Integer.parseInt(new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8));
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ValidationException", "NextToken is not valid.", 400);
+        }
+    }
+
+    private static double epochSeconds(Instant instant) {
+        return instant.toEpochMilli() / 1000.0;
+    }
+
+    private String clusterIdentifierOrNull(JsonNode request) {
+        return textOrNull(request, "ClusterIdentifier");
+    }
+
+    private static String requiredText(JsonNode request, String name) {
+        String value = textOrNull(request, name);
+        if (value == null || value.isBlank()) {
+            throw new AwsException("ValidationException", name + " is required.", 400);
+        }
+        return value;
+    }
+
+    private static String textOrNull(JsonNode request, String name) {
+        JsonNode node = request.get(name);
+        return node == null || node.isNull() ? null : node.asText();
     }
 
     private static AwsException notImplemented(String op) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -1,0 +1,82 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+public class RedshiftDataService implements Resettable {
+
+    private final RedshiftDataResourceResolver resolver;
+    private final RedshiftDataConnectionFactory connectionFactory;
+    private final RedshiftDataStatementStore store;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public RedshiftDataService(RedshiftDataResourceResolver resolver,
+                               RedshiftDataConnectionFactory connectionFactory,
+                               RedshiftDataStatementStore store,
+                               ObjectMapper objectMapper) {
+        this.resolver = resolver;
+        this.connectionFactory = connectionFactory;
+        this.store = store;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void clear() {
+        store.clear();
+    }
+
+    public ObjectNode executeStatement(JsonNode request, String region) {
+        throw notImplemented("ExecuteStatement");
+    }
+
+    public ObjectNode batchExecuteStatement(JsonNode request, String region) {
+        throw notImplemented("BatchExecuteStatement");
+    }
+
+    public ObjectNode describeStatement(JsonNode request) {
+        throw notImplemented("DescribeStatement");
+    }
+
+    public ObjectNode getStatementResult(JsonNode request) {
+        throw notImplemented("GetStatementResult");
+    }
+
+    public ObjectNode getStatementResultV2(JsonNode request) {
+        throw notImplemented("GetStatementResultV2");
+    }
+
+    public ObjectNode listStatements(JsonNode request) {
+        throw notImplemented("ListStatements");
+    }
+
+    public ObjectNode cancelStatement(JsonNode request) {
+        throw notImplemented("CancelStatement");
+    }
+
+    public ObjectNode listDatabases(JsonNode request, String region) {
+        throw notImplemented("ListDatabases");
+    }
+
+    public ObjectNode listSchemas(JsonNode request, String region) {
+        throw notImplemented("ListSchemas");
+    }
+
+    public ObjectNode listTables(JsonNode request, String region) {
+        throw notImplemented("ListTables");
+    }
+
+    public ObjectNode describeTable(JsonNode request, String region) {
+        throw notImplemented("DescribeTable");
+    }
+
+    private static AwsException notImplemented(String op) {
+        return new AwsException("ValidationException", op + " is not implemented yet.", 400);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -15,7 +15,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -239,19 +241,150 @@ public class RedshiftDataService implements Resettable {
         return line.toString();
     }
 
-    // ── Not yet implemented (Tasks 4 and 5) ────────────────────────────────
+    // ── BatchExecuteStatement ──────────────────────────────────────────────
 
     public ObjectNode batchExecuteStatement(JsonNode request, String region) {
-        throw notImplemented("BatchExecuteStatement");
+        JsonNode sqlsNode = request.get("Sqls");
+        if (sqlsNode == null || !sqlsNode.isArray() || sqlsNode.isEmpty()) {
+            throw new AwsException("ValidationException", "Sqls must be a non-empty array of SQL statements.", 400);
+        }
+        List<String> sqls = new ArrayList<>();
+        for (JsonNode n : sqlsNode) {
+            sqls.add(n.asText());
+        }
+
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver.resolve(request, region);
+
+        RedshiftDataStatementStore.StoredStatement parent = newStatement(request);
+        parent.batch = true;
+        parent.sql = String.join("; ", sqls);
+        parent.sqls = sqls;
+        parent.clusterIdentifier = clusterIdentifierOrNull(request);
+        parent.dbUser = textOrNull(request, "DbUser");
+        parent.database = target.database();
+        parent.resultFormat = request.path("ResultFormat").asText("JSON");
+        parent.subStatements = new ArrayList<>();
+
+        long totalDuration = 0;
+        try (Connection connection = connectionFactory.open(target)) {
+            connection.setAutoCommit(false);
+            boolean failed = false;
+            for (int n = 0; n < sqls.size(); n++) {
+                RedshiftDataStatementStore.StoredStatement sub = new RedshiftDataStatementStore.StoredStatement();
+                sub.id = parent.id + ":" + (n + 1);
+                sub.sql = sqls.get(n);
+                sub.sqls = List.of(sqls.get(n));
+                sub.clusterIdentifier = parent.clusterIdentifier;
+                sub.database = parent.database;
+                sub.dbUser = parent.dbUser;
+                sub.resultFormat = parent.resultFormat;
+                Instant now = Instant.now();
+                sub.createdAt = now;
+                sub.updatedAt = now;
+                try {
+                    runOnConnection(sub, connection, sqls.get(n), Map.of());
+                } catch (SQLException e) {
+                    sub.status = RedshiftDataStatementStore.Status.FAILED;
+                    sub.error = e.getMessage();
+                    sub.updatedAt = Instant.now();
+                    parent.subStatements.add(sub);
+                    store.put(sub);
+                    totalDuration += sub.durationNanos;
+                    parent.status = RedshiftDataStatementStore.Status.FAILED;
+                    parent.error = e.getMessage();
+                    connection.rollback();
+                    failed = true;
+                    break;
+                }
+                sub.updatedAt = Instant.now();
+                parent.subStatements.add(sub);
+                store.put(sub);
+                totalDuration += sub.durationNanos;
+            }
+            if (!failed) {
+                connection.commit();
+                parent.status = RedshiftDataStatementStore.Status.FINISHED;
+            }
+        } catch (SQLException e) {
+            parent.status = RedshiftDataStatementStore.Status.FAILED;
+            parent.error = e.getMessage();
+        }
+
+        for (int i = parent.subStatements.size() - 1; i >= 0; i--) {
+            RedshiftDataStatementStore.StoredStatement sub = parent.subStatements.get(i);
+            if (sub.hasResultSet) {
+                parent.hasResultSet = true;
+                parent.columnMetadata = sub.columnMetadata;
+                parent.rows = sub.rows;
+                parent.resultRows = sub.resultRows;
+                parent.resultSize = sub.resultSize;
+                break;
+            }
+        }
+        parent.durationNanos = totalDuration;
+        parent.updatedAt = Instant.now();
+        store.put(parent);
+        return executeResponse(parent);
     }
+
+    // ── ListStatements ─────────────────────────────────────────────────────
 
     public ObjectNode listStatements(JsonNode request) {
-        throw notImplemented("ListStatements");
+        String nameFilter = textOrNull(request, "StatementName");
+        String statusFilter = textOrNull(request, "Status");
+        int maxResults = request.path("MaxResults").asInt(100);
+        int offset = decodeToken(textOrNull(request, "NextToken"));
+
+        List<RedshiftDataStatementStore.StoredStatement> all = store.values().stream()
+                .filter(s -> s.id.indexOf(':') < 0)
+                .filter(s -> nameFilter == null || nameFilter.equals(s.statementName))
+                .filter(s -> statusFilter == null || statusFilter.equalsIgnoreCase(s.status.name()))
+                .sorted(Comparator.comparing((RedshiftDataStatementStore.StoredStatement s) -> s.createdAt).reversed())
+                .toList();
+
+        ObjectNode response = objectMapper.createObjectNode();
+        ArrayNode statements = response.putArray("Statements");
+        int end = Math.min(offset + maxResults, all.size());
+        for (int i = offset; i < end; i++) {
+            RedshiftDataStatementStore.StoredStatement s = all.get(i);
+            ObjectNode node = statements.addObject();
+            node.put("Id", s.id);
+            node.put("QueryString", s.sql);
+            ArrayNode queryStrings = node.putArray("QueryStrings");
+            for (String sql : s.sqls != null ? s.sqls : List.of(s.sql)) {
+                queryStrings.add(sql);
+            }
+            node.put("Status", s.status.name());
+            node.put("CreatedAt", epochSeconds(s.createdAt));
+            node.put("UpdatedAt", epochSeconds(s.updatedAt));
+            if (s.statementName != null) {
+                node.put("StatementName", s.statementName);
+            }
+            node.put("IsBatchStatement", s.batch);
+            node.put("ResultRows", s.resultRows);
+            node.put("ResultSize", s.resultSize);
+            node.put("Duration", s.durationNanos);
+        }
+        if (end < all.size()) {
+            response.put("NextToken", encodeToken(end));
+        }
+        return response;
     }
 
+    // ── CancelStatement ────────────────────────────────────────────────────
+
     public ObjectNode cancelStatement(JsonNode request) {
-        throw notImplemented("CancelStatement");
+        RedshiftDataStatementStore.StoredStatement stored = require(request);
+        if (stored.status != RedshiftDataStatementStore.Status.FINISHED) {
+            stored.status = RedshiftDataStatementStore.Status.ABORTED;
+            stored.updatedAt = Instant.now();
+        }
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("Status", true);
+        return response;
     }
+
+    // ── Not yet implemented (Task 5) ───────────────────────────────────────
 
     public ObjectNode listDatabases(JsonNode request, String region) {
         throw notImplemented("ListDatabases");

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataService.java
@@ -351,7 +351,12 @@ public class RedshiftDataService implements Resettable {
     public ObjectNode listStatements(JsonNode request) {
         String nameFilter = textOrNull(request, "StatementName");
         String statusFilter = textOrNull(request, "Status");
+        // AWS caps MaxResults at 100 and treats 0 or absent as the default. An unclamped
+        // value of 0 would emit the same NextToken forever, so a follower would loop.
         int maxResults = request.path("MaxResults").asInt(100);
+        if (maxResults <= 0 || maxResults > 100) {
+            maxResults = 100;
+        }
         int offset = decodeToken(textOrNull(request, "NextToken"));
 
         List<RedshiftDataStatementStore.StoredStatement> all = store.values().stream()
@@ -474,10 +479,12 @@ public class RedshiftDataService implements Resettable {
         String schema = textOrNull(request, "Schema");
         String table = requiredText(request, "Table");
         boolean withSchema = schema != null && !schema.isBlank();
+        // Table and Schema name a specific table, not a pattern: match exactly so a name
+        // containing '_' or '%' cannot pull columns from other tables into ColumnList.
         String sql = "SELECT column_name, data_type, character_maximum_length, is_nullable, "
                 + "numeric_precision, numeric_scale, column_default, table_schema, table_name "
-                + "FROM information_schema.columns WHERE table_name LIKE ? "
-                + (withSchema ? "AND table_schema LIKE ? " : "")
+                + "FROM information_schema.columns WHERE table_name = ? "
+                + (withSchema ? "AND table_schema = ? " : "")
                 + "ORDER BY ordinal_position";
 
         List<ObjectNode> columns = new ArrayList<>();

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParameters.java
@@ -166,7 +166,7 @@ final class RedshiftDataSqlParameters {
                 continue;
             }
             if (c == '\'' || c == '"') {
-                i = skipQuoted(sql, i, c);
+                i = skipQuoted(sql, i, c, isEscapeStringStart(sql, i, c));
                 continue;
             }
             if (c == '$') {
@@ -186,11 +186,32 @@ final class RedshiftDataSqlParameters {
         return false;
     }
 
-    private static int skipQuoted(String sql, int start, char quote) {
+    /**
+     * Whether the quote at {@code quotePos} opens a PostgreSQL escape string
+     * ({@code E'...'} / {@code e'...'}), inside which a backslash escapes the
+     * next character. Plain {@code '...'} literals do not process backslashes
+     * under {@code standard_conforming_strings}.
+     */
+    private static boolean isEscapeStringStart(String sql, int quotePos, char quote) {
+        if (quote != '\'' || quotePos == 0) {
+            return false;
+        }
+        char prefix = sql.charAt(quotePos - 1);
+        if (prefix != 'e' && prefix != 'E') {
+            return false;
+        }
+        return quotePos - 1 == 0 || !isNamePart(sql.charAt(quotePos - 2));
+    }
+
+    private static int skipQuoted(String sql, int start, char quote, boolean backslashEscapes) {
         int len = sql.length();
         int i = start + 1;
         while (i < len) {
             char c = sql.charAt(i);
+            if (backslashEscapes && c == '\\' && i + 1 < len) {
+                i += 2;
+                continue;
+            }
             if (c == quote) {
                 if (i + 1 < len && sql.charAt(i + 1) == quote) {
                     i += 2;
@@ -218,7 +239,7 @@ final class RedshiftDataSqlParameters {
     }
 
     private static int copyQuoted(String sql, int start, char quote, StringBuilder out) {
-        int end = skipQuoted(sql, start, quote);
+        int end = skipQuoted(sql, start, quote, isEscapeStringStart(sql, start, quote));
         out.append(sql, start, end);
         return end;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParameters.java
@@ -1,0 +1,189 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Translates Redshift Data API {@code SqlParameter} bindings into JDBC
+ * {@link PreparedStatement} bindings.
+ *
+ * <p>The Data API uses named placeholders ({@code :name}); JDBC uses positional
+ * {@code ?}. {@link #parse(String)} rewrites the SQL to positional form while
+ * recording the placeholder order. Redshift Data API parameter values are always
+ * strings on the wire, so {@link #bind} binds every placeholder with
+ * {@link PreparedStatement#setString}; PostgreSQL coerces to the column type.
+ */
+final class RedshiftDataSqlParameters {
+
+    private RedshiftDataSqlParameters() {
+    }
+
+    record ParsedSql(String sql, List<String> parameterOrder) {
+    }
+
+    /**
+     * Rewrites {@code :name} placeholders to positional {@code ?}, skipping over
+     * string literals, quoted identifiers, line and block comments, PostgreSQL
+     * {@code ::} casts, and dollar-quoted strings so a colon inside any of those
+     * is left untouched. Backslash is not treated as a string-literal escape
+     * (the PostgreSQL default with {@code standard_conforming_strings} on).
+     */
+    static ParsedSql parse(String sql) {
+        StringBuilder out = new StringBuilder(sql.length());
+        List<String> order = new ArrayList<>();
+        int len = sql.length();
+        int i = 0;
+        while (i < len) {
+            char c = sql.charAt(i);
+            if (c == '-' && i + 1 < len && sql.charAt(i + 1) == '-') {
+                int end = sql.indexOf('\n', i);
+                end = end < 0 ? len : end;
+                out.append(sql, i, end);
+                i = end;
+                continue;
+            }
+            if (c == '/' && i + 1 < len && sql.charAt(i + 1) == '*') {
+                int end = sql.indexOf("*/", i + 2);
+                end = end < 0 ? len : end + 2;
+                out.append(sql, i, end);
+                i = end;
+                continue;
+            }
+            if (c == '\'' || c == '"') {
+                i = copyQuoted(sql, i, c, out);
+                continue;
+            }
+            if (c == '$') {
+                int consumed = copyDollarQuoted(sql, i, out);
+                if (consumed > i) {
+                    i = consumed;
+                    continue;
+                }
+                out.append(c);
+                i++;
+                continue;
+            }
+            if (c == ':') {
+                if (i + 1 < len && sql.charAt(i + 1) == ':') {
+                    out.append("::");
+                    i += 2;
+                    continue;
+                }
+                if (i + 1 < len && isNameStart(sql.charAt(i + 1))) {
+                    int j = i + 1;
+                    while (j < len && isNamePart(sql.charAt(j))) {
+                        j++;
+                    }
+                    order.add(sql.substring(i + 1, j));
+                    out.append('?');
+                    i = j;
+                    continue;
+                }
+            }
+            out.append(c);
+            i++;
+        }
+        return new ParsedSql(out.toString(), order);
+    }
+
+    /**
+     * Binds each positional placeholder from {@code order} with the matching
+     * value in {@code valuesByName}.
+     *
+     * @throws AwsException if a placeholder has no supplied value
+     */
+    static void bind(PreparedStatement statement, List<String> order, Map<String, String> valuesByName)
+            throws SQLException {
+        for (int position = 0; position < order.size(); position++) {
+            String name = order.get(position);
+            if (!valuesByName.containsKey(name)) {
+                throw new AwsException("ValidationException",
+                        "SQL references parameter :" + name + " but no matching value was supplied.", 400);
+            }
+            String value = valuesByName.get(name);
+            if (value == null) {
+                statement.setNull(position + 1, Types.NULL);
+            } else {
+                statement.setString(position + 1, value);
+            }
+        }
+    }
+
+    /**
+     * Reads a Data API {@code {name, value}} array into an insertion-ordered map.
+     */
+    static Map<String, String> parseParameters(JsonNode request, String field) {
+        JsonNode array = request.get(field);
+        if (array == null || array.isNull()) {
+            return Map.of();
+        }
+        if (!array.isArray()) {
+            throw new AwsException("ValidationException", field + " must be an array of {name, value} objects.", 400);
+        }
+        Map<String, String> byName = new LinkedHashMap<>();
+        for (JsonNode parameter : array) {
+            if (parameter == null || !parameter.isObject() || !parameter.hasNonNull("name")) {
+                throw new AwsException("ValidationException", "Each parameter must be an object with a name.", 400);
+            }
+            String name = parameter.get("name").asText();
+            JsonNode value = parameter.get("value");
+            String text = value == null || value.isNull() ? null : value.asText();
+            if (byName.putIfAbsent(name, text) != null) {
+                throw new AwsException("ValidationException", "Duplicate parameter name :" + name + ".", 400);
+            }
+        }
+        return byName;
+    }
+
+    private static int copyQuoted(String sql, int start, char quote, StringBuilder out) {
+        int len = sql.length();
+        out.append(quote);
+        int i = start + 1;
+        while (i < len) {
+            char c = sql.charAt(i);
+            out.append(c);
+            if (c == quote) {
+                if (i + 1 < len && sql.charAt(i + 1) == quote) {
+                    out.append(quote);
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        return i;
+    }
+
+    private static int copyDollarQuoted(String sql, int start, StringBuilder out) {
+        int len = sql.length();
+        int tagEnd = start + 1;
+        while (tagEnd < len && isNamePart(sql.charAt(tagEnd))) {
+            tagEnd++;
+        }
+        if (tagEnd >= len || sql.charAt(tagEnd) != '$') {
+            return start;
+        }
+        String tag = sql.substring(start, tagEnd + 1);
+        int close = sql.indexOf(tag, tagEnd + 1);
+        int end = close < 0 ? len : close + tag.length();
+        out.append(sql, start, end);
+        return end;
+    }
+
+    private static boolean isNameStart(char c) {
+        return Character.isLetter(c) || c == '_';
+    }
+
+    private static boolean isNamePart(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParameters.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParameters.java
@@ -143,16 +143,56 @@ final class RedshiftDataSqlParameters {
         return byName;
     }
 
-    private static int copyQuoted(String sql, int start, char quote, StringBuilder out) {
+    /**
+     * Whether {@code sql} holds more than one statement, applying the same
+     * literal / identifier / comment / dollar-quote skipping as {@link #parse}
+     * so a {@code ;} inside any of those is not counted. Trailing {@code ;}
+     * characters (with only whitespace after) are permitted.
+     */
+    static boolean isMultiStatement(String sql) {
         int len = sql.length();
-        out.append(quote);
+        int i = 0;
+        boolean sawSemicolon = false;
+        while (i < len) {
+            char c = sql.charAt(i);
+            if (c == '-' && i + 1 < len && sql.charAt(i + 1) == '-') {
+                int end = sql.indexOf('\n', i);
+                i = end < 0 ? len : end;
+                continue;
+            }
+            if (c == '/' && i + 1 < len && sql.charAt(i + 1) == '*') {
+                int end = sql.indexOf("*/", i + 2);
+                i = end < 0 ? len : end + 2;
+                continue;
+            }
+            if (c == '\'' || c == '"') {
+                i = skipQuoted(sql, i, c);
+                continue;
+            }
+            if (c == '$') {
+                int consumed = skipDollarQuoted(sql, i);
+                if (consumed > i) {
+                    i = consumed;
+                    continue;
+                }
+            }
+            if (c == ';') {
+                sawSemicolon = true;
+            } else if (sawSemicolon && !Character.isWhitespace(c)) {
+                return true;
+            }
+            i++;
+        }
+        return false;
+    }
+
+    private static int skipQuoted(String sql, int start, char quote) {
+        int len = sql.length();
         int i = start + 1;
         while (i < len) {
             char c = sql.charAt(i);
-            out.append(c);
             if (c == quote) {
                 if (i + 1 < len && sql.charAt(i + 1) == quote) {
-                    out.append(quote);
                     i += 2;
                     continue;
                 }
@@ -163,7 +203,7 @@ final class RedshiftDataSqlParameters {
         return i;
     }
 
-    private static int copyDollarQuoted(String sql, int start, StringBuilder out) {
+    private static int skipDollarQuoted(String sql, int start) {
         int len = sql.length();
         int tagEnd = start + 1;
         while (tagEnd < len && isNamePart(sql.charAt(tagEnd))) {
@@ -174,8 +214,20 @@ final class RedshiftDataSqlParameters {
         }
         String tag = sql.substring(start, tagEnd + 1);
         int close = sql.indexOf(tag, tagEnd + 1);
-        int end = close < 0 ? len : close + tag.length();
+        return close < 0 ? len : close + tag.length();
+    }
+
+    private static int copyQuoted(String sql, int start, char quote, StringBuilder out) {
+        int end = skipQuoted(sql, start, quote);
         out.append(sql, start, end);
+        return end;
+    }
+
+    private static int copyDollarQuoted(String sql, int start, StringBuilder out) {
+        int end = skipDollarQuoted(sql, start);
+        if (end > start) {
+            out.append(sql, start, end);
+        }
         return end;
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
@@ -29,7 +29,9 @@ class RedshiftDataStatementStore {
     private final ConcurrentMap<String, StoredStatement> statements = new ConcurrentHashMap<>();
     private final Duration ttl;
     private final Clock clock;
-    private final ScheduledExecutorService sweeper;
+    // Created by the CDI lifecycle in start(); the test constructor never starts it, so unit
+    // tests that build the store directly drive sweep() by hand and spawn no background thread.
+    private ScheduledExecutorService sweeper;
 
     @Inject
     RedshiftDataStatementStore(EmulatorConfig config) {
@@ -39,21 +41,23 @@ class RedshiftDataStatementStore {
     RedshiftDataStatementStore(int resultTtlHours, Clock clock) {
         this.ttl = Duration.ofHours(Math.max(1, resultTtlHours));
         this.clock = clock;
-        this.sweeper = Executors.newSingleThreadScheduledExecutor(r -> {
-            Thread t = new Thread(r, "redshift-data-statement-sweep");
-            t.setDaemon(true);
-            return t;
-        });
     }
 
     @PostConstruct
     void start() {
+        sweeper = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "redshift-data-statement-sweep");
+            t.setDaemon(true);
+            return t;
+        });
         sweeper.scheduleAtFixedRate(this::sweepSafely, 30, 30, TimeUnit.MINUTES);
     }
 
     @PreDestroy
     void stop() {
-        sweeper.shutdownNow();
+        if (sweeper != null) {
+            sweeper.shutdownNow();
+        }
     }
 
     void put(StoredStatement statement) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
@@ -1,0 +1,110 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@ApplicationScoped
+class RedshiftDataStatementStore {
+
+    private static final Logger LOG = Logger.getLogger(RedshiftDataStatementStore.class);
+
+    enum Status { PICKED, STARTED, FINISHED, FAILED, ABORTED }
+
+    private final ConcurrentMap<String, StoredStatement> statements = new ConcurrentHashMap<>();
+    private final Duration ttl;
+    private final Clock clock;
+    private final ScheduledExecutorService sweeper;
+
+    @Inject
+    RedshiftDataStatementStore(EmulatorConfig config) {
+        this(config.services().redshiftData().resultTtlHours(), Clock.systemUTC());
+    }
+
+    RedshiftDataStatementStore(int resultTtlHours, Clock clock) {
+        this.ttl = Duration.ofHours(Math.max(1, resultTtlHours));
+        this.clock = clock;
+        this.sweeper = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "redshift-data-statement-sweep");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @PostConstruct
+    void start() {
+        sweeper.scheduleAtFixedRate(this::sweepSafely, 30, 30, TimeUnit.MINUTES);
+    }
+
+    @PreDestroy
+    void stop() {
+        sweeper.shutdownNow();
+    }
+
+    void put(StoredStatement statement) {
+        statements.put(statement.id, statement);
+    }
+
+    StoredStatement get(String id) {
+        return statements.get(id);
+    }
+
+    Collection<StoredStatement> values() {
+        return statements.values();
+    }
+
+    void clear() {
+        statements.clear();
+    }
+
+    void sweep() {
+        Instant cutoff = Instant.now(clock).minus(ttl);
+        statements.values().removeIf(s -> s.createdAt.isBefore(cutoff));
+    }
+
+    private void sweepSafely() {
+        try {
+            sweep();
+        } catch (Exception e) {
+            LOG.warn("Failed to sweep expired Redshift Data API statements", e);
+        }
+    }
+
+    static final class StoredStatement {
+        String id;
+        String sql;
+        List<String> sqls;
+        boolean batch;
+        String statementName;
+        String clusterIdentifier;
+        String database;
+        String dbUser;
+        String resultFormat = "JSON";
+        Status status;
+        String error;
+        Instant createdAt;
+        Instant updatedAt;
+        long durationNanos;
+        boolean hasResultSet;
+        long resultRows;
+        long resultSize;
+        ArrayNode columnMetadata;
+        List<ArrayNode> rows;
+        List<StoredStatement> subStatements;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
@@ -1,7 +1,12 @@
 package io.github.hectorvent.floci.services.redshiftdata;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -11,10 +16,8 @@ import org.jboss.logging.Logger;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -26,7 +29,10 @@ class RedshiftDataStatementStore {
 
     enum Status { PICKED, STARTED, FINISHED, FAILED, ABORTED }
 
-    private final ConcurrentMap<String, StoredStatement> statements = new ConcurrentHashMap<>();
+    // Statements live in the configured storage backend like every other service's state
+    // (memory mode by default, so they are still lost on restart as documented). The TTL
+    // sweep below evicts entries the emulator would otherwise keep forever.
+    private final AccountAwareStorageBackend<StoredStatement> statements;
     private final Duration ttl;
     private final Clock clock;
     // Created by the CDI lifecycle in start(); the test constructor never starts it, so unit
@@ -34,11 +40,15 @@ class RedshiftDataStatementStore {
     private ScheduledExecutorService sweeper;
 
     @Inject
-    RedshiftDataStatementStore(EmulatorConfig config) {
-        this(config.services().redshiftData().resultTtlHours(), Clock.systemUTC());
+    RedshiftDataStatementStore(StorageFactory storageFactory, EmulatorConfig config) {
+        this.statements = storageFactory.create("redshift-data", "statements.json",
+                new TypeReference<Map<String, StoredStatement>>() {});
+        this.ttl = Duration.ofHours(Math.max(1, config.services().redshiftData().resultTtlHours()));
+        this.clock = Clock.systemUTC();
     }
 
     RedshiftDataStatementStore(int resultTtlHours, Clock clock) {
+        this.statements = AccountAwareStorageBackend.inMemory("000000000000");
         this.ttl = Duration.ofHours(Math.max(1, resultTtlHours));
         this.clock = clock;
     }
@@ -65,11 +75,11 @@ class RedshiftDataStatementStore {
     }
 
     StoredStatement get(String id) {
-        return statements.get(id);
+        return statements.get(id).orElse(null);
     }
 
-    Collection<StoredStatement> values() {
-        return statements.values();
+    List<StoredStatement> values() {
+        return statements.scan(k -> true);
     }
 
     void clear() {
@@ -78,7 +88,14 @@ class RedshiftDataStatementStore {
 
     void sweep() {
         Instant cutoff = Instant.now(clock).minus(ttl);
-        statements.values().removeIf(s -> s.createdAt.isBefore(cutoff));
+        // The sweep thread has no request context, so it iterates every account's partition
+        // and deletes per account rather than through the current-account view.
+        for (AccountAwareStorageBackend.AccountEntry<StoredStatement> entry
+                : statements.scanAllAccountEntries(k -> true)) {
+            if (entry.value().createdAt.isBefore(cutoff)) {
+                statements.deleteForAccount(entry.accountId(), entry.key());
+            }
+        }
     }
 
     private void sweepSafely() {
@@ -89,6 +106,8 @@ class RedshiftDataStatementStore {
         }
     }
 
+    @RegisterForReflection
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
     static final class StoredStatement {
         String id;
         String sql;

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStore.java
@@ -27,6 +27,7 @@ class RedshiftDataStatementStore {
 
     private static final Logger LOG = Logger.getLogger(RedshiftDataStatementStore.class);
 
+    @RegisterForReflection
     enum Status { PICKED, STARTED, FINISHED, FAILED, ABORTED }
 
     // Statements live in the configured storage backend like every other service's state

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -348,6 +348,9 @@ floci:
     rds-data:
       enabled: true
       transaction-ttl-seconds: 180
+    redshift-data:
+      enabled: true
+      result-ttl-hours: 24
     neptune:
       enabled: true
       proxy-base-port: 8182

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataApiIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataApiIntegrationTest.java
@@ -1,0 +1,175 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import io.github.hectorvent.floci.services.redshift.RedshiftService;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class RedshiftDataApiIntegrationTest {
+
+    @Inject
+    RedshiftService redshift;
+
+    private String clusterId;
+
+    @BeforeAll
+    static void configure() {
+        Assumptions.assumeTrue(dockerAvailable(), "Docker is required for Redshift Data API integration tests");
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static boolean dockerAvailable() {
+        try {
+            Process p = new ProcessBuilder("docker", "version", "--format", "{{.Server.Version}}")
+                    .redirectErrorStream(true).start();
+            return p.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @AfterEach
+    void cleanUp() {
+        if (clusterId != null) {
+            redshift.deleteCluster(clusterId);
+            clusterId = null;
+        }
+    }
+
+    private static String quote(String s) {
+        return "\"" + s.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    private String executeAndWait(String sql) {
+        String id = RestAssuredJsonUtils.awsAction("RedshiftData", "ExecuteStatement", """
+                {"Sql": %s, "ClusterIdentifier": "%s", "DbUser": "admin", "Database": "dev"}
+                """.formatted(quote(sql), clusterId))
+                .then().statusCode(200).extract().path("Id");
+        awaitFinished(id);
+        return id;
+    }
+
+    private void awaitFinished(String id) {
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(250)).until(() -> {
+            String status = RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeStatement",
+                    "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("Status");
+            assertTrue(!"FAILED".equals(status) && !"ABORTED".equals(status),
+                    () -> "statement " + id + " ended " + status);
+            return "FINISHED".equals(status);
+        });
+    }
+
+    private static int asInt(Object value) {
+        return ((Number) value).intValue();
+    }
+
+    @Test
+    void executeDescribeGetResultRoundTrip() {
+        clusterId = "it-rsdata-roundtrip";
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+
+        executeAndWait("CREATE TABLE t (id int, name varchar(20))");
+        String insertId = executeAndWait("INSERT INTO t VALUES (1, 'a'), (2, 'b')");
+        Object insertRows = RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeStatement",
+                "{\"Id\":\"" + insertId + "\"}").then().statusCode(200).extract().path("ResultRows");
+        assertEquals(2, asInt(insertRows));
+
+        String selectId = executeAndWait("SELECT id, name FROM t ORDER BY id");
+        var result = RestAssuredJsonUtils.awsAction("RedshiftData", "GetStatementResult",
+                "{\"Id\":\"" + selectId + "\"}").then().statusCode(200).extract();
+        assertEquals(2, asInt(result.path("TotalNumRows")));
+        assertEquals("id", result.path("ColumnMetadata[0].name"));
+        assertEquals(1, asInt(result.path("Records[0][0].longValue")));
+        assertEquals("a", result.path("Records[0][1].stringValue"));
+    }
+
+    @Test
+    void parameterisedStatement() {
+        clusterId = "it-rsdata-param";
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+        executeAndWait("CREATE TABLE p (id int)");
+        executeAndWait("INSERT INTO p VALUES (1), (2), (3)");
+
+        String id = RestAssuredJsonUtils.awsAction("RedshiftData", "ExecuteStatement", """
+                {"Sql": "SELECT id FROM p WHERE id = :id",
+                 "ClusterIdentifier": "%s", "DbUser": "admin", "Database": "dev",
+                 "Parameters": [{"name": "id", "value": "2"}]}
+                """.formatted(clusterId)).then().statusCode(200).extract().path("Id");
+        awaitFinished(id);
+
+        Object rows = RestAssuredJsonUtils.awsAction("RedshiftData", "GetStatementResult",
+                "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("TotalNumRows");
+        assertEquals(1, asInt(rows));
+    }
+
+    @Test
+    void batchExecuteReportsSubStatements() {
+        clusterId = "it-rsdata-batch";
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+        executeAndWait("CREATE TABLE bt (id int)");
+
+        String id = RestAssuredJsonUtils.awsAction("RedshiftData", "BatchExecuteStatement", """
+                {"Sqls": ["INSERT INTO bt VALUES (1)", "SELECT count(*) AS c FROM bt"],
+                 "ClusterIdentifier": "%s", "DbUser": "admin", "Database": "dev"}
+                """.formatted(clusterId)).then().statusCode(200).extract().path("Id");
+        awaitFinished(id);
+
+        List<?> subs = RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeStatement",
+                "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("SubStatements");
+        assertEquals(2, subs.size());
+
+        Object first = RestAssuredJsonUtils.awsAction("RedshiftData", "GetStatementResult",
+                "{\"Id\":\"" + id + "\"}").then().statusCode(200)
+                .extract().path("Records[0][0].longValue");
+        assertEquals(1, asInt(first));
+    }
+
+    @Test
+    void schemaIntrospection() {
+        clusterId = "it-rsdata-schema";
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+        executeAndWait("CREATE TABLE si (a int, b int)");
+
+        String target = "\"ClusterIdentifier\": \"" + clusterId + "\", \"DbUser\": \"admin\", \"Database\": \"dev\"";
+        RestAssuredJsonUtils.awsAction("RedshiftData", "ListDatabases", "{" + target + "}")
+                .then().statusCode(200).body("Databases", hasItem("dev"));
+        RestAssuredJsonUtils.awsAction("RedshiftData", "ListTables", "{" + target + ", \"TablePattern\": \"si\"}")
+                .then().statusCode(200).body("Tables.name", hasItem("si"));
+        List<?> columns = RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeTable",
+                "{" + target + ", \"Table\": \"si\"}").then().statusCode(200).extract().path("ColumnList");
+        assertEquals(2, columns.size());
+    }
+
+    @Test
+    void workgroupNameIsRejected() {
+        RestAssuredJsonUtils.awsAction("RedshiftData", "ExecuteStatement",
+                "{\"Sql\": \"SELECT 1\", \"WorkgroupName\": \"wg\", \"Database\": \"dev\"}")
+                .then().statusCode(400).body("__type", containsString("ValidationException"));
+    }
+
+    @Test
+    void executionErrorSurfacesThroughDescribeNotHttp() {
+        clusterId = "it-rsdata-err";
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+        String id = RestAssuredJsonUtils.awsAction("RedshiftData", "ExecuteStatement", """
+                {"Sql": "SELECT * FROM nope", "ClusterIdentifier": "%s", "DbUser": "admin", "Database": "dev"}
+                """.formatted(clusterId)).then().statusCode(200).extract().path("Id");
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(250)).until(() ->
+                "FAILED".equals(RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeStatement",
+                        "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("Status")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataApiIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataApiIntegrationTest.java
@@ -139,6 +139,27 @@ class RedshiftDataApiIntegrationTest {
     }
 
     @Test
+    void batchRollsBackEveryStatementWhenOneFails() {
+        clusterId = "it-rsdata-batch-rollback";
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+        executeAndWait("CREATE TABLE br (id int)");
+
+        String id = RestAssuredJsonUtils.awsAction("RedshiftData", "BatchExecuteStatement", """
+                {"Sqls": ["INSERT INTO br VALUES (1)", "INSERT INTO br (nope) VALUES (2)"],
+                 "ClusterIdentifier": "%s", "DbUser": "admin", "Database": "dev"}
+                """.formatted(clusterId)).then().statusCode(200).extract().path("Id");
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(250)).until(() ->
+                "FAILED".equals(RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeStatement",
+                        "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("Status")));
+
+        // The first INSERT must have been rolled back with the batch: br is empty.
+        String countId = executeAndWait("SELECT count(*) AS c FROM br");
+        Object count = RestAssuredJsonUtils.awsAction("RedshiftData", "GetStatementResult",
+                "{\"Id\":\"" + countId + "\"}").then().statusCode(200).extract().path("Records[0][0].longValue");
+        assertEquals(0, asInt(count));
+    }
+
+    @Test
     void schemaIntrospection() {
         clusterId = "it-rsdata-schema";
         redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataColumnMetadataTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataColumnMetadataTest.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.h2.Driver;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedshiftDataColumnMetadataTest {
+
+    static {
+        Driver.load();
+    }
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Test
+    void emitsEveryColumnMetadataFieldForEachColumn() throws Exception {
+        String url = "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1";
+        try (Connection c = DriverManager.getConnection(url, "sa", "");
+             Statement st = c.createStatement()) {
+            st.execute("create table t (id int not null, name varchar(50))");
+            try (ResultSet rs = st.executeQuery("select id as id, name as name from t")) {
+                ArrayNode columns = RedshiftDataColumnMetadata.toColumnMetadata(om, rs.getMetaData());
+                assertEquals(2, columns.size());
+                var id = columns.get(0);
+                assertEquals("ID", id.get("name").asText().toUpperCase());
+                assertTrue(id.has("label"));
+                assertTrue(id.has("typeName"));
+                assertTrue(id.has("nullable"));
+                assertTrue(id.has("length"));
+                assertTrue(id.has("precision"));
+                assertTrue(id.has("scale"));
+                assertTrue(id.has("isCaseSensitive"));
+                assertTrue(id.has("isCurrency"));
+                assertTrue(id.has("isSigned"));
+                assertTrue(id.has("schemaName"));
+                assertTrue(id.has("tableName"));
+                assertTrue(id.has("columnDefault"));
+            }
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataFieldMapperTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataFieldMapperTest.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Types;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedshiftDataFieldMapperTest {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Test
+    void mapsEachJdbcTypeToTheRightFieldVariant() {
+        assertEquals(7L, RedshiftDataFieldMapper.toField(om, 7, Types.INTEGER, false).get("longValue").asLong());
+        assertEquals(7L, RedshiftDataFieldMapper.toField(om, 7L, Types.BIGINT, false).get("longValue").asLong());
+        assertEquals(1.5, RedshiftDataFieldMapper.toField(om, 1.5d, Types.DOUBLE, false).get("doubleValue").asDouble());
+        assertTrue(RedshiftDataFieldMapper.toField(om, true, Types.BOOLEAN, false).get("booleanValue").asBoolean());
+        assertEquals("12.34",
+                RedshiftDataFieldMapper.toField(om, new java.math.BigDecimal("12.34"), Types.NUMERIC, false)
+                        .get("stringValue").asText());
+        assertEquals("hello",
+                RedshiftDataFieldMapper.toField(om, "hello", Types.VARCHAR, false).get("stringValue").asText());
+        assertTrue(RedshiftDataFieldMapper.toField(om, null, Types.VARCHAR, true).get("isNull").asBoolean());
+
+        ObjectNode blob = RedshiftDataFieldMapper.toField(om, new byte[] {1, 2, 3}, Types.VARBINARY, false);
+        assertTrue(blob.has("blobValue"));
+    }
+
+    @Test
+    void serializedSizeIsMonotonic() {
+        ArrayNode oneRow = om.createArrayNode();
+        oneRow.add(om.createObjectNode().put("stringValue", "abc"));
+        long small = RedshiftDataFieldMapper.serializedSize(List.of(oneRow));
+
+        ArrayNode bigRow = om.createArrayNode();
+        bigRow.add(om.createObjectNode().put("stringValue", "abcdefghij"));
+        long big = RedshiftDataFieldMapper.serializedSize(List.of(oneRow, bigRow));
+
+        assertTrue(big > small);
+        assertEquals("abc".getBytes(StandardCharsets.UTF_8).length, small);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataRegistrationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataRegistrationIntegrationTest.java
@@ -1,0 +1,50 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+class RedshiftDataRegistrationIntegrationTest {
+
+    private static final String TARGET = "X-Amz-Target";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void redshiftDataTargetReachesTheHandler() {
+        // The stub service throws ValidationException("... not implemented yet");
+        // the point is that it is NOT an UnknownOperationException from the catalog.
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header(TARGET, "RedshiftData.ExecuteStatement")
+            .body("{\"Sql\":\"select 1\",\"ClusterIdentifier\":\"none\",\"DbUser\":\"admin\",\"Database\":\"dev\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("__type", not(containsString("UnknownOperation")));
+    }
+
+    @Test
+    void deprecatedExecuteSqlIsRejected() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header(TARGET, "RedshiftData.ExecuteSql")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolverTest.java
@@ -1,0 +1,143 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.redshift.RedshiftService;
+import io.github.hectorvent.floci.services.redshift.model.Cluster;
+import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
+import io.github.hectorvent.floci.services.secretsmanager.model.SecretVersion;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedshiftDataResourceResolverTest {
+
+    private static final String REGION = "us-east-1";
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private static Cluster cluster() {
+        Cluster c = new Cluster();
+        c.setClusterIdentifier("wh");
+        c.setMasterUsername("admin");
+        c.setMasterPassword("Secret123");
+        c.setContainerHost("127.0.0.1");
+        c.setContainerPort(55432);
+        return c;
+    }
+
+    private RedshiftDataResourceResolver resolver(RedshiftService redshift, SecretsManagerService secrets) {
+        return new RedshiftDataResourceResolver(redshift, secrets, mapper);
+    }
+
+    @Test
+    void resolvesClusterIdentifierAndMasterDbUser() {
+        RedshiftService redshift = mock(RedshiftService.class);
+        when(redshift.describeClusters("wh")).thenReturn(List.of(cluster()));
+
+        ObjectNode req = mapper.createObjectNode();
+        req.put("ClusterIdentifier", "wh");
+        req.put("DbUser", "admin");
+        req.put("Database", "dev");
+
+        RedshiftDataResourceResolver.DatabaseTarget target =
+                resolver(redshift, mock(SecretsManagerService.class)).resolve(req, REGION);
+
+        assertEquals("127.0.0.1", target.host());
+        assertEquals(55432, target.port());
+        assertEquals("dev", target.database());
+        assertEquals("admin", target.user());
+        assertEquals("Secret123", target.password());
+    }
+
+    @Test
+    void rejectsWorkgroupName() {
+        ObjectNode req = mapper.createObjectNode();
+        req.put("WorkgroupName", "wg-1");
+        req.put("Database", "dev");
+        AwsException e = assertThrows(AwsException.class,
+                () -> resolver(mock(RedshiftService.class), mock(SecretsManagerService.class)).resolve(req, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void rejectsUnknownCluster() {
+        RedshiftService redshift = mock(RedshiftService.class);
+        when(redshift.describeClusters("missing"))
+                .thenThrow(new AwsException("ClusterNotFound", "Cluster missing not found", 404));
+        ObjectNode req = mapper.createObjectNode();
+        req.put("ClusterIdentifier", "missing");
+        req.put("DbUser", "admin");
+        req.put("Database", "dev");
+        AwsException e = assertThrows(AwsException.class,
+                () -> resolver(redshift, mock(SecretsManagerService.class)).resolve(req, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void rejectsNonMasterDbUser() {
+        RedshiftService redshift = mock(RedshiftService.class);
+        when(redshift.describeClusters("wh")).thenReturn(List.of(cluster()));
+        ObjectNode req = mapper.createObjectNode();
+        req.put("ClusterIdentifier", "wh");
+        req.put("DbUser", "analyst");
+        req.put("Database", "dev");
+        AwsException e = assertThrows(AwsException.class,
+                () -> resolver(redshift, mock(SecretsManagerService.class)).resolve(req, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void resolvesSecretArn() {
+        RedshiftService redshift = mock(RedshiftService.class);
+        when(redshift.describeClusters("wh")).thenReturn(List.of(cluster()));
+        SecretsManagerService secrets = mock(SecretsManagerService.class);
+        SecretVersion secret = new SecretVersion();
+        secret.setSecretString("{\"username\":\"svc\",\"password\":\"p4ss\"}");
+        when(secrets.getSecretValue(eq("arn:aws:secretsmanager:us-east-1:000000000000:secret:wh-creds"), any(), any(), eq(REGION)))
+                .thenReturn(secret);
+
+        ObjectNode req = mapper.createObjectNode();
+        req.put("SecretArn", "arn:aws:secretsmanager:us-east-1:000000000000:secret:wh-creds");
+        req.put("ClusterIdentifier", "wh");
+        req.put("Database", "dev");
+
+        RedshiftDataResourceResolver.DatabaseTarget target = resolver(redshift, secrets).resolve(req, REGION);
+        assertEquals("svc", target.user());
+        assertEquals("p4ss", target.password());
+    }
+
+    @Test
+    void rejectsCrossRegionSecretArn() {
+        ObjectNode req = mapper.createObjectNode();
+        req.put("SecretArn", "arn:aws:secretsmanager:eu-west-1:000000000000:secret:wh-creds");
+        req.put("ClusterIdentifier", "wh");
+        req.put("Database", "dev");
+        AwsException e = assertThrows(AwsException.class,
+                () -> resolver(mock(RedshiftService.class), mock(SecretsManagerService.class)).resolve(req, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void rejectsClusterWithNoContainerRuntime() {
+        Cluster c = cluster();
+        c.setContainerHost("");
+        c.setContainerPort(0);
+        RedshiftService redshift = mock(RedshiftService.class);
+        when(redshift.describeClusters("wh")).thenReturn(List.of(c));
+        ObjectNode req = mapper.createObjectNode();
+        req.put("ClusterIdentifier", "wh");
+        req.put("DbUser", "admin");
+        req.put("Database", "dev");
+        AwsException e = assertThrows(AwsException.class,
+                () -> resolver(redshift, mock(SecretsManagerService.class)).resolve(req, REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
@@ -281,4 +281,25 @@ class RedshiftDataServiceTest {
         assertTrue(service.cancelStatement(idOf(id)).get("Status").asBoolean());
         assertEquals("FAILED", service.describeStatement(idOf(id)).get("Status").asText());
     }
+
+    @Test
+    void listStatementsWithZeroMaxResultsDoesNotEmitANonTerminatingToken() {
+        service.executeStatement(req("select 1"), REGION);
+        service.executeStatement(req("select 2"), REGION);
+        ObjectNode result = service.listStatements(om.createObjectNode().put("MaxResults", 0));
+        assertEquals(2, result.get("Statements").size());
+        assertFalse(result.has("NextToken"));
+    }
+
+    @Test
+    void describeTableMatchesTheExactNameNotAPattern() {
+        service.executeStatement(req("create table a_b (x int)"), REGION);
+        service.executeStatement(req("create table axb (y int, z int)"), REGION);
+
+        ObjectNode descReq = targetReq();
+        descReq.put("Table", "a_b");
+        ObjectNode described = service.describeTable(descReq, REGION);
+        assertEquals(1, described.get("ColumnList").size());
+        assertEquals("x", described.get("ColumnList").get(0).get("name").asText().toLowerCase());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
@@ -195,4 +195,37 @@ class RedshiftDataServiceTest {
         AwsException e = assertThrows(AwsException.class, () -> service.cancelStatement(idOf("missing")));
         assertEquals("ResourceNotFoundException", e.getErrorCode());
     }
+
+    private ObjectNode targetReq() {
+        ObjectNode r = om.createObjectNode();
+        r.put("ClusterIdentifier", "wh");
+        r.put("DbUser", "admin");
+        r.put("Database", "dev");
+        return r;
+    }
+
+    @Test
+    void listTablesAndDescribeTableReadInformationSchema() {
+        service.executeStatement(req("create table cat (id int not null, name varchar(30))"), REGION);
+
+        ObjectNode listReq = targetReq();
+        listReq.put("TablePattern", "cat");
+        ObjectNode tables = service.listTables(listReq, REGION);
+        assertTrue(tables.get("Tables").findValuesAsText("name").stream()
+                .anyMatch(n -> n.equalsIgnoreCase("cat")));
+
+        ObjectNode descReq = targetReq();
+        descReq.put("Table", "cat");
+        ObjectNode described = service.describeTable(descReq, REGION);
+        assertEquals("cat", described.get("TableName").asText());
+        assertEquals(2, described.get("ColumnList").size());
+        assertTrue(described.get("ColumnList").get(0).has("typeName"));
+        assertTrue(described.get("ColumnList").get(0).has("nullable"));
+    }
+
+    @Test
+    void listSchemasReturnsSchemata() {
+        ObjectNode schemas = service.listSchemas(targetReq(), REGION);
+        assertTrue(schemas.get("Schemas").size() >= 1);
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
@@ -292,6 +292,13 @@ class RedshiftDataServiceTest {
     }
 
     @Test
+    void listStatementsRejectsMaxResultsAboveOneHundred() {
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.listStatements(om.createObjectNode().put("MaxResults", 500)));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
     void describeTableMatchesTheExactNameNotAPattern() {
         service.executeStatement(req("create table a_b (x int)"), REGION);
         service.executeStatement(req("create table axb (y int, z int)"), REGION);

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
@@ -124,4 +124,75 @@ class RedshiftDataServiceTest {
                 () -> service.executeStatement(req("select 1; select 2"), REGION));
         assertEquals("ValidationException", e.getErrorCode());
     }
+
+    private ObjectNode batchReq(String... sqls) {
+        ObjectNode r = om.createObjectNode();
+        r.put("ClusterIdentifier", "wh");
+        r.put("DbUser", "admin");
+        r.put("Database", "dev");
+        var array = r.putArray("Sqls");
+        for (String sql : sqls) {
+            array.add(sql);
+        }
+        return r;
+    }
+
+    @Test
+    void batchExecutesInOneTransactionAndDescribeShowsSubStatements() {
+        String id = service.batchExecuteStatement(batchReq(
+                "create table b (id int)",
+                "insert into b values (1), (2)",
+                "select count(*) as c from b"), REGION).get("Id").asText();
+
+        ObjectNode describe = service.describeStatement(idOf(id));
+        assertEquals("FINISHED", describe.get("Status").asText());
+        assertEquals(3, describe.get("SubStatements").size());
+
+        ObjectNode result = service.getStatementResult(idOf(id));
+        assertEquals(1, result.get("Records").size());
+        assertEquals(2L, result.get("Records").get(0).get(0).get("longValue").asLong());
+    }
+
+    @Test
+    void batchRollsBackWhenASubStatementFails() {
+        String id = service.batchExecuteStatement(batchReq(
+                "create table r1 (id int)",
+                "insert into r1 values (1)",
+                "insert into r1 (nope) values (2)"), REGION).get("Id").asText();
+
+        ObjectNode describe = service.describeStatement(idOf(id));
+        assertEquals("FAILED", describe.get("Status").asText());
+        assertFalse(describe.get("Error").asText().isBlank());
+    }
+
+    @Test
+    void listStatementsIsNewestFirstAndFiltersByName() {
+        ObjectNode a = req("select 1");
+        a.put("StatementName", "alpha");
+        service.executeStatement(a, REGION);
+        ObjectNode b = req("select 2");
+        b.put("StatementName", "beta");
+        service.executeStatement(b, REGION);
+
+        ObjectNode all = service.listStatements(om.createObjectNode());
+        assertTrue(all.get("Statements").size() >= 2);
+
+        ObjectNode filtered = service.listStatements(om.createObjectNode().put("StatementName", "alpha"));
+        assertEquals(1, filtered.get("Statements").size());
+        assertEquals("alpha", filtered.get("Statements").get(0).get("StatementName").asText());
+    }
+
+    @Test
+    void cancelOnFinishedStatementReturnsTrueWithoutChangingIt() {
+        service.executeStatement(req("create table cf (id int)"), REGION);
+        String id = service.executeStatement(req("select id from cf"), REGION).get("Id").asText();
+        assertTrue(service.cancelStatement(idOf(id)).get("Status").asBoolean());
+        assertEquals("FINISHED", service.describeStatement(idOf(id)).get("Status").asText());
+    }
+
+    @Test
+    void cancelUnknownIdIsResourceNotFound() {
+        AwsException e = assertThrows(AwsException.class, () -> service.cancelStatement(idOf("missing")));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
@@ -1,0 +1,127 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.h2.Driver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.DriverManager;
+import java.time.Clock;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedshiftDataServiceTest {
+
+    static {
+        Driver.load();
+    }
+
+    private static final String REGION = "us-east-1";
+
+    private final ObjectMapper om = new ObjectMapper();
+    private String jdbcUrl;
+    private RedshiftDataService service;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        jdbcUrl = "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE";
+
+        RedshiftDataResourceResolver resolver = mock(RedshiftDataResourceResolver.class);
+        when(resolver.resolve(any(), any())).thenReturn(new RedshiftDataResourceResolver.DatabaseTarget(
+                "arn:aws:redshift:us-east-1:000000000000:cluster:wh", "127.0.0.1", 5439, "dev", "admin", "x"));
+
+        RedshiftDataConnectionFactory factory = mock(RedshiftDataConnectionFactory.class);
+        when(factory.open(any())).thenAnswer(inv -> DriverManager.getConnection(jdbcUrl, "sa", ""));
+
+        service = new RedshiftDataService(resolver, factory,
+                new RedshiftDataStatementStore(24, Clock.systemUTC()), om);
+    }
+
+    private ObjectNode req(String sql) {
+        ObjectNode r = om.createObjectNode();
+        r.put("Sql", sql);
+        r.put("ClusterIdentifier", "wh");
+        r.put("DbUser", "admin");
+        r.put("Database", "dev");
+        return r;
+    }
+
+    private ObjectNode idOf(String id) {
+        return om.createObjectNode().put("Id", id);
+    }
+
+    @Test
+    void executeStoresFinishedResultAndDescribeReportsIt() {
+        String createId = service.executeStatement(req("create table t (id int, name varchar(20))"), REGION)
+                .get("Id").asText();
+        ObjectNode createDescribe = service.describeStatement(idOf(createId));
+        assertEquals("FINISHED", createDescribe.get("Status").asText());
+        assertFalse(createDescribe.get("HasResultSet").asBoolean());
+
+        service.executeStatement(req("insert into t values (1, 'a'), (2, 'b')"), REGION);
+
+        String selectId = service.executeStatement(req("select id, name from t order by id"), REGION)
+                .get("Id").asText();
+        ObjectNode selectDescribe = service.describeStatement(idOf(selectId));
+        assertEquals("FINISHED", selectDescribe.get("Status").asText());
+        assertTrue(selectDescribe.get("HasResultSet").asBoolean());
+        assertEquals(2, selectDescribe.get("ResultRows").asInt());
+
+        ObjectNode result = service.getStatementResult(idOf(selectId));
+        assertEquals(2, result.get("Records").size());
+        assertEquals(1L, result.get("Records").get(0).get(0).get("longValue").asLong());
+        assertEquals("a", result.get("Records").get(0).get(1).get("stringValue").asText());
+        assertTrue(result.get("ColumnMetadata").get(0).get("name").asText().equalsIgnoreCase("id"));
+    }
+
+    @Test
+    void executionErrorIsStoredAsFailedButExecuteStillReturnsAnId() {
+        ObjectNode response = service.executeStatement(req("select * from does_not_exist"), REGION);
+        String id = response.get("Id").asText();
+        ObjectNode describe = service.describeStatement(idOf(id));
+        assertEquals("FAILED", describe.get("Status").asText());
+        assertFalse(describe.get("Error").asText().isBlank());
+    }
+
+    @Test
+    void getStatementResultOnUpdateStatementIsRejected() {
+        service.executeStatement(req("create table u (id int)"), REGION);
+        String id = service.executeStatement(req("insert into u values (1)"), REGION).get("Id").asText();
+        AwsException e = assertThrows(AwsException.class, () -> service.getStatementResult(idOf(id)));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void unknownIdIsResourceNotFound() {
+        AwsException e = assertThrows(AwsException.class, () -> service.describeStatement(idOf("nope")));
+        assertEquals("ResourceNotFoundException", e.getErrorCode());
+    }
+
+    @Test
+    void parameterisedSelectBindsValues() {
+        service.executeStatement(req("create table p (id int)"), REGION);
+        service.executeStatement(req("insert into p values (1), (2), (3)"), REGION);
+        ObjectNode r = req("select id from p where id = :id");
+        r.putArray("Parameters").addObject().put("name", "id").put("value", "2");
+        String id = service.executeStatement(r, REGION).get("Id").asText();
+        ObjectNode result = service.getStatementResult(idOf(id));
+        assertEquals(1, result.get("Records").size());
+        assertEquals(2L, result.get("Records").get(0).get(0).get("longValue").asLong());
+    }
+
+    @Test
+    void rejectsMultiStatementSql() {
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.executeStatement(req("select 1; select 2"), REGION));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataServiceTest.java
@@ -228,4 +228,57 @@ class RedshiftDataServiceTest {
         ObjectNode schemas = service.listSchemas(targetReq(), REGION);
         assertTrue(schemas.get("Schemas").size() >= 1);
     }
+
+    @Test
+    void singleStatementWithATrailingCommentContainingASemicolonIsAllowed() {
+        String id = service.executeStatement(req("select 1 as one -- pick; the; first\n"), REGION)
+                .get("Id").asText();
+        assertEquals("FINISHED", service.describeStatement(idOf(id)).get("Status").asText());
+    }
+
+    @Test
+    void getStatementResultV2ReturnsTypedRecordsByDefault() {
+        service.executeStatement(req("create table v2 (id int, name varchar(20))"), REGION);
+        service.executeStatement(req("insert into v2 values (1, 'a')"), REGION);
+        String id = service.executeStatement(req("select id, name from v2 order by id"), REGION)
+                .get("Id").asText();
+
+        ObjectNode result = service.getStatementResultV2(idOf(id));
+        assertEquals("JSON", result.get("ResultFormat").asText());
+        assertEquals(1, result.get("Records").size());
+        assertEquals(1L, result.get("Records").get(0).get(0).get("longValue").asLong());
+        assertEquals("a", result.get("Records").get(0).get(1).get("stringValue").asText());
+    }
+
+    @Test
+    void getStatementResultV2CsvFormatQuotesEmbeddedDelimiters() {
+        service.executeStatement(req("create table v2csv (v varchar(20))"), REGION);
+        service.executeStatement(req("insert into v2csv values ('a,b')"), REGION);
+        ObjectNode r = req("select v from v2csv");
+        r.put("ResultFormat", "CSV");
+        String id = service.executeStatement(r, REGION).get("Id").asText();
+
+        ObjectNode result = service.getStatementResultV2(idOf(id));
+        assertEquals("CSV", result.get("ResultFormat").asText());
+        assertEquals("\"a,b\"", result.get("Records").get(0).get("CSVRecords").asText());
+    }
+
+    @Test
+    void malformedNextTokenIsRejected() {
+        service.executeStatement(req("create table tok (id int)"), REGION);
+        service.executeStatement(req("insert into tok values (1)"), REGION);
+        String id = service.executeStatement(req("select id from tok"), REGION).get("Id").asText();
+        ObjectNode r = idOf(id);
+        r.put("NextToken", "not-base64!!");
+        AwsException e = assertThrows(AwsException.class, () -> service.getStatementResult(r));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void cancelOnFailedStatementLeavesItFailed() {
+        String id = service.executeStatement(req("select * from missing_table"), REGION).get("Id").asText();
+        assertEquals("FAILED", service.describeStatement(idOf(id)).get("Status").asText());
+        assertTrue(service.cancelStatement(idOf(id)).get("Status").asBoolean());
+        assertEquals("FAILED", service.describeStatement(idOf(id)).get("Status").asText());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParametersTest.java
@@ -94,4 +94,27 @@ class RedshiftDataSqlParametersTest {
         assertTrue(RedshiftDataSqlParameters.isMultiStatement("select 1; select 2"));
         assertTrue(RedshiftDataSqlParameters.isMultiStatement("insert into t values (1); delete from t"));
     }
+
+    @Test
+    void backslashEscapedQuoteInsideAnEscapeStringDoesNotEndTheLiteral() {
+        // E'it\'s :value' is one string literal; :value is literal text, not a bind marker.
+        RedshiftDataSqlParameters.ParsedSql parsed =
+                RedshiftDataSqlParameters.parse("select E'it\\'s :value' as v where id = :id");
+        assertEquals("select E'it\\'s :value' as v where id = ?", parsed.sql());
+        assertEquals(List.of("id"), parsed.parameterOrder());
+    }
+
+    @Test
+    void escapeStringWithAnEscapedQuoteIsNotSeenAsMultiStatement() {
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select E'a\\';b' as v"));
+    }
+
+    @Test
+    void plainLiteralStillTreatsBackslashLiterally() {
+        // Not an E'' string: backslash is an ordinary character, '' still ends the literal.
+        RedshiftDataSqlParameters.ParsedSql parsed =
+                RedshiftDataSqlParameters.parse("select 'a\\' , :x");
+        assertEquals("select 'a\\' , ?", parsed.sql());
+        assertEquals(List.of("x"), parsed.parameterOrder());
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParametersTest.java
@@ -1,0 +1,80 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.h2.Driver;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedshiftDataSqlParametersTest {
+
+    static {
+        Driver.load();
+    }
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Test
+    void rewritesNamedPlaceholdersInOrderAndSkipsLiteralsAndCasts() {
+        RedshiftDataSqlParameters.ParsedSql parsed = RedshiftDataSqlParameters.parse(
+                "select * from t where a = :a and b = ':b' and c = :a and d = 1::int");
+        assertEquals("select * from t where a = ? and b = ':b' and c = ? and d = 1::int", parsed.sql());
+        assertEquals(List.of("a", "a"), parsed.parameterOrder());
+    }
+
+    @Test
+    void bindsValuesAsStringsAndDatabaseCoerces() throws Exception {
+        String url = "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL";
+        try (Connection c = DriverManager.getConnection(url, "sa", "")) {
+            c.createStatement().execute("create table t (id int, name varchar(20))");
+            c.createStatement().execute("insert into t values (2, 'bob')");
+            RedshiftDataSqlParameters.ParsedSql parsed =
+                    RedshiftDataSqlParameters.parse("select name from t where id = :id");
+            try (PreparedStatement ps = c.prepareStatement(parsed.sql())) {
+                RedshiftDataSqlParameters.bind(ps, parsed.parameterOrder(), Map.of("id", "2"));
+                try (ResultSet rs = ps.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals("bob", rs.getString(1));
+                }
+            }
+        }
+    }
+
+    @Test
+    void missingParameterValueIsRejected() throws Exception {
+        String url = "jdbc:h2:mem:" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1";
+        try (Connection c = DriverManager.getConnection(url, "sa", "")) {
+            c.createStatement().execute("create table t (id int)");
+            RedshiftDataSqlParameters.ParsedSql parsed =
+                    RedshiftDataSqlParameters.parse("select * from t where id = :id");
+            try (PreparedStatement ps = c.prepareStatement(parsed.sql())) {
+                AwsException e = assertThrows(AwsException.class,
+                        () -> RedshiftDataSqlParameters.bind(ps, parsed.parameterOrder(), Map.of()));
+                assertEquals("ValidationException", e.getErrorCode());
+            }
+        }
+    }
+
+    @Test
+    void parseParametersReadsNameValueObjectsAndRejectsDuplicates() {
+        ObjectNode request = om.createObjectNode();
+        var params = request.putArray("Parameters");
+        params.addObject().put("name", "id").put("value", "1");
+        params.addObject().put("name", "id").put("value", "2");
+        AwsException e = assertThrows(AwsException.class,
+                () -> RedshiftDataSqlParameters.parseParameters(request, "Parameters"));
+        assertEquals("ValidationException", e.getErrorCode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParametersTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataSqlParametersTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -76,5 +77,21 @@ class RedshiftDataSqlParametersTest {
         AwsException e = assertThrows(AwsException.class,
                 () -> RedshiftDataSqlParameters.parseParameters(request, "Parameters"));
         assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void isMultiStatementIgnoresSemicolonsInsideCommentsLiteralsAndDollarQuotes() {
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select 1 -- a; b\n"));
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select * from t /* x; y */ where a = 1"));
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select ';' as sep"));
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select $tag$a;b$tag$"));
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select 1;"));
+        assertFalse(RedshiftDataSqlParameters.isMultiStatement("select 1 ;  \n "));
+    }
+
+    @Test
+    void isMultiStatementDetectsARealSecondStatement() {
+        assertTrue(RedshiftDataSqlParameters.isMultiStatement("select 1; select 2"));
+        assertTrue(RedshiftDataSqlParameters.isMultiStatement("insert into t values (1); delete from t"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStoreTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStoreTest.java
@@ -1,0 +1,53 @@
+package io.github.hectorvent.floci.services.redshiftdata;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class RedshiftDataStatementStoreTest {
+
+    private static RedshiftDataStatementStore.StoredStatement statement(String id, Instant createdAt) {
+        RedshiftDataStatementStore.StoredStatement s = new RedshiftDataStatementStore.StoredStatement();
+        s.id = id;
+        s.createdAt = createdAt;
+        s.updatedAt = createdAt;
+        s.status = RedshiftDataStatementStore.Status.FINISHED;
+        return s;
+    }
+
+    @Test
+    void putThenGet() {
+        RedshiftDataStatementStore store = new RedshiftDataStatementStore(24, Clock.systemUTC());
+        store.put(statement("a", Instant.now()));
+        assertNotNull(store.get("a"));
+        assertNull(store.get("missing"));
+    }
+
+    @Test
+    void sweepEvictsEntriesOlderThanTtl() {
+        Instant now = Instant.parse("2026-09-07T00:00:00Z");
+        Clock fixed = Clock.fixed(now, ZoneOffset.UTC);
+        RedshiftDataStatementStore store = new RedshiftDataStatementStore(24, fixed);
+        store.put(statement("old", now.minus(Duration.ofHours(25))));
+        store.put(statement("fresh", now.minus(Duration.ofHours(1))));
+
+        store.sweep();
+
+        assertNull(store.get("old"));
+        assertNotNull(store.get("fresh"));
+    }
+
+    @Test
+    void clearEmptiesStore() {
+        RedshiftDataStatementStore store = new RedshiftDataStatementStore(24, Clock.systemUTC());
+        store.put(statement("a", Instant.now()));
+        store.clear();
+        assertNull(store.get("a"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStoreTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataStatementStoreTest.java
@@ -1,14 +1,23 @@
 package io.github.hectorvent.floci.services.redshiftdata;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RedshiftDataStatementStoreTest {
 
@@ -49,5 +58,83 @@ class RedshiftDataStatementStoreTest {
         store.put(statement("a", Instant.now()));
         store.clear();
         assertNull(store.get("a"));
+    }
+
+    @Test
+    void valuesReturnsEveryStoredStatement() {
+        RedshiftDataStatementStore store = new RedshiftDataStatementStore(24, Clock.systemUTC());
+        store.put(statement("a", Instant.now()));
+        store.put(statement("b", Instant.now()));
+        assertEquals(2, store.values().size());
+    }
+
+    /**
+     * The store is now backed by StorageFactory, so a persistent-mode backend serializes
+     * StoredStatement to JSON and reads it back through the same TypeReference the backend uses.
+     * This exercises the reflection / field-visibility annotations plus the ArrayNode, enum,
+     * Instant, and nested sub-statement fields with the exact mapper PersistentStorage builds.
+     */
+    @Test
+    void storedStatementRoundTripsThroughThePersistentStorageMapper() throws Exception {
+        ObjectMapper mapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        ArrayNode columnMetadata = mapper.createArrayNode();
+        columnMetadata.addObject().put("name", "id").put("typeName", "int4").put("nullable", 1);
+        ArrayNode row = mapper.createArrayNode();
+        row.addObject().put("longValue", 7L);
+        row.addObject().put("stringValue", "seven");
+
+        RedshiftDataStatementStore.StoredStatement sub = new RedshiftDataStatementStore.StoredStatement();
+        sub.id = "parent:1";
+        sub.sql = "insert into t values (7)";
+        sub.status = RedshiftDataStatementStore.Status.FINISHED;
+        sub.createdAt = Instant.parse("2026-09-08T10:00:00Z");
+        sub.updatedAt = sub.createdAt;
+
+        RedshiftDataStatementStore.StoredStatement original = new RedshiftDataStatementStore.StoredStatement();
+        original.id = "parent";
+        original.sql = "insert into t values (7); select * from t";
+        original.sqls = List.of("insert into t values (7)", "select * from t");
+        original.batch = true;
+        original.statementName = "load";
+        original.clusterIdentifier = "wh";
+        original.database = "dev";
+        original.dbUser = "admin";
+        original.resultFormat = "CSV";
+        original.status = RedshiftDataStatementStore.Status.FINISHED;
+        original.error = null;
+        original.createdAt = Instant.parse("2026-09-08T10:00:00Z");
+        original.updatedAt = Instant.parse("2026-09-08T10:00:01Z");
+        original.durationNanos = 123_456L;
+        original.hasResultSet = true;
+        original.resultRows = 1;
+        original.resultSize = 42;
+        original.columnMetadata = columnMetadata;
+        original.rows = List.of(row);
+        original.subStatements = List.of(sub);
+
+        String json = mapper.writeValueAsString(Map.of("parent", original));
+        Map<String, RedshiftDataStatementStore.StoredStatement> back =
+                mapper.readValue(json, new TypeReference<Map<String, RedshiftDataStatementStore.StoredStatement>>() {});
+
+        RedshiftDataStatementStore.StoredStatement restored = back.get("parent");
+        assertNotNull(restored);
+        assertEquals("parent", restored.id);
+        assertEquals(List.of("insert into t values (7)", "select * from t"), restored.sqls);
+        assertTrue(restored.batch);
+        assertEquals("CSV", restored.resultFormat);
+        assertEquals(RedshiftDataStatementStore.Status.FINISHED, restored.status);
+        assertEquals(Instant.parse("2026-09-08T10:00:01Z"), restored.updatedAt);
+        assertEquals(123_456L, restored.durationNanos);
+        assertTrue(restored.hasResultSet);
+        assertEquals("id", restored.columnMetadata.get(0).get("name").asText());
+        assertEquals(1, restored.rows.size());
+        assertEquals(7L, restored.rows.get(0).get(0).get("longValue").asLong());
+        assertEquals("seven", restored.rows.get(0).get(1).get("stringValue").asText());
+        assertEquals(1, restored.subStatements.size());
+        assertEquals("parent:1", restored.subStatements.get(0).id);
+        assertEquals(RedshiftDataStatementStore.Status.FINISHED, restored.subStatements.get(0).status);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -179,6 +179,9 @@ floci:
     rds-data:
       enabled: true
       transaction-ttl-seconds: 180
+    redshift-data:
+      enabled: true
+      result-ttl-hours: 24
     neptune:
       enabled: true
       proxy-base-port: 8182

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -179,7 +179,7 @@ services:
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java, mode: switch }
     # SubnetIds / VpcSecurityGroupIds / TagKeys are labels of an inner member-name
-    # switch (memberKeyRegex), not actions — same shape as the rds exclusions above.
+    # switch (memberKeyRegex), not actions, same shape as the rds exclusions above.
     exclude_actions: [SubnetIds, VpcSecurityGroupIds, TagKeys]
   - service: redshiftdata
     doc: docs/services/redshift-data.md

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -181,6 +181,13 @@ services:
     # SubnetIds / VpcSecurityGroupIds / TagKeys are labels of an inner member-name
     # switch (memberKeyRegex), not actions — same shape as the rds exclusions above.
     exclude_actions: [SubnetIds, VpcSecurityGroupIds, TagKeys]
+  - service: redshiftdata
+    doc: docs/services/redshift-data.md
+    sources:
+      - { path: src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataJsonHandler.java, mode: switch }
+    # ExecuteSql / BatchExecuteSql are the deprecated pre-2020 operations: the handler
+    # recognizes them only to return a ValidationException, they are not supported actions.
+    exclude_actions: [ExecuteSql, BatchExecuteSql]
   - service: cognitoidentity
     doc: docs/services/cognitoidentity.md
     sources:


### PR DESCRIPTION
## Summary

Adds a new `redshift-data` service emulating the Amazon Redshift Data API (JSON 1.1, `X-Amz-Target: RedshiftData.*`), sub-project A of the Redshift API expansion. It resolves a target Redshift cluster from `ClusterIdentifier` + `DbUser` or `SecretArn`, connects straight to the cluster's PostgreSQL container over JDBC, executes SQL synchronously, and serves the asynchronous-shaped polling contract from an in-memory statement store swept on a 24 h TTL.

New package `services/redshiftdata/`, mirroring `services/rdsdata/`: `RedshiftDataResourceResolver`, `RedshiftDataConnectionFactory`, `RedshiftDataStatementStore`, `RedshiftDataFieldMapper`, `RedshiftDataColumnMetadata`, `RedshiftDataSqlParameters`, `RedshiftDataService` (implements `Resettable`), `RedshiftDataJsonHandler`. Registered in `ResolvedServiceCatalog` and dispatched from `AwsJson11Controller` like `athena` (no JAX-RS controller), gated on `redshift.enabled && redshift-data.enabled`.

Operations: `ExecuteStatement`, `BatchExecuteStatement`, `DescribeStatement`, `GetStatementResult`, `GetStatementResultV2`, `ListStatements`, `CancelStatement`, `ListDatabases`, `ListSchemas`, `ListTables`, `DescribeTable`. Deprecated `ExecuteSql` / `BatchExecuteSql` return `ValidationException`.

Behaviour, stated explicitly:

- **Synchronous execution.** A statement is terminal (`FINISHED` / `FAILED`) by the time `ExecuteStatement` returns; no `SUBMITTED` → `STARTED` progression.
- **Execution errors are not HTTP errors.** A failed statement is stored `FAILED` with an `Error`, and `ExecuteStatement` still returns 200 with the `Id`. Callers see it through `DescribeStatement`.
- **Results in memory**, lost on restart; `ListStatements` returns only what is in memory.
- **`WorkgroupName` (Redshift Serverless) rejected.** Non-master `DbUser` rejected until `GetClusterCredentials` lands.
- **`BatchExecuteStatement`** runs `Sqls` in one transaction, rolls back and marks the batch `FAILED` on the first failing sub-statement, exposes `SubStatements`.
- **Paging**: 1000 rows, `NextToken` is an opaque base64 offset.

Spec: `docs/superpowers/specs/2026-09-04-redshift-data-api-design.md`. Plan: `docs/superpowers/plans/2026-09-07-redshift-data-api.md`.

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

- Wire protocol verified with the AWS SDK for Java v2 `RedshiftDataClient` (`software.amazon.awssdk:redshiftdata`, managed by the `awssdk` BOM already in `compatibility-tests/sdk-test-java`): `compatibility-tests/sdk-test-java/.../RedshiftDataOperationsTest.java` drives create-cluster → `executeStatement` → poll `describeStatement` → `getStatementResult` against a running Floci and unmarshals the responses through the SDK models (this validates the epoch-seconds timestamp encoding and the `Field` / `ColumnMetadata` shapes).
- The in-repo `RedshiftDataApiIntegrationTest` drives the HTTP endpoint with RestAssured against a real Docker Redshift cluster (RDS Data API and Redshift interceptor tests use the same pattern; the main module carries no AWS SDK dependency).
- Error mapping: `AwsException` thrown from the handler is converted by `AwsJson11Controller` / `JsonErrorResponseUtils`; `ResourceNotFoundException` / `ValidationException` at HTTP 400 matches the AWS JSON-protocol convention.

## Checklist

- [x] `./mvnw test` passes locally — 39 `redshift-data` tests plus 224 shared-surface regression tests (JSON 1.1 routing, service catalog, config, `RedshiftOperationsTest`, `RdsData*`); `./mvnw clean package -DskipTests` succeeds; `make docs-sync` / `make docs-check` (`regen_action_docs.py --strict`, `check_service_matrix.py --strict`) pass. The Docker-gated `RedshiftDataApiIntegrationTest` and the compatibility test compile and skip where Docker is unavailable.
- [x] New or updated integration test added — `RedshiftDataApiIntegrationTest` (RestAssured + real cluster, includes a transactional batch-rollback assertion) and `RedshiftDataOperationsTest` (AWS SDK).
- [x] Commit messages follow Conventional Commits.

Docs: new `docs/services/redshift-data.md`, Service Matrix row in `docs/services/index.md`, cross-link from `docs/services/redshift.md`, `mkdocs.yml` nav entry, `tools/docs/services.yaml` registration. The managed policy `AmazonRedshiftDataFullAccess` is already present in `src/main/resources/iam/managed-policies.yaml`.
