### PR TITLE
fix(dynamodb): make TransactWriteItems atomic

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -86,6 +86,7 @@ public class DynamoDbService implements ResourceProvider {
     // Items stored per table: storageKey -> Map<itemKey, item>
     // itemKey is "pk" or "pk#sk" depending on table schema
     private final ConcurrentHashMap<String, ConcurrentSkipListMap<String, JsonNode>> itemsByTable = new ConcurrentHashMap<>();
+
     // Per-item locks: storageKey -> itemKey -> ReentrantLock. Locks are created lazily
     // on first access and cleared with the table (see deleteTable); transactWriteItems
     // relies on ReentrantLock's re-entrancy so the inner put/update/delete calls do
@@ -183,7 +184,7 @@ public class DynamoDbService implements ResourceProvider {
 
     private void persistItems(String storageKey) {
         if (itemStore == null) return;
-        var items = itemsByTable.get(scopedItemsKey(storageKey));
+        var items = currentItems(storageKey, false);
         if (items != null) {
             itemStore.put(storageKey, new HashMap<>(items));
         } else {
@@ -559,6 +560,17 @@ public class DynamoDbService implements ResourceProvider {
                                   String region, String returnValuesOnConditionCheckFailure,
                                   boolean shouldPersist,
                                   Consumer<Runnable> deferredStreamEvents) {
+        return putItemInternal(tableName, item, conditionExpression, exprAttrNames, exprAttrValues,
+                region, returnValuesOnConditionCheckFailure, shouldPersist, deferredStreamEvents, null);
+    }
+
+    private JsonNode putItemInternal(String tableName, JsonNode item,
+                                  String conditionExpression,
+                                  JsonNode exprAttrNames, JsonNode exprAttrValues,
+                                  String region, String returnValuesOnConditionCheckFailure,
+                                  boolean shouldPersist,
+                                  Consumer<Runnable> deferredStreamEvents,
+                                  Map<String, ConcurrentSkipListMap<String, JsonNode>> stagedItems) {
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
@@ -571,7 +583,7 @@ public class DynamoDbService implements ResourceProvider {
         validateIndexKeyTypes(table, normalizedItem, false);
 
         return withItemLock(storageKey, itemKey, () -> {
-            var tableItems = itemsByTable.computeIfAbsent(scopedItemsKey(storageKey), k -> new ConcurrentSkipListMap<>());
+            var tableItems = itemsFor(storageKey, stagedItems, true);
 
             JsonNode existing = tableItems.get(itemKey);
 
@@ -615,7 +627,7 @@ public class DynamoDbService implements ResourceProvider {
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, key, true);
-        var items = itemsByTable.get(scopedItemsKey(storageKey));
+        var items = currentItems(storageKey, false);
         if (items == null) {
             LOG.tracev("Got item from {0}: key={1} item=<not found>", canonicalTableName, itemKey);
             return null;
@@ -656,6 +668,17 @@ public class DynamoDbService implements ResourceProvider {
                                          String region, String returnValuesOnConditionCheckFailure,
                                          boolean shouldPersist,
                                          Consumer<Runnable> deferredStreamEvents) {
+        return deleteItemInternal(tableName, key, conditionExpression, exprAttrNames, exprAttrValues,
+                region, returnValuesOnConditionCheckFailure, shouldPersist, deferredStreamEvents, null);
+    }
+
+    private JsonNode deleteItemInternal(String tableName, JsonNode key,
+                                         String conditionExpression,
+                                         JsonNode exprAttrNames, JsonNode exprAttrValues,
+                                         String region, String returnValuesOnConditionCheckFailure,
+                                         boolean shouldPersist,
+                                         Consumer<Runnable> deferredStreamEvents,
+                                         Map<String, ConcurrentSkipListMap<String, JsonNode>> stagedItems) {
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
@@ -664,7 +687,7 @@ public class DynamoDbService implements ResourceProvider {
         String itemKey = buildItemKey(table, key, true);
 
         return withItemLock(storageKey, itemKey, () -> {
-            var items = itemsByTable.get(scopedItemsKey(storageKey));
+            var items = itemsFor(storageKey, stagedItems, false);
             if (items == null) return null;
 
             if (conditionExpression != null) {
@@ -739,6 +762,20 @@ public class DynamoDbService implements ResourceProvider {
                                              String returnValuesOnConditionCheckFailure,
                                              boolean shouldPersist,
                                              Consumer<Runnable> deferredStreamEvents) {
+        return updateItemInternal(tableName, key, attributeUpdates, updateExpression,
+                expressionAttrNames, expressionAttrValues, returnValues,
+                conditionExpression, region, returnValuesOnConditionCheckFailure, shouldPersist,
+                deferredStreamEvents, null);
+    }
+
+    private UpdateResult updateItemInternal(String tableName, JsonNode key, JsonNode attributeUpdates,
+                                             String updateExpression,
+                                             JsonNode expressionAttrNames, JsonNode expressionAttrValues,
+                                             String returnValues, String conditionExpression, String region,
+                                             String returnValuesOnConditionCheckFailure,
+                                             boolean shouldPersist,
+                                             Consumer<Runnable> deferredStreamEvents,
+                                             Map<String, ConcurrentSkipListMap<String, JsonNode>> stagedItems) {
         String canonicalTableName = canonicalTableName(region, tableName);
         String storageKey = regionKey(region, canonicalTableName);
         TableDefinition table = tableStore.get(storageKey)
@@ -747,7 +784,7 @@ public class DynamoDbService implements ResourceProvider {
         String itemKey = buildItemKey(table, key, true);
 
         return withItemLock(storageKey, itemKey, () -> {
-            var items = itemsByTable.computeIfAbsent(scopedItemsKey(storageKey), k -> new ConcurrentSkipListMap<>());
+            var items = itemsFor(storageKey, stagedItems, true);
 
             // Get existing item or create new one from key
             JsonNode existing = items.get(itemKey);
@@ -1330,11 +1367,26 @@ public class DynamoDbService implements ResourceProvider {
                 acquired.add(lock);
             }
 
-            // First pass: evaluate all conditions and collect failures.
+            List<Runnable> pendingStreamEvents = new ArrayList<>();
+            Set<String> affectedStorageKeys = new LinkedHashSet<>();
+            Map<String, ConcurrentSkipListMap<String, JsonNode>> staged = new HashMap<>();
+            for (TransactParticipant participant : toAcquire.keySet()) {
+                ConcurrentSkipListMap<String, JsonNode> stagedTable =
+                        staged.computeIfAbsent(participant.storageKey(), ignored -> new ConcurrentSkipListMap<>());
+                ConcurrentSkipListMap<String, JsonNode> live = itemsByTable.get(scopedItemsKey(participant.storageKey()));
+                if (live != null) {
+                    JsonNode existing = live.get(participant.itemKey());
+                    if (existing != null) {
+                        stagedTable.put(participant.itemKey(), existing);
+                    }
+                }
+            }
+
             List<TransactionCanceledException.CancellationReason> cancellationReasons = new ArrayList<>();
             boolean hasFailed = false;
             for (JsonNode transactItem : transactItems) {
-                TransactionCanceledException.CancellationReason failReason = evaluateTransactCondition(transactItem, region);
+                TransactionCanceledException.CancellationReason failReason =
+                        evaluateTransactCondition(transactItem, region, staged);
                 if (failReason != null) {
                     hasFailed = true;
                     cancellationReasons.add(failReason);
@@ -1342,87 +1394,57 @@ public class DynamoDbService implements ResourceProvider {
                     cancellationReasons.add(new TransactionCanceledException.CancellationReason("", null));
                 }
             }
-
             if (hasFailed) {
                 throw new TransactionCanceledException(cancellationReasons);
             }
 
-            // Pre-validation pass: validate all operations before mutating memory or emitting stream effects
             for (JsonNode transactItem : transactItems) {
-                validateTransactItem(transactItem, region);
+                validateTransactItem(transactItem, region, staged);
             }
-
-            // Second pass: apply all writes with rollback protection and deferred streams
-            record RollbackEntry(String storageKey, String itemKey, JsonNode previousValue) {}
-            List<RollbackEntry> rollbackList = new ArrayList<>();
-            List<Runnable> pendingStreamEvents = new ArrayList<>();
-            Set<String> affectedStorageKeys = new LinkedHashSet<>();
-            boolean transactionSucceeded = false;
-            try {
-                for (JsonNode transactItem : transactItems) {
-                    if (transactItem.has("Put")) {
-                        JsonNode put = transactItem.get("Put");
-                        String tableName = put.path("TableName").asText();
-                        JsonNode item = put.get("Item");
-                        String canonicalTableName = canonicalTableName(region, tableName);
-                        String storageKey = regionKey(region, canonicalTableName);
-                        TableDefinition table = tableStore.get(storageKey)
-                                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
-                        String itemKey = buildItemKey(table, item);
-                        JsonNode prev = putItemInternal(tableName, item, null, null, null, region, "NONE", false, pendingStreamEvents::add);
-                        rollbackList.add(new RollbackEntry(storageKey, itemKey, prev));
-                        affectedStorageKeys.add(storageKey);
-                    } else if (transactItem.has("Delete")) {
-                        JsonNode del = transactItem.get("Delete");
-                        String tableName = del.path("TableName").asText();
-                        JsonNode key = del.get("Key");
-                        String canonicalTableName = canonicalTableName(region, tableName);
-                        String storageKey = regionKey(region, canonicalTableName);
-                        TableDefinition table = tableStore.get(storageKey)
-                                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
-                        String itemKey = buildItemKey(table, key, true);
-                        JsonNode prev = deleteItemInternal(tableName, key, null, null, null, region, "NONE", false, pendingStreamEvents::add);
-                        rollbackList.add(new RollbackEntry(storageKey, itemKey, prev));
-                        affectedStorageKeys.add(storageKey);
-                    } else if (transactItem.has("Update")) {
-                        JsonNode upd = transactItem.get("Update");
-                        String tableName = upd.path("TableName").asText();
-                        JsonNode key = upd.get("Key");
-                        String canonicalTableName = canonicalTableName(region, tableName);
-                        String storageKey = regionKey(region, canonicalTableName);
-                        TableDefinition table = tableStore.get(storageKey)
-                                .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
-                        String itemKey = buildItemKey(table, key, true);
-                        String updateExpression = upd.has("UpdateExpression") ? upd.get("UpdateExpression").asText() : null;
-                        JsonNode exprAttrNames = upd.has("ExpressionAttributeNames") ? upd.get("ExpressionAttributeNames") : null;
-                        JsonNode exprAttrValues = upd.has("ExpressionAttributeValues") ? upd.get("ExpressionAttributeValues") : null;
-                        UpdateResult res = updateItemInternal(tableName, key, null, updateExpression, exprAttrNames, exprAttrValues,
-                                   "NONE", null, region, "NONE", false, pendingStreamEvents::add);
-                        rollbackList.add(new RollbackEntry(storageKey, itemKey, res.oldItem()));
-                        affectedStorageKeys.add(storageKey);
-                    }
-                    // ConditionCheck-only items are handled in the first pass only
-                }
-                for (String storageKey : affectedStorageKeys) {
-                    persistItems(storageKey);
-                }
-                transactionSucceeded = true;
-            } finally {
-                if (!transactionSucceeded) {
-                    for (int i = rollbackList.size() - 1; i >= 0; i--) {
-                        RollbackEntry r = rollbackList.get(i);
-                        var tableItems = itemsByTable.get(scopedItemsKey(r.storageKey()));
-                        if (tableItems != null) {
-                            if (r.previousValue() == null) {
-                                tableItems.remove(r.itemKey());
-                            } else {
-                                tableItems.put(r.itemKey(), r.previousValue());
-                            }
-                        }
-                    }
+            for (JsonNode transactItem : transactItems) {
+                if (transactItem.has("Put")) {
+                    JsonNode put = transactItem.get("Put");
+                    String tableName = put.path("TableName").asText();
+                    String storageKey = regionKey(region, canonicalTableName(region, tableName));
+                    putItemInternal(tableName, put.get("Item"), null, null, null, region, "NONE", false,
+                            pendingStreamEvents::add, staged);
+                    affectedStorageKeys.add(storageKey);
+                } else if (transactItem.has("Delete")) {
+                    JsonNode del = transactItem.get("Delete");
+                    String tableName = del.path("TableName").asText();
+                    String storageKey = regionKey(region, canonicalTableName(region, tableName));
+                    deleteItemInternal(tableName, del.get("Key"), null, null, null, region, "NONE", false,
+                            pendingStreamEvents::add, staged);
+                    affectedStorageKeys.add(storageKey);
+                } else if (transactItem.has("Update")) {
+                    JsonNode upd = transactItem.get("Update");
+                    String tableName = upd.path("TableName").asText();
+                    String storageKey = regionKey(region, canonicalTableName(region, tableName));
+                    updateItemInternal(tableName, upd.get("Key"), null,
+                            upd.has("UpdateExpression") ? upd.get("UpdateExpression").asText() : null,
+                            upd.has("ExpressionAttributeNames") ? upd.get("ExpressionAttributeNames") : null,
+                            upd.has("ExpressionAttributeValues") ? upd.get("ExpressionAttributeValues") : null,
+                            "NONE", null, region, "NONE", false, pendingStreamEvents::add, staged);
+                    affectedStorageKeys.add(storageKey);
                 }
             }
 
+            // Each participant remains protected by the locks acquired above. Only participant
+            // entries are committed, so concurrent writes to other items are never overwritten.
+            for (TransactParticipant participant : toAcquire.keySet()) {
+                ConcurrentSkipListMap<String, JsonNode> live = itemsByTable.computeIfAbsent(
+                        scopedItemsKey(participant.storageKey()), ignored -> new ConcurrentSkipListMap<>());
+                ConcurrentSkipListMap<String, JsonNode> stagedTable = staged.get(participant.storageKey());
+                JsonNode value = stagedTable.get(participant.itemKey());
+                if (value == null) {
+                    live.remove(participant.itemKey());
+                } else {
+                    live.put(participant.itemKey(), value);
+                }
+            }
+            for (String storageKey : affectedStorageKeys) {
+                persistItems(storageKey);
+            }
             for (Runnable streamEvent : pendingStreamEvents) {
                 streamEvent.run();
             }
@@ -1469,6 +1491,12 @@ public class DynamoDbService implements ResourceProvider {
     }
 
     private TransactionCanceledException.CancellationReason evaluateTransactCondition(JsonNode transactItem, String region) {
+        return evaluateTransactCondition(transactItem, region, null);
+    }
+
+    private TransactionCanceledException.CancellationReason evaluateTransactCondition(
+            JsonNode transactItem, String region,
+            Map<String, ConcurrentSkipListMap<String, JsonNode>> stagedItems) {
         JsonNode target;
         if (transactItem.has("Put")) {
             target = transactItem.get("Put");
@@ -1501,7 +1529,7 @@ public class DynamoDbService implements ResourceProvider {
                 .orElseThrow(() -> resourceNotFoundException(canonicalTableName));
 
         String itemKey = buildItemKey(table, key);
-        var tableItems = itemsByTable.get(scopedItemsKey(storageKey));
+        var tableItems = itemsFor(storageKey, stagedItems, false);
         JsonNode existing = tableItems != null ? tableItems.get(itemKey) : null;
 
         try {
@@ -1536,6 +1564,11 @@ public class DynamoDbService implements ResourceProvider {
     }
 
     private void validateTransactItem(JsonNode transactItem, String region) {
+        validateTransactItem(transactItem, region, null);
+    }
+
+    private void validateTransactItem(JsonNode transactItem, String region,
+                                      Map<String, ConcurrentSkipListMap<String, JsonNode>> stagedItems) {
         if (transactItem.has("Put")) {
             JsonNode put = transactItem.get("Put");
             String tableName = canonicalTableName(region, put.path("TableName").asText());
@@ -1572,7 +1605,7 @@ public class DynamoDbService implements ResourceProvider {
                 throw new AwsException("ValidationException", "Key is required for Update", 400);
             }
             String itemKey = buildItemKey(table, key, true);
-            var items = itemsByTable.get(scopedItemsKey(storageKey));
+            var items = itemsFor(storageKey, stagedItems, false);
             JsonNode existing = items != null ? items.get(itemKey) : null;
             ObjectNode item = existing != null ? existing.deepCopy() : key.deepCopy();
 
@@ -2967,6 +3000,25 @@ public class DynamoDbService implements ResourceProvider {
     // can be used directly as an itemsByTable/itemLocks key.
     private String scopedItemsKey(String storageKey) {
         return regionResolver.getAccountId() + "/" + storageKey;
+    }
+
+    private ConcurrentSkipListMap<String, JsonNode> currentItems(String storageKey, boolean create) {
+        return itemsFor(storageKey, null, create);
+    }
+
+    private ConcurrentSkipListMap<String, JsonNode> itemsFor(
+            String storageKey,
+            Map<String, ConcurrentSkipListMap<String, JsonNode>> stagedItems,
+            boolean create) {
+        if (stagedItems != null) {
+            if (create) {
+                return stagedItems.computeIfAbsent(storageKey, ignored -> new ConcurrentSkipListMap<>());
+            }
+            return stagedItems.get(storageKey);
+        }
+        return create
+                ? itemsByTable.computeIfAbsent(scopedItemsKey(storageKey), k -> new ConcurrentSkipListMap<>())
+                : itemsByTable.get(scopedItemsKey(storageKey));
     }
 
     private ReentrantLock lockFor(String storageKey, String itemKey) {

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3467,6 +3467,57 @@ given()
     }
 
     @Test
+    void transactWriteFailureIsAtomicThroughAwsProtocol() {
+        String firstTable = "TxAtomicPublicOne";
+        String secondTable = "TxAtomicPublicTwo";
+        String createTable = """
+                {
+                  "TableName":"%s",
+                  "KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+                  "AttributeDefinitions":[{"AttributeName":"pk","AttributeType":"S"}],
+                  "BillingMode":"PAY_PER_REQUEST"
+                }
+                """;
+
+        for (String table : new String[]{firstTable, secondTable}) {
+            given().header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+                    .contentType(DYNAMODB_CONTENT_TYPE)
+                    .body(createTable.formatted(table))
+                    .when().post("/")
+                    .then().statusCode(200);
+        }
+
+        String transaction = """
+                {
+                  "TransactItems":[
+                    {"Put":{"TableName":"%s","Item":{"pk":{"S":"new"}}}},
+                    {"ConditionCheck":{"TableName":"%s","Key":{"pk":{"S":"bad"}},
+                      "ConditionExpression":"attribute_exists(pk)"}}
+                  ]
+                }
+                """.formatted(firstTable, secondTable);
+
+        given().header("X-Amz-Target", "DynamoDB_20120810.TransactWriteItems")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body(transaction)
+                .when().post("/")
+                .then().statusCode(400)
+                .body("__type", equalTo("TransactionCanceledException"));
+
+        for (String table : new String[]{firstTable, secondTable}) {
+            given().header("X-Amz-Target", "DynamoDB_20120810.GetItem")
+                    .contentType(DYNAMODB_CONTENT_TYPE)
+                    .body("{\"TableName\":\"%s\",\"Key\":{\"pk\":{\"S\":\"new\"}}}".formatted(table))
+                    .when().post("/")
+                    .then().statusCode(200)
+                    .body("Item", nullValue());
+        }
+
+        deleteTable(firstTable);
+        deleteTable(secondTable);
+    }
+
+    @Test
     void nullTypedKeyAttributeIsRejected() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 class DynamoDbServiceTest {
 
@@ -76,6 +77,99 @@ class DynamoDbServiceTest {
             node.set(kvPairs[i], attributeValue("S", kvPairs[i + 1]));
         }
         return node;
+    }
+
+    @Test
+    void transactWriteDoesNotPartiallyApplyAfterFailedConditionCheck() throws Exception {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        JsonNode put = mapper.readTree("""
+                {"Put":{"TableName":"Users","Item":{"userId":{"S":"new"},"name":{"S":"created"}}}}
+                """);
+        JsonNode invalidUpdate = mapper.readTree("""
+                {"ConditionCheck":{"TableName":"Users","Key":{"userId":{"S":"missing"}},
+                  "ConditionExpression":"attribute_exists(userId)"}}
+                """);
+
+        assertThrows(AwsException.class, () -> service.transactWriteItems(List.of(put, invalidUpdate), region));
+
+        assertNull(service.getItem("Users", mapper.readTree("{\"userId\":{\"S\":\"new\"}}"), region));
+    }
+
+    @Test
+    void transactWriteDoesNotPartiallyApplyAcrossTablesAfterFailedConditionCheck() throws Exception {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        createOrdersTable(region);
+        JsonNode put = mapper.readTree("""
+                {"Put":{"TableName":"Users","Item":{"userId":{"S":"new"}}}}
+                """);
+        JsonNode invalidUpdate = mapper.readTree("""
+                {"ConditionCheck":{"TableName":"Orders","Key":{"customerId":{"S":"c"},"orderId":{"S":"o"}},
+                  "ConditionExpression":"attribute_exists(customerId)"}}
+                """);
+
+        assertThrows(AwsException.class, () -> service.transactWriteItems(List.of(put, invalidUpdate), region));
+
+        assertNull(service.getItem("Users", mapper.readTree("{\"userId\":{\"S\":\"new\"}}"), region));
+        assertNull(service.getItem("Orders", mapper.readTree("{\"customerId\":{\"S\":\"c\"},\"orderId\":{\"S\":\"o\"}}"), region));
+    }
+
+    @Test
+    void failedTransactWritePublishesNoStreamOrKinesisEvents() throws Exception {
+        String region = "eu-west-1";
+        DynamoDbStreamService stream = mock(DynamoDbStreamService.class);
+        KinesisStreamingForwarder kinesis = mock(KinesisStreamingForwarder.class);
+        service = new DynamoDbService(new InMemoryStorage<>(), null,
+                new RegionResolver(region, "000000000000"), stream, kinesis);
+        createUsersTable(region);
+        JsonNode put = mapper.readTree("""
+                {"Put":{"TableName":"Users","Item":{"userId":{"S":"new"}}}}
+                """);
+        JsonNode invalidUpdate = mapper.readTree("""
+                {"ConditionCheck":{"TableName":"Users","Key":{"userId":{"S":"missing"}},
+                  "ConditionExpression":"attribute_exists(userId)"}}
+                """);
+
+        assertThrows(AwsException.class, () -> service.transactWriteItems(List.of(put, invalidUpdate), region));
+
+        verifyNoInteractions(stream, kinesis);
+    }
+
+    @Test
+    void validTransactWriteCommitsAllMutations() throws Exception {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        JsonNode put = mapper.readTree("""
+                {"Put":{"TableName":"Users","Item":{"userId":{"S":"new"}}}}
+                """);
+        JsonNode update = mapper.readTree("""
+                {"Update":{"TableName":"Users","Key":{"userId":{"S":"existing"}},
+                  "UpdateExpression":"SET #name = :name",
+                  "ExpressionAttributeNames":{"#name":"name"},
+                  "ExpressionAttributeValues":{":name":{"S":"updated"}}}}
+                """);
+
+        service.putItem("Users", mapper.readTree("{\"userId\":{\"S\":\"existing\"}}"), region);
+        service.transactWriteItems(List.of(put, update), region);
+
+        assertNotNull(service.getItem("Users", mapper.readTree("{\"userId\":{\"S\":\"new\"}}"), region));
+        assertEquals("updated", service.getItem("Users", mapper.readTree("{\"userId\":{\"S\":\"existing\"}}"), region).path("name").path("S").asText());
+    }
+
+    @Test
+    void failedTransactWriteLeavesExistingItemsUnchanged() throws Exception {
+        String region = "eu-west-1";
+        createUsersTable(region);
+        service.putItem("Users", item("userId", "existing", "name", "before"), region);
+        JsonNode invalidUpdate = mapper.readTree("""
+                {"ConditionCheck":{"TableName":"Users","Key":{"userId":{"S":"existing"}},
+                  "ConditionExpression":"attribute_not_exists(userId)"}}
+                """);
+
+        assertThrows(AwsException.class, () -> service.transactWriteItems(List.of(invalidUpdate), region));
+
+        assertEquals("before", service.getItem("Users", mapper.readTree("{\"userId\":{\"S\":\"existing\"}}"), region).path("name").path("S").asText());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes partial mutations from failed `TransactWriteItems` requests. Mutations are now staged per participant, validated before live storage changes, committed only after the complete transaction succeeds, and side effects are published afterward.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

A failed transaction previously could leave earlier writes committed and could publish stream or Kinesis effects. The implementation now preserves all-or-nothing item behavior while retaining deterministic lock ordering and idempotency handling.

The fix does not include stream-iterator, ownership, or unrelated DynamoDB refactors.

## Checklist

- [ ] `./mvnw test` passes locally — the full suite exceeded the available timeout
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Validation run

- `./mvnw -q -DskipTests compile`
- `./mvnw -q -Dtest=DynamoDbServiceTest,DynamoDbConcurrencyIntegrationTest test`
- `./mvnw -q -Dtest=DynamoDbIntegrationTest#transactWriteFailureIsAtomicThroughAwsProtocol test`
- Diagnostics and `git diff --check` passed
