### PR TITLE
fix(sfn): fail States.Runtime on an unresolvable JSONPath in a payload template

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -2871,14 +2871,17 @@ public class AslExecutor {
                     String path = val.asText();
                     if (path.startsWith("$$.")) {
                         // Context reference: $$. → resolve against context as $.
-                        resolved.set(realKey, resolvePath("$." + path.substring(3), context));
+                        String contextPath = "$." + path.substring(3);
+                        resolved.set(realKey, context == null
+                                ? NullNode.getInstance()
+                                : resolvePayloadTemplateReference(contextPath, context, null, key, context));
                     } else if ("$$".equals(path)) {
                         resolved.set(realKey, context);
                     } else {
                         // Pass the Context Object through so a $$. reference nested inside an
                         // intrinsic (e.g. States.Format(..., $$.Map.Item.Value.x)) can resolve it;
                         // for a plain $. or States.* input reference, context is simply ignored.
-                        resolved.set(realKey, resolvePath(path, input, context));
+                        resolved.set(realKey, resolvePayloadTemplateReference(path, input, context, key, input));
                     }
                 } else if (val.isObject() || val.isArray()) {
                     resolved.set(key, resolveParameters(val, input, context));
@@ -2941,6 +2944,117 @@ public class AslExecutor {
             return MissingNode.getInstance();
         }
         return walkPath(splitPathSegments(path), 0, root);
+    }
+
+    /**
+     * Resolves a {@code ".$"} payload template reference (a {@code Parameters}, {@code
+     * ResultSelector}, or {@code ItemSelector} field). AWS keeps one narrow leniency here: an
+     * out-of-range array index resolves to null and the state keeps running (confirmed against
+     * real AWS). Every other unresolvable reference, such as a missing object key at any depth,
+     * fails the state with {@code States.Runtime} naming the path, the field, and the input it
+     * was resolved against, rather than silently continuing with null. Wildcard paths keep the
+     * pre-existing null-collapsing behavior, since a projection already filters out its own
+     * misses rather than failing.
+     *
+     * @param path         the reference path or {@code States.*} intrinsic taken from the field's
+     *                     {@code ".$"} value
+     * @param searchRoot   what the path is resolved against
+     * @param context      the Context Object, for a {@code States.*} intrinsic argument nested in
+     *                     the reference
+     * @param fieldKey     the original template key (including its {@code ".$"} suffix), named in
+     *                     the failure cause
+     * @param reportedInput the value named as "the input" in the failure cause
+     */
+    private JsonNode resolvePayloadTemplateReference(String path, JsonNode searchRoot, JsonNode context,
+                                                       String fieldKey, JsonNode reportedInput) {
+        if (path == null || "$".equals(path)) {
+            return searchRoot;
+        }
+        if (path.startsWith("States.")) {
+            return evaluateIntrinsic(path, searchRoot, context);
+        }
+        if (!path.startsWith("$.") && !path.startsWith("$[")) {
+            return NullNode.getInstance();
+        }
+        String[] parts = splitPathSegments(path);
+        if (containsWildcard(parts)) {
+            JsonNode value = walkPath(parts, 0, searchRoot);
+            return value.isMissingNode() ? NullNode.getInstance() : value;
+        }
+        PathLookup lookup = walkPathTracked(parts, 0, searchRoot);
+        if (!lookup.value.isMissingNode()) {
+            return lookup.value;
+        }
+        if (lookup.outOfRangeArrayIndex) {
+            return NullNode.getInstance();
+        }
+        throw new FailStateException("States.Runtime",
+                "The JSONPath '" + path + "' specified for the field '" + fieldKey
+                        + "' could not be found in the input '" + reportedInput + "'");
+    }
+
+    private static boolean containsWildcard(String[] parts) {
+        for (String part : parts) {
+            if ("*".equals(part)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The result of {@link #walkPathTracked}: the resolved value (or a {@link MissingNode}), and
+     * whether the miss was specifically an out-of-range array index, the one case AWS resolves to
+     * null instead of failing the state.
+     */
+    private static final class PathLookup {
+        final JsonNode value;
+        final boolean outOfRangeArrayIndex;
+
+        PathLookup(JsonNode value, boolean outOfRangeArrayIndex) {
+            this.value = value;
+            this.outOfRangeArrayIndex = outOfRangeArrayIndex;
+        }
+    }
+
+    /**
+     * Walks a wildcard-free reference path like {@link #walkPath}, but also reports whether an
+     * unresolved result came from indexing past the end of an array, which real AWS resolves to
+     * null, as opposed to a missing object key or a step through a non-container value at any
+     * position, which fails the state.
+     */
+    private PathLookup walkPathTracked(String[] parts, int idx, JsonNode current) {
+        for (int i = idx; i < parts.length; i++) {
+            if (current == null || current.isMissingNode() || current.isNull()) {
+                return new PathLookup(MissingNode.getInstance(), false);
+            }
+            String part = parts[i];
+            boolean arrayIndexStep = current.isArray() && isArrayIndex(part);
+            int index = arrayIndexStep ? parseArrayIndex(part) : -1;
+            if (arrayIndexStep && index < 0) {
+                return new PathLookup(MissingNode.getInstance(), true);
+            }
+            JsonNode next = arrayIndexStep ? current.path(index) : current.path(part);
+            if (next.isMissingNode()) {
+                return new PathLookup(MissingNode.getInstance(), arrayIndexStep);
+            }
+            current = next;
+        }
+        return new PathLookup(current, false);
+    }
+
+    /**
+     * Parses an all-digit path segment as an array index, returning -1 for a value that overflows
+     * {@code int} rather than throwing, since AWS treats any index past the end of the array
+     * (including one too large to represent) as an out-of-range miss instead of a parse failure.
+     */
+    private static int parseArrayIndex(String segment) {
+        try {
+            long value = Long.parseLong(segment);
+            return value > Integer.MAX_VALUE ? -1 : (int) value;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
     }
 
     /** Splits dotted, indexed, wildcard, and bracket-quoted AWS reference-path segments. */

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorUnresolvableJsonPathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorUnresolvableJsonPathTest.java
@@ -1,0 +1,158 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A {@code ".$"} payload template field (Parameters, ResultSelector, ItemSelector) whose JSONPath
+ * does not resolve against the effective input fails the state with {@code States.Runtime},
+ * matching real AWS and Step Functions Local 2.0.0, instead of silently resolving to null.
+ * Fixes issue #2521.
+ *
+ * <p>AWS keeps one narrow leniency here: an out-of-range array index still resolves to null and
+ * the execution keeps running (see {@link AslExecutorIntrinsicMissingArgumentTest}, which pins
+ * the same path failing when passed to a {@code States.*} intrinsic instead).
+ */
+class AslExecutorUnresolvableJsonPathTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private AslExecutor newExecutor() {
+        return new AslExecutor(null, null, null, null, null, null, null, null,
+                null, null, null, null, null, mapper, null, null, null, null, null);
+    }
+
+    @Test
+    void unresolvableNestedPathFailsWithTheCauseAwsWrites() throws Exception {
+        var failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> resolve("{\"missing.$\":\"$.nope.deep\"}", "{\"other\":1}"));
+
+        assertEquals("States.Runtime", failure.error);
+        assertEquals("The JSONPath '$.nope.deep' specified for the field 'missing.$' could not "
+                + "be found in the input '{\"other\":1}'", failure.cause);
+    }
+
+    @Test
+    void unresolvableTopLevelPathFails() throws Exception {
+        var failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> resolve("{\"missing.$\":\"$.nope\"}", "{\"other\":1}"));
+
+        assertEquals("The JSONPath '$.nope' specified for the field 'missing.$' could not be "
+                + "found in the input '{\"other\":1}'", failure.cause);
+    }
+
+    /** A field that resolves fine must be unaffected. */
+    @Test
+    void resolvablePathStillSucceeds() throws Exception {
+        var resolved = resolve("{\"picked.$\":\"$.other\"}", "{\"other\":1}");
+
+        assertEquals(1, resolved.path("picked").asInt());
+    }
+
+    /**
+     * An out-of-range array index is the one place AWS keeps the old null-and-succeed behavior;
+     * verified against real AWS in us-east-1 (see the sibling comment in
+     * {@link AslExecutorIntrinsicMissingArgumentTest#indexPastTheEndOfAnArrayFails}).
+     */
+    @Test
+    void outOfRangeArrayIndexStillResolvesToNull() throws Exception {
+        var resolved = resolve("{\"idx.$\":\"$.items[5]\"}", "{\"items\":[1,2]}");
+
+        assertEquals("null", resolved.path("idx").toString());
+    }
+
+    /**
+     * An all-digit index too large to fit in an {@code int} is still an out-of-range array access,
+     * not a parse failure, so it must resolve to null the same as an ordinary out-of-range index.
+     */
+    @Test
+    void indexBeyondIntRangeStillResolvesToNull() throws Exception {
+        var resolved = resolve("{\"idx.$\":\"$.items[99999999999999999999]\"}", "{\"items\":[1,2]}");
+
+        assertEquals("null", resolved.path("idx").toString());
+    }
+
+    /** An explicit null value is present, not missing, so it must not fail. */
+    @Test
+    void explicitNullValueStillSucceeds() throws Exception {
+        var resolved = resolve("{\"v.$\":\"$.nul\"}", "{\"nul\":null}");
+
+        assertEquals("null", resolved.path("v").toString());
+    }
+
+    /** A miss at any nesting depth inside the template fails, not only at the top level. */
+    @Test
+    void unresolvablePathFailsAtAnyNestingDepth() throws Exception {
+        var failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> resolve("{\"outer\":{\"missing.$\":\"$.a.b.c\"}}", "{\"a\":{\"x\":1}}"));
+
+        assertEquals("The JSONPath '$.a.b.c' specified for the field 'missing.$' could not be "
+                + "found in the input '{\"a\":{\"x\":1}}'", failure.cause);
+    }
+
+    /** ResultSelector and ItemSelector run through the same resolver, so they fail the same way. */
+    @Test
+    void resultSelectorFailsOnAnUnresolvablePath() throws Exception {
+        var failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> resolve("{\"missing.$\":\"$.nope\"}", "[{\"other\":1}]"));
+
+        assertEquals("The JSONPath '$.nope' specified for the field 'missing.$' could not be "
+                + "found in the input '[{\"other\":1}]'", failure.cause);
+    }
+
+    /** Indexing through a value that is not an array or object fails, matching AWS. */
+    @Test
+    void navigatingThroughANonContainerValueFails() throws Exception {
+        var failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> resolve("{\"v.$\":\"$.other.x\"}", "{\"other\":1}"));
+
+        assertEquals("States.Runtime", failure.error);
+        assertEquals("The JSONPath '$.other.x' specified for the field 'v.$' could not be found "
+                + "in the input '{\"other\":1}'", failure.cause);
+    }
+
+    /** A wildcard projection matching nothing is an empty array, not a failure. */
+    @Test
+    void wildcardMatchingNothingStaysAnEmptyArray() throws Exception {
+        var resolved = resolve("{\"names.$\":\"$.items[*].name\"}", "{\"items\":[1,2]}");
+
+        assertEquals(0, resolved.path("names").size());
+    }
+
+    /**
+     * An unresolvable {@code $$.} Context Object reference fails too, and names the Context
+     * Object as the input, since that is what the path was actually resolved against.
+     */
+    @Test
+    void unresolvableContextReferenceFailsAndNamesTheContextObject() throws Exception {
+        var context = mapper.readTree("{\"State\":{\"Name\":\"P\"}}");
+        var template = mapper.readTree("{\"missing.$\":\"$$.Nope.Deep\"}");
+
+        var failure = assertThrows(AslExecutor.FailStateException.class,
+                () -> newExecutor().resolveParameters(template, mapper.readTree("{\"other\":1}"), context));
+
+        assertEquals("States.Runtime", failure.error);
+        assertEquals("The JSONPath '$.Nope.Deep' specified for the field 'missing.$' could not "
+                + "be found in the input '{\"State\":{\"Name\":\"P\"}}'", failure.cause);
+    }
+
+    /** A resolvable Context Object reference is unaffected. */
+    @Test
+    void resolvableContextReferenceStillSucceeds() throws Exception {
+        var context = mapper.readTree("{\"Execution\":{\"Name\":\"exec1\"}}");
+        var template = mapper.readTree("{\"name.$\":\"$$.Execution.Name\"}");
+
+        var resolved = newExecutor().resolveParameters(template, mapper.readTree("{}"), context);
+
+        assertEquals("exec1", resolved.path("name").asText());
+    }
+
+    private JsonNode resolve(String template, String input) throws Exception {
+        return newExecutor().resolveParameters(
+                mapper.readTree(template), mapper.readTree(input), mapper.createObjectNode());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsUnresolvableJsonPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsUnresolvableJsonPathIntegrationTest.java
@@ -1,0 +1,148 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * End to end coverage for issue #2521. A {@code ".$"} Parameters field whose JSONPath does not
+ * resolve against the input used to resolve to null and the execution succeeded; real AWS and
+ * Step Functions Local 2.0.0 fail the execution with {@code States.Runtime}.
+ */
+@QuarkusTest
+class StepFunctionsUnresolvableJsonPathIntegrationTest {
+
+    private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    /** The exact reproduction from issue #2521. */
+    @Test
+    void unresolvableParametersPathFailsTheExecution() throws Exception {
+        var definition = """
+                {"StartAt":"Pick","States":{
+                  "Pick":{"Type":"Pass","Parameters":{"missing.$":"$.nope.deep"},"End":true}}}
+                """;
+
+        var describe = run("unresolvable-jsonpath", definition, "{\"other\":1}");
+
+        assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
+        assertEquals("States.Runtime", describe.jsonPath().getString("error"));
+        assertEquals("The JSONPath '$.nope.deep' specified for the field 'missing.$' could not "
+                + "be found in the input '{\"other\":1}'",
+                describe.jsonPath().getString("cause"));
+    }
+
+    /**
+     * States.Runtime is never caught, matching the intrinsic-argument precedent. A Map carries
+     * the Catch because AWS refuses it on a Pass.
+     */
+    @Test
+    void catchAllDoesNotSwallowTheFailure() throws Exception {
+        var definition = """
+                {"StartAt":"M","States":{
+                  "M":{"Type":"Map","ItemsPath":"$.items",
+                    "Parameters":{"missing.$":"$.nope"},
+                    "Iterator":{"StartAt":"P","States":{"P":{"Type":"Pass","End":true}}},
+                    "Catch":[{"ErrorEquals":["States.ALL"],"Next":"Caught"}],"End":true},
+                  "Caught":{"Type":"Pass","End":true}}}
+                """;
+
+        var describe = run("unresolvable-jsonpath-catch-all", definition, "{\"items\":[1,2]}");
+
+        assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
+        assertEquals("States.Runtime", describe.jsonPath().getString("error"));
+    }
+
+    /** An out-of-range array index still resolves to null and the execution succeeds. */
+    @Test
+    void outOfRangeArrayIndexStillSucceeds() throws Exception {
+        var definition = """
+                {"StartAt":"Pick","States":{
+                  "Pick":{"Type":"Pass","Parameters":{"idx.$":"$.items[5]"},"End":true}}}
+                """;
+
+        var describe = run("unresolvable-jsonpath-array-index", definition, "{\"items\":[1,2]}");
+
+        assertEquals("SUCCEEDED", describe.jsonPath().getString("status"), describe.body().asString());
+        assertEquals("{\"idx\":null}", describe.jsonPath().getString("output"));
+    }
+
+    /** ResultSelector runs through the same resolver and fails the same way. */
+    @Test
+    void unresolvableResultSelectorPathFailsTheExecution() throws Exception {
+        var definition = """
+                {"StartAt":"M","States":{
+                  "M":{"Type":"Map","ItemsPath":"$.items",
+                    "ItemProcessor":{"StartAt":"P","States":{"P":{"Type":"Pass","End":true}}},
+                    "ResultSelector":{"missing.$":"$.nope"},"End":true}}}
+                """;
+
+        var describe = run("unresolvable-jsonpath-result-selector", definition, "{\"items\":[1,2]}");
+
+        assertEquals("FAILED", describe.jsonPath().getString("status"), describe.body().asString());
+        assertEquals("States.Runtime", describe.jsonPath().getString("error"));
+        assertEquals("The JSONPath '$.nope' specified for the field 'missing.$' could not be "
+                + "found in the input '[1,2]'",
+                describe.jsonPath().getString("cause"));
+    }
+
+    private Response run(String label, String definition, String input) throws InterruptedException {
+        var smArn = create(label + "-" + System.currentTimeMillis(), definition);
+        var execArn = start(smArn, input);
+        for (var i = 0; i < 50; i++) {
+            var resp = describe(execArn);
+            var status = resp.jsonPath().getString("status");
+            if (!"RUNNING".equals(status)) {
+                return resp;
+            }
+            Thread.sleep(100);
+        }
+        fail("Execution did not complete");
+        return null;
+    }
+
+    private String create(String name, String definition) {
+        var resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.CreateStateMachine")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("{\"name\":\"" + name + "\",\"definition\":" + quote(definition)
+                        + ",\"roleArn\":\"" + ROLE_ARN + "\"}")
+                .when().post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("stateMachineArn");
+    }
+
+    private String start(String smArn, String input) {
+        var resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.StartExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("{\"stateMachineArn\":\"" + smArn + "\",\"input\":" + quote(input) + "}")
+                .when().post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("executionArn");
+    }
+
+    private Response describe(String execArn) {
+        return given()
+                .header("X-Amz-Target", "AWSStepFunctions.DescribeExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("{\"executionArn\":\"" + execArn + "\"}")
+                .when().post("/");
+    }
+
+    private static String quote(String raw) {
+        return "\"" + raw.replace("\\", "\\\\").replace("\"", "\\\"")
+                .replace("\n", "\\n").replace("\r", "\\r").replace("\t", "\\t") + "\"";
+    }
+}


### PR DESCRIPTION
## Summary

A payload template field (`"name.$": "$.some.path"`) whose JSONPath does not resolve against the effective input currently returns `null` and lets the state succeed. Real AWS and Step Functions Local fail the execution with `States.Runtime`, naming the unresolvable path and field in the cause.

`resolveParameters` (shared by `Parameters`, `ResultSelector`, `ItemSelector`/`ItemTransform`, and `ItemReader` `Parameters`) now routes each `.$` field through a path walk that distinguishes an out-of-range array index (kept as a documented AWS leniency, still resolves to null) from every other unresolved reference (missing object key at any depth, indexing into a non-container), which now raises `States.Runtime` with cause:

`The JSONPath '<path>' specified for the field '<key>' could not be found in the input '<input>'`

Wildcard paths (`$[*]...`) keep their existing null-collapsing behavior, since projections already filter their own misses.

This is a separate code path from PR #3002's `MissingIntrinsicArgumentException` mechanism for `States.*` intrinsic function arguments (which already fails on any miss with no leniency); the two were kept independent rather than merged.

Closes #2521

## Type of change

- [x] Bug fix (`fix:`)

## AWS Compatibility

Per the Amazon States Language input/output processing documentation, a `.$` field whose JSONPath does not resolve against the effective input must fail the state with error `States.Runtime`. Verified against the issue's exact repro (compared to Step Functions Local 2.0.0's `executionFailedEventDetails.cause` wording) and matched that cause format.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits