### PR TITLE
feat(kinesis): implement UpdateShardCount API

### DIFF
--- a/docs/services/kinesis.md
+++ b/docs/services/kinesis.md
@@ -36,6 +36,7 @@
 | `DisableEnhancedMonitoring` | - |
 | `UpdateStreamMode` | - |
 | `UpdateMaxRecordSize` | - |
+| `UpdateShardCount` | - |
 <!-- floci:actions:end -->
 
 ## Local Inspection Endpoints
@@ -71,6 +72,24 @@ A `LATEST` iterator is positioned at the shard tip at the moment the iterator is
 ## Record Routing
 
 `PutRecord` and `PutRecords` honor `ExplicitHashKey` when it is provided. The value must be a decimal integer in the Kinesis hash-key space, and records are written to the open shard whose `HashKeyRange` contains that value. Without `ExplicitHashKey`, Floci keeps using the partition key to choose a shard.
+
+## Shard Scaling (UpdateShardCount)
+
+`UpdateShardCount` enforces the documented default limits: at most double the current
+open shard count per call, at most ten calls per rolling 24-hour period per stream, a
+10000-shard ceiling, and the asymmetric rule that a stream already above 10000 shards can
+only move to a target strictly below it.
+
+The minimum bound (`TargetShardCount` cannot go below half the current open shard count)
+rounds up for an odd current count, so `current=5` accepts `target=3` but rejects
+`target=2`. AWS's documentation says only "below half" with no stated rounding, so which
+direction an odd count rounds is Floci's own call rather than observed AWS behavior; this
+is the more conservative reading (fewer shards allowed, not more).
+
+AWS also documents a separate 10 TPS call-rate limit on this action ("Make over 10 TPS.
+TPS over 10 will trigger the LimitExceededException"), independent of the ten-calls-per-24h
+limit above. Floci does not simulate real-time request throttling for this or any other
+action, so that limit is intentionally unenforced here.
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandler.java
@@ -72,6 +72,7 @@ public class KinesisJsonHandler {
             case "DisableEnhancedMonitoring" -> handleDisableEnhancedMonitoring(request, region);
             case "UpdateStreamMode" -> handleUpdateStreamMode(request, region);
             case "UpdateMaxRecordSize" -> handleUpdateMaxRecordSize(request, region);
+            case "UpdateShardCount" -> handleUpdateShardCount(request, region);
             default -> Response.status(400)
                     .entity(new AwsErrorResponse("UnsupportedOperation", "Operation " + action + " is not supported."))
                     .build();
@@ -180,6 +181,24 @@ public class KinesisJsonHandler {
         }
         service.updateMaxRecordSize(extractStreamNameFromArn(streamArn), size, region);
         return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    private Response handleUpdateShardCount(JsonNode request, String region) {
+        String streamName = resolveStreamName(request);
+        JsonNode targetNode = request.path("TargetShardCount");
+        if (!targetNode.isIntegralNumber() || !targetNode.canConvertToInt()) {
+            throw new AwsException("InvalidArgumentException", "TargetShardCount must be an integer", 400);
+        }
+        String scalingType = request.path("ScalingType").asText(null);
+        KinesisService.UpdateShardCountResult result =
+                service.updateShardCount(streamName, targetNode.intValue(), scalingType, region);
+
+        ObjectNode response = objectMapper.createObjectNode();
+        response.put("StreamName", result.streamName());
+        response.put("StreamARN", result.streamArn());
+        response.put("CurrentShardCount", result.currentShardCount());
+        response.put("TargetShardCount", result.targetShardCount());
+        return Response.ok(response).build();
     }
 
     private String extractStreamNameFromArn(String streamArn) {

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/KinesisService.java
@@ -16,6 +16,7 @@ import org.jboss.logging.Logger;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,6 +45,14 @@ public class KinesisService implements ResourceProvider {
     private static final int MAX_RECORD_SIZE_KIB = 10240;
     private static final int MAX_RECORDS_PER_REQUEST = 500;
     private static final int MAX_REQUEST_SIZE_BYTES = 10 * 1024 * 1024;
+    /**
+     * UpdateShardCount's documented default limits: the per-account/region shard-per-stream
+     * ceiling, and how many scaling calls a stream may take in a rolling 24-hour window.
+     */
+    private static final int MAX_SHARDS_PER_STREAM = 10000;
+    private static final int MAX_SHARD_COUNT_UPDATES_PER_DAY = 10;
+    private static final Duration SHARD_COUNT_UPDATE_WINDOW = Duration.ofHours(24);
+    private static final String UNIFORM_SCALING = "UNIFORM_SCALING";
     private static final String MIN_HASH_KEY_VALUE = "0";
     private static final String INITIAL_SEQUENCE_NUMBER = "0";
     private static final BigInteger MIN_HASH_KEY = BigInteger.ZERO;
@@ -465,6 +474,166 @@ public class KinesisService implements ResourceProvider {
 
     private String subtractOne(String val) {
         return new BigInteger(val).subtract(BigInteger.ONE).toString();
+    }
+
+    public record UpdateShardCountResult(String streamName, String streamArn,
+                                          int currentShardCount, int targetShardCount) {}
+
+    /**
+     * Reshards a stream to {@code targetShardCount} open shards using uniform scaling: the only
+     * scaling type AWS documents. Internally this is expressed purely as a sequence of
+     * {@link #splitShard} and {@link #mergeShards} calls, exactly as real Kinesis performs
+     * UpdateShardCount as splits or merges on individual shards, so shard lineage
+     * (parent/adjacent-parent) comes out identical to calling those APIs by hand.
+     */
+    public UpdateShardCountResult updateShardCount(String streamName, int targetShardCount, String scalingType, String region) {
+        if (!UNIFORM_SCALING.equals(scalingType)) {
+            throw new AwsException("InvalidArgumentException",
+                    "ScalingType must be UNIFORM_SCALING, got: " + scalingType, 400);
+        }
+        if (targetShardCount < 1) {
+            throw new AwsException("InvalidArgumentException",
+                    "TargetShardCount must be at least 1, got: " + targetShardCount, 400);
+        }
+
+        String key = regionKey(region, streamName);
+        int currentOpenShardCount;
+        synchronized (lockFor(key)) {
+            KinesisStream stream = resolveStream(streamName, region);
+
+            if ("ON_DEMAND".equals(stream.getStreamMode())) {
+                throw new AwsException("ValidationException",
+                        "UpdateShardCount is only supported for data streams with the provisioned capacity mode.",
+                        400);
+            }
+            if (!"ACTIVE".equals(stream.getStreamStatus())) {
+                throw new AwsException("ResourceInUseException",
+                        "Stream " + streamName + " is not ACTIVE (current state: " + stream.getStreamStatus() + ")", 400);
+            }
+
+            currentOpenShardCount = (int) stream.getShards().stream().filter(s -> !s.isClosed()).count();
+            validateTargetShardCount(streamName, currentOpenShardCount, targetShardCount);
+            recordShardCountUpdate(stream, key);
+
+            applyUniformScaling(streamName, stream, currentOpenShardCount, targetShardCount, region);
+
+            return new UpdateShardCountResult(streamName, stream.getStreamArn(), currentOpenShardCount, targetShardCount);
+        }
+    }
+
+    /**
+     * Enforces UpdateShardCount's documented default limits. The minimum bound rounds up for an
+     * odd current shard count ({@code (n + 1) / 2}), so current=5 accepts target=3 but rejects
+     * target=2; AWS documents only "below half" with no stated rounding, so the rounding direction
+     * here is Floci's own call, chosen as the more conservative reading. AWS's separate 10 TPS
+     * call-rate limit on this action is not enforced: Floci does not simulate real-time request
+     * throttling for any action.
+     */
+    private void validateTargetShardCount(String streamName, int currentOpenShardCount, int targetShardCount) {
+        int maxAllowed = currentOpenShardCount * 2;
+        int minAllowed = (currentOpenShardCount + 1) / 2;
+        if (targetShardCount > maxAllowed) {
+            throw new AwsException("LimitExceededException",
+                    "TargetShardCount of " + targetShardCount + " for stream " + streamName
+                            + " exceeds double the current open shard count of " + currentOpenShardCount + ".", 400);
+        }
+        if (targetShardCount < minAllowed) {
+            throw new AwsException("LimitExceededException",
+                    "TargetShardCount of " + targetShardCount + " for stream " + streamName
+                            + " is below half the current open shard count of " + currentOpenShardCount + ".", 400);
+        }
+        if (targetShardCount > MAX_SHARDS_PER_STREAM) {
+            throw new AwsException("LimitExceededException",
+                    "TargetShardCount of " + targetShardCount + " exceeds the shard limit of "
+                            + MAX_SHARDS_PER_STREAM + " shards per stream.", 400);
+        }
+        if (currentOpenShardCount > MAX_SHARDS_PER_STREAM && targetShardCount >= MAX_SHARDS_PER_STREAM) {
+            throw new AwsException("LimitExceededException",
+                    "Stream " + streamName + " already has more than " + MAX_SHARDS_PER_STREAM
+                            + " shards; it can only be scaled down below that limit.", 400);
+        }
+    }
+
+    /** Enforces the "no more than ten UpdateShardCount calls per rolling 24 hours" default limit. */
+    private void recordShardCountUpdate(KinesisStream stream, String storageKey) {
+        Instant now = Instant.now();
+        Instant windowStart = now.minus(SHARD_COUNT_UPDATE_WINDOW);
+        List<Instant> recent = new ArrayList<>(stream.getShardCountUpdateTimestamps().stream()
+                .filter(t -> t.isAfter(windowStart))
+                .toList());
+        if (recent.size() >= MAX_SHARD_COUNT_UPDATES_PER_DAY) {
+            throw new AwsException("LimitExceededException",
+                    "Stream " + stream.getStreamName() + " has already been scaled "
+                            + MAX_SHARD_COUNT_UPDATES_PER_DAY + " times in the past 24 hours.", 400);
+        }
+        recent.add(now);
+        stream.setShardCountUpdateTimestamps(recent);
+        store.put(storageKey, stream);
+    }
+
+    /**
+     * Reaches {@code targetShardCount} open shards by splitting the widest open shards (scale up)
+     * or merging the narrowest disjoint adjacent pairs (scale down), so the resulting topology
+     * stays as close to equal-width as the existing shard layout allows.
+     */
+    private void applyUniformScaling(String streamName, KinesisStream stream,
+                                      int currentOpenShardCount, int targetShardCount, String region) {
+        if (targetShardCount > currentOpenShardCount) {
+            int splitsNeeded = targetShardCount - currentOpenShardCount;
+            List<KinesisShard> splitCandidates = stream.getShards().stream()
+                    .filter(s -> !s.isClosed())
+                    .sorted(Comparator.comparing(KinesisService::hashRangeWidth).reversed()
+                            .thenComparing(KinesisShard::getShardId))
+                    .limit(splitsNeeded)
+                    .toList();
+            for (KinesisShard parent : splitCandidates) {
+                splitShard(streamName, parent.getShardId(), midpointHashKey(parent.getHashKeyRange()), region);
+            }
+        } else if (targetShardCount < currentOpenShardCount) {
+            int mergesNeeded = currentOpenShardCount - targetShardCount;
+            List<KinesisShard> openByHashKey = stream.getShards().stream()
+                    .filter(s -> !s.isClosed())
+                    .sorted(Comparator.comparing(s -> new BigInteger(s.getHashKeyRange().startingHashKey())))
+                    .toList();
+
+            List<int[]> narrowestFirstDisjointPairs = narrowestFirstDisjointAdjacentPairs(openByHashKey);
+            for (int i = 0; i < mergesNeeded; i++) {
+                int[] pair = narrowestFirstDisjointPairs.get(i);
+                KinesisShard shard1 = openByHashKey.get(pair[0]);
+                KinesisShard shard2 = openByHashKey.get(pair[1]);
+                mergeShards(streamName, shard1.getShardId(), shard2.getShardId(), region);
+            }
+        }
+    }
+
+    /**
+     * Every disjoint adjacent-pair merge candidate among {@code openByHashKey}, narrowest
+     * combined hash-range width first. Only the fixed (0,1), (2,3), ... parity pairing is
+     * considered: those pairs never share a shard, so merging any prefix of this list is always
+     * valid regardless of how many merges are actually needed, and picking the narrowest pairs
+     * first keeps the resulting topology as close to equal-width as the existing layout allows.
+     */
+    private static List<int[]> narrowestFirstDisjointAdjacentPairs(List<KinesisShard> openByHashKey) {
+        List<int[]> pairs = new ArrayList<>();
+        for (int i = 0; i + 1 < openByHashKey.size(); i += 2) {
+            pairs.add(new int[]{i, i + 1});
+        }
+        pairs.sort(Comparator.comparing(pair ->
+                hashRangeWidth(openByHashKey.get(pair[0])).add(hashRangeWidth(openByHashKey.get(pair[1])))));
+        return pairs;
+    }
+
+    private static BigInteger hashRangeWidth(KinesisShard shard) {
+        BigInteger start = new BigInteger(shard.getHashKeyRange().startingHashKey());
+        BigInteger end = new BigInteger(shard.getHashKeyRange().endingHashKey());
+        return end.subtract(start).add(BigInteger.ONE);
+    }
+
+    private static String midpointHashKey(KinesisShard.HashKeyRange range) {
+        BigInteger start = new BigInteger(range.startingHashKey());
+        BigInteger end = new BigInteger(range.endingHashKey());
+        BigInteger width = end.subtract(start).add(BigInteger.ONE);
+        return start.add(width.divide(BigInteger.TWO)).toString();
     }
 
     public record PutRecordResult(String sequenceNumber, String shardId) {}

--- a/src/main/java/io/github/hectorvent/floci/services/kinesis/model/KinesisStream.java
+++ b/src/main/java/io/github/hectorvent/floci/services/kinesis/model/KinesisStream.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -28,6 +29,11 @@ public class KinesisStream {
     private Set<String> enhancedMonitoringMetrics = new HashSet<>();
     // AWS's default; streams persisted before this field existed read as the default too.
     private int maxRecordSizeInKiB = 1024;
+    /**
+     * UpdateShardCount call timestamps, kept to enforce the rolling 24-hour scaling-operation
+     * limit. Streams persisted before this field existed read back as an empty history.
+     */
+    private List<Instant> shardCountUpdateTimestamps = new ArrayList<>();
 
     public KinesisStream() {}
 
@@ -78,4 +84,9 @@ public class KinesisStream {
 
     public Set<String> getEnhancedMonitoringMetrics() { return enhancedMonitoringMetrics; }
     public void setEnhancedMonitoringMetrics(Set<String> enhancedMonitoringMetrics) { this.enhancedMonitoringMetrics = enhancedMonitoringMetrics; }
+
+    public List<Instant> getShardCountUpdateTimestamps() { return shardCountUpdateTimestamps; }
+    public void setShardCountUpdateTimestamps(List<Instant> shardCountUpdateTimestamps) {
+        this.shardCountUpdateTimestamps = shardCountUpdateTimestamps == null ? new ArrayList<>() : shardCountUpdateTimestamps;
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisJsonHandlerTest.java
@@ -1177,6 +1177,127 @@ class KinesisJsonHandlerTest {
         assertEquals("ResourceNotFoundException", ex.getErrorCode());
     }
 
+    private ObjectNode updateShardCount(String streamName, int targetShardCount, String scalingType) {
+        ObjectNode req = MAPPER.createObjectNode();
+        req.put("StreamName", streamName);
+        req.put("TargetShardCount", targetShardCount);
+        req.put("ScalingType", scalingType);
+        return responseEntity(handler.handle("UpdateShardCount", req, REGION));
+    }
+
+    @Test
+    void updateShardCountScalesUpAndReturnsExpectedShape() {
+        createStream("test-stream", 2);
+
+        ObjectNode response = updateShardCount("test-stream", 4, "UNIFORM_SCALING");
+        assertEquals("test-stream", response.get("StreamName").asText());
+        assertEquals(streamArn("test-stream"), response.get("StreamARN").asText());
+        assertEquals(2, response.get("CurrentShardCount").asInt());
+        assertEquals(4, response.get("TargetShardCount").asInt());
+
+        ObjectNode summaryReq = MAPPER.createObjectNode();
+        summaryReq.put("StreamName", "test-stream");
+        ObjectNode summary = (ObjectNode) responseEntity(
+                handler.handle("DescribeStreamSummary", summaryReq, REGION)).get("StreamDescriptionSummary");
+        assertEquals(4, summary.get("OpenShardCount").asInt());
+    }
+
+    @Test
+    void updateShardCountScalesDown() {
+        createStream("test-stream", 4);
+
+        ObjectNode response = updateShardCount("test-stream", 2, "UNIFORM_SCALING");
+        assertEquals(4, response.get("CurrentShardCount").asInt());
+        assertEquals(2, response.get("TargetShardCount").asInt());
+
+        ObjectNode summaryReq = MAPPER.createObjectNode();
+        summaryReq.put("StreamName", "test-stream");
+        ObjectNode summary = (ObjectNode) responseEntity(
+                handler.handle("DescribeStreamSummary", summaryReq, REGION)).get("StreamDescriptionSummary");
+        assertEquals(2, summary.get("OpenShardCount").asInt());
+    }
+
+    @Test
+    void updateShardCountRejectsTargetAboveDouble() {
+        createStream("test-stream", 2);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> updateShardCount("test-stream", 5, "UNIFORM_SCALING"));
+        assertEquals("LimitExceededException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountRejectsTargetBelowHalf() {
+        createStream("test-stream", 4);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> updateShardCount("test-stream", 1, "UNIFORM_SCALING"));
+        assertEquals("LimitExceededException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountRejectsNonUniformScalingType() {
+        createStream("test-stream", 2);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> updateShardCount("test-stream", 4, "BOGUS"));
+        assertEquals("InvalidArgumentException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountRejectsOnDemandStream() {
+        ObjectNode create = MAPPER.createObjectNode();
+        create.put("StreamName", "on-demand-stream");
+        create.put("ShardCount", 2);
+        create.putObject("StreamModeDetails").put("StreamMode", "ON_DEMAND");
+        assertThat(handler.handle("CreateStream", create, REGION).getStatus(), is(200));
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> updateShardCount("on-demand-stream", 4, "UNIFORM_SCALING"));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountRejectsAStreamThatIsNotActive() {
+        createStream("test-stream", 2);
+        service.describeStream("test-stream", REGION).setStreamStatus("UPDATING");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> updateShardCount("test-stream", 4, "UNIFORM_SCALING"));
+        assertEquals("ResourceInUseException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountRejectsUnknownStream() {
+        AwsException ex = assertThrows(AwsException.class,
+                () -> updateShardCount("missing-stream", 2, "UNIFORM_SCALING"));
+        assertEquals("ResourceNotFoundException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountLineageAfterSplitCoversWholeParentRange() {
+        createStream("test-stream", 1);
+
+        updateShardCount("test-stream", 2, "UNIFORM_SCALING");
+
+        ObjectNode descReq = MAPPER.createObjectNode();
+        descReq.put("StreamName", "test-stream");
+        ArrayNode shards = (ArrayNode) responseEntity(
+                handler.handle("DescribeStream", descReq, REGION)).get("StreamDescription").get("Shards");
+        assertEquals(3, shards.size());
+
+        ObjectNode parent = (ObjectNode) shards.get(0);
+        List<ObjectNode> children = new java.util.ArrayList<>();
+        for (JsonNode s : shards) {
+            if (s.has("ParentShardId") && s.get("ParentShardId").asText().equals(parent.get("ShardId").asText())) {
+                children.add((ObjectNode) s);
+            }
+        }
+        assertEquals(2, children.size());
+        assertFalse(children.get(0).has("AdjacentParentShardId"));
+        assertFalse(children.get(1).has("AdjacentParentShardId"));
+    }
+
     @Test
     void createStreamAppliesTagsFromTheRequest() {
         ObjectNode create = MAPPER.createObjectNode();

--- a/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/kinesis/KinesisServiceTest.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -446,6 +447,182 @@ class KinesisServiceTest {
         assertTrue(updated.getShards().get(0).isClosed());
         assertTrue(updated.getShards().get(1).isClosed());
         assertFalse(updated.getShards().get(2).isClosed());
+    }
+
+    @Test
+    void updateShardCountScalesUpToDouble() {
+        kinesisService.createStream("my-stream", 2, REGION);
+
+        KinesisService.UpdateShardCountResult result =
+                kinesisService.updateShardCount("my-stream", 4, "UNIFORM_SCALING", REGION);
+
+        assertEquals(2, result.currentShardCount());
+        assertEquals(4, result.targetShardCount());
+        assertEquals("my-stream", result.streamName());
+
+        KinesisStream updated = kinesisService.describeStream("my-stream", REGION);
+        List<KinesisShard> openShards = updated.getShards().stream().filter(s -> !s.isClosed()).toList();
+        assertEquals(4, openShards.size());
+        assertEquals(2, updated.getShards().stream().filter(KinesisShard::isClosed).count());
+    }
+
+    @Test
+    void updateShardCountScalesDownToHalf() {
+        kinesisService.createStream("my-stream", 4, REGION);
+
+        KinesisService.UpdateShardCountResult result =
+                kinesisService.updateShardCount("my-stream", 2, "UNIFORM_SCALING", REGION);
+
+        assertEquals(4, result.currentShardCount());
+        assertEquals(2, result.targetShardCount());
+
+        KinesisStream updated = kinesisService.describeStream("my-stream", REGION);
+        List<KinesisShard> openShards = updated.getShards().stream().filter(s -> !s.isClosed()).toList();
+        assertEquals(2, openShards.size());
+        assertEquals(4, updated.getShards().stream().filter(KinesisShard::isClosed).count());
+    }
+
+    @Test
+    void updateShardCountRejectsTargetAboveDouble() {
+        kinesisService.createStream("my-stream", 2, REGION);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> kinesisService.updateShardCount("my-stream", 5, "UNIFORM_SCALING", REGION));
+        assertEquals("LimitExceededException", ex.getErrorCode());
+
+        assertEquals(2, kinesisService.describeStream("my-stream", REGION).getShards().size());
+    }
+
+    @Test
+    void updateShardCountRejectsTargetBelowHalf() {
+        kinesisService.createStream("my-stream", 4, REGION);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> kinesisService.updateShardCount("my-stream", 1, "UNIFORM_SCALING", REGION));
+        assertEquals("LimitExceededException", ex.getErrorCode());
+
+        assertEquals(4, kinesisService.describeStream("my-stream", REGION).getShards().size());
+    }
+
+    @Test
+    void updateShardCountAllowsExactlyHalfRoundedUp() {
+        // current=5, half rounded up is 3: 2 is rejected, 3 is the lowest allowed target.
+        kinesisService.createStream("my-stream", 5, REGION);
+
+        assertThrows(AwsException.class,
+                () -> kinesisService.updateShardCount("my-stream", 2, "UNIFORM_SCALING", REGION));
+
+        KinesisService.UpdateShardCountResult result =
+                kinesisService.updateShardCount("my-stream", 3, "UNIFORM_SCALING", REGION);
+        assertEquals(3, result.targetShardCount());
+    }
+
+    @Test
+    void updateShardCountRejectsNonUniformScalingType() {
+        kinesisService.createStream("my-stream", 2, REGION);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> kinesisService.updateShardCount("my-stream", 4, "BISECTION", REGION));
+        assertEquals("InvalidArgumentException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountRejectsOnDemandStream() {
+        kinesisService.createStream("my-stream", 2, "ON_DEMAND", REGION);
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> kinesisService.updateShardCount("my-stream", 4, "UNIFORM_SCALING", REGION));
+        assertEquals("ValidationException", ex.getErrorCode());
+    }
+
+    @Test
+    void updateShardCountSplitLineageRecordsParentAndCoversWholeRange() {
+        kinesisService.createStream("my-stream", 2, REGION);
+        KinesisStream before = kinesisService.describeStream("my-stream", REGION);
+        List<String> originalOpenIds = before.getShards().stream().map(KinesisShard::getShardId).toList();
+
+        kinesisService.updateShardCount("my-stream", 4, "UNIFORM_SCALING", REGION);
+
+        KinesisStream after = kinesisService.describeStream("my-stream", REGION);
+        List<KinesisShard> newOpenShards = after.getShards().stream()
+                .filter(s -> !s.isClosed())
+                .toList();
+        assertEquals(4, newOpenShards.size());
+
+        for (KinesisShard child : newOpenShards) {
+            assertNotNull(child.getParentShardId(), "each split child must record its parent");
+            assertTrue(originalOpenIds.contains(child.getParentShardId()),
+                    "split child's parent must be one of the pre-scaling open shards");
+            assertNull(child.getAdjacentParentShardId(), "a split child has no adjacent parent");
+        }
+
+        for (String originalId : originalOpenIds) {
+            KinesisShard closedParent = after.getShards().stream()
+                    .filter(s -> s.getShardId().equals(originalId))
+                    .findFirst().orElseThrow();
+            assertTrue(closedParent.isClosed(), "original open shards must be closed after a split");
+
+            List<KinesisShard> children = newOpenShards.stream()
+                    .filter(s -> originalId.equals(s.getParentShardId()))
+                    .toList();
+            assertEquals(2, children.size(), "each split parent must have exactly two children");
+            KinesisShard first = children.get(0);
+            KinesisShard second = children.get(1);
+            assertEquals(closedParent.getHashKeyRange().startingHashKey(), first.getHashKeyRange().startingHashKey());
+            assertEquals(closedParent.getHashKeyRange().endingHashKey(), second.getHashKeyRange().endingHashKey());
+            assertEquals(
+                    new java.math.BigInteger(first.getHashKeyRange().endingHashKey()).add(java.math.BigInteger.ONE).toString(),
+                    second.getHashKeyRange().startingHashKey(),
+                    "children must tile the parent's range with no gap or overlap");
+        }
+    }
+
+    @Test
+    void updateShardCountMergeLineageRecordsBothParents() {
+        kinesisService.createStream("my-stream", 4, REGION);
+        KinesisStream before = kinesisService.describeStream("my-stream", REGION);
+        List<KinesisShard> originalOpenShards = before.getShards().stream()
+                .sorted(Comparator.comparing(s -> new java.math.BigInteger(s.getHashKeyRange().startingHashKey())))
+                .toList();
+
+        kinesisService.updateShardCount("my-stream", 2, "UNIFORM_SCALING", REGION);
+
+        KinesisStream after = kinesisService.describeStream("my-stream", REGION);
+        List<KinesisShard> newOpenShards = after.getShards().stream()
+                .filter(s -> !s.isClosed())
+                .toList();
+        assertEquals(2, newOpenShards.size());
+
+        List<String> expectedParents = originalOpenShards.stream().map(KinesisShard::getShardId).toList();
+        List<String> actualParentPairs = new ArrayList<>();
+        for (KinesisShard mergedShard : newOpenShards) {
+            assertNotNull(mergedShard.getParentShardId(), "merge child must record its first parent");
+            assertNotNull(mergedShard.getAdjacentParentShardId(), "merge child must record its adjacent parent");
+            actualParentPairs.add(mergedShard.getParentShardId());
+            actualParentPairs.add(mergedShard.getAdjacentParentShardId());
+        }
+        assertEquals(new HashSet<>(expectedParents), new HashSet<>(actualParentPairs));
+
+        for (String originalId : expectedParents) {
+            KinesisShard closedParent = after.getShards().stream()
+                    .filter(s -> s.getShardId().equals(originalId))
+                    .findFirst().orElseThrow();
+            assertTrue(closedParent.isClosed(), "merged parent shards must be closed");
+        }
+    }
+
+    @Test
+    void updateShardCountRejectsMoreThanTenScalesInRollingDay() {
+        kinesisService.createStream("my-stream", 128, REGION);
+        String streamName = "my-stream";
+        for (int i = 0; i < 10; i++) {
+            int target = 128 + (i % 2 == 0 ? 1 : -1);
+            kinesisService.updateShardCount(streamName, target, "UNIFORM_SCALING", REGION);
+        }
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> kinesisService.updateShardCount(streamName, 129, "UNIFORM_SCALING", REGION));
+        assertEquals("LimitExceededException", ex.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements the Kinesis `UpdateShardCount` action, which was previously unimplemented (fell through to `UnsupportedOperation`). Closes #3064.

`ScalingType` accepts only `UNIFORM_SCALING`, matching AWS. Reshard is expressed as a sequence of the existing `splitShard`/`mergeShards` operations rather than a new resharding algorithm:

- Scale up: the widest open shards are split (via `splitShard`) until the target count is reached, so shard lineage (`ParentShardId`) is produced by the same code path `SplitShard` uses.
- Scale down: open shards are paired up by a fixed (0,1), (2,3), ... adjacency (by starting hash key) so any subset of pairs is always mergeable without conflicts, and the narrowest-combined-width pairs are merged first (via `mergeShards`) until the target count is reached, giving correct `ParentShardId`/`AdjacentParentShardId` lineage.

Validation enforces AWS's documented default limits for this API:
- `TargetShardCount` must not exceed double, or fall below half (rounded up), the current open shard count -> `LimitExceededException`. The round-up direction for an odd current count is floci's own conservative choice: AWS's docs say only "below half" with no stated rounding, and this is now called out explicitly in docs/services/kinesis.md and the method's Javadoc rather than implied as observed AWS behavior.
- `TargetShardCount` must not exceed 10000 shards per stream, and a stream already above that limit can only be scaled further down -> `LimitExceededException`.
- No more than 10 `UpdateShardCount` calls per stream in a rolling 24-hour window -> `LimitExceededException`. AWS separately documents a 10 TPS call-rate limit on this action; that one is intentionally unsimulated, matching floci's lack of real-time request throttling elsewhere, and this is now documented explicitly too.
- The stream must be `PROVISIONED` (not `ON_DEMAND`) -> `ValidationException`.
- The stream must be `ACTIVE` -> `ResourceInUseException`.
- `ScalingType` other than `UNIFORM_SCALING`, or a malformed `TargetShardCount` -> `InvalidArgumentException`.

Response returns `StreamName`, `StreamARN`, `CurrentShardCount` (the open shard count before scaling, matching the documented example), and `TargetShardCount`.

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

Verified against the `UpdateShardCount` API reference (https://docs.aws.amazon.com/kinesis/latest/APIReference/API_UpdateShardCount.html) for request/response shape, the documented default limits, and the modeled error list. The resharding dev guide (https://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-resharding.html) confirms resharding is always pairwise (one parent splits into two children, or two parents merge into one child), which is exactly what the existing `SplitShard`/`MergeShards` machinery already implements and this change reuses.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits