### PR TITLE
feat(iot): configurable DescribeEndpoint address for published AWS IoT ports

### DIFF
--- a/docs/configuration/environment-variables.md
+++ b/docs/configuration/environment-variables.md
@@ -324,6 +324,19 @@ See [Initialization Hooks](./initialization-hooks.md) for lifecycle phases and s
 |---|---|---|
 | `FLOCI_SERVICES_PIPES_ENABLED` | `true` | Enable the EventBridge Pipes service |
 
+### IoT Core
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_SERVICES_IOT_ENABLED` | `true` | Enable the IoT Core service |
+| `FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS` | _(none)_ | Value `DescribeEndpoint` returns for every endpoint type, and the domain name of the AWS-managed domain configurations. Set it to a bare hostname when the AWS IoT ports (8883, 443, 8443) reach Floci; the name is added to the server certificate. Defaults to the host and port of `FLOCI_BASE_URL`, with `FLOCI_HOSTNAME` applied |
+| `FLOCI_SERVICES_IOT_RULE_SQL_STRICT` | `false` | Reject topic rules whose SQL falls outside the evaluated subset, as AWS does |
+| `FLOCI_SERVICES_IOT_MQTT_ENABLED` | `true` | Run the embedded MQTT broker |
+| `FLOCI_SERVICES_IOT_MQTT_AUTO_START` | `false` | Start the broker at boot instead of on the first IoT API call |
+| `FLOCI_SERVICES_IOT_MQTT_HOST` | `0.0.0.0` | Address the broker listens on |
+| `FLOCI_SERVICES_IOT_MQTT_PORT` | `1883` | Plaintext MQTT port |
+| `FLOCI_SERVICES_IOT_MQTT_TLS_PORT` | `8883` | MQTT over TLS port, opened while `FLOCI_TLS_ENABLED` is `true`; `0` disables it |
+
 ---
 
 ## Services — Container-Backed

--- a/docs/configuration/tls.md
+++ b/docs/configuration/tls.md
@@ -58,7 +58,7 @@ When `FLOCI_TLS_ENABLED=true` and no custom certificate is provided, Floci keeps
 - Includes `localhost`, `127.0.0.1`, `0.0.0.0`, `*.localhost`, `localhost.floci.io`,
   `*.localhost.floci.io`, `*.execute-api.localhost.floci.io`, and
   `*.execute-api.localhost.localstack.cloud` as Subject Alternative Names (SANs)
-- Automatically includes custom hostnames from `FLOCI_HOSTNAME` and `FLOCI_BASE_URL` in the SANs
+- Automatically includes custom hostnames from `FLOCI_HOSTNAME`, `FLOCI_BASE_URL` and `FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS` in the SANs
 - Is regenerated when hostname configuration changes between restarts, or when it was not issued by the current CA
 
 The CA is created once and never rotates on its own. If its files are missing, corrupt or do not match each other, Floci generates a new CA, logs a warning, and reissues the server certificate; clients then need the new `ca.pem`.
@@ -125,7 +125,7 @@ No additional configuration is needed: Vert.x handles TLS at the transport layer
 
 ## MQTT over TLS (8883)
 
-When TLS is enabled, the IoT MQTT broker also listens on port 8883 with the same certificate as the HTTPS endpoint, hostnames learned at runtime included. Devices connect with `ssl://` trusting `ca.pem`; see [IoT Core](../services/iot.md#mqtt-over-tls).
+When TLS is enabled, the IoT MQTT broker also listens on port 8883 with the same certificate as the HTTPS endpoint, hostnames learned at runtime included. Devices connect with `ssl://` trusting `ca.pem`; see [IoT Core](../services/iot.md#mqtt-over-tls). Devices that take the hostname from `DescribeEndpoint` and add their own port need `FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS`, see [Endpoint address](../services/iot.md#endpoint-address).
 
 ## SDK Configuration Examples
 

--- a/docs/services/iot.md
+++ b/docs/services/iot.md
@@ -64,7 +64,7 @@ Status: control plane only.
 
 Current limitations:
 
-- A custom domain does not change where the broker listens. `DescribeEndpoint` keeps returning Floci's own address, and pointing DNS at the emulator is outside its scope.
+- A custom domain does not change where the broker listens or what `DescribeEndpoint` returns (see [Endpoint address](#endpoint-address)), and pointing DNS at the emulator is outside its scope.
 - Server certificate ARNs are stored as given and reported `VALID`; they are not checked against ACM.
 
 ## MQTT Broker
@@ -111,6 +111,28 @@ The connection is admitted when all of these hold, otherwise the broker answers 
 Policy variables are substituted and are also available as condition keys: `iot:ClientId`, `aws:SourceIp`, `iot:DomainName` (the server name the client sent in the TLS handshake, absent when it dialled an IP address), `iot:Connection.Thing.IsAttached` and, only when the client id names a thing attached to the certificate with `AttachThingPrincipal`, `iot:Connection.Thing.ThingName`, `iot:Connection.Thing.ThingTypeName` and `iot:Connection.Thing.Attributes[name]`. A statement that uses a variable Floci cannot resolve, such as the certificate variables `iot:Certificate.*`, matches nothing.
 
 Differences from AWS: AWS rejects an unregistered, inactive or expired certificate during the TLS handshake and closes an MQTT 3.1.1 connection it does not authorize without a `CONNACK`; Floci completes the handshake and always answers with the return code, so the reason is visible to the client. Deactivating the certificate or detaching the policy takes effect on the next connect; established sessions are not dropped. Policies attached to thing groups are not consulted, and exclusive thing attachment (`thingPrincipalType`) is not modelled: the thing is always the one named by the client id.
+
+### Endpoint address
+
+`DescribeEndpoint` returns `host:4566` by default, the host and port of Floci's base URL, because that is where the HTTP data plane lives and IoT Data clients build `https://<endpointAddress>` from it. The four AWS-managed domain configurations report the same value as their `domainName`.
+
+AWS returns a bare hostname and lets each client add its own port: 8883 for MQTT with a client certificate, 443 for HTTPS and MQTT over WebSocket, 8443 for HTTPS with a client certificate. With TLS enabled, Floci serves MQTT on 8883 and HTTPS on 443 next to 4566. When those ports reach Floci, set `FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS` and `DescribeEndpoint` answers like AWS:
+
+```yaml
+services:
+  floci:
+    image: floci/floci:latest
+    environment:
+      FLOCI_TLS_ENABLED: "true"
+      FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS: iot.example.localhost.floci.io
+    ports:
+      - "4566:4566"
+      - "8883:8883"   # MQTT over TLS
+      - "443:443"     # HTTPS data plane, https://<endpointAddress>/topics/<topic>
+      - "8443:443"    # optional: the HTTPS port AWS uses with client certificates
+```
+
+The value is a hostname or `host:port`, never a URL, and is returned as is for every endpoint type: AWS hands out one hostname per type (`iot:Data-ATS`, `iot:Data`, `iot:Jobs`, `iot:CredentialProvider`), Floci answers all four with this one. The name is added to the generated server certificate, like `FLOCI_HOSTNAME`, so devices verify it on 8883 and 443; a name under `localhost.floci.io` resolves to `127.0.0.1` on its own, any other needs a DNS or `/etc/hosts` entry. Floci does not detect published ports itself: unset, or set to an empty value, `DescribeEndpoint` keeps returning `host:4566`, so the plain `-p 4566:4566` setup keeps working for IoT Data clients.
 
 ## Reserved Topics
 

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.config;
 
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalInt;
@@ -40,6 +41,18 @@ public interface EmulatorConfig {
             url = "https://" + url.substring(7);
         }
         return url;
+    }
+
+    /**
+     * The address IoT Core's DescribeEndpoint returns for every endpoint type, also the domain
+     * name of the AWS-managed domain configurations: {@code floci.services.iot.endpoint-address}
+     * when set, otherwise the host and port of {@link #effectiveBaseUrl()}.
+     */
+    default String iotEndpointAddress() {
+        return services().iot().endpointAddress()
+                .map(String::strip)
+                .filter(address -> !address.isEmpty())
+                .orElseGet(() -> URI.create(effectiveBaseUrl()).getAuthority());
     }
 
     @WithDefault("us-east-1")
@@ -789,6 +802,15 @@ public interface EmulatorConfig {
          */
         @WithDefault("false")
         boolean ruleSqlStrict();
+
+        /**
+         * Returned as is by DescribeEndpoint for every endpoint type when set. AWS returns a bare
+         * hostname and clients add their own port: 8883 for MQTT, 443 for HTTPS and MQTT over
+         * WebSocket, 8443 for HTTPS with a client certificate. Set it when those ports reach Floci
+         * (8883 to the MQTT TLS listener, 443 and 8443 to the HTTPS listener). Unset, DescribeEndpoint
+         * returns the host and port of the base URL. Env: FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS
+         */
+        Optional<String> endpointAddress();
 
         MqttConfig mqtt();
     }

--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -298,7 +298,8 @@ public class TlsConfigSource implements ConfigSource {
     }
 
     /**
-     * Extracts custom hostnames from FLOCI_HOSTNAME and FLOCI_BASE_URL configuration.
+     * Extracts custom hostnames from FLOCI_HOSTNAME, FLOCI_BASE_URL and
+     * FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS configuration.
      * Filters out default values like "localhost" and "127.0.0.1".
      * Returns a deduplicated list of custom hostnames.
      *
@@ -325,6 +326,26 @@ public class TlsConfigSource implements ConfigSource {
             }
         } catch (URISyntaxException e) {
             LOG.warnv("TLS: failed to parse base URL for hostname extraction: {0}", baseUrl);
+        }
+
+        // Extract from FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS: devices verify that name on 8883 and 443
+        String iotEndpoint = resolveProperty("floci.services.iot.endpoint-address", "").strip();
+        if (!iotEndpoint.isEmpty()) {
+            try {
+                // A URL or a path here is a typo: java.net.URI would read "https" as the host.
+                URI uri = new URI("//" + iotEndpoint);
+                String host = uri.getHost();
+                if (host == null || !uri.getPath().isEmpty() || uri.getUserInfo() != null) {
+                    LOG.warnv("TLS: floci.services.iot.endpoint-address is not a host or host:port, not added to the certificate: {0}",
+                            iotEndpoint);
+                } else if (!isDefaultHostname(host)) {
+                    hostnames.add(host);
+                    LOG.debugv("TLS: extracted hostname from floci.services.iot.endpoint-address: {0}", host);
+                }
+            } catch (URISyntaxException e) {
+                LOG.warnv("TLS: failed to parse floci.services.iot.endpoint-address for hostname extraction: {0}",
+                        iotEndpoint);
+            }
         }
 
         List<String> result = new ArrayList<>(hostnames);

--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -332,10 +332,10 @@ public class TlsConfigSource implements ConfigSource {
         String iotEndpoint = resolveProperty("floci.services.iot.endpoint-address", "").strip();
         if (!iotEndpoint.isEmpty()) {
             try {
-                // A URL or a path here is a typo: java.net.URI would read "https" as the host.
+                // Anything beyond host[:port] is a typo: java.net.URI would read "https" as the host of a URL.
                 URI uri = new URI("//" + iotEndpoint);
                 String host = uri.getHost();
-                if (host == null || !uri.getPath().isEmpty() || uri.getUserInfo() != null) {
+                if (host == null || uri.getUserInfo() != null || !iotEndpoint.equals(uri.getRawAuthority())) {
                     LOG.warnv("TLS: floci.services.iot.endpoint-address is not a host or host:port, not added to the certificate: {0}",
                             iotEndpoint);
                 } else if (!isDefaultHostname(host)) {

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationService.java
@@ -19,7 +19,6 @@ import io.github.hectorvent.floci.services.iot.model.IotDomainConfiguration.TlsC
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -278,24 +277,31 @@ public class IotDomainConfigurationService {
     /**
      * The default-endpoint configurations AWS creates for every account: AWS_MANAGED, ENABLED, no
      * server certificate, and the address DescribeEndpoint returns as their domain name. They can
-     * be updated and tagged like any other, but not deleted.
+     * be updated and tagged like any other, but not deleted. A stored one whose domain name no
+     * longer matches that address (the emulator restarted with another base URL or
+     * {@code floci.services.iot.endpoint-address}) takes the current one and keeps everything else.
      */
     private void seedAwsManaged(String region) {
+        String domainName = config.iotEndpointAddress();
         synchronized (lock) {
             AWS_MANAGED.forEach((name, serviceType) -> {
                 String key = key(region, name);
-                if (store.get(key).isEmpty()) {
-                    store.put(key, awsManaged(name, serviceType, region));
+                IotDomainConfiguration existing = store.get(key).orElse(null);
+                if (existing == null) {
+                    store.put(key, awsManaged(name, serviceType, domainName, region));
+                } else if (!domainName.equals(existing.getDomainName())) {
+                    existing.setDomainName(domainName);
+                    store.put(key, existing);
                 }
             });
         }
     }
 
-    private IotDomainConfiguration awsManaged(String name, String serviceType, String region) {
+    private IotDomainConfiguration awsManaged(String name, String serviceType, String domainName, String region) {
         IotDomainConfiguration configuration = new IotDomainConfiguration();
         configuration.setDomainConfigurationName(name);
         configuration.setDomainConfigurationArn(arn(name, region));
-        configuration.setDomainName(URI.create(config.effectiveBaseUrl()).getAuthority());
+        configuration.setDomainName(domainName);
         configuration.setServiceType(serviceType);
         configuration.setDomainConfigurationStatus("ENABLED");
         configuration.setDomainType("AWS_MANAGED");

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotService.java
@@ -47,7 +47,6 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -224,8 +223,7 @@ public class IotService {
             throw new AwsException("InvalidRequestException", "Unsupported endpoint type: " + effectiveType, 400);
         }
         startMqttIfEnabled();
-        URI baseUri = URI.create(config.effectiveBaseUrl());
-        return baseUri.getAuthority();
+        return config.iotEndpointAddress();
     }
 
     public Thing createThing(String thingName, Map<String, String> attributes, String region) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -586,6 +586,7 @@ floci:
     iot:
       enabled: true
       rule-sql-strict: false
+      # endpoint-address: ""  # DescribeEndpoint value when the AWS IoT ports (8883, 443, 8443) reach Floci; default: host and port of base-url
       mqtt:
         enabled: true
         auto-start: false

--- a/src/test/java/io/github/hectorvent/floci/config/EmulatorConfigIotEndpointAddressTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/EmulatorConfigIotEndpointAddressTest.java
@@ -1,0 +1,61 @@
+package io.github.hectorvent.floci.config;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link EmulatorConfig#iotEndpointAddress()}: the configured address when there is one,
+ * otherwise the host and port of the effective base URL.
+ */
+class EmulatorConfigIotEndpointAddressTest {
+
+    private static EmulatorConfig config(String effectiveBaseUrl, Optional<String> endpointAddress) {
+        EmulatorConfig config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        when(config.effectiveBaseUrl()).thenReturn(effectiveBaseUrl);
+        when(config.services().iot().endpointAddress()).thenReturn(endpointAddress);
+        when(config.iotEndpointAddress()).thenCallRealMethod();
+        return config;
+    }
+
+    @Test
+    void unsetFallsBackToTheHostAndPortOfTheBaseUrl() {
+        assertEquals("localhost:4566", config("http://localhost:4566", Optional.empty()).iotEndpointAddress());
+    }
+
+    @Test
+    void fallbackDropsSchemeAndPath() {
+        assertEquals("floci:4566", config("https://floci:4566/", Optional.empty()).iotEndpointAddress());
+    }
+
+    @Test
+    void configuredAddressIsReturnedVerbatim() {
+        assertEquals("iot.example.localhost.floci.io",
+                config("http://localhost:4566", Optional.of("iot.example.localhost.floci.io")).iotEndpointAddress());
+    }
+
+    @Test
+    void configuredAddressKeepsAPortTheOperatorAdded() {
+        assertEquals("iot.example.localhost.floci.io:8443",
+                config("http://localhost:4566", Optional.of("iot.example.localhost.floci.io:8443")).iotEndpointAddress());
+    }
+
+    @Test
+    void surroundingWhitespaceIsDropped() {
+        assertEquals("iot.example.localhost.floci.io",
+                config("http://localhost:4566", Optional.of("  iot.example.localhost.floci.io\n")).iotEndpointAddress());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "   ", "\t\n"})
+    void blankAddressCountsAsUnset(String blank) {
+        assertEquals("localhost:4566", config("http://localhost:4566", Optional.of(blank)).iotEndpointAddress());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateGenerationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificateGenerationTest.java
@@ -45,6 +45,7 @@ class TlsConfigSourceCertificateGenerationTest {
         System.clearProperty("floci.storage.persistent-path");
         System.clearProperty("floci.hostname");
         System.clearProperty("floci.base-url");
+        System.clearProperty("floci.services.iot.endpoint-address");
     }
 
     /**
@@ -215,6 +216,36 @@ class TlsConfigSourceCertificateGenerationTest {
             "Metadata should include 'myhost' hostname");
         assertTrue(json.contains("localhost"), 
             "Metadata should include default 'localhost' hostname");
+    }
+
+    /**
+     * The IoT endpoint address is what devices verify on 8883 and 443, so the boot certificate
+     * covers it even when it has more labels than the wildcard SAN matches.
+     */
+    @Test
+    void testCertificateIncludesIotEndpointAddress() throws Exception {
+        System.setProperty("floci.services.iot.endpoint-address", "iot.example.localhost.floci.io:8883");
+
+        new TlsConfigSource();
+
+        List<String> sans = extractSansFromCertificate(tempDir.resolve("tls/floci-server.crt"));
+        assertTrue(sans.contains("iot.example.localhost.floci.io"), sans.toString());
+        assertFalse(sans.contains("iot.example.localhost.floci.io:8883"), "the port is not part of the name");
+        assertTrue(Files.readString(tempDir.resolve("tls/floci-server.metadata.json")).contains("iot.example.localhost.floci.io"),
+            "the metadata records it as a configured name, so a later change is detected");
+    }
+
+    @Test
+    void testIotEndpointAddressAddedAfterBootRegeneratesTheCertificate() throws Exception {
+        new TlsConfigSource();
+        Path certFile = tempDir.resolve("tls/floci-server.crt");
+        assertFalse(extractSansFromCertificate(certFile).contains("iot.example.localhost.floci.io"));
+
+        System.setProperty("floci.services.iot.endpoint-address", "iot.example.localhost.floci.io");
+        new TlsConfigSource();
+
+        assertTrue(extractSansFromCertificate(certFile).contains("iot.example.localhost.floci.io"),
+            "a changed endpoint address is a hostname configuration change");
     }
 
     // ==================== Helper Methods ====================

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceHostnameExtractionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceHostnameExtractionTest.java
@@ -310,7 +310,8 @@ class TlsConfigSourceHostnameExtractionTest {
     @Test
     void testIotEndpointAddressWithASchemeOrPathIsSkipped() throws Exception {
         for (String typo : List.of("https://iot.example.localhost.floci.io", "iot.example.localhost.floci.io:8443/",
-                "user@iot.example.localhost.floci.io", "iot.example.localhost.floci.io:abc")) {
+                "user@iot.example.localhost.floci.io", "iot.example.localhost.floci.io:abc",
+                "iot.example.localhost.floci.io?x=1", "iot.example.localhost.floci.io#fragment")) {
             System.setProperty("floci.services.iot.endpoint-address", typo);
 
             assertTrue(invokeExtractCustomHostnames().isEmpty(), typo);

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceHostnameExtractionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceHostnameExtractionTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * Tests the extractCustomHostnames() method to verify:
  * - Extraction from FLOCI_HOSTNAME
  * - Extraction from FLOCI_BASE_URL (DNS names and IP addresses)
+ * - Extraction from FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS (the port, when given, is dropped)
  * - Filtering of default values (localhost, 127.0.0.1, 0.0.0.0)
  * - Deduplication of hostnames
  * - Edge case handling (malformed URLs, missing host, IPv6 addresses)
@@ -24,6 +25,7 @@ class TlsConfigSourceHostnameExtractionTest {
     void cleanupSystemProperties() {
         System.clearProperty("floci.hostname");
         System.clearProperty("floci.base-url");
+        System.clearProperty("floci.services.iot.endpoint-address");
     }
 
     /**
@@ -241,6 +243,78 @@ class TlsConfigSourceHostnameExtractionTest {
         // IPv6 loopback should be extracted (URI.getHost() returns it with brackets)
         assertTrue(hostnames.contains("[::1]"), 
             "Should extract IPv6 address '[::1]' from FLOCI_BASE_URL");
+    }
+
+    /**
+     * The IoT endpoint address is a name devices verify on 8883 and 443, so it joins the SANs.
+     */
+    @Test
+    void testExtractFromIotEndpointAddress() throws Exception {
+        System.setProperty("floci.services.iot.endpoint-address", "iot.example.localhost.floci.io");
+
+        List<String> hostnames = invokeExtractCustomHostnames();
+
+        assertEquals(List.of("iot.example.localhost.floci.io"), hostnames);
+    }
+
+    @Test
+    void testIotEndpointAddressPortIsDropped() throws Exception {
+        System.setProperty("floci.services.iot.endpoint-address", "iot.example.localhost.floci.io:8443");
+
+        List<String> hostnames = invokeExtractCustomHostnames();
+
+        assertEquals(List.of("iot.example.localhost.floci.io"), hostnames);
+    }
+
+    @Test
+    void testIotEndpointAddressKeepsAnIpv6Literal() throws Exception {
+        System.setProperty("floci.services.iot.endpoint-address", "[fd00::10]:8883");
+
+        List<String> hostnames = invokeExtractCustomHostnames();
+
+        assertEquals(List.of("[fd00::10]"), hostnames);
+    }
+
+    @Test
+    void testIotEndpointAddressDefaultHostIsFiltered() throws Exception {
+        System.setProperty("floci.services.iot.endpoint-address", "localhost:4566");
+
+        List<String> hostnames = invokeExtractCustomHostnames();
+
+        assertTrue(hostnames.isEmpty(), "localhost is covered by the default SANs");
+    }
+
+    @Test
+    void testIotEndpointAddressIsDeduplicatedAgainstHostname() throws Exception {
+        System.setProperty("floci.hostname", "floci");
+        System.setProperty("floci.services.iot.endpoint-address", "floci:8883");
+
+        List<String> hostnames = invokeExtractCustomHostnames();
+
+        assertEquals(List.of("floci"), hostnames);
+    }
+
+    @Test
+    void testUnparsableIotEndpointAddressIsSkipped() throws Exception {
+        System.setProperty("floci.services.iot.endpoint-address", "not a host");
+
+        List<String> hostnames = invokeExtractCustomHostnames();
+
+        assertTrue(hostnames.isEmpty(), "an address that is not a host is logged and skipped, not fatal");
+    }
+
+    /**
+     * A URL instead of a host is an operator typo: java.net.URI would read "https" as the host,
+     * so the value is skipped rather than adding a wrong name to the certificate.
+     */
+    @Test
+    void testIotEndpointAddressWithASchemeOrPathIsSkipped() throws Exception {
+        for (String typo : List.of("https://iot.example.localhost.floci.io", "iot.example.localhost.floci.io:8443/",
+                "user@iot.example.localhost.floci.io", "iot.example.localhost.floci.io:abc")) {
+            System.setProperty("floci.services.iot.endpoint-address", typo);
+
+            assertTrue(invokeExtractCustomHostnames().isEmpty(), typo);
+        }
     }
 
     // ==================== Helper Methods ====================

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotDescribeEndpointOverrideIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotDescribeEndpointOverrideIntegrationTest.java
@@ -1,0 +1,78 @@
+package io.github.hectorvent.floci.services.iot;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * With {@code floci.services.iot.endpoint-address} set, DescribeEndpoint answers with that value
+ * for every endpoint type, the way AWS returns a bare hostname that devices complete with their
+ * own port. {@link IotIntegrationTest} and {@link IotEndpointHostnameIntegrationTest} keep
+ * guarding the unset case, the host and port of the base URL.
+ */
+@QuarkusTest
+@TestProfile(IotDescribeEndpointOverrideIntegrationTest.Profile.class)
+class IotDescribeEndpointOverrideIntegrationTest {
+
+    static final String ENDPOINT_ADDRESS = "iot.example.localhost.floci.io";
+
+    @Test
+    void omittedEndpointTypeReturnsTheConfiguredAddress() {
+        given()
+        .when()
+            .get("/endpoint")
+        .then()
+            .statusCode(200)
+            .body("endpointAddress", equalTo(ENDPOINT_ADDRESS));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"iot:Data-ATS", "iot:Data", "iot:Jobs", "iot:CredentialProvider"})
+    void everyEndpointTypeReturnsTheConfiguredAddressVerbatim(String endpointType) {
+        given()
+            .queryParam("endpointType", endpointType)
+        .when()
+            .get("/endpoint")
+        .then()
+            .statusCode(200)
+            .body("endpointAddress", equalTo(ENDPOINT_ADDRESS));
+    }
+
+    @Test
+    void unsupportedEndpointTypeIsStillRejected() {
+        given()
+            .queryParam("endpointType", "iot:Nonsense")
+        .when()
+            .get("/endpoint")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"iot:Data-ATS", "iot:Data", "iot:Jobs", "iot:CredentialProvider"})
+    void awsManagedDomainConfigurationsReportTheConfiguredAddress(String name) {
+        given()
+        .when()
+            .get("/domainConfigurations/" + name)
+        .then()
+            .statusCode(200)
+            .body("domainType", equalTo("AWS_MANAGED"))
+            .body("domainName", equalTo(ENDPOINT_ADDRESS));
+    }
+
+    public static final class Profile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci.services.iot.endpoint-address", ENDPOINT_ADDRESS);
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationServiceTest.java
@@ -13,13 +13,16 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -39,13 +42,15 @@ class IotDomainConfigurationServiceTest {
             "arn:aws:acm:us-east-1:000000000000:certificate/22222222-2222-2222-2222-222222222222";
 
     private final ObjectMapper mapper = new ObjectMapper();
+    /** What DescribeEndpoint answers; tests change it to model a restart with another address. */
+    private final AtomicReference<String> endpointAddress = new AtomicReference<>("localhost:4566");
     private final IotDomainConfigurationService service = new IotDomainConfigurationService(
-            new InMemoryStorage<>(), new RegionResolver(REGION, "000000000000"), endpointConfig(),
+            new InMemoryStorage<>(), new RegionResolver(REGION, "000000000000"), endpointConfig(endpointAddress),
             mock(TlsCertificateManager.class));
 
-    private static EmulatorConfig endpointConfig() {
+    private static EmulatorConfig endpointConfig(AtomicReference<String> endpointAddress) {
         EmulatorConfig config = mock(EmulatorConfig.class);
-        when(config.effectiveBaseUrl()).thenReturn("http://localhost:4566");
+        when(config.iotEndpointAddress()).thenAnswer(invocation -> endpointAddress.get());
         return config;
     }
 
@@ -204,6 +209,45 @@ class IotDomainConfigurationServiceTest {
     }
 
     @Test
+    void awsManagedConfigurationsCarryTheDescribeEndpointAddress() {
+        endpointAddress.set("iot.example.localhost.floci.io");
+
+        for (String name : List.of("iot:Data-ATS", "iot:Data", "iot:CredentialProvider", "iot:Jobs")) {
+            assertEquals("iot.example.localhost.floci.io",
+                    service.describeDomainConfiguration(name, REGION).getDomainName(), name);
+        }
+    }
+
+    @Test
+    void awsManagedDomainNameFollowsTheAddressAfterSeeding() {
+        IotDomainConfiguration seeded = service.describeDomainConfiguration("iot:Data-ATS", REGION);
+        String seededArn = seeded.getDomainConfigurationArn();
+        assertEquals("localhost:4566", seeded.getDomainName());
+        service.updateDomainConfiguration("iot:Data-ATS",
+                mapper.createObjectNode().put("domainConfigurationStatus", "DISABLED"), REGION);
+        Instant statusChanged = service.describeDomainConfiguration("iot:Data-ATS", REGION).getLastStatusChangeDate();
+        service.tagResource(seededArn, Map.of("team", "devices"));
+        service.createDomainConfiguration("iot-domain", customDomainRequest(), REGION);
+
+        endpointAddress.set("iot.example.localhost.floci.io");
+
+        IotDomainConfiguration refreshed = service.describeDomainConfiguration("iot:Data-ATS", REGION);
+        assertEquals("iot.example.localhost.floci.io", refreshed.getDomainName());
+        assertEquals(seededArn, refreshed.getDomainConfigurationArn(), "refreshed in place, not seeded again");
+        assertEquals("DISABLED", refreshed.getDomainConfigurationStatus(), "an earlier update is kept");
+        assertEquals(statusChanged, refreshed.getLastStatusChangeDate(), "a new address is not a status change");
+        assertEquals(Map.of("team", "devices"), service.listTagsForResource(seededArn), "tags survive the refresh");
+        assertEquals("DATA", refreshed.getServiceType());
+        List<IotDomainConfiguration> listed = service.listDomainConfigurations(REGION, null, null, null).items();
+        assertEquals(List.of("iot.example.localhost.floci.io", "iot.example.localhost.floci.io",
+                        "iot.example.localhost.floci.io", "iot.example.localhost.floci.io"),
+                listed.stream().filter(item -> "AWS_MANAGED".equals(item.getDomainType()))
+                        .map(IotDomainConfiguration::getDomainName).toList(),
+                "every AWS-managed configuration follows");
+        assertEquals("iot.example.com", service.describeDomainConfiguration("iot-domain", REGION).getDomainName(),
+                "a customer-managed domain keeps its own name");
+    }
+    @Test
     void awsManagedConfigurationsCanBeUpdatedAndTaggedButNotDeleted() {
         IotDomainConfiguration legacy = service.updateDomainConfiguration("iot:Data",
                 mapper.createObjectNode().put("domainConfigurationStatus", "DISABLED"), REGION);
@@ -271,6 +315,35 @@ class IotDomainConfigurationServiceTest {
                 write.get();
             }
             assertEquals(writers, service.listTagsForResource(arn).size(), "a concurrent tag write must not drop another writer's key");
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void concurrentFirstDescribesSeedOneManagedConfigurationPerRegion() throws Exception {
+        int callers = 16;
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService pool = Executors.newFixedThreadPool(callers);
+        try {
+            List<Future<IotDomainConfiguration>> results = new ArrayList<>();
+            for (int i = 0; i < callers; i++) {
+                String address = i % 2 == 0 ? "localhost:4566" : "iot.example.localhost.floci.io";
+                results.add(pool.submit(() -> {
+                    start.await();
+                    endpointAddress.set(address);
+                    return service.describeDomainConfiguration("iot:Jobs", "eu-north-1");
+                }));
+            }
+            start.countDown();
+            Set<String> arns = new HashSet<>();
+            for (Future<IotDomainConfiguration> result : results) {
+                IotDomainConfiguration seen = result.get();
+                assertNotNull(seen.getDomainName());
+                arns.add(seen.getDomainConfigurationArn());
+            }
+            assertEquals(1, arns.size(), "seeded once, whichever address the callers raced with: " + arns);
+            assertEquals(endpointAddress.get(), service.describeDomainConfiguration("iot:Jobs", "eu-north-1").getDomainName());
         } finally {
             pool.shutdownNow();
         }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationServiceTest.java
@@ -343,7 +343,10 @@ class IotDomainConfigurationServiceTest {
                 arns.add(seen.getDomainConfigurationArn());
             }
             assertEquals(1, arns.size(), "seeded once, whichever address the callers raced with: " + arns);
-            assertEquals(endpointAddress.get(), service.describeDomainConfiguration("iot:Jobs", "eu-north-1").getDomainName());
+            endpointAddress.set("iot.example.localhost.floci.io");
+            assertEquals("iot.example.localhost.floci.io",
+                    service.describeDomainConfiguration("iot:Jobs", "eu-north-1").getDomainName(),
+                    "the next describe brings the seeded record to the current address");
         } finally {
             pool.shutdownNow();
         }

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationTlsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotDomainConfigurationTlsServiceTest.java
@@ -42,7 +42,7 @@ class IotDomainConfigurationTlsServiceTest {
 
     private static EmulatorConfig endpointConfig() {
         EmulatorConfig config = mock(EmulatorConfig.class);
-        when(config.effectiveBaseUrl()).thenReturn("http://localhost:4566");
+        when(config.iotEndpointAddress()).thenReturn("localhost:4566");
         return config;
     }
 


### PR DESCRIPTION
## Summary

AWS IoT `DescribeEndpoint` returns a bare hostname, and devices add their own port: 8883 for MQTT, 443 for HTTPS and MQTT over WebSocket, 8443 for HTTPS with a client certificate. Floci returns `host:4566`, because its HTTP data plane lives there and IoT Data clients build `https://<endpoint>` from that value. Both answers are right for their callers. From inside a container Floci cannot tell whether the operator published the AWS ports, so this stays the operator's choice.

This PR adds one optional setting, `FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS` (`floci.services.iot.endpoint-address`). When set, `DescribeEndpoint` returns it as is, for every endpoint type. Unset, nothing changes.

Two more places follow the address so that everything agrees:

- The four AWS-managed domain configurations (`iot:Data-ATS`, `iot:Data`, `iot:CredentialProvider`, `iot:Jobs`) report it as their `domainName`, as they do on AWS. One stored by an earlier run picks up a changed address instead of keeping the old value.
- The name joins the generated server certificate, like `FLOCI_HOSTNAME` does, so devices can verify it on 8883 and 443. A wildcard SAN covers one label only, so a name such as `iot.example.localhost.floci.io` needs this.

The docs show the compose port layout this is meant for: 8883 for MQTT over TLS and 443 for the HTTPS data plane, which Floci binds itself when TLS is on.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| `DescribeEndpoint` | `endpointType` `iot:Data-ATS`, `iot:Data`, `iot:Jobs`, `iot:CredentialProvider` | ✅ | One address for all four. AWS hands out one hostname per type. |
| `DescribeEndpoint` | `endpointType` omitted or empty | ✅ | Same address |
| `DescribeEndpoint` | Unknown `endpointType` | ✅ | `InvalidRequestException`, HTTP 400, unchanged |
| `DescribeEndpoint` | `iot:DeviceAdvisor`, `iot:Data-Beta` | ❌ | Device Advisor and beta endpoints are not emulated |
| Setting | `FLOCI_SERVICES_IOT_ENDPOINT_ADDRESS` set | ✅ | Returned as is. Surrounding whitespace is dropped, a blank value counts as unset. |
| Setting | Unset | ✅ | `host:port` of the base URL, with `FLOCI_HOSTNAME` applied, as before |
| Setting | Detecting published ports | ❌ | On purpose: `docker run -p 4566:4566` must keep working for IoT Data clients |
| Setting | A URL instead of a host | 🟡 | Returned as is by `DescribeEndpoint`. Not added to the certificate; Floci logs a warning at startup instead. |
| Domain configurations | `DescribeDomainConfiguration` of an AWS-managed name | ✅ | `domainName` is the same address, refreshed after a restart with another address |
| Domain configurations | `ListDomainConfigurations` | ✅ | Unchanged. The AWS summary carries name, ARN and service type only. |
| TLS | Server certificate covers the address | ✅ | Host part only, a port is dropped. Same rules as `FLOCI_HOSTNAME`: generated certificate only, read from the environment or system properties. |
| TLS | Reissue for a hostname learned at runtime | ✅ | Keeps the name |

## Files

- `EmulatorConfig`: `IotServiceConfig.endpointAddress()` and `iotEndpointAddress()`, the one place that resolves the address, next to `effectiveBaseUrl()`.
- `IotService.describeEndpoint` and `IotDomainConfigurationService.seedAwsManaged` read it. The seed refreshes a stale managed domain name under the existing lock and touches nothing else.
- `TlsConfigSource.extractCustomHostnames`: the address host joins the certificate SANs and the metadata, so a change between restarts regenerates the leaf.
- `application.yml`: commented example, like the other optional keys. The test `application.yml` needs nothing, a test profile supplies the value.
- Tests: `IotDescribeEndpointOverrideIntegrationTest` (profile with the setting: every endpoint type, the 400, the managed domain names), `EmulatorConfigIotEndpointAddressTest`, `IotDomainConfigurationServiceTest` (managed names follow the address, a refresh keeps ARN, status, status date, tags and a customer-managed domain, 16 threads seeding at once), `TlsConfigSourceHostnameExtractionTest` and `TlsConfigSourceCertificateGenerationTest` (SAN present, port dropped, IPv6 literal kept, default host filtered, unparsable or URL-shaped values skipped, regeneration after a change). `IotIntegrationTest` and `IotEndpointHostnameIntegrationTest` keep guarding the default.
- Docs: `docs/services/iot.md` (new Endpoint address section), `docs/configuration/tls.md`, `docs/configuration/environment-variables.md` (IoT Core table).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Checked against the IoT API reference for `DescribeEndpoint`, the developer guide pages "Device communication protocols" and "Connect devices to AWS IoT", and the `iot` service model in botocore (`DescribeEndpointResponse.endpointAddress` is a plain string, `DomainConfigurationSummary` has no `domainName`).

Verified with AWS CLI 2.36 against a local build running with the setting and TLS on: `aws iot describe-endpoint` returns the bare hostname for every type, `describe-domain-configuration --domain-configuration-name iot:Data-ATS` reports the same `domainName`, `openssl s_client` verifies the name on 8883 and 443 against `/_floci/ca.pem`, and `aws --endpoint-url https://<address> iot-data publish` followed by `get-retained-message` round-trips through port 443, the way a client that took the hostname from `DescribeEndpoint` would. The Java SDK compatibility `IotTest` passes against that build (its three MQTT cases dial the compose host name and cannot run outside compose).

## Checklist

- [x] `./mvnw test` passes locally. The single-fork run on my machine stops at the surefire heap limit after 14409 tests (0 failures; the one error is `ContainerPlatformDockerIntegrationTest`, which needs an amd64 Docker image), so the classes it never reached were run separately with `-Dtest`, together with every IoT, TLS and config class. `make docs-check` passes.
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
