### PR TITLE
fix(lambda): honor MaximumBatchingWindowInSeconds on SQS event source mappings

### DIFF
--- a/docs/services/lambda.md
+++ b/docs/services/lambda.md
@@ -737,6 +737,29 @@ aws lambda create-event-source-mapping \
   --endpoint-url $AWS_ENDPOINT_URL
 ```
 
+### MaximumBatchingWindowInSeconds (SQS)
+
+`CreateEventSourceMapping` and `UpdateEventSourceMapping` accept a
+`MaximumBatchingWindowInSeconds` integer between 0 and 300. `GetEventSourceMapping`
+and `ListEventSourceMappings` echo it back when set; responses omit the field when
+it was never configured. Values outside 0 to 300 are rejected with
+`InvalidParameterValueException`.
+
+When the window is greater than 0, the SQS poller holds an underfilled batch open,
+accumulating messages across polls, and invokes the function once the batch reaches
+`BatchSize` or the window elapses since the first buffered message, whichever comes
+first. A window of 0 (or an unset window) invokes as soon as any message is
+available, which is the previous behaviour.
+
+```bash
+aws lambda create-event-source-mapping \
+  --function-name my-function \
+  --event-source-arn $QUEUE_ARN \
+  --batch-size 10 \
+  --maximum-batching-window-in-seconds 5 \
+  --endpoint-url $AWS_ENDPOINT_URL
+```
+
 ### ScalingConfig (SQS only)
 
 `CreateEventSourceMapping` and `UpdateEventSourceMapping` accept a

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -349,6 +349,9 @@ public class LambdaController {
             node.put("EventSourceArn", esm.getEventSourceArn());
         }
         node.put("BatchSize", esm.getBatchSize());
+        if (esm.getMaximumBatchingWindowInSeconds() != null) {
+            node.put("MaximumBatchingWindowInSeconds", esm.getMaximumBatchingWindowInSeconds());
+        }
         node.put("State", esm.getState());
         node.put("LastModified", (double) esm.getLastModified() / 1000.0);
         // Omitted rather than nulled when unset, so a mapping created without a starting position

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1236,6 +1236,7 @@ public class LambdaService implements ResourceProvider {
         ResolvedFunctionTarget target = resolveFunctionTarget(resolvedRegion, fnRef);
 
         int batchSize = toInt(request.get("BatchSize"), 10);
+        Integer maximumBatchingWindowInSeconds = parseMaximumBatchingWindow(request);
         boolean enabled = !Boolean.FALSE.equals(request.get("Enabled"));
 
         @SuppressWarnings("unchecked")
@@ -1268,6 +1269,7 @@ public class LambdaService implements ResourceProvider {
         esm.setQueueUrl(queueUrl);
         esm.setRegion(resolvedRegion);
         esm.setBatchSize(batchSize);
+        esm.setMaximumBatchingWindowInSeconds(maximumBatchingWindowInSeconds);
         esm.setEnabled(enabled);
         esm.setState(enabled ? "Enabled" : "Disabled");
         esm.setScalingConfig(scalingConfig);
@@ -1629,6 +1631,33 @@ public class LambdaService implements ResourceProvider {
         return new ScalingConfig((int) longValue);
     }
 
+    /**
+     * Parses {@code MaximumBatchingWindowInSeconds} out of a create/update request and applies
+     * AWS-level validation: it must be an integer in [0, 300]. Returns {@code null} when the field
+     * is absent so a create leaves it unset and an update leaves the stored value untouched.
+     */
+    private Integer parseMaximumBatchingWindow(Map<String, Object> request) {
+        Object raw = request.get("MaximumBatchingWindowInSeconds");
+        if (raw == null) {
+            return null;
+        }
+        if (!(raw instanceof Number)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "MaximumBatchingWindowInSeconds must be a numeric value", 400);
+        }
+        double d = ((Number) raw).doubleValue();
+        if (Double.isNaN(d) || Double.isInfinite(d) || d != Math.floor(d)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "MaximumBatchingWindowInSeconds must be an integer", 400);
+        }
+        long value = ((Number) raw).longValue();
+        if (value < 0 || value > 300) {
+            throw new AwsException("InvalidParameterValueException",
+                    "MaximumBatchingWindowInSeconds must be between 0 and 300 (got " + value + ")", 400);
+        }
+        return (int) value;
+    }
+
     private void startPollingHelper(EventSourceMapping esm) {
         if (esm.getEventSourceArn() == null) {
             return;
@@ -1680,6 +1709,9 @@ public class LambdaService implements ResourceProvider {
 
         if (request.containsKey("BatchSize")) {
             esm.setBatchSize(toInt(request.get("BatchSize"), esm.getBatchSize()));
+        }
+        if (request.containsKey("MaximumBatchingWindowInSeconds")) {
+            esm.setMaximumBatchingWindowInSeconds(parseMaximumBatchingWindow(request));
         }
         if (request.containsKey("Enabled")) {
             boolean nowEnabled = !Boolean.FALSE.equals(request.get("Enabled"));

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
@@ -174,15 +174,17 @@ public class SqsEventSourcePoller implements Resettable {
                 }
 
                 // MaximumBatchingWindowInSeconds holds an underfilled batch open: keep messages
-                // received across earlier polls invisible (visibility must cover the window) and
-                // only invoke once the batch fills or the window since the first message expires.
+                // received across earlier polls invisible and only invoke once the batch fills or
+                // the window since the first buffered message expires.
                 int window = esm.getMaximumBatchingWindowInSeconds() == null
                         ? 0 : esm.getMaximumBatchingWindowInSeconds();
-                int visibilityTimeout = Math.max(fn.getTimeout() + 30, window + 30);
+                // A message can be buffered for the whole window and then processed for the full
+                // function timeout, so visibility has to cover both plus AWS's 30s margin, not the
+                // larger of the two. Otherwise a long invoke can outlive the visibility and another
+                // consumer receives the message, causing a duplicate delivery and a stale handle.
+                int visibilityTimeout = fn.getTimeout() + Math.max(window, 0) + 30;
 
-                PendingBatch pending = window > 0
-                        ? pendingBatches.computeIfAbsent(esm.getUuid(), k -> new PendingBatch())
-                        : null;
+                PendingBatch pending = pendingBatches.get(esm.getUuid());
                 int alreadyBuffered = pending != null ? pending.messages.size() : 0;
                 int wanted = Math.max(1, esm.getBatchSize() - alreadyBuffered);
 
@@ -190,12 +192,22 @@ public class SqsEventSourcePoller implements Resettable {
                         esm.getQueueUrl(), wanted, visibilityTimeout, 0, esm.getRegion());
 
                 List<Message> messages;
-                if (pending == null) {
-                    if (received.isEmpty()) {
+                if (window <= 0) {
+                    // No window, or one that was just turned off: deliver now, draining anything a
+                    // previous positive window had buffered so those messages are not stranded
+                    // until their visibility expires (and cannot be replayed if the window returns).
+                    List<Message> batch = pending != null ? pending.messages : new ArrayList<>();
+                    pendingBatches.remove(esm.getUuid());
+                    batch.addAll(received);
+                    if (batch.isEmpty()) {
                         return;
                     }
-                    messages = received;
+                    messages = batch;
                 } else {
+                    if (pending == null) {
+                        pending = new PendingBatch();
+                        pendingBatches.put(esm.getUuid(), pending);
+                    }
                     if (pending.messages.isEmpty() && !received.isEmpty()) {
                         pending.windowStartedAtMs = clockMs.getAsLong();
                     }

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePoller.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 /**
@@ -57,6 +58,11 @@ public class SqsEventSourcePoller implements Resettable {
     private final ConcurrentHashMap<String, Long> timerIds = new ConcurrentHashMap<>();
     // Tracks ESMs with an in-flight poll to prevent concurrent deliveries of the same message
     private final ConcurrentHashMap<String, Boolean> activePolls = new ConcurrentHashMap<>();
+    // Underfilled batches held open by MaximumBatchingWindowInSeconds, keyed by ESM uuid. Only ever
+    // mutated inside the activePolls-guarded section, so one thread touches a given entry at a time.
+    private final ConcurrentHashMap<String, PendingBatch> pendingBatches = new ConcurrentHashMap<>();
+    // Wall clock for the batching-window deadline; overridable so tests can advance it without sleeping.
+    private volatile LongSupplier clockMs = System::currentTimeMillis;
     private final ExecutorService pollExecutor = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "esm-poller");
         t.setDaemon(true);
@@ -103,6 +109,18 @@ public class SqsEventSourcePoller implements Resettable {
         timerIds.values().forEach(vertx::cancelTimer);
         timerIds.clear();
         activePolls.clear();
+        pendingBatches.clear();
+    }
+
+    /** Test seam: replace the wall clock used for the batching-window deadline. */
+    void setClockForTest(LongSupplier clockMs) {
+        this.clockMs = clockMs;
+    }
+
+    /** Messages received across earlier polls that a batching window is still holding open. */
+    private static final class PendingBatch {
+        final List<Message> messages = new ArrayList<>();
+        long windowStartedAtMs;
     }
 
     public void startPolling(EventSourceMapping esm) {
@@ -127,6 +145,7 @@ public class SqsEventSourcePoller implements Resettable {
 
     public void stopPolling(String uuid) {
         Long timerId = timerIds.remove(uuid);
+        pendingBatches.remove(uuid);
         if (timerId != null) {
             vertx.cancelTimer(timerId);
             LOG.debugv("Stopped polling ESM {0}", uuid);
@@ -154,12 +173,44 @@ public class SqsEventSourcePoller implements Resettable {
                     return;
                 }
 
-                int visibilityTimeout = fn.getTimeout() + 30;
-                List<Message> messages = sqsService.receiveMessage(
-                        esm.getQueueUrl(), esm.getBatchSize(), visibilityTimeout, 0, esm.getRegion());
+                // MaximumBatchingWindowInSeconds holds an underfilled batch open: keep messages
+                // received across earlier polls invisible (visibility must cover the window) and
+                // only invoke once the batch fills or the window since the first message expires.
+                int window = esm.getMaximumBatchingWindowInSeconds() == null
+                        ? 0 : esm.getMaximumBatchingWindowInSeconds();
+                int visibilityTimeout = Math.max(fn.getTimeout() + 30, window + 30);
 
-                if (messages.isEmpty()) {
-                    return;
+                PendingBatch pending = window > 0
+                        ? pendingBatches.computeIfAbsent(esm.getUuid(), k -> new PendingBatch())
+                        : null;
+                int alreadyBuffered = pending != null ? pending.messages.size() : 0;
+                int wanted = Math.max(1, esm.getBatchSize() - alreadyBuffered);
+
+                List<Message> received = sqsService.receiveMessage(
+                        esm.getQueueUrl(), wanted, visibilityTimeout, 0, esm.getRegion());
+
+                List<Message> messages;
+                if (pending == null) {
+                    if (received.isEmpty()) {
+                        return;
+                    }
+                    messages = received;
+                } else {
+                    if (pending.messages.isEmpty() && !received.isEmpty()) {
+                        pending.windowStartedAtMs = clockMs.getAsLong();
+                    }
+                    pending.messages.addAll(received);
+                    if (pending.messages.isEmpty()) {
+                        return;
+                    }
+                    boolean batchFull = pending.messages.size() >= esm.getBatchSize();
+                    boolean windowElapsed =
+                            clockMs.getAsLong() - pending.windowStartedAtMs >= window * 1000L;
+                    if (!batchFull && !windowElapsed) {
+                        return;
+                    }
+                    messages = new ArrayList<>(pending.messages);
+                    pendingBatches.remove(esm.getUuid());
                 }
 
                 LOG.infov("ESM {0}: received {1} message(s)", esm.getUuid(), messages.size());

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -22,6 +22,7 @@ public class EventSourceMapping {
     private String region;
     private boolean enabled = true;
     private int batchSize = 10;
+    private Integer maximumBatchingWindowInSeconds;
     private String state = "Enabled";
     private long lastModified;
     private String startingPosition;
@@ -65,6 +66,12 @@ public class EventSourceMapping {
 
     public int getBatchSize() { return batchSize; }
     public void setBatchSize(int batchSize) { this.batchSize = batchSize; }
+
+    /** Seconds to accumulate an underfilled batch before invoking; {@code null} or 0 means invoke as soon as messages arrive. */
+    public Integer getMaximumBatchingWindowInSeconds() { return maximumBatchingWindowInSeconds; }
+    public void setMaximumBatchingWindowInSeconds(Integer maximumBatchingWindowInSeconds) {
+        this.maximumBatchingWindowInSeconds = maximumBatchingWindowInSeconds;
+    }
 
     public String getState() { return state; }
     public void setState(String state) { this.state = state; }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -141,6 +141,62 @@ class EsmIntegrationTest {
     }
 
     @Test
+    void maximumBatchingWindowRoundTripsThroughCreateGetAndUpdate() {
+        String uuid = given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "BatchSize": 2,
+                    "MaximumBatchingWindowInSeconds": 5
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(202)
+            .body("MaximumBatchingWindowInSeconds", equalTo(5))
+        .extract()
+            .path("UUID");
+
+        given()
+        .when()
+            .get(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(200)
+            .body("MaximumBatchingWindowInSeconds", equalTo(5));
+
+        given()
+            .contentType("application/json")
+            .body("{\"MaximumBatchingWindowInSeconds\": 0}")
+        .when()
+            .put(LAMBDA_BASE + "/event-source-mappings/" + uuid)
+        .then()
+            .statusCode(202)
+            .body("MaximumBatchingWindowInSeconds", equalTo(0));
+
+        given().delete(LAMBDA_BASE + "/event-source-mappings/" + uuid).then().statusCode(202);
+    }
+
+    @Test
+    void createEventSourceMappingRejectsMaximumBatchingWindowAbove300() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                    "FunctionName": "%s",
+                    "EventSourceArn": "%s",
+                    "MaximumBatchingWindowInSeconds": 301
+                }
+                """.formatted(FUNCTION_NAME, QUEUE_ARN))
+        .when()
+            .post(LAMBDA_BASE + "/event-source-mappings")
+        .then()
+            .statusCode(400);
+    }
+
+    @Test
     void updateEventSourceMappingReturnsFailureConfig() {
         String streamArn = "arn:aws:dynamodb:us-east-1:000000000000:table/esm-table/stream/2026-01-01T00:00:00.000";
         String destinationArn = "arn:aws:sqs:us-east-1:000000000000:esm-updated-failure-config-dlq";

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EventSourceMappingSerializationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EventSourceMappingSerializationTest.java
@@ -97,6 +97,38 @@ class EventSourceMappingSerializationTest {
     }
 
     @Test
+    void maximumBatchingWindowRoundTripsThroughJacksonAndIsOmittedWhenUnset() throws Exception {
+        EventSourceMapping esm = new EventSourceMapping();
+        esm.setUuid("esm-window-001");
+        esm.setMaximumBatchingWindowInSeconds(5);
+
+        EventSourceMapping deserialized = objectMapper.readValue(
+                objectMapper.writeValueAsString(esm), EventSourceMapping.class);
+        assertEquals(5, deserialized.getMaximumBatchingWindowInSeconds());
+
+        assertNull(new EventSourceMapping().getMaximumBatchingWindowInSeconds());
+    }
+
+    @Test
+    void buildEsmResponseEmitsMaximumBatchingWindowOnlyWhenSet() {
+        EventSourceMapping esm = new EventSourceMapping();
+        esm.setUuid("esm-window-002");
+        esm.setFunctionArn("arn:aws:lambda:us-east-1:123456789012:function:sqsConsumer");
+        esm.setEventSourceArn("arn:aws:sqs:us-east-1:123456789012:my-queue");
+        esm.setBatchSize(2);
+        esm.setState("Enabled");
+        esm.setLastModified(1700000000000L);
+
+        assertFalse(controller.buildEsmResponse(esm).containsKey("MaximumBatchingWindowInSeconds"));
+
+        esm.setMaximumBatchingWindowInSeconds(5);
+        assertEquals(5, controller.buildEsmResponse(esm).get("MaximumBatchingWindowInSeconds"));
+
+        esm.setMaximumBatchingWindowInSeconds(0);
+        assertEquals(0, controller.buildEsmResponse(esm).get("MaximumBatchingWindowInSeconds"));
+    }
+
+    @Test
     void testBuildEsmResponseWithEventSourceArnPresent() {
         EventSourceMapping esm = new EventSourceMapping();
         esm.setUuid("esm-sqs-001");

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -471,6 +472,86 @@ class SqsEventSourcePollerTest {
                 }
             }
         }
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private void pollUntilInvoked(EventSourceMapping esm, LambdaFunction fn) {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (true) {
+            poller.pollAndInvoke(esm);
+            try {
+                verify(executorService, timeout(2000))
+                        .invoke(eq(fn), any(byte[].class), eq(InvocationType.RequestResponse));
+                return;
+            } catch (AssertionError retry) {
+                if (System.currentTimeMillis() > deadline) {
+                    throw retry;
+                }
+                sleep(25);
+            }
+        }
+    }
+
+    @Test
+    void batchingWindowHoldsUnderfilledBatchUntilTheWindowElapses() {
+        LambdaFunction fn = stubThrowFn();
+        EventSourceMapping esm = esm();
+        esm.setBatchSize(2);
+        esm.setMaximumBatchingWindowInSeconds(5);
+
+        AtomicLong now = new AtomicLong(0);
+        poller.setClockForTest(now::get);
+
+        when(sqsService.receiveMessage(eq(esm.getQueueUrl()), anyInt(), anyInt(), anyInt(), eq("us-east-1")))
+                .thenReturn(List.of(message("m1")))
+                .thenReturn(List.of());
+        when(executorService.invoke(eq(fn), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(new InvokeResult());
+
+        // Polls inside the window buffer the record without invoking.
+        for (int i = 0; i < 4; i++) {
+            poller.pollAndInvoke(esm);
+            sleep(25);
+            now.addAndGet(1000); // reaches 4s, short of the 5s window
+        }
+        verify(sqsService, atLeast(1))
+                .receiveMessage(eq(esm.getQueueUrl()), anyInt(), anyInt(), anyInt(), eq("us-east-1"));
+        verify(executorService, never()).invoke(any(), any(), any());
+        verify(sqsService, never()).deleteMessage(any(), any(), any());
+
+        // Once the window elapses the buffered record is delivered.
+        now.set(5000);
+        pollUntilInvoked(esm, fn);
+        verify(sqsService, timeout(2000)).deleteMessage(esm.getQueueUrl(), "rh-m1", "us-east-1");
+    }
+
+    @Test
+    void batchingWindowFlushesEarlyOnceTheBatchIsFull() {
+        LambdaFunction fn = stubThrowFn();
+        EventSourceMapping esm = esm();
+        esm.setBatchSize(2);
+        esm.setMaximumBatchingWindowInSeconds(30);
+
+        poller.setClockForTest(() -> 0L); // the window never expires on its own
+
+        when(sqsService.receiveMessage(eq(esm.getQueueUrl()), anyInt(), anyInt(), anyInt(), eq("us-east-1")))
+                .thenReturn(List.of(message("m1")))
+                .thenReturn(List.of(message("m2")))
+                .thenReturn(List.of());
+        when(executorService.invoke(eq(fn), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(new InvokeResult());
+
+        pollUntilInvoked(esm, fn);
+
+        verify(sqsService, timeout(2000)).deleteMessage(esm.getQueueUrl(), "rh-m1", "us-east-1");
+        verify(sqsService, timeout(2000)).deleteMessage(esm.getQueueUrl(), "rh-m2", "us-east-1");
     }
 
     private static final String BODY_PATTERN = "{\"body\":{\"type\":[\"order\"]}}";

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/SqsEventSourcePollerTest.java
@@ -554,6 +554,54 @@ class SqsEventSourcePollerTest {
         verify(sqsService, timeout(2000)).deleteMessage(esm.getQueueUrl(), "rh-m2", "us-east-1");
     }
 
+    @Test
+    void batchingWindowVisibilityTimeoutCoversTheWindowPlusFunctionTimeout() {
+        EventSourceMapping esm = esm();
+        esm.setMaximumBatchingWindowInSeconds(60);
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("throwfn");
+        fn.setTimeout(120);
+        when(functionStore.getForAccount("000000000000", "us-east-1", "throwfn"))
+                .thenReturn(Optional.of(fn));
+        poller.setClockForTest(() -> 0L);
+        when(sqsService.receiveMessage(eq(esm.getQueueUrl()), anyInt(), anyInt(), anyInt(), eq("us-east-1")))
+                .thenReturn(List.of());
+
+        poller.pollAndInvoke(esm);
+
+        ArgumentCaptor<Integer> visibility = ArgumentCaptor.forClass(Integer.class);
+        verify(sqsService, timeout(2000)).receiveMessage(
+                eq(esm.getQueueUrl()), anyInt(), visibility.capture(), anyInt(), eq("us-east-1"));
+        // held up to 60s buffered, then up to 120s executing, plus AWS's 30s margin
+        assertEquals(120 + 60 + 30, visibility.getValue());
+    }
+
+    @Test
+    void turningTheBatchingWindowOffDeliversAnAlreadyBufferedBatch() {
+        LambdaFunction fn = stubThrowFn();
+        EventSourceMapping esm = esm();
+        esm.setBatchSize(10);
+        esm.setMaximumBatchingWindowInSeconds(300);
+        poller.setClockForTest(() -> 0L); // the window never elapses on its own
+
+        when(sqsService.receiveMessage(eq(esm.getQueueUrl()), anyInt(), anyInt(), anyInt(), eq("us-east-1")))
+                .thenReturn(List.of(message("m1")))
+                .thenReturn(List.of());
+        when(executorService.invoke(eq(fn), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(new InvokeResult());
+
+        // Poll once with the window open: the record is buffered, not delivered.
+        poller.pollAndInvoke(esm);
+        verify(sqsService, timeout(2000))
+                .receiveMessage(eq(esm.getQueueUrl()), anyInt(), anyInt(), anyInt(), eq("us-east-1"));
+        verify(executorService, never()).invoke(any(), any(), any());
+
+        // Window turned off: the next poll must flush the stranded batch instead of ignoring it.
+        esm.setMaximumBatchingWindowInSeconds(0);
+        pollUntilInvoked(esm, fn);
+        verify(sqsService, timeout(2000)).deleteMessage(esm.getQueueUrl(), "rh-m1", "us-east-1");
+    }
+
     private static final String BODY_PATTERN = "{\"body\":{\"type\":[\"order\"]}}";
 
     @Test


### PR DESCRIPTION
## Summary

Lambda SQS event source mappings silently accepted and dropped `MaximumBatchingWindowInSeconds`: it was missing from the `EventSourceMapping` model, so Create/Get/Update never returned it, and `SqsEventSourcePoller` invoked the function on the first receive without accumulating to a window.

This PR:

- Adds `maximumBatchingWindowInSeconds` to `EventSourceMapping` and parses/validates it (integer 0 to 300, `InvalidParameterValueException` otherwise) in `CreateEventSourceMapping` and `UpdateEventSourceMapping`.
- Returns it from `CreateEventSourceMapping`, `GetEventSourceMapping`, `UpdateEventSourceMapping` and `ListEventSourceMappings`, omitting the field when it was never configured.
- Makes `SqsEventSourcePoller` hold an underfilled batch open when the window is greater than 0: messages are buffered across polls (kept invisible with a visibility timeout that covers the window) and the function is invoked once the buffer reaches `BatchSize` or the window elapses since the first buffered message, whichever comes first. A window of 0 or unset keeps the previous invoke-on-first-receive behavior.

Payload-based splitting (the reproduction's `payload` case) is explicitly out of scope per the issue and is unchanged.

Closes #3155

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `MaximumBatchingWindowInSeconds` was accepted on the wire but never persisted, returned, or enforced, so an underfilled batch with a five-second window was dispatched after roughly one poll interval (about 1 second) instead of waiting for the window.

Wire shape follows the [CreateEventSourceMapping API](https://docs.aws.amazon.com/lambda/latest/api/API_CreateEventSourceMapping.html): a top-level integer `MaximumBatchingWindowInSeconds`, valid range 0 to 300. Behavior follows [Using Lambda with SQS](https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html) (accumulate until batch size, batching window, or payload limit).

## Checklist

- [x] `./mvnw test` passes locally (ran `EsmIntegrationTest`, `SqsEventSourcePollerTest`, `EventSourceMappingSerializationTest`, `LambdaServiceTest`, `KinesisEventSourcePollerTest`, `DynamoDbStreamsEventSourcePollerTest`: 178 tests, 0 failures; full suite not run in this environment)
- [x] New or updated integration test added (`EsmIntegrationTest` create/get/update round-trip and range validation; `SqsEventSourcePollerTest` window-hold and batch-full-flush)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
