### PR TITLE
fix(sts): validate SAML assertions before assuming roles

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StsTest.java
@@ -1,10 +1,46 @@
 package com.floci.test;
 
 import org.junit.jupiter.api.*;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.CreateRoleRequest;
+import software.amazon.awssdk.services.iam.model.CreateSamlProviderRequest;
+import software.amazon.awssdk.services.iam.model.CreateSamlProviderResponse;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.model.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
+import javax.xml.crypto.dsig.DigestMethod;
+import javax.xml.crypto.dsig.Reference;
+import javax.xml.crypto.dsig.SignatureMethod;
+import javax.xml.crypto.dsig.SignedInfo;
+import javax.xml.crypto.dsig.Transform;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.dom.DOMSignContext;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayInputStream;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
 import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -12,14 +48,44 @@ import static org.assertj.core.api.Assertions.*;
 class StsTest {
 
     private static StsClient sts;
+    private static IamClient iam;
+    private static KeyPair signingKeys;
+    private static String providerArn;
+    private static String allowedRoleArn;
+    private static String allowedRoleName;
 
     @BeforeAll
-    static void setup() {
+    static void setup() throws Exception {
         sts = TestFixtures.stsClient();
+        iam = TestFixtures.iamClient();
+        signingKeys = createSigningKeys();
+
+        String issuer = "https://sdk-test.example.test/saml";
+        String providerName = TestFixtures.uniqueName("sdk-saml");
+        String certificate = createCertificate(signingKeys);
+        String metadata = "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\""
+                + issuer + "\"><md:IDPSSODescriptor><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>"
+                + certificate + "</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor></md:IDPSSODescriptor></md:EntityDescriptor>";
+        CreateSamlProviderResponse provider = iam.createSAMLProvider(CreateSamlProviderRequest.builder()
+                .name(providerName)
+                .samlMetadataDocument(metadata)
+                .build());
+        providerArn = provider.samlProviderArn();
+
+        allowedRoleName = TestFixtures.uniqueName("sdk-saml-role");
+        String trustPolicy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\""
+                + providerArn + "\"},\"Action\":\"sts:AssumeRoleWithSAML\"}]}";
+        allowedRoleArn = iam.createRole(CreateRoleRequest.builder()
+                .roleName(allowedRoleName)
+                .assumeRolePolicyDocument(trustPolicy)
+                .build()).role().arn();
     }
 
     @AfterAll
     static void cleanup() {
+        if (iam != null) {
+            iam.close();
+        }
         if (sts != null) {
             sts.close();
         }
@@ -142,13 +208,7 @@ class StsTest {
 
     @Test
     void assumeRoleWithSaml() {
-        AssumeRoleWithSamlResponse response = sts.assumeRoleWithSAML(
-                AssumeRoleWithSamlRequest.builder()
-                        .roleArn("arn:aws:iam::000000000000:role/saml-role")
-                        .principalArn("arn:aws:iam::000000000000:saml-provider/MySAML")
-                        .samlAssertion("base64-encoded-saml-assertion")
-                        .durationSeconds(3600)
-                        .build());
+        AssumeRoleWithSamlResponse response = validAssumeRoleWithSaml();
 
         assertThat(response.credentials()).isNotNull();
         assertThat(response.credentials().accessKeyId()).startsWith("ASIA");
@@ -159,15 +219,10 @@ class StsTest {
 
     @Test
     void assumeRoleWithSamlAssumedRoleUser() {
-        AssumeRoleWithSamlResponse response = sts.assumeRoleWithSAML(
-                AssumeRoleWithSamlRequest.builder()
-                        .roleArn("arn:aws:iam::000000000000:role/my-saml-role")
-                        .principalArn("arn:aws:iam::000000000000:saml-provider/Corp")
-                        .samlAssertion("assertion")
-                        .build());
+        AssumeRoleWithSamlResponse response = validAssumeRoleWithSaml();
 
         assertThat(response.assumedRoleUser()).isNotNull();
-        assertThat(response.assumedRoleUser().arn()).contains("assumed-role/my-saml-role/");
+        assertThat(response.assumedRoleUser().arn()).contains("assumed-role/" + allowedRoleName + "/");
     }
 
     @Test
@@ -229,5 +284,74 @@ class StsTest {
                 .isInstanceOf(StsException.class)
                 .extracting(e -> ((StsException) e).statusCode())
                 .isEqualTo(400);
+    }
+
+    private static AssumeRoleWithSamlResponse validAssumeRoleWithSaml() {
+        String issuer = "https://sdk-test.example.test/saml";
+        return sts.assumeRoleWithSAML(AssumeRoleWithSamlRequest.builder()
+                .roleArn(allowedRoleArn)
+                .principalArn(providerArn)
+                .samlAssertion(signedAssertion(allowedRoleArn, providerArn, issuer))
+                .durationSeconds(3600)
+                .build());
+    }
+
+    private static KeyPair createSigningKeys() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        return generator.generateKeyPair();
+    }
+
+    private static String createCertificate(KeyPair keys) throws Exception {
+        Instant now = Instant.now();
+        X500Name name = new X500Name("CN=Floci SDK SAML test provider");
+        X509CertificateHolder holder = new JcaX509v3CertificateBuilder(
+                name, BigInteger.ONE, Date.from(now.minusSeconds(60)), Date.from(now.plusSeconds(3600)),
+                name, keys.getPublic())
+                .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").build(keys.getPrivate()));
+        X509Certificate certificate = new JcaX509CertificateConverter().setProvider("BC").getCertificate(holder);
+        certificate.verify(keys.getPublic());
+        return Base64.getEncoder().encodeToString(certificate.getEncoded());
+    }
+
+    private static String signedAssertion(String roleArn, String principalArn, String issuer) {
+        String id = "_" + UUID.randomUUID();
+        Instant expiry = Instant.now().plusSeconds(300);
+        String xml = "<saml:Assertion xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + id
+                + "\" Version=\"2.0\" IssueInstant=\"" + Instant.now() + "\"><saml:Issuer>" + issuer
+                + "</saml:Issuer><saml:Subject><saml:NameID Format=\"persistent\">sdk-test-subject</saml:NameID>"
+                + "<saml:SubjectConfirmation><saml:SubjectConfirmationData Recipient=\"https://signin.aws.amazon.com/saml\" NotOnOrAfter=\""
+                + expiry + "\"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore=\""
+                + Instant.now().minusSeconds(30) + "\" NotOnOrAfter=\"" + expiry
+                + "\"><saml:AudienceRestriction><saml:Audience>urn:amazon:webservices</saml:Audience></saml:AudienceRestriction></saml:Conditions>"
+                + "<saml:AttributeStatement><saml:Attribute Name=\"https://aws.amazon.com/SAML/Attributes/Role\"><saml:AttributeValue>"
+                + roleArn + "," + principalArn + "</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>";
+        try {
+            DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
+            parserFactory.setNamespaceAware(true);
+            Document document = parserFactory.newDocumentBuilder().parse(
+                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            Element assertion = document.getDocumentElement();
+            assertion.setIdAttribute("ID", true);
+            XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+            Reference reference = factory.newReference("#" + id,
+                    factory.newDigestMethod(DigestMethod.SHA256, null),
+                    List.of(factory.newTransform(Transform.ENVELOPED,
+                                                (javax.xml.crypto.dsig.spec.TransformParameterSpec) null)), null, null);
+            SignedInfo signedInfo = factory.newSignedInfo(
+                    factory.newCanonicalizationMethod("http://www.w3.org/2001/10/xml-exc-c14n#",
+                                                (javax.xml.crypto.dsig.spec.C14NMethodParameterSpec) null),
+                    factory.newSignatureMethod(SignatureMethod.RSA_SHA256, null), List.of(reference));
+            factory.newXMLSignature(signedInfo, null)
+                    .sign(new DOMSignContext(signingKeys.getPrivate(), assertion));
+            var transformer = TransformerFactory.newInstance().newTransformer();
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+            StringWriter output = new StringWriter();
+            transformer.transform(new DOMSource(document), new StreamResult(output));
+            return Base64.getEncoder().encodeToString(output.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not create SAML assertion", e);
+        }
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StsTest.java
@@ -315,23 +315,33 @@ class StsTest {
         return Base64.getEncoder().encodeToString(certificate.getEncoded());
     }
 
+    private static Document parseDocument(String xml) throws Exception {
+        DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
+        parserFactory.setNamespaceAware(true);
+        parserFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        parserFactory.setXIncludeAware(false);
+        parserFactory.setExpandEntityReferences(false);
+        return parserFactory.newDocumentBuilder().parse(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
     private static String signedAssertion(String roleArn, String principalArn, String issuer) {
         String id = "_" + UUID.randomUUID();
         Instant expiry = Instant.now().plusSeconds(300);
         String xml = "<saml:Assertion xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"" + id
                 + "\" Version=\"2.0\" IssueInstant=\"" + Instant.now() + "\"><saml:Issuer>" + issuer
                 + "</saml:Issuer><saml:Subject><saml:NameID Format=\"persistent\">sdk-test-subject</saml:NameID>"
-                + "<saml:SubjectConfirmation><saml:SubjectConfirmationData Recipient=\"https://signin.aws.amazon.com/saml\" NotOnOrAfter=\""
+                + "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><saml:SubjectConfirmationData Recipient=\"https://signin.aws.amazon.com/saml\" NotOnOrAfter=\""
                 + expiry + "\"/></saml:SubjectConfirmation></saml:Subject><saml:Conditions NotBefore=\""
                 + Instant.now().minusSeconds(30) + "\" NotOnOrAfter=\"" + expiry
                 + "\"><saml:AudienceRestriction><saml:Audience>urn:amazon:webservices</saml:Audience></saml:AudienceRestriction></saml:Conditions>"
                 + "<saml:AttributeStatement><saml:Attribute Name=\"https://aws.amazon.com/SAML/Attributes/Role\"><saml:AttributeValue>"
                 + roleArn + "," + principalArn + "</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>";
         try {
-            DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
-            parserFactory.setNamespaceAware(true);
-            Document document = parserFactory.newDocumentBuilder().parse(
-                    new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            Document document = parseDocument(xml);
             Element assertion = document.getDocumentElement();
             assertion.setIdAttribute("ID", true);
             XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StsTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/StsTest.java
@@ -23,12 +23,11 @@ import javax.xml.crypto.dsig.SignedInfo;
 import javax.xml.crypto.dsig.Transform;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 import javax.xml.crypto.dsig.dom.DOMSignContext;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.ByteArrayInputStream;
+
 import java.io.StringWriter;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -315,18 +314,6 @@ class StsTest {
         return Base64.getEncoder().encodeToString(certificate.getEncoded());
     }
 
-    private static Document parseDocument(String xml) throws Exception {
-        DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
-        parserFactory.setNamespaceAware(true);
-        parserFactory.setFeature(javax.xml.XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        parserFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        parserFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        parserFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        parserFactory.setXIncludeAware(false);
-        parserFactory.setExpandEntityReferences(false);
-        return parserFactory.newDocumentBuilder().parse(
-                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
-    }
 
     private static String signedAssertion(String roleArn, String principalArn, String issuer) {
         String id = "_" + UUID.randomUUID();
@@ -341,7 +328,7 @@ class StsTest {
                 + "<saml:AttributeStatement><saml:Attribute Name=\"https://aws.amazon.com/SAML/Attributes/Role\"><saml:AttributeValue>"
                 + roleArn + "," + principalArn + "</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>";
         try {
-            Document document = parseDocument(xml);
+            Document document = XmlParser.parseDocument(xml);
             Element assertion = document.getDocumentElement();
             assertion.setIdAttribute("ID", true);
             XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/XmlParser.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/XmlParser.java
@@ -1,0 +1,27 @@
+package com.floci.test;
+
+import org.w3c.dom.Document;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+/** Secure XML parsing shared by compatibility-test fixtures. */
+final class XmlParser {
+    private XmlParser() {
+    }
+
+    static Document parseDocument(String xml) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder().parse(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
@@ -1,12 +1,17 @@
 package io.github.hectorvent.floci.core.common;
 
 import org.jboss.logging.Logger;
+import org.w3c.dom.Document;
 
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+import java.io.ByteArrayInputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,6 +41,23 @@ public final class XmlParser {
     }
 
     private XmlParser() {}
+
+    /**
+     * Parses XML into a namespace-aware DOM document with external entities and
+     * DTD processing disabled. DOM is required by the JDK XML-DSig API.
+     */
+    public static Document parseDocument(String xml) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder().parse(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
 
     /**
      * Reads the text content of the current element if it is a leaf (contains only text).

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -70,7 +70,7 @@ public class IamQueryHandler {
             // Identity providers & server certificates
             case "ListSAMLProviders" -> handleListSAMLProviders(authorization);
             case "CreateSAMLProvider" -> handleCreateSAMLProvider(params, authorization);
-            case "GetSAMLProvider" -> handleGetSAMLProvider(params);
+            case "GetSAMLProvider" -> handleGetSAMLProvider(params, authorization);
             case "ListOpenIDConnectProviders" -> handleListOpenIDConnectProviders(params);
             case "CreateOpenIDConnectProvider" -> handleCreateOpenIDConnectProvider(params);
             case "GetOpenIDConnectProvider" -> handleGetOpenIDConnectProvider(params);
@@ -333,8 +333,9 @@ public class IamQueryHandler {
                 new XmlBuilder().elem("SAMLProviderArn", provider.getArn()).build())).build();
     }
 
-    private Response handleGetSAMLProvider(MultivaluedMap<String, String> params) {
-        SAMLProvider provider = samlProviderService.get(getParam(params, "SAMLProviderArn"));
+    private Response handleGetSAMLProvider(MultivaluedMap<String, String> params, String authorization) {
+        String accountId = accountResolver.resolve(authorization);
+        SAMLProvider provider = samlProviderService.getForAccount(accountId, getParam(params, "SAMLProviderArn"));
         String metadata = "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\""
                 + provider.getEntityId() + "\"><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>"
                 + provider.getCertificate() + "</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor></md:EntityDescriptor>";

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamQueryHandler.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.iam.model.IamRole;
 import io.github.hectorvent.floci.services.iam.model.IamUser;
 import io.github.hectorvent.floci.services.iam.model.InstanceProfile;
 import io.github.hectorvent.floci.services.iam.model.OpenIDConnectProvider;
+import io.github.hectorvent.floci.services.iam.model.SAMLProvider;
 import io.github.hectorvent.floci.services.iam.model.PolicyVersion;
 import io.github.hectorvent.floci.services.iam.model.CallerContext;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -38,13 +39,15 @@ public class IamQueryHandler {
     private final IamService iamService;
     private final IamPolicyEvaluator policyEvaluator;
     private final AccountResolver accountResolver;
+    private final SAMLProviderService samlProviderService;
 
     @Inject
     public IamQueryHandler(IamService iamService, IamPolicyEvaluator policyEvaluator,
-                           AccountResolver accountResolver) {
+                           AccountResolver accountResolver, SAMLProviderService samlProviderService) {
         this.iamService = iamService;
         this.policyEvaluator = policyEvaluator;
         this.accountResolver = accountResolver;
+        this.samlProviderService = samlProviderService;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params, String authorization) {
@@ -64,8 +67,10 @@ public class IamQueryHandler {
             case "ListMFADevices" -> handleListMFADevices(params);
             case "GetLoginProfile" -> handleGetLoginProfile(params);
 
-            // Identity providers & server certificates (read-only, not modeled)
-            case "ListSAMLProviders" -> handleListSAMLProviders(params);
+            // Identity providers & server certificates
+            case "ListSAMLProviders" -> handleListSAMLProviders(authorization);
+            case "CreateSAMLProvider" -> handleCreateSAMLProvider(params, authorization);
+            case "GetSAMLProvider" -> handleGetSAMLProvider(params);
             case "ListOpenIDConnectProviders" -> handleListOpenIDConnectProviders(params);
             case "CreateOpenIDConnectProvider" -> handleCreateOpenIDConnectProvider(params);
             case "GetOpenIDConnectProvider" -> handleGetOpenIDConnectProvider(params);
@@ -312,13 +317,30 @@ public class IamQueryHandler {
                 AwsNamespaces.IAM, 404);
     }
 
-    private Response handleListSAMLProviders(MultivaluedMap<String, String> params) {
-        // SAML identity providers are not modeled; return the wire-accurate empty
-        // list (ListSAMLProviders is not paginated — no Marker/IsTruncated).
-        String result = new XmlBuilder()
-                .start("SAMLProviderList").end("SAMLProviderList")
-                .build();
-        return Response.ok(AwsQueryResponse.envelope("ListSAMLProviders", AwsNamespaces.IAM, result)).build();
+    private Response handleListSAMLProviders(String authorization) {
+        var xml = new XmlBuilder().start("SAMLProviderList");
+        for (SAMLProvider provider : samlProviderService.list(accountResolver.resolve(authorization))) {
+            xml.start("member").elem("Arn", provider.getArn()).end("member");
+        }
+        xml.end("SAMLProviderList");
+        return Response.ok(AwsQueryResponse.envelope("ListSAMLProviders", AwsNamespaces.IAM, xml.build())).build();
+    }
+
+    private Response handleCreateSAMLProvider(MultivaluedMap<String, String> params, String authorization) {
+        SAMLProvider provider = samlProviderService.create(accountResolver.resolve(authorization),
+                getParam(params, "Name"), getParam(params, "SAMLMetadataDocument"));
+        return Response.ok(AwsQueryResponse.envelope("CreateSAMLProvider", AwsNamespaces.IAM,
+                new XmlBuilder().elem("SAMLProviderArn", provider.getArn()).build())).build();
+    }
+
+    private Response handleGetSAMLProvider(MultivaluedMap<String, String> params) {
+        SAMLProvider provider = samlProviderService.get(getParam(params, "SAMLProviderArn"));
+        String metadata = "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\""
+                + provider.getEntityId() + "\"><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>"
+                + provider.getCertificate() + "</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor></md:EntityDescriptor>";
+        return Response.ok(AwsQueryResponse.envelope("GetSAMLProvider", AwsNamespaces.IAM,
+                new XmlBuilder().elem("SAMLProviderArn", provider.getArn()).elem("CreateDate", isoDate(provider.getCreateDate()))
+                        .elem("ValidUntil", isoDate(provider.getCreateDate().plusSeconds(31536000))).elem("SAMLMetadataDocument", metadata).build())).build();
     }
 
     // ListOpenIDConnectProviders is not paginated and carries only ARNs — the client fetches

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLAssertionVerifier.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLAssertionVerifier.java
@@ -4,12 +4,11 @@ import io.github.hectorvent.floci.services.iam.model.SAMLProvider;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-
 import javax.xml.crypto.dsig.XMLSignature;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 import javax.xml.crypto.dsig.dom.DOMValidateContext;
 import java.io.ByteArrayInputStream;
-
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -36,66 +35,117 @@ final class SAMLAssertionVerifier {
             byte[] bytes = Base64.getDecoder().decode(encoded);
             var document = SAMLXml.document(new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
             Element assertion = document.getDocumentElement();
-            if ("Response".equals(assertion.getLocalName())) assertion = first(assertion, SAML, "Assertion");
-            if (assertion == null || !"Assertion".equals(assertion.getLocalName()) || !SAML.equals(assertion.getNamespaceURI())) throw invalid("assertion root");
+            if ("Response".equals(assertion.getLocalName())) {
+                assertion = first(assertion, SAML, "Assertion");
+            }
+            if (assertion == null || !"Assertion".equals(assertion.getLocalName())
+                    || !SAML.equals(assertion.getNamespaceURI())) {
+                throw invalid("assertion root");
+            }
             String assertionId = assertion.getAttribute("ID");
-            if (assertionId == null || assertionId.isBlank()) throw invalid("assertion ID");
+            if (assertionId == null || assertionId.isBlank()) {
+                throw invalid("assertion ID");
+            }
             assertion.setIdAttribute("ID", true);
             Element signature = first(assertion, DS, "Signature");
-            if (signature == null) throw invalid("signature missing");
+            if (signature == null) {
+                throw invalid("signature missing");
+            }
             X509Certificate certificate = certificate(provider.getCertificate());
             var context = new DOMValidateContext(certificate.getPublicKey(), signature);
             context.setProperty("org.jcp.xml.dsig.secureValidation", Boolean.TRUE);
             XMLSignature xmlSignature = XMLSignatureFactory.getInstance("DOM").unmarshalXMLSignature(context);
             if (xmlSignature.getSignedInfo().getReferences().size() != 1
                     || !(xmlSignature.getSignedInfo().getReferences().get(0) instanceof javax.xml.crypto.dsig.Reference reference)
-                    || !("#" + assertionId).equals(reference.getURI())) throw invalid("signature reference");
-            if (!xmlSignature.validate(context)) throw invalid("signature validation");
+                    || !("#" + assertionId).equals(reference.getURI())) {
+                throw invalid("signature reference");
+            }
+            if (!xmlSignature.validate(context)) {
+                throw invalid("signature validation");
+            }
 
             String issuer = childText(assertion, SAML, "Issuer");
-            if (!provider.getEntityId().equals(issuer)) throw invalid("issuer");
+            if (!provider.getEntityId().equals(issuer)) {
+                throw invalid("issuer");
+            }
             Element conditions = first(assertion, SAML, "Conditions");
-            if (conditions == null) throw invalid("conditions missing");
+            if (conditions == null) {
+                throw invalid("conditions missing");
+            }
             Instant notBefore = instant(conditions.getAttribute("NotBefore"));
             Instant notOnOrAfter = instant(conditions.getAttribute("NotOnOrAfter"));
-            if (notBefore != null && now.isBefore(notBefore)) throw invalid("not before");
-            if (notOnOrAfter == null || !now.isBefore(notOnOrAfter)) throw invalid("assertion expiry");
+            if (notBefore != null && now.isBefore(notBefore)) {
+                throw invalid("not before");
+            }
+            if (notOnOrAfter == null || !now.isBefore(notOnOrAfter)) {
+                throw invalid("assertion expiry");
+            }
             Element restriction = first(conditions, SAML, "AudienceRestriction");
-            if (restriction == null || !hasText(restriction, SAML, "Audience", AUDIENCE)) throw invalid("audience");
+            if (restriction == null || !hasText(restriction, SAML, "Audience", AUDIENCE)) {
+                throw invalid("audience");
+            }
 
             Element subject = first(assertion, SAML, "Subject");
             String name = childText(subject, SAML, "NameID");
-            if (name == null || name.isBlank()) throw invalid("subject");
+            if (name == null || name.isBlank()) {
+                throw invalid("subject");
+            }
             Element nameId = first(subject, SAML, "NameID");
             String subjectType = nameId == null ? null : nameId.getAttribute("Format");
             NodeList confirmations = subject == null
-                    ? null : ((Element) subject).getElementsByTagNameNS(SAML, "SubjectConfirmationData");
-            if (confirmations == null || confirmations.getLength() == 0) throw invalid("subject confirmation missing");
+                    ? null : ((Element) subject).getElementsByTagNameNS(SAML, "SubjectConfirmation");
+            if (confirmations == null || confirmations.getLength() == 0) {
+                throw invalid("subject confirmation missing");
+            }
+            boolean validBearer = false;
             for (int i = 0; i < confirmations.getLength(); i++) {
                 Element confirmation = (Element) confirmations.item(i);
-                String recipient = confirmation.getAttribute("Recipient");
-                if (!"https://signin.aws.amazon.com/saml".equals(recipient)) throw invalid("recipient");
-                Instant confirmationExpiry = instant(confirmation.getAttribute("NotOnOrAfter"));
-                if (confirmationExpiry == null || !now.isBefore(confirmationExpiry)) throw invalid("confirmation expiry");
+                if (!"urn:oasis:names:tc:SAML:2.0:cm:bearer".equals(confirmation.getAttribute("Method"))) {
+                    continue;
+                }
+                Element confirmationData = first(confirmation, SAML, "SubjectConfirmationData");
+                if (confirmationData == null) {
+                    continue;
+                }
+                String recipient = confirmationData.getAttribute("Recipient");
+                Instant confirmationExpiry = instant(confirmationData.getAttribute("NotOnOrAfter"));
+                if ("https://signin.aws.amazon.com/saml".equals(recipient)
+                        && confirmationExpiry != null && now.isBefore(confirmationExpiry)) {
+                    validBearer = true;
+                    break;
+                }
+            }
+            if (!validBearer) {
+                throw invalid("valid bearer subject confirmation missing");
             }
 
             List<RolePair> roles = new ArrayList<>();
             NodeList attributes = assertion.getElementsByTagNameNS(SAML, "Attribute");
             for (int i = 0; i < attributes.getLength(); i++) {
                 Element attribute = (Element) attributes.item(i);
-                if (!"https://aws.amazon.com/SAML/Attributes/Role".equals(attribute.getAttribute("Name"))) continue;
+                if (!"https://aws.amazon.com/SAML/Attributes/Role".equals(attribute.getAttribute("Name"))) {
+                    continue;
+                }
                 NodeList values = attribute.getElementsByTagNameNS(SAML, "AttributeValue");
                 for (int j = 0; j < values.getLength(); j++) {
                     String[] pair = values.item(j).getTextContent().trim().split(",", -1);
-                    if (pair.length != 2) throw invalid("role pair format");
-                    if (pair[0].startsWith("arn:aws:iam::") && pair[1].contains(":saml-provider/")) roles.add(new RolePair(pair[0], pair[1]));
-                    else if (pair[1].startsWith("arn:aws:iam::") && pair[0].contains(":saml-provider/")) roles.add(new RolePair(pair[1], pair[0]));
-                    else throw invalid("role pair ARN");
+                    if (pair.length != 2) {
+                        throw invalid("role pair format");
+                    }
+                    if (pair[0].startsWith("arn:aws:iam::") && pair[1].contains(":saml-provider/")) {
+                        roles.add(new RolePair(pair[0], pair[1]));
+                    } else if (pair[1].startsWith("arn:aws:iam::") && pair[0].contains(":saml-provider/")) {
+                        roles.add(new RolePair(pair[1], pair[0]));
+                    } else {
+                        throw invalid("role pair ARN");
+                    }
                 }
             }
-            if (roles.isEmpty()) throw invalid("role pair missing");
+            if (roles.isEmpty()) {
+                throw invalid("role pair missing");
+            }
             String nameQualifier = java.util.Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-1")
-                    .digest((issuer + provider.getArn()).getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+                    .digest((issuer + provider.getArn()).getBytes(StandardCharsets.UTF_8)));
             return new Verified(issuer, name, subjectType, nameQualifier, notOnOrAfter, roles);
         } catch (InvalidAssertionException e) {
             throw e;
@@ -110,7 +160,9 @@ final class SAMLAssertionVerifier {
     }
 
     private static Element first(org.w3c.dom.Node parent, String namespace, String local) {
-        if (parent == null) return null;
+        if (parent == null) {
+            return null;
+        }
         NodeList list = ((Element) parent).getElementsByTagNameNS(namespace, local);
         return list.getLength() == 0 ? null : (Element) list.item(0);
     }
@@ -121,14 +173,27 @@ final class SAMLAssertionVerifier {
 
     private static boolean hasText(org.w3c.dom.Node parent, String namespace, String local, String expected) {
         NodeList list = ((Element) parent).getElementsByTagNameNS(namespace, local);
-        for (int i = 0; i < list.getLength(); i++) if (expected.equals(list.item(i).getTextContent().trim())) return true;
+        for (int i = 0; i < list.getLength(); i++) {
+            if (expected.equals(list.item(i).getTextContent().trim())) {
+                return true;
+            }
+        }
         return false;
     }
+
     private static Instant instant(String text) {
-        if (text == null || text.isBlank()) return null;
-        try { return Instant.parse(text); } catch (DateTimeParseException e) { throw new IllegalArgumentException(e); }
+        if (text == null || text.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(text);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
-    private static InvalidAssertionException invalid(String reason) { return new InvalidAssertionException(reason); }
+    private static InvalidAssertionException invalid(String reason) {
+        return new InvalidAssertionException(reason);
+    }
 
     static final class InvalidAssertionException extends Exception {
         InvalidAssertionException(Throwable cause) { super(cause); }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLAssertionVerifier.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLAssertionVerifier.java
@@ -1,0 +1,138 @@
+package io.github.hectorvent.floci.services.iam;
+
+import io.github.hectorvent.floci.services.iam.model.SAMLProvider;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+
+import javax.xml.crypto.dsig.XMLSignature;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.dom.DOMValidateContext;
+import java.io.ByteArrayInputStream;
+
+import java.security.MessageDigest;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/** Verifies the specific SAML assertion contract consumed by STS. */
+final class SAMLAssertionVerifier {
+    private static final String SAML = "urn:oasis:names:tc:SAML:2.0:assertion";
+    private static final String DS = "http://www.w3.org/2000/09/xmldsig#";
+    private static final String AUDIENCE = "urn:amazon:webservices";
+
+    private SAMLAssertionVerifier() {}
+
+    record Verified(String issuer, String subject, String subjectType, String nameQualifier,
+                    Instant expiration, List<RolePair> roles) {}
+    record RolePair(String roleArn, String principalArn) {}
+
+    static Verified verify(String encoded, SAMLProvider provider, Instant now) throws InvalidAssertionException {
+        try {
+            byte[] bytes = Base64.getDecoder().decode(encoded);
+            var document = SAMLXml.document(new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
+            Element assertion = document.getDocumentElement();
+            if ("Response".equals(assertion.getLocalName())) assertion = first(assertion, SAML, "Assertion");
+            if (assertion == null || !"Assertion".equals(assertion.getLocalName()) || !SAML.equals(assertion.getNamespaceURI())) throw invalid("assertion root");
+            String assertionId = assertion.getAttribute("ID");
+            if (assertionId == null || assertionId.isBlank()) throw invalid("assertion ID");
+            assertion.setIdAttribute("ID", true);
+            Element signature = first(assertion, DS, "Signature");
+            if (signature == null) throw invalid("signature missing");
+            X509Certificate certificate = certificate(provider.getCertificate());
+            var context = new DOMValidateContext(certificate.getPublicKey(), signature);
+            context.setProperty("org.jcp.xml.dsig.secureValidation", Boolean.TRUE);
+            XMLSignature xmlSignature = XMLSignatureFactory.getInstance("DOM").unmarshalXMLSignature(context);
+            if (xmlSignature.getSignedInfo().getReferences().size() != 1
+                    || !(xmlSignature.getSignedInfo().getReferences().get(0) instanceof javax.xml.crypto.dsig.Reference reference)
+                    || !("#" + assertionId).equals(reference.getURI())) throw invalid("signature reference");
+            if (!xmlSignature.validate(context)) throw invalid("signature validation");
+
+            String issuer = childText(assertion, SAML, "Issuer");
+            if (!provider.getEntityId().equals(issuer)) throw invalid("issuer");
+            Element conditions = first(assertion, SAML, "Conditions");
+            if (conditions == null) throw invalid("conditions missing");
+            Instant notBefore = instant(conditions.getAttribute("NotBefore"));
+            Instant notOnOrAfter = instant(conditions.getAttribute("NotOnOrAfter"));
+            if (notBefore != null && now.isBefore(notBefore)) throw invalid("not before");
+            if (notOnOrAfter == null || !now.isBefore(notOnOrAfter)) throw invalid("assertion expiry");
+            Element restriction = first(conditions, SAML, "AudienceRestriction");
+            if (restriction == null || !hasText(restriction, SAML, "Audience", AUDIENCE)) throw invalid("audience");
+
+            Element subject = first(assertion, SAML, "Subject");
+            String name = childText(subject, SAML, "NameID");
+            if (name == null || name.isBlank()) throw invalid("subject");
+            Element nameId = first(subject, SAML, "NameID");
+            String subjectType = nameId == null ? null : nameId.getAttribute("Format");
+            NodeList confirmations = subject == null
+                    ? null : ((Element) subject).getElementsByTagNameNS(SAML, "SubjectConfirmationData");
+            if (confirmations == null || confirmations.getLength() == 0) throw invalid("subject confirmation missing");
+            for (int i = 0; i < confirmations.getLength(); i++) {
+                Element confirmation = (Element) confirmations.item(i);
+                String recipient = confirmation.getAttribute("Recipient");
+                if (!"https://signin.aws.amazon.com/saml".equals(recipient)) throw invalid("recipient");
+                Instant confirmationExpiry = instant(confirmation.getAttribute("NotOnOrAfter"));
+                if (confirmationExpiry == null || !now.isBefore(confirmationExpiry)) throw invalid("confirmation expiry");
+            }
+
+            List<RolePair> roles = new ArrayList<>();
+            NodeList attributes = assertion.getElementsByTagNameNS(SAML, "Attribute");
+            for (int i = 0; i < attributes.getLength(); i++) {
+                Element attribute = (Element) attributes.item(i);
+                if (!"https://aws.amazon.com/SAML/Attributes/Role".equals(attribute.getAttribute("Name"))) continue;
+                NodeList values = attribute.getElementsByTagNameNS(SAML, "AttributeValue");
+                for (int j = 0; j < values.getLength(); j++) {
+                    String[] pair = values.item(j).getTextContent().trim().split(",", -1);
+                    if (pair.length != 2) throw invalid("role pair format");
+                    if (pair[0].startsWith("arn:aws:iam::") && pair[1].contains(":saml-provider/")) roles.add(new RolePair(pair[0], pair[1]));
+                    else if (pair[1].startsWith("arn:aws:iam::") && pair[0].contains(":saml-provider/")) roles.add(new RolePair(pair[1], pair[0]));
+                    else throw invalid("role pair ARN");
+                }
+            }
+            if (roles.isEmpty()) throw invalid("role pair missing");
+            String nameQualifier = java.util.Base64.getEncoder().encodeToString(MessageDigest.getInstance("SHA-1")
+                    .digest((issuer + provider.getArn()).getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+            return new Verified(issuer, name, subjectType, nameQualifier, notOnOrAfter, roles);
+        } catch (InvalidAssertionException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new InvalidAssertionException(e);
+        }
+    }
+
+    private static X509Certificate certificate(String encoded) throws Exception {
+        byte[] der = Base64.getDecoder().decode(encoded.replaceAll("\\s+", ""));
+        return (X509Certificate) CertificateFactory.getInstance("X.509").generateCertificate(new ByteArrayInputStream(der));
+    }
+
+    private static Element first(org.w3c.dom.Node parent, String namespace, String local) {
+        if (parent == null) return null;
+        NodeList list = ((Element) parent).getElementsByTagNameNS(namespace, local);
+        return list.getLength() == 0 ? null : (Element) list.item(0);
+    }
+    private static String childText(org.w3c.dom.Node parent, String namespace, String local) {
+        Element e = first(parent, namespace, local);
+        return e == null ? null : e.getTextContent().trim();
+    }
+
+    private static boolean hasText(org.w3c.dom.Node parent, String namespace, String local, String expected) {
+        NodeList list = ((Element) parent).getElementsByTagNameNS(namespace, local);
+        for (int i = 0; i < list.getLength(); i++) if (expected.equals(list.item(i).getTextContent().trim())) return true;
+        return false;
+    }
+    private static Instant instant(String text) {
+        if (text == null || text.isBlank()) return null;
+        try { return Instant.parse(text); } catch (DateTimeParseException e) { throw new IllegalArgumentException(e); }
+    }
+    private static InvalidAssertionException invalid(String reason) { return new InvalidAssertionException(reason); }
+
+    static final class InvalidAssertionException extends Exception {
+        InvalidAssertionException(Throwable cause) { super(cause); }
+        InvalidAssertionException(String message) { super(message); }
+    }
+
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLProviderService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLProviderService.java
@@ -1,0 +1,91 @@
+package io.github.hectorvent.floci.services.iam;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.iam.model.SAMLProvider;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/** Minimal IAM SAML provider registry used by STS assertion verification. */
+@ApplicationScoped
+public class SAMLProviderService {
+    private static final Pattern ARN = Pattern.compile("^arn:aws:iam::(\\d{12}):saml-provider/[A-Za-z0-9+=,.@_-]{1,128}$");
+    private final StorageBackend<String, SAMLProvider> providers;
+
+    @Inject
+    public SAMLProviderService(StorageFactory storageFactory) {
+        this(storageFactory.create("iam", "iam-saml-providers.json", new TypeReference<>() {}));
+    }
+
+    SAMLProviderService(StorageBackend<String, SAMLProvider> providers) {
+        this.providers = providers;
+    }
+
+    public SAMLProvider create(String accountId, String name, String metadata) {
+        String arn = "arn:aws:iam::" + accountId + ":saml-provider/" + name;
+        if (!ARN.matcher(arn).matches()) {
+            throw new AwsException("InvalidInput", "Invalid SAML provider name.", 400);
+        }
+        if (metadata == null || metadata.isBlank()) {
+            throw new AwsException("InvalidInput", "SAML metadata document must not be empty.", 400);
+        }
+        SAMLMetadata.Parsed parsed;
+        try {
+            parsed = SAMLMetadata.parse(metadata);
+        } catch (Exception e) {
+            throw new AwsException("InvalidInput", "The SAML metadata document is invalid.", 400);
+        }
+        SAMLProvider provider = new SAMLProvider();
+        provider.setArn(arn);
+        provider.setEntityId(parsed.entityId());
+        provider.setCertificate(parsed.certificateBase64());
+        if (providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
+            aware.putForAccount(accountId, arn, provider);
+        } else {
+            providers.put(arn, provider);
+        }
+        return provider;
+    }
+
+    public Optional<SAMLProvider> find(String arn) {
+        var matcher = ARN.matcher(arn == null ? "" : arn);
+        if (matcher.matches() && providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
+            return aware.getForAccount(matcher.group(1), arn);
+        }
+        return providers.get(arn);
+    }
+    public List<SAMLProvider> list(String accountId) {
+        if (providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
+            return aware.scanForAccount(accountId, k -> true);
+        }
+        return providers.scan(k -> true);
+    }
+
+    public SAMLProvider get(String arn) {
+        return find(arn).orElseThrow(() -> new AwsException("NoSuchEntity",
+                "The SAML provider with ARN " + arn + " cannot be found.", 404));
+    }
+
+    /** Metadata parser shared by provider registration and the assertion verifier. */
+    static final class SAMLMetadata {
+        private SAMLMetadata() {}
+        record Parsed(String entityId, String certificateBase64) {}
+
+        static Parsed parse(String metadata) throws Exception {
+            var doc = SAMLXml.document(metadata);
+            var entity = doc.getDocumentElement().getAttribute("entityID");
+            var cert = SAMLXml.text(doc, "X509Certificate");
+            if (entity == null || entity.isBlank() || cert == null || cert.isBlank()) throw new Exception();
+            Base64.getDecoder().decode(cert.replaceAll("\\s+", ""));
+            return new Parsed(entity, cert.replaceAll("\\s+", ""));
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLProviderService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLProviderService.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 public class SAMLProviderService {
     private static final Pattern ARN = Pattern.compile("^arn:aws:iam::(\\d{12}):saml-provider/[A-Za-z0-9+=,.@_-]{1,128}$");
     private final StorageBackend<String, SAMLProvider> providers;
+    private final Object providerLock = new Object();
 
     @Inject
     public SAMLProviderService(StorageFactory storageFactory) {
@@ -47,21 +48,39 @@ public class SAMLProviderService {
         provider.setArn(arn);
         provider.setEntityId(parsed.entityId());
         provider.setCertificate(parsed.certificateBase64());
-        if (providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
-            aware.putForAccount(accountId, arn, provider);
-        } else {
-            providers.put(arn, provider);
+        synchronized (providerLock) {
+            if (findForAccount(accountId, arn).isPresent()) {
+                throw new AwsException("EntityAlreadyExists",
+                        "SAML provider " + arn + " already exists.", 409);
+            }
+            if (providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
+                aware.putForAccount(accountId, arn, provider);
+            } else {
+                providers.put(arn, provider);
+            }
         }
         return provider;
     }
 
     public Optional<SAMLProvider> find(String arn) {
         var matcher = ARN.matcher(arn == null ? "" : arn);
-        if (matcher.matches() && providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
-            return aware.getForAccount(matcher.group(1), arn);
+        if (matcher.matches()) {
+            return findForAccount(matcher.group(1), arn);
         }
         return providers.get(arn);
     }
+
+    public Optional<SAMLProvider> findForAccount(String accountId, String arn) {
+        var matcher = ARN.matcher(arn == null ? "" : arn);
+        if (!matcher.matches() || !matcher.group(1).equals(accountId)) {
+            return Optional.empty();
+        }
+        if (providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
+            return aware.getForAccount(accountId, arn);
+        }
+        return providers.get(arn);
+    }
+
     public List<SAMLProvider> list(String accountId) {
         if (providers instanceof AccountAwareStorageBackend<SAMLProvider> aware) {
             return aware.scanForAccount(accountId, k -> true);
@@ -69,21 +88,24 @@ public class SAMLProviderService {
         return providers.scan(k -> true);
     }
 
-    public SAMLProvider get(String arn) {
-        return find(arn).orElseThrow(() -> new AwsException("NoSuchEntity",
+    public SAMLProvider getForAccount(String accountId, String arn) {
+        return findForAccount(accountId, arn).orElseThrow(() -> new AwsException("NoSuchEntity",
                 "The SAML provider with ARN " + arn + " cannot be found.", 404));
     }
 
     /** Metadata parser shared by provider registration and the assertion verifier. */
     static final class SAMLMetadata {
-        private SAMLMetadata() {}
+        private SAMLMetadata() {
+        }
         record Parsed(String entityId, String certificateBase64) {}
 
         static Parsed parse(String metadata) throws Exception {
             var doc = SAMLXml.document(metadata);
             var entity = doc.getDocumentElement().getAttribute("entityID");
             var cert = SAMLXml.text(doc, "X509Certificate");
-            if (entity == null || entity.isBlank() || cert == null || cert.isBlank()) throw new Exception();
+            if (entity == null || entity.isBlank() || cert == null || cert.isBlank()) {
+                throw new Exception();
+            }
             Base64.getDecoder().decode(cert.replaceAll("\\s+", ""));
             return new Parsed(entity, cert.replaceAll("\\s+", ""));
         }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLTrustPolicyEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLTrustPolicyEvaluator.java
@@ -12,8 +12,10 @@ import java.util.Map;
 @ApplicationScoped
 public class SAMLTrustPolicyEvaluator {
     private final ObjectMapper mapper;
-    @Inject public SAMLTrustPolicyEvaluator(ObjectMapper mapper) { this.mapper = mapper; }
-
+    @Inject
+    public SAMLTrustPolicyEvaluator(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
 
     public boolean allows(String document, String providerArn, Map<String, List<String>> claims) {
         try {
@@ -22,8 +24,12 @@ public class SAMLTrustPolicyEvaluator {
                 boolean allowed = false;
                 for (JsonNode statement : statements) {
                     int result = evaluate(statement, providerArn, claims);
-                    if (result < 0) return false;
-                    if (result > 0) allowed = true;
+                    if (result < 0) {
+                        return false;
+                    }
+                    if (result > 0) {
+                        allowed = true;
+                    }
                 }
                 return allowed;
             }
@@ -35,17 +41,25 @@ public class SAMLTrustPolicyEvaluator {
 
     private int evaluate(JsonNode statement, String providerArn, Map<String, List<String>> claims) {
         if (!actionApplies(statement) || !principal(statement.path("Principal"), providerArn)
-                || !conditionsSatisfied(statement.get("Condition"), claims)) return 0;
+                || !conditionsSatisfied(statement.get("Condition"), claims)) {
+            return 0;
+        }
         return "Deny".equalsIgnoreCase(statement.path("Effect").asText()) ? -1 : 1;
     }
 
     private boolean conditionsSatisfied(JsonNode condition, Map<String, List<String>> claims) {
-        if (condition == null || condition.isNull()) return true;
-        if (!condition.isObject()) return false;
+        if (condition == null || condition.isNull()) {
+            return true;
+        }
+        if (!condition.isObject()) {
+            return false;
+        }
         var operators = condition.fields();
         while (operators.hasNext()) {
             var operator = operators.next();
-            if (!operator.getValue().isObject()) return false;
+            if (!operator.getValue().isObject()) {
+                return false;
+            }
             var entries = operator.getValue().fields();
             while (entries.hasNext()) {
                 var entry = entries.next();
@@ -57,27 +71,55 @@ public class SAMLTrustPolicyEvaluator {
                         ? java.util.stream.StreamSupport.stream(entry.getValue().spliterator(), false)
                                 .filter(JsonNode::isTextual).map(JsonNode::asText).toList()
                         : entry.getValue().isTextual() ? List.of(entry.getValue().asText()) : List.of();
-                if (expected.isEmpty()) return false;
-                boolean matches = actual.stream().anyMatch(value -> expected.stream().anyMatch(pattern ->
-                        "StringLike".equals(operator.getKey())
-                                ? WebIdentityTrustPolicyEvaluator.globMatchesCaseSensitive(pattern, value)
-                                : "StringEquals".equals(operator.getKey()) && pattern.equals(value)));
-                if (!matches) return false;
+                if (expected.isEmpty() || actual.isEmpty()) {
+                    return false;
+                }
+                if (!operatorMatches(operator.getKey(), actual, expected)) {
+                    return false;
+                }
             }
         }
         return true;
     }
 
+    private boolean operatorMatches(String operator, List<String> actual, List<String> expected) {
+        if ("StringEquals".equals(operator)) {
+            return actual.stream().anyMatch(value -> expected.contains(value));
+        }
+        if ("StringLike".equals(operator)) {
+            return actual.stream().anyMatch(value -> expected.stream().anyMatch(pattern ->
+                    WebIdentityTrustPolicyEvaluator.globMatchesCaseSensitive(pattern, value)));
+        }
+        if ("StringNotEquals".equals(operator)) {
+            return actual.stream().allMatch(value -> expected.stream().noneMatch(value::equals));
+        }
+        if ("StringNotLike".equals(operator)) {
+            return actual.stream().allMatch(value -> expected.stream().noneMatch(pattern ->
+                    WebIdentityTrustPolicyEvaluator.globMatchesCaseSensitive(pattern, value)));
+        }
+        return false;
+    }
+
     private boolean actionApplies(JsonNode statement) {
         JsonNode action = statement.get("Action");
-        if (action != null) return action(action);
+        if (action != null) {
+            return action(action);
+        }
         JsonNode notAction = statement.get("NotAction");
         return notAction != null && !action(notAction);
     }
 
     private boolean action(JsonNode node) {
-        if (node.isTextual()) return matches(node.asText());
-        if (node.isArray()) for (JsonNode value : node) if (value.isTextual() && matches(value.asText())) return true;
+        if (node.isTextual()) {
+            return matches(node.asText());
+        }
+        if (node.isArray()) {
+            for (JsonNode value : node) {
+                if (value.isTextual() && matches(value.asText())) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
     private boolean matches(String action) {
@@ -86,10 +128,20 @@ public class SAMLTrustPolicyEvaluator {
     }
     private boolean principal(JsonNode node, String providerArn) {
         JsonNode federated = node.isObject() ? node.get("Federated") : null;
-        if (federated == null) return "*".equals(node.asText());
-        if (federated.isTextual()) return "*".equals(federated.asText()) || providerArn.equals(federated.asText());
-        if (federated.isArray()) for (JsonNode value : federated) if (value.isTextual()
-                && ("*".equals(value.asText()) || providerArn.equals(value.asText()))) return true;
+        if (federated == null) {
+            return "*".equals(node.asText());
+        }
+        if (federated.isTextual()) {
+            return "*".equals(federated.asText()) || providerArn.equals(federated.asText());
+        }
+        if (federated.isArray()) {
+            for (JsonNode value : federated) {
+                if (value.isTextual()
+                        && ("*".equals(value.asText()) || providerArn.equals(value.asText()))) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLTrustPolicyEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLTrustPolicyEvaluator.java
@@ -1,0 +1,95 @@
+package io.github.hectorvent.floci.services.iam;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+
+/** Evaluates the federated principal and SAML action in a role trust policy. */
+@ApplicationScoped
+public class SAMLTrustPolicyEvaluator {
+    private final ObjectMapper mapper;
+    @Inject public SAMLTrustPolicyEvaluator(ObjectMapper mapper) { this.mapper = mapper; }
+
+
+    public boolean allows(String document, String providerArn, Map<String, List<String>> claims) {
+        try {
+            JsonNode statements = mapper.readTree(document).path("Statement");
+            if (statements.isArray()) {
+                boolean allowed = false;
+                for (JsonNode statement : statements) {
+                    int result = evaluate(statement, providerArn, claims);
+                    if (result < 0) return false;
+                    if (result > 0) allowed = true;
+                }
+                return allowed;
+            }
+            return statements.isObject() && evaluate(statements, providerArn, claims) > 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private int evaluate(JsonNode statement, String providerArn, Map<String, List<String>> claims) {
+        if (!actionApplies(statement) || !principal(statement.path("Principal"), providerArn)
+                || !conditionsSatisfied(statement.get("Condition"), claims)) return 0;
+        return "Deny".equalsIgnoreCase(statement.path("Effect").asText()) ? -1 : 1;
+    }
+
+    private boolean conditionsSatisfied(JsonNode condition, Map<String, List<String>> claims) {
+        if (condition == null || condition.isNull()) return true;
+        if (!condition.isObject()) return false;
+        var operators = condition.fields();
+        while (operators.hasNext()) {
+            var operator = operators.next();
+            if (!operator.getValue().isObject()) return false;
+            var entries = operator.getValue().fields();
+            while (entries.hasNext()) {
+                var entry = entries.next();
+                String key = entry.getKey();
+                int colon = key.indexOf(':');
+                String claimName = colon < 0 ? key : key.substring(colon + 1);
+                List<String> actual = claims.getOrDefault(claimName, List.of());
+                List<String> expected = entry.getValue().isArray()
+                        ? java.util.stream.StreamSupport.stream(entry.getValue().spliterator(), false)
+                                .filter(JsonNode::isTextual).map(JsonNode::asText).toList()
+                        : entry.getValue().isTextual() ? List.of(entry.getValue().asText()) : List.of();
+                if (expected.isEmpty()) return false;
+                boolean matches = actual.stream().anyMatch(value -> expected.stream().anyMatch(pattern ->
+                        "StringLike".equals(operator.getKey())
+                                ? WebIdentityTrustPolicyEvaluator.globMatchesCaseSensitive(pattern, value)
+                                : "StringEquals".equals(operator.getKey()) && pattern.equals(value)));
+                if (!matches) return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean actionApplies(JsonNode statement) {
+        JsonNode action = statement.get("Action");
+        if (action != null) return action(action);
+        JsonNode notAction = statement.get("NotAction");
+        return notAction != null && !action(notAction);
+    }
+
+    private boolean action(JsonNode node) {
+        if (node.isTextual()) return matches(node.asText());
+        if (node.isArray()) for (JsonNode value : node) if (value.isTextual() && matches(value.asText())) return true;
+        return false;
+    }
+    private boolean matches(String action) {
+        String regex = action.replace(".", "\\.").replace("*", ".*").replace("?", ".");
+        return "sts:AssumeRoleWithSAML".matches("(?i)^" + regex + "$");
+    }
+    private boolean principal(JsonNode node, String providerArn) {
+        JsonNode federated = node.isObject() ? node.get("Federated") : null;
+        if (federated == null) return "*".equals(node.asText());
+        if (federated.isTextual()) return "*".equals(federated.asText()) || providerArn.equals(federated.asText());
+        if (federated.isArray()) for (JsonNode value : federated) if (value.isTextual()
+                && ("*".equals(value.asText()) || providerArn.equals(value.asText()))) return true;
+        return false;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLXml.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLXml.java
@@ -1,32 +1,23 @@
 package io.github.hectorvent.floci.services.iam;
 
+import io.github.hectorvent.floci.core.common.XmlParser;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-import javax.xml.XMLConstants;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-
 final class SAMLXml {
-    private SAMLXml() {}
+    private SAMLXml() {
+    }
 
     static Document document(String xml) throws Exception {
-        var factory = DocumentBuilderFactory.newInstance();
-        factory.setNamespaceAware(true);
-        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-        factory.setXIncludeAware(false);
-        factory.setExpandEntityReferences(false);
-        return factory.newDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        return XmlParser.parseDocument(xml);
     }
 
     static String text(Document document, String localName) {
         NodeList nodes = document.getElementsByTagNameNS("*", localName);
-        if (nodes.getLength() == 0) return null;
+        if (nodes.getLength() == 0) {
+            return null;
+        }
         return nodes.item(0).getTextContent().trim();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/SAMLXml.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/SAMLXml.java
@@ -1,0 +1,37 @@
+package io.github.hectorvent.floci.services.iam;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+
+final class SAMLXml {
+    private SAMLXml() {}
+
+    static Document document(String xml) throws Exception {
+        var factory = DocumentBuilderFactory.newInstance();
+        factory.setNamespaceAware(true);
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+        factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+        factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+        factory.setXIncludeAware(false);
+        factory.setExpandEntityReferences(false);
+        return factory.newDocumentBuilder().parse(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    static String text(Document document, String localName) {
+        NodeList nodes = document.getElementsByTagNameNS("*", localName);
+        if (nodes.getLength() == 0) return null;
+        return nodes.item(0).getTextContent().trim();
+    }
+
+    static String text(Node parent, String namespace, String localName) {
+        NodeList nodes = ((org.w3c.dom.Element) parent).getElementsByTagNameNS(namespace, localName);
+        return nodes.getLength() == 0 ? null : nodes.item(0).getTextContent().trim();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.iam;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.AwsNamespaces;
 import io.github.hectorvent.floci.core.common.AwsQueryController;
 import io.github.hectorvent.floci.core.common.AwsQueryResponse;
@@ -48,6 +49,8 @@ public class StsQueryHandler {
     private final WebIdentityTrustPolicyEvaluator webIdentityTrustEvaluator;
     private final WebIdentityTokenVerifier tokenVerifier;
     private final OidcIssuerKeyLookup oidcIssuerKeys;
+    private final SAMLProviderService samlProviderService;
+    private final SAMLTrustPolicyEvaluator samlTrustEvaluator;
 
     @Context
     HttpHeaders headers;
@@ -57,7 +60,9 @@ public class StsQueryHandler {
                            EmulatorConfig config, AssumeRolePolicyEvaluator trustPolicyEvaluator,
                            WebIdentityTrustPolicyEvaluator webIdentityTrustEvaluator,
                            WebIdentityTokenVerifier tokenVerifier,
-                           OidcIssuerKeyLookup oidcIssuerKeys) {
+                           OidcIssuerKeyLookup oidcIssuerKeys,
+                           SAMLProviderService samlProviderService,
+                           SAMLTrustPolicyEvaluator samlTrustEvaluator) {
         this.iamService = iamService;
         this.accountResolver = accountResolver;
         this.regionResolver = regionResolver;
@@ -66,6 +71,8 @@ public class StsQueryHandler {
         this.webIdentityTrustEvaluator = webIdentityTrustEvaluator;
         this.tokenVerifier = tokenVerifier;
         this.oidcIssuerKeys = oidcIssuerKeys;
+        this.samlProviderService = samlProviderService;
+        this.samlTrustEvaluator = samlTrustEvaluator;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params) {
@@ -327,39 +334,55 @@ public class StsQueryHandler {
 
     private Response handleAssumeRoleWithSAML(MultivaluedMap<String, String> params) {
         Response validation = validateRequired(params, "RoleArn", "PrincipalArn", "SAMLAssertion");
-        if (validation != null) {
-            return validation;
-        }
+        if (validation != null) return validation;
         String roleArn = getParam(params, "RoleArn");
-        String sessionName = "saml-session";
+        String principalArn = getParam(params, "PrincipalArn");
         int durationSeconds = getIntParam(params, "DurationSeconds", 3600);
 
+        var provider = samlProviderService.find(principalArn).orElseThrow(() ->
+                new AwsException("InvalidIdentityToken", "The SAML provider is not trusted.", 400));
+        SAMLAssertionVerifier.Verified verified;
+        try {
+            verified = SAMLAssertionVerifier.verify(getParam(params, "SAMLAssertion"), provider, Instant.now());
+        } catch (SAMLAssertionVerifier.InvalidAssertionException e) {
+            throw new AwsException("InvalidIdentityToken", "The SAML assertion is invalid.", 400);
+        }
+        boolean rolePair = verified.roles().stream().anyMatch(pair ->
+                roleArn.equals(pair.roleArn()) && principalArn.equals(pair.principalArn()));
+        if (!rolePair) throw new AwsException("InvalidIdentityToken",
+                "The SAML assertion does not contain the requested role and principal.", 400);
+
+        String callerAccountId = regionResolver.getAccountId();
+        String accountId = AwsArnUtils.accountOrDefault(roleArn, callerAccountId);
+        String roleName = roleArn.contains("/") ? roleArn.substring(roleArn.lastIndexOf('/') + 1) : "UnknownRole";
+        IamRole role = iamService.findRole(accountId, roleName).orElseThrow(() ->
+                new AwsException("AccessDenied", "Not authorized to perform sts:AssumeRoleWithSAML on resource: " + roleArn, 403));
+        if (!samlTrustEvaluator.allows(role.getAssumeRolePolicyDocument(), principalArn, Map.of(
+                "aud", List.of(STS_AUDIENCE),
+                "iss", List.of(verified.issuer()),
+                "sub", List.of(verified.subject()),
+                "namequalifier", List.of(verified.nameQualifier())))) {
+            throw new AwsException("AccessDenied", "Not authorized to perform sts:AssumeRoleWithSAML on resource: " + roleArn, 403);
+        }
+
+        String sessionName = verified.subject().replaceAll("[^A-Za-z0-9+=,.@_-]", "_");
+        if (sessionName.length() > 64) sessionName = sessionName.substring(0, 64);
+        Instant requestedExpiration = Instant.now().plusSeconds(durationSeconds);
+        Instant roleExpiration = Instant.now().plusSeconds(role.getMaxSessionDuration());
+        Instant expiration = verified.expiration().isBefore(requestedExpiration) ? verified.expiration() : requestedExpiration;
+        if (roleExpiration.isBefore(expiration)) expiration = roleExpiration;
         String accessKeyId = "ASIA" + randomId(16);
         String secretKey = randomSecret(40);
         String sessionToken = randomSecret(200);
-        Instant expiration = Instant.now().plusSeconds(durationSeconds);
-
-        String roleName = roleArn.contains("/") ? roleArn.substring(roleArn.lastIndexOf('/') + 1) : "UnknownRole";
-        String callerAccountId = regionResolver.getAccountId();
-        String accountId = AwsArnUtils.accountOrDefault(roleArn, callerAccountId);
         String assumedRoleArn = AwsArnUtils.Arn.of("sts", "", accountId, "assumed-role/" + roleName + "/" + sessionName).toString();
         String assumedRoleId = "AROA" + randomId(16) + ":" + sessionName;
 
         iamService.registerSession(accessKeyId, secretKey, sessionToken, roleArn, expiration, null, callerAccountId);
-
         String result = new XmlBuilder()
                 .raw(credentialsXml(accessKeyId, secretKey, sessionToken, expiration))
-                .start("AssumedRoleUser")
-                  .elem("Arn", assumedRoleArn)
-                  .elem("AssumedRoleId", assumedRoleId)
-                .end("AssumedRoleUser")
-                .elem("PackedPolicySize", "0")
-                .elem("Issuer", "https://saml.example.com")
-                .elem("Audience", "urn:amazon:webservices")
-                .elem("NameQualifier", "saml-qualifier")
-                .elem("SubjectType", "persistent")
-                .elem("Subject", "saml-subject")
-                .build();
+                .start("AssumedRoleUser").elem("Arn", assumedRoleArn).elem("AssumedRoleId", assumedRoleId).end("AssumedRoleUser")
+                .elem("PackedPolicySize", "0").elem("Issuer", verified.issuer()).elem("Audience", "urn:amazon:webservices")
+                .elem("NameQualifier", verified.nameQualifier()).elem("SubjectType", verified.subjectType()).elem("Subject", verified.subject()).build();
         return Response.ok(AwsQueryResponse.envelope("AssumeRoleWithSAML", AwsNamespaces.STS, result)).build();
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/StsQueryHandler.java
@@ -334,7 +334,9 @@ public class StsQueryHandler {
 
     private Response handleAssumeRoleWithSAML(MultivaluedMap<String, String> params) {
         Response validation = validateRequired(params, "RoleArn", "PrincipalArn", "SAMLAssertion");
-        if (validation != null) return validation;
+        if (validation != null) {
+            return validation;
+        }
         String roleArn = getParam(params, "RoleArn");
         String principalArn = getParam(params, "PrincipalArn");
         int durationSeconds = getIntParam(params, "DurationSeconds", 3600);
@@ -349,8 +351,10 @@ public class StsQueryHandler {
         }
         boolean rolePair = verified.roles().stream().anyMatch(pair ->
                 roleArn.equals(pair.roleArn()) && principalArn.equals(pair.principalArn()));
-        if (!rolePair) throw new AwsException("InvalidIdentityToken",
-                "The SAML assertion does not contain the requested role and principal.", 400);
+        if (!rolePair) {
+            throw new AwsException("InvalidIdentityToken",
+                    "The SAML assertion does not contain the requested role and principal.", 400);
+        }
 
         String callerAccountId = regionResolver.getAccountId();
         String accountId = AwsArnUtils.accountOrDefault(roleArn, callerAccountId);
@@ -366,11 +370,15 @@ public class StsQueryHandler {
         }
 
         String sessionName = verified.subject().replaceAll("[^A-Za-z0-9+=,.@_-]", "_");
-        if (sessionName.length() > 64) sessionName = sessionName.substring(0, 64);
+        if (sessionName.length() > 64) {
+            sessionName = sessionName.substring(0, 64);
+        }
         Instant requestedExpiration = Instant.now().plusSeconds(durationSeconds);
         Instant roleExpiration = Instant.now().plusSeconds(role.getMaxSessionDuration());
         Instant expiration = verified.expiration().isBefore(requestedExpiration) ? verified.expiration() : requestedExpiration;
-        if (roleExpiration.isBefore(expiration)) expiration = roleExpiration;
+        if (roleExpiration.isBefore(expiration)) {
+            expiration = roleExpiration;
+        }
         String accessKeyId = "ASIA" + randomId(16);
         String secretKey = randomSecret(40);
         String sessionToken = randomSecret(200);

--- a/src/main/java/io/github/hectorvent/floci/services/iam/model/SAMLProvider.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/model/SAMLProvider.java
@@ -1,0 +1,26 @@
+package io.github.hectorvent.floci.services.iam.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.time.Instant;
+
+@RegisterForReflection
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SAMLProvider {
+    private String arn;
+    private String entityId;
+    private String certificate;
+    private Instant createDate = Instant.now();
+
+    public SAMLProvider() {}
+
+    public String getArn() { return arn; }
+    public void setArn(String arn) { this.arn = arn; }
+    public String getEntityId() { return entityId; }
+    public void setEntityId(String entityId) { this.entityId = entityId; }
+    public String getCertificate() { return certificate; }
+    public void setCertificate(String certificate) { this.certificate = certificate; }
+    public Instant getCreateDate() { return createDate; }
+    public void setCreateDate(Instant createDate) { this.createDate = createDate; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/AssumeRoleWithSamlValidationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/AssumeRoleWithSamlValidationIntegrationTest.java
@@ -1,0 +1,229 @@
+package io.github.hectorvent.floci.services.iam;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.crypto.dsig.DigestMethod;
+import javax.xml.crypto.dsig.Reference;
+import javax.xml.crypto.dsig.SignatureMethod;
+import javax.xml.crypto.dsig.SignedInfo;
+import javax.xml.crypto.dsig.Transform;
+import javax.xml.crypto.dsig.XMLSignatureFactory;
+import javax.xml.crypto.dsig.dom.DOMSignContext;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.startsWith;
+
+@QuarkusTest
+class AssumeRoleWithSamlValidationIntegrationTest {
+    private static final String ACCOUNT = "000000000000";
+    private static final String ISSUER = "https://idp.example.test/saml";
+    private static final String PROVIDER_NAME = "greptile-saml";
+    private static final String PROVIDER = "arn:aws:iam::" + ACCOUNT + ":saml-provider/" + PROVIDER_NAME;
+    private static final String AUDIENCE = "urn:amazon:webservices";
+    private static final String SAML_NS = "urn:oasis:names:tc:SAML:2.0:assertion";
+    private static KeyPair signingKeys;
+    private static String certificateBase64;
+
+    @BeforeAll
+    static void createSigningCertificate() throws Exception {
+        Security.addProvider(new BouncyCastleProvider());
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        signingKeys = generator.generateKeyPair();
+        Instant now = Instant.now();
+        X500Name name = new X500Name("CN=Floci SAML test provider");
+        X509CertificateHolder holder = new JcaX509v3CertificateBuilder(
+                name, BigInteger.ONE, Date.from(now.minusSeconds(60)), Date.from(now.plusSeconds(3600)),
+                name, signingKeys.getPublic())
+                .build(new JcaContentSignerBuilder("SHA256withRSA").setProvider("BC").build(signingKeys.getPrivate()));
+        X509Certificate certificate = new JcaX509CertificateConverter().setProvider("BC").getCertificate(holder);
+        certificate.verify(signingKeys.getPublic());
+        certificateBase64 = Base64.getEncoder().encodeToString(certificate.getEncoded());
+    }
+
+    @Test
+    void malformedAssertionIsRejected() {
+        String role = createRole(true);
+        assume(role, "not-an-assertion", PROVIDER).statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void unsignedAssertionIsRejected() {
+        String role = createRole(true);
+        assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, false), PROVIDER)
+                .statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void expiredAssertionIsRejected() {
+        String role = createRole(true);
+        assume(role, assertion(role, PROVIDER, Instant.now().minusSeconds(1), AUDIENCE, ISSUER, true), PROVIDER)
+                .statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void wrongAudienceIsRejected() {
+        String role = createRole(true);
+        assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), "wrong-audience", ISSUER, true), PROVIDER)
+                .statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void wrongIssuerIsRejected() {
+        String role = createRole(true);
+        assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, "https://wrong.example.test", true), PROVIDER)
+                .statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void alteredAssertionIsRejected() {
+        String role = createRole(true);
+        String altered = tamper(assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true),
+                "saml-subject", "altered-subject");
+        assume(role, altered, PROVIDER).statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void wrongRoleAndPrincipalPairIsRejected() {
+        String role = createRole(true);
+        String otherRole = "arn:aws:iam::" + ACCOUNT + ":role/not-the-requested-role";
+        assume(role, assertion(otherRole, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true), PROVIDER)
+                .statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void trustPolicyDenialIsRejected() {
+        String role = createRole(false);
+        assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true), PROVIDER)
+                .statusCode(403).body(containsString("AccessDenied"));
+    }
+
+    @Test
+    void unregisteredProviderIsRejected() {
+        String role = "arn:aws:iam::" + ACCOUNT + ":role/unknown-provider-role";
+        assume(role, Base64.getEncoder().encodeToString("<Assertion/>".getBytes(StandardCharsets.UTF_8)),
+                "arn:aws:iam::" + ACCOUNT + ":saml-provider/not-registered")
+                .statusCode(400).body(containsString("InvalidIdentityToken"));
+    }
+
+    @Test
+    void validSignedAssertionReturnsCredentialsAndSamlFields() {
+        String role = createRole(true);
+        assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true), PROVIDER)
+                .statusCode(200)
+                .body("AssumeRoleWithSAMLResponse.AssumeRoleWithSAMLResult.Credentials.AccessKeyId", startsWith("ASIA"))
+                .body("AssumeRoleWithSAMLResponse.AssumeRoleWithSAMLResult.Issuer", containsString(ISSUER))
+                .body("AssumeRoleWithSAMLResponse.AssumeRoleWithSAMLResult.Audience", containsString(AUDIENCE))
+                .body("AssumeRoleWithSAMLResponse.AssumeRoleWithSAMLResult.Subject", containsString("saml-subject"));
+    }
+
+    private static io.restassured.response.ValidatableResponse assume(String role, String assertion, String provider) {
+        return given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "AssumeRoleWithSAML")
+                .formParam("RoleArn", role)
+                .formParam("PrincipalArn", provider)
+                .formParam("SAMLAssertion", assertion)
+                .header("Authorization", auth("sts"))
+                .when().post("/").then();
+    }
+
+    private static String createRole(boolean allow) {
+        String role = "saml-role-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        String trust = allow
+                ? "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\"" + PROVIDER + "\"},\"Action\":\"sts:AssumeRoleWithSAML\"}]}"
+                : "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Principal\":{\"Federated\":\"" + PROVIDER + "\"},\"Action\":\"sts:AssumeRoleWithSAML\"}]}";
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateRole").formParam("RoleName", role)
+                .formParam("AssumeRolePolicyDocument", trust)
+                .header("Authorization", auth("iam")).when().post("/").then().statusCode(200);
+        registerProvider();
+        return "arn:aws:iam::" + ACCOUNT + ":role/" + role;
+    }
+
+    private static void registerProvider() {
+        String metadata = "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"" + ISSUER
+                + "\"><md:IDPSSODescriptor><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>"
+                + certificateBase64 + "</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor></md:IDPSSODescriptor></md:EntityDescriptor>";
+        given().contentType("application/x-www-form-urlencoded").formParam("Action", "CreateSAMLProvider")
+                .formParam("Name", PROVIDER_NAME).formParam("SAMLMetadataDocument", metadata)
+                .header("Authorization", auth("iam")).when().post("/").then().statusCode(200);
+    }
+
+    private static String tamper(String encoded, String original, String replacement) {
+        String xml = new String(Base64.getDecoder().decode(encoded), StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(xml.replace(original, replacement).getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String auth(String service) {
+        return "AWS4-HMAC-SHA256 Credential=" + ACCOUNT + "/20260907/us-east-1/" + service
+                + "/aws4_request, SignedHeaders=host, Signature=test";
+    }
+
+    private static String assertion(String role, String provider, Instant expiry, String audience,
+                                    String issuer, boolean sign) {
+        String id = "_" + UUID.randomUUID();
+        String xml = "<saml:Assertion xmlns:saml=\"" + SAML_NS + "\" ID=\"" + id + "\" Version=\"2.0\" IssueInstant=\""
+                + Instant.now() + "\"><saml:Issuer>" + issuer + "</saml:Issuer><saml:Subject><saml:NameID Format=\"persistent\">saml-subject</saml:NameID>"
+                + "<saml:SubjectConfirmation><saml:SubjectConfirmationData Recipient=\"https://signin.aws.amazon.com/saml\" NotOnOrAfter=\"" + expiry + "\"/></saml:SubjectConfirmation></saml:Subject>"
+                + "<saml:Conditions NotBefore=\"" + Instant.now().minusSeconds(30) + "\" NotOnOrAfter=\"" + expiry + "\"><saml:AudienceRestriction><saml:Audience>" + audience + "</saml:Audience></saml:AudienceRestriction></saml:Conditions>"
+                + "<saml:AttributeStatement><saml:Attribute Name=\"https://aws.amazon.com/SAML/Attributes/Role\"><saml:AttributeValue>" + role + "," + provider + "</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>";
+        try {
+            DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
+            parserFactory.setNamespaceAware(true);
+            Document document = parserFactory.newDocumentBuilder()
+                    .parse(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            if (!sign) return encoded(document);
+            Element assertion = document.getDocumentElement();
+            assertion.setIdAttribute("ID", true);
+            XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");
+            Reference reference = factory.newReference("#" + id,
+                    factory.newDigestMethod(DigestMethod.SHA256, null),
+                    List.of(factory.newTransform(Transform.ENVELOPED, (javax.xml.crypto.dsig.spec.TransformParameterSpec) null)), null, null);
+            SignedInfo signedInfo = factory.newSignedInfo(
+                    factory.newCanonicalizationMethod("http://www.w3.org/2001/10/xml-exc-c14n#", (javax.xml.crypto.dsig.spec.C14NMethodParameterSpec) null),
+                    factory.newSignatureMethod(SignatureMethod.RSA_SHA256, null), List.of(reference));
+            factory.newXMLSignature(signedInfo, null)
+                    .sign(new DOMSignContext(signingKeys.getPrivate(), assertion));
+            return encoded(document);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String encoded(Document document) throws Exception {
+        var transformer = TransformerFactory.newInstance().newTransformer();
+        transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "yes");
+        StringWriter output = new StringWriter();
+        transformer.transform(new DOMSource(document), new StreamResult(output));
+        return Base64.getEncoder().encodeToString(output.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/AssumeRoleWithSamlValidationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/AssumeRoleWithSamlValidationIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.iam;
 
+import io.github.hectorvent.floci.core.common.XmlParser;
 import io.quarkus.test.junit.QuarkusTest;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -20,7 +21,6 @@ import javax.xml.crypto.dsig.Transform;
 import javax.xml.crypto.dsig.XMLSignatureFactory;
 import javax.xml.crypto.dsig.dom.DOMSignContext;
 
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
@@ -251,10 +251,7 @@ class AssumeRoleWithSamlValidationIntegrationTest {
                 + "<saml:Conditions NotBefore=\"" + Instant.now().minusSeconds(30) + "\" NotOnOrAfter=\"" + expiry + "\"><saml:AudienceRestriction><saml:Audience>" + audience + "</saml:Audience></saml:AudienceRestriction></saml:Conditions>"
                 + "<saml:AttributeStatement><saml:Attribute Name=\"https://aws.amazon.com/SAML/Attributes/Role\"><saml:AttributeValue>" + role + "," + provider + "</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>";
         try {
-            DocumentBuilderFactory parserFactory = DocumentBuilderFactory.newInstance();
-            parserFactory.setNamespaceAware(true);
-            Document document = parserFactory.newDocumentBuilder()
-                    .parse(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+            Document document = XmlParser.parseDocument(xml);
             if (!sign) {
                 return encoded(document);
             }

--- a/src/test/java/io/github/hectorvent/floci/services/iam/AssumeRoleWithSamlValidationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/AssumeRoleWithSamlValidationIntegrationTest.java
@@ -52,6 +52,7 @@ class AssumeRoleWithSamlValidationIntegrationTest {
     private static final String SAML_NS = "urn:oasis:names:tc:SAML:2.0:assertion";
     private static KeyPair signingKeys;
     private static String certificateBase64;
+    private static boolean providerRegistered;
 
     @BeforeAll
     static void createSigningCertificate() throws Exception {
@@ -136,6 +137,44 @@ class AssumeRoleWithSamlValidationIntegrationTest {
     }
 
     @Test
+    void conditionalTrustPolicyDenyIsNotBypassed() {
+        String role = "saml-conditional-deny-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        String trust = "{\"Version\":\"2012-10-17\",\"Statement\":["
+                + "{\"Effect\":\"Allow\",\"Principal\":{\"Federated\":\"" + PROVIDER
+                + "\"},\"Action\":\"sts:AssumeRoleWithSAML\"},"
+                + "{\"Effect\":\"Deny\",\"Principal\":{\"Federated\":\"" + PROVIDER
+                + "\"},\"Action\":\"sts:AssumeRoleWithSAML\",\"Condition\":{\"StringNotEquals\":{\"saml:iss\":\"https://other.example.test\"}}}]}";
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateRole").formParam("RoleName", role)
+                .formParam("AssumeRolePolicyDocument", trust)
+                .header("Authorization", auth("iam")).when().post("/").then().statusCode(200);
+        ensureProviderRegistered();
+        String roleArn = "arn:aws:iam::" + ACCOUNT + ":role/" + role;
+        assume(roleArn, assertion(roleArn, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true), PROVIDER)
+                .statusCode(403).body(containsString("AccessDenied"));
+    }
+
+    @Test
+    void duplicateProviderCreationIsRejected() {
+        String metadata = "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\""
+                + ISSUER + "\"><md:IDPSSODescriptor><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>"
+                + certificateBase64 + "</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor></md:IDPSSODescriptor></md:EntityDescriptor>";
+        given().contentType("application/x-www-form-urlencoded")
+                .formParam("Action", "CreateSAMLProvider").formParam("Name", PROVIDER_NAME)
+                .formParam("SAMLMetadataDocument", metadata)
+                .header("Authorization", auth("iam")).when().post("/").then()
+                .statusCode(409).body(containsString("EntityAlreadyExists"));
+    }
+
+    @Test
+    void validBearerConfirmationIsAcceptedWithUnrelatedConfirmation() {
+        String role = createRole(true);
+        assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true, true), PROVIDER)
+                .statusCode(200)
+                .body("AssumeRoleWithSAMLResponse.AssumeRoleWithSAMLResult.Credentials.AccessKeyId", startsWith("ASIA"));
+    }
+
+    @Test
     void validSignedAssertionReturnsCredentialsAndSamlFields() {
         String role = createRole(true);
         assume(role, assertion(role, PROVIDER, Instant.now().plusSeconds(300), AUDIENCE, ISSUER, true), PROVIDER)
@@ -165,8 +204,15 @@ class AssumeRoleWithSamlValidationIntegrationTest {
                 .formParam("Action", "CreateRole").formParam("RoleName", role)
                 .formParam("AssumeRolePolicyDocument", trust)
                 .header("Authorization", auth("iam")).when().post("/").then().statusCode(200);
-        registerProvider();
+        ensureProviderRegistered();
         return "arn:aws:iam::" + ACCOUNT + ":role/" + role;
+    }
+
+    private static void ensureProviderRegistered() {
+        if (!providerRegistered) {
+            registerProvider();
+            providerRegistered = true;
+        }
     }
 
     private static void registerProvider() {
@@ -190,10 +236,18 @@ class AssumeRoleWithSamlValidationIntegrationTest {
 
     private static String assertion(String role, String provider, Instant expiry, String audience,
                                     String issuer, boolean sign) {
+        return assertion(role, provider, expiry, audience, issuer, sign, false);
+    }
+
+    private static String assertion(String role, String provider, Instant expiry, String audience,
+                                    String issuer, boolean sign, boolean unrelatedConfirmation) {
         String id = "_" + UUID.randomUUID();
+        String extraConfirmation = unrelatedConfirmation
+                ? "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:sender-vouches\"><saml:SubjectConfirmationData Recipient=\"https://unrelated.example.test\" NotOnOrAfter=\"" + Instant.now().minusSeconds(1) + "\"/></saml:SubjectConfirmation>"
+                : "";
         String xml = "<saml:Assertion xmlns:saml=\"" + SAML_NS + "\" ID=\"" + id + "\" Version=\"2.0\" IssueInstant=\""
                 + Instant.now() + "\"><saml:Issuer>" + issuer + "</saml:Issuer><saml:Subject><saml:NameID Format=\"persistent\">saml-subject</saml:NameID>"
-                + "<saml:SubjectConfirmation><saml:SubjectConfirmationData Recipient=\"https://signin.aws.amazon.com/saml\" NotOnOrAfter=\"" + expiry + "\"/></saml:SubjectConfirmation></saml:Subject>"
+                + extraConfirmation + "<saml:SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><saml:SubjectConfirmationData Recipient=\"https://signin.aws.amazon.com/saml\" NotOnOrAfter=\"" + expiry + "\"/></saml:SubjectConfirmation></saml:Subject>"
                 + "<saml:Conditions NotBefore=\"" + Instant.now().minusSeconds(30) + "\" NotOnOrAfter=\"" + expiry + "\"><saml:AudienceRestriction><saml:Audience>" + audience + "</saml:Audience></saml:AudienceRestriction></saml:Conditions>"
                 + "<saml:AttributeStatement><saml:Attribute Name=\"https://aws.amazon.com/SAML/Attributes/Role\"><saml:AttributeValue>" + role + "," + provider + "</saml:AttributeValue></saml:Attribute></saml:AttributeStatement></saml:Assertion>";
         try {
@@ -201,7 +255,9 @@ class AssumeRoleWithSamlValidationIntegrationTest {
             parserFactory.setNamespaceAware(true);
             Document document = parserFactory.newDocumentBuilder()
                     .parse(new java.io.ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
-            if (!sign) return encoded(document);
+            if (!sign) {
+                return encoded(document);
+            }
             Element assertion = document.getDocumentElement();
             assertion.setIdAttribute("ID", true);
             XMLSignatureFactory factory = XMLSignatureFactory.getInstance("DOM");

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -458,7 +458,7 @@ class IamIntegrationTest {
 
     @Test
     @Order(53)
-    void listSamlProvidersReturnsEmptyList() {
+    void listSamlProvidersReturnsWireCompatibleResult() {
         given()
             .formParam("Action", "ListSAMLProviders")
             .header("Authorization",
@@ -468,7 +468,7 @@ class IamIntegrationTest {
         .then()
             .statusCode(200)
             .contentType("application/xml")
-            .body("ListSAMLProvidersResponse.ListSAMLProvidersResult.SAMLProviderList", isEmptyOrNullString());
+            .body("ListSAMLProvidersResponse.ListSAMLProvidersResult.SAMLProviderList", notNullValue());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamIntegrationTest.java
@@ -473,6 +473,24 @@ class IamIntegrationTest {
 
     @Test
     @Order(54)
+    void getSamlProviderDoesNotCrossAccountBoundaries() {
+        String providerName = "cross-account-saml-" + System.nanoTime();
+        String metadata = "<md:EntityDescriptor xmlns:md=\"urn:oasis:names:tc:SAML:2.0:metadata\" entityID=\"https://idp.example.test/"
+                + providerName + "\"><md:IDPSSODescriptor><md:KeyDescriptor use=\"signing\"><ds:KeyInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:X509Data><ds:X509Certificate>Y2VydA==</ds:X509Certificate></ds:X509Data></ds:KeyInfo></md:KeyDescriptor></md:IDPSSODescriptor></md:EntityDescriptor>";
+        String ownerAuth = "AWS4-HMAC-SHA256 Credential=111111111111/20260227/us-east-1/iam/aws4_request";
+        String otherAccountAuth = "AWS4-HMAC-SHA256 Credential=222222222222/20260227/us-east-1/iam/aws4_request";
+        given().formParam("Action", "CreateSAMLProvider").formParam("Name", providerName)
+                .formParam("SAMLMetadataDocument", metadata).header("Authorization", ownerAuth)
+                .when().post("/").then().statusCode(200);
+
+        given().formParam("Action", "GetSAMLProvider")
+                .formParam("SAMLProviderArn", "arn:aws:iam::111111111111:saml-provider/" + providerName)
+                .header("Authorization", otherAccountAuth)
+                .when().post("/").then().statusCode(404).body("ErrorResponse.Error.Code", equalTo("NoSuchEntity"));
+    }
+
+    @Test
+    @Order(55)
     void listOpenIdConnectProvidersReturnsEmptyList() {
         given()
             .formParam("Action", "ListOpenIDConnectProviders")


### PR DESCRIPTION
## Summary

Validate SAML assertions before issuing credentials for `AssumeRoleWithSAML`, including signature, issuer, audience, expiry, recipient, role/principal pair, and registered provider checks. Add minimal SAML provider persistence and AWS Query API support for create, list, and get operations.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, malformed, unsigned, expired, tampered, or otherwise invalid SAML assertions could reach role assumption. The implementation now returns AWS-compatible `InvalidIdentityToken` or `AccessDenied` errors while preserving the STS Query protocol, XML response format, and valid SAML credential response fields.

## Checklist

- [ ] `./mvnw test` passes locally — full suite timed out after 10 minutes in unrelated API Gateway/Lambda container integration tests
- [x] Focused tests pass: `./mvnw -q -Dtest=AssumeRoleWithSamlValidationIntegrationTest,AssumeRoleTrustPolicyIntegrationTest,IamIntegrationTest test`
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Additional validation passed:

- `./mvnw -q -DskipTests compile`
- `git diff --check`
