### PR TITLE
fix(swf): improve polling mechanism with timeout and backoff strategy

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/swf/SwfServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/swf/SwfServiceTest.java
@@ -58,6 +58,8 @@ class SwfServiceTest {
 
     private static final String REGION = "us-east-1";
     private static final String DOMAIN = "unit-domain";
+    /** Upper bound for {@link #pollFor}; generous so a loaded CI runner cannot starve it. */
+    private static final Duration POLL_TIMEOUT = Duration.ofSeconds(10);
 
     private MutableClock clock;
     private SwfService service;
@@ -1199,9 +1201,15 @@ class SwfServiceTest {
      *
      * <p>Tolerates a transient empty poll so the concurrency tests can call this from
      * several threads: another thread may hold the task this caller wants at that instant.
+     *
+     * <p>Bounded by wall-clock time rather than an attempt count: with several pollers on
+     * one task list, a caller can repeatedly claim and release siblings' tasks, and those
+     * round trips take microseconds. A fixed attempt budget then burns out well before the
+     * wanted task becomes pollable under CI contention.
      */
     private SwfDecisionTask pollFor(String workflowId) {
-        for (int attempt = 0; attempt < 200; attempt++) {
+        long deadline = System.nanoTime() + POLL_TIMEOUT.toNanos();
+        while (System.nanoTime() < deadline) {
             Optional<SwfDecisionTask> claimed = service.pollForDecisionTask(REGION, DOMAIN, "tl", "d");
             if (claimed.isPresent()) {
                 SwfDecisionTask task = claimed.get();
@@ -1210,10 +1218,11 @@ class SwfServiceTest {
                 }
                 // Release a sibling's task so its own poller can claim it.
                 service.respondDecisionTaskCompleted(task.getTaskToken(), List.of(), null);
-                continue;
             }
+            // Back off after a steal too, so the sibling's own poller gets a window to
+            // claim the task just released instead of this thread grabbing it again.
             try {
-                Thread.sleep(5);
+                Thread.sleep(claimed.isPresent() ? 1 : 5);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 break;


### PR DESCRIPTION
## Summary

Fixes: #3188 
In SwfService, the six child decision tasks are scheduled synchronously within `respondDecisionTaskCompleted`, and releasing a sibling task with zero decisions causes it to be immediately rescheduled; thus, the service is functioning correctly. The root cause is the hypothesis raised in the issue: `pollFor` had a fixed limit of 200 attempts and only slept when a poll returned empty. With six threads stealing and returning tasks to one another within the same task list, each attempt takes mere microseconds, and the limit is exhausted in ~30ms—exactly the duration recorded in the CI failure.

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X ] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)


