### PR TITLE
fix(cloudwatch): wrap TagResource and UntagResource in their declared Result element

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsQueryHandler.java
@@ -285,7 +285,10 @@ public class CloudWatchMetricsQueryHandler {
         } else {
             metricsService.tagResource(arn, tags, region);
         }
-        return Response.ok(AwsQueryResponse.envelopeNoResult("TagResource", null)).build();
+        // TagResourceOutput is an empty structure with a declared resultWrapper, so the
+        // wrapper element must be present. The AWS Go SDK v2 unmarshaler, behind the
+        // Terraform AWS provider, fails on a response without it.
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("TagResource", null)).build();
     }
 
     private Response handleUntagResource(MultivaluedMap<String, String> params, String region) {
@@ -301,7 +304,7 @@ public class CloudWatchMetricsQueryHandler {
         } else {
             metricsService.untagResource(arn, keys, region);
         }
-        return Response.ok(AwsQueryResponse.envelopeNoResult("UntagResource", null)).build();
+        return Response.ok(AwsQueryResponse.envelopeEmptyResult("UntagResource", null)).build();
     }
 
     // ──────────────────────────── Dashboards ────────────────────────────

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsTagResourceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsTagResourceIntegrationTest.java
@@ -1,0 +1,95 @@
+package io.github.hectorvent.floci.services.cloudwatch.metrics;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * TagResource and UntagResource have an empty output structure in the CloudWatch API model,
+ * so their Query responses still carry the Result wrapper element. The AWS Go SDK v2
+ * unmarshaler behind the Terraform AWS provider fails on a response without it.
+ */
+@QuarkusTest
+class CloudWatchMetricsTagResourceIntegrationTest {
+
+    private static final String CW_SCOPE =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/monitoring/aws4_request";
+    private static final String ALARM_NAME = "tag-wrapper-alarm";
+    private static final String ALARM_ARN =
+            "arn:aws:cloudwatch:us-east-1:000000000000:alarm:" + ALARM_NAME;
+
+    @Test
+    void tagAndUntagResponsesCarryTheirResultElements() {
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CW_SCOPE)
+            .formParam("Action", "PutMetricAlarm")
+            .formParam("AlarmName", ALARM_NAME)
+            .formParam("MetricName", "CPUUtilization")
+            .formParam("Namespace", "AWS/EC2")
+            .formParam("ComparisonOperator", "GreaterThanThreshold")
+            .formParam("EvaluationPeriods", "1")
+            .formParam("Period", "60")
+            .formParam("Statistic", "Average")
+            .formParam("Threshold", "80")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CW_SCOPE)
+            .formParam("Action", "TagResource")
+            .formParam("ResourceARN", ALARM_ARN)
+            .formParam("Tags.member.1.Key", "env")
+            .formParam("Tags.member.1.Value", "prod")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(containsString("<TagResourceResult"))
+            .body("TagResourceResponse.ResponseMetadata.RequestId", not(equalTo("")));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CW_SCOPE)
+            .formParam("Action", "ListTagsForResource")
+            .formParam("ResourceARN", ALARM_ARN)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("ListTagsForResourceResponse.ListTagsForResourceResult.Tags.member.Key", equalTo("env"))
+            .body("ListTagsForResourceResponse.ListTagsForResourceResult.Tags.member.Value", equalTo("prod"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CW_SCOPE)
+            .formParam("Action", "UntagResource")
+            .formParam("ResourceARN", ALARM_ARN)
+            .formParam("TagKeys.member.1", "env")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(containsString("<UntagResourceResult"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", CW_SCOPE)
+            .formParam("Action", "ListTagsForResource")
+            .formParam("ResourceARN", ALARM_ARN)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(not(containsString("<Key>env</Key>")));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsTagsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudwatch/metrics/CloudWatchMetricsTagsTest.java
@@ -118,6 +118,49 @@ class CloudWatchMetricsTagsTest {
     }
 
     @Test
+    void tagResourceQueryResponseCarriesTheResultWrapper() {
+        // TagResourceOutput is an empty structure, so the Query response still declares a
+        // TagResourceResult element. The AWS Go SDK v2 unmarshaler rejects a response without it.
+        MetricAlarm alarm = new MetricAlarm();
+        alarm.setAlarmName("test-alarm");
+        alarm.setAlarmArn("arn:aws:cloudwatch:us-east-1:000000000000:alarm:test-alarm");
+        service.putMetricAlarm(alarm, REGION);
+
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("ResourceARN", alarm.getAlarmArn());
+        params.add("Tags.member.1.Key", "env");
+        params.add("Tags.member.1.Value", "prod");
+
+        Response response = queryHandler.handle("TagResource", params, REGION);
+        String xml = (String) response.getEntity();
+
+        assertTrue(xml.contains("<TagResourceResponse>"), xml);
+        assertTrue(xml.contains("<TagResourceResult"), xml);
+        assertTrue(xml.contains("<ResponseMetadata>"), xml);
+        assertEquals("prod", service.listTagsForResource(alarm.getAlarmArn(), REGION).get("env"));
+    }
+
+    @Test
+    void untagResourceQueryResponseCarriesTheResultWrapper() {
+        MetricAlarm alarm = new MetricAlarm();
+        alarm.setAlarmName("test-alarm");
+        alarm.setAlarmArn("arn:aws:cloudwatch:us-east-1:000000000000:alarm:test-alarm");
+        service.putMetricAlarm(alarm, REGION);
+        service.tagResource(alarm.getAlarmArn(), Map.of("env", "prod"), REGION);
+
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.add("ResourceARN", alarm.getAlarmArn());
+        params.add("TagKeys.member.1", "env");
+
+        Response response = queryHandler.handle("UntagResource", params, REGION);
+        String xml = (String) response.getEntity();
+
+        assertTrue(xml.contains("<UntagResourceResponse>"), xml);
+        assertTrue(xml.contains("<UntagResourceResult"), xml);
+        assertTrue(service.listTagsForResource(alarm.getAlarmArn(), REGION).isEmpty());
+    }
+
+    @Test
     void listTagsJsonResponse() {
         MetricAlarm alarm = new MetricAlarm();
         alarm.setAlarmName("test-alarm");


### PR DESCRIPTION
## Summary

Ports lex00/floci#89. CloudWatch's `TagResource` and `UntagResource` have an empty output structure in the API model, and the model still declares a `resultWrapper` for it. Floci answered both with a bare `TagResourceResponse` and no Result child. The AWS Go SDK v2 Query unmarshaler behind the Terraform AWS provider rejects that with "TagResourceResult node not found", so tagging an alarm from Terraform failed client side even though the tag had landed.

Both responses now go through `envelopeEmptyResult`, the helper `DeleteDashboards` already uses for the same shape. Nothing changes for the operations whose model has no output shape at all, such as `PutMetricAlarm`, which keep the bare response.

Unit tests assert the wrapper on both responses and that the tag write still lands. An integration test drives the Query protocol against a real alarm and checks the tag through a full tag and untag cycle.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior. AWS returns `<TagResourceResponse><TagResourceResult/><ResponseMetadata>...` for a successful `TagResource`. Floci omitted the Result element, which the Go SDK treats as a deserialization failure.

## Checklist

- [x] `./mvnw test` passes locally for the CloudWatch tags and dashboards tests
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
