### PR TITLE
fix(compat): retry RedshiftTest's SDK calls past a brief connection-refused hiccup

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.redshift.RedshiftClient;
 import software.amazon.awssdk.services.redshift.model.Cluster;
 import software.amazon.awssdk.services.redshift.model.CreateClusterRequest;
@@ -24,6 +25,10 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.Statement;
 
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.Supplier;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -35,23 +40,43 @@ public class RedshiftTest {
         return TestFixtures.redshiftClient();
     }
 
+    // github.com/floci-io/floci/issues/2789: this class's first request intermittently hits
+    // "Connection refused" even after the AWS SDK's own 4 built-in attempts (whose backoff totals
+    // under a second) and even after CI's "wait for floci to be ready" step reports success - a
+    // brief port-publish/network-alias hiccup between the test runner and floci containers that
+    // self-resolves almost immediately. Retrying the whole call, not just relying on the SDK's
+    // built-in attempts, gives it long enough to clear.
+    private static <T> T withRetry(Supplier<T> action) throws InterruptedException {
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(30));
+        SdkClientException last = null;
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                return action.get();
+            } catch (SdkClientException e) {
+                last = e;
+                Thread.sleep(1000);
+            }
+        }
+        throw last;
+    }
+
     @Test
     @Order(1)
     public void testCreateCluster() throws Exception {
         RedshiftClient client = getClient();
-        CreateClusterResponse res = client.createCluster(CreateClusterRequest.builder()
+        CreateClusterResponse res = withRetry(() -> client.createCluster(CreateClusterRequest.builder()
                 .clusterIdentifier("test-cluster")
                 .nodeType("dc2.large")
                 .masterUsername("admin")
                 .masterUserPassword("Password123")
-                .build());
-        
+                .build()));
+
         assertEquals("test-cluster", res.cluster().clusterIdentifier());
-        
-        DescribeClustersResponse describeRes = client.describeClusters(DescribeClustersRequest.builder()
+
+        DescribeClustersResponse describeRes = withRetry(() -> client.describeClusters(DescribeClustersRequest.builder()
                 .clusterIdentifier("test-cluster")
-                .build());
-                
+                .build()));
+
         Cluster cluster = describeRes.clusters().get(0);
         assertEquals("test-cluster", cluster.clusterIdentifier());
         // Terraform's AWS provider polls these two on create and validates them on read (issue #3098).
@@ -108,11 +133,11 @@ public class RedshiftTest {
 
     @Test
     @Order(3)
-    public void testDeleteCluster() {
+    public void testDeleteCluster() throws Exception {
         RedshiftClient client = getClient();
-        DeleteClusterResponse res = client.deleteCluster(DeleteClusterRequest.builder()
+        DeleteClusterResponse res = withRetry(() -> client.deleteCluster(DeleteClusterRequest.builder()
                 .clusterIdentifier("test-cluster")
-                .build());
+                .build()));
         assertEquals("test-cluster", res.cluster().clusterIdentifier());
         assertEquals("deleting", res.cluster().clusterStatus());
     }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 
+import java.net.ConnectException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -46,6 +47,12 @@ public class RedshiftTest {
     // brief port-publish/network-alias hiccup between the test runner and floci containers that
     // self-resolves almost immediately. Retrying the whole call, not just relying on the SDK's
     // built-in attempts, gives it long enough to clear.
+    //
+    // Only a pre-handshake ConnectException is worth retrying (review, PR #3216): a broader catch
+    // of SdkClientException would also retry failures that can happen after floci already processed
+    // the request, e.g. a response reset mid-stream on createCluster/deleteCluster - a retry there
+    // resubmits and gets back a real ClusterAlreadyExists/ClusterNotFound, which masks the original
+    // failure behind an unrelated one instead of fixing the flake.
     private static <T> T withRetry(Supplier<T> action) throws InterruptedException {
         Instant deadline = Instant.now().plus(Duration.ofSeconds(30));
         SdkClientException last = null;
@@ -53,11 +60,23 @@ public class RedshiftTest {
             try {
                 return action.get();
             } catch (SdkClientException e) {
+                if (!isConnectionRefused(e)) {
+                    throw e;
+                }
                 last = e;
                 Thread.sleep(1000);
             }
         }
         throw last;
+    }
+
+    private static boolean isConnectionRefused(Throwable e) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            if (cause instanceof ConnectException) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #2789. `RedshiftTest.testCreateCluster` and `testDeleteCluster` intermittently fail the `native / sdk-test-java` CI job with `Connection refused`, on PRs that never touch Redshift or anything network-related (confirmed on #2472 and #2729).

The AWS SDK's own built-in retries (4 attempts) already ran and still failed - their total backoff is under a second, and the issue's own investigation found the floci server's log showed a single continuous run (no restart/crash) for the whole job, with a *different*, larger Redshift test in the same suite running later and passing. That points to a brief port-publish/network-alias hiccup between the test runner and floci containers that self-resolves almost immediately, just not within the SDK's own sub-second retry window.

Wraps each SDK call in this class in a 30-second retry loop (`withRetry`) that only catches `SdkClientException` - a genuine service-level error (e.g. `ClusterAlreadyExists`) still surfaces immediately rather than being retried into a timeout. This mirrors the retry pattern `RedshiftOperationsTest.awaitPostgresConnection` already uses successfully for its JDBC connection in the same module.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

N/A - this only changes a compatibility test's resilience to a CI-infrastructure race, not product behavior.

## Checklist

- [x] Verified against a local floci instance: `testCreateCluster` and `testDeleteCluster` pass
- [x] Could not reproduce the actual CI-only race locally (same as the issue reporter, who diagnosed it from CI logs only)
- [x] Commit messages follow Conventional Commits
