### PR TITLE
fix(cloudfront): stop duplicating CachedMethods into AllowedMethods.Items

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
@@ -1972,12 +1972,7 @@ public class CloudFrontController {
         xml.raw(xmlTrustedKeyGroups(
                 dcb.isTrustedKeyGroupsEnabled(), dcb.getTrustedKeyGroups()));
 
-        List<String> allowed = dcb.getAllowedMethods();
-        if (allowed == null || allowed.isEmpty()) {
-            allowed = List.of("GET", "HEAD");
-        }
-        xml.raw(xmlQuantityItems("AllowedMethods", "Method", allowed.size(),
-                allowed.stream().map(m -> "<Method>" + XmlBuilder.escape(m) + "</Method>").toList()));
+        xml.raw(xmlAllowedMethods(dcb.getAllowedMethods(), dcb.getCachedMethods()));
 
         xml.raw(xmlFunctionAssociations(dcb.getFunctionAssociations()));
         xml.raw(xmlLambdaFunctionAssociations(dcb.getLambdaFunctionAssociations()));
@@ -2002,12 +1997,7 @@ public class CloudFrontController {
         xml.raw(xmlTrustedKeyGroups(
                 cb.isTrustedKeyGroupsEnabled(), cb.getTrustedKeyGroups()));
 
-        List<String> allowed = cb.getAllowedMethods();
-        if (allowed == null || allowed.isEmpty()) {
-            allowed = List.of("GET", "HEAD");
-        }
-        xml.raw(xmlQuantityItems("AllowedMethods", "Method", allowed.size(),
-                allowed.stream().map(m -> "<Method>" + XmlBuilder.escape(m) + "</Method>").toList()));
+        xml.raw(xmlAllowedMethods(cb.getAllowedMethods(), cb.getCachedMethods()));
 
         xml.raw(xmlFunctionAssociations(cb.getFunctionAssociations()));
         xml.raw(xmlLambdaFunctionAssociations(cb.getLambdaFunctionAssociations()));
@@ -2303,6 +2293,28 @@ public class CloudFrontController {
     /** Renders a possibly-null value as a string, using the empty string for {@code null}. */
     private static String str(Object value) {
         return value != null ? value.toString() : "";
+    }
+
+    // AllowedMethods.CachedMethods is a nested Quantity/Items pair, not a sibling of AllowedMethods
+    // itself. Terraform's aws_cloudfront_distribution requires both allowed_methods and
+    // cached_methods on every cache behavior, so omitting this sub-object is a permanent diff.
+    private String xmlAllowedMethods(List<String> allowedMethods, List<String> cachedMethods) {
+        List<String> allowed = allowedMethods == null || allowedMethods.isEmpty()
+                ? List.of("GET", "HEAD") : allowedMethods;
+        XmlBuilder xml = new XmlBuilder().start("AllowedMethods").elem("Quantity", allowed.size());
+        xml.start("Items");
+        for (String method : allowed) {
+            xml.elem("Method", method);
+        }
+        xml.end("Items");
+        if (cachedMethods != null && !cachedMethods.isEmpty()) {
+            xml.start("CachedMethods").elem("Quantity", cachedMethods.size()).start("Items");
+            for (String method : cachedMethods) {
+                xml.elem("Method", method);
+            }
+            xml.end("Items").end("CachedMethods");
+        }
+        return xml.end("AllowedMethods").build();
     }
 
     private String xmlQuantityItems(String wrapper, String itemTag, int count, List<String> items) {
@@ -2844,11 +2856,13 @@ public class CloudFrontController {
             XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
             boolean inDcb = false;
             boolean inAllowedMethods = false;
+            boolean inCachedMethods = false;
             boolean inTrustedKeyGroups = false;
             boolean sawTrustedKeyGroups = false;
             Boolean trustedKeyGroupsEnabled = null;
             Integer trustedKeyGroupsQuantity = null;
             List<String> allowedMethods = new ArrayList<>();
+            List<String> cachedMethods = new ArrayList<>();
             List<String> trustedKeyGroups = new ArrayList<>();
             boolean inLambdaAssociations = false;
             boolean inFunctionAssociations = false;
@@ -2940,6 +2954,9 @@ public class CloudFrontController {
                         case "AllowedMethods" -> {
                             if (inDcb) inAllowedMethods = true;
                         }
+                        case "CachedMethods" -> {
+                            if (inAllowedMethods) inCachedMethods = true;
+                        }
                         case "TargetOriginId" -> {
                             if (inDcb) dcb.setTargetOriginId(r.getElementText());
                         }
@@ -2965,13 +2982,18 @@ public class CloudFrontController {
                             if (inDcb) dcb.setCompress("true".equalsIgnoreCase(r.getElementText()));
                         }
                         case "Method" -> {
-                            if (inAllowedMethods) allowedMethods.add(r.getElementText());
+                            if (inCachedMethods) {
+                                cachedMethods.add(r.getElementText());
+                            } else if (inAllowedMethods) {
+                                allowedMethods.add(r.getElementText());
+                            }
                         }
                         default -> {
                         }
                     }
                 } else if (event == XMLStreamConstants.END_ELEMENT) {
                     switch (r.getLocalName()) {
+                        case "CachedMethods" -> inCachedMethods = false;
                         case "AllowedMethods" -> inAllowedMethods = false;
                         case "TrustedKeyGroups" -> inTrustedKeyGroups = false;
                         case "DefaultCacheBehavior" -> inDcb = false;
@@ -2997,6 +3019,9 @@ public class CloudFrontController {
             r.close();
             if (!allowedMethods.isEmpty()) {
                 dcb.setAllowedMethods(allowedMethods);
+            }
+            if (!cachedMethods.isEmpty()) {
+                dcb.setCachedMethods(cachedMethods);
             }
             if (!trustedKeyGroups.isEmpty()) {
                 dcb.setTrustedKeyGroups(trustedKeyGroups);
@@ -3044,12 +3069,14 @@ public class CloudFrontController {
             boolean inCacheBehaviors = false;
             boolean inCacheBehavior = false;
             boolean inAllowedMethods = false;
+            boolean inCachedMethods = false;
             boolean inTrustedKeyGroups = false;
             CacheBehavior current = null;
             boolean sawTrustedKeyGroups = false;
             Boolean trustedKeyGroupsEnabled = null;
             Integer trustedKeyGroupsQuantity = null;
             List<String> allowedMethods = new ArrayList<>();
+            List<String> cachedMethods = new ArrayList<>();
             List<String> trustedKeyGroups = new ArrayList<>();
             boolean inLambdaAssociations = false;
             boolean inFunctionAssociations = false;
@@ -3074,6 +3101,7 @@ public class CloudFrontController {
                                 trustedKeyGroupsEnabled = null;
                                 trustedKeyGroupsQuantity = null;
                                 allowedMethods = new ArrayList<>();
+                                cachedMethods = new ArrayList<>();
                                 trustedKeyGroups = new ArrayList<>();
                                 lambdaAssociations = new ArrayList<>();
                                 functionAssociations = new ArrayList<>();
@@ -3156,6 +3184,9 @@ public class CloudFrontController {
                         case "AllowedMethods" -> {
                             if (inCacheBehavior) inAllowedMethods = true;
                         }
+                        case "CachedMethods" -> {
+                            if (inAllowedMethods) inCachedMethods = true;
+                        }
                         case "PathPattern" -> {
                             if (inCacheBehavior && current != null) current.setPathPattern(r.getElementText());
                         }
@@ -3182,13 +3213,18 @@ public class CloudFrontController {
                             }
                         }
                         case "Method" -> {
-                            if (inAllowedMethods) allowedMethods.add(r.getElementText());
+                            if (inCachedMethods) {
+                                cachedMethods.add(r.getElementText());
+                            } else if (inAllowedMethods) {
+                                allowedMethods.add(r.getElementText());
+                            }
                         }
                         default -> {
                         }
                     }
                 } else if (event == XMLStreamConstants.END_ELEMENT) {
                     switch (r.getLocalName()) {
+                        case "CachedMethods" -> inCachedMethods = false;
                         case "AllowedMethods" -> inAllowedMethods = false;
                         case "TrustedKeyGroups" -> inTrustedKeyGroups = false;
                         case "LambdaFunctionAssociations" -> inLambdaAssociations = false;
@@ -3209,6 +3245,9 @@ public class CloudFrontController {
                             if (inCacheBehavior && current != null) {
                                 if (!allowedMethods.isEmpty()) {
                                     current.setAllowedMethods(allowedMethods);
+                                }
+                                if (!cachedMethods.isEmpty()) {
+                                    current.setCachedMethods(cachedMethods);
                                 }
                                 if (!trustedKeyGroups.isEmpty()) {
                                     current.setTrustedKeyGroups(trustedKeyGroups);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
@@ -192,6 +192,56 @@ class CloudFrontControllerTest {
     }
 
     @Test
+    void defaultCacheBehaviorEchoesCachedMethodsWithoutDuplicatingAllowedMethods() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        // AWS nests CachedMethods inside AllowedMethods. A parser that doesn't scope Method
+        // elements to the right block folds the CachedMethods items into AllowedMethods too,
+        // producing duplicates (["GET","HEAD","GET","HEAD","OPTIONS"]) and dropping CachedMethods.
+        String body = distributionConfigBody("").replace(
+                """
+                <AllowedMethods><Quantity>2</Quantity><Items>
+                      <Method>GET</Method><Method>HEAD</Method></Items></AllowedMethods>""",
+                """
+                <AllowedMethods><Quantity>3</Quantity><Items>
+                      <Method>GET</Method><Method>HEAD</Method><Method>OPTIONS</Method></Items>
+                      <CachedMethods><Quantity>2</Quantity><Items>
+                        <Method>GET</Method><Method>HEAD</Method></Items></CachedMethods>
+                    </AllowedMethods>""");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-cm");
+            d.setEtag("etag-cm");
+            return d;
+        });
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+
+        when(service.getDistribution("dist-cm")).thenReturn(captor.getValue());
+
+        try (Response dist = controller.getDistribution("dist-cm")) {
+            String xml = (String) dist.getEntity();
+            int start = xml.indexOf("<AllowedMethods>");
+            int end = xml.indexOf("</AllowedMethods>") + "</AllowedMethods>".length();
+            String block = xml.substring(start, end);
+
+            int cachedStart = block.indexOf("<CachedMethods>");
+            assertTrue(cachedStart >= 0, "AllowedMethods must echo a nested CachedMethods object");
+            String outer = block.substring(0, cachedStart);
+            String cached = block.substring(cachedStart);
+
+            assertEquals(List.of("GET", "HEAD", "OPTIONS"), XmlParser.extractAll(outer, "Method"),
+                    "AllowedMethods.Items must not include CachedMethods entries");
+            assertEquals(List.of("GET", "HEAD"), XmlParser.extractAll(cached, "Method"));
+        }
+    }
+
+    @Test
     void orderedCacheBehaviorRoundTripsLambdaFunctionAssociations() {
         CloudFrontService service = mock(CloudFrontService.class);
         CloudFrontController controller = new CloudFrontController(service);


### PR DESCRIPTION
## Summary

Follow-up to #2767 (the TrustedSigners nil-deref crash from that issue was already fixed by #3015). That fix explicitly left two smaller fidelity gaps from the same issue as follow-ups. This PR fixes one of them: `AllowedMethods`/`CachedMethods` handling on `DefaultCacheBehavior` and `CacheBehavior`.

`CachedMethods` is a nested `Quantity`/`Items` object inside `AllowedMethods`, not a sibling element. The request parser tracked a single "inside AllowedMethods" flag across the whole element, so `Method` entries nested inside `CachedMethods` were folded into the parsed `AllowedMethods` list too, and `CachedMethods` itself was silently dropped.

Since `terraform-provider-aws`'s `aws_cloudfront_distribution` requires both `allowed_methods` and `cached_methods` on every cache behavior, this produced a permanent per-plan diff on every floci-managed distribution: `AllowedMethods.Items` came back with duplicates (e.g. `["GET","HEAD","GET","HEAD","OPTIONS"]`), and `CachedMethods` was missing entirely.

The other gap from #2767 (`ForwardedValues`/`MinTTL`/`DefaultTTL`/`MaxTTL` dropped on read-back for the legacy `forwarded_values` cache-behavior path) is a separate, larger change and is filed as #3208. It doesn't affect the modern `cache_policy_id` path, which floci already supports fully.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `GetDistribution`/`GetDistributionConfig` echoed `AllowedMethods.Items` with `CachedMethods`' entries duplicated in, and never echoed `CachedMethods` itself, even though it was accepted on create/update. Verified against the AWS `AllowedMethods` API reference: `CachedMethods` is documented as a nested `Quantity`/`Items` sub-object, optional but with its own item list distinct from the parent's.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits