### PR TITLE
fix(pipes): restore a CloudFormation snapshot without re-validating it

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
@@ -134,6 +134,9 @@ public class PipesService implements TagHandler, ResourceProvider {
                            DesiredState desiredState, String enrichment,
                            JsonNode sourceParameters, JsonNode targetParameters,
                            JsonNode enrichmentParameters, String region) {
+        Pipe pipe = describePipe(name, region);
+        validateSourceConfiguration(pipe.getSource(),
+                sourceParameters != null ? sourceParameters : pipe.getSourceParameters());
         return writePipeConfiguration(name, target, roleArn, description, desiredState, enrichment,
                 sourceParameters, targetParameters, enrichmentParameters, region, false);
     }
@@ -141,6 +144,10 @@ public class PipesService implements TagHandler, ResourceProvider {
     /**
      * Puts the pipe back to a configuration held in full: a property given as null is cleared, so
      * the pipe ends up carrying exactly what is passed here and nothing the caller left out.
+     *
+     * <p>The configuration was accepted when the pipe was written, so it is not validated again:
+     * a snapshot that predates a rule added since must still be restorable, or a CloudFormation
+     * rollback would fail on the very pipe it is putting back.
      */
     public Pipe restorePipe(String name, String target, String roleArn, String description,
                             DesiredState desiredState, String enrichment,
@@ -166,11 +173,6 @@ public class PipesService implements TagHandler, ResourceProvider {
         Pipe pipe = storage.get(key)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Pipe " + name + " does not exist.", 404));
-
-        JsonNode effectiveSourceParameters = sourceParameters == null && !clearUnsetProperties
-                ? pipe.getSourceParameters()
-                : sourceParameters;
-        validateSourceConfiguration(pipe.getSource(), effectiveSourceParameters);
 
         writeProperty(target, clearUnsetProperties, pipe::setTarget);
         writeProperty(roleArn, clearUnsetProperties, pipe::setRoleArn);

--- a/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/pipes/PipesService.java
@@ -134,9 +134,6 @@ public class PipesService implements TagHandler, ResourceProvider {
                            DesiredState desiredState, String enrichment,
                            JsonNode sourceParameters, JsonNode targetParameters,
                            JsonNode enrichmentParameters, String region) {
-        Pipe pipe = describePipe(name, region);
-        validateSourceConfiguration(pipe.getSource(),
-                sourceParameters != null ? sourceParameters : pipe.getSourceParameters());
         return writePipeConfiguration(name, target, roleArn, description, desiredState, enrichment,
                 sourceParameters, targetParameters, enrichmentParameters, region, false);
     }
@@ -162,7 +159,11 @@ public class PipesService implements TagHandler, ResourceProvider {
      *
      * <p>With {@code clearUnsetProperties} false, a null property leaves the pipe's value alone:
      * that is what UpdatePipe promises its callers. With it true, a null property clears the pipe's
-     * value, which is what putting a pipe back to a configuration recorded in full needs.
+     * value, which is what putting a pipe back to a configuration recorded in full needs; that
+     * configuration was accepted when it was written, so only the update path validates.
+     *
+     * <p>Validation runs on the same retrieved pipe the write then mutates, so a pipe replaced
+     * between two lookups cannot be validated as one pipe and updated as another.
      */
     private Pipe writePipeConfiguration(String name, String target, String roleArn, String description,
                                         DesiredState desiredState, String enrichment,
@@ -173,6 +174,11 @@ public class PipesService implements TagHandler, ResourceProvider {
         Pipe pipe = storage.get(key)
                 .orElseThrow(() -> new AwsException("NotFoundException",
                         "Pipe " + name + " does not exist.", 404));
+
+        if (!clearUnsetProperties) {
+            validateSourceConfiguration(pipe.getSource(),
+                    sourceParameters != null ? sourceParameters : pipe.getSourceParameters());
+        }
 
         writeProperty(target, clearUnsetProperties, pipe::setTarget);
         writeProperty(roleArn, clearUnsetProperties, pipe::setRoleArn);

--- a/src/test/java/io/github/hectorvent/floci/services/pipes/PipesServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/pipes/PipesServiceTest.java
@@ -25,13 +25,15 @@ class PipesServiceTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
+    private AccountAwareStorageBackend<Pipe> storage;
     private PipesService pipesService;
 
     @BeforeEach
     void setUp() {
+        storage = AccountAwareStorageBackend.inMemory("000000000000");
         StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
-        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
-                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
+        Mockito.doReturn(storage).when(storageFactory)
+                .create(Mockito.anyString(), Mockito.anyString(), Mockito.any());
 
         RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
 
@@ -231,6 +233,38 @@ class PipesServiceTest {
         assertEquals("arn:aws:iam::000000000000:role/original-role", restored.getRoleArn());
         assertEquals(DesiredState.STOPPED, restored.getDesiredState());
         assertEquals(PipeState.STOPPED, restored.getCurrentState());
+    }
+
+    /**
+     * A restore puts back a configuration that was accepted when it was written, so it is not run
+     * through the source validation again. A persisted pipe can predate a rule added since, and a
+     * CloudFormation rollback that re-validated its snapshot would fail on the very pipe it is
+     * putting back. The pipe is seeded straight into storage, as one written before the Kafka
+     * TopicName check existed would be.
+     */
+    @Test
+    void restorePipeDoesNotRevalidateAnAlreadyAcceptedConfiguration() {
+        JsonNode legacyParameters = sourceParameters("""
+                {"SelfManagedKafkaParameters":{"BatchSize":10}}""");
+        Pipe legacy = new Pipe();
+        legacy.setName("legacy-pipe");
+        legacy.setArn("arn:aws:pipes:us-east-1:000000000000:pipe/legacy-pipe");
+        legacy.setSource("smk://broker:9092");
+        legacy.setTarget("arn:aws:sqs:us-east-1:000000000000:target");
+        legacy.setRoleArn("arn:aws:iam::000000000000:role/role");
+        legacy.setDesiredState(DesiredState.RUNNING);
+        legacy.setCurrentState(PipeState.RUNNING);
+        legacy.setSourceParameters(legacyParameters);
+        storage.put("us-east-1::legacy-pipe", legacy);
+
+        Pipe restored = pipesService.restorePipe("legacy-pipe",
+                "arn:aws:sqs:us-east-1:000000000000:target",
+                "arn:aws:iam::000000000000:role/role",
+                null, null, null, legacyParameters, null, null, "us-east-1");
+
+        assertEquals(legacyParameters, restored.getSourceParameters());
+        assertEquals(legacyParameters,
+                pipesService.describePipe("legacy-pipe", "us-east-1").getSourceParameters());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`PipesService.restorePipe` — the write path behind both `PipesCfnProvisioner.restorePipeAfterFailedUpdate` and `rollbackUpdate` — went through `writePipeConfiguration`, which ran `validateSourceConfiguration` on the snapshot exactly as `UpdatePipe` does. A persisted pipe whose configuration predates a validation rule (a Kafka source without `TopicName`, or a Kinesis/DynamoDB `ParallelizationFactor` outside `[1, 10]` since #3192) therefore could not be put back after a failed stack update: `restorePipe` threw `ValidationException` and the resource ended `UPDATE_ROLLBACK_FAILED`.

Validation now lives on the `updatePipe` path only; `writePipeConfiguration` is a plain write, so a restore puts back the configuration that was already accepted. The javadoc on `restorePipe` records why it is not re-validated.

Fixes #3209

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire change. `CreatePipe`/`UpdatePipe` keep rejecting invalid `SourceParameters` exactly as before (existing `createPipe*`/`updatePipeRejectsInvalidParallelizationFactor` tests unchanged); only the internal CloudFormation restore stops re-checking a snapshot it did not author. A rollback's contract on AWS is to reinstate the prior state, not to re-admit it.

## Checklist

- [ ] `./mvnw test` passes locally — ran the three Pipes test classes below locally (58 tests); leaving the full 1,300-class suite to CI
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`PipesServiceTest.restorePipeDoesNotRevalidateAnAlreadyAcceptedConfiguration` seeds a self-managed Kafka pipe without `TopicName` straight into storage (the issue's reproduction) and restores it. Without the fix it fails with `SourceParameters.SelfManagedKafkaParameters.TopicName is required`; `PipesServiceTest`, `PipesCfnProvisionerTest` and `PipesCfnRollbackRestoresExactConfigurationTest` (58 tests) pass with it.
