### PR TITLE
fix(autoscaling): validate monitoring booleans

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingQueryHandler.java
@@ -1405,7 +1405,7 @@ public class AutoScalingQueryHandler {
     private Boolean nullableBoolParam(MultivaluedMap<String, String> p, String key) {
         String val = p.getFirst(key);
         if (val == null || val.isBlank()) { return null; }
-        return Boolean.parseBoolean(val);
+        return parseOptionalBoolean(val, key);
     }
 
     private List<LaunchConfigurationBlockDeviceMapping> parseLaunchConfigurationBlockDeviceMappings(
@@ -1516,7 +1516,7 @@ public class AutoScalingQueryHandler {
                     "1 validation error detected: Value '" + val + "' at '" + key
                             + "' failed to satisfy constraint: Member must be a valid boolean", 400);
         }
-        return Boolean.parseBoolean(val);
+        return parseOptionalBoolean(val, key);
     }
 
     private String intString(Integer value) {

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingIntegrationTest.java
@@ -134,6 +134,23 @@ class AutoScalingIntegrationTest {
 
     @Test
     @Order(44)
+    void launchConfigurationRejectsInvalidInstanceMonitoringBoolean() {
+        given()
+                .formParam("Action", "CreateLaunchConfiguration")
+                .formParam("LaunchConfigurationName", "my-lc-invalid-monitoring")
+                .formParam("ImageId", "ami-12345678")
+                .formParam("InstanceType", "t3.micro")
+                .formParam("InstanceMonitoring.Enabled", "not-a-boolean")
+                .header("Authorization", AUTH)
+            .when()
+                .post("/")
+            .then()
+                .statusCode(400)
+                .body(containsString("ValidationError"));
+    }
+
+    @Test
+    @Order(45)
     void launchConfigurationRejectsAMappingWithoutADeviceName() {
         given()
                 .formParam("Action", "CreateLaunchConfiguration")


### PR DESCRIPTION
## Summary

- validate `InstanceMonitoring.Enabled` as a strict boolean for Auto Scaling launch configurations
- reject malformed values instead of silently coercing them to `false`
- add integration coverage for invalid monitoring booleans

## AWS Compatibility

Validated against the official Amazon EC2 Auto Scaling `CreateLaunchConfiguration` API/CLI contract, where `InstanceMonitoring.Enabled` is a Boolean (`true` or `false`). Invalid strings must not be accepted as a valid false value.

## Validation

- `AutoScalingIntegrationTest` passes
- `git diff --check origin/main...HEAD` passes

## Context

This change was split out of #3128 per review so the Verified Permissions PR remains service-scoped.
