### PR TITLE
test(stepfunctions): add test for result selector unwrapping payload with bare function name

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaInvokeResultTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaInvokeResultTest.java
@@ -171,6 +171,33 @@ class AslExecutorLambdaInvokeResultTest {
     }
 
     @Test
+    void resultSelectorUnwrapsPayloadWhenFunctionNameIsABareName() throws Exception {
+        // Scenario (c) of issue #2544: the function is referenced by its bare name and the
+        // documented "$.Payload" selector must reach the function output, not resolve to null.
+        Execution execution = run("""
+                {
+                  "StartAt": "T",
+                  "States": {
+                    "T": {
+                      "Type": "Task",
+                      "Resource": "arn:aws:states:::lambda:invoke",
+                      "Parameters": {"FunctionName": "%s", "Payload.$": "$"},
+                      "ResultSelector": {"unwrapped.$": "$.Payload"},
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(FUNCTION_NAME));
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        JsonNode output = objectMapper.readTree(execution.getOutput());
+        assertTrue(output.path("unwrapped").isObject(), "$.Payload must resolve to the function output");
+        assertEquals("RET", output.path("unwrapped").path("marker").asText());
+        assertEquals(1, output.path("unwrapped").path("echo").path("in").asInt());
+        assertEquals(1, output.size());
+    }
+
+    @Test
     void outputPathPayloadUnwrapsTheOptimizedInvokeResult() throws Exception {
         Execution execution = run("""
                 {


### PR DESCRIPTION
## Summary

 Fixes: #2544 
The behavior described in issue #2544 has already been fixed in the current `main` branch. The fix was introduced via PR #2165; I simply ran a regression test.

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

<!-- For new actions: which SDK version and AWS CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)



