### PR TITLE
fix(config): accept any Host header again after the Quarkus 3.39 upgrade

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,10 +13,17 @@ quarkus:
   http:
     port: ${floci.port}
     host: 0.0.0.0
-    # Quarkus 3.38 added a Host-header validation filter that only accepts localhost by default
-    # (DNS-rebinding protection for local dev servers). An emulator is reached under whatever name
-    # its clients use: a compose service name via FLOCI_HOSTNAME, localhost.floci.io, and the
-    # virtual-host style S3 names, so the filter must not require localhost.
+    # Quarkus 3.38 added a Host-header validation filter (DNS-rebinding protection for a dev server)
+    # that it switches on by itself whenever the server is bound to loopback, which Floci does in
+    # TLS mode: Quarkus listens on 127.0.0.1:4510/4511 behind the TCP proxy on 4566, and the proxy
+    # passes the client's Host header through untouched. The filter is an exact-match set with no
+    # wildcard support, and with require-localhost it admits only localhost, 127.0.0.1 and [::1].
+    # An emulator has to answer under the names it documents and puts in its certificate
+    # (localhost.floci.io, *.localhost.floci.io, *.execute-api.localhost.floci.io,
+    # host.docker.internal) and under whatever a compose file calls it (FLOCI_HOSTNAME), none of
+    # which an exact-match allow-list can express. Disabling the check restores the behaviour of
+    # every release before Quarkus 3.39 and of the non-TLS mode, where Quarkus never enables it;
+    # the access boundary of a local emulator is the IAM and signature enforcement configuration.
     host-validation:
       require-localhost: false
     limits:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,12 @@ quarkus:
   http:
     port: ${floci.port}
     host: 0.0.0.0
+    # Quarkus 3.38 added a Host-header validation filter that only accepts localhost by default
+    # (DNS-rebinding protection for local dev servers). An emulator is reached under whatever name
+    # its clients use: a compose service name via FLOCI_HOSTNAME, localhost.floci.io, and the
+    # virtual-host style S3 names, so the filter must not require localhost.
+    host-validation:
+      require-localhost: false
     limits:
       max-body-size: ${floci.protocols.max-request-size}M
   datasource:


### PR DESCRIPTION
## Summary

Quarkus 3.38 added a Host-header validation filter (`HostValidationFilter`) that answers an empty HTTP 400 to any request whose `Host` does not resolve locally, before the request reaches the application and without logging. #3175 moved Floci from 3.37.4 to 3.39.2, so since then every client that addresses the emulator by a compose service name (`FLOCI_HOSTNAME=floci`, the shape the sdk-test-java compatibility suite and multi-container setups use) or by a public-looking name is rejected, `/_floci/health` included.

`quarkus.http.host-validation.require-localhost` is now `false`, with the reason next to it in `application.yml`. An emulator is reached under whatever name its clients use, so the DNS-rebinding protection the filter offers a local dev server does not apply here.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behaviour: with the default filter, `curl -H 'Host: floci:4566' http://localhost:4566/_floci/health` against a fresh compose Floci returns an empty 400 (`Host: localhost:4566` returns 200); the sdk-test-java suite run on a compose network reports 1,061 errors, one per request. The filter is an exact-match set that Quarkus enables by itself because Floci binds it to loopback behind its TCP proxy in TLS mode; with the default it admits only `localhost`, `127.0.0.1` and `[::1]`, so every hostname Floci documents and puts in its certificate (`localhost.floci.io`, `*.localhost.floci.io`, `*.execute-api.localhost.floci.io`, `host.docker.internal`) and any compose service name was refused. The CI compat jobs address Floci as `localhost`, which is why they stayed green. With the setting, the same suite runs 1,725 tests with only the pre-existing `Ec2Tests` failures.

## Checklist

- [x] `./mvnw test` passes locally: the filter only runs in the prod profile, so the QuarkusTest suites cannot observe it either way; CloudFormation, provisioner and EC2 packages ran green on this tree apart from the pre-existing ACM `Id` schema-gap row
- [ ] New or updated integration test added: not possible in a QuarkusTest for the same reason; the sdk-test-java compatibility suite on a compose network is the guard (1,061 errors before, green after)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

