### PR TITLE
fix(dynamodb): word BatchWriteItem key rejections the way AWS does

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -1102,7 +1102,8 @@ public class DynamoDbJsonHandler {
                 JsonNode keyNode = writeReq.has("PutRequest")
                         ? writeReq.get("PutRequest").get("Item")
                         : writeReq.get("DeleteRequest").get("Key");
-                String key = dynamoDbService.buildItemKey(bwTable, keyNode);
+                String key = dynamoDbService.buildItemKey(bwTable, keyNode,
+                        DynamoDbService.KeySurface.BATCH_WRITE);
                 if (!seen.add(key)) {
                     throw new AwsException("ValidationException",
                             "Provided list of item keys contains duplicates", 400);

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -3089,12 +3089,12 @@ public class DynamoDbService implements ResourceProvider {
     }
 
     private AwsException missingKeyException(KeySurface surface) {
-        if (surface == KeySurface.KEY_ARGUMENT) {
+        if (surface == KeySurface.ITEM_BODY) {
             return new AwsException("ValidationException",
-                    "The provided key element does not match the schema", 400);
+                    "One of the required keys was not given a value", 400);
         }
         return new AwsException("ValidationException",
-                "One of the required keys was not given a value", 400);
+                "The provided key element does not match the schema", 400);
     }
 
     // A wire-format AttributeValue must be a JSON object with exactly one type member.

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -1228,14 +1228,14 @@ public class DynamoDbService implements ResourceProvider {
                     }
                     JsonNode normalizedItem = DynamoDbNumberUtils.normalizeNumbersInItem(item);
                     DynamoDbItemSize.validateSize(normalizedItem);
-                    itemKey = buildItemKey(table, normalizedItem);
+                    itemKey = buildItemKey(table, normalizedItem, KeySurface.BATCH_WRITE);
                     validateIndexKeyTypes(table, normalizedItem, false);
                 } else if (writeRequest.has("DeleteRequest")) {
                     JsonNode key = writeRequest.get("DeleteRequest").get("Key");
                     if (key == null) {
                         throw new AwsException("ValidationException", "Key is required for DeleteRequest", 400);
                     }
-                    itemKey = buildItemKey(table, key, true);
+                    itemKey = buildItemKey(table, key, KeySurface.BATCH_WRITE);
                 } else {
                     continue;
                 }
@@ -3054,39 +3054,47 @@ public class DynamoDbService implements ResourceProvider {
         }
     }
 
+    // AWS words a key rejection by the surface the key arrived on. A Key argument and a
+    // BatchWriteItem entry report a schema mismatch, a PutItem item body names the types,
+    // and BatchWriteItem alone uses the "are not valid." form for an empty value.
+    enum KeySurface { ITEM_BODY, KEY_ARGUMENT, BATCH_WRITE }
+
     String buildItemKey(TableDefinition table, JsonNode item) {
-        return buildItemKey(table, item, false);
+        return buildItemKey(table, item, KeySurface.ITEM_BODY);
     }
 
     String buildItemKey(TableDefinition table, JsonNode item, boolean isKeyArg) {
+        return buildItemKey(table, item, isKeyArg ? KeySurface.KEY_ARGUMENT : KeySurface.ITEM_BODY);
+    }
+
+    String buildItemKey(TableDefinition table, JsonNode item, KeySurface surface) {
         String pkName = table.getPartitionKeyName();
         JsonNode pkAttr = item.get(pkName);
         if (pkAttr == null) {
-            if (isKeyArg) {
-                throw new AwsException("ValidationException",
-                        "The provided key element does not match the schema", 400);
-            }
-            throw new AwsException("ValidationException",
-                    "One of the required keys was not given a value", 400);
+            throw missingKeyException(surface);
         }
-        validateKeyAttributeValue(table, pkAttr, pkName, isKeyArg);
+        validateKeyAttributeValue(table, pkAttr, pkName, surface);
 
         String pk = extractScalarValue(pkAttr);
         String skName = table.getSortKeyName();
         if (skName != null) {
             JsonNode skAttr = item.get(skName);
             if (skAttr == null) {
-                if (isKeyArg) {
-                    throw new AwsException("ValidationException",
-                            "The provided key element does not match the schema", 400);
-                }
-                throw new AwsException("ValidationException",
-                        "One of the required keys was not given a value", 400);
+                throw missingKeyException(surface);
             }
-            validateKeyAttributeValue(table, skAttr, skName, isKeyArg);
+            validateKeyAttributeValue(table, skAttr, skName, surface);
             return pk + "#" + extractScalarValue(skAttr);
         }
         return pk;
+    }
+
+    private AwsException missingKeyException(KeySurface surface) {
+        if (surface == KeySurface.KEY_ARGUMENT) {
+            return new AwsException("ValidationException",
+                    "The provided key element does not match the schema", 400);
+        }
+        return new AwsException("ValidationException",
+                "One of the required keys was not given a value", 400);
     }
 
     // A wire-format AttributeValue must be a JSON object with exactly one type member.
@@ -3108,27 +3116,35 @@ public class DynamoDbService implements ResourceProvider {
         }
     }
 
-    private void validateKeyAttributeValue(TableDefinition table, JsonNode attr, String keyName, boolean isKeyArg) {
+    private void validateKeyAttributeValue(TableDefinition table, JsonNode attr, String keyName,
+                                            KeySurface surface) {
         if (attr == null) {
             return;
         }
         validateAttributeValueShape(attr);
         String expectedType = keyAttributeType(table, keyName);
         if (expectedType != null && !attr.has(expectedType)) {
-            // AWS words the type mismatch differently for a Key argument
-            // (Get/Delete/Update) than for a PutItem item body.
-            if (isKeyArg) {
+            if (surface == KeySurface.ITEM_BODY) {
                 throw new AwsException("ValidationException",
-                        "The provided key element does not match the schema", 400);
+                        "One or more parameter values were invalid: Type mismatch for key " + keyName
+                        + " expected: " + expectedType + " actual: " + attr.fieldNames().next(), 400);
             }
             throw new AwsException("ValidationException",
-                    "One or more parameter values were invalid: Type mismatch for key " + keyName
-                    + " expected: " + expectedType + " actual: " + attr.fieldNames().next(), 400);
+                    "The provided key element does not match the schema", 400);
         }
         if (attr.has("S") && attr.get("S").asText().isEmpty()) {
+            String prefix = surface == KeySurface.BATCH_WRITE
+                    ? "One or more parameter values are not valid. "
+                    : "One or more parameter values were invalid: ";
+            throw new AwsException("ValidationException", prefix
+                    + "The AttributeValue for a key attribute cannot contain an empty string value. Key: "
+                    + keyName, 400);
+        }
+        if (attr.has("B") && attr.get("B").asText().isEmpty()) {
             throw new AwsException("ValidationException",
-                    "One or more parameter values were invalid: "
-                    + "The AttributeValue for a key attribute cannot contain an empty string value. Key: " + keyName, 400);
+                    "One or more parameter values are not valid. "
+                    + "The AttributeValue for a key attribute cannot contain an empty binary value. Key: "
+                    + keyName, 400);
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -3054,9 +3054,9 @@ public class DynamoDbService implements ResourceProvider {
         }
     }
 
-    // AWS words a key rejection by the surface the key arrived on. A Key argument and a
-    // BatchWriteItem entry report a schema mismatch, a PutItem item body names the types,
-    // and BatchWriteItem alone uses the "are not valid." form for an empty value.
+    // AWS words a key rejection by the surface the key arrived on. A PutItem item body
+    // names the mismatched types, a Key argument and a BatchWriteItem entry report a
+    // schema mismatch instead. An empty key value is worded the same on every surface.
     enum KeySurface { ITEM_BODY, KEY_ARGUMENT, BATCH_WRITE }
 
     String buildItemKey(TableDefinition table, JsonNode item) {
@@ -3133,10 +3133,8 @@ public class DynamoDbService implements ResourceProvider {
                     "The provided key element does not match the schema", 400);
         }
         if (attr.has("S") && attr.get("S").asText().isEmpty()) {
-            String prefix = surface == KeySurface.BATCH_WRITE
-                    ? "One or more parameter values are not valid. "
-                    : "One or more parameter values were invalid: ";
-            throw new AwsException("ValidationException", prefix
+            throw new AwsException("ValidationException",
+                    "One or more parameter values are not valid. "
                     + "The AttributeValue for a key attribute cannot contain an empty string value. Key: "
                     + keyName, 400);
         }

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -3017,6 +3017,67 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void batchWriteItemReportsAKeySchemaMismatchTheWayAwsDoes() {
+        createUsersTable("us-east-1");
+        var wrongType = mapper.createObjectNode();
+        wrongType.set("userId", attributeValue("N", "5"));
+
+        var error = assertThrows(AwsException.class, () -> service.batchWriteItem(
+                Map.of("Users", List.of(putRequest(wrongType))), "us-east-1"));
+        assertEquals("The provided key element does not match the schema", error.getMessage());
+    }
+
+    @Test
+    void putItemStillNamesTheMismatchedKeyTypes() {
+        createUsersTable("us-east-1");
+        var wrongType = mapper.createObjectNode();
+        wrongType.set("userId", attributeValue("N", "5"));
+
+        var error = assertThrows(AwsException.class,
+                () -> service.putItem("Users", wrongType, "us-east-1"));
+        assertEquals("One or more parameter values were invalid: Type mismatch for key userId "
+                + "expected: S actual: N", error.getMessage());
+    }
+
+    @Test
+    void batchWriteItemUsesItsOwnEmptyStringKeyWording() {
+        createUsersTable("us-east-1");
+        ObjectNode emptyKey = mapper.createObjectNode();
+        emptyKey.set("userId", attributeValue("S", ""));
+
+        AwsException batchError = assertThrows(AwsException.class, () -> service.batchWriteItem(
+                Map.of("Users", List.of(putRequest(emptyKey))), "us-east-1"));
+        assertEquals("One or more parameter values are not valid. The AttributeValue for a key "
+                + "attribute cannot contain an empty string value. Key: userId", batchError.getMessage());
+
+        AwsException putError = assertThrows(AwsException.class,
+                () -> service.putItem("Users", emptyKey, "us-east-1"));
+        assertEquals("One or more parameter values were invalid: The AttributeValue for a key "
+                + "attribute cannot contain an empty string value. Key: userId", putError.getMessage());
+    }
+
+    @Test
+    void rejectsAnEmptyBinaryKeyValue() {
+        service.createTable("Binaries",
+                List.of(new KeySchemaElement("pk", "HASH")),
+                List.of(new AttributeDefinition("pk", "B")),
+                5L, 5L, "us-east-1");
+        ObjectNode emptyBinary = mapper.createObjectNode();
+        emptyBinary.set("pk", attributeValue("B", ""));
+
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.putItem("Binaries", emptyBinary, "us-east-1"));
+        assertEquals("One or more parameter values are not valid. The AttributeValue for a key "
+                + "attribute cannot contain an empty binary value. Key: pk", error.getMessage());
+    }
+
+    private JsonNode putRequest(ObjectNode item) {
+        ObjectNode request = mapper.createObjectNode();
+        request.set("PutRequest", mapper.createObjectNode().set("Item", item));
+        return request;
+    }
+
+    @Test
     void updateItemWithNestedDottedPathSetAndRemove() {
         createOrdersTable("us-east-1");
         service.putItem("Orders", item("customerId", "c1", "orderId", "o1"), "us-east-1");

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -3055,20 +3055,24 @@ class DynamoDbServiceTest {
     }
 
     @Test
-    void batchWriteItemUsesItsOwnEmptyStringKeyWording() {
+    void everySurfaceUsesTheSameEmptyStringKeyWording() {
         createUsersTable("us-east-1");
         ObjectNode emptyKey = mapper.createObjectNode();
         emptyKey.set("userId", attributeValue("S", ""));
+        String expected = "One or more parameter values are not valid. The AttributeValue for a key "
+                + "attribute cannot contain an empty string value. Key: userId";
 
         AwsException batchError = assertThrows(AwsException.class, () -> service.batchWriteItem(
                 Map.of("Users", List.of(putRequest(emptyKey))), "us-east-1"));
-        assertEquals("One or more parameter values are not valid. The AttributeValue for a key "
-                + "attribute cannot contain an empty string value. Key: userId", batchError.getMessage());
+        assertEquals(expected, batchError.getMessage());
 
         AwsException putError = assertThrows(AwsException.class,
                 () -> service.putItem("Users", emptyKey, "us-east-1"));
-        assertEquals("One or more parameter values were invalid: The AttributeValue for a key "
-                + "attribute cannot contain an empty string value. Key: userId", putError.getMessage());
+        assertEquals(expected, putError.getMessage());
+
+        AwsException getError = assertThrows(AwsException.class,
+                () -> service.getItem("Users", emptyKey, "us-east-1"));
+        assertEquals(expected, getError.getMessage());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbServiceTest.java
@@ -3028,6 +3028,21 @@ class DynamoDbServiceTest {
     }
 
     @Test
+    void batchWriteItemReportsAMissingKeyAsASchemaMismatch() {
+        createUsersTable("us-east-1");
+        var noKey = mapper.createObjectNode();
+        noKey.set("name", attributeValue("S", "x"));
+
+        var putError = assertThrows(AwsException.class, () -> service.batchWriteItem(
+                Map.of("Users", List.of(putRequest(noKey))), "us-east-1"));
+        assertEquals("The provided key element does not match the schema", putError.getMessage());
+
+        var deleteError = assertThrows(AwsException.class, () -> service.batchWriteItem(
+                Map.of("Users", List.of(deleteRequest(noKey))), "us-east-1"));
+        assertEquals("The provided key element does not match the schema", deleteError.getMessage());
+    }
+
+    @Test
     void putItemStillNamesTheMismatchedKeyTypes() {
         createUsersTable("us-east-1");
         var wrongType = mapper.createObjectNode();
@@ -3074,6 +3089,12 @@ class DynamoDbServiceTest {
     private JsonNode putRequest(ObjectNode item) {
         ObjectNode request = mapper.createObjectNode();
         request.set("PutRequest", mapper.createObjectNode().set("Item", item));
+        return request;
+    }
+
+    private JsonNode deleteRequest(ObjectNode key) {
+        ObjectNode request = mapper.createObjectNode();
+        request.set("DeleteRequest", mapper.createObjectNode().set("Key", key));
         return request;
     }
 


### PR DESCRIPTION
## Summary

Fixes wording in error messages for `BatchWriteItem`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wording diff are found https://github.com/paritysuite/dynamodb-conformance and verified with real AWS ap-northeast-1.

A key value can arrive on three surfaces, and AWS words the rejection differently on each. The boolean that told a Key argument from a PutItem item body is now an enum with a third value for BatchWriteItem.

BatchWriteItem reports a schema mismatch rather than naming the types, and uses the "are not valid." form for an empty key value. PutItem and TransactWriteItems keep the "Type mismatch for key" form.

An empty binary key value is now rejected on every surface. It was accepted before, where the empty string was already rejected.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

