### PR TITLE
fix(test): tear down the organization DetectiveIntegrationTest creates

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/detective/DetectiveIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/detective/DetectiveIntegrationTest.java
@@ -4,6 +4,7 @@ import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -19,14 +20,30 @@ class DetectiveIntegrationTest {
     @Inject
     OrganizationsService organizationsService;
 
+    private boolean createdOrganization;
+
     @BeforeAll
     static void configureRestAssured() {
         RestAssuredJsonUtils.configureAwsContentTypes();
     }
 
+    /**
+     * Organizations state is shared by every test in the JVM and keyed by the management account,
+     * so an organization left behind here makes the next class that creates one under
+     * {@code 000000000000} (e.g. {@code OrganizationsIntegrationTest}) fail with
+     * AlreadyInOrganizationException.
+     */
+    @AfterEach
+    void deleteTheOrganizationThisTestCreated() {
+        if (createdOrganization) {
+            organizationsService.deleteOrganization("000000000000");
+        }
+    }
+
     @Test
     void organizationGraphAndMemberLifecycleMatchesAwsContract() {
         organizationsService.createOrganization("000000000000", "ALL");
+        createdOrganization = true;
         String enableBody = post("/orgs/enableAdminAccount", "{\"AccountId\":\"000000000000\"}")
                 .statusCode(200).extract().asString();
         assertTrue(enableBody.isEmpty());


### PR DESCRIPTION
## Summary

`DetectiveIntegrationTest.organizationGraphAndMemberLifecycleMatchesAwsContract()` calls `organizationsService.createOrganization("000000000000", "ALL")` through the injected service and the class has no teardown, so the organization outlives the test. Organizations state is shared by every `@QuarkusTest` class in the same Surefire fork, so once Detective runs, `OrganizationsIntegrationTest`'s `@Order(1) createOrganization` on the same default account gets `AlreadyInOrganizationException` and the 28 ordered tests after it cascade (`Tests run: 50, Failures: 29` on CI shard 3).

Fix: delete the organization in `@AfterEach`, mirroring the teardown #3158 added for the StackSets leak. The teardown is guarded by a flag set right after `createOrganization`, so it only runs for the test that created one — `-Dtest=DetectiveIntegrationTest#invalidAdminAccountIdReturnsValidationError` keeps working instead of failing with `AWSOrganizationsNotInUseException`. The organization has no member accounts or OUs at that point (Detective members are not Organizations accounts), so `deleteOrganization` succeeds directly.

Fixes #3226

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No production behavior change; test isolation only.

## Checklist

- [x] `./mvnw test` passes locally — verified with the reproduction from the issue:
  - before: `./mvnw test -Dtest=DetectiveIntegrationTest,OrganizationsIntegrationTest` → `Tests run: 52, Failures: 29`, `OrganizationsIntegrationTest.createOrganization` failing with `AlreadyInOrganizationException`
  - after: same command passes (Detective's `Created organization` is followed by `Deleted organization` before Organizations creates its own); `-Dtest=DetectiveIntegrationTest#invalidAdminAccountIdReturnsValidationError` also passes
- [x] New or updated integration test added — the existing `DetectiveIntegrationTest` is updated; no new test since the fix is the teardown itself
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
