### PR TITLE
feat(athena): support ListTagsForResource for workgroups

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/AthenaTest.java
@@ -326,4 +326,30 @@ class AthenaTest {
             }
         }
     }
+
+    /**
+     * github.com/floci-io/floci/issues/2791: terraform-provider-aws's read/refresh for
+     * aws_athena_workgroup calls ListTagsForResource unconditionally. Round-trips through the
+     * real AthenaClient (rather than raw JSON) to validate the request/response shapes.
+     */
+    @Test
+    @Order(10)
+    @DisplayName("listTagsForResource returns the tags set on workgroup creation")
+    void listTagsForResourceReturnsTagsSetOnCreation() {
+        String groupName = "sdk-tags-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        athena.createWorkGroup(CreateWorkGroupRequest.builder()
+                .name(groupName)
+                .tags(software.amazon.awssdk.services.athena.model.Tag.builder()
+                        .key("env").value("prod").build())
+                .build());
+
+        ListTagsForResourceResponse response = athena.listTagsForResource(
+                ListTagsForResourceRequest.builder()
+                        .resourceARN("arn:aws:athena:us-east-1:000000000000:workgroup/" + groupName)
+                        .build());
+
+        assertThat(response.tags()).hasSize(1);
+        assertThat(response.tags().get(0).key()).isEqualTo("env");
+        assertThat(response.tags().get(0).value()).isEqualTo("prod");
+    }
 }

--- a/docs/services/athena.md
+++ b/docs/services/athena.md
@@ -23,6 +23,7 @@ Floci emulates Amazon Athena with **real SQL execution** powered by a [floci-duc
 | `ListDatabases` | - |
 | `ListTableMetadata` | - |
 | `GetTableMetadata` | - |
+| `ListTagsForResource` | Returns the tags on a workgroup |
 | `DeleteWorkGroup` | Deletes a workgroup |
 <!-- floci:actions:end -->
 

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaJsonHandler.java
@@ -94,6 +94,10 @@ public class AthenaJsonHandler {
                 String tableName = request.get("TableName").asText();
                 yield Response.ok(Map.of("TableMetadata", athenaService.getTableMetadata(catalog, database, tableName))).build();
             }
+            case "ListTagsForResource" -> {
+                String resourceArn = request.path("ResourceARN").asText(null);
+                yield Response.ok(Map.of("Tags", athenaService.listTagsForResource(resourceArn))).build();
+            }
             case "DeleteWorkGroup" -> {
                 String wg = request.path("WorkGroup").asText(null);
                 if (wg == null || !wg.matches("[a-zA-Z0-9._-]{1,128}")) {

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -223,7 +223,11 @@ public class AthenaService {
         } catch (IllegalArgumentException e) {
             throw new AwsException("InvalidRequestException", "Invalid ResourceARN: " + resourceArn, 400);
         }
-        if (!arn.resource().startsWith("workgroup/")) {
+        // pgermosen (review, #3242): without this, an ARN naming a completely different
+        // service (e.g. a Neptune workgroup/-shaped resource that coincidentally shares this
+        // region and name) would resolve instead of being rejected the way a live account
+        // rejects a ResourceARN naming the wrong service.
+        if (!"athena".equals(arn.service()) || !arn.resource().startsWith("workgroup/")) {
             throw new AwsException("InvalidRequestException",
                     "Unsupported resource type for ListTagsForResource: " + resourceArn, 400);
         }

--- a/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/AthenaService.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.athena;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.CsvParser;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
@@ -204,6 +205,36 @@ public class AthenaService {
 
     public void deleteWorkGroup(String name, String region) {
         workGroupStore.delete(workGroupKey(region, name));
+    }
+
+    /**
+     * github.com/floci-io/floci/issues/2791: terraform-provider-aws calls this on every
+     * aws_athena_workgroup refresh, tags or not. Only workgroup ARNs are supported - the
+     * primary workgroup can't be tagged and always answers with an empty list, matching a live
+     * account (CreateWorkGroup already rejects "primary", so it can never carry real tags).
+     */
+    public List<WorkGroupTag> listTagsForResource(String resourceArn) {
+        if (resourceArn == null || resourceArn.isBlank()) {
+            throw new AwsException("InvalidRequestException", "ResourceARN is required.", 400);
+        }
+        AwsArnUtils.Arn arn;
+        try {
+            arn = AwsArnUtils.parse(resourceArn);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("InvalidRequestException", "Invalid ResourceARN: " + resourceArn, 400);
+        }
+        if (!arn.resource().startsWith("workgroup/")) {
+            throw new AwsException("InvalidRequestException",
+                    "Unsupported resource type for ListTagsForResource: " + resourceArn, 400);
+        }
+        String name = arn.resource().substring("workgroup/".length());
+        if (DEFAULT_WORKGROUP.equals(name)) {
+            return List.of();
+        }
+        WorkGroup workGroup = workGroupStore.get(workGroupKey(arn.region(), name))
+                .orElseThrow(() -> new AwsException("InvalidRequestException",
+                        "WorkGroup " + name + " is not found.", 400));
+        return workGroup.getTags();
     }
 
     public List<Map<String, Object>> listWorkGroups(String region) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaListTagsForResourceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaListTagsForResourceIntegrationTest.java
@@ -142,6 +142,39 @@ class AthenaListTagsForResourceIntegrationTest {
     }
 
     @Test
+    void listTagsForResourceRejectsAnArnFromADifferentService() {
+        // Create a real workgroup so an unguarded service check would still resolve this: an
+        // ARN naming a different service (a Neptune workgroup/-shaped resource, say) but the
+        // same region and workgroup name must be rejected, not resolved to this workgroup's tags.
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "cross-service-workgroup"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "ResourceARN": "arn:aws:neptune:us-east-1:000000000000:workgroup/cross-service-workgroup"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+    }
+
+    @Test
     void listTagsForResourceRejectsBlankResourceArn() {
         given()
             .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")

--- a/src/test/java/io/github/hectorvent/floci/services/athena/AthenaListTagsForResourceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/AthenaListTagsForResourceIntegrationTest.java
@@ -1,0 +1,156 @@
+package io.github.hectorvent.floci.services.athena;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * github.com/floci-io/floci/issues/2791: terraform-provider-aws's read/refresh for
+ * aws_athena_workgroup calls ListTagsForResource unconditionally, even with no tags set.
+ */
+@QuarkusTest
+class AthenaListTagsForResourceIntegrationTest {
+
+    private static final String CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void listTagsForResourceReturnsTagsSetOnCreate() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-tagged",
+                  "Tags": [
+                    { "Key": "env", "Value": "prod" },
+                    { "Key": "team", "Value": "data" }
+                  ]
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "ResourceARN": "arn:aws:athena:us-east-1:000000000000:workgroup/analytics-tagged"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags.size()", equalTo(2))
+            .body("Tags.Key", contains("env", "team"))
+            .body("Tags.Value", contains("prod", "data"));
+    }
+
+    @Test
+    void listTagsForResourceOnUntaggedWorkGroupReturnsEmptyList() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.CreateWorkGroup")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "Name": "analytics-untagged"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "ResourceARN": "arn:aws:athena:us-east-1:000000000000:workgroup/analytics-untagged"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags.size()", equalTo(0));
+    }
+
+    @Test
+    void listTagsForResourceOnPrimaryWorkGroupReturnsEmptyList() {
+        // CreateWorkGroup rejects "primary", so it can never carry real tags - matches a live account.
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "ResourceARN": "arn:aws:athena:us-east-1:000000000000:workgroup/primary"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("Tags.size()", equalTo(0));
+    }
+
+    @Test
+    void listTagsForResourceOnMissingWorkGroupReturnsInvalidRequestException() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "ResourceARN": "arn:aws:athena:us-east-1:000000000000:workgroup/does-not-exist"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+    }
+
+    @Test
+    void listTagsForResourceRejectsUnsupportedResourceType() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "ResourceARN": "arn:aws:athena:us-east-1:000000000000:datacatalog/AwsDataCatalog"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+    }
+
+    @Test
+    void listTagsForResourceRejectsBlankResourceArn() {
+        given()
+            .header("X-Amz-Target", "AmazonAthena.ListTagsForResource")
+            .contentType(CONTENT_TYPE)
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("InvalidRequestException"));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2791. `terraform-provider-aws`'s read/refresh for `aws_athena_workgroup` calls `ListTagsForResource` on every refresh cycle, even when no `tags` are set on the resource. Floci's Athena handler didn't support the action:

```
Error: listing tags for Athena WorkGroup ...: InvalidAction: Action ListTagsForResource is not supported
```

Parses the workgroup name out of the `ResourceARN` (using the existing `AwsArnUtils` helper already used elsewhere in the codebase) and returns the tags already captured on `CreateWorkGroup` - `WorkGroup`/`WorkGroupTag` already had everything needed, this was purely a missing action.

The primary workgroup always answers with an empty list, matching a live account: `CreateWorkGroup` already rejects `"primary"`, so it can never carry real tags. An `ARN` naming an unsupported resource type, or a workgroup that doesn't exist, faults with `InvalidRequestException`, matching the rest of this handler's not-found cases (e.g. `GetWorkGroup`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Adds `ListTagsForResource` support for Athena workgroup ARNs (`arn:aws:athena:<region>:<account>:workgroup/<name>`). Unblocks `aws_athena_workgroup` in the Terraform/OpenTofu compatibility suites, which needed this to complete its read/refresh cycle.

## Checklist

- [x] `./mvnw test` passes locally (full `athena` package: 51 tests, 0 failures - the 1 error is the pre-existing, unrelated `SocketTimeoutException` flake documented on other PRs in this repo)
- [x] New integration test added (`AthenaListTagsForResourceIntegrationTest`, 6 cases)
- [x] Commit messages follow Conventional Commits
