### PR TITLE
fix(ec2): nest cidrBlockState in AssociateVpcCidrBlock response

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -2632,7 +2632,7 @@ public class Ec2QueryHandler {
                 .start("cidrBlockAssociation")
                 .elem("associationId", assoc.getAssociationId())
                 .elem("cidrBlock", assoc.getCidrBlock())
-                .elem("cidrBlockState", assoc.getCidrBlockState())
+                .start("cidrBlockState").elem("state", assoc.getCidrBlockState()).end("cidrBlockState")
                 .end("cidrBlockAssociation")
                 .end("AssociateVpcCidrBlockResponse");
         return xmlResponse(xml.build());

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcCidrBlockAssociationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcCidrBlockAssociationIntegrationTest.java
@@ -1,0 +1,65 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * AssociateVpcCidrBlock returned cidrBlockState as a bare string
+ * ({@code <cidrBlockState>associated</cidrBlockState>}) instead of the nested shape the real API
+ * uses ({@code <cidrBlockState><state>associated</state></cidrBlockState>}), the same shape
+ * DescribeVpcs already returned for the identical association. The AWS SDK waiter that
+ * terraform-provider-aws uses for aws_vpc_ipv4_cidr_block_association parses the nested form, so
+ * it never saw a valid state and polled DescribeVpcs until it gave up, hanging `terraform apply`
+ * on any secondary_cidr_blocks entry.
+ */
+@QuarkusTest
+class Ec2VpcCidrBlockAssociationIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/ec2/aws4_request";
+
+    @Test
+    void associateVpcCidrBlockReturnsNestedCidrBlockState() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.94.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String associationId = given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.95.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("AssociateVpcCidrBlockResponse.cidrBlockAssociation.cidrBlock", equalTo("10.95.0.0/24"))
+            // The regression: this must be the nested element, not a bare string value.
+            .body("AssociateVpcCidrBlockResponse.cidrBlockAssociation.cidrBlockState.state",
+                    equalTo("associated"))
+            .extract().path("AssociateVpcCidrBlockResponse.cidrBlockAssociation.associationId");
+
+        // Same association, read back through DescribeVpcs, must agree on both shape and state.
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("VpcId.1", vpcId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.cidrBlockAssociationSet.item.find { "
+                    + "it.associationId == '" + associationId + "' }.cidrBlockState.state",
+                    equalTo("associated"));
+    }
+}


### PR DESCRIPTION
## Summary

`AssociateVpcCidrBlock` serialized `cidrBlockState` as a bare string
(`<cidrBlockState>associated</cidrBlockState>`) instead of the nested `<state>`
element the real AWS API uses — the same shape Floci's own `DescribeVpcs`
already returns correctly for the same association
(`<cidrBlockState><state>associated</state></cidrBlockState>`).

`terraform-provider-aws`'s AWS SDK Go v2 client deserializes `cidrBlockState`
as a `VpcCidrBlockState{ State, StatusMessage }` struct. With the flat string,
the create-waiter for `aws_vpc_ipv4_cidr_block_association` never observes a
valid state on the initial response and polls `DescribeVpcs` up to 25 times,
hanging `terraform apply` for minutes on any module/config using
`secondary_cidr_blocks` — e.g. `terraform-aws-modules/vpc/aws`.

`Ec2QueryHandler.handleAssociateVpcCidrBlock` built the response with
`.elem("cidrBlockState", ...)` (flat), while the sibling code path for
`DescribeVpcs` (`vpcXml`) and the IPv6 equivalent already used
`.start("cidrBlockState").elem("state", ...).end("cidrBlockState")` (nested).
This PR aligns `AssociateVpcCidrBlock` with the existing, correct pattern.

Closes #3241

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behaviour: the wire response for `AssociateVpcCidrBlock` nested
`cidrBlockState` as a bare string instead of AWS's `<cidrBlockState><state>...`
element, which `aws-sdk-go-v2` (and therefore `terraform-provider-aws`) can't
deserialize into a valid state — the create-waiter for
`aws_vpc_ipv4_cidr_block_association` polls up to 25 times before giving up.
No other wire changes: `DescribeVpcs` and the IPv6 equivalent already used the
correct nested shape.

## Checklist

- [x] `./mvnw test` passes locally: reverting just the handler fix makes the
  new `Ec2VpcCidrBlockAssociationIntegrationTest` fail (`BUILD FAILURE`, 1
  failure); with the fix restored, the new test and the existing
  `Ec2VpcIpv6CidrBlockIntegrationTest` suite both pass (4 tests, 0 failures)
- [x] New or updated integration test added:
  `Ec2VpcCidrBlockAssociationIntegrationTest` — creates a VPC, associates a
  secondary CIDR block, and asserts
  `cidrBlockAssociation.cidrBlockState.state == "associated"` on the
  `AssociateVpcCidrBlock` response itself (the regression check — it fails
  against the old flat-string shape), then confirms the same association is
  readable via `DescribeVpcs` with a matching state
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Also reproduced end-to-end with `terraform-aws-modules/vpc/aws` +
`secondary_cidr_blocks`, confirming `terraform apply` no longer hangs on
`aws_vpc_ipv4_cidr_block_association`.
