### PR TITLE
fix(ec2): return not found for missing launch templates

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2DescribeLaunchTemplatesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2DescribeLaunchTemplatesTest.java
@@ -1,0 +1,67 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.RequestLaunchTemplateData;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Ec2DescribeLaunchTemplatesTest {
+
+    @Test
+    void missingNameCanTriggerCreateThenDescribe() {
+        String name = "sdk-describe-" + UUID.randomUUID();
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            Ec2Exception error = assertThrows(Ec2Exception.class,
+                    () -> ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name)));
+            assertThat(error.statusCode()).isEqualTo(400);
+            assertThat(error.awsErrorDetails().errorCode())
+                    .isEqualTo("InvalidLaunchTemplateName.NotFoundException");
+
+            String id = ec2.createLaunchTemplate(r -> r.launchTemplateName(name)
+                    .launchTemplateData(RequestLaunchTemplateData.builder()
+                            .imageId("ami-0abcdef1234567890").build()))
+                    .launchTemplate().launchTemplateId();
+            try {
+                assertThat(ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name)).launchTemplates())
+                        .singleElement().satisfies(t -> assertThat(t.launchTemplateId()).isEqualTo(id));
+                assertThat(ec2.describeLaunchTemplates(r -> r.launchTemplateIds(id)).launchTemplates())
+                        .singleElement().satisfies(t -> assertThat(t.launchTemplateName()).isEqualTo(name));
+                Ec2Exception mixed = assertThrows(Ec2Exception.class,
+                        () -> ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name, name + "-missing")));
+                assertThat(mixed.awsErrorDetails().errorCode())
+                        .isEqualTo("InvalidLaunchTemplateName.NotFoundException");
+                Ec2Exception mixedIds = assertThrows(Ec2Exception.class,
+                        () -> ec2.describeLaunchTemplates(r -> r.launchTemplateIds(id, "lt-00000000000000000")));
+                assertThat(mixedIds.awsErrorDetails().errorCode()).isEqualTo("InvalidLaunchTemplateId.NotFound");
+                assertThat(ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name)
+                        .filters(f -> f.name("launch-template-name").values(name + "-missing"))).launchTemplates())
+                        .isEmpty();
+            } finally {
+                ec2.deleteLaunchTemplate(r -> r.launchTemplateId(id));
+            }
+        }
+    }
+
+    @Test
+    void missingIdIsAnSdkError() {
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            Ec2Exception error = assertThrows(Ec2Exception.class,
+                    () -> ec2.describeLaunchTemplates(r -> r.launchTemplateIds("lt-00000000000000000")));
+            assertThat(error.statusCode()).isEqualTo(400);
+            assertThat(error.awsErrorDetails().errorCode()).isEqualTo("InvalidLaunchTemplateId.NotFound");
+        }
+    }
+
+    @Test
+    void unmatchedFilterStillReturnsAnEmptyList() {
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            assertThat(ec2.describeLaunchTemplates(r -> r.filters(f -> f.name("launch-template-name")
+                    .values("missing-" + UUID.randomUUID()))).launchTemplates()).isEmpty();
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconciler.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
 import io.github.hectorvent.floci.services.ec2.model.Reservation;
@@ -553,12 +554,21 @@ public class AutoScalingReconciler {
         if ((ltId == null || ltId.isBlank()) && (ltName == null || ltName.isBlank())) {
             return null;
         }
-        List<LaunchTemplate> launchTemplates = ec2Service.describeLaunchTemplates(
-                asg.getRegion(),
-                ltId == null || ltId.isBlank() ? List.of() : List.of(ltId),
-                ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
-                Map.of());
-        return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+        try {
+            List<LaunchTemplate> launchTemplates = ec2Service.describeLaunchTemplates(
+                    asg.getRegion(),
+                    ltId == null || ltId.isBlank() ? List.of() : List.of(ltId),
+                    ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
+                    Map.of());
+            return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+        } catch (AwsException e) {
+            if (isMissingLaunchTemplate(e)) {
+                LOG.warnv("ASG {0}: launch template {1} is unavailable", asg.getAutoScalingGroupName(),
+                        ltId == null || ltId.isBlank() ? ltName : ltId);
+                return null;
+            }
+            throw e;
+        }
     }
 
     private MixedInstancesPolicy.LaunchTemplateSpecification mixedInstancesLaunchTemplateSpecification(
@@ -584,12 +594,26 @@ public class AutoScalingReconciler {
             AutoScalingGroup asg, MixedInstancesPolicy.LaunchTemplateSpecification specification) {
         String ltId = specification.getLaunchTemplateId();
         String ltName = specification.getLaunchTemplateName();
-        List<LaunchTemplate> launchTemplates = ec2Service.describeLaunchTemplates(
-                asg.getRegion(),
-                ltId == null || ltId.isBlank() ? List.of() : List.of(ltId),
-                ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
-                Map.of());
-        return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+        try {
+            List<LaunchTemplate> launchTemplates = ec2Service.describeLaunchTemplates(
+                    asg.getRegion(),
+                    ltId == null || ltId.isBlank() ? List.of() : List.of(ltId),
+                    ltName == null || ltName.isBlank() ? List.of() : List.of(ltName),
+                    Map.of());
+            return launchTemplates.isEmpty() ? null : launchTemplates.get(0);
+        } catch (AwsException e) {
+            if (isMissingLaunchTemplate(e)) {
+                LOG.warnv("ASG {0}: mixed-instances launch template {1} is unavailable",
+                        asg.getAutoScalingGroupName(), ltId == null || ltId.isBlank() ? ltName : ltId);
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isMissingLaunchTemplate(AwsException e) {
+        return "InvalidLaunchTemplateId.NotFound".equals(e.getErrorCode())
+                || "InvalidLaunchTemplateName.NotFoundException".equals(e.getErrorCode());
     }
 
     private String mixedInstancesInstanceType(AutoScalingGroup asg, LaunchTemplate version) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -4417,8 +4417,22 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     public List<LaunchTemplate> describeLaunchTemplates(String region, List<String> ids,
                                                         List<String> names, Map<String, List<String>> filters) {
         ensureDefaultResources(region);
-        return launchTemplates.scan(k -> true).stream()
+        List<LaunchTemplate> regionalTemplates = launchTemplates.scan(k -> true).stream()
                 .filter(lt -> lt.getRegion().equals(region))
+                .toList();
+        for (String id : ids) {
+            if (regionalTemplates.stream().noneMatch(lt -> id.equals(lt.getLaunchTemplateId()))) {
+                throw new AwsException("InvalidLaunchTemplateId.NotFound",
+                        "The specified launch template does not exist.", 400);
+            }
+        }
+        for (String name : names) {
+            if (regionalTemplates.stream().noneMatch(lt -> name.equals(lt.getLaunchTemplateName()))) {
+                throw new AwsException("InvalidLaunchTemplateName.NotFoundException",
+                        "The specified launch template does not exist.", 400);
+            }
+        }
+        return regionalTemplates.stream()
                 .filter(lt -> ids.isEmpty() || ids.contains(lt.getLaunchTemplateId()))
                 .filter(lt -> names.isEmpty() || names.contains(lt.getLaunchTemplateName()))
                 .filter(lt -> matchesFilters(lt, filters, region))

--- a/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/autoscaling/AutoScalingReconcilerTest.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.services.autoscaling.model.AutoScalingGroup;
 import io.github.hectorvent.floci.services.autoscaling.model.LaunchConfiguration;
 import io.github.hectorvent.floci.services.autoscaling.model.MixedInstancesPolicy;
 import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.InstanceState;
 import io.github.hectorvent.floci.services.ec2.model.LaunchTemplate;
@@ -140,6 +141,35 @@ class AutoScalingReconcilerTest {
         assertEquals("development", tags.getValue().get(0).getValue());
         assertEquals("job-id", tags.getValue().get(1).getKey());
         assertEquals("2001", tags.getValue().get(1).getValue());
+    }
+
+    @Test
+    void missingLaunchTemplateDoesNotAbortAutoScalingBookkeeping() {
+        AutoScalingService asgService = mock(AutoScalingService.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        ElbV2Service elbV2Service = mock(ElbV2Service.class);
+        AutoScalingReconciler reconciler = new AutoScalingReconciler(asgService, ec2Service, elbV2Service);
+        AutoScalingGroup asg = new AutoScalingGroup();
+        asg.setRegion("us-east-1");
+        asg.setAutoScalingGroupName("missing-template-asg");
+        asg.setDesiredCapacity(1);
+        asg.setLaunchTemplateName("missing-template");
+
+        when(ec2Service.describeLaunchTemplates("us-east-1", List.of(), List.of("missing-template"), Map.of()))
+                .thenThrow(new AwsException("InvalidLaunchTemplateName.NotFoundException",
+                        "The specified launch template does not exist.", 400));
+
+        reconciler.reconcile(asg);
+
+        verify(asgService).saveAutoScalingGroup(asg);
+        verify(asgService).completeInstanceRefreshIfSettled("us-east-1", "missing-template-asg");
+        verify(ec2Service, never()).runInstances(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyInt(), org.mockito.ArgumentMatchers.anyInt(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyList(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyList(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2DescribeLaunchTemplatesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2DescribeLaunchTemplatesIntegrationTest.java
@@ -1,0 +1,113 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class Ec2DescribeLaunchTemplatesIntegrationTest {
+
+    private RequestSpecification request(String action, String region) {
+        return given().formParam("Action", action)
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260908/"
+                        + region + "/ec2/aws4_request");
+    }
+
+    private String create(String name) {
+        return request("CreateLaunchTemplate", "us-east-1")
+                .formParam("LaunchTemplateName", name)
+                .formParam("LaunchTemplateData.ImageId", "ami-0abcdef1234567890")
+                .post("/").then().statusCode(200)
+                .extract().xmlPath().getString("CreateLaunchTemplateResponse.launchTemplate.launchTemplateId");
+    }
+
+    @Test
+    void missingNameReturnsAwsNotFound() {
+        request("DescribeLaunchTemplates", "us-east-1")
+                .formParam("LaunchTemplateName.1", "missing-" + UUID.randomUUID())
+                .post("/").then().statusCode(400)
+                .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateName.NotFoundException"));
+    }
+
+    @Test
+    void missingIdReturnsAwsNotFound() {
+        request("DescribeLaunchTemplates", "us-east-1")
+                .formParam("LaunchTemplateId.1", "lt-00000000000000000")
+                .post("/").then().statusCode(400)
+                .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateId.NotFound"));
+    }
+
+    @Test
+    void existingTemplatesRoundTripAndMixedRequestsFail() {
+        String name = "describe-" + UUID.randomUUID();
+        String id = create(name);
+        try {
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateName.1", name)
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.launchTemplateId", equalTo(id));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateId.1", id)
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.launchTemplateName", equalTo(name));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateName.1", name)
+                    .formParam("LaunchTemplateName.2", name + "-missing")
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateName.NotFoundException"));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateId.1", id)
+                    .formParam("LaunchTemplateId.2", "lt-00000000000000000")
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateId.NotFound"));
+            request("DescribeLaunchTemplates", "us-west-2")
+                    .formParam("LaunchTemplateName.1", name)
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateName.NotFoundException"));
+            request("DescribeLaunchTemplates", "us-west-2")
+                    .formParam("LaunchTemplateId.1", id)
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateId.NotFound"));
+        } finally {
+            request("DeleteLaunchTemplate", "us-east-1").formParam("LaunchTemplateId", id)
+                    .post("/").then().statusCode(200);
+        }
+    }
+
+    @Test
+    void filtersDoNotTurnExistingResourcesIntoNotFoundErrors() {
+        String name = "filter-" + UUID.randomUUID();
+        String id = create(name);
+        try {
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.find { it.launchTemplateId == '"
+                            + id + "' }.launchTemplateId", equalTo(id));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("Filter.1.Name", "launch-template-name")
+                    .formParam("Filter.1.Value.1", name + "-missing")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.size()", equalTo(0));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateName.1", name)
+                    .formParam("Filter.1.Name", "launch-template-name")
+                    .formParam("Filter.1.Value.1", name + "-missing")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.size()", equalTo(0));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateId.1", id)
+                    .formParam("Filter.1.Name", "launch-template-name")
+                    .formParam("Filter.1.Value.1", name + "-missing")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.size()", equalTo(0));
+        } finally {
+            request("DeleteLaunchTemplate", "us-east-1").formParam("LaunchTemplateId", id)
+                    .post("/").then().statusCode(200);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3234. Make EC2 `DescribeLaunchTemplates` return AWS-compatible not-found errors when callers explicitly request a missing launch-template name or ID.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Karpenter 1.8.8 uses `InvalidLaunchTemplateName.NotFoundException` to distinguish a missing named template and then create it. Floci previously returned HTTP 200 with `LaunchTemplates: []`, causing Karpenter EC2NodeClass validation to stop with `launch-template-count=0`.

The service now validates explicit IDs and names in the requested region before applying filters and returns `InvalidLaunchTemplateId.NotFound` or `InvalidLaunchTemplateName.NotFoundException` as appropriate. Existing templates still round-trip, mixed explicit requests fail when any requested resource is absent, and unmatched filter-only queries still return an empty successful list.

Regression coverage includes the AWS Query response and AWS SDK for Java 2.52.0 compatibility suite. The focused Floci suite passes 168 tests, including existing EC2, CloudFormation, and AutoScaling coverage. The SDK compatibility module compiles successfully.

## Checklist

- [x] `./mvnw test` passes locally for the focused regression and existing affected coverage
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
