### PR TITLE
fix(lambda): treat an event invoke config on another account's function as a replacement

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LambdaEventInvokeConfigCfnProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LambdaEventInvokeConfigCfnProvisioner.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.lambda.LambdaArnUtils;
@@ -26,7 +27,8 @@ import java.util.Set;
  *
  * <p>Both identifier parts are create-only. An update that still names the same function version
  * or alias, whether by the same text or by another form of the function name (a short name and
- * the function's ARN address one configuration), applies the template's settings through the
+ * the function's ARN address one configuration; another account's or Region's function does not),
+ * applies the template's settings through the
  * merge-style update call, as the AWS handler does, so a setting the template drops keeps its
  * stored value. The settings the configuration had are kept on the resource so a failed stack
  * update can put them back. An update that names another function or qualifier creates the
@@ -98,11 +100,24 @@ public class LambdaEventInvokeConfigCfnProvisioner implements CfnResourceProvisi
             LambdaArnUtils.ResolvedFunctionRef prior = LambdaArnUtils.resolve(priorFunction);
             LambdaArnUtils.ResolvedFunctionRef current = LambdaArnUtils.resolve(functionName);
             return prior.name().equals(current.name())
-                    && (prior.region() == null || current.region() == null
-                        || prior.region().equals(current.region()));
-        } catch (AwsException malformed) {
+                    && sameWhenBothKnown(prior.region(), current.region())
+                    && sameWhenBothKnown(accountOf(priorFunction), accountOf(functionName));
+        } catch (AwsException | IllegalArgumentException malformed) {
             return false;
         }
+    }
+
+    /** The account of a full ARN; a short name or partial ARN names the caller's own, so it agrees with any. */
+    private static String accountOf(String functionName) {
+        if (!functionName.startsWith("arn:")) {
+            return null;
+        }
+        String account = AwsArnUtils.parse(functionName).accountId();
+        return account == null || account.isBlank() ? null : account;
+    }
+
+    private static boolean sameWhenBothKnown(String prior, String current) {
+        return prior == null || current == null || prior.equals(current);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LambdaEventInvokeConfigCfnProvisionerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/provisioners/LambdaEventInvokeConfigCfnProvisionerTest.java
@@ -322,6 +322,21 @@ class LambdaEventInvokeConfigCfnProvisionerTest {
         assertNull(provisioner.updateCleanupPhysicalId(r));
     }
 
+    /** The service keys configurations by the function's full ARN, so another account's function is another target. */
+    @Test
+    void theSameNameInAnotherAccountIsAnotherTarget() {
+        StackResource r = provision("""
+                {"FunctionName": "arn:aws:lambda:us-east-1:222222222222:function:orders", "Qualifier": "$LATEST"}
+                """, "arn:aws:lambda:us-east-1:111111111111:function:orders|$LATEST");
+
+        verify(lambda).putEventInvokeConfig(eq(REGION),
+                eq("arn:aws:lambda:us-east-1:222222222222:function:orders"), eq("$LATEST"), anyMap());
+        verify(lambda, never()).updateEventInvokeConfig(anyString(), anyString(), anyString(), anyMap());
+        assertTrue(provisioner.hasReplacementUpdate(r));
+        assertEquals("arn:aws:lambda:us-east-1:111111111111:function:orders|$LATEST",
+                provisioner.updateCleanupPhysicalId(r));
+    }
+
     @Test
     void theSameNameInAnotherRegionIsAnotherTarget() {
         StackResource r = provision("""


### PR DESCRIPTION
## Summary

Follow-up to #3230. The check that decides whether an `AWS::Lambda::EventInvokeConfig` update still names the same function version or alias compared the function name and Region of two ARNs, but not their account. A template that moved the configuration from `arn:aws:lambda:us-east-1:111111111111:function:orders` to the same name in account `222222222222` was therefore applied in place under the prior physical id instead of being treated as a replacement, and no cleanup of the displaced configuration was recorded.

The account is now compared as well whenever both sides carry one. A short name or a partial ARN names the caller's own account, so it still counts as the same target as the function's full ARN, which is the case the check exists for.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | --- | --- |
| Update | Short name to full ARN of the same function | ✅ | Unchanged: in place under the prior id |
| Update | Same name in another account | ✅ | Now a replacement through `ReplacementCleanup`, like another Region |

## AWS Compatibility

Lambda keys an event invoke configuration by the function's full ARN, so a same-named function in another account is a different resource; CloudFormation replaces on a `FunctionName` change. Covered by the unit test `theSameNameInAnotherAccountIsAnotherTarget`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [ ] `./mvnw test` passes locally. Ran per class instead: `LambdaEventInvokeConfigCfnProvisionerTest` and `CloudFormationLambdaEventInvokeConfigIntegrationTest`.
- [x] New or updated integration test added (unit test; the integration test still covers the lifecycle)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
