### PR TITLE
fix(ec2): match cidr-block-association filters on DescribeVpcs

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -6144,6 +6144,18 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 // 2026-08-25: it matches only the primary block, not a secondary
                 // cidr-block-association entry).
                 case "cidr", "cidr-block" -> matchesValue(values, vpc.getCidrBlock());
+                case "cidr-block-association.association-id" -> vpc.getCidrBlockAssociationSet().stream()
+                        .anyMatch(a -> matchesValue(values, a.getAssociationId()));
+                case "cidr-block-association.cidr-block" -> vpc.getCidrBlockAssociationSet().stream()
+                        .anyMatch(a -> matchesValue(values, a.getCidrBlock()));
+                case "cidr-block-association.state" -> vpc.getCidrBlockAssociationSet().stream()
+                        .anyMatch(a -> matchesValue(values, a.getCidrBlockState()));
+                case "ipv6-cidr-block-association.association-id" -> vpc.getIpv6CidrBlockAssociationSet().stream()
+                        .anyMatch(a -> matchesValue(values, a.getAssociationId()));
+                case "ipv6-cidr-block-association.ipv6-cidr-block" -> vpc.getIpv6CidrBlockAssociationSet().stream()
+                        .anyMatch(a -> matchesValue(values, a.getIpv6CidrBlock()));
+                case "ipv6-cidr-block-association.state" -> vpc.getIpv6CidrBlockAssociationSet().stream()
+                        .anyMatch(a -> matchesValue(values, a.getIpv6CidrBlockState()));
                 default -> true;
             };
         }

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcCidrBlockAssociationFilterIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2VpcCidrBlockAssociationFilterIntegrationTest.java
@@ -1,0 +1,285 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+/**
+ * DescribeVpcs ignored the {@code cidr-block-association.*} and {@code ipv6-cidr-block-association.*}
+ * filters (unrecognized filter names fell through to the catch-all {@code default -> true} in
+ * {@code matchesFilter}, so every VPC in the account matched regardless of the requested
+ * association). terraform-provider-aws's waiter for aws_vpc_ipv4_cidr_block_association polls
+ * DescribeVpcs filtered by {@code cidr-block-association.association-id} and asserts exactly one
+ * VPC comes back; with more than one VPC in the account the assertion failed with a "too many
+ * results" error that the SDK treats as not-found-yet, so the waiter retried until it timed out,
+ * hanging `terraform apply` on any secondary_cidr_blocks entry.
+ */
+@QuarkusTest
+class Ec2VpcCidrBlockAssociationFilterIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260908/us-east-1/ec2/aws4_request";
+
+    @Test
+    void describeVpcsFiltersByCidrBlockAssociationId() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.96.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        // A second, unrelated VPC must not match the first VPC's association filter.
+        given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.97.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String associationId = given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.98.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("AssociateVpcCidrBlockResponse.cidrBlockAssociation.associationId");
+
+        // This is the exact filter terraform-provider-aws's waiter sends: it must return only
+        // the one VPC owning that association, not every VPC in the account.
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "cidr-block-association.association-id")
+            .formParam("Filter.1.Value.1", associationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item.vpcId", equalTo(vpcId));
+    }
+
+    @Test
+    void describeVpcsFiltersByCidrBlockAssociationCidrBlock() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.99.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.100.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "cidr-block-association.cidr-block")
+            .formParam("Filter.1.Value.1", "10.100.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item.vpcId", equalTo(vpcId));
+    }
+
+    @Test
+    void describeVpcsFiltersByCidrBlockAssociationState() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.101.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        // A second, unrelated VPC must not match on state alone either.
+        given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.102.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("CidrBlock", "10.103.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "cidr-block-association.state")
+            .formParam("Filter.1.Value.1", "associated")
+            .formParam("Filter.2.Name", "cidr-block-association.cidr-block")
+            .formParam("Filter.2.Value.1", "10.103.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item.vpcId", equalTo(vpcId));
+    }
+
+    @Test
+    void describeVpcsFiltersByIpv6CidrBlockAssociationId() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.104.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        // A second, unrelated VPC must not match the first VPC's IPv6 association filter.
+        given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.105.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String associationId = given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("AmazonProvidedIpv6CidrBlock", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("AssociateVpcCidrBlockResponse.ipv6CidrBlockAssociation.associationId");
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "ipv6-cidr-block-association.association-id")
+            .formParam("Filter.1.Value.1", associationId)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item.vpcId", equalTo(vpcId));
+    }
+
+    @Test
+    void describeVpcsFiltersByIpv6CidrBlockAssociationCidrBlock() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.106.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        String ipv6CidrBlock = given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("AmazonProvidedIpv6CidrBlock", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("AssociateVpcCidrBlockResponse.ipv6CidrBlockAssociation.ipv6CidrBlock");
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "ipv6-cidr-block-association.ipv6-cidr-block")
+            .formParam("Filter.1.Value.1", ipv6CidrBlock)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item.vpcId", equalTo(vpcId));
+    }
+
+    @Test
+    void describeVpcsFiltersByIpv6CidrBlockAssociationState() {
+        String vpcId = given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.107.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("CreateVpcResponse.vpc.vpcId");
+
+        // A second, unrelated VPC must not match on state alone either.
+        given()
+            .formParam("Action", "CreateVpc")
+            .formParam("CidrBlock", "10.108.0.0/24")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String ipv6CidrBlock = given()
+            .formParam("Action", "AssociateVpcCidrBlock")
+            .formParam("VpcId", vpcId)
+            .formParam("AmazonProvidedIpv6CidrBlock", "true")
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .extract().path("AssociateVpcCidrBlockResponse.ipv6CidrBlockAssociation.ipv6CidrBlock");
+
+        given()
+            .formParam("Action", "DescribeVpcs")
+            .formParam("Filter.1.Name", "ipv6-cidr-block-association.state")
+            .formParam("Filter.1.Value.1", "associated")
+            .formParam("Filter.2.Name", "ipv6-cidr-block-association.ipv6-cidr-block")
+            .formParam("Filter.2.Value.1", ipv6CidrBlock)
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("DescribeVpcsResponse.vpcSet.item.size()", equalTo(1))
+            .body("DescribeVpcsResponse.vpcSet.item.vpcId", equalTo(vpcId));
+    }
+}


### PR DESCRIPTION
## Summary

`DescribeVpcs` ignores the `cidr-block-association.*` and `ipv6-cidr-block-association.*`
filters. `matchesFilter`'s VPC `switch` only recognized `vpc-id`, `state`, `is-default`, and
`cidr`/`cidr-block`; every other filter name fell through to `default -> true`, so the filter
was silently ignored and every VPC in the account matched.

This adds the six documented filters:

- `cidr-block-association.association-id`
- `cidr-block-association.cidr-block`
- `cidr-block-association.state`
- `ipv6-cidr-block-association.association-id`
- `ipv6-cidr-block-association.ipv6-cidr-block`
- `ipv6-cidr-block-association.state`

`terraform-provider-aws`'s waiter for `aws_vpc_ipv4_cidr_block_association`
(`waitVPCCIDRBlockAssociationCreated` / `findVPCCIDRBlockAssociationByID`) polls `DescribeVpcs`
with `Filter.1.Name=cidr-block-association.association-id` and asserts the response contains
exactly one VPC. With the filter ignored, any account with more than one VPC (e.g. the default
VPC plus the one being created) gets every VPC back, and the provider's
`tfresource.AssertSingleValueResult` raises a `TooManyResultsError`. That error type implements
`As(**retry.NotFoundError)`, so the SDK's retry machinery treats "too many results" the same as
"not found yet" instead of failing fast — the waiter just polls forever until its 10-minute
create timeout, hanging `terraform apply` on any `secondary_cidr_blocks` entry.

Fixes #3256, which has the full repro and evidence (raw XML showing the filter being ignored).

Related to #3241 / #3243: same `secondary_cidr_blocks` / `aws_vpc_ipv4_cidr_block_association`
path, but an independent bug. #3243 fixes the *shape* of `AssociateVpcCidrBlock`'s
`cidrBlockState`; this fixes `DescribeVpcs` ignoring the filter the waiter uses on every
subsequent poll. Applying #3243 alone does not unblock `terraform apply` with
`secondary_cidr_blocks` — this reproduces independently of it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behaviour: `DescribeVpcs` accepted the six `cidr-block-association.*` /
`ipv6-cidr-block-association.*` filters syntactically but never evaluated them, matching every
VPC in the account regardless of the filter value. Filter names and semantics follow the
documented `DescribeVpcs` filter list (`association-id`, `cidr-block` / `ipv6-cidr-block`, and
`state` per association). No other wire changes.

## Checklist

- [x] `./mvnw test` passes locally: ran the full EC2 VPC-related suite (`Ec2IntegrationTest`,
  `Ec2ServiceTest`, `Ec2ServicePersistenceTest`, `CloudControlServiceTest`, plus the new and
  existing CIDR association tests) — all green, no regressions
- [x] New or updated integration test added: `Ec2VpcCidrBlockAssociationFilterIntegrationTest`,
  covering `cidr-block-association.association-id` and `cidr-block-association.cidr-block`
  against a multi-VPC account (asserts the filter narrows to the one VPC owning the
  association, not every VPC)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Verified locally against a real `terraform apply` with `terraform-aws-modules/vpc/aws ~> 6.0`
and `secondary_cidr_blocks`: previously hung until timeout, now completes in ~14s.
