### PR TITLE
fix(acm): reflect the requested ValidationDomain in DescribeCertificate

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmJsonHandler.java
@@ -508,18 +508,24 @@ public class AcmJsonHandler {
 
     /**
      * Reads the requested {@code DomainValidationOptions} into a {@code ValidationDomain} per
-     * {@code DomainName}. Incomplete entries are skipped, so a caller that omits {@code ValidationDomain}
-     * keeps the default of validating the domain against itself.
+     * {@code DomainName}. Both members are required, so an entry missing either is rejected rather
+     * than dropped back to the default of validating the domain against itself.
      */
     private Map<String, String> parseDomainValidationOptions(JsonNode optionsNode) {
-        if (!optionsNode.isArray()) return Map.of();
+        if (!optionsNode.isArray()) {
+            return Map.of();
+        }
         Map<String, String> validationDomains = new LinkedHashMap<>();
         for (JsonNode option : optionsNode) {
             String domainName = option.path("DomainName").asText(null);
             String validationDomain = option.path("ValidationDomain").asText(null);
-            if (domainName != null && !domainName.isBlank() && validationDomain != null && !validationDomain.isBlank()) {
-                validationDomains.put(domainName, validationDomain);
+            if (domainName == null || domainName.isBlank() || validationDomain == null || validationDomain.isBlank()) {
+                throw new io.github.hectorvent.floci.core.common.AwsException(
+                    "InvalidDomainValidationOptionsException",
+                    "One or more values in the DomainValidationOption structure is incorrect.",
+                    400);
             }
+            validationDomains.put(domainName, validationDomain);
         }
         return validationDomains;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmJsonHandler.java
@@ -69,9 +69,7 @@ public class AcmJsonHandler {
         Certificate cert = service.describeCertificate(certificateArn, region);
         boolean domainMatchesCertificate = domain.equalsIgnoreCase(cert.getDomainName())
             || cert.getSubjectAlternativeNames().stream().anyMatch(domain::equalsIgnoreCase);
-        boolean validationDomainIsSuperdomain = domain.equalsIgnoreCase(validationDomain)
-            || domain.toLowerCase(java.util.Locale.ROOT).endsWith("." + validationDomain.toLowerCase(java.util.Locale.ROOT));
-        if (!domainMatchesCertificate || !validationDomainIsSuperdomain) {
+        if (!domainMatchesCertificate || !AcmService.isValidationDomainOf(domain, validationDomain)) {
             return Response.status(400)
                 .entity(new AwsErrorResponse("InvalidDomainValidationOptionsException",
                     "One or more values in the DomainValidationOption structure is incorrect."))
@@ -95,9 +93,10 @@ public class AcmJsonHandler {
         String certAuthorityArn = request.path("CertificateAuthorityArn").asText(null);
         CertificateOptions options = parseOptions(request.path("Options"));
         Map<String, String> tags = parseTags(request.path("Tags"));
+        Map<String, String> validationDomains = parseDomainValidationOptions(request.path("DomainValidationOptions"));
 
         Certificate cert = service.requestCertificate(domainName, sans, validationMethod,
-            idempotencyToken, keyAlgorithm, certAuthorityArn, options, tags, region);
+            idempotencyToken, keyAlgorithm, certAuthorityArn, options, tags, validationDomains, region);
 
         ObjectNode response = objectMapper.createObjectNode();
         response.put("CertificateArn", cert.getArn());
@@ -505,6 +504,24 @@ public class AcmJsonHandler {
             tags.put(key, value);
         }
         return tags;
+    }
+
+    /**
+     * Reads the requested {@code DomainValidationOptions} into a {@code ValidationDomain} per
+     * {@code DomainName}. Incomplete entries are skipped, so a caller that omits {@code ValidationDomain}
+     * keeps the default of validating the domain against itself.
+     */
+    private Map<String, String> parseDomainValidationOptions(JsonNode optionsNode) {
+        if (!optionsNode.isArray()) return Map.of();
+        Map<String, String> validationDomains = new LinkedHashMap<>();
+        for (JsonNode option : optionsNode) {
+            String domainName = option.path("DomainName").asText(null);
+            String validationDomain = option.path("ValidationDomain").asText(null);
+            if (domainName != null && !domainName.isBlank() && validationDomain != null && !validationDomain.isBlank()) {
+                validationDomains.put(domainName, validationDomain);
+            }
+        }
+        return validationDomains;
     }
 
     private ValidationMethod parseValidationMethod(String method) {

--- a/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/acm/AcmService.java
@@ -108,9 +108,24 @@ public class AcmService implements ResourceProvider {
                                           String idempotencyToken, KeyAlgorithm keyAlgorithm,
                                           String certAuthorityArn, CertificateOptions options,
                                           Map<String, String> tags, String region) {
+        return requestCertificate(domainName, sans, validationMethod, idempotencyToken, keyAlgorithm,
+            certAuthorityArn, options, tags, Map.of(), region);
+    }
+
+    /**
+     * @param validationDomains the {@code ValidationDomain} of each requested {@code DomainValidationOptions}
+     *                          entry, keyed by its {@code DomainName}. Domains absent from the map validate
+     *                          against themselves, which is what AWS reports when the caller supplies nothing.
+     */
+    public Certificate requestCertificate(String domainName, List<String> sans, ValidationMethod validationMethod,
+                                          String idempotencyToken, KeyAlgorithm keyAlgorithm,
+                                          String certAuthorityArn, CertificateOptions options,
+                                          Map<String, String> tags, Map<String, String> validationDomains,
+                                          String region) {
         logSecurityWarningOnce();
         validateDomainName(domainName);
         validateSans(sans);
+        Map<String, String> requestedValidationDomains = indexValidationDomains(validationDomains, domainName, sans);
         if (tags != null) {
             validateTags(tags);
         }
@@ -182,7 +197,8 @@ public class AcmService implements ResourceProvider {
 
         List<DomainValidation> validations = new ArrayList<>();
         for (String san : allSans) {
-            validations.add(generateDomainValidation(san, validationMethod, status));
+            validations.add(generateDomainValidation(san, requestedValidationDomains.get(san.toLowerCase(Locale.ROOT)),
+                validationMethod, status));
         }
         cert.setDomainValidationOptions(validations);
 
@@ -720,14 +736,56 @@ public class AcmService implements ResourceProvider {
     }
 
     /**
+     * Indexes the {@code ValidationDomain} of each requested {@code DomainValidationOptions} entry by a
+     * lowercased {@code DomainName}, rejecting the entries AWS rejects: a {@code DomainName} that is not
+     * part of the request, and a {@code ValidationDomain} that is neither the domain itself nor one of
+     * its superdomains.
+     */
+    private Map<String, String> indexValidationDomains(Map<String, String> validationDomains,
+                                                       String domainName, List<String> sans) {
+        if (validationDomains == null || validationDomains.isEmpty()) {
+            return Map.of();
+        }
+        Set<String> requested = new HashSet<>();
+        requested.add(domainName.toLowerCase(Locale.ROOT));
+        if (sans != null) {
+            sans.forEach(san -> requested.add(san.toLowerCase(Locale.ROOT)));
+        }
+        Map<String, String> indexed = new HashMap<>();
+        validationDomains.forEach((domain, validationDomain) -> {
+            String key = domain.toLowerCase(Locale.ROOT);
+            if (!requested.contains(key) || !isValidationDomainOf(domain, validationDomain)) {
+                throw new AwsException("InvalidDomainValidationOptionsException",
+                    "One or more values in the DomainValidationOption structure is incorrect.", 400);
+            }
+            indexed.put(key, validationDomain);
+        });
+        return indexed;
+    }
+
+    /**
+     * A {@code ValidationDomain} is only usable for a domain when it is that domain or one of its
+     * superdomains: it is the suffix of the mailboxes ACM will accept an approval from.
+     */
+    static boolean isValidationDomainOf(String domain, String validationDomain) {
+        String lowerDomain = domain.toLowerCase(Locale.ROOT);
+        String lowerValidationDomain = validationDomain.toLowerCase(Locale.ROOT);
+        return lowerDomain.equals(lowerValidationDomain) || lowerDomain.endsWith("." + lowerValidationDomain);
+    }
+
+    /**
      * Generates a domain validation entry whose status follows the certificate: an ISSUED
      * certificate has validated every domain, a PENDING_VALIDATION one has not yet.
+     *
+     * @param requestedValidationDomain the {@code ValidationDomain} the caller asked for, or {@code null}
+     *                                  to validate the domain against itself
      */
-    private DomainValidation generateDomainValidation(String domain, ValidationMethod method, CertificateStatus status) {
+    private DomainValidation generateDomainValidation(String domain, String requestedValidationDomain,
+                                                      ValidationMethod method, CertificateStatus status) {
         String validationToken = generateValidationToken(domain);
-        String validationDomain = baseDomain(domain);
+        String recordBase = baseDomain(domain);
         ResourceRecord resourceRecord = new ResourceRecord(
-            "_" + validationToken.substring(0, 32) + "." + validationDomain + ".",
+            "_" + validationToken.substring(0, 32) + "." + recordBase + ".",
             "CNAME",
             "_" + validationToken.substring(32) + ".acm-validations.aws."
         );
@@ -736,7 +794,7 @@ public class AcmService implements ResourceProvider {
 
         return new DomainValidation(
             domain,
-            domain,
+            requestedValidationDomain != null ? requestedValidationDomain : domain,
             validationStatus,
             method != null ? method.name() : "DNS",
             resourceRecord,

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmValidationDomainIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmValidationDomainIntegrationTest.java
@@ -1,0 +1,111 @@
+package io.github.hectorvent.floci.services.acm;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+
+/**
+ * DescribeCertificate reports the ValidationDomain the caller asked for on RequestCertificate: it
+ * is the suffix of the mailboxes ACM accepts an approval from, so a caller reading it back has to
+ * be able to tell whether the request was taken as sent.
+ */
+@QuarkusTest
+class AcmValidationDomainIntegrationTest {
+
+    private static final String ACM_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void requestedValidationDomainIsReflectedPerDomain() {
+        String certificateArn = requestCertificate("""
+            {
+                "DomainName": "probe.example.validation-domain.test",
+                "SubjectAlternativeNames": ["www.other.validation-domain.test"],
+                "ValidationMethod": "EMAIL",
+                "DomainValidationOptions": [
+                    {"DomainName": "probe.example.validation-domain.test", "ValidationDomain": "validation-domain.test"},
+                    {"DomainName": "www.other.validation-domain.test", "ValidationDomain": "other.validation-domain.test"}
+                ]
+            }
+            """).statusCode(200).extract().jsonPath().getString("CertificateArn");
+
+        describeCertificate(certificateArn)
+            .body("Certificate.DomainValidationOptions.find { it.DomainName == 'probe.example.validation-domain.test' }.ValidationDomain",
+                Matchers.equalTo("validation-domain.test"))
+            .body("Certificate.DomainValidationOptions.find { it.DomainName == 'www.other.validation-domain.test' }.ValidationDomain",
+                Matchers.equalTo("other.validation-domain.test"));
+    }
+
+    @Test
+    void domainWithoutRequestedValidationDomainValidatesAgainstItself() {
+        String certificateArn = requestCertificate("""
+            {
+                "DomainName": "probe.default.validation-domain.test",
+                "ValidationMethod": "EMAIL"
+            }
+            """).statusCode(200).extract().jsonPath().getString("CertificateArn");
+
+        describeCertificate(certificateArn)
+            .body("Certificate.DomainValidationOptions[0].ValidationDomain",
+                Matchers.equalTo("probe.default.validation-domain.test"));
+    }
+
+    @Test
+    void validationDomainThatIsNotASuperdomainIsRejected() {
+        requestCertificate("""
+            {
+                "DomainName": "probe.reject.validation-domain.test",
+                "ValidationMethod": "EMAIL",
+                "DomainValidationOptions": [
+                    {"DomainName": "probe.reject.validation-domain.test", "ValidationDomain": "unrelated.example.net"}
+                ]
+            }
+            """)
+            .statusCode(400)
+            .body("__type", Matchers.equalTo("InvalidDomainValidationOptionsException"));
+    }
+
+    @Test
+    void validationDomainForADomainOutsideTheRequestIsRejected() {
+        requestCertificate("""
+            {
+                "DomainName": "probe.unknown.validation-domain.test",
+                "ValidationMethod": "EMAIL",
+                "DomainValidationOptions": [
+                    {"DomainName": "absent.validation-domain.test", "ValidationDomain": "validation-domain.test"}
+                ]
+            }
+            """)
+            .statusCode(400)
+            .body("__type", Matchers.equalTo("InvalidDomainValidationOptionsException"));
+    }
+
+    private static io.restassured.response.ValidatableResponse requestCertificate(String body) {
+        return given()
+            .header("X-Amz-Target", "CertificateManager.RequestCertificate")
+            .contentType(ACM_CONTENT_TYPE)
+            .body(body)
+        .when()
+            .post("/")
+        .then();
+    }
+
+    private static io.restassured.response.ValidatableResponse describeCertificate(String certificateArn) {
+        return given()
+            .header("X-Amz-Target", "CertificateManager.DescribeCertificate")
+            .contentType(ACM_CONTENT_TYPE)
+            .body("{\"CertificateArn\":\"" + certificateArn + "\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/acm/AcmValidationDomainIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/acm/AcmValidationDomainIntegrationTest.java
@@ -88,6 +88,36 @@ class AcmValidationDomainIntegrationTest {
             .body("__type", Matchers.equalTo("InvalidDomainValidationOptionsException"));
     }
 
+    @Test
+    void entryWithoutAValidationDomainIsRejected() {
+        requestCertificate("""
+            {
+                "DomainName": "probe.incomplete.validation-domain.test",
+                "ValidationMethod": "EMAIL",
+                "DomainValidationOptions": [
+                    {"DomainName": "probe.incomplete.validation-domain.test"}
+                ]
+            }
+            """)
+            .statusCode(400)
+            .body("__type", Matchers.equalTo("InvalidDomainValidationOptionsException"));
+    }
+
+    @Test
+    void entryWithoutADomainNameIsRejected() {
+        requestCertificate("""
+            {
+                "DomainName": "probe.nameless.validation-domain.test",
+                "ValidationMethod": "EMAIL",
+                "DomainValidationOptions": [
+                    {"ValidationDomain": "validation-domain.test"}
+                ]
+            }
+            """)
+            .statusCode(400)
+            .body("__type", Matchers.equalTo("InvalidDomainValidationOptionsException"));
+    }
+
     private static io.restassured.response.ValidatableResponse requestCertificate(String body) {
         return given()
             .header("X-Amz-Target", "CertificateManager.RequestCertificate")


### PR DESCRIPTION
## Summary

Fixes #3251.

`RequestCertificate` ignored `DomainValidationOptions` completely: `AcmJsonHandler` never read the field, and `AcmService.generateDomainValidation` built every entry as `new DomainValidation(domain, domain, ...)`, so `DescribeCertificate` always reported `ValidationDomain` equal to the FQDN.

This carries the requested `ValidationDomain` through per `DomainName` to the stored `DomainValidation`, and rejects the entries AWS rejects with `InvalidDomainValidationOptionsException`:

- a `DomainName` that is not the certificate domain or one of the requested SANs
- a `ValidationDomain` that is neither the domain itself nor one of its superdomains

That superdomain rule was already implemented inline for `ResendValidationEmail`, so it moves into a shared `AcmService.isValidationDomainOf` helper instead of living in two places. Domains with no requested entry keep validating against themselves, which is what AWS reports when the caller supplies nothing, so the default output is unchanged.

The 9-arg `requestCertificate` overload is kept so `AcmCfnProvisioner` (which documents `DomainValidationOptions` as accepted and ignored) is untouched.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: the request's `DomainValidationOptions[].ValidationDomain` was silently dropped. Since that value selects the mailboxes ACM accepts an approval from (`admin@`, `postmaster@`, ... of the validation domain), a caller reading it back could not tell whether the request was taken as sent.

Semantics come from the [API reference](https://docs.aws.amazon.com/acm/latest/APIReference/API_DomainValidationOption.html) — `ValidationDomain` "must be the same as the `DomainName` value or a superdomain of the `DomainName` value", and `DescribeCertificate` reports the domain ACM used to send validation emails. Like the reporter, I have no AWS account to diff a live response against; the rejection rule matches what this repo already enforces for `ResendValidationEmail`.

## Checklist

- [x] `./mvnw test` passes locally (ran `-Dtest='Acm*'`: 130 tests, all green)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

New `AcmValidationDomainIntegrationTest` covers the round trip (including a second entry for a SAN), the unchanged default, and the rejection paths: a `ValidationDomain` that is not a superdomain, a `DomainName` outside the request, and an entry missing either required member. Five of its six cases fail on `main`; the reflection case fails with exactly the issue's `Actual: probe.example.validation-domain.test`.

