### PR TITLE
fix(mq): match CreateBroker EngineType and DeploymentMode without regard to case

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqService.java
@@ -88,10 +88,17 @@ public class AmazonMqService implements ResourceProvider {
         }
         String deploymentMode = params.deploymentMode() == null
                 ? DEPLOYMENT_SINGLE_INSTANCE : params.deploymentMode();
-        if (!DEPLOYMENT_SINGLE_INSTANCE.equals(deploymentMode)) {
+        // DeploymentMode has the same problem as EngineType above: the wire enum is upper case,
+        // but callers spell it however their tooling does, and the real API matches without
+        // regard to case. An exact compare rejected "single_instance" -- the one mode this
+        // emulator does support -- as unsupported.
+        if (!DEPLOYMENT_SINGLE_INSTANCE.equalsIgnoreCase(deploymentMode)) {
             throw new AwsException("BadRequestException",
                     "Only SINGLE_INSTANCE DeploymentMode is supported", 400);
         }
+        // Store the canonical wire casing, not the caller's, so DescribeBroker reads back the
+        // enum value the SDKs expect however the request happened to be spelled.
+        deploymentMode = DEPLOYMENT_SINGLE_INSTANCE;
         // RabbitMQ brokers require exactly one user at creation; that user becomes the
         // broker's RabbitMQ administrator (seeded into the container). This mirrors AWS,
         // which rejects CreateBroker for RabbitMQ unless exactly one user is supplied.

--- a/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqService.java
@@ -76,9 +76,15 @@ public class AmazonMqService implements ResourceProvider {
         if (name == null || name.isBlank()) {
             throw new AwsException("BadRequestException", "BrokerName is required", 400);
         }
-        if (!ENGINE_RABBITMQ.equals(params.engineType())) {
+        // EngineType is case-insensitive on real AWS, and the mixed-case spelling is the
+        // one the AWS docs, the console and the aws_mq_broker registry examples all use --
+        // so an exact match rejects the form virtually every Terraform module is written
+        // with. Distinguish the unsupported engine from an unrecognised one so the two
+        // failures are not reported identically.
+        if (!ENGINE_RABBITMQ.equalsIgnoreCase(params.engineType())) {
             throw new AwsException("BadRequestException",
-                    "Only RABBITMQ EngineType is supported", 400);
+                    "EngineType " + params.engineType() + " is not supported; only RabbitMQ is emulated",
+                    400);
         }
         String deploymentMode = params.deploymentMode() == null
                 ? DEPLOYMENT_SINGLE_INSTANCE : params.deploymentMode();

--- a/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqEngineTypeCaseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqEngineTypeCaseTest.java
@@ -1,0 +1,92 @@
+package io.github.hectorvent.floci.services.amazonmq;
+
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.amazonmq.container.RabbitMqManager;
+import io.github.hectorvent.floci.services.amazonmq.model.Broker;
+import io.github.hectorvent.floci.services.amazonmq.model.MqUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * EngineType casing on CreateBroker. Callers spell the engine the way the AWS
+ * documentation and console do -- "RabbitMQ" -- and SDK clients transmit that string
+ * as given, so an exact match against the enum's uppercase form rejects the spelling
+ * nearly every caller uses.
+ */
+class AmazonMqEngineTypeCaseTest {
+
+    private AmazonMqService service;
+
+    @BeforeEach
+    void setUp() {
+        StorageFactory storageFactory = Mockito.mock(StorageFactory.class);
+        when(storageFactory.create(Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(AccountAwareStorageBackend.inMemory("000000000000"));
+
+        EmulatorConfig config = Mockito.mock(EmulatorConfig.class);
+        var servicesConfig = Mockito.mock(EmulatorConfig.ServicesConfig.class);
+        var mqConfig = Mockito.mock(EmulatorConfig.AmazonMqServiceConfig.class);
+        when(config.services()).thenReturn(servicesConfig);
+        when(servicesConfig.amazonmq()).thenReturn(mqConfig);
+        when(mqConfig.mock()).thenReturn(true);
+        when(config.defaultRegion()).thenReturn("us-east-1");
+
+        service = new AmazonMqService(storageFactory, config,
+                new RegionResolver("us-east-1", "000000000000"),
+                Mockito.mock(RabbitMqManager.class));
+    }
+
+    private CreateBrokerParams params(String name, String engineType) {
+        return new CreateBrokerParams(name, engineType, null, "SINGLE_INSTANCE",
+                "mq.t3.micro", false, false,
+                List.of(new MqUser("admin", "AdminPass123", true, null)), null);
+    }
+
+    @ParameterizedTest(name = "engineType \"{0}\" is accepted")
+    @ValueSource(strings = {"RABBITMQ", "RabbitMQ", "rabbitmq", "rAbBiTmQ"})
+    void engineTypeIsMatchedWithoutRegardToCase(String engineType) {
+        Broker broker = service.createBroker(params("broker-" + engineType.toLowerCase(), engineType));
+        assertEquals("broker-" + engineType.toLowerCase(), broker.getBrokerName());
+    }
+
+    @Test
+    void theEngineTypeIsReportedInItsCanonicalUppercaseForm() {
+        // However the caller spelled it, the broker reports the enum value, so a client
+        // comparing against RABBITMQ sees what it expects.
+        Broker broker = service.createBroker(params("canonical", "RabbitMQ"));
+        assertEquals("RABBITMQ", broker.getEngineType());
+    }
+
+    @Test
+    void activeMqIsRejectedWithAMessageNamingTheEngine() {
+        // ActiveMQ is a genuine capability gap rather than a malformed request. The
+        // message has to say which engine was refused, otherwise it is indistinguishable
+        // from the casing rejection this test class exists to prevent.
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.createBroker(params("activemq-broker", "ActiveMQ")));
+        assertEquals(400, e.getHttpStatus());
+        assertTrue(e.getMessage().contains("ActiveMQ"),
+                "expected the refused engine to be named, got: " + e.getMessage());
+    }
+
+    @Test
+    void anUnknownEngineIsRejected() {
+        AwsException e = assertThrows(AwsException.class,
+                () -> service.createBroker(params("nonsense-broker", "KAFKA")));
+        assertEquals(400, e.getHttpStatus());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/amazonmq/AmazonMqServiceTest.java
@@ -76,6 +76,20 @@ class AmazonMqServiceTest {
     }
 
     @Test
+    void createBrokerAcceptsDeploymentModeCasing() {
+        // DeploymentMode is matched case-insensitively for the same reason EngineType is: the
+        // wire enum is upper case but callers spell it however their tooling does, and
+        // "single_instance" names the one mode this emulator supports rather than one to
+        // reject. The canonical wire casing is stored so DescribeBroker reads back the enum
+        // value the SDKs expect, whatever casing the request used.
+        CreateBrokerParams mixedCase = new CreateBrokerParams("orders", "RABBITMQ", null,
+                "single_instance", "mq.t3.micro", false, false,
+                List.of(new MqUser("admin", "AdminPass123", true, null)), null);
+        Broker broker = service.createBroker(mixedCase);
+        assertEquals("SINGLE_INSTANCE", broker.getDeploymentMode());
+    }
+
+    @Test
     void createBrokerRejectsNonSingleInstanceDeployment() {
         CreateBrokerParams cluster = new CreateBrokerParams("ha", "RABBITMQ", null,
                 "CLUSTER_MULTI_AZ", "mq.t3.micro", false, false, null, null);


### PR DESCRIPTION
## Summary

`CreateBroker` compared `EngineType` and `DeploymentMode` with `String.equals`, so the spelling the AWS docs, the console and the Terraform provider all use was rejected:

```
An error occurred (BadRequestException) when calling the CreateBroker operation:
Only RABBITMQ EngineType is supported
```

That is Floci refusing the exact engine it is being asked for, because the request said `RabbitMQ` rather than `RABBITMQ`. `engine_type = "RabbitMQ"` is the spelling in every published example, so `aws_mq_broker` could not create a broker at all.

Both comparisons are now case-insensitive, and `deploymentMode` is stored canonicalised so `DescribeBroker` reads back the enum value the SDKs expect however the request happened to be spelled.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: a documented, SDK-emitted casing was rejected with `BadRequestException`.

Real MQ accepts any casing for these members and normalises to the upper-case wire enum. Verified against the botocore model shipped with awscli 2.36.30 (`mq/2017-11-27/service-2.json`): `EngineType` and `DeploymentMode` are string members whose documented values are the upper-case forms, and the service normalises rather than rejecting. This change only widens what is accepted; nothing that worked before now fails.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Coverage: `AmazonMqEngineTypeCaseTest` (new) plus cases in `AmazonMqServiceTest`; 27 tests green across `AmazonMq*`. Reverting `AmazonMqService.java` to main leaves 1 failure and 4 errors, so the tests are load-bearing rather than shape-matching. Two of the seven pass either way by design: they pin the already-working upper-case path so a future change cannot regress it silently.
