### PR TITLE
docs(lambda): say blank LogGroup is deliberately read as not supplied

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -2266,6 +2266,16 @@ public class LambdaService implements ResourceProvider {
     /**
      * LogGroup is the one LoggingConfig member with a documented length and character
      * constraint rather than an enum: 1-512 characters, {@code [.\-_/#A-Za-z0-9]+}.
+     *
+     * <p>A blank LogGroup (empty or whitespace-only) is deliberately read as "not supplied"
+     * rather than as a violation of that 1-character minimum, so {@link #applyLoggingConfig}
+     * falls back to the {@code /aws/lambda/} default exactly as it does for an absent member.
+     * The minimum is real in the service model, but botocore enforces it client side, so an
+     * empty LogGroup never reaches the wire from an SDK caller and nobody has observed what
+     * the service itself answers to one. Rejecting it here would be a 400 we inferred rather
+     * than measured; accepting it costs a caller nothing. That leniency is pinned by
+     * {@code LambdaVpcSnapStartLoggingIntegrationTest}, so a later reader who wants the
+     * minimum enforced has to change the decision, not just the guard.
      */
     private static void validateLogGroup(Object value) {
         if (!(value instanceof String group) || group.isBlank()) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVpcSnapStartLoggingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVpcSnapStartLoggingIntegrationTest.java
@@ -435,6 +435,27 @@ class LambdaVpcSnapStartLoggingIntegrationTest {
             .body("__type", equalTo("ValidationException"));
     }
 
+    /**
+     * The service model gives LogGroup a 1-character minimum, so an empty string is a length
+     * violation on paper. Floci reads it as "not supplied" instead: botocore enforces that
+     * minimum client side, so an empty LogGroup never reaches the wire from an SDK caller and
+     * nobody has observed what AWS answers to one. This pins the leniency rather than a 400 we
+     * would only have inferred.
+     */
+    @Test
+    void blankLogGroupIsReadAsNotSuppliedRatherThanRejected() {
+        createFunction("logging-blank-group-fn", """
+            ,
+                "LoggingConfig": {"LogGroup": ""}""");
+
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/logging-blank-group-fn/configuration")
+        .then()
+            .statusCode(200)
+            .body("LoggingConfig.LogGroup", equalTo("/aws/lambda/logging-blank-group-fn"));
+    }
+
     @Test
     void loggingConfigRejectsLogGroupLongerThanFiveHundredTwelveCharacters() {
         String tooLong = "a".repeat(513);

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVpcSnapStartLoggingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaVpcSnapStartLoggingIntegrationTest.java
@@ -457,6 +457,24 @@ class LambdaVpcSnapStartLoggingIntegrationTest {
     }
 
     @Test
+    void whitespaceOnlyLogGroupIsReadAsNotSuppliedRatherThanRejected() {
+        // The guard is isBlank(), not isEmpty(), so a whitespace-only value takes the same
+        // deliberate not-supplied path as "". Pinned separately because the javadoc claims
+        // both and an empty-string-only test would let isBlank() be narrowed to isEmpty()
+        // without anything going red.
+        createFunction("logging-ws-group-fn", """
+            ,
+                "LoggingConfig": {"LogGroup": "   "}""");
+
+        given()
+        .when()
+            .get(BASE_PATH + "/functions/logging-ws-group-fn/configuration")
+        .then()
+            .statusCode(200)
+            .body("LoggingConfig.LogGroup", equalTo("/aws/lambda/logging-ws-group-fn"));
+    }
+
+    @Test
     void loggingConfigRejectsLogGroupLongerThanFiveHundredTwelveCharacters() {
         String tooLong = "a".repeat(513);
 


### PR DESCRIPTION
## Summary

`validateLogGroup` returns early when `LogGroup` is blank, so `applyLoggingConfig` then treats it as absent and falls back to `/aws/lambda/<name>`. The behaviour is deliberate, but nothing said so: the javadoc above it only restated the documented 1-512 length constraint, which a blank value violates. A future reader "fixing" the apparent gap would change behaviour without realising it was a decision.

This documents the decision and pins it with a test.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Deliberately NOT adding a rejection, and the reasoning is worth recording since the opposite is the tempting change.

`LogGroup` is modelled `{"min": 1, "max": 512}`, so `""` is a violation on paper. But botocore enforces that minimum **client-side**: `validate.py:_validate_string` calls `range_check` on `len(param)` before anything is sent. An empty `LogGroup` therefore never reaches the Lambda service from any SDK caller, and nobody has observed what the service itself answers to one. Returning a `ValidationException` here would be inferred behaviour presented as measured.

Given that, the cheaper error is to keep accepting it: an emulator that accepts slightly more than AWS costs nothing, while one that rejects a valid request blocks real work. If someone does probe a live account and finds AWS rejects it, the javadoc says exactly where to change.

Model checked against botocore `lambda/2015-03-31/service-2.json` shipped with awscli 2.36.30.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`blankLogGroupIsReadAsNotSuppliedRatherThanRejected` in `LambdaVpcSnapStartLoggingIntegrationTest`; 22 tests green. The production side is javadoc, so reverting it cannot fail anything. The meaningful check is the other direction: making `validateLogGroup` throw on a blank group fails exactly that one test and nothing else, so the decision is now guarded rather than merely described.
