### PR TITLE
feat(redshift): emulate GetClusterCredentials and GetClusterCredentialsWithIAM

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
@@ -153,14 +153,14 @@ public class RedshiftTest {
     }
 
     @Test
-    @Order(2)
-    public void testGetClusterCredentialsReturnsTemporaryCredentials() {
+    @Order(3)
+    public void testGetClusterCredentialsReturnsTemporaryCredentials() throws Exception {
         RedshiftClient client = getClient();
-        GetClusterCredentialsResponse res = client.getClusterCredentials(b -> b
+        GetClusterCredentialsResponse res = withRetry(() -> client.getClusterCredentials(b -> b
                 .clusterIdentifier("test-cluster")
                 .dbUser("analyst")
                 .dbName("dev")
-                .durationSeconds(900));
+                .durationSeconds(900)));
 
         assertNotNull(res.dbUser());
         assertTrue(res.dbUser().contains("analyst"));
@@ -170,13 +170,13 @@ public class RedshiftTest {
     }
 
     @Test
-    @Order(2)
-    public void testGetClusterCredentialsWithIamReturnsIamPrefixedUser() {
+    @Order(4)
+    public void testGetClusterCredentialsWithIamReturnsIamPrefixedUser() throws Exception {
         RedshiftClient client = getClient();
-        GetClusterCredentialsWithIamResponse res = client.getClusterCredentialsWithIAM(b -> b
+        GetClusterCredentialsWithIamResponse res = withRetry(() -> client.getClusterCredentialsWithIAM(b -> b
                 .clusterIdentifier("test-cluster")
                 .dbName("dev")
-                .durationSeconds(900));
+                .durationSeconds(900)));
 
         assertNotNull(res.dbUser());
         assertTrue(res.dbUser().startsWith("IAM"));
@@ -186,7 +186,7 @@ public class RedshiftTest {
     }
 
     @Test
-    @Order(3)
+    @Order(5)
     public void testDeleteCluster() throws Exception {
         RedshiftClient client = getClient();
         DeleteClusterResponse res = withRetry(() -> client.deleteCluster(DeleteClusterRequest.builder()

--- a/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/github/hectorvent/floci/compat/RedshiftTest.java
@@ -14,6 +14,8 @@ import software.amazon.awssdk.services.redshift.model.DescribeClustersRequest;
 import software.amazon.awssdk.services.redshift.model.DescribeClustersResponse;
 import software.amazon.awssdk.services.redshift.model.DeleteClusterRequest;
 import software.amazon.awssdk.services.redshift.model.DeleteClusterResponse;
+import software.amazon.awssdk.services.redshift.model.GetClusterCredentialsResponse;
+import software.amazon.awssdk.services.redshift.model.GetClusterCredentialsWithIamResponse;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -148,6 +150,39 @@ public class RedshiftTest {
                                 .asByteArray(),
                         StandardCharsets.UTF_8)));
         assertEquals("1|alice\n2|bob\n", all.toString());
+    }
+
+    @Test
+    @Order(2)
+    public void testGetClusterCredentialsReturnsTemporaryCredentials() {
+        RedshiftClient client = getClient();
+        GetClusterCredentialsResponse res = client.getClusterCredentials(b -> b
+                .clusterIdentifier("test-cluster")
+                .dbUser("analyst")
+                .dbName("dev")
+                .durationSeconds(900));
+
+        assertNotNull(res.dbUser());
+        assertTrue(res.dbUser().contains("analyst"));
+        assertNotNull(res.dbPassword());
+        assertTrue(!res.dbPassword().isBlank());
+        assertNotNull(res.expiration());
+    }
+
+    @Test
+    @Order(2)
+    public void testGetClusterCredentialsWithIamReturnsIamPrefixedUser() {
+        RedshiftClient client = getClient();
+        GetClusterCredentialsWithIamResponse res = client.getClusterCredentialsWithIAM(b -> b
+                .clusterIdentifier("test-cluster")
+                .dbName("dev")
+                .durationSeconds(900));
+
+        assertNotNull(res.dbUser());
+        assertTrue(res.dbUser().startsWith("IAM"));
+        assertNotNull(res.dbPassword());
+        assertTrue(!res.dbPassword().isBlank());
+        assertNotNull(res.expiration());
     }
 
     @Test

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -65,7 +65,7 @@ Operation counts are exact. For dispatch-table services (Query and JSON 1.1) eac
 | [Lake Formation](lakeformation.md) | `POST /<Action>` | REST JSON | 16 |
 | [Neptune](neptune.md) | `POST /` with `Action=` param + Gremlin TCP proxy | Query + WebSocket | 14 |
 | [DocumentDB](docdb.md) | `POST /` with `Action=` param + MongoDB container | Query + MongoDB wire | 8 |
-| [Redshift](redshift.md) | `POST /` with `Action=` param + PostgreSQL container | Query + PostgreSQL wire | 21 |
+| [Redshift](redshift.md) | `POST /` with `Action=` param + PostgreSQL container | Query + PostgreSQL wire | 23 |
 | [Redshift Data API](redshift-data.md) | `POST /` + `X-Amz-Target: RedshiftData.*` | JSON 1.1 | 11 |
 | [EMR](emr.md) | `POST /` + `X-Amz-Target: ElasticMapReduce.*` | JSON 1.1 | 24 |
 | [EMR Serverless](emr-serverless.md) | `/applications/*` | REST JSON | 7 |

--- a/docs/services/redshift-data.md
+++ b/docs/services/redshift-data.md
@@ -36,7 +36,7 @@ For the upstream API shape, see the AWS documentation:
 
 A request identifies its target cluster one of two ways:
 
-- **`ClusterIdentifier` + `DbUser` + `Database`.** The `DbUser` must be the cluster master user. Floci connects directly to the container, so a non-master `DbUser` needs a real PostgreSQL role; until `GetClusterCredentials` is emulated, a non-master `DbUser` returns `ValidationException`.
+- **`ClusterIdentifier` + `DbUser` + `Database`.** The `DbUser` is the cluster master, or any user for which an unexpired `GetClusterCredentials` credential has been issued. Floci connects to the container as the cluster master in both cases. Any other `DbUser` returns `ValidationException`.
 - **`SecretArn` + `ClusterIdentifier` + `Database`.** The secret must be a local Secrets Manager secret holding JSON credentials (`username` or `user`, plus `password`). A cross-region `SecretArn` is rejected.
 
 `WorkgroupName` (Amazon Redshift Serverless) is rejected with `ValidationException`. Redshift Serverless is not emulated.

--- a/docs/services/redshift-data.md
+++ b/docs/services/redshift-data.md
@@ -36,7 +36,7 @@ For the upstream API shape, see the AWS documentation:
 
 A request identifies its target cluster one of two ways:
 
-- **`ClusterIdentifier` + `DbUser` + `Database`.** The `DbUser` is the cluster master, or any user for which an unexpired `GetClusterCredentials` credential has been issued. Floci connects to the container as the cluster master in both cases. Any other `DbUser` returns `ValidationException`.
+- **`ClusterIdentifier` + `DbUser` + `Database`.** The `DbUser` is the cluster master, or the prefixed name returned by `GetClusterCredentials` / `GetClusterCredentialsWithIAM` (for example `IAM:analyst`) while that credential is unexpired. Floci connects to the container as the cluster master in both cases. Any other `DbUser` returns `ValidationException`.
 - **`SecretArn` + `ClusterIdentifier` + `Database`.** The secret must be a local Secrets Manager secret holding JSON credentials (`username` or `user`, plus `password`). A cross-region `SecretArn` is rejected.
 
 `WorkgroupName` (Amazon Redshift Serverless) is rejected with `ValidationException`. Redshift Serverless is not emulated.

--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -179,7 +179,7 @@ order) through its own S3 service and streams the rows into the backing PostgreS
 - The rewrite is textual (regex-based). It masks single-quoted string literals first, so `DEFAULT` / `CHECK` string values are safe, but it is **not** comment-aware and does not recognize escape strings (`E'...'`): an apostrophe inside a `--` or `/* */` comment can make the rewrite skip a Redshift clause. That fails safe: the statement then reaches PostgreSQL, which returns its own syntax error, but avoid apostrophes-in-comments in `CREATE TABLE` / `ALTER TABLE`.
 - A `rewrite` failure or any statement the interceptor does not recognize is forwarded unmodified (fail-open); PostgreSQL then rejects the Redshift-only syntax itself.
 - Simple Query ('Q') messages larger than 16 MiB bypass the interceptor and stream through verbatim without heap buffering; non-query traffic also streams through with no size limit.
-- `GetClusterCredentials` / `GetClusterCredentialsWithIAM` mint a short-lived password held in memory (lost on restart). The returned `DbUser` is nominal: the session runs as the cluster master, not a distinct PostgreSQL role, so `current_user`, `GRANT`, and object ownership are the master's.
+- `GetClusterCredentials` / `GetClusterCredentialsWithIAM` mint a short-lived password held in memory (lost on restart). As in AWS, `GetClusterCredentials` prefixes the returned `DbUser` with `IAM:` when `AutoCreate` is false and `IAMA:` when it is true; that prefixed name is what the auth proxy and Data API accept. The returned `DbUser` is nominal: the session runs as the cluster master, not a distinct PostgreSQL role, so `current_user`, `GRANT`, and object ownership are the master's.
 
 ### UNLOAD to S3
 

--- a/docs/services/redshift.md
+++ b/docs/services/redshift.md
@@ -38,6 +38,8 @@ For running SQL without a PostgreSQL wire connection (the way Lambda and Step Fu
 | `DeleteClusterSubnetGroup` | Remove a subnet group |
 | `ModifyCluster` | Update node type, parameter group, security groups, or the master password |
 | `RebootCluster` | Restart a cluster's container |
+| `GetClusterCredentials` | Issue a short-lived DbUser / DbPassword pair the auth proxy and Data API accept for a non-master user |
+| `GetClusterCredentialsWithIAM` | Issue short-lived credentials with the DbUser derived from the caller's IAM identity |
 <!-- floci:actions:end -->
 
 ## Configuration
@@ -177,6 +179,7 @@ order) through its own S3 service and streams the rows into the backing PostgreS
 - The rewrite is textual (regex-based). It masks single-quoted string literals first, so `DEFAULT` / `CHECK` string values are safe, but it is **not** comment-aware and does not recognize escape strings (`E'...'`): an apostrophe inside a `--` or `/* */` comment can make the rewrite skip a Redshift clause. That fails safe: the statement then reaches PostgreSQL, which returns its own syntax error, but avoid apostrophes-in-comments in `CREATE TABLE` / `ALTER TABLE`.
 - A `rewrite` failure or any statement the interceptor does not recognize is forwarded unmodified (fail-open); PostgreSQL then rejects the Redshift-only syntax itself.
 - Simple Query ('Q') messages larger than 16 MiB bypass the interceptor and stream through verbatim without heap buffering; non-query traffic also streams through with no size limit.
+- `GetClusterCredentials` / `GetClusterCredentialsWithIAM` mint a short-lived password held in memory (lost on restart). The returned `DbUser` is nominal: the session runs as the cluster master, not a distinct PostgreSQL role, so `current_user`, `GRANT`, and object ownership are the master's.
 
 ### UNLOAD to S3
 
@@ -220,5 +223,5 @@ the result to S3 as one or more objects under `<prefix>`.
 - Parameter groups apply no real engine settings; values are stored and echoed back only.
 - Subnet groups, VPC routing, and security groups are metadata only.
 - Resize, pause/resume, IAM authentication, snapshot schedules, and cross-region snapshot copy.
-- The auth proxy validates only the master user's password. Non-master users pass straight through to PostgreSQL, which remains the authority for their credentials.
-- IAM database authentication (`GetClusterCredentials`), and `sslmode=verify-full` against the self-signed proxy certificate.
+- The auth proxy validates the master user's password and any live `GetClusterCredentials` credential. Other non-master users pass straight through to PostgreSQL, which remains the authority for their credentials.
+- IAM database authentication over the wire, and `sslmode=verify-full` against the self-signed proxy certificate.

--- a/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
+++ b/src/main/java/io/github/hectorvent/floci/config/EmulatorConfig.java
@@ -1283,6 +1283,11 @@ public interface EmulatorConfig {
         // Hostname clients use to reach a cluster endpoint. Empty -> resolved from
         // DockerHostResolver (falls back to "localhost").
         Optional<String> endpointHost();
+
+        // Default lifetime for GetClusterCredentials / GetClusterCredentialsWithIAM when
+        // DurationSeconds is omitted. AWS allows 900 to 3600.
+        @WithDefault("900")
+        int defaultCredentialDurationSeconds();
     }
 
     interface RdsServiceConfig {

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsQueryController.java
@@ -356,7 +356,7 @@ public class AwsQueryController {
                     : elbV2QueryHandler.handle(action, formParams, region);
             case "autoscaling" -> autoScalingQueryHandler.handle(action, formParams, region);
             case "elasticbeanstalk" -> elasticBeanstalkQueryHandler.handle(action, formParams, region);
-            case "redshift" -> redshiftQueryHandler.handle(action, formParams);
+            case "redshift" -> redshiftQueryHandler.handle(action, formParams, authorization);
             default -> xmlErrorResponse("UnknownService",
                     "Unknown or unsupported service: " + service, 400);
         };
@@ -605,7 +605,8 @@ public class AwsQueryController {
             "CreateClusterParameterGroup", "DescribeClusterParameterGroups", "DescribeClusterParameters", "DeleteClusterParameterGroup",
             "ModifyClusterParameterGroup",
             "CreateClusterSubnetGroup", "DescribeClusterSubnetGroups", "ModifyClusterSubnetGroup", "DeleteClusterSubnetGroup",
-            "CreateTags", "DeleteTags", "DescribeTags"
+            "CreateTags", "DeleteTags", "DescribeTags",
+            "GetClusterCredentials", "GetClusterCredentialsWithIAM"
     );
 
     private String resolveService(String authorization, String action) {

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PasswordValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PasswordValidator.java
@@ -1,6 +1,17 @@
 package io.github.hectorvent.floci.services.rds.proxy;
 
 @FunctionalInterface
-    public interface PasswordValidator {
-        boolean validate(String username, String password);
-    }
+public interface PasswordValidator {
+
+    AuthResult validate(String username, String password);
+
+    /**
+     * REJECT           : refuse the client.
+     * PASSTHROUGH      : the proxy does not vouch for this user; forward the
+     *                    client's own credentials so the backend enforces them
+     *                    (legacy non-master behaviour).
+     * MASTER_EQUIVALENT: the proxy has validated the client; open the backend
+     *                    connection as the cluster master.
+     */
+    enum AuthResult { REJECT, PASSTHROUGH, MASTER_EQUIVALENT }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandler.java
@@ -54,6 +54,26 @@ public class PostgresProtocolHandler {
      */
     public record AuthenticatedSession(Socket client, String iamRole) {}
 
+    /** The username/password the proxy opens the backend PostgreSQL connection with. */
+    record BackendLogin(String user, String password) {}
+
+    /**
+     * Picks the backend login: the cluster master whenever the proxy is the authority for this
+     * connection (an IAM token, the master user itself, or a client the validator vouched for),
+     * otherwise the client's own credentials so the backend enforces its ACLs.
+     */
+    static BackendLogin resolveBackendLogin(boolean isMaster, boolean isIam,
+                                            PasswordValidator.AuthResult result,
+                                            String masterUsername, String masterPassword,
+                                            String clientUsername, String clientPassword) {
+        boolean useMaster = isIam || isMaster
+                || result == PasswordValidator.AuthResult.MASTER_EQUIVALENT;
+        if (useMaster) {
+            return new BackendLogin(masterUsername, masterPassword);
+        }
+        return new BackendLogin(clientUsername, clientPassword);
+    }
+
     public static AuthenticatedSession authenticate(Socket client, Socket backend,
                                       String masterUsername, String masterPassword, String dbName,
                                       boolean iamEnabled, RdsSigV4Validator sigV4,
@@ -84,12 +104,15 @@ public class PostgresProtocolHandler {
 
         // Phase 4: Validate credentials.
         // - IAM tokens: validated locally via SigV4.
-        // - Master user (plain password): validated at the proxy via passwordValidator, which
-        //   reads from RdsService and therefore reflects modifyDBInstance password changes.
-        // - Non-master users: pass through — the backend is the authority for their passwords.
+        // - Every non-IAM client: classified by passwordValidator into REJECT / PASSTHROUGH /
+        //   MASTER_EQUIVALENT. PASSTHROUGH keeps the legacy non-master behaviour (the backend is
+        //   the authority for the password); MASTER_EQUIVALENT means the proxy vouched for the
+        //   client, so the backend leg runs as the cluster master. The RDS validator reads from
+        //   RdsService, so a master login still reflects modifyDBInstance password changes.
         boolean isIam = iamEnabled && clientPassword.contains("X-Amz-Signature");
         boolean isMaster = masterUsername.equals(clientUsername);
 
+        PasswordValidator.AuthResult authResult = PasswordValidator.AuthResult.PASSTHROUGH;
         if (isIam) {
             if (!sigV4.validate(clientPassword, clientUsername)) {
                 sendErrorResponse(clientOut, "FATAL", "28P01",
@@ -99,8 +122,9 @@ public class PostgresProtocolHandler {
                 closeQuietly(backend);
                 return null;
             }
-        } else if (isMaster) {
-            if (!passwordValidator.validate(clientUsername, clientPassword)) {
+        } else {
+            authResult = passwordValidator.validate(clientUsername, clientPassword);
+            if (authResult == PasswordValidator.AuthResult.REJECT) {
                 sendErrorResponse(clientOut, "FATAL", "28P01",
                         "password authentication failed for user \"" + clientUsername + "\"");
                 clientOut.flush();
@@ -113,13 +137,16 @@ public class PostgresProtocolHandler {
         // Phase 5: Connect to backend PostgreSQL.
         // IAM and master: use master credentials — the backend has the original container password
         // and is never updated directly, so the proxy always authenticates as master.
-        // Non-master: forward the client's own credentials so the backend enforces its own ACLs.
+        // Non-master: forward the client's own credentials so the backend enforces its own ACLs,
+        // unless the proxy vouched for the client (MASTER_EQUIVALENT).
         InputStream backendIn = backend.getInputStream();
         OutputStream backendOut = backend.getOutputStream();
 
         String effectiveDbName = resolveEffectiveDbName(startup.database(), dbName);
-        String backendUser = (isIam || isMaster) ? masterUsername : clientUsername;
-        String backendPass = (isIam || isMaster) ? masterPassword : clientPassword;
+        BackendLogin backendLogin = resolveBackendLogin(isMaster, isIam, authResult,
+                masterUsername, masterPassword, clientUsername, clientPassword);
+        String backendUser = backendLogin.user();
+        String backendPass = backendLogin.password();
         sendStartupToBackend(backendOut, backendUser, effectiveDbName);
         backendOut.flush();
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsAuthProxy.java
@@ -27,7 +27,7 @@ public class RdsAuthProxy {
     private final DatabaseEngine engine;
     private final RdsSigV4Validator sigV4;
     private final RdsProxyTlsCertificates tlsCertificates;
-    private final PasswordValidator passwordValidator;
+    private final MasterPasswordCheck passwordValidator;
 
     private volatile boolean running;
     private ServerSocket serverSocket;
@@ -36,7 +36,7 @@ public class RdsAuthProxy {
                         DatabaseEngine engine, boolean iamEnabled,
                         String masterUsername, String masterPassword, String dbName,
                         RdsSigV4Validator sigV4, RdsProxyTlsCertificates tlsCertificates,
-                        PasswordValidator passwordValidator) {
+                        MasterPasswordCheck passwordValidator) {
         this.instanceId = instanceId;
         this.backendHost = backendHost;
         this.backendPort = backendPort;
@@ -99,19 +99,30 @@ public class RdsAuthProxy {
             backend = new Socket(backendHost, backendPort);
             backend.setTcpNoDelay(true);
 
+            // RDS only proxy-validates the master user; a non-master user passes through so the
+            // backend enforces its own credentials.
+            PasswordValidator authAdapter = (user, pass) -> {
+                if (!masterUsername.equals(user)) {
+                    return PasswordValidator.AuthResult.PASSTHROUGH;
+                }
+                return passwordValidator.validate(user, pass)
+                        ? PasswordValidator.AuthResult.MASTER_EQUIVALENT
+                        : PasswordValidator.AuthResult.REJECT;
+            };
+
             switch (engine) {
                 case POSTGRES -> {
                     PostgresProtocolHandler.AuthenticatedSession session =
                             PostgresProtocolHandler.authenticate(
                                     client, backend, masterUsername, masterPassword, dbName,
-                                    iamEnabled, sigV4, tlsCertificates, passwordValidator::validate);
+                                    iamEnabled, sigV4, tlsCertificates, authAdapter);
                     if (session != null) {
                         PostgresProtocolHandler.bridge(session, backend);
                     }
                 }
                 case MYSQL, MARIADB -> MySqlProtocolHandler.handleAuth(
                         client, backend, masterUsername, masterPassword,
-                        iamEnabled, sigV4, tlsCertificates, passwordValidator::validate);
+                        iamEnabled, sigV4, tlsCertificates, authAdapter);
             }
         } catch (Exception e) {
             LOG.debugv("RDS connection error for instance {0}: {1}", instanceId, e.getMessage());
@@ -135,10 +146,12 @@ public class RdsAuthProxy {
     }
 
     /**
-     * Callback for password validation — implemented by RdsService.
+     * Callback for master-password validation, implemented by RdsService. Returns true when the
+     * supplied master credentials are current. Non-master users are never asked here: the backend
+     * database is the authority for their passwords.
      */
     @FunctionalInterface
-    public interface PasswordValidator {
+    public interface MasterPasswordCheck {
         boolean validate(String username, String password);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsProxyManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/RdsProxyManager.java
@@ -30,7 +30,7 @@ public class RdsProxyManager {
                                         int proxyPort, String backendHost, int backendPort,
                                         String advertisedHost,
                                         String masterUsername, String masterPassword, String dbName,
-                                        RdsAuthProxy.PasswordValidator passwordValidator) {
+                                        RdsAuthProxy.MasterPasswordCheck passwordValidator) {
         tlsCertificates.ensureHost(advertisedHost);
         RdsAuthProxy proxy = new RdsAuthProxy(
                 instanceId, backendHost, backendPort, engine, iamEnabled,

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBroker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBroker.java
@@ -1,0 +1,77 @@
+package io.github.hectorvent.floci.services.redshift;
+
+import io.github.hectorvent.floci.core.common.Resettable;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Holds the short-lived credentials minted by GetClusterCredentials /
+ * GetClusterCredentialsWithIAM. No real PostgreSQL role is created: a live
+ * credential is a signal to the auth proxy and the Data API resolver that the
+ * connection should run as the cluster master (the DbUser is nominal).
+ */
+@ApplicationScoped
+public class RedshiftCredentialBroker implements Resettable {
+
+    public enum Match { MASTER_EQUIVALENT, REJECT, PASSTHROUGH }
+
+    private static final String PASSWORD_ALPHABET =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final int PASSWORD_LENGTH = 32;
+
+    private final SecureRandom random = new SecureRandom();
+    private final ConcurrentHashMap<String, TempCredential> store = new ConcurrentHashMap<>();
+
+    public TempCredential issue(String accountId, String clusterId, String dbUser,
+                                List<String> dbGroups, int durationSeconds) {
+        String password = randomPassword();
+        Instant expiresAt = Instant.now().plusSeconds(durationSeconds);
+        List<String> groups = dbGroups == null ? List.of() : List.copyOf(dbGroups);
+        TempCredential credential = new TempCredential(dbUser, password, expiresAt, groups);
+        store.put(key(accountId, clusterId, dbUser), credential);
+        return credential;
+    }
+
+    public Optional<TempCredential> resolve(String accountId, String clusterId, String dbUser) {
+        String key = key(accountId, clusterId, dbUser);
+        TempCredential credential = store.get(key);
+        if (credential == null) {
+            return Optional.empty();
+        }
+        if (!credential.expiresAt().isAfter(Instant.now())) {
+            store.remove(key, credential);
+            return Optional.empty();
+        }
+        return Optional.of(credential);
+    }
+
+    public Match classify(String accountId, String clusterId, String username, String password) {
+        Optional<TempCredential> credential = resolve(accountId, clusterId, username);
+        if (credential.isEmpty()) {
+            return Match.PASSTHROUGH;
+        }
+        return credential.get().password().equals(password) ? Match.MASTER_EQUIVALENT : Match.REJECT;
+    }
+
+    @Override
+    public void clear() {
+        store.clear();
+    }
+
+    private String randomPassword() {
+        StringBuilder sb = new StringBuilder(PASSWORD_LENGTH);
+        for (int i = 0; i < PASSWORD_LENGTH; i++) {
+            sb.append(PASSWORD_ALPHABET.charAt(random.nextInt(PASSWORD_ALPHABET.length())));
+        }
+        return sb.toString();
+    }
+
+    private static String key(String accountId, String clusterId, String dbUser) {
+        return accountId + ":" + clusterId + ":" + dbUser;
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBroker.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBroker.java
@@ -8,12 +8,17 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Holds the short-lived credentials minted by GetClusterCredentials /
  * GetClusterCredentialsWithIAM. No real PostgreSQL role is created: a live
  * credential is a signal to the auth proxy and the Data API resolver that the
  * connection should run as the cluster master (the DbUser is nominal).
+ *
+ * <p>AWS keeps every issued credential valid until its own expiry, so a second
+ * call for the same DbUser does not invalidate the first: each key holds a list
+ * of unexpired credentials.
  */
 @ApplicationScoped
 public class RedshiftCredentialBroker implements Resettable {
@@ -25,7 +30,7 @@ public class RedshiftCredentialBroker implements Resettable {
     private static final int PASSWORD_LENGTH = 32;
 
     private final SecureRandom random = new SecureRandom();
-    private final ConcurrentHashMap<String, TempCredential> store = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, CopyOnWriteArrayList<TempCredential>> store = new ConcurrentHashMap<>();
 
     public TempCredential issue(String accountId, String clusterId, String dbUser,
                                 List<String> dbGroups, int durationSeconds) {
@@ -33,34 +38,60 @@ public class RedshiftCredentialBroker implements Resettable {
         Instant expiresAt = Instant.now().plusSeconds(durationSeconds);
         List<String> groups = dbGroups == null ? List.of() : List.copyOf(dbGroups);
         TempCredential credential = new TempCredential(dbUser, password, expiresAt, groups);
-        store.put(key(accountId, clusterId, dbUser), credential);
+        store.compute(key(accountId, clusterId, dbUser), (k, existing) -> {
+            CopyOnWriteArrayList<TempCredential> list =
+                    existing == null ? new CopyOnWriteArrayList<>() : existing;
+            list.removeIf(RedshiftCredentialBroker::isExpired);
+            list.add(credential);
+            return list;
+        });
         return credential;
     }
 
     public Optional<TempCredential> resolve(String accountId, String clusterId, String dbUser) {
-        String key = key(accountId, clusterId, dbUser);
-        TempCredential credential = store.get(key);
-        if (credential == null) {
-            return Optional.empty();
-        }
-        if (!credential.expiresAt().isAfter(Instant.now())) {
-            store.remove(key, credential);
-            return Optional.empty();
-        }
-        return Optional.of(credential);
+        return liveCredentials(key(accountId, clusterId, dbUser)).stream().findFirst();
     }
 
     public Match classify(String accountId, String clusterId, String username, String password) {
-        Optional<TempCredential> credential = resolve(accountId, clusterId, username);
-        if (credential.isEmpty()) {
+        List<TempCredential> live = liveCredentials(key(accountId, clusterId, username));
+        if (live.isEmpty()) {
             return Match.PASSTHROUGH;
         }
-        return credential.get().password().equals(password) ? Match.MASTER_EQUIVALENT : Match.REJECT;
+        return live.stream().anyMatch(c -> c.password().equals(password))
+                ? Match.MASTER_EQUIVALENT
+                : Match.REJECT;
+    }
+
+    /**
+     * Drops every credential minted for a cluster. Called when a cluster is deleted so a
+     * later cluster created with the same identifier does not inherit master-equivalent
+     * access from a stale credential.
+     */
+    public void revokeCluster(String accountId, String clusterId) {
+        String prefix = accountId + ":" + clusterId + ":";
+        store.keySet().removeIf(k -> k.startsWith(prefix));
     }
 
     @Override
     public void clear() {
         store.clear();
+    }
+
+    // Package-private hook for tests: number of unexpired credentials held for a DbUser.
+    int liveCredentialCountForTesting(String accountId, String clusterId, String dbUser) {
+        return liveCredentials(key(accountId, clusterId, dbUser)).size();
+    }
+
+    private List<TempCredential> liveCredentials(String key) {
+        CopyOnWriteArrayList<TempCredential> list = store.get(key);
+        if (list == null) {
+            return List.of();
+        }
+        return list.stream().filter(c -> !isExpired(c)).toList();
+    }
+
+    private static boolean isExpired(TempCredential credential) {
+        return !credential.expiresAt().isAfter(Instant.now());
     }
 
     private String randomPassword() {

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolver.java
@@ -43,7 +43,8 @@ public class RedshiftIamDbUserResolver {
             return parts.length >= 2 ? "IAMR:" + parts[1] : FALLBACK_DB_USER;
         }
         if (resource.startsWith("user/")) {
-            return "IAM:" + resource.substring("user/".length());
+            // Drop any IAM path prefix (user/team/alice -> alice), matching how AWS names the DbUser.
+            return "IAM:" + resource.substring(resource.lastIndexOf('/') + 1);
         }
         LOG.warnv("GetClusterCredentialsWithIAM caller ARN {0} is not a user or role; using {1}",
                 arn.get(), FALLBACK_DB_USER);

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolver.java
@@ -1,12 +1,52 @@
 package io.github.hectorvent.floci.services.redshift;
 
+import io.github.hectorvent.floci.core.common.AccountResolver;
+import io.github.hectorvent.floci.services.iam.IamService;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
 
+import java.util.Optional;
+
+/**
+ * Derives the Redshift Data API DbUser name for GetClusterCredentialsWithIAM from
+ * the caller's IAM identity: an IAM user becomes "IAM:<name>", an assumed role
+ * becomes "IAMR:<role>". When the caller cannot be resolved (for example a bare
+ * test key with no registered identity) the call still succeeds with a fixed
+ * fallback so local and CI flows are not blocked.
+ */
 @ApplicationScoped
 public class RedshiftIamDbUserResolver {
 
-    /** Placeholder until Task 6: returns the fallback IAM role DB user. */
+    private static final Logger LOG = Logger.getLogger(RedshiftIamDbUserResolver.class);
+    private static final String FALLBACK_DB_USER = "IAMR:floci";
+
+    private final IamService iamService;
+    private final AccountResolver accountResolver;
+
+    @Inject
+    public RedshiftIamDbUserResolver(IamService iamService, AccountResolver accountResolver) {
+        this.iamService = iamService;
+        this.accountResolver = accountResolver;
+    }
+
     public String resolveDbUser(String authorizationHeader) {
-        return "IAMR:floci";
+        String accessKeyId = accountResolver.extractAccessKeyId(authorizationHeader);
+        Optional<String> arn = iamService.resolveCallerArn(accessKeyId);
+        if (arn.isEmpty()) {
+            LOG.warnv("GetClusterCredentialsWithIAM caller could not be resolved; using {0}", FALLBACK_DB_USER);
+            return FALLBACK_DB_USER;
+        }
+        String resource = arn.get().substring(arn.get().lastIndexOf(':') + 1);
+        if (resource.startsWith("assumed-role/")) {
+            String[] parts = resource.split("/");
+            return parts.length >= 2 ? "IAMR:" + parts[1] : FALLBACK_DB_USER;
+        }
+        if (resource.startsWith("user/")) {
+            return "IAM:" + resource.substring("user/".length());
+        }
+        LOG.warnv("GetClusterCredentialsWithIAM caller ARN {0} is not a user or role; using {1}",
+                arn.get(), FALLBACK_DB_USER);
+        return FALLBACK_DB_USER;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolver.java
@@ -1,0 +1,12 @@
+package io.github.hectorvent.floci.services.redshift;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RedshiftIamDbUserResolver {
+
+    /** Placeholder until Task 6: returns the fallback IAM role DB user. */
+    public String resolveDbUser(String authorizationHeader) {
+        return "IAMR:floci";
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -25,6 +26,8 @@ import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class RedshiftQueryHandler {
+
+    private static final Logger LOG = Logger.getLogger(RedshiftQueryHandler.class);
 
     // GetClusterCredentials DurationSeconds bounds, inclusive (AWS: 900 to 3600).
     private static final int MIN_CREDENTIAL_DURATION_SECONDS = 900;
@@ -478,7 +481,7 @@ public class RedshiftQueryHandler {
     private int resolveDurationSeconds(MultivaluedMap<String, String> params) {
         String raw = params.getFirst("DurationSeconds");
         if (raw == null || raw.isBlank()) {
-            return config.services().redshift().defaultCredentialDurationSeconds();
+            return defaultDurationSeconds();
         }
         int duration;
         try {
@@ -492,6 +495,20 @@ public class RedshiftQueryHandler {
                             + " and " + MAX_CREDENTIAL_DURATION_SECONDS, 400);
         }
         return duration;
+    }
+
+    // The YAML default is operator-supplied, so hold it to the same AWS bounds as a request
+    // value: an out-of-range override falls back to the AWS minimum rather than minting a
+    // credential that is already expired or outlives the documented range.
+    private int defaultDurationSeconds() {
+        int configured = config.services().redshift().defaultCredentialDurationSeconds();
+        if (configured < MIN_CREDENTIAL_DURATION_SECONDS || configured > MAX_CREDENTIAL_DURATION_SECONDS) {
+            LOG.warnv("floci.services.redshift.default-credential-duration-seconds={0} is outside the "
+                    + "AWS range {1} to {2}; using {1}", configured,
+                    MIN_CREDENTIAL_DURATION_SECONDS, MAX_CREDENTIAL_DURATION_SECONDS);
+            return MIN_CREDENTIAL_DURATION_SECONDS;
+        }
+        return configured;
     }
 
     private String getClusterCredentialsXml(String operation, TempCredential credential) {

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -444,8 +444,9 @@ public class RedshiftQueryHandler {
             String dbUser = requireParam(params, "DbUser");
             // describeClusters throws ClusterNotFound (404) for an unknown id.
             service.describeClusters(clusterId);
+            // AWS prefixes the returned name IAMA: when AutoCreate is true, IAM: when it is false.
             boolean autoCreate = Boolean.parseBoolean(params.getFirst("AutoCreate"));
-            String effectiveDbUser = autoCreate ? "IAM:" + dbUser : dbUser;
+            String effectiveDbUser = (autoCreate ? "IAMA:" : "IAM:") + dbUser;
             int duration = resolveDurationSeconds(params);
             List<String> dbGroups = memberList(params, "DbGroups");
 

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -451,6 +451,18 @@ public class RedshiftQueryHandler {
             return Response.ok(getClusterCredentialsXml("GetClusterCredentials", credential))
                     .type(MediaType.APPLICATION_XML).build();
         }
+        case "GetClusterCredentialsWithIAM" -> {
+            String clusterId = requireParam(params, "ClusterIdentifier");
+            service.describeClusters(clusterId);
+            String dbUser = iamDbUserResolver.resolveDbUser(authorizationHeader);
+            int duration = resolveDurationSeconds(params);
+            List<String> dbGroups = memberList(params, "DbGroups");
+
+            TempCredential credential = credentialBroker.issue(
+                    regionResolver.getAccountId(), clusterId, dbUser, dbGroups, duration);
+            return Response.ok(getClusterCredentialsXml("GetClusterCredentialsWithIAM", credential))
+                    .type(MediaType.APPLICATION_XML).build();
+        }
         default -> throw new AwsException("InvalidAction", "Action " + action + " is not supported", 400);
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.redshift;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.XmlBuilder;
 import io.github.hectorvent.floci.services.redshift.model.Cluster;
 import io.github.hectorvent.floci.services.redshift.model.ClusterParameterGroup;
@@ -13,6 +15,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -22,14 +25,33 @@ import java.util.regex.Pattern;
 
 @ApplicationScoped
 public class RedshiftQueryHandler {
+
+    // GetClusterCredentials DurationSeconds bounds, inclusive (AWS: 900 to 3600).
+    private static final int MIN_CREDENTIAL_DURATION_SECONDS = 900;
+    private static final int MAX_CREDENTIAL_DURATION_SECONDS = 3600;
+
     private final RedshiftService service;
+    private final RedshiftCredentialBroker credentialBroker;
+    private final EmulatorConfig config;
+    private final RedshiftIamDbUserResolver iamDbUserResolver;
+    private final RegionResolver regionResolver;
 
     @Inject
-    public RedshiftQueryHandler(RedshiftService service) {
+    public RedshiftQueryHandler(RedshiftService service, RedshiftCredentialBroker credentialBroker,
+                                EmulatorConfig config, RedshiftIamDbUserResolver iamDbUserResolver,
+                                RegionResolver regionResolver) {
         this.service = service;
+        this.credentialBroker = credentialBroker;
+        this.config = config;
+        this.iamDbUserResolver = iamDbUserResolver;
+        this.regionResolver = regionResolver;
     }
 
     public Response handle(String action, MultivaluedMap<String, String> params) {
+        return handle(action, params, null);
+    }
+
+    public Response handle(String action, MultivaluedMap<String, String> params, String authorizationHeader) {
         switch (action) {
         case "CreateCluster" -> {
             String identifier = params.getFirst("ClusterIdentifier");
@@ -414,8 +436,73 @@ public class RedshiftQueryHandler {
                     .build();
             return Response.ok(xml).type(MediaType.APPLICATION_XML).build();
         }
+        case "GetClusterCredentials" -> {
+            String clusterId = requireParam(params, "ClusterIdentifier");
+            String dbUser = requireParam(params, "DbUser");
+            // describeClusters throws ClusterNotFound (404) for an unknown id.
+            service.describeClusters(clusterId);
+            boolean autoCreate = Boolean.parseBoolean(params.getFirst("AutoCreate"));
+            String effectiveDbUser = autoCreate ? "IAM:" + dbUser : dbUser;
+            int duration = resolveDurationSeconds(params);
+            List<String> dbGroups = memberList(params, "DbGroups");
+
+            TempCredential credential = credentialBroker.issue(
+                    regionResolver.getAccountId(), clusterId, effectiveDbUser, dbGroups, duration);
+            return Response.ok(getClusterCredentialsXml("GetClusterCredentials", credential))
+                    .type(MediaType.APPLICATION_XML).build();
+        }
         default -> throw new AwsException("InvalidAction", "Action " + action + " is not supported", 400);
         }
+    }
+
+    private static String requireParam(MultivaluedMap<String, String> params, String name) {
+        String value = params.getFirst(name);
+        if (value == null || value.isBlank()) {
+            throw new AwsException("InvalidParameterValue", name + " is required", 400);
+        }
+        return value;
+    }
+
+    private int resolveDurationSeconds(MultivaluedMap<String, String> params) {
+        String raw = params.getFirst("DurationSeconds");
+        if (raw == null || raw.isBlank()) {
+            return config.services().redshift().defaultCredentialDurationSeconds();
+        }
+        int duration;
+        try {
+            duration = Integer.parseInt(raw);
+        } catch (NumberFormatException e) {
+            throw new AwsException("InvalidParameterValue", "DurationSeconds must be an integer", 400);
+        }
+        if (duration < MIN_CREDENTIAL_DURATION_SECONDS || duration > MAX_CREDENTIAL_DURATION_SECONDS) {
+            throw new AwsException("InvalidParameterValue",
+                    "DurationSeconds must be between " + MIN_CREDENTIAL_DURATION_SECONDS
+                            + " and " + MAX_CREDENTIAL_DURATION_SECONDS, 400);
+        }
+        return duration;
+    }
+
+    private String getClusterCredentialsXml(String operation, TempCredential credential) {
+        XmlBuilder builder = new XmlBuilder()
+                .start(operation + "Response")
+                  .start(operation + "Result")
+                    .elem("DbUser", credential.dbUser())
+                    .elem("DbPassword", credential.password())
+                    .elem("Expiration", DateTimeFormatter.ISO_INSTANT.format(credential.expiresAt()));
+        if (!credential.dbGroups().isEmpty()) {
+            builder.start("DbGroups");
+            for (String group : credential.dbGroups()) {
+                builder.elem("DbGroup", group);
+            }
+            builder.end("DbGroups");
+        }
+        return builder
+                  .end(operation + "Result")
+                  .start("ResponseMetadata")
+                    .elem("RequestId", "test-req-id")
+                  .end("ResponseMetadata")
+                .end(operation + "Response")
+                .build();
     }
 
     private String buildClusterXml(Cluster cluster) {
@@ -549,6 +636,7 @@ public class RedshiftQueryHandler {
             case "SubnetIds" -> quoted + "(\\.member|\\.SubnetIdentifier)?\\.\\d+";
             case "VpcSecurityGroupIds" -> quoted + "(\\.member|\\.VpcSecurityGroupId)?\\.\\d+";
             case "TagKeys" -> quoted + "(\\.member|\\.TagKey)?\\.\\d+";
+            case "DbGroups" -> quoted + "(\\.member|\\.DbGroup)?\\.\\d+";
             default -> quoted + "(\\.member)?\\.\\d+";
         };
     }

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -947,15 +947,19 @@ public class RedshiftService {
     private PasswordValidator passwordValidatorFor(String accountId, String clusterIdentifier) {
         return (user, password) -> {
             Optional<Cluster> cluster = clusters.getForAccount(accountId, clusterIdentifier);
-            boolean masterUser = cluster.map(c -> user.equals(c.getMasterUsername())).orElse(false);
-            if (masterUser) {
+            if (cluster.isEmpty()) {
+                // No cluster row to validate against: vouch for nothing. Falling through to the
+                // broker would classify an unknown user as PASSTHROUGH, and the wire proxy reads
+                // isMaster from its own start-time config, so a PASSTHROUGH there still opens the
+                // backend as master, authenticating any password for the master username.
+                return PasswordValidator.AuthResult.REJECT;
+            }
+            Cluster c = cluster.get();
+            if (user.equals(c.getMasterUsername())) {
                 // The master username is authoritative here: a wrong password must be rejected,
                 // never handed to the broker (which only knows minted DbUsers) and never passed
                 // through as if the user were unknown.
-                boolean passwordMatches = cluster
-                        .map(c -> password.equals(c.getMasterPassword()))
-                        .orElse(false);
-                return passwordMatches
+                return password.equals(c.getMasterPassword())
                         ? PasswordValidator.AuthResult.MASTER_EQUIVALENT
                         : PasswordValidator.AuthResult.REJECT;
             }

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -136,6 +136,9 @@ public class RedshiftService {
         if (clusters.get(identifier).isPresent()) {
             throw new AwsException("ClusterAlreadyExists", "Cluster " + identifier + " already exists", 400);
         }
+        // A previous cluster with this identifier may have been deleted without its temp
+        // credentials being cleared; drop them so the new cluster starts with none.
+        credentialBroker.revokeCluster(clusters.accountId(), identifier);
 
         Cluster cluster = new Cluster();
         cluster.setClusterIdentifier(identifier);
@@ -223,7 +226,10 @@ public class RedshiftService {
         containerManager.stop(clusters.accountId(), identifier);
         clusters.delete(identifier);
         clusters.flush();
-        
+        // Invalidate any GetClusterCredentials passwords so a cluster later recreated with this
+        // identifier does not accept them as master-equivalent.
+        credentialBroker.revokeCluster(clusters.accountId(), identifier);
+
         cluster.setClusterStatus("deleting");
         return cluster;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -6,7 +6,7 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.DockerHostResolver;
 import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
-import io.github.hectorvent.floci.services.rds.proxy.RdsAuthProxy;
+import io.github.hectorvent.floci.services.rds.proxy.PasswordValidator;
 import io.github.hectorvent.floci.services.redshift.proxy.RedshiftProxyManager;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.redshift.container.RedshiftContainerHandle;
@@ -51,13 +51,15 @@ public class RedshiftService {
     private final RegionResolver regionResolver;
     private final RedshiftProxyManager proxyManager;
     private final DockerHostResolver dockerHostResolver;
+    private final RedshiftCredentialBroker credentialBroker;
     // Proxy ports currently handed out, so allocateProxyPort never double-assigns within this JVM.
     private final Set<Integer> usedPorts = ConcurrentHashMap.newKeySet();
 
     @Inject
     public RedshiftService(StorageFactory storageFactory, RedshiftContainerManager containerManager,
                             EmulatorConfig config, RegionResolver regionResolver,
-                            RedshiftProxyManager proxyManager, DockerHostResolver dockerHostResolver) {
+                            RedshiftProxyManager proxyManager, DockerHostResolver dockerHostResolver,
+                            RedshiftCredentialBroker credentialBroker) {
         this.clusters = storageFactory.create("redshift", "redshift-clusters.json", new TypeReference<Map<String, Cluster>>() {});
         this.snapshots = storageFactory.create("redshift", "redshift-snapshots.json", new TypeReference<Map<String, Snapshot>>() {});
         this.parameterGroups = storageFactory.create("redshift", "redshift-parameter-groups.json", new TypeReference<Map<String, ClusterParameterGroup>>() {});
@@ -67,6 +69,7 @@ public class RedshiftService {
         this.regionResolver = regionResolver;
         this.proxyManager = proxyManager;
         this.dockerHostResolver = dockerHostResolver;
+        this.credentialBroker = credentialBroker;
     }
 
     // Recreate Docker containers for persisted clusters on app restart (across every account, not just default)
@@ -936,11 +939,29 @@ public class RedshiftService {
         return accountId + ":" + clusterIdentifier;
     }
 
-    // Validates the master password at the proxy against current cluster state, so a
-    // ModifyCluster password change is reflected for new connections without a proxy restart.
-    private RdsAuthProxy.PasswordValidator passwordValidatorFor(String accountId, String clusterIdentifier) {
-        return (user, password) -> clusters.getForAccount(accountId, clusterIdentifier)
-                .map(c -> user.equals(c.getMasterUsername()) && password.equals(c.getMasterPassword()))
-                .orElse(false);
+    // Classifies a proxy login against current cluster state: the master pair and any live
+    // GetClusterCredentials credential both run the backend leg as the cluster master, a known
+    // broker user with a stale password is rejected, everyone else passes through to the backend.
+    // Reading cluster state per call means a ModifyCluster password change takes effect for new
+    // connections without a proxy restart.
+    private PasswordValidator passwordValidatorFor(String accountId, String clusterIdentifier) {
+        return (user, password) -> {
+            boolean master = clusters.getForAccount(accountId, clusterIdentifier)
+                    .map(c -> user.equals(c.getMasterUsername()) && password.equals(c.getMasterPassword()))
+                    .orElse(false);
+            if (master) {
+                return PasswordValidator.AuthResult.MASTER_EQUIVALENT;
+            }
+            return switch (credentialBroker.classify(accountId, clusterIdentifier, user, password)) {
+                case MASTER_EQUIVALENT -> PasswordValidator.AuthResult.MASTER_EQUIVALENT;
+                case REJECT -> PasswordValidator.AuthResult.REJECT;
+                case PASSTHROUGH -> PasswordValidator.AuthResult.PASSTHROUGH;
+            };
+        };
+    }
+
+    // Package-private hook for tests: passwordValidatorFor is otherwise private.
+    PasswordValidator passwordValidatorForTesting(String accountId, String clusterIdentifier) {
+        return passwordValidatorFor(accountId, clusterIdentifier);
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -946,11 +946,18 @@ public class RedshiftService {
     // connections without a proxy restart.
     private PasswordValidator passwordValidatorFor(String accountId, String clusterIdentifier) {
         return (user, password) -> {
-            boolean master = clusters.getForAccount(accountId, clusterIdentifier)
-                    .map(c -> user.equals(c.getMasterUsername()) && password.equals(c.getMasterPassword()))
-                    .orElse(false);
-            if (master) {
-                return PasswordValidator.AuthResult.MASTER_EQUIVALENT;
+            Optional<Cluster> cluster = clusters.getForAccount(accountId, clusterIdentifier);
+            boolean masterUser = cluster.map(c -> user.equals(c.getMasterUsername())).orElse(false);
+            if (masterUser) {
+                // The master username is authoritative here: a wrong password must be rejected,
+                // never handed to the broker (which only knows minted DbUsers) and never passed
+                // through as if the user were unknown.
+                boolean passwordMatches = cluster
+                        .map(c -> password.equals(c.getMasterPassword()))
+                        .orElse(false);
+                return passwordMatches
+                        ? PasswordValidator.AuthResult.MASTER_EQUIVALENT
+                        : PasswordValidator.AuthResult.REJECT;
             }
             return switch (credentialBroker.classify(accountId, clusterIdentifier, user, password)) {
                 case MASTER_EQUIVALENT -> PasswordValidator.AuthResult.MASTER_EQUIVALENT;

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftService.java
@@ -174,6 +174,7 @@ public class RedshiftService {
             try { containerManager.stop(clusters.accountId(), identifier); } catch (Exception ex) { LOG.warnv(ex, "Failed to stop container during rollback of cluster {0}", identifier); }
             if (proxyStopped) {
                 clusters.delete(identifier);
+                credentialBroker.revokeCluster(clusters.accountId(), identifier);
             } else {
                 cluster.setClusterStatus("failed");
                 clusters.put(identifier, cluster);
@@ -185,6 +186,7 @@ public class RedshiftService {
             try { containerManager.stop(clusters.accountId(), identifier); } catch (Exception ex) { LOG.warnv(ex, "Failed to stop container during rollback of cluster {0}", identifier); }
             if (proxyStopped) {
                 clusters.delete(identifier);
+                credentialBroker.revokeCluster(clusters.accountId(), identifier);
             } else {
                 cluster.setClusterStatus("failed");
                 clusters.put(identifier, cluster);

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/TempCredential.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/TempCredential.java
@@ -1,0 +1,7 @@
+package io.github.hectorvent.floci.services.redshift;
+
+import java.time.Instant;
+import java.util.List;
+
+public record TempCredential(String dbUser, String password, Instant expiresAt, List<String> dbGroups) {
+}

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftAuthProxy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftAuthProxy.java
@@ -1,7 +1,7 @@
 package io.github.hectorvent.floci.services.redshift.proxy;
 
+import io.github.hectorvent.floci.services.rds.proxy.PasswordValidator;
 import io.github.hectorvent.floci.services.rds.proxy.PostgresProtocolHandler;
-import io.github.hectorvent.floci.services.rds.proxy.RdsAuthProxy;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyTlsCertificates;
 import io.github.hectorvent.floci.services.rds.proxy.RdsSigV4Validator;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -32,7 +32,7 @@ public class RedshiftAuthProxy {
     private final String dbName;
     private final RdsSigV4Validator sigV4;
     private final RdsProxyTlsCertificates tlsCertificates;
-    private final RdsAuthProxy.PasswordValidator passwordValidator;
+    private final PasswordValidator passwordValidator;
     private final S3Service s3Service;
 
     private volatile boolean running;
@@ -41,7 +41,7 @@ public class RedshiftAuthProxy {
     public RedshiftAuthProxy(String clusterKey, String backendHost, int backendPort,
                              String masterUsername, String masterPassword, String dbName,
                              RdsSigV4Validator sigV4, RdsProxyTlsCertificates tlsCertificates,
-                             RdsAuthProxy.PasswordValidator passwordValidator,
+                             PasswordValidator passwordValidator,
                              S3Service s3Service) {
         this.clusterKey = clusterKey;
         this.backendHost = backendHost;
@@ -145,7 +145,7 @@ public class RedshiftAuthProxy {
             PostgresProtocolHandler.AuthenticatedSession session =
                     PostgresProtocolHandler.authenticate(
                             client, backend, masterUsername, masterPassword, dbName,
-                            false, sigV4, tlsCertificates, passwordValidator::validate);
+                            false, sigV4, tlsCertificates, passwordValidator);
             if (session != null) {
                 // Redshift-only DDL (DISTKEY/SORTKEY/ENCODE/...) is rewritten for the plain
                 // PostgreSQL backend on the way through; every other message is relayed verbatim.

--- a/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftProxyManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftProxyManager.java
@@ -1,6 +1,6 @@
 package io.github.hectorvent.floci.services.redshift.proxy;
 
-import io.github.hectorvent.floci.services.rds.proxy.RdsAuthProxy;
+import io.github.hectorvent.floci.services.rds.proxy.PasswordValidator;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyTlsCertificates;
 import io.github.hectorvent.floci.services.rds.proxy.RdsSigV4Validator;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -46,7 +46,7 @@ public class RedshiftProxyManager {
     public synchronized void startProxy(String relayKey, int proxyPort,
                                         String backendHost, int backendPort, String advertisedHost,
                                         String masterUsername, String masterPassword, String dbName,
-                                        RdsAuthProxy.PasswordValidator passwordValidator) {
+                                        PasswordValidator passwordValidator) {
         // A prior unclosable entry for this key is left in place: its listener may still
         // be bound, and only a successful stop (never a fresh start) may drop it.
         // Make sure the self-signed proxy certificate covers the host clients will connect to,

--- a/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolver.java
+++ b/src/main/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolver.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.redshift.RedshiftCredentialBroker;
 import io.github.hectorvent.floci.services.redshift.RedshiftService;
 import io.github.hectorvent.floci.services.redshift.model.Cluster;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
@@ -20,14 +22,20 @@ class RedshiftDataResourceResolver {
     private final RedshiftService redshiftService;
     private final SecretsManagerService secretsManagerService;
     private final ObjectMapper objectMapper;
+    private final RedshiftCredentialBroker credentialBroker;
+    private final RegionResolver regionResolver;
 
     @Inject
     RedshiftDataResourceResolver(RedshiftService redshiftService,
                                  SecretsManagerService secretsManagerService,
-                                 ObjectMapper objectMapper) {
+                                 ObjectMapper objectMapper,
+                                 RedshiftCredentialBroker credentialBroker,
+                                 RegionResolver regionResolver) {
         this.redshiftService = redshiftService;
         this.secretsManagerService = secretsManagerService;
         this.objectMapper = objectMapper;
+        this.credentialBroker = credentialBroker;
+        this.regionResolver = regionResolver;
     }
 
     DatabaseTarget resolve(JsonNode request, String region) {
@@ -71,11 +79,19 @@ class RedshiftDataResourceResolver {
         String clusterId = requiredText(request, "ClusterIdentifier");
         String dbUser = requiredText(request, "DbUser");
         Cluster cluster = cluster(clusterId);
-        if (!dbUser.equals(cluster.getMasterUsername())) {
-            throw validation("DbUser " + dbUser + " is not the cluster master; create it first or use "
-                    + "GetClusterCredentials (not yet emulated).");
+
+        if (dbUser.equals(cluster.getMasterUsername())) {
+            return target(clusterArn(clusterId, null), cluster, database, dbUser, cluster.getMasterPassword());
         }
-        return target(clusterArn(clusterId, null), cluster, database, dbUser, cluster.getMasterPassword());
+        boolean liveCredential = credentialBroker
+                .resolve(regionResolver.getAccountId(), clusterId, dbUser)
+                .isPresent();
+        if (liveCredential) {
+            // The minted DbUser is nominal: connect as the cluster master.
+            return target(clusterArn(clusterId, null), cluster, database,
+                    cluster.getMasterUsername(), cluster.getMasterPassword());
+        }
+        throw validation("DbUser " + dbUser + " has no active credentials; call GetClusterCredentials first.");
     }
 
     private Cluster cluster(String clusterId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -352,6 +352,7 @@ floci:
       image-version: postgres:15-alpine
       proxy-base-port: 7100
       proxy-max-port: 7199
+      default-credential-duration-seconds: 900   # GetClusterCredentials default lifetime (900-3600)
       # endpoint-host: localhost                 # Hostname clients use; empty -> DockerHostResolver
     rds:
       enabled: true

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -5032,8 +5032,8 @@ class RdsServiceTest {
 
         restoredService.restorePersistedRuntime();
 
-        ArgumentCaptor<RdsAuthProxy.PasswordValidator> validator =
-                ArgumentCaptor.forClass(RdsAuthProxy.PasswordValidator.class);
+        ArgumentCaptor<RdsAuthProxy.MasterPasswordCheck> validator =
+                ArgumentCaptor.forClass(RdsAuthProxy.MasterPasswordCheck.class);
         verify(restoredProxyManager).startProxy(eq("db-proxy:" + proxy.getDbProxyArn()),
                 eq(DatabaseEngine.POSTGRES),
                 eq(false), eq(5432), eq("127.0.0.1"), eq(15432), any(), eq("admin"),

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandlerTest.java
@@ -66,7 +66,7 @@ class MySqlProtocolHandlerTest {
                         MySqlProtocolHandler.handleAuth(
                                 proxyClient, backend, "admin", "secret",
                                 false, testSigV4Validator(), testTlsCertificates(),
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -128,7 +128,7 @@ class MySqlProtocolHandlerTest {
                         MySqlProtocolHandler.handleAuth(
                                 proxyClient, backend, "admin", "secret",
                                 false, testSigV4Validator(), testTlsCertificates(),
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -184,7 +184,7 @@ class MySqlProtocolHandlerTest {
                         MySqlProtocolHandler.handleAuth(
                                 proxyClient, backend, "admin", "secret",
                                 false, testSigV4Validator(), tlsCertificates,
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -282,7 +282,7 @@ class MySqlProtocolHandlerTest {
                         MySqlProtocolHandler.handleAuth(
                                 proxyClient, backend, "admin", "secret",
                                 false, testSigV4Validator(), tlsCertificates,
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerAuthResultTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerAuthResultTest.java
@@ -1,0 +1,49 @@
+package io.github.hectorvent.floci.services.rds.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import static io.github.hectorvent.floci.services.rds.proxy.PasswordValidator.AuthResult;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PostgresProtocolHandlerAuthResultTest {
+
+    @Test
+    void masterAlwaysUsesMasterBackendCredentials() {
+        PostgresProtocolHandler.BackendLogin login = PostgresProtocolHandler.resolveBackendLogin(
+                true, false, AuthResult.MASTER_EQUIVALENT,
+                "master", "masterpass", "alice", "alicepass");
+
+        assertEquals("master", login.user());
+        assertEquals("masterpass", login.password());
+    }
+
+    @Test
+    void iamUsesMasterBackendCredentials() {
+        PostgresProtocolHandler.BackendLogin login = PostgresProtocolHandler.resolveBackendLogin(
+                false, true, AuthResult.PASSTHROUGH,
+                "master", "masterpass", "arn:role", "token");
+
+        assertEquals("master", login.user());
+        assertEquals("masterpass", login.password());
+    }
+
+    @Test
+    void nonMasterPassthroughForwardsClientCredentials() {
+        PostgresProtocolHandler.BackendLogin login = PostgresProtocolHandler.resolveBackendLogin(
+                false, false, AuthResult.PASSTHROUGH,
+                "master", "masterpass", "alice", "alicepass");
+
+        assertEquals("alice", login.user());
+        assertEquals("alicepass", login.password());
+    }
+
+    @Test
+    void nonMasterMasterEquivalentUsesMasterBackendCredentials() {
+        PostgresProtocolHandler.BackendLogin login = PostgresProtocolHandler.resolveBackendLogin(
+                false, false, AuthResult.MASTER_EQUIVALENT,
+                "master", "masterpass", "temp-user", "minted-pass");
+
+        assertEquals("master", login.user());
+        assertEquals("masterpass", login.password());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/PostgresProtocolHandlerTest.java
@@ -60,7 +60,7 @@ class PostgresProtocolHandlerTest {
                 new MemorySocket(input.toByteArray()), mock(Socket.class),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
 
         assertEquals("PostgreSQL startup message length exceeds the 1048576 byte limit: 1048577",
                 error.getMessage());
@@ -81,7 +81,7 @@ class PostgresProtocolHandlerTest {
                 client, new MemorySocket(new byte[0]),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
     }
 
     @Test
@@ -95,7 +95,7 @@ class PostgresProtocolHandlerTest {
                 new MemorySocket(input.toByteArray()), new MemorySocket(new byte[0]),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
 
         assertEquals("PostgreSQL startup message length is below the 8 byte minimum: -1",
                 error.getMessage());
@@ -113,7 +113,7 @@ class PostgresProtocolHandlerTest {
                 new MemorySocket(input.toByteArray()), new MemorySocket(new byte[0]),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
 
         assertEquals("PostgreSQL password message length is below the 5 byte minimum: 4",
                 error.getMessage());
@@ -130,7 +130,7 @@ class PostgresProtocolHandlerTest {
                 new MemorySocket(startupAndPassword()), new MemorySocket(backendInput.toByteArray()),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
 
         assertEquals("PostgreSQL backend authentication message length exceeds the 1048576 byte limit: 1048577",
                 error.getMessage());
@@ -150,7 +150,7 @@ class PostgresProtocolHandlerTest {
                 new MemorySocket(startupAndPassword()), new MemorySocket(backendInput.toByteArray()),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
 
         assertEquals("PostgreSQL backend message length exceeds the 1048576 byte limit: 1048577",
                 error.getMessage());
@@ -170,7 +170,7 @@ class PostgresProtocolHandlerTest {
                 new MemorySocket(startupAndPassword()), new MemorySocket(backendInput.toByteArray()),
                 "dbadmin", "adminpass", "postgres",
                 false, testSigV4Validator(), testTlsCertificates(),
-                (user, pass) -> true));
+                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT));
 
         assertEquals("PostgreSQL SASL continue message length exceeds the 1048576 byte limit: 1048577",
                 error.getMessage());
@@ -217,7 +217,7 @@ class PostgresProtocolHandlerTest {
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                         if (session != null) {
                             PostgresProtocolHandler.bridge(session, backend);
                         }
@@ -275,7 +275,7 @@ class PostgresProtocolHandlerTest {
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                         if (session != null) {
                             PostgresProtocolHandler.bridge(session, backend);
                         }
@@ -333,7 +333,7 @@ class PostgresProtocolHandlerTest {
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                         if (session != null) {
                             PostgresProtocolHandler.bridge(session, backend);
                         }
@@ -400,7 +400,7 @@ class PostgresProtocolHandlerTest {
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), tlsCertificates,
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                         if (session != null) {
                             PostgresProtocolHandler.bridge(session, backend);
                         }
@@ -454,7 +454,7 @@ class PostgresProtocolHandlerTest {
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), tlsCertificates,
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                         if (session != null) {
                             PostgresProtocolHandler.bridge(session, backend);
                         }
@@ -504,7 +504,7 @@ class PostgresProtocolHandlerTest {
                                 proxyClient, backend,
                                 "dbadmin", "adminpass", "postgres",
                                 false, testSigV4Validator(), testTlsCertificates(),
-                                (user, pass) -> true);
+                                (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                         if (session != null) {
                             PostgresProtocolHandler.bridge(session, backend);
                         }
@@ -856,7 +856,7 @@ class PostgresProtocolHandlerTest {
                         proxyClient, backend,
                         "dbadmin", "adminpass", "postgres",
                         true, testSigV4Validator(), testTlsCertificates(),
-                        (user, pass) -> true);
+                        (user, pass) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
                 if (session != null) {
                     PostgresProtocolHandler.bridge(session, backend);
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBrokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBrokerTest.java
@@ -1,0 +1,94 @@
+package io.github.hectorvent.floci.services.redshift;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedshiftCredentialBrokerTest {
+
+    private RedshiftCredentialBroker broker;
+
+    @BeforeEach
+    void setUp() {
+        broker = new RedshiftCredentialBroker();
+    }
+
+    @Test
+    void issueReturnsPopulatedCredentialWithFutureExpiry() {
+        TempCredential cred = broker.issue("acc", "clus", "analyst", List.of("etl"), 900);
+
+        assertEquals("analyst", cred.dbUser());
+        assertFalse(cred.password().isBlank());
+        assertTrue(cred.expiresAt().isAfter(Instant.now()));
+        assertEquals(List.of("etl"), cred.dbGroups());
+    }
+
+    @Test
+    void resolveReturnsLiveCredential() {
+        broker.issue("acc", "clus", "analyst", List.of(), 900);
+
+        Optional<TempCredential> found = broker.resolve("acc", "clus", "analyst");
+
+        assertTrue(found.isPresent());
+        assertEquals("analyst", found.get().dbUser());
+    }
+
+    @Test
+    void resolveMissesForUnknownUser() {
+        assertTrue(broker.resolve("acc", "clus", "nobody").isEmpty());
+    }
+
+    @Test
+    void resolveEvictsExpiredCredential() {
+        broker.issue("acc", "clus", "analyst", List.of(), 0);
+
+        assertTrue(broker.resolve("acc", "clus", "analyst").isEmpty());
+    }
+
+    @Test
+    void issueOverwritesPreviousCredentialForSameUser() {
+        TempCredential first = broker.issue("acc", "clus", "analyst", List.of(), 900);
+        TempCredential second = broker.issue("acc", "clus", "analyst", List.of(), 900);
+
+        assertTrue(first.password() != null && second.password() != null);
+        Optional<TempCredential> live = broker.resolve("acc", "clus", "analyst");
+        assertTrue(live.isPresent());
+        assertEquals(second.password(), live.get().password());
+    }
+
+    @Test
+    void classifyMatchesMasterEquivalentOnCorrectPassword() {
+        TempCredential cred = broker.issue("acc", "clus", "analyst", List.of(), 900);
+
+        assertEquals(RedshiftCredentialBroker.Match.MASTER_EQUIVALENT,
+                broker.classify("acc", "clus", "analyst", cred.password()));
+    }
+
+    @Test
+    void classifyRejectsKnownUserWithWrongPassword() {
+        broker.issue("acc", "clus", "analyst", List.of(), 900);
+
+        assertEquals(RedshiftCredentialBroker.Match.REJECT,
+                broker.classify("acc", "clus", "analyst", "wrong"));
+    }
+
+    @Test
+    void classifyPassesThroughUnknownUser() {
+        assertEquals(RedshiftCredentialBroker.Match.PASSTHROUGH,
+                broker.classify("acc", "clus", "stranger", "whatever"));
+    }
+
+    @Test
+    void clearRemovesAllCredentials() {
+        broker.issue("acc", "clus", "analyst", List.of(), 900);
+        broker.clear();
+        assertTrue(broker.resolve("acc", "clus", "analyst").isEmpty());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBrokerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftCredentialBrokerTest.java
@@ -53,14 +53,44 @@ class RedshiftCredentialBrokerTest {
     }
 
     @Test
-    void issueOverwritesPreviousCredentialForSameUser() {
+    void issueKeepsEveryUnexpiredCredentialForSameUser() {
         TempCredential first = broker.issue("acc", "clus", "analyst", List.of(), 900);
         TempCredential second = broker.issue("acc", "clus", "analyst", List.of(), 900);
 
-        assertTrue(first.password() != null && second.password() != null);
-        Optional<TempCredential> live = broker.resolve("acc", "clus", "analyst");
-        assertTrue(live.isPresent());
-        assertEquals(second.password(), live.get().password());
+        // AWS keeps each issued password valid until its own expiry: a reissue must not
+        // invalidate a still-live credential.
+        assertEquals(RedshiftCredentialBroker.Match.MASTER_EQUIVALENT,
+                broker.classify("acc", "clus", "analyst", first.password()));
+        assertEquals(RedshiftCredentialBroker.Match.MASTER_EQUIVALENT,
+                broker.classify("acc", "clus", "analyst", second.password()));
+    }
+
+    @Test
+    void issuePrunesExpiredCredentialsForSameUser() {
+        broker.issue("acc", "clus", "analyst", List.of(), 0);
+        TempCredential live = broker.issue("acc", "clus", "analyst", List.of(), 900);
+
+        assertEquals(RedshiftCredentialBroker.Match.MASTER_EQUIVALENT,
+                broker.classify("acc", "clus", "analyst", live.password()));
+        assertEquals(1, broker.liveCredentialCountForTesting("acc", "clus", "analyst"));
+    }
+
+    @Test
+    void revokeClusterDropsEveryCredentialForThatCluster() {
+        TempCredential a = broker.issue("acc", "clus", "analyst", List.of(), 900);
+        broker.issue("acc", "clus", "etl", List.of(), 900);
+        TempCredential other = broker.issue("acc", "other", "analyst", List.of(), 900);
+
+        broker.revokeCluster("acc", "clus");
+
+        assertTrue(broker.resolve("acc", "clus", "analyst").isEmpty());
+        assertEquals(RedshiftCredentialBroker.Match.PASSTHROUGH,
+                broker.classify("acc", "clus", "analyst", a.password()));
+        assertEquals(RedshiftCredentialBroker.Match.PASSTHROUGH,
+                broker.classify("acc", "clus", "etl", "anything"));
+        // A same-named DbUser on a different cluster is untouched.
+        assertEquals(RedshiftCredentialBroker.Match.MASTER_EQUIVALENT,
+                broker.classify("acc", "other", "analyst", other.password()));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftGetClusterCredentialsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftGetClusterCredentialsIntegrationTest.java
@@ -1,0 +1,99 @@
+package io.github.hectorvent.floci.services.redshift;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * End-to-end: a non-master DbUser works for the Redshift Data API once
+ * GetClusterCredentials has minted a credential for it. The wire proxy and the
+ * Data API both connect to the container as the cluster master.
+ */
+@QuarkusTest
+class RedshiftGetClusterCredentialsIntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=test/20260822/us-east-1/redshift/aws4_request";
+
+    @Inject
+    RedshiftService redshift;
+
+    private String clusterId;
+
+    @BeforeAll
+    static void configure() {
+        Assumptions.assumeTrue(dockerAvailable(), "Docker is required for this integration test");
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    private static boolean dockerAvailable() {
+        try {
+            Process p = new ProcessBuilder("docker", "version", "--format", "{{.Server.Version}}")
+                    .redirectErrorStream(true).start();
+            return p.waitFor() == 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @AfterEach
+    void cleanUp() {
+        if (clusterId != null) {
+            redshift.deleteCluster(clusterId);
+            clusterId = null;
+        }
+    }
+
+    private void awaitFinished(String id) {
+        Awaitility.await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(250)).until(() -> {
+            String status = RestAssuredJsonUtils.awsAction("RedshiftData", "DescribeStatement",
+                    "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("Status");
+            assertTrue(!"FAILED".equals(status) && !"ABORTED".equals(status),
+                    () -> "statement " + id + " ended " + status);
+            return "FINISHED".equals(status);
+        });
+    }
+
+    @Test
+    void nonMasterDbUserWorksAfterGetClusterCredentials() {
+        clusterId = "it-gcc-" + System.currentTimeMillis();
+        redshift.createCluster(clusterId, "dc2.large", "admin", "Secret123");
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "GetClusterCredentials")
+            .formParam("ClusterIdentifier", clusterId)
+            .formParam("DbUser", "analyst")
+            .formParam("DurationSeconds", "900")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(containsString("<DbUser>analyst</DbUser>"))
+            .body(containsString("<DbPassword>"))
+            .body(containsString("<Expiration>"));
+
+        String id = RestAssuredJsonUtils.awsAction("RedshiftData", "ExecuteStatement", """
+                {"Sql": "SELECT 1", "ClusterIdentifier": "%s", "DbUser": "analyst", "Database": "dev"}
+                """.formatted(clusterId)).then().statusCode(200).extract().path("Id");
+        awaitFinished(id);
+
+        Object value = RestAssuredJsonUtils.awsAction("RedshiftData", "GetStatementResult",
+                "{\"Id\":\"" + id + "\"}").then().statusCode(200).extract().path("Records[0][0].longValue");
+        assertEquals(1, ((Number) value).intValue());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftGetClusterCredentialsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftGetClusterCredentialsIntegrationTest.java
@@ -83,12 +83,13 @@ class RedshiftGetClusterCredentialsIntegrationTest {
         .then()
             .statusCode(200)
             .contentType("application/xml")
-            .body(containsString("<DbUser>analyst</DbUser>"))
+            .body(containsString("<DbUser>IAM:analyst</DbUser>"))
             .body(containsString("<DbPassword>"))
             .body(containsString("<Expiration>"));
 
+        // A client passes back the exact DbUser that GetClusterCredentials returned.
         String id = RestAssuredJsonUtils.awsAction("RedshiftData", "ExecuteStatement", """
-                {"Sql": "SELECT 1", "ClusterIdentifier": "%s", "DbUser": "analyst", "Database": "dev"}
+                {"Sql": "SELECT 1", "ClusterIdentifier": "%s", "DbUser": "IAM:analyst", "Database": "dev"}
                 """.formatted(clusterId)).then().statusCode(200).extract().path("Id");
         awaitFinished(id);
 

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolverTest.java
@@ -34,6 +34,15 @@ class RedshiftIamDbUserResolverTest {
     }
 
     @Test
+    void stripsIamPathPrefixFromUserName() {
+        when(accountResolver.extractAccessKeyId("auth")).thenReturn("AKIA123");
+        when(iamService.resolveCallerArn("AKIA123"))
+                .thenReturn(Optional.of("arn:aws:iam::000000000000:user/team/lead/alice"));
+
+        assertEquals("IAM:alice", resolver.resolveDbUser("auth"));
+    }
+
+    @Test
     void mapsAssumedRoleArnToIamrPrefix() {
         when(accountResolver.extractAccessKeyId("auth")).thenReturn("ASIA123");
         when(iamService.resolveCallerArn("ASIA123"))

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftIamDbUserResolverTest.java
@@ -1,0 +1,59 @@
+package io.github.hectorvent.floci.services.redshift;
+
+import io.github.hectorvent.floci.core.common.AccountResolver;
+import io.github.hectorvent.floci.services.iam.IamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class RedshiftIamDbUserResolverTest {
+
+    private IamService iamService;
+    private AccountResolver accountResolver;
+    private RedshiftIamDbUserResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        iamService = mock(IamService.class);
+        accountResolver = mock(AccountResolver.class);
+        resolver = new RedshiftIamDbUserResolver(iamService, accountResolver);
+    }
+
+    @Test
+    void mapsIamUserArnToIamPrefix() {
+        when(accountResolver.extractAccessKeyId("auth")).thenReturn("AKIA123");
+        when(iamService.resolveCallerArn("AKIA123"))
+                .thenReturn(Optional.of("arn:aws:iam::000000000000:user/alice"));
+
+        assertEquals("IAM:alice", resolver.resolveDbUser("auth"));
+    }
+
+    @Test
+    void mapsAssumedRoleArnToIamrPrefix() {
+        when(accountResolver.extractAccessKeyId("auth")).thenReturn("ASIA123");
+        when(iamService.resolveCallerArn("ASIA123"))
+                .thenReturn(Optional.of("arn:aws:sts::000000000000:assumed-role/Deployer/session-1"));
+
+        assertEquals("IAMR:Deployer", resolver.resolveDbUser("auth"));
+    }
+
+    @Test
+    void fallsBackWhenCallerUnresolved() {
+        when(accountResolver.extractAccessKeyId("auth")).thenReturn("AKIA123");
+        when(iamService.resolveCallerArn("AKIA123")).thenReturn(Optional.empty());
+
+        assertEquals("IAMR:floci", resolver.resolveDbUser("auth"));
+    }
+
+    @Test
+    void fallsBackWhenHeaderMissing() {
+        when(accountResolver.extractAccessKeyId(null)).thenReturn(null);
+
+        assertEquals("IAMR:floci", resolver.resolveDbUser(null));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -409,7 +409,7 @@ class RedshiftQueryHandlerTest {
 
         assertEquals(200, response.getStatus());
         String xml = (String) response.getEntity();
-        assertTrue(xml.contains("<DbUser>analyst</DbUser>"));
+        assertTrue(xml.contains("<DbUser>IAM:analyst</DbUser>"));
         assertTrue(xml.contains("<DbPassword>"));
         assertTrue(xml.contains("<Expiration>"));
         assertTrue(xml.contains("<GetClusterCredentialsResult>"));
@@ -424,7 +424,7 @@ class RedshiftQueryHandlerTest {
 
         handler.handle("GetClusterCredentials", params);
 
-        assertTrue(credentialBroker.resolve("acc", "c1", "analyst").isPresent());
+        assertTrue(credentialBroker.resolve("acc", "c1", "IAM:analyst").isPresent());
     }
 
     @Test
@@ -448,7 +448,7 @@ class RedshiftQueryHandlerTest {
 
         handler.handle("GetClusterCredentials", params);
 
-        java.time.Instant expiresAt = credentialBroker.resolve("acc", "c1", "analyst").orElseThrow().expiresAt();
+        java.time.Instant expiresAt = credentialBroker.resolve("acc", "c1", "IAM:analyst").orElseThrow().expiresAt();
         assertTrue(expiresAt.isAfter(java.time.Instant.now().plusSeconds(800)),
                 "an out-of-range config default must fall back to the AWS minimum, not be used as-is");
     }
@@ -480,12 +480,25 @@ class RedshiftQueryHandlerTest {
     }
 
     @Test
-    void getClusterCredentialsAutoCreatePrefixesIamOnDbUser() {
+    void getClusterCredentialsAutoCreateTruePrefixesIamaOnDbUser() {
         when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
         params.putSingle("ClusterIdentifier", "c1");
         params.putSingle("DbUser", "analyst");
         params.putSingle("AutoCreate", "true");
+
+        Response response = handler.handle("GetClusterCredentials", params);
+
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DbUser>IAMA:analyst</DbUser>"));
+    }
+
+    @Test
+    void getClusterCredentialsAutoCreateFalsePrefixesIamOnDbUser() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
 
         Response response = handler.handle("GetClusterCredentials", params);
 

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -439,6 +439,21 @@ class RedshiftQueryHandlerTest {
     }
 
     @Test
+    void getClusterCredentialsClampsAnOutOfRangeConfigDefault() {
+        when(config.services().redshift().defaultCredentialDurationSeconds()).thenReturn(5);
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+
+        handler.handle("GetClusterCredentials", params);
+
+        java.time.Instant expiresAt = credentialBroker.resolve("acc", "c1", "analyst").orElseThrow().expiresAt();
+        assertTrue(expiresAt.isAfter(java.time.Instant.now().plusSeconds(800)),
+                "an out-of-range config default must fall back to the AWS minimum, not be used as-is");
+    }
+
+    @Test
     void getClusterCredentialsRejectsDurationBelowMinimum() {
         when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
         MultivaluedMap<String, String> params = new MultivaluedHashMap<>();

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -506,4 +506,35 @@ class RedshiftQueryHandlerTest {
                 () -> handler.handle("GetClusterCredentials", params));
         assertEquals("ClusterNotFound", ex.getErrorCode());
     }
+
+    // ── GetClusterCredentialsWithIAM ─────────────────────────────────────────
+
+    @Test
+    void getClusterCredentialsWithIamDerivesDbUserFromCaller() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        when(iamDbUserResolver.resolveDbUser(any())).thenReturn("IAMR:Deployer");
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+
+        Response response = handler.handle("GetClusterCredentialsWithIAM", params);
+
+        assertEquals(200, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DbUser>IAMR:Deployer</DbUser>"));
+        assertTrue(xml.contains("<GetClusterCredentialsWithIAMResult>"));
+    }
+
+    @Test
+    void getClusterCredentialsWithIamIgnoresDbUserParam() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        when(iamDbUserResolver.resolveDbUser(any())).thenReturn("IAM:alice");
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "ignored");
+
+        Response response = handler.handle("GetClusterCredentialsWithIAM", params);
+
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DbUser>IAM:alice</DbUser>"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandlerTest.java
@@ -1,6 +1,8 @@
 package io.github.hectorvent.floci.services.redshift;
 
+import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.services.redshift.model.Cluster;
 import io.github.hectorvent.floci.services.redshift.model.ClusterParameterGroup;
 import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
@@ -26,11 +28,30 @@ class RedshiftQueryHandlerTest {
 
     private RedshiftQueryHandler handler;
     private RedshiftService service;
+    private RedshiftCredentialBroker credentialBroker;
+    private EmulatorConfig config;
+    private RedshiftIamDbUserResolver iamDbUserResolver;
+    private RegionResolver regionResolver;
 
     @BeforeEach
     void setUp() {
         service = mock(RedshiftService.class);
-        handler = new RedshiftQueryHandler(service);
+        credentialBroker = new RedshiftCredentialBroker();
+        config = mock(EmulatorConfig.class, RETURNS_DEEP_STUBS);
+        when(config.services().redshift().defaultCredentialDurationSeconds()).thenReturn(900);
+        iamDbUserResolver = mock(RedshiftIamDbUserResolver.class);
+        regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn("acc");
+        handler = new RedshiftQueryHandler(service, credentialBroker, config, iamDbUserResolver, regionResolver);
+    }
+
+    private Cluster availableCluster(String id) {
+        Cluster c = new Cluster();
+        c.setClusterIdentifier(id);
+        c.setMasterUsername("admin");
+        c.setMasterPassword("SecretPass1");
+        c.setClusterStatus("available");
+        return c;
     }
 
     @Test
@@ -373,5 +394,116 @@ class RedshiftQueryHandlerTest {
         assertTrue(xml.contains("<Tags>"));
         assertTrue(xml.contains("<Key>env</Key>"));
         assertTrue(xml.contains("<Value>prod</Value>"));
+    }
+
+    // ── GetClusterCredentials ────────────────────────────────────────────────
+
+    @Test
+    void getClusterCredentialsReturnsUserPasswordAndExpiration() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+
+        Response response = handler.handle("GetClusterCredentials", params);
+
+        assertEquals(200, response.getStatus());
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DbUser>analyst</DbUser>"));
+        assertTrue(xml.contains("<DbPassword>"));
+        assertTrue(xml.contains("<Expiration>"));
+        assertTrue(xml.contains("<GetClusterCredentialsResult>"));
+    }
+
+    @Test
+    void getClusterCredentialsStoresCredentialInBroker() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+
+        handler.handle("GetClusterCredentials", params);
+
+        assertTrue(credentialBroker.resolve("acc", "c1", "analyst").isPresent());
+    }
+
+    @Test
+    void getClusterCredentialsRejectsMissingDbUser() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("GetClusterCredentials", params));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void getClusterCredentialsRejectsDurationBelowMinimum() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+        params.putSingle("DurationSeconds", "899");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("GetClusterCredentials", params));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void getClusterCredentialsRejectsDurationAboveMaximum() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+        params.putSingle("DurationSeconds", "3601");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("GetClusterCredentials", params));
+        assertEquals("InvalidParameterValue", ex.getErrorCode());
+    }
+
+    @Test
+    void getClusterCredentialsAutoCreatePrefixesIamOnDbUser() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+        params.putSingle("AutoCreate", "true");
+
+        Response response = handler.handle("GetClusterCredentials", params);
+
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DbUser>IAM:analyst</DbUser>"));
+    }
+
+    @Test
+    void getClusterCredentialsEchoesDbGroups() {
+        when(service.describeClusters("c1")).thenReturn(List.of(availableCluster("c1")));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "c1");
+        params.putSingle("DbUser", "analyst");
+        params.putSingle("DbGroups.member.1", "etl");
+        params.putSingle("DbGroups.member.2", "readonly");
+
+        Response response = handler.handle("GetClusterCredentials", params);
+
+        String xml = (String) response.getEntity();
+        assertTrue(xml.contains("<DbGroup>etl</DbGroup>"));
+        assertTrue(xml.contains("<DbGroup>readonly</DbGroup>"));
+    }
+
+    @Test
+    void getClusterCredentialsPropagatesClusterNotFound() {
+        when(service.describeClusters("missing"))
+                .thenThrow(new AwsException("ClusterNotFound", "Cluster missing not found", 404));
+        MultivaluedMap<String, String> params = new MultivaluedHashMap<>();
+        params.putSingle("ClusterIdentifier", "missing");
+        params.putSingle("DbUser", "analyst");
+
+        AwsException ex = assertThrows(AwsException.class,
+                () -> handler.handle("GetClusterCredentials", params));
+        assertEquals("ClusterNotFound", ex.getErrorCode());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -1129,6 +1129,16 @@ class RedshiftServiceTest {
     }
 
     @Test
+    void passwordValidatorRejectsEverythingWhenClusterRowIsAbsent() {
+        when(clusterBackend.getForAccount("acc", "gone")).thenReturn(Optional.empty());
+
+        PasswordValidator validator = service.passwordValidatorForTesting("acc", "gone");
+
+        assertEquals(PasswordValidator.AuthResult.REJECT, validator.validate("admin", "SecretPass1"));
+        assertEquals(PasswordValidator.AuthResult.REJECT, validator.validate("analyst", "anything"));
+    }
+
+    @Test
     void passwordValidatorRejectsMasterUserWithWrongPassword() {
         seedCluster("acc", "c1");
 

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -353,6 +353,18 @@ class RedshiftServiceTest {
     }
 
     @Test
+    void deleteClusterRevokesItsGetClusterCredentialsCredentials() {
+        Cluster c = new Cluster();
+        c.setClusterIdentifier("test-c");
+        when(clusterBackend.get("test-c")).thenReturn(Optional.of(c));
+        credentialBroker.issue("111111111111", "test-c", "analyst", List.of(), 900);
+
+        service.deleteCluster("test-c");
+
+        assertTrue(credentialBroker.resolve("111111111111", "test-c", "analyst").isEmpty());
+    }
+
+    @Test
     void deleteClusterAbortsAndKeepsMetadataWhenTheProxyWontStop() {
         Cluster c = new Cluster();
         c.setClusterIdentifier("test-c");

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -255,14 +255,21 @@ class RedshiftServiceTest {
     void createClusterRemovesMetadataOnFailure() {
         when(clusterBackend.accountId()).thenReturn("111111111111");
         when(clusterBackend.get("c1")).thenReturn(Optional.empty());
+        // Simulate a concurrent GetClusterCredentials landing while the row exists, then fail
+        // container startup so the rollback path runs.
         when(cm.start(eq("111111111111"), eq("c1"), eq("admin"), eq("password123")))
-                .thenThrow(new RuntimeException("startup failed"));
+                .thenAnswer(inv -> {
+                    credentialBroker.issue("111111111111", "c1", "analyst", List.of(), 900);
+                    throw new RuntimeException("startup failed");
+                });
 
         assertThrows(AwsException.class, () ->
                 service.createCluster("c1", "dc2.large", "admin", "password123"));
 
         verify(clusterBackend).delete("c1");
         verify(clusterBackend, atLeastOnce()).flush();
+        // The rollback that removes the cluster row must also drop that credential.
+        assertTrue(credentialBroker.resolve("111111111111", "c1", "analyst").isEmpty());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -1129,6 +1129,16 @@ class RedshiftServiceTest {
     }
 
     @Test
+    void passwordValidatorRejectsMasterUserWithWrongPassword() {
+        seedCluster("acc", "c1");
+
+        PasswordValidator validator = service.passwordValidatorForTesting("acc", "c1");
+
+        assertEquals(PasswordValidator.AuthResult.REJECT,
+                validator.validate("admin", "not-the-master-password"));
+    }
+
+    @Test
     void passwordValidatorAcceptsLiveBrokerCredentialAsMasterEquivalent() {
         seedCluster("acc", "c1");
         TempCredential cred = credentialBroker.issue("acc", "c1", "analyst", List.of(), 900);

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/RedshiftServiceTest.java
@@ -14,6 +14,7 @@ import io.github.hectorvent.floci.services.redshift.model.ClusterSubnetGroup;
 import io.github.hectorvent.floci.services.redshift.model.Endpoint;
 import io.github.hectorvent.floci.services.redshift.model.Parameter;
 import io.github.hectorvent.floci.services.redshift.model.Snapshot;
+import io.github.hectorvent.floci.services.rds.proxy.PasswordValidator;
 import io.github.hectorvent.floci.services.redshift.proxy.RedshiftProxyManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,6 +47,7 @@ class RedshiftServiceTest {
     private RegionResolver regionResolver;
     private RedshiftProxyManager proxyManager;
     private DockerHostResolver dockerHostResolver;
+    private RedshiftCredentialBroker credentialBroker;
     private RedshiftService service;
 
     @BeforeEach
@@ -85,7 +87,10 @@ class RedshiftServiceTest {
 
         regionResolver = new RegionResolver("us-east-1", "111111111111");
 
-        service = new RedshiftService(sf, cm, config, regionResolver, proxyManager, dockerHostResolver);
+        credentialBroker = new RedshiftCredentialBroker();
+
+        service = new RedshiftService(sf, cm, config, regionResolver, proxyManager, dockerHostResolver,
+                credentialBroker);
     }
 
     /** Absolute dump path as {@code createSnapshot} now stores it: under {@code <persistentPath>/redshift-dumps/<accountId>}. */
@@ -1100,5 +1105,58 @@ class RedshiftServiceTest {
     private static String extractResourceId(String arn) {
         String resource = arn.substring(arn.lastIndexOf(':') + 1);
         return resource.contains("/") ? resource.substring(resource.lastIndexOf('/') + 1) : resource;
+    }
+
+    // ── passwordValidatorFor / GetClusterCredentials broker wiring ─────────────
+
+    private void seedCluster(String accountId, String clusterId) {
+        Cluster cluster = new Cluster();
+        cluster.setClusterIdentifier(clusterId);
+        cluster.setMasterUsername("admin");
+        cluster.setMasterPassword("SecretPass1");
+        when(clusterBackend.getForAccount(accountId, clusterId)).thenReturn(Optional.of(cluster));
+    }
+
+    @Test
+    void passwordValidatorAcceptsMasterPair() {
+        seedCluster("acc", "c1");
+
+        PasswordValidator validator =
+                service.passwordValidatorForTesting("acc", "c1");
+
+        assertEquals(PasswordValidator.AuthResult.MASTER_EQUIVALENT,
+                validator.validate("admin", "SecretPass1"));
+    }
+
+    @Test
+    void passwordValidatorAcceptsLiveBrokerCredentialAsMasterEquivalent() {
+        seedCluster("acc", "c1");
+        TempCredential cred = credentialBroker.issue("acc", "c1", "analyst", List.of(), 900);
+        PasswordValidator validator =
+                service.passwordValidatorForTesting("acc", "c1");
+
+        assertEquals(PasswordValidator.AuthResult.MASTER_EQUIVALENT,
+                validator.validate("analyst", cred.password()));
+    }
+
+    @Test
+    void passwordValidatorRejectsKnownBrokerUserWithWrongPassword() {
+        seedCluster("acc", "c1");
+        credentialBroker.issue("acc", "c1", "analyst", List.of(), 900);
+        PasswordValidator validator =
+                service.passwordValidatorForTesting("acc", "c1");
+
+        assertEquals(PasswordValidator.AuthResult.REJECT,
+                validator.validate("analyst", "nope"));
+    }
+
+    @Test
+    void passwordValidatorPassesThroughUnknownUser() {
+        seedCluster("acc", "c1");
+        PasswordValidator validator =
+                service.passwordValidatorForTesting("acc", "c1");
+
+        assertEquals(PasswordValidator.AuthResult.PASSTHROUGH,
+                validator.validate("someone-else", "whatever"));
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftAuthProxyTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftAuthProxyTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.redshift.proxy;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.services.acm.CertificateGenerator;
+import io.github.hectorvent.floci.services.rds.proxy.PasswordValidator;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyTlsCertificates;
 import io.github.hectorvent.floci.services.rds.proxy.RdsSigV4Validator;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -69,7 +70,7 @@ class RedshiftAuthProxyTest {
         int proxyPort = freePort();
         proxy = new RedshiftAuthProxy("111111111111:c1", "localhost", fakeBackend.getLocalPort(),
                 "admin", "Secret123", "dev",
-                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> true,
+                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT,
                 mock(S3Service.class));
         proxy.start(proxyPort);
 
@@ -123,7 +124,7 @@ class RedshiftAuthProxyTest {
         int proxyPort = freePort();
         proxy = new RedshiftAuthProxy("111111111111:c1", "localhost", fakeBackend.getLocalPort(),
                 "admin", "Secret123", "dev",
-                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> true,
+                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT,
                 mock(S3Service.class));
         proxy.start(proxyPort);
 
@@ -154,7 +155,7 @@ class RedshiftAuthProxyTest {
 
         proxy = new RedshiftAuthProxy("111111111111:c1", "localhost", fakeBackend.getLocalPort(),
                 "admin", "Secret123", "dev",
-                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> true,
+                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT,
                 mock(S3Service.class));
         proxy.start(proxyPort); // must not throw despite the port being busy at first
 
@@ -167,7 +168,7 @@ class RedshiftAuthProxyTest {
         int proxyPort = freePort();
         proxy = new RedshiftAuthProxy("111111111111:c1", "localhost", fakeBackend.getLocalPort(),
                 "admin", "old", "dev",
-                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> true,
+                mock(RdsSigV4Validator.class), realTls(), (user, pw) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT,
                 mock(S3Service.class));
         proxy.start(proxyPort);
 

--- a/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftProxyManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshift/proxy/RedshiftProxyManagerTest.java
@@ -1,5 +1,6 @@
 package io.github.hectorvent.floci.services.redshift.proxy;
 
+import io.github.hectorvent.floci.services.rds.proxy.PasswordValidator;
 import io.github.hectorvent.floci.services.rds.proxy.RdsProxyTlsCertificates;
 import io.github.hectorvent.floci.services.rds.proxy.RdsSigV4Validator;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -34,7 +35,7 @@ class RedshiftProxyManagerTest {
 
     private static void start(RedshiftProxyManager manager, String key, int proxyPort) {
         manager.startProxy(key, proxyPort, "localhost", 1, "localhost",
-                "admin", "secret", "dev", (user, password) -> true);
+                "admin", "secret", "dev", (user, password) -> PasswordValidator.AuthResult.MASTER_EQUIVALENT);
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolverTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/redshiftdata/RedshiftDataResourceResolverTest.java
@@ -3,6 +3,8 @@ package io.github.hectorvent.floci.services.redshiftdata;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.redshift.RedshiftCredentialBroker;
 import io.github.hectorvent.floci.services.redshift.RedshiftService;
 import io.github.hectorvent.floci.services.redshift.model.Cluster;
 import io.github.hectorvent.floci.services.secretsmanager.SecretsManagerService;
@@ -21,7 +23,9 @@ import static org.mockito.Mockito.when;
 class RedshiftDataResourceResolverTest {
 
     private static final String REGION = "us-east-1";
+    private static final String ACCOUNT = "acc";
     private final ObjectMapper mapper = new ObjectMapper();
+    private final RedshiftCredentialBroker broker = new RedshiftCredentialBroker();
 
     private static Cluster cluster() {
         Cluster c = new Cluster();
@@ -34,7 +38,9 @@ class RedshiftDataResourceResolverTest {
     }
 
     private RedshiftDataResourceResolver resolver(RedshiftService redshift, SecretsManagerService secrets) {
-        return new RedshiftDataResourceResolver(redshift, secrets, mapper);
+        RegionResolver regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenReturn(ACCOUNT);
+        return new RedshiftDataResourceResolver(redshift, secrets, mapper, broker, regionResolver);
     }
 
     @Test
@@ -92,6 +98,24 @@ class RedshiftDataResourceResolverTest {
         AwsException e = assertThrows(AwsException.class,
                 () -> resolver(redshift, mock(SecretsManagerService.class)).resolve(req, REGION));
         assertEquals("ValidationException", e.getErrorCode());
+    }
+
+    @Test
+    void resolvesLiveMintedDbUserAsMaster() {
+        RedshiftService redshift = mock(RedshiftService.class);
+        when(redshift.describeClusters("wh")).thenReturn(List.of(cluster()));
+        broker.issue(ACCOUNT, "wh", "analyst", List.of(), 900);
+
+        ObjectNode req = mapper.createObjectNode();
+        req.put("ClusterIdentifier", "wh");
+        req.put("DbUser", "analyst");
+        req.put("Database", "dev");
+
+        RedshiftDataResourceResolver.DatabaseTarget target =
+                resolver(redshift, mock(SecretsManagerService.class)).resolve(req, REGION);
+
+        assertEquals("admin", target.user());
+        assertEquals("Secret123", target.password());
     }
 
     @Test

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -175,6 +175,7 @@ floci:
       image-version: postgres:15-alpine
       proxy-base-port: 7100
       proxy-max-port: 7199
+      default-credential-duration-seconds: 900
     rds:
       enabled: true
       mock: false

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -219,9 +219,10 @@ services:
     doc: docs/services/redshift.md
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/redshift/RedshiftQueryHandler.java, mode: switch }
-    # SubnetIds / VpcSecurityGroupIds / TagKeys are labels of an inner member-name
-    # switch (memberKeyRegex), not actions, same shape as the rds exclusions above.
-    exclude_actions: [SubnetIds, VpcSecurityGroupIds, TagKeys]
+    # SubnetIds / VpcSecurityGroupIds / TagKeys / DbGroups are labels of an inner
+    # member-name switch (memberKeyRegex), not actions, same shape as the rds
+    # exclusions above.
+    exclude_actions: [SubnetIds, VpcSecurityGroupIds, TagKeys, DbGroups]
   - service: redshiftdata
     doc: docs/services/redshift-data.md
     sources:


### PR DESCRIPTION
## Summary

Emulates `redshift:GetClusterCredentials` and `redshift:GetClusterCredentialsWithIAM`. Both mint a short-lived `DbUser` / `DbPassword` pair that the PostgreSQL wire auth proxy and the Redshift Data API accept for a non-master user, without creating a real PostgreSQL role.

How it works: a Floci-side credential shim. The action stores a `TempCredential` (with expiry) in an in-memory `RedshiftCredentialBroker`. When the proxy or the Data API sees a live minted credential, it opens the real backend connection as the cluster master (the `DbUser` is nominal, so `current_user`, `GRANT`, and object ownership are the master's; this is documented as a limitation).

To carry that decision, the shared `PasswordValidator` contract used by the RDS/Redshift PostgreSQL proxy handlers widens from `boolean` to a three-value `AuthResult` (`REJECT` / `PASSTHROUGH` / `MASTER_EQUIVALENT`). RDS behaviour is unchanged: its own master-password callback (renamed `RdsAuthProxy.MasterPasswordCheck` to free the `PasswordValidator` name) is adapted at the handler boundary, and a non-master RDS user still passes straight through to the backend.

Main changes:
- `RedshiftCredentialBroker` + `TempCredential` (in-memory, `Resettable`, no `StorageFactory`).
- `PasswordValidator` -> `AuthResult`; `PostgresProtocolHandler.resolveBackendLogin(...)` selects the backend login.
- `RedshiftService.passwordValidatorFor` consults the broker; the master username is always decided on its own password (match -> `MASTER_EQUIVALENT`, mismatch -> `REJECT`), and an absent cluster row -> `REJECT`.
- `RedshiftQueryHandler`: two new Query-protocol actions; `AwsQueryController` registers them and forwards the `Authorization` header.
- `RedshiftIamDbUserResolver`: maps the caller's IAM identity to `IAM:<user>` / `IAMR:<role>`, `IAMR:floci` fallback.
- `RedshiftDataResourceResolver`: a non-master `DbUser` with a live minted credential resolves to the master connection instead of `ValidationException`.
- New config `floci.services.redshift.default-credential-duration-seconds` (default `900`; `DurationSeconds` range 900-3600 inclusive).
- Docs: `docs/services/redshift.md` (regenerated action table + limitations), `docs/services/redshift-data.md`, Service Matrix.

Note: the `GetClusterCredentials` response also echoes a `<DbGroups>` element, which the real AWS shape omits. It is an intentional Floci extension (SDK v2 ignores unknown elements on unmarshal).

## Type of change

- [x] New feature (`feat:`)

## AWS Compatibility

- New actions verified against AWS SDK for Java v2 (`software.amazon.awssdk:redshift`, the version pinned in `compatibility-tests/sdk-test-java`): `RedshiftClient.getClusterCredentials` / `getClusterCredentialsWithIAM`, asserting `dbUser` / `dbPassword` / `expiration` are populated. Wire format is AWS Query protocol XML built with `XmlBuilder`, routed through `AwsQueryController.REDSHIFT_ACTIONS`.
- `DurationSeconds` outside 900-3600, a non-integer value, and a missing `DbUser` return `InvalidParameterValue`; an unknown `ClusterIdentifier` propagates `ClusterNotFound` (404).

## Checklist

- [x] `./mvnw test` passes locally: every affected suite passes (`RedshiftServiceTest`, `RedshiftQueryHandlerTest`, `RedshiftCredentialBrokerTest`, `RedshiftIamDbUserResolverTest`, `PostgresProtocolHandlerTest`, `PostgresProtocolHandlerAuthResultTest`, `MySqlProtocolHandlerTest`, `RdsServiceTest`, `RedshiftAuthProxyTest`, `RedshiftProxyManagerTest`, `RedshiftDataResourceResolverTest`, `RedshiftDataServiceTest`, `RedshiftOperationsTest`). A full-suite local run could not complete on this machine (the compile step was repeatedly killed by an OS resource limit, unrelated to these changes); CI runs the full suite.
- [x] New or updated integration test added: `RedshiftGetClusterCredentialsIntegrationTest` (Docker-gated, end-to-end: mint a credential for a non-master `DbUser`, then run `SELECT 1` through the Data API as that user), plus SDK compat coverage in `compatibility-tests/sdk-test-java/.../RedshiftTest.java`.
- [x] Commit messages follow Conventional Commits.
