### PR TITLE
fix(ec2): answer DescribeTransitGatewayConnects with an empty list

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -385,6 +385,7 @@ and `DescribeTransitGateways` include it.
 | CreateTransitGatewayVpcAttachment | Attaches a VPC to a transit gateway through one subnet per availability zone. |
 | DescribeTransitGatewayVpcAttachments | Lists or returns VPC attachments with their subnets and options. |
 | DescribeTransitGatewayAttachments | Returns the same attachments in the resource-agnostic shape, including the route table association. |
+| DescribeTransitGatewayConnects | Always returns an empty list, since Connect attachments cannot be created yet; requested ids are still validated. |
 | ModifyTransitGatewayVpcAttachment | Adds or removes attachment subnets and updates its options. |
 | DeleteTransitGatewayVpcAttachment | Deletes a VPC attachment. |
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -110,6 +110,7 @@ public class Ec2QueryHandler {
                         handleDescribeTransitGatewayVpcAttachments(params, region);
                 case "DescribeTransitGatewayAttachments" ->
                         handleDescribeTransitGatewayAttachments(params, region);
+                case "DescribeTransitGatewayConnects" -> handleDescribeTransitGatewayConnects(params, region);
                 case "ModifyTransitGatewayVpcAttachment" ->
                         handleModifyTransitGatewayVpcAttachment(params, region);
                 case "DeleteTransitGatewayVpcAttachment" ->
@@ -2178,6 +2179,18 @@ public class Ec2QueryHandler {
             xml.start("item").raw(item.build()).end("item");
         }
         xml.end("transitGatewayAttachments").end("DescribeTransitGatewayAttachmentsResponse");
+        return xmlResponse(xml.build());
+    }
+
+    /** floci does not yet support creating Connect attachments, so this is always an empty list. */
+    private Response handleDescribeTransitGatewayConnects(MultivaluedMap<String, String> p, String region) {
+        service.describeTransitGatewayConnects(region, getList(p, "TransitGatewayAttachmentIds"), getFilters(p));
+        XmlBuilder xml = new XmlBuilder()
+                .start("DescribeTransitGatewayConnectsResponse", AwsNamespaces.EC2)
+                .elem("requestId", UUID.randomUUID().toString())
+                .start("transitGatewayConnectSet")
+                .end("transitGatewayConnectSet")
+                .end("DescribeTransitGatewayConnectsResponse");
         return xmlResponse(xml.build());
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1610,6 +1610,22 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * floci does not yet support creating Connect attachments, so this always answers with an
+     * empty list, the same thing a real account with none would get back. Requested ids still
+     * validate the same way {@link #describeTransitGatewayVpcAttachments} validates VPC attachment
+     * ids, since Connect attachments share the same {@code tgw-attach-} id namespace.
+     */
+    public List<TransitGatewayVpcAttachment> describeTransitGatewayConnects(
+            String region, List<String> attachmentIds, Map<String, List<String>> filters) {
+        attachmentIds.forEach(Ec2Service::requireWellFormedAttachmentId);
+        if (!attachmentIds.isEmpty()) {
+            throw new AwsException("InvalidTransitGatewayConnectID.NotFound",
+                    "Transit Gateway Connect " + attachmentIds.get(0) + " was deleted or does not exist.", 400);
+        }
+        return List.of();
+    }
+
     public TransitGatewayVpcAttachment modifyTransitGatewayVpcAttachment(
             String region, String attachmentId, List<String> addSubnetIds, List<String> removeSubnetIds,
             TransitGatewayVpcAttachmentOptions changes) {

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -1611,19 +1611,19 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
     }
 
     /**
-     * floci does not yet support creating Connect attachments, so this always answers with an
-     * empty list, the same thing a real account with none would get back. Requested ids still
+     * floci does not yet support creating Connect attachments, so the Query handler always
+     * answers with an empty set, the same thing a real account with none would get back; this
+     * only validates the request (a dedicated Connect model can replace it later). Requested ids still
      * validate the same way {@link #describeTransitGatewayVpcAttachments} validates VPC attachment
      * ids, since Connect attachments share the same {@code tgw-attach-} id namespace.
      */
-    public List<TransitGatewayVpcAttachment> describeTransitGatewayConnects(
+    public void describeTransitGatewayConnects(
             String region, List<String> attachmentIds, Map<String, List<String>> filters) {
         attachmentIds.forEach(Ec2Service::requireWellFormedAttachmentId);
         if (!attachmentIds.isEmpty()) {
             throw new AwsException("InvalidTransitGatewayConnectID.NotFound",
                     "Transit Gateway Connect " + attachmentIds.get(0) + " was deleted or does not exist.", 400);
         }
-        return List.of();
     }
 
     public TransitGatewayVpcAttachment modifyTransitGatewayVpcAttachment(

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -2598,6 +2598,32 @@ class Ec2ServiceTest {
                 "a well-formed id that does not exist is a different failure");
     }
 
+    /**
+     * floci does not yet support creating Connect attachments, so LZA's tgw-associations-and-
+     * propagations module, which describes them unconditionally alongside VPC attachments, needs
+     * this to at least answer with an empty account-wide list rather than an unrecognized-action
+     * error (LZA fidelity gap: AWSAccelerator-ToolkitProject build 29 failed with "Operation
+     * DescribeTransitGatewayConnects is not supported").
+     */
+    @Test
+    void describeTransitGatewayConnectsReturnsEmptyWhenNoneExist() {
+        Ec2Service service = prefixListService();
+
+        assertEquals(0, service.describeTransitGatewayConnects("us-east-1", List.of(), Map.of()).size());
+    }
+
+    @Test
+    void describeTransitGatewayConnectsRejectsAMalformedOrUnknownId() {
+        Ec2Service service = prefixListService();
+
+        assertEquals("InvalidTransitGatewayAttachmentID.Malformed", assertThrows(AwsException.class,
+                () -> service.describeTransitGatewayConnects("us-east-1", List.of("tgw-connect-nope"), Map.of()))
+                .getErrorCode());
+        assertEquals("InvalidTransitGatewayConnectID.NotFound", assertThrows(AwsException.class,
+                () -> service.describeTransitGatewayConnects("us-east-1",
+                        List.of("tgw-attach-0123456789abcdef0"), Map.of())).getErrorCode());
+    }
+
     /** The gateway's owner is its own field, sourced from the gateway rather than from the VPC. */
     @Test
     void anAttachmentRecordsBothOwnersSeparately() {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -2609,7 +2610,7 @@ class Ec2ServiceTest {
     void describeTransitGatewayConnectsReturnsEmptyWhenNoneExist() {
         Ec2Service service = prefixListService();
 
-        assertEquals(0, service.describeTransitGatewayConnects("us-east-1", List.of(), Map.of()).size());
+        assertDoesNotThrow(() -> service.describeTransitGatewayConnects("us-east-1", List.of(), Map.of()));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2TransitGatewayVpcAttachmentIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2TransitGatewayVpcAttachmentIntegrationTest.java
@@ -205,4 +205,43 @@ class Ec2TransitGatewayVpcAttachmentIntegrationTest {
         .then().statusCode(200)
             .body("DeleteTransitGatewayResponse.transitGateway.state", equalTo("deleted"));
     }
+
+    /**
+     * Connect attachments cannot be created yet, so the describe answers with the AWS-shaped
+     * empty collection: the EC2 namespace, a requestId, and an empty transitGatewayConnectSet.
+     */
+    @Test
+    @Order(7)
+    void describeTransitGatewayConnectsAnswersAnEmptySetOverTheQueryProtocol() {
+        String body = given()
+            .formParam("Action", "DescribeTransitGatewayConnects")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(200)
+            .body("DescribeTransitGatewayConnectsResponse.requestId", not(equalTo("")))
+            .extract().asString();
+
+        assertThat(body, containsString("<DescribeTransitGatewayConnectsResponse xmlns=\"http://ec2.amazonaws.com/doc/2016-11-15/\">"));
+        assertThat(body, containsString("<transitGatewayConnectSet></transitGatewayConnectSet>"));
+    }
+
+    @Test
+    @Order(8)
+    void describeTransitGatewayConnectsRejectsMalformedAndUnknownIdsOverTheQueryProtocol() {
+        given()
+            .formParam("Action", "DescribeTransitGatewayConnects")
+            .formParam("TransitGatewayAttachmentIds.1", "tgw-connect-nope")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidTransitGatewayAttachmentID.Malformed"));
+
+        given()
+            .formParam("Action", "DescribeTransitGatewayConnects")
+            .formParam("TransitGatewayAttachmentIds.1", "tgw-attach-0123456789abcdef0")
+            .header("Authorization", AUTH_HEADER)
+        .when().post("/")
+        .then().statusCode(400)
+            .body("Response.Errors.Error.Code", equalTo("InvalidTransitGatewayConnectID.NotFound"));
+    }
 }


### PR DESCRIPTION
## Summary

Adds `DescribeTransitGatewayConnects` to the EC2 Query handler, answering with an empty `transitGatewayConnectSet` for every account.

**Provenance: LZA-verified.** Landing Zone Accelerator's `tgw-associations-and-propagations` custom resource calls this action unconditionally, right next to `DescribeTransitGatewayVpcAttachments`, when it reconciles attachment associations. Because the action was entirely unhandled, the LZA `NetworkAssociations` stage failed with `Operation DescribeTransitGatewayConnects is not supported` (AWSAccelerator-ToolkitProject build 29 on a phase-2 run against floci). floci cannot create Connect attachments yet, so an empty list is exactly what a real account with none returns, and the stage proceeds.

## Wire fidelity (botocore `ec2/2016-11-15/service-2.json`)

- `DescribeTransitGatewayConnectsResult.TransitGatewayConnects` is serialized as `transitGatewayConnectSet`; the response carries that element (empty) plus `requestId`, with no `nextToken` since there is nothing to page.
- `DescribeTransitGatewayConnectsRequest.TransitGatewayAttachmentIds` is a `TransitGatewayAttachmentIdStringList`; Connect attachments share the `tgw-attach-` id namespace with VPC attachments, so requested ids are validated with the same well-formedness check the VPC describe uses (`InvalidTransitGatewayAttachmentID.Malformed`). A well-formed id that does not exist gets `InvalidTransitGatewayConnectID.NotFound`, mirroring AWS's per-resource NotFound codes for Connect attachments.
- `Filters` is accepted and parsed but not applied, since there is never anything to filter.

The deterministic wire-fidelity extractor was run over the EC2 service against the current botocore model; it emits no packet for this operation because its request members carry no enum, pattern, or length constraints.

## Local review

The local code-review pass was run over `Ec2Service.java` and `Ec2QueryHandler.java`. It produced 27 findings, none of which touch the code this PR adds; all are in pre-existing EC2 code outside this PR's scope and are tracked in the fork's local issue ledger for separate follow-up.

## Deliberate scope notes

- This is a read-only stub on purpose: `CreateTransitGatewayConnect` and friends are not implemented, so there is no state to describe. When Connect attachments land, this handler is the natural place to return them.
- `docs/services/ec2.md` gets one hand-written row in the Transit Gateway VPC Attachments table saying the action always returns an empty list; `make docs-check` passes.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: the action returned the generic unsupported-operation error, which LZA treats as fatal. Verified against the botocore EC2 model above. The empty-list answer is what a real account with no Connect attachments returns, which is the condition LZA's module handles today.

## Checklist

- [x] `Ec2ServiceTest` passes locally (139 tests) on top of current `main`; the two new tests cover the empty answer and the malformed / unknown id paths
- [x] New or updated test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
