### PR TITLE
fix(iam): report the real default version of AWS-managed policies

### DIFF
--- a/docs/services/iam.md
+++ b/docs/services/iam.md
@@ -274,7 +274,23 @@ Floci seeds a catalog of commonly-used AWS managed policies at startup. These ar
 **Other execution roles**
 `AmazonS3ObjectLambdaExecutionRolePolicy` · `CloudWatchLambdaInsightsExecutionRolePolicy` · `CloudWatchLambdaApplicationSignalsExecutionRolePolicy` · `AWSConfigRulesExecutionRole` · `AWSMSKReplicatorExecutionRole` · `AWS-SSM-DiagnosisAutomation-ExecutionRolePolicy` · `AWS-SSM-RemediationAutomation-ExecutionRolePolicy` · `AmazonSageMakerGeospatialExecutionRole` · `AmazonSageMakerCanvasEMRServerlessExecutionRolePolicy` · `SageMakerStudioBedrockFunctionExecutionRolePolicy` · `SageMakerStudioDomainExecutionRolePolicy` · `SageMakerStudioQueryExecutionRolePolicy` · `AmazonDataZoneDomainExecutionRolePolicy` · `AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy` · `AWSPartnerCentralSellingResourceSnapshotJobExecutionRolePolicy`
 
-All seeded policies use a permissive wildcard document since Floci does not enforce IAM policy evaluation by default.
+Every catalog entry carries the real policy document of its current default version, generated from the public [iam-dataset](https://github.com/iann0036/iam-dataset), so `GetPolicyVersion` returns the same statements a real account would and enforcement mode evaluates them faithfully.
+
+### Version numbers
+
+AWS revises its managed policies in place, so their default version is rarely `v1`: `AmazonS3ReadOnlyAccess` is on `v3`, `ReadOnlyAccess` far beyond that, while `AdministratorAccess` has never been revised. Floci reports the version id AWS publishes for each policy, the date the policy was first created as `CreateDate`, and the date of its current default version as `UpdateDate`:
+
+```bash
+aws --endpoint-url http://localhost:4566 iam get-policy \
+  --policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+# -> DefaultVersionId: "v3", CreateDate: 2015-02-06T18:40:00Z, UpdateDate: 2023-08-10T21:31:39Z
+
+aws --endpoint-url http://localhost:4566 iam list-policy-versions \
+  --policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
+# -> a single entry, v3, IsDefaultVersion: true
+```
+
+Only the default version's document is bundled. Requesting a superseded version (`v1` or `v2` of `AmazonS3ReadOnlyAccess`) returns `NoSuchEntity`, the same answer AWS gives once it has pruned a managed policy's history, and `ListPolicyVersions` lists only the default. AWS managed policies remain read-only: `CreatePolicyVersion`, `SetDefaultPolicyVersion` and `DeletePolicyVersion` are rejected with `AccessDenied`.
 
 ## Optional Local Deployer Principal
 

--- a/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/AwsManagedPolicies.java
@@ -10,15 +10,18 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * Catalog of AWS managed policies, loaded from {@code iam/managed-policies.yaml}.
  *
  * <p>Floci resolves {@code arn:aws:iam::aws:policy/*} ARNs against this catalog, so an ARN
- * that is absent returns {@code NoSuchEntity} — the same as real AWS. Carrying the full
+ * that is absent returns {@code NoSuchEntity}, the same as real AWS. Carrying the full
  * published list is what keeps that faithful in both directions: policies AWS actually
  * publishes attach cleanly, while typos and invented names are still rejected. A curated
  * subset would reject valid configurations; resolving every well-formed ARN would accept
@@ -27,6 +30,18 @@ import java.util.Map;
  * <p>Policy documents are loaded from the versioned data generated from the public AWS managed
  * policy dataset. Entries without a document are omitted so an unavailable policy fails closed
  * through the normal {@code NoSuchEntity} path rather than receiving broader permissions.
+ *
+ * <p>Each document is the policy's <em>current default version</em>, and the version id it is
+ * served under comes from {@code iam/managed-policy-versions.json} rather than being assumed to
+ * be {@code v1}: AWS revises its managed policies in place, so {@code AmazonS3ReadOnlyAccess}
+ * is on {@code v3} while {@code AdministratorAccess} is still {@code v1}. That file also carries
+ * the policy's own creation date and the date of its current version, which back the
+ * {@code CreateDate} and {@code UpdateDate} of {@code GetPolicy} respectively. Only the default
+ * version's document is bundled, since the dataset does not carry superseded documents, so an
+ * older version id is reported as {@code NoSuchEntity}, as AWS itself does once it prunes a
+ * managed policy's history down to five versions. A policy missing from the versions file
+ * keeps the {@code v1} default so a partial refresh degrades to the old behaviour instead of
+ * dropping the policy.
  */
 final class AwsManagedPolicies {
 
@@ -36,8 +51,22 @@ final class AwsManagedPolicies {
 
     private static final String CATALOG_RESOURCE_NAME = "iam/managed-policies.yaml";
     private static final String DOCUMENTS_RESOURCE_NAME = "iam/managed-policy-documents.json";
+    private static final String VERSIONS_RESOURCE_NAME = "iam/managed-policy-versions.json";
 
-    record ManagedPolicyDef(String name, String path, String description, String document) {
+    private static final String FALLBACK_VERSION_ID = "v1";
+    private static final Pattern VERSION_ID = Pattern.compile("v[1-9][0-9]*");
+
+    /**
+     * One resolvable AWS managed policy.
+     *
+     * @param document         the document of the policy's current default version
+     * @param defaultVersionId the version id AWS reports for that document, e.g. {@code v3}
+     * @param createDate       when AWS first published the policy, or {@code null} if unknown
+     * @param updateDate       when AWS published the current default version, or {@code null}
+     *                         if unknown
+     */
+    record ManagedPolicyDef(String name, String path, String description, String document,
+                            String defaultVersionId, Instant createDate, Instant updateDate) {
         String arn() {
             return ARN_PREFIX + path + name;
         }
@@ -58,6 +87,7 @@ final class AwsManagedPolicies {
             ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
             Catalog catalog = mapper.readValue(in, Catalog.class);
             Map<String, JsonNode> documents = loadDocuments();
+            Map<String, VersionEntry> versions = loadVersions();
             List<ManagedPolicyDef> defs = new ArrayList<>();
             for (CatalogEntry entry : catalog.policies == null ? List.<CatalogEntry>of() : catalog.policies) {
                 if (entry.name == null || entry.name.isBlank() || entry.path == null || entry.path.isBlank()) {
@@ -69,14 +99,44 @@ final class AwsManagedPolicies {
                             entry.name);
                     continue;
                 }
-                defs.add(new ManagedPolicyDef(entry.name, entry.path, entry.description, document.toString()));
+                VersionEntry version = versions.get(entry.name);
+                defs.add(new ManagedPolicyDef(entry.name, entry.path, entry.description, document.toString(),
+                        defaultVersionId(entry.name, version),
+                        parseDate(entry.name, "createDate", version == null ? null : version.createDate),
+                        parseDate(entry.name, "updateDate", version == null ? null : version.updateDate)));
             }
-            LOG.debugv("Loaded {0} AWS managed policies from {1} and {2}",
-                    defs.size(), CATALOG_RESOURCE_NAME, DOCUMENTS_RESOURCE_NAME);
+            LOG.debugv("Loaded {0} AWS managed policies from {1}, {2} and {3}",
+                    defs.size(), CATALOG_RESOURCE_NAME, DOCUMENTS_RESOURCE_NAME, VERSIONS_RESOURCE_NAME);
             return List.copyOf(defs);
         } catch (IOException e) {
             throw new UncheckedIOException(
                     "Failed to read the AWS managed policy catalog: " + CATALOG_RESOURCE_NAME, e);
+        }
+    }
+
+    private static String defaultVersionId(String name, VersionEntry version) {
+        if (version == null || version.defaultVersionId == null || version.defaultVersionId.isBlank()) {
+            LOG.debugv("No AWS managed policy version recorded for {0}; reporting it as {1}",
+                    name, FALLBACK_VERSION_ID);
+            return FALLBACK_VERSION_ID;
+        }
+        if (!VERSION_ID.matcher(version.defaultVersionId).matches()) {
+            LOG.warnv("Ignoring malformed AWS managed policy version {0} for {1}; reporting it as {2}",
+                    version.defaultVersionId, name, FALLBACK_VERSION_ID);
+            return FALLBACK_VERSION_ID;
+        }
+        return version.defaultVersionId;
+    }
+
+    private static Instant parseDate(String name, String field, String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException e) {
+            LOG.warnv("Ignoring malformed AWS managed policy {0} {1} for {2}", field, value, name);
+            return null;
         }
     }
 
@@ -93,6 +153,19 @@ final class AwsManagedPolicies {
         }
     }
 
+    private static Map<String, VersionEntry> loadVersions() throws IOException {
+        try (InputStream in = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream(VERSIONS_RESOURCE_NAME)) {
+            if (in == null) {
+                throw new IllegalStateException(
+                        "AWS managed policy versions not found on the classpath: " + VERSIONS_RESOURCE_NAME);
+            }
+            ObjectMapper jsonMapper = new ObjectMapper();
+            return jsonMapper.readValue(in, jsonMapper.getTypeFactory()
+                    .constructMapType(Map.class, String.class, VersionEntry.class));
+        }
+    }
+
     @RegisterForReflection
     @JsonIgnoreProperties(ignoreUnknown = true)
     static final class Catalog {
@@ -105,5 +178,16 @@ final class AwsManagedPolicies {
         public String name;
         public String path;
         public String description;
+    }
+
+    /** The version metadata AWS publishes for one policy. */
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static final class VersionEntry {
+        public String defaultVersionId;
+        /** ISO-8601 instant at which AWS created the policy. */
+        public String createDate;
+        /** ISO-8601 instant at which AWS created the current default version. */
+        public String updateDate;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -276,8 +276,17 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
         Map<String, IamPolicy> catalog = new LinkedHashMap<>();
         for (AwsManagedPolicies.ManagedPolicyDef def : AwsManagedPolicies.POLICIES) {
             String arn = def.arn();
+            // The bundled document is the policy's current default version, served under the
+            // version id AWS actually reports for it (v3 for AmazonS3ReadOnlyAccess, v1 for
+            // AdministratorAccess) so GetPolicy/ListPolicyVersions match a real account.
+            // Superseded versions are not bundled, so they resolve to NoSuchEntity.
+            Instant now = Instant.now();
+            Instant updateDate = def.updateDate() != null ? def.updateDate() : now;
+            Instant createDate = def.createDate() != null ? def.createDate() : updateDate;
+            PolicyVersion defaultVersion = new PolicyVersion(
+                    def.defaultVersionId(), def.document(), true, updateDate);
             catalog.put(arn, new IamPolicy("ANPA" + randomId(16), def.name(), def.path(), arn,
-                    def.description(), def.document()));
+                    def.description(), defaultVersion, createDate, updateDate));
         }
         return catalog;
     }

--- a/src/main/java/io/github/hectorvent/floci/services/iam/model/IamPolicy.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/model/IamPolicy.java
@@ -40,16 +40,36 @@ public class IamPolicy {
 
     public IamPolicy(String policyId, String policyName, String path, String arn,
                      String description, String document) {
+        this(policyId, policyName, path, arn, description, new PolicyVersion("v1", document, true));
+    }
+
+    private IamPolicy(String policyId, String policyName, String path, String arn,
+                      String description, PolicyVersion v1) {
+        this(policyId, policyName, path, arn, description, v1, v1.getCreateDate(), v1.getCreateDate());
+    }
+
+    /**
+     * Creates a policy whose single stored version is {@code defaultVersion}, which need not
+     * be {@code v1}. AWS-managed policies are bundled at whatever version AWS has revised them
+     * to (for example {@code v3}), with only that version's document available, so the version
+     * counter starts just past it. {@code createDate} is when the policy itself was first
+     * published and {@code updateDate} when its current default version was, the two dates
+     * {@code GetPolicy} reports separately.
+     */
+    public IamPolicy(String policyId, String policyName, String path, String arn,
+                     String description, PolicyVersion defaultVersion,
+                     Instant createDate, Instant updateDate) {
         this.policyId = policyId;
         this.policyName = policyName;
         this.path = path;
         this.arn = arn;
         this.description = description;
-        this.createDate = Instant.now();
-        this.updateDate = Instant.now();
-        PolicyVersion v1 = new PolicyVersion("v1", document, true);
-        this.versions.put("v1", v1);
-        this.nextVersionNumber = 2;
+        this.createDate = createDate;
+        this.updateDate = updateDate;
+        defaultVersion.setDefaultVersion(true);
+        this.defaultVersionId = defaultVersion.getVersionId();
+        this.versions.put(defaultVersion.getVersionId(), defaultVersion);
+        this.nextVersionNumber = Integer.parseInt(defaultVersion.getVersionId().substring(1)) + 1;
     }
 
     public String getDefaultDocument() {

--- a/src/main/java/io/github/hectorvent/floci/services/iam/model/PolicyVersion.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/model/PolicyVersion.java
@@ -17,10 +17,14 @@ public class PolicyVersion {
     public PolicyVersion() {}
 
     public PolicyVersion(String versionId, String document, boolean defaultVersion) {
+        this(versionId, document, defaultVersion, Instant.now());
+    }
+
+    public PolicyVersion(String versionId, String document, boolean defaultVersion, Instant createDate) {
         this.versionId = versionId;
         this.document = document;
         this.defaultVersion = defaultVersion;
-        this.createDate = Instant.now();
+        this.createDate = createDate;
     }
 
     public String getVersionId() { return versionId; }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,7 +38,8 @@ quarkus:
     resources:
       # The Pricing service reads its bundled snapshot, EC2 reads its image
       # catalog (ec2/image-catalog.yaml), IAM reads its AWS managed-policy
-      # catalog (iam/managed-policies.yaml and iam/managed-policy-documents.json), AppSync's GraphQL parser reads its
+      # catalog (iam/managed-policies.yaml, iam/managed-policy-documents.json and
+      # iam/managed-policy-versions.json), AppSync's GraphQL parser reads its
       # message bundles, and API Gateway's Velocity engine reads its default
       # properties at runtime via
       # ClassLoader#getResourceAsStream. Quarkus's static resource analysis

--- a/src/main/resources/iam/managed-policies.yaml
+++ b/src/main/resources/iam/managed-policies.yaml
@@ -8,6 +8,17 @@
 # Policy documents are stored in iam/managed-policy-documents.json, keyed by policy name.
 # The documents are generated from the public AWS managed policy dataset cited below.
 #
+# Each document is the policy's current default version. The version id AWS reports for it
+# (e.g. v3 for AmazonS3ReadOnlyAccess) is stored in iam/managed-policy-versions.json, also
+# keyed by policy name, together with the policy's creation date (createDate) and the date
+# of its current default version (updateDate), the two dates GetPolicy reports. The version
+# id and updateDate come from the same dataset (the "version" and "updatedate" fields of
+# aws/managed_policies.json); createDate comes from the "Creation time" published on each
+# policy's page of the AWS managed policy reference,
+# https://docs.aws.amazon.com/aws-managed-policy/latest/reference/, which is minute-precise,
+# and falls back to the dataset's date for policies that no longer have a page. Only the
+# default version's document is bundled, so superseded version ids resolve to NoSuchEntity.
+#
 # Names and paths derive from the public AWS managed policy list, via
 # https://github.com/iann0036/iam-dataset (MIT). To refresh against a real account:
 #   aws iam list-policies --scope AWS

--- a/src/main/resources/iam/managed-policy-versions.json
+++ b/src/main/resources/iam/managed-policy-versions.json
@@ -1,0 +1,7831 @@
+{
+  "AIDevOpsAgentAccessPolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2026-03-26T03:42:00Z",
+    "updateDate": "2026-08-12T23:07:09Z"
+  },
+  "AIDevOpsAgentActionsPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-06-23T22:27:00Z",
+    "updateDate": "2026-08-19T22:47:28Z"
+  },
+  "AIDevOpsAgentFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2026-03-26T03:42:00Z",
+    "updateDate": "2026-06-26T23:57:19Z"
+  },
+  "AIDevOpsAgentReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-03-26T03:42:00Z",
+    "updateDate": "2026-06-11T00:57:11Z"
+  },
+  "AIDevOpsConstellationAccessPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-05T16:27:17Z",
+    "updateDate": "2026-08-05T16:27:17Z"
+  },
+  "AIDevOpsOperatorAppAccessPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2026-03-26T03:42:00Z",
+    "updateDate": "2026-06-26T23:57:22Z"
+  },
+  "AIOpsAssistantIncidentReportPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-10-10T22:04:00Z",
+    "updateDate": "2026-02-12T18:00:18Z"
+  },
+  "AIOpsAssistantPolicy": {
+    "defaultVersionId": "v15",
+    "createDate": "2024-12-02T16:21:00Z",
+    "updateDate": "2026-02-12T17:57:22Z"
+  },
+  "AIOpsConsoleAdminPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2024-12-02T23:51:00Z",
+    "updateDate": "2026-02-12T17:58:14Z"
+  },
+  "AIOpsOperatorAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2024-12-02T23:51:00Z",
+    "updateDate": "2026-02-12T17:57:25Z"
+  },
+  "AIOpsReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-02T23:51:00Z",
+    "updateDate": "2026-02-12T17:57:11Z"
+  },
+  "APIGatewayServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2017-10-20T17:23:00Z",
+    "updateDate": "2021-07-12T22:24:40Z"
+  },
+  "AWS-SSM-Automation-DiagnosisBucketPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-15T23:31:17Z",
+    "updateDate": "2024-11-15T23:31:17Z"
+  },
+  "AWS-SSM-DiagnosisAutomation-AdministrationRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2024-11-16T00:01:00Z",
+    "updateDate": "2026-08-29T00:47:07Z"
+  },
+  "AWS-SSM-DiagnosisAutomation-ExecutionRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2024-11-16T00:08:00Z",
+    "updateDate": "2026-08-28T21:37:07Z"
+  },
+  "AWS-SSM-DiagnosisAutomation-OperationalAccountAdministrationRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-16T00:11:14Z",
+    "updateDate": "2024-11-16T00:11:14Z"
+  },
+  "AWS-SSM-RemediationAutomation-AdministrationRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-11-16T00:14:00Z",
+    "updateDate": "2026-02-12T17:57:43Z"
+  },
+  "AWS-SSM-RemediationAutomation-ExecutionRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-11-16T00:17:00Z",
+    "updateDate": "2026-02-12T17:58:49Z"
+  },
+  "AWS-SSM-RemediationAutomation-OperationalAccountAdministrationRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-16T00:25:12Z",
+    "updateDate": "2024-11-16T00:25:12Z"
+  },
+  "AWSAccountActivityAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2026-02-20T20:57:12Z"
+  },
+  "AWSAccountManagementFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-30T23:20:37Z",
+    "updateDate": "2021-09-30T23:20:37Z"
+  },
+  "AWSAccountManagementReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-30T23:29:53Z",
+    "updateDate": "2021-09-30T23:29:53Z"
+  },
+  "AWSAccountSettingsManagementRole": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-12-11T17:49:00Z",
+    "updateDate": "2026-09-01T15:17:07Z"
+  },
+  "AWSAccountUsageReportAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:19Z",
+    "updateDate": "2015-02-06T18:41:19Z"
+  },
+  "AWSAgentRegistryServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-06T14:27:00Z",
+    "updateDate": "2026-08-21T16:57:22Z"
+  },
+  "AWSAgentlessDiscoveryService": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-08-02T01:35:00Z",
+    "updateDate": "2020-02-24T23:08:23Z"
+  },
+  "AWSAppConfigServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-05-08T18:42:12Z",
+    "updateDate": "2026-05-08T18:42:12Z"
+  },
+  "AWSAppFabricFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-06-27T19:51:17Z",
+    "updateDate": "2023-06-27T19:51:17Z"
+  },
+  "AWSAppFabricReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-06-27T19:52:02Z",
+    "updateDate": "2023-06-27T19:52:02Z"
+  },
+  "AWSAppFabricServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-06-26T21:07:45Z",
+    "updateDate": "2023-06-26T21:07:45Z"
+  },
+  "AWSAppMeshEnvoyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-07-03T21:29:37Z",
+    "updateDate": "2019-07-03T21:29:37Z"
+  },
+  "AWSAppMeshFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2019-04-16T17:50:00Z",
+    "updateDate": "2021-01-07T19:54:08Z"
+  },
+  "AWSAppMeshPreviewEnvoyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-05T23:32:39Z",
+    "updateDate": "2019-08-05T23:32:39Z"
+  },
+  "AWSAppMeshPreviewServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-06-19T19:07:00Z",
+    "updateDate": "2019-08-21T21:06:29Z"
+  },
+  "AWSAppMeshReadOnly": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-04-16T17:51:00Z",
+    "updateDate": "2021-01-07T19:53:16Z"
+  },
+  "AWSAppMeshServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-06-03T18:30:00Z",
+    "updateDate": "2023-10-10T16:46:37Z"
+  },
+  "AWSAppRunnerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-01-11T04:02:09Z",
+    "updateDate": "2022-01-11T04:02:09Z"
+  },
+  "AWSAppRunnerReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-02-24T21:24:15Z",
+    "updateDate": "2022-02-24T21:24:15Z"
+  },
+  "AWSAppRunnerServicePolicyForECRAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-05-14T19:17:21Z",
+    "updateDate": "2021-05-14T19:17:21Z"
+  },
+  "AWSAppSyncAdministrator": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-03-20T21:20:00Z",
+    "updateDate": "2019-11-04T19:23:49Z"
+  },
+  "AWSAppSyncInvokeFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-03-20T21:21:20Z",
+    "updateDate": "2018-03-20T21:21:20Z"
+  },
+  "AWSAppSyncPushToCloudWatchLogs": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-04-09T19:38:55Z",
+    "updateDate": "2018-04-09T19:38:55Z"
+  },
+  "AWSAppSyncSchemaAuthor": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-03-20T21:21:00Z",
+    "updateDate": "2023-02-01T18:36:20Z"
+  },
+  "AWSAppSyncServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-01-21T19:56:53Z",
+    "updateDate": "2020-01-21T19:56:53Z"
+  },
+  "AWSApplicationAutoScalingCustomResourcePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-06-04T23:22:44Z",
+    "updateDate": "2018-06-04T23:22:44Z"
+  },
+  "AWSApplicationAutoscalingAppStreamFleetPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-10-20T19:04:06Z",
+    "updateDate": "2017-10-20T19:04:06Z"
+  },
+  "AWSApplicationAutoscalingCassandraTablePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-03-18T22:49:23Z",
+    "updateDate": "2020-03-18T22:49:23Z"
+  },
+  "AWSApplicationAutoscalingComprehendEndpointPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-14T18:39:07Z",
+    "updateDate": "2019-11-14T18:39:07Z"
+  },
+  "AWSApplicationAutoscalingDynamoDBTablePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-10-20T21:34:57Z",
+    "updateDate": "2017-10-20T21:34:57Z"
+  },
+  "AWSApplicationAutoscalingEC2SpotFleetRequestPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-10-25T18:23:27Z",
+    "updateDate": "2017-10-25T18:23:27Z"
+  },
+  "AWSApplicationAutoscalingECSServicePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-10-25T23:53:00Z",
+    "updateDate": "2026-05-20T21:27:13Z"
+  },
+  "AWSApplicationAutoscalingEMRInstanceGroupPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-10-26T00:57:39Z",
+    "updateDate": "2017-10-26T00:57:39Z"
+  },
+  "AWSApplicationAutoscalingElastiCacheRGPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-08-17T23:41:00Z",
+    "updateDate": "2025-03-26T17:37:06Z"
+  },
+  "AWSApplicationAutoscalingKafkaClusterPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-24T18:36:01Z",
+    "updateDate": "2020-08-24T18:36:01Z"
+  },
+  "AWSApplicationAutoscalingLambdaConcurrencyPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-10-21T20:04:17Z",
+    "updateDate": "2019-10-21T20:04:17Z"
+  },
+  "AWSApplicationAutoscalingNeptuneClusterPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-02T21:14:55Z",
+    "updateDate": "2021-09-02T21:14:55Z"
+  },
+  "AWSApplicationAutoscalingRDSClusterPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-10-17T17:46:00Z",
+    "updateDate": "2018-08-07T19:14:24Z"
+  },
+  "AWSApplicationAutoscalingSageMakerEndpointPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-02-06T19:58:00Z",
+    "updateDate": "2023-11-13T18:52:34Z"
+  },
+  "AWSApplicationAutoscalingWorkSpacesPoolPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-17T18:39:07Z",
+    "updateDate": "2024-06-17T18:39:07Z"
+  },
+  "AWSApplicationDiscoveryAgentAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-05-11T21:38:00Z",
+    "updateDate": "2020-02-24T22:26:45Z"
+  },
+  "AWSApplicationDiscoveryAgentlessCollectorAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-08-16T21:00:59Z",
+    "updateDate": "2022-08-16T21:00:59Z"
+  },
+  "AWSApplicationDiscoveryServiceFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2016-05-11T21:30:00Z",
+    "updateDate": "2019-06-19T21:21:26Z"
+  },
+  "AWSApplicationMigrationAgentInstallationPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-06-19T07:51:00Z",
+    "updateDate": "2022-09-20T11:21:24Z"
+  },
+  "AWSApplicationMigrationAgentPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-04-07T07:00:00Z",
+    "updateDate": "2022-09-20T11:13:40Z"
+  },
+  "AWSApplicationMigrationAgentPolicy_v2": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-06-06T14:14:38Z",
+    "updateDate": "2022-06-06T14:14:38Z"
+  },
+  "AWSApplicationMigrationConversionServerPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-04-07T06:48:58Z",
+    "updateDate": "2021-04-07T06:48:58Z"
+  },
+  "AWSApplicationMigrationEC2Access": {
+    "defaultVersionId": "v10",
+    "createDate": "2021-04-07T07:05:00Z",
+    "updateDate": "2026-02-12T18:00:41Z"
+  },
+  "AWSApplicationMigrationFSxProxyPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-05-31T13:12:00Z",
+    "updateDate": "2026-08-09T12:17:24Z"
+  },
+  "AWSApplicationMigrationFSxProxyVPCPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-05-31T13:27:13Z",
+    "updateDate": "2026-05-31T13:27:13Z"
+  },
+  "AWSApplicationMigrationFullAccess": {
+    "defaultVersionId": "v14",
+    "createDate": "2021-04-07T06:56:00Z",
+    "updateDate": "2026-08-03T10:57:21Z"
+  },
+  "AWSApplicationMigrationMGHAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-04-07T07:10:01Z",
+    "updateDate": "2021-04-07T07:10:01Z"
+  },
+  "AWSApplicationMigrationNetworkMigrationCustomResource": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-05T11:34:00Z",
+    "updateDate": "2026-02-12T17:58:53Z"
+  },
+  "AWSApplicationMigrationNetworkMigrationMultiAccount": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-11-10T09:04:00Z",
+    "updateDate": "2026-07-30T07:42:10Z"
+  },
+  "AWSApplicationMigrationReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2021-04-07T07:15:00Z",
+    "updateDate": "2026-07-01T14:57:15Z"
+  },
+  "AWSApplicationMigrationReplicationServerPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-04-07T07:21:00Z",
+    "updateDate": "2026-05-31T13:27:26Z"
+  },
+  "AWSApplicationMigrationSSMAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-11-27T09:29:00Z",
+    "updateDate": "2026-02-12T18:00:51Z"
+  },
+  "AWSApplicationMigrationServiceEc2InstancePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-08-22T13:19:00Z",
+    "updateDate": "2024-01-03T14:19:47Z"
+  },
+  "AWSApplicationMigrationServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2021-04-07T06:43:00Z",
+    "updateDate": "2026-07-19T15:12:24Z"
+  },
+  "AWSApplicationMigrationVCenterClientPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-08T12:53:08Z",
+    "updateDate": "2021-11-08T12:53:08Z"
+  },
+  "AWSArtifactAccountSync": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-04-10T23:04:33Z",
+    "updateDate": "2018-04-10T23:04:33Z"
+  },
+  "AWSArtifactAgreementsFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-11-22T19:36:00Z",
+    "updateDate": "2026-02-12T18:02:13Z"
+  },
+  "AWSArtifactAgreementsReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-11-22T19:36:00Z",
+    "updateDate": "2026-02-12T18:00:59Z"
+  },
+  "AWSArtifactComplianceInquiriesFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-06-30T19:27:00Z",
+    "updateDate": "2026-07-23T20:12:25Z"
+  },
+  "AWSArtifactComplianceInquiriesReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-30T19:42:13Z",
+    "updateDate": "2026-06-30T19:42:13Z"
+  },
+  "AWSArtifactReportsReadOnlyAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-01-02T22:42:00Z",
+    "updateDate": "2026-02-12T17:58:35Z"
+  },
+  "AWSArtifactServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-08-21T20:27:31Z",
+    "updateDate": "2023-08-21T20:27:31Z"
+  },
+  "AWSAuditManagerAdministratorAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-12-11T20:02:00Z",
+    "updateDate": "2024-05-15T23:46:15Z"
+  },
+  "AWSAuditManagerServiceRolePolicy": {
+    "defaultVersionId": "v11",
+    "createDate": "2020-12-08T15:12:00Z",
+    "updateDate": "2026-06-02T20:12:13Z"
+  },
+  "AWSAutoScalingPlansEC2AutoScalingPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-08-23T22:46:59Z",
+    "updateDate": "2018-08-23T22:46:59Z"
+  },
+  "AWSBCMDataExportsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-10T17:40:19Z",
+    "updateDate": "2024-06-10T17:40:19Z"
+  },
+  "AWSBackupAccessPointOperatorAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-06T16:12:24Z",
+    "updateDate": "2026-08-06T16:12:24Z"
+  },
+  "AWSBackupAuditAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-08-24T01:02:00Z",
+    "updateDate": "2023-04-10T21:23:31Z"
+  },
+  "AWSBackupDataTransferAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-10T22:48:05Z",
+    "updateDate": "2022-11-10T22:48:05Z"
+  },
+  "AWSBackupFullAccess": {
+    "defaultVersionId": "v30",
+    "createDate": "2019-11-18T22:21:00Z",
+    "updateDate": "2026-02-12T18:02:46Z"
+  },
+  "AWSBackupGatewayServiceRolePolicyForVirtualMachineMetadataSync": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-12-15T19:43:11Z",
+    "updateDate": "2022-12-15T19:43:11Z"
+  },
+  "AWSBackupGuardDutyRolePolicyForScans": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-20T03:34:00Z",
+    "updateDate": "2026-02-12T17:59:22Z"
+  },
+  "AWSBackupOperatorAccess": {
+    "defaultVersionId": "v28",
+    "createDate": "2019-11-18T22:23:00Z",
+    "updateDate": "2026-02-12T17:59:22Z"
+  },
+  "AWSBackupOrganizationAdminAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-06-24T16:23:00Z",
+    "updateDate": "2022-11-18T18:26:40Z"
+  },
+  "AWSBackupRestoreAccessForSAPHANA": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-10T22:43:27Z",
+    "updateDate": "2022-11-10T22:43:27Z"
+  },
+  "AWSBackupSearchOperatorAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-02-27T21:52:00Z",
+    "updateDate": "2026-02-12T18:00:43Z"
+  },
+  "AWSBackupServiceLinkedRolePolicyForBackup": {
+    "defaultVersionId": "v31",
+    "createDate": "2020-06-02T23:08:00Z",
+    "updateDate": "2026-02-12T17:59:36Z"
+  },
+  "AWSBackupServiceLinkedRolePolicyForBackupTest": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-12T17:37:29Z",
+    "updateDate": "2020-05-12T17:37:29Z"
+  },
+  "AWSBackupServiceRolePolicyForBackup": {
+    "defaultVersionId": "v30",
+    "createDate": "2019-01-10T21:01:00Z",
+    "updateDate": "2026-02-23T19:42:11Z"
+  },
+  "AWSBackupServiceRolePolicyForIndexing": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-17T18:37:00Z",
+    "updateDate": "2026-02-12T18:02:44Z"
+  },
+  "AWSBackupServiceRolePolicyForItemRestores": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-17T18:37:00Z",
+    "updateDate": "2026-02-12T18:03:10Z"
+  },
+  "AWSBackupServiceRolePolicyForRestores": {
+    "defaultVersionId": "v36",
+    "createDate": "2019-01-12T00:23:00Z",
+    "updateDate": "2026-08-27T23:57:07Z"
+  },
+  "AWSBackupServiceRolePolicyForS3Backup": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-02-18T17:40:00Z",
+    "updateDate": "2026-08-24T18:17:18Z"
+  },
+  "AWSBackupServiceRolePolicyForS3Restore": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-02-18T17:39:00Z",
+    "updateDate": "2023-02-07T00:06:00Z"
+  },
+  "AWSBackupServiceRolePolicyForScans": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-20T03:34:00Z",
+    "updateDate": "2026-02-12T18:00:45Z"
+  },
+  "AWSBatchFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2016-12-06T19:35:00Z",
+    "updateDate": "2022-10-24T16:09:09Z"
+  },
+  "AWSBatchServiceEventTargetRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-02-28T22:31:13Z",
+    "updateDate": "2018-02-28T22:31:13Z"
+  },
+  "AWSBatchServiceRole": {
+    "defaultVersionId": "v14",
+    "createDate": "2016-12-06T19:36:00Z",
+    "updateDate": "2026-08-25T22:27:28Z"
+  },
+  "AWSBatchServiceRolePolicyForSageMaker": {
+    "defaultVersionId": "v2",
+    "createDate": "2025-07-15T21:37:00Z",
+    "updateDate": "2026-04-16T17:27:13Z"
+  },
+  "AWSBedrockAgentCoreGatewayNetworkServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-28T22:12:08Z",
+    "updateDate": "2026-03-28T22:12:08Z"
+  },
+  "AWSBedrockAgentCoreIdentityNetworkServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-15T00:42:19Z",
+    "updateDate": "2026-04-15T00:42:19Z"
+  },
+  "AWSBedrockAgentCoreRuntimeInstancesServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-05T09:57:23Z",
+    "updateDate": "2026-08-05T09:57:23Z"
+  },
+  "AWSBillingConductorFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2022-04-13T18:02:00Z",
+    "updateDate": "2026-02-12T18:01:18Z"
+  },
+  "AWSBillingConductorReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-04-13T18:02:00Z",
+    "updateDate": "2026-02-12T17:57:37Z"
+  },
+  "AWSBillingReadOnlyAccess": {
+    "defaultVersionId": "v28",
+    "createDate": "2020-08-27T20:08:00Z",
+    "updateDate": "2026-07-30T22:12:29Z"
+  },
+  "AWSBillingServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-09-11T16:19:07Z",
+    "updateDate": "2025-09-11T16:19:07Z"
+  },
+  "AWSBudgetsActionsWithAWSResourceControlAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-10-15T17:19:12Z",
+    "updateDate": "2020-10-15T17:19:12Z"
+  },
+  "AWSBudgetsActions_RolePolicyForResourceAdministrationWithSSM": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-05-25T19:03:00Z",
+    "updateDate": "2026-04-07T19:27:19Z"
+  },
+  "AWSBudgetsReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-10-15T17:18:00Z",
+    "updateDate": "2024-06-17T17:41:25Z"
+  },
+  "AWSBudgetsSpendLimitMemberRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2026-07-18T00:57:00Z",
+    "updateDate": "2026-08-13T20:47:33Z"
+  },
+  "AWSBugBustFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-06-24T07:03:00Z",
+    "updateDate": "2021-07-22T20:04:29Z"
+  },
+  "AWSBugBustPlayerAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-06-24T07:15:00Z",
+    "updateDate": "2021-06-24T07:15:00Z"
+  },
+  "AWSBugBustServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-06-24T06:59:05Z",
+    "updateDate": "2021-06-24T06:59:05Z"
+  },
+  "AWSCertificateManagerFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-01-21T17:02:00Z",
+    "updateDate": "2020-08-17T22:18:28Z"
+  },
+  "AWSCertificateManagerPrivateCAAuditor": {
+    "defaultVersionId": "v4",
+    "createDate": "2018-10-23T16:51:00Z",
+    "updateDate": "2020-08-17T22:54:12Z"
+  },
+  "AWSCertificateManagerPrivateCAFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-10-23T16:54:50Z",
+    "updateDate": "2018-10-23T16:54:50Z"
+  },
+  "AWSCertificateManagerPrivateCAPrivilegedUser": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-06-20T17:43:00Z",
+    "updateDate": "2026-02-12T18:00:06Z"
+  },
+  "AWSCertificateManagerPrivateCAReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-10-23T16:57:00Z",
+    "updateDate": "2020-08-17T22:54:22Z"
+  },
+  "AWSCertificateManagerPrivateCAUser": {
+    "defaultVersionId": "v7",
+    "createDate": "2018-10-23T16:53:00Z",
+    "updateDate": "2026-02-12T17:58:48Z"
+  },
+  "AWSCertificateManagerReadOnly": {
+    "defaultVersionId": "v7",
+    "createDate": "2016-01-21T17:07:00Z",
+    "updateDate": "2026-08-13T18:07:23Z"
+  },
+  "AWSChatbotServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-18T16:39:50Z",
+    "updateDate": "2019-11-18T16:39:50Z"
+  },
+  "AWSCleanRoomsFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-01-12T16:10:00Z",
+    "updateDate": "2024-03-21T15:35:13Z"
+  },
+  "AWSCleanRoomsFullAccessNoQuerying": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-01-12T16:12:00Z",
+    "updateDate": "2026-02-12T17:57:59Z"
+  },
+  "AWSCleanRoomsMLFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-11-29T21:02:00Z",
+    "updateDate": "2026-02-12T18:03:10Z"
+  },
+  "AWSCleanRoomsMLReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-11-29T20:55:00Z",
+    "updateDate": "2026-02-12T18:00:49Z"
+  },
+  "AWSCleanRoomsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-01-12T16:10:48Z",
+    "updateDate": "2023-01-12T16:10:48Z"
+  },
+  "AWSCleanRoomsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-12-15T17:49:09Z",
+    "updateDate": "2025-12-15T17:49:09Z"
+  },
+  "AWSCloud9Administrator": {
+    "defaultVersionId": "v7",
+    "createDate": "2017-11-30T16:17:00Z",
+    "updateDate": "2026-02-12T18:00:39Z"
+  },
+  "AWSCloud9EnvironmentMember": {
+    "defaultVersionId": "v9",
+    "createDate": "2017-11-30T16:18:00Z",
+    "updateDate": "2026-02-12T17:59:00Z"
+  },
+  "AWSCloud9SSMInstanceProfile": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-14T11:40:49Z",
+    "updateDate": "2020-05-14T11:40:49Z"
+  },
+  "AWSCloud9ServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2017-11-30T13:44:00Z",
+    "updateDate": "2026-09-03T23:17:07Z"
+  },
+  "AWSCloud9User": {
+    "defaultVersionId": "v12",
+    "createDate": "2017-11-30T16:16:00Z",
+    "updateDate": "2026-02-12T18:00:52Z"
+  },
+  "AWSCloudFormationFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-07-26T21:50:35Z",
+    "updateDate": "2019-07-26T21:50:35Z"
+  },
+  "AWSCloudFormationReadOnlyAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2026-02-12T18:02:00Z"
+  },
+  "AWSCloudFrontLogger": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-06-12T20:15:00Z",
+    "updateDate": "2019-11-22T19:33:51Z"
+  },
+  "AWSCloudFrontVPCOriginServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-24T17:45:25Z",
+    "updateDate": "2024-10-24T17:45:25Z"
+  },
+  "AWSCloudHSMFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:39:51Z",
+    "updateDate": "2015-02-06T18:39:51Z"
+  },
+  "AWSCloudHSMReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:39:52Z",
+    "updateDate": "2015-02-06T18:39:52Z"
+  },
+  "AWSCloudHSMRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:23Z",
+    "updateDate": "2015-02-06T18:41:23Z"
+  },
+  "AWSCloudMapDiscoverInstanceAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-29T00:02:00Z",
+    "updateDate": "2023-09-20T21:48:09Z"
+  },
+  "AWSCloudMapFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-28T23:57:00Z",
+    "updateDate": "2020-07-29T19:15:35Z"
+  },
+  "AWSCloudMapReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-28T23:45:00Z",
+    "updateDate": "2023-09-20T21:47:45Z"
+  },
+  "AWSCloudMapRegisterInstanceAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-11-29T00:04:00Z",
+    "updateDate": "2023-09-20T21:47:06Z"
+  },
+  "AWSCloudShellFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T18:07:44Z",
+    "updateDate": "2020-12-15T18:07:44Z"
+  },
+  "AWSCloudTrail_FullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-10-08T23:41:00Z",
+    "updateDate": "2021-02-22T19:01:00Z"
+  },
+  "AWSCloudTrail_ReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-06-14T17:19:05Z",
+    "updateDate": "2022-06-14T17:19:05Z"
+  },
+  "AWSCloudWatchAlarms_ActionSSMIncidentsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-04-27T13:30:52Z",
+    "updateDate": "2021-04-27T13:30:52Z"
+  },
+  "AWSCodeArtifactAdminAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-16T23:53:23Z",
+    "updateDate": "2020-06-16T23:53:23Z"
+  },
+  "AWSCodeArtifactReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-25T21:23:52Z",
+    "updateDate": "2020-06-25T21:23:52Z"
+  },
+  "AWSCodeBuildAdminAccess": {
+    "defaultVersionId": "v20",
+    "createDate": "2016-12-01T19:04:00Z",
+    "updateDate": "2026-02-12T18:01:51Z"
+  },
+  "AWSCodeBuildDeveloperAccess": {
+    "defaultVersionId": "v21",
+    "createDate": "2016-12-01T19:02:00Z",
+    "updateDate": "2026-02-12T18:01:34Z"
+  },
+  "AWSCodeBuildReadOnlyAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2016-12-01T19:03:00Z",
+    "updateDate": "2026-02-12T18:02:34Z"
+  },
+  "AWSCodeCommitFullAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2015-07-09T17:02:00Z",
+    "updateDate": "2026-02-12T18:00:23Z"
+  },
+  "AWSCodeCommitPowerUser": {
+    "defaultVersionId": "v18",
+    "createDate": "2015-07-09T17:06:00Z",
+    "updateDate": "2026-02-12T17:57:24Z"
+  },
+  "AWSCodeCommitReadOnly": {
+    "defaultVersionId": "v14",
+    "createDate": "2015-07-09T17:05:00Z",
+    "updateDate": "2026-02-12T18:00:25Z"
+  },
+  "AWSCodeDeployDeployerAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-05-19T18:18:00Z",
+    "updateDate": "2026-02-12T18:02:10Z"
+  },
+  "AWSCodeDeployFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-05-19T18:13:00Z",
+    "updateDate": "2026-02-12T17:58:37Z"
+  },
+  "AWSCodeDeployReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-05-19T18:21:00Z",
+    "updateDate": "2026-02-12T17:57:13Z"
+  },
+  "AWSCodeDeployRole": {
+    "defaultVersionId": "v11",
+    "createDate": "2015-05-04T18:05:00Z",
+    "updateDate": "2023-08-16T20:38:58Z"
+  },
+  "AWSCodeDeployRoleForCloudFormation": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-19T17:12:52Z",
+    "updateDate": "2020-05-19T17:12:52Z"
+  },
+  "AWSCodeDeployRoleForECS": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-11-27T20:40:00Z",
+    "updateDate": "2019-09-23T22:37:46Z"
+  },
+  "AWSCodeDeployRoleForECSLimited": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-11-27T20:42:00Z",
+    "updateDate": "2019-09-23T22:10:29Z"
+  },
+  "AWSCodeDeployRoleForLambda": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-11-28T14:05:00Z",
+    "updateDate": "2019-12-03T19:53:10Z"
+  },
+  "AWSCodeDeployRoleForLambdaLimited": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-17T17:14:14Z",
+    "updateDate": "2020-08-17T17:14:14Z"
+  },
+  "AWSCodePipelineApproverAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-07-28T18:59:00Z",
+    "updateDate": "2017-08-02T17:24:58Z"
+  },
+  "AWSCodePipelineCustomActionAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-07-09T17:02:54Z",
+    "updateDate": "2015-07-09T17:02:54Z"
+  },
+  "AWSCodePipeline_FullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-08-03T22:38:00Z",
+    "updateDate": "2024-03-14T17:06:23Z"
+  },
+  "AWSCodePipeline_ReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-03T22:25:17Z",
+    "updateDate": "2020-08-03T22:25:17Z"
+  },
+  "AWSCodeStarFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-04-19T16:23:00Z",
+    "updateDate": "2023-03-28T00:06:28Z"
+  },
+  "AWSCodeStarNotificationsServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-11-05T16:10:00Z",
+    "updateDate": "2020-03-19T16:01:55Z"
+  },
+  "AWSCodeStarServiceRole": {
+    "defaultVersionId": "v12",
+    "createDate": "2017-04-19T15:20:00Z",
+    "updateDate": "2021-09-20T19:11:03Z"
+  },
+  "AWSCompromisedKeyQuarantine": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-11T18:04:13Z",
+    "updateDate": "2020-08-11T18:04:13Z"
+  },
+  "AWSCompromisedKeyQuarantineV2": {
+    "defaultVersionId": "v5",
+    "createDate": "2021-04-21T22:30:00Z",
+    "updateDate": "2024-10-02T16:41:39Z"
+  },
+  "AWSCompromisedKeyQuarantineV3": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-08-21T17:36:00Z",
+    "updateDate": "2026-03-16T16:27:14Z"
+  },
+  "AWSConfigMultiAccountSetupPolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-06-17T18:03:00Z",
+    "updateDate": "2023-02-24T01:39:49Z"
+  },
+  "AWSConfigRemediationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-06-18T21:21:35Z",
+    "updateDate": "2019-06-18T21:21:35Z"
+  },
+  "AWSConfigRole": {
+    "defaultVersionId": "v42",
+    "updateDate": "2022-02-10T18:33:55Z"
+  },
+  "AWSConfigRoleForOrganizations": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-03-19T22:53:00Z",
+    "updateDate": "2020-11-24T20:19:13Z"
+  },
+  "AWSConfigRulesExecutionRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-03-25T17:59:00Z",
+    "updateDate": "2019-05-13T21:33:30Z"
+  },
+  "AWSConfigServiceRolePolicy": {
+    "defaultVersionId": "v95",
+    "createDate": "2018-05-30T23:31:00Z",
+    "updateDate": "2026-08-27T22:07:08Z"
+  },
+  "AWSConfigThirdPartyServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-22T17:57:23Z",
+    "updateDate": "2026-06-22T17:57:23Z"
+  },
+  "AWSConfigUserAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-18T19:38:00Z",
+    "updateDate": "2019-03-18T20:27:47Z"
+  },
+  "AWSConnector": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-11T17:14:00Z",
+    "updateDate": "2015-09-28T19:50:38Z"
+  },
+  "AWSControlTowerAccountServiceRolePolicy": {
+    "defaultVersionId": "v11",
+    "createDate": "2023-06-05T22:04:00Z",
+    "updateDate": "2026-05-20T19:27:15Z"
+  },
+  "AWSControlTowerCloudTrailRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-05T21:19:00Z",
+    "updateDate": "2026-02-12T18:02:33Z"
+  },
+  "AWSControlTowerIdentityCenterManagementPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-10-03T18:34:00Z",
+    "updateDate": "2026-02-12T18:00:23Z"
+  },
+  "AWSControlTowerServiceRolePolicy": {
+    "defaultVersionId": "v21",
+    "createDate": "2019-05-03T18:19:00Z",
+    "updateDate": "2026-05-20T20:12:23Z"
+  },
+  "AWSCostAndUsageReportAutomationPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-01T21:27:29Z",
+    "updateDate": "2021-11-01T21:27:29Z"
+  },
+  "AWSDMSFleetAdvisorServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-06T09:10:42Z",
+    "updateDate": "2023-03-06T09:10:42Z"
+  },
+  "AWSDMSServerlessServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2023-05-18T20:28:00Z",
+    "updateDate": "2026-02-12T17:58:40Z"
+  },
+  "AWSDataExchangeDataGrantOwnerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-24T14:43:43Z",
+    "updateDate": "2024-10-24T14:43:43Z"
+  },
+  "AWSDataExchangeDataGrantReceiverFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-24T14:45:58Z",
+    "updateDate": "2024-10-24T14:45:58Z"
+  },
+  "AWSDataExchangeFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2019-11-13T19:27:00Z",
+    "updateDate": "2024-06-24T19:54:18Z"
+  },
+  "AWSDataExchangeProviderFullAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2019-11-13T19:27:00Z",
+    "updateDate": "2024-08-15T17:32:54Z"
+  },
+  "AWSDataExchangeReadOnly": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-11-13T19:27:00Z",
+    "updateDate": "2024-10-24T14:40:40Z"
+  },
+  "AWSDataExchangeServiceRolePolicyForLicenseManagement": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-10T14:54:27Z",
+    "updateDate": "2024-10-10T14:54:27Z"
+  },
+  "AWSDataExchangeServiceRolePolicyForOrganizationDiscovery": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-10T14:33:13Z",
+    "updateDate": "2024-10-10T14:33:13Z"
+  },
+  "AWSDataExchangeSubscriberFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2019-11-13T19:27:00Z",
+    "updateDate": "2024-05-21T17:36:35Z"
+  },
+  "AWSDataLifecycleManagerSSMFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-10-31T20:29:00Z",
+    "updateDate": "2023-11-16T22:31:54Z"
+  },
+  "AWSDataLifecycleManagerServiceRole": {
+    "defaultVersionId": "v10",
+    "createDate": "2018-07-06T19:34:00Z",
+    "updateDate": "2026-02-12T17:59:28Z"
+  },
+  "AWSDataLifecycleManagerServiceRoleForAMIManagement": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-10-21T19:39:00Z",
+    "updateDate": "2021-08-19T17:03:44Z"
+  },
+  "AWSDataPipeline_FullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-01-19T23:14:00Z",
+    "updateDate": "2017-08-17T18:48:39Z"
+  },
+  "AWSDataPipeline_PowerUser": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-01-19T23:16:00Z",
+    "updateDate": "2017-08-17T18:49:42Z"
+  },
+  "AWSDataSyncDiscoveryServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-20T22:19:51Z",
+    "updateDate": "2023-03-20T22:19:51Z"
+  },
+  "AWSDataSyncFullAccess": {
+    "defaultVersionId": "v16",
+    "createDate": "2019-01-18T19:40:00Z",
+    "updateDate": "2026-02-12T18:03:11Z"
+  },
+  "AWSDataSyncReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-01-18T19:18:00Z",
+    "updateDate": "2020-06-30T17:59:22Z"
+  },
+  "AWSDataSyncServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-10-09T17:45:00Z",
+    "updateDate": "2025-04-15T16:37:06Z"
+  },
+  "AWSDeadlineCloud-FleetWorker": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-04-01T17:21:47Z",
+    "updateDate": "2024-04-01T17:21:47Z"
+  },
+  "AWSDeadlineCloud-UserAccessFarms": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-04-01T16:54:00Z",
+    "updateDate": "2026-05-29T20:27:22Z"
+  },
+  "AWSDeadlineCloud-UserAccessFleets": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-04-01T17:01:00Z",
+    "updateDate": "2026-05-29T21:27:30Z"
+  },
+  "AWSDeadlineCloud-UserAccessJobs": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-04-01T17:05:00Z",
+    "updateDate": "2024-10-07T18:24:52Z"
+  },
+  "AWSDeadlineCloud-UserAccessQueues": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-04-01T17:10:00Z",
+    "updateDate": "2024-10-07T18:25:13Z"
+  },
+  "AWSDeadlineCloud-WorkerHost": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-04-01T17:28:00Z",
+    "updateDate": "2026-02-12T17:58:06Z"
+  },
+  "AWSDeepLensLambdaFunctionAccessPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-11-29T15:47:00Z",
+    "updateDate": "2019-06-11T23:11:55Z"
+  },
+  "AWSDeepLensServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2017-11-29T15:46:00Z",
+    "updateDate": "2019-09-25T19:25:06Z"
+  },
+  "AWSDeepRacerAccountAdminAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-28T01:27:13Z",
+    "updateDate": "2021-10-28T01:27:13Z"
+  },
+  "AWSDeepRacerCloudFormationAccessPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-02-28T21:59:00Z",
+    "updateDate": "2019-06-14T17:02:04Z"
+  },
+  "AWSDeepRacerDefaultMultiUserAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-28T01:27:13Z",
+    "updateDate": "2021-10-28T01:27:13Z"
+  },
+  "AWSDeepRacerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-10-05T22:03:10Z",
+    "updateDate": "2020-10-05T22:03:10Z"
+  },
+  "AWSDeepRacerRoboMakerAccessPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-02-28T21:59:58Z",
+    "updateDate": "2019-02-28T21:59:58Z"
+  },
+  "AWSDeepRacerServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-02-28T21:58:00Z",
+    "updateDate": "2019-06-12T20:55:34Z"
+  },
+  "AWSDenyAll": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-05-01T22:36:00Z",
+    "updateDate": "2023-12-18T16:42:05Z"
+  },
+  "AWSDeviceFarmFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-07-13T16:37:38Z",
+    "updateDate": "2015-07-13T16:37:38Z"
+  },
+  "AWSDeviceFarmServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-09-20T21:02:28Z",
+    "updateDate": "2022-09-20T21:02:28Z"
+  },
+  "AWSDeviceFarmTestGridServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-05-26T22:01:35Z",
+    "updateDate": "2021-05-26T22:01:35Z"
+  },
+  "AWSDirectConnectFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2019-04-30T15:29:29Z"
+  },
+  "AWSDirectConnectReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2020-05-18T18:48:22Z"
+  },
+  "AWSDirectConnectServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-01-14T18:35:27Z",
+    "updateDate": "2021-01-14T18:35:27Z"
+  },
+  "AWSDirectoryServiceDataFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-09-18T21:45:17Z",
+    "updateDate": "2024-09-18T21:45:17Z"
+  },
+  "AWSDirectoryServiceDataReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-09-18T22:00:34Z",
+    "updateDate": "2024-09-18T22:00:34Z"
+  },
+  "AWSDirectoryServiceFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2024-04-02T20:38:17Z"
+  },
+  "AWSDirectoryServiceReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2018-09-25T21:54:01Z"
+  },
+  "AWSDirectoryServiceServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-07-11T00:22:07Z",
+    "updateDate": "2025-07-11T00:22:07Z"
+  },
+  "AWSDiscoveryContinuousExportFirehosePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-08-09T18:29:00Z",
+    "updateDate": "2021-06-08T17:32:46Z"
+  },
+  "AWSEC2CapacityManagerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-10-09T22:04:07Z",
+    "updateDate": "2025-10-09T22:04:07Z"
+  },
+  "AWSEC2CapacityReservationFleetRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-09-29T14:43:00Z",
+    "updateDate": "2025-03-03T23:22:06Z"
+  },
+  "AWSEC2FleetServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-03-21T00:08:00Z",
+    "updateDate": "2020-05-04T20:10:31Z"
+  },
+  "AWSEC2SpotFleetServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-10-23T19:13:00Z",
+    "updateDate": "2020-03-16T19:16:21Z"
+  },
+  "AWSEC2SpotServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-09-18T18:51:00Z",
+    "updateDate": "2018-12-12T00:13:51Z"
+  },
+  "AWSEC2SqlHaInstancePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-13T01:49:00Z",
+    "updateDate": "2026-02-12T18:01:26Z"
+  },
+  "AWSEC2SqlHaServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-11-13T01:34:10Z",
+    "updateDate": "2025-11-13T01:34:10Z"
+  },
+  "AWSEC2VssRestorePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-25T23:12:16Z",
+    "updateDate": "2026-03-25T23:12:16Z"
+  },
+  "AWSEC2VssSnapshotPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-03-27T16:32:00Z",
+    "updateDate": "2024-11-20T17:44:08Z"
+  },
+  "AWSECRPullThroughCache_ServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-11-26T21:51:00Z",
+    "updateDate": "2026-05-12T18:12:08Z"
+  },
+  "AWSElasticBeanstalkCustomPlatformforEC2Role": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-02-21T22:50:30Z",
+    "updateDate": "2017-02-21T22:50:30Z"
+  },
+  "AWSElasticBeanstalkEKSImageBuild": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-02T21:27:26Z",
+    "updateDate": "2026-07-02T21:27:26Z"
+  },
+  "AWSElasticBeanstalkEKSObservability": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-02T21:27:19Z",
+    "updateDate": "2026-07-02T21:27:19Z"
+  },
+  "AWSElasticBeanstalkEKSTagging": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-02T21:27:19Z",
+    "updateDate": "2026-07-02T21:27:19Z"
+  },
+  "AWSElasticBeanstalkEnhancedHealth": {
+    "defaultVersionId": "v4",
+    "createDate": "2016-02-08T23:17:00Z",
+    "updateDate": "2018-04-09T22:12:53Z"
+  },
+  "AWSElasticBeanstalkMaintenance": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-01-11T23:22:00Z",
+    "updateDate": "2024-04-29T21:48:04Z"
+  },
+  "AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2021-03-03T22:18:00Z",
+    "updateDate": "2026-02-12T17:58:35Z"
+  },
+  "AWSElasticBeanstalkManagedUpdatesServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2019-11-21T22:35:00Z",
+    "updateDate": "2026-03-13T16:12:13Z"
+  },
+  "AWSElasticBeanstalkMulticontainerDocker": {
+    "defaultVersionId": "v5",
+    "createDate": "2016-02-08T23:15:00Z",
+    "updateDate": "2026-04-29T19:27:11Z"
+  },
+  "AWSElasticBeanstalkReadOnly": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-01-22T19:02:00Z",
+    "updateDate": "2026-05-19T13:27:10Z"
+  },
+  "AWSElasticBeanstalkRoleCWL": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-05T21:49:06Z",
+    "updateDate": "2020-06-05T21:49:06Z"
+  },
+  "AWSElasticBeanstalkRoleCore": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-06-05T21:48:00Z",
+    "updateDate": "2024-04-30T00:01:53Z"
+  },
+  "AWSElasticBeanstalkRoleECS": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-06-05T21:47:00Z",
+    "updateDate": "2023-03-23T22:43:56Z"
+  },
+  "AWSElasticBeanstalkRoleRDS": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-05T21:46:55Z",
+    "updateDate": "2020-06-05T21:46:55Z"
+  },
+  "AWSElasticBeanstalkRoleSNS": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-05T21:46:22Z",
+    "updateDate": "2020-06-05T21:46:22Z"
+  },
+  "AWSElasticBeanstalkRoleWorkerTier": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-05T21:43:37Z",
+    "updateDate": "2020-06-05T21:43:37Z"
+  },
+  "AWSElasticBeanstalkService": {
+    "defaultVersionId": "v17",
+    "createDate": "2016-04-11T20:27:00Z",
+    "updateDate": "2023-05-10T19:29:34Z"
+  },
+  "AWSElasticBeanstalkServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2017-09-13T23:46:00Z",
+    "updateDate": "2026-08-18T17:17:24Z"
+  },
+  "AWSElasticBeanstalkWebTier": {
+    "defaultVersionId": "v9",
+    "createDate": "2016-02-08T23:08:00Z",
+    "updateDate": "2026-04-29T19:27:16Z"
+  },
+  "AWSElasticBeanstalkWorkerTier": {
+    "defaultVersionId": "v8",
+    "createDate": "2016-02-08T23:12:00Z",
+    "updateDate": "2026-04-29T19:27:06Z"
+  },
+  "AWSElasticDisasterRecoveryAgentInstallationPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2021-11-17T10:37:00Z",
+    "updateDate": "2023-11-27T12:38:51Z"
+  },
+  "AWSElasticDisasterRecoveryAgentPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-17T10:32:00Z",
+    "updateDate": "2023-11-27T13:44:15Z"
+  },
+  "AWSElasticDisasterRecoveryConsoleFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2021-11-17T10:46:00Z",
+    "updateDate": "2026-02-12T17:57:43Z"
+  },
+  "AWSElasticDisasterRecoveryConsoleFullAccess_v2": {
+    "defaultVersionId": "v10",
+    "createDate": "2023-11-27T13:35:00Z",
+    "updateDate": "2026-06-18T22:57:18Z"
+  },
+  "AWSElasticDisasterRecoveryConversionServerPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-11-17T13:42:00Z",
+    "updateDate": "2023-11-27T13:13:38Z"
+  },
+  "AWSElasticDisasterRecoveryCrossAccountReplicationPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-05-14T07:16:00Z",
+    "updateDate": "2024-01-17T13:19:58Z"
+  },
+  "AWSElasticDisasterRecoveryEc2InstancePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-05-26T12:30:00Z",
+    "updateDate": "2023-11-27T13:39:44Z"
+  },
+  "AWSElasticDisasterRecoveryFailbackInstallationPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-17T11:02:00Z",
+    "updateDate": "2023-11-27T13:43:08Z"
+  },
+  "AWSElasticDisasterRecoveryFailbackPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-17T10:41:00Z",
+    "updateDate": "2026-07-22T18:42:25Z"
+  },
+  "AWSElasticDisasterRecoveryLaunchActionsPolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-09-13T07:38:00Z",
+    "updateDate": "2026-06-18T22:57:16Z"
+  },
+  "AWSElasticDisasterRecoveryNetworkReplicationPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-06-11T12:36:00Z",
+    "updateDate": "2024-01-02T13:25:23Z"
+  },
+  "AWSElasticDisasterRecoveryReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2021-11-17T10:50:00Z",
+    "updateDate": "2026-08-18T14:47:15Z"
+  },
+  "AWSElasticDisasterRecoveryRecoveryInstancePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-11-17T10:20:00Z",
+    "updateDate": "2023-11-27T13:11:08Z"
+  },
+  "AWSElasticDisasterRecoveryReplicationServerPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-17T13:34:00Z",
+    "updateDate": "2023-11-27T13:28:14Z"
+  },
+  "AWSElasticDisasterRecoveryServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2021-11-17T10:56:00Z",
+    "updateDate": "2025-01-05T14:07:06Z"
+  },
+  "AWSElasticDisasterRecoveryStagingAccountPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-05-26T09:49:00Z",
+    "updateDate": "2023-11-27T13:07:49Z"
+  },
+  "AWSElasticDisasterRecoveryStagingAccountPolicy_v2": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-01-05T12:11:00Z",
+    "updateDate": "2023-11-27T13:32:09Z"
+  },
+  "AWSElasticLoadBalancingClassicServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-09-19T22:36:00Z",
+    "updateDate": "2019-10-07T23:04:27Z"
+  },
+  "AWSElasticLoadBalancingServiceRolePolicy": {
+    "defaultVersionId": "v14",
+    "createDate": "2017-09-19T22:19:00Z",
+    "updateDate": "2026-02-12T17:58:08Z"
+  },
+  "AWSElementalMediaConnectCreateBridge": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-19T16:57:15Z",
+    "updateDate": "2026-03-19T16:57:15Z"
+  },
+  "AWSElementalMediaConnectCreateFlow": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-19T16:57:07Z",
+    "updateDate": "2026-03-19T16:57:07Z"
+  },
+  "AWSElementalMediaConnectDeleteBridge": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-19T19:57:17Z",
+    "updateDate": "2026-03-19T19:57:17Z"
+  },
+  "AWSElementalMediaConnectDeleteFlow": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-19T19:57:09Z",
+    "updateDate": "2026-03-19T19:57:09Z"
+  },
+  "AWSElementalMediaConnectFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-12T20:07:00Z",
+    "updateDate": "2026-02-12T18:03:12Z"
+  },
+  "AWSElementalMediaConnectReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-12T20:07:00Z",
+    "updateDate": "2026-02-12T17:58:48Z"
+  },
+  "AWSElementalMediaConvertFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-06-25T19:25:00Z",
+    "updateDate": "2019-06-10T22:52:25Z"
+  },
+  "AWSElementalMediaConvertReadOnly": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-06-25T19:25:00Z",
+    "updateDate": "2019-06-10T22:52:18Z"
+  },
+  "AWSElementalMediaLiveFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-07-08T17:07:14Z",
+    "updateDate": "2020-07-08T17:07:14Z"
+  },
+  "AWSElementalMediaLiveReadOnly": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-07-08T16:38:00Z",
+    "updateDate": "2024-07-22T17:08:46Z"
+  },
+  "AWSElementalMediaPackageFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-12-29T23:39:52Z",
+    "updateDate": "2017-12-29T23:39:52Z"
+  },
+  "AWSElementalMediaPackageReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-12-30T00:04:29Z",
+    "updateDate": "2017-12-30T00:04:29Z"
+  },
+  "AWSElementalMediaPackageV2FullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-07-25T20:29:37Z",
+    "updateDate": "2023-07-25T20:29:37Z"
+  },
+  "AWSElementalMediaPackageV2ReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-07-25T20:31:25Z",
+    "updateDate": "2023-07-25T20:31:25Z"
+  },
+  "AWSElementalMediaStoreFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-03-05T23:15:31Z",
+    "updateDate": "2018-03-05T23:15:31Z"
+  },
+  "AWSElementalMediaStoreReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-03-08T19:48:22Z",
+    "updateDate": "2018-03-08T19:48:22Z"
+  },
+  "AWSElementalMediaTailorFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-23T00:04:39Z",
+    "updateDate": "2021-11-23T00:04:39Z"
+  },
+  "AWSElementalMediaTailorReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-23T00:05:01Z",
+    "updateDate": "2021-11-23T00:05:01Z"
+  },
+  "AWSEnhancedClassicNetworkingMangementPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-09-20T17:29:09Z",
+    "updateDate": "2017-09-20T17:29:09Z"
+  },
+  "AWSEntityResolutionConsoleFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2023-08-17T17:54:00Z",
+    "updateDate": "2026-02-12T18:02:20Z"
+  },
+  "AWSEntityResolutionConsoleReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-08-17T18:18:36Z",
+    "updateDate": "2023-08-17T18:18:36Z"
+  },
+  "AWSFMAdminFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-05-09T18:06:00Z",
+    "updateDate": "2022-10-20T23:39:06Z"
+  },
+  "AWSFMAdminReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-05-09T20:07:00Z",
+    "updateDate": "2022-10-31T22:42:13Z"
+  },
+  "AWSFMMemberReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-05-09T21:05:29Z",
+    "updateDate": "2018-05-09T21:05:29Z"
+  },
+  "AWSFaultInjectionSimulatorEC2Access": {
+    "defaultVersionId": "v10",
+    "createDate": "2022-10-26T20:39:00Z",
+    "updateDate": "2026-02-12T17:59:38Z"
+  },
+  "AWSFaultInjectionSimulatorECSAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2022-10-26T20:37:00Z",
+    "updateDate": "2026-02-12T18:02:55Z"
+  },
+  "AWSFaultInjectionSimulatorEKSAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2022-10-26T20:34:00Z",
+    "updateDate": "2026-02-12T17:58:33Z"
+  },
+  "AWSFaultInjectionSimulatorNetworkAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-10-26T20:32:00Z",
+    "updateDate": "2026-02-12T17:58:26Z"
+  },
+  "AWSFaultInjectionSimulatorRDSAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-10-26T20:30:00Z",
+    "updateDate": "2026-02-12T18:00:17Z"
+  },
+  "AWSFaultInjectionSimulatorSSMAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2022-10-26T15:33:00Z",
+    "updateDate": "2026-02-12T17:58:33Z"
+  },
+  "AWSFinSpaceServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-05-12T16:42:00Z",
+    "updateDate": "2023-12-01T21:05:00Z"
+  },
+  "AWSForWordPressPluginPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-10-30T00:27:00Z",
+    "updateDate": "2026-09-03T20:17:07Z"
+  },
+  "AWSGitSyncServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-11-16T17:05:00Z",
+    "updateDate": "2024-04-26T18:12:31Z"
+  },
+  "AWSGlobalAcceleratorSLRPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2019-04-05T19:39:00Z",
+    "updateDate": "2024-10-29T18:23:36Z"
+  },
+  "AWSGlueConsoleFullAccess": {
+    "defaultVersionId": "v14",
+    "createDate": "2017-08-14T13:37:00Z",
+    "updateDate": "2023-07-14T14:37:54Z"
+  },
+  "AWSGlueConsoleSageMakerNotebookFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-10-05T17:52:00Z",
+    "updateDate": "2021-07-15T15:24:19Z"
+  },
+  "AWSGlueDataBrewServiceRole": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-12-04T21:26:00Z",
+    "updateDate": "2024-03-20T23:28:52Z"
+  },
+  "AWSGlueSchemaRegistryFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-20T00:19:00Z",
+    "updateDate": "2020-11-20T00:19:00Z"
+  },
+  "AWSGlueSchemaRegistryReadonlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-20T00:20:06Z",
+    "updateDate": "2020-11-20T00:20:06Z"
+  },
+  "AWSGlueServiceNotebookRole": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-08-14T13:37:00Z",
+    "updateDate": "2023-10-09T15:59:41Z"
+  },
+  "AWSGlueServiceRole": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-08-14T13:37:00Z",
+    "updateDate": "2023-09-11T16:39:47Z"
+  },
+  "AWSGrafanaAccountAdministrator": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-02-23T00:20:00Z",
+    "updateDate": "2022-02-15T22:36:18Z"
+  },
+  "AWSGrafanaConsoleReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-02-23T00:10:00Z",
+    "updateDate": "2022-02-15T22:30:54Z"
+  },
+  "AWSGrafanaWorkspacePermissionManagement": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-02-23T00:15:00Z",
+    "updateDate": "2023-03-15T22:17:26Z"
+  },
+  "AWSGrafanaWorkspacePermissionManagementV2": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-01-05T18:39:46Z",
+    "updateDate": "2024-01-05T18:39:46Z"
+  },
+  "AWSGreengrassFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-05-03T00:47:37Z",
+    "updateDate": "2017-05-03T00:47:37Z"
+  },
+  "AWSGreengrassReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-10-30T16:01:43Z",
+    "updateDate": "2018-10-30T16:01:43Z"
+  },
+  "AWSGreengrassResourceAccessRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-02-14T21:17:00Z",
+    "updateDate": "2018-11-14T00:35:02Z"
+  },
+  "AWSGroundStationAgentInstancePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-03-29T15:23:00Z",
+    "updateDate": "2026-02-12T18:02:36Z"
+  },
+  "AWSHealthFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-12-06T12:30:00Z",
+    "updateDate": "2020-11-16T18:11:34Z"
+  },
+  "AWSHealthImagingFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-07-25T23:39:40Z",
+    "updateDate": "2023-07-25T23:39:40Z"
+  },
+  "AWSHealthImagingReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-07-25T23:40:00Z",
+    "updateDate": "2023-08-01T15:18:49Z"
+  },
+  "AWSHealthImagingServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-01-30T18:34:13Z",
+    "updateDate": "2026-01-30T18:34:13Z"
+  },
+  "AWSHealthOmicsServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-04T22:57:11Z",
+    "updateDate": "2026-03-04T22:57:11Z"
+  },
+  "AWSHealth_EventProcessorServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-01-13T19:24:56Z",
+    "updateDate": "2023-01-13T19:24:56Z"
+  },
+  "AWSIAMIdentityCenterAllowListForIdentityContext": {
+    "defaultVersionId": "v12",
+    "createDate": "2023-11-08T15:21:00Z",
+    "updateDate": "2024-10-01T14:19:12Z"
+  },
+  "AWSIAMRoleManagerServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-07-15T23:57:00Z",
+    "updateDate": "2026-08-05T19:42:25Z"
+  },
+  "AWSIPAMServiceRolePolicy": {
+    "defaultVersionId": "v11",
+    "createDate": "2021-11-30T19:08:00Z",
+    "updateDate": "2026-02-12T17:59:10Z"
+  },
+  "AWSIQContractServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-22T19:28:39Z",
+    "updateDate": "2019-08-22T19:28:39Z"
+  },
+  "AWSIQFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-04-04T23:13:00Z",
+    "updateDate": "2019-09-25T20:22:34Z"
+  },
+  "AWSIQPermissionServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-22T19:36:29Z",
+    "updateDate": "2019-08-22T19:36:29Z"
+  },
+  "AWSIdentityCenterExternalManagementPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-11-22T00:34:00Z",
+    "updateDate": "2026-02-12T17:57:38Z"
+  },
+  "AWSIdentitySyncFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-03-23T23:29:33Z",
+    "updateDate": "2022-03-23T23:29:33Z"
+  },
+  "AWSIdentitySyncReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-03-23T23:29:52Z",
+    "updateDate": "2022-03-23T23:29:52Z"
+  },
+  "AWSImageBuilderFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-12-20T18:25:00Z",
+    "updateDate": "2021-04-13T17:33:42Z"
+  },
+  "AWSImageBuilderReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-19T22:29:23Z",
+    "updateDate": "2019-12-19T22:29:23Z"
+  },
+  "AWSImportExportFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:43Z",
+    "updateDate": "2015-02-06T18:40:43Z"
+  },
+  "AWSImportExportReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:42Z",
+    "updateDate": "2015-02-06T18:40:42Z"
+  },
+  "AWSIncidentManagerIncidentAccessServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-11-13T00:01:00Z",
+    "updateDate": "2024-02-20T23:02:11Z"
+  },
+  "AWSIncidentManagerResolverAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-05-10T06:12:00Z",
+    "updateDate": "2026-02-12T18:01:23Z"
+  },
+  "AWSIncidentManagerServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-05-10T03:34:00Z",
+    "updateDate": "2025-01-28T02:52:06Z"
+  },
+  "AWSIoTAnalyticsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-06-18T23:02:45Z",
+    "updateDate": "2018-06-18T23:02:45Z"
+  },
+  "AWSIoTAnalyticsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-06-18T21:37:49Z",
+    "updateDate": "2018-06-18T21:37:49Z"
+  },
+  "AWSIoTConfigAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2015-10-27T21:52:00Z",
+    "updateDate": "2019-09-27T20:48:00Z"
+  },
+  "AWSIoTConfigReadOnlyAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2015-10-27T21:52:00Z",
+    "updateDate": "2019-09-27T20:52:40Z"
+  },
+  "AWSIoTDataAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-10-27T21:51:00Z",
+    "updateDate": "2021-06-23T21:34:47Z"
+  },
+  "AWSIoTDeviceDefenderAddThingsToThingGroupMitigationAction": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-07T17:55:37Z",
+    "updateDate": "2019-08-07T17:55:37Z"
+  },
+  "AWSIoTDeviceDefenderAudit": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-07-18T21:17:00Z",
+    "updateDate": "2019-11-25T23:52:43Z"
+  },
+  "AWSIoTDeviceDefenderEnableIoTLoggingMitigationAction": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-07T17:04:07Z",
+    "updateDate": "2019-08-07T17:04:07Z"
+  },
+  "AWSIoTDeviceDefenderPublishFindingsToSNSMitigationAction": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-07T17:04:37Z",
+    "updateDate": "2019-08-07T17:04:37Z"
+  },
+  "AWSIoTDeviceDefenderReplaceDefaultPolicyMitigationAction": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-07T17:04:57Z",
+    "updateDate": "2019-08-07T17:04:57Z"
+  },
+  "AWSIoTDeviceDefenderUpdateCACertMitigationAction": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-07T17:05:49Z",
+    "updateDate": "2019-08-07T17:05:49Z"
+  },
+  "AWSIoTDeviceDefenderUpdateDeviceCertMitigationAction": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-08-07T17:06:00Z",
+    "updateDate": "2019-08-07T17:06:00Z"
+  },
+  "AWSIoTDeviceTesterForFreeRTOSFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2020-02-12T20:33:00Z",
+    "updateDate": "2023-08-10T20:30:07Z"
+  },
+  "AWSIoTDeviceTesterForGreengrassFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-02-20T21:21:00Z",
+    "updateDate": "2020-06-25T17:01:56Z"
+  },
+  "AWSIoTEventsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-10T22:51:57Z",
+    "updateDate": "2019-01-10T22:51:57Z"
+  },
+  "AWSIoTEventsReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-01-10T22:50:00Z",
+    "updateDate": "2019-09-23T17:22:04Z"
+  },
+  "AWSIoTFleetHubFederationAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2020-12-15T08:08:00Z",
+    "updateDate": "2022-04-04T18:03:01Z"
+  },
+  "AWSIoTFleetwiseServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-09-21T23:27:00Z",
+    "updateDate": "2025-10-16T04:04:07Z"
+  },
+  "AWSIoTFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-10-08T15:19:00Z",
+    "updateDate": "2022-05-19T21:39:11Z"
+  },
+  "AWSIoTLogging": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-10-08T15:17:25Z",
+    "updateDate": "2015-10-08T15:17:25Z"
+  },
+  "AWSIoTManagedIntegrationsFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-03-05T19:22:00Z",
+    "updateDate": "2026-02-12T18:00:12Z"
+  },
+  "AWSIoTManagedIntegrationsRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-03-05T21:22:06Z",
+    "updateDate": "2025-03-05T21:22:06Z"
+  },
+  "AWSIoTOTAUpdate": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-12-20T20:36:53Z",
+    "updateDate": "2017-12-20T20:36:53Z"
+  },
+  "AWSIoTRuleActions": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-10-08T15:14:00Z",
+    "updateDate": "2018-01-16T19:28:19Z"
+  },
+  "AWSIoTSiteWiseConsoleFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-05-31T21:37:49Z",
+    "updateDate": "2019-05-31T21:37:49Z"
+  },
+  "AWSIoTSiteWiseFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-12-04T20:53:39Z",
+    "updateDate": "2018-12-04T20:53:39Z"
+  },
+  "AWSIoTSiteWiseMonitorPortalAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-19T20:01:21Z",
+    "updateDate": "2020-05-19T20:01:21Z"
+  },
+  "AWSIoTSiteWiseMonitorServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-11-14T00:59:00Z",
+    "updateDate": "2019-12-13T22:19:25Z"
+  },
+  "AWSIoTSiteWiseReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2018-12-04T20:55:00Z",
+    "updateDate": "2026-02-12T18:00:49Z"
+  },
+  "AWSIoTThingsRegistration": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-12-01T20:21:00Z",
+    "updateDate": "2020-10-05T19:20:12Z"
+  },
+  "AWSIoTTwinMakerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-13T18:59:42Z",
+    "updateDate": "2023-11-13T18:59:42Z"
+  },
+  "AWSIoTWirelessDataAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T15:31:39Z",
+    "updateDate": "2020-12-15T15:31:39Z"
+  },
+  "AWSIoTWirelessFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T15:27:57Z",
+    "updateDate": "2020-12-15T15:27:57Z"
+  },
+  "AWSIoTWirelessFullPublishAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T15:29:59Z",
+    "updateDate": "2020-12-15T15:29:59Z"
+  },
+  "AWSIoTWirelessGatewayCertManager": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T15:30:48Z",
+    "updateDate": "2020-12-15T15:30:48Z"
+  },
+  "AWSIoTWirelessLogging": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T15:32:40Z",
+    "updateDate": "2020-12-15T15:32:40Z"
+  },
+  "AWSIoTWirelessReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-15T15:28:56Z",
+    "updateDate": "2020-12-15T15:28:56Z"
+  },
+  "AWSKeyManagementServiceCustomKeyStoresServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-14T20:10:00Z",
+    "updateDate": "2023-11-10T19:03:34Z"
+  },
+  "AWSKeyManagementServiceMultiRegionKeysServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-06-16T15:37:00Z",
+    "updateDate": "2024-11-13T22:53:54Z"
+  },
+  "AWSKeyManagementServicePowerUser": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2017-03-07T00:55:11Z"
+  },
+  "AWSLakeFormationCrossAccountManager": {
+    "defaultVersionId": "v9",
+    "createDate": "2020-08-04T20:59:00Z",
+    "updateDate": "2026-02-12T18:01:14Z"
+  },
+  "AWSLakeFormationDataAdmin": {
+    "defaultVersionId": "v6",
+    "createDate": "2019-08-08T17:33:00Z",
+    "updateDate": "2026-02-12T18:02:56Z"
+  },
+  "AWSLambdaBasicDurableExecutionRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-12-02T15:04:00Z",
+    "updateDate": "2026-02-12T18:01:44Z"
+  },
+  "AWSLambdaBasicExecutionRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T15:03:43Z",
+    "updateDate": "2015-04-09T15:03:43Z"
+  },
+  "AWSLambdaDynamoDBExecutionRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T15:09:29Z",
+    "updateDate": "2015-04-09T15:09:29Z"
+  },
+  "AWSLambdaENIManagementAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-12-06T00:37:00Z",
+    "updateDate": "2020-10-01T20:07:26Z"
+  },
+  "AWSLambdaExecute": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:46Z",
+    "updateDate": "2015-02-06T18:40:46Z"
+  },
+  "AWSLambdaFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2017-11-27T23:22:38Z"
+  },
+  "AWSLambdaInvocation-DynamoDB": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:47Z",
+    "updateDate": "2015-02-06T18:40:47Z"
+  },
+  "AWSLambdaKinesisExecutionRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-04-09T15:14:00Z",
+    "updateDate": "2018-11-19T20:09:24Z"
+  },
+  "AWSLambdaMSKExecutionRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-08-11T17:35:00Z",
+    "updateDate": "2022-08-02T20:08:02Z"
+  },
+  "AWSLambdaManagedEC2ResourceOperator": {
+    "defaultVersionId": "v5",
+    "createDate": "2025-11-30T08:34:00Z",
+    "updateDate": "2026-06-10T20:27:31Z"
+  },
+  "AWSLambdaNetworkConnectorOperatorPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-22T15:27:20Z",
+    "updateDate": "2026-06-22T15:27:20Z"
+  },
+  "AWSLambdaReplicator": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-05-23T17:53:00Z",
+    "updateDate": "2017-12-08T00:17:54Z"
+  },
+  "AWSLambdaRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:28Z",
+    "updateDate": "2015-02-06T18:41:28Z"
+  },
+  "AWSLambdaSQSQueueExecutionRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-06-14T21:50:45Z",
+    "updateDate": "2018-06-14T21:50:45Z"
+  },
+  "AWSLambdaServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2025-11-30T08:04:00Z",
+    "updateDate": "2026-06-22T15:12:14Z"
+  },
+  "AWSLambdaVPCAccessExecutionRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-02-11T23:15:00Z",
+    "updateDate": "2024-01-05T22:38:26Z"
+  },
+  "AWSLambda_FullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2020-11-17T21:14:00Z",
+    "updateDate": "2026-02-12T18:00:51Z"
+  },
+  "AWSLambda_ReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2020-11-17T21:10:00Z",
+    "updateDate": "2026-02-12T18:02:55Z"
+  },
+  "AWSLicenseManagerConsumptionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-08-11T23:18:08Z",
+    "updateDate": "2021-08-11T23:18:08Z"
+  },
+  "AWSLicenseManagerLinuxSubscriptionsServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-12-20T18:54:00Z",
+    "updateDate": "2024-07-08T22:04:56Z"
+  },
+  "AWSLicenseManagerMasterAccountRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2018-11-26T19:03:00Z",
+    "updateDate": "2022-05-31T20:50:26Z"
+  },
+  "AWSLicenseManagerMemberAccountRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-26T19:04:00Z",
+    "updateDate": "2019-11-15T22:09:32Z"
+  },
+  "AWSLicenseManagerServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2018-11-26T19:02:00Z",
+    "updateDate": "2025-11-19T18:34:07Z"
+  },
+  "AWSLicenseManagerUserSubscriptionsServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2022-07-30T01:17:00Z",
+    "updateDate": "2026-07-10T20:42:22Z"
+  },
+  "AWSM2ServicePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-06-07T20:26:39Z",
+    "updateDate": "2022-06-07T20:26:39Z"
+  },
+  "AWSMCPSignInOAuthAccessPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-09T06:57:15Z",
+    "updateDate": "2026-07-09T06:57:15Z"
+  },
+  "AWSMSKReplicatorExecutionRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-12-06T00:07:00Z",
+    "updateDate": "2024-03-25T21:36:08Z"
+  },
+  "AWSManagedAccountManagementAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-20T19:57:12Z",
+    "updateDate": "2026-07-20T19:57:12Z"
+  },
+  "AWSManagedAccountUserEntitlementAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-17T21:42:25Z",
+    "updateDate": "2026-07-17T21:42:25Z"
+  },
+  "AWSManagedAdvancedFeaturesActivationAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-21T14:27:10Z",
+    "updateDate": "2026-07-21T14:27:10Z"
+  },
+  "AWSManagedBudgetsSpendLimitManagementAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-07-17T21:12:00Z",
+    "updateDate": "2026-08-07T21:07:17Z"
+  },
+  "AWSManagedControlPolicyManagementAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-21T14:27:23Z",
+    "updateDate": "2026-07-21T14:27:23Z"
+  },
+  "AWSManagedServiceAccessManagementAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-21T17:57:17Z",
+    "updateDate": "2026-07-21T17:57:17Z"
+  },
+  "AWSManagedServicesDeploymentToolkitPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-06-09T18:33:00Z",
+    "updateDate": "2024-04-04T20:41:54Z"
+  },
+  "AWSManagedServices_ContactsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-23T17:07:46Z",
+    "updateDate": "2023-03-23T17:07:46Z"
+  },
+  "AWSManagedServices_DetectiveControlsConfig_ServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-12-19T23:11:17Z",
+    "updateDate": "2022-12-19T23:11:17Z"
+  },
+  "AWSManagedServices_EventsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-02-07T18:41:22Z",
+    "updateDate": "2023-02-07T18:41:22Z"
+  },
+  "AWSManagedServices_SelfServiceReporting_ServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-01-08T21:22:06Z",
+    "updateDate": "2025-01-08T21:22:06Z"
+  },
+  "AWSManagedSettingsAdminAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2026-07-22T01:27:00Z",
+    "updateDate": "2026-09-01T00:37:08Z"
+  },
+  "AWSManagedSettingsReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-07-22T01:12:00Z",
+    "updateDate": "2026-08-21T18:07:16Z"
+  },
+  "AWSManagedSignUpAdminAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-20T19:27:24Z",
+    "updateDate": "2026-07-20T19:27:24Z"
+  },
+  "AWSManagementConsoleAdministratorAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2025-08-14T21:19:00Z",
+    "updateDate": "2026-03-23T16:42:15Z"
+  },
+  "AWSManagementConsoleBasicUserAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2025-08-14T20:34:00Z",
+    "updateDate": "2026-03-17T22:12:09Z"
+  },
+  "AWSMarketplaceAmiIngestion": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-09-25T20:55:10Z",
+    "updateDate": "2020-09-25T20:55:10Z"
+  },
+  "AWSMarketplaceDeploymentServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-15T23:34:33Z",
+    "updateDate": "2023-11-15T23:34:33Z"
+  },
+  "AWSMarketplaceDiscoveryFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-05-07T17:12:10Z",
+    "updateDate": "2026-05-07T17:12:10Z"
+  },
+  "AWSMarketplaceFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2015-02-11T17:21:00Z",
+    "updateDate": "2026-02-12T18:00:23Z"
+  },
+  "AWSMarketplaceGetEntitlements": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-03-27T19:37:00Z",
+    "updateDate": "2024-04-05T01:27:20Z"
+  },
+  "AWSMarketplaceLicenseManagementServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-03T08:33:40Z",
+    "updateDate": "2020-12-03T08:33:40Z"
+  },
+  "AWSMarketplaceManageSubscriptions": {
+    "defaultVersionId": "v9",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-05-07T16:42:22Z"
+  },
+  "AWSMarketplaceMeteringFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-03-17T22:39:22Z",
+    "updateDate": "2016-03-17T22:39:22Z"
+  },
+  "AWSMarketplaceMeteringRegisterUsage": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-21T01:17:54Z",
+    "updateDate": "2019-11-21T01:17:54Z"
+  },
+  "AWSMarketplaceProcurementSystemAdminFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-06-25T13:07:00Z",
+    "updateDate": "2026-04-21T22:27:10Z"
+  },
+  "AWSMarketplacePurchaseOrdersServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-27T15:12:37Z",
+    "updateDate": "2021-10-27T15:12:37Z"
+  },
+  "AWSMarketplaceRead-only": {
+    "defaultVersionId": "v13",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-05-07T17:12:10Z"
+  },
+  "AWSMarketplaceResaleAuthorizationServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-03-05T18:47:00Z",
+    "updateDate": "2025-08-01T15:19:07Z"
+  },
+  "AWSMarketplaceSellerFullAccess": {
+    "defaultVersionId": "v33",
+    "createDate": "2019-07-02T20:40:00Z",
+    "updateDate": "2026-08-12T16:47:10Z"
+  },
+  "AWSMarketplaceSellerOfferManagement": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-11-19T00:41:00Z",
+    "updateDate": "2026-03-31T16:57:09Z"
+  },
+  "AWSMarketplaceSellerProductsFullAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2019-07-02T21:06:00Z",
+    "updateDate": "2026-02-19T19:12:10Z"
+  },
+  "AWSMarketplaceSellerProductsReadOnly": {
+    "defaultVersionId": "v7",
+    "createDate": "2019-07-02T21:40:00Z",
+    "updateDate": "2026-02-12T18:01:38Z"
+  },
+  "AWSMcpServiceActionsFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-21T22:49:00Z",
+    "updateDate": "2026-02-12T17:57:26Z"
+  },
+  "AWSMediaConnectServicePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-04-03T22:11:00Z",
+    "updateDate": "2025-10-29T21:34:07Z"
+  },
+  "AWSMediaLiveAnywhereServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-04-14T22:07:06Z",
+    "updateDate": "2025-04-14T22:07:06Z"
+  },
+  "AWSMediaTailorServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-17T22:27:10Z",
+    "updateDate": "2021-09-17T22:27:10Z"
+  },
+  "AWSMigrationHubDMSAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-08-14T14:00:00Z",
+    "updateDate": "2019-10-07T17:51:53Z"
+  },
+  "AWSMigrationHubDiscoveryAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-08-14T13:30:00Z",
+    "updateDate": "2020-08-06T17:34:42Z"
+  },
+  "AWSMigrationHubFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-08-14T14:02:00Z",
+    "updateDate": "2019-06-19T21:14:41Z"
+  },
+  "AWSMigrationHubOrchestratorConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-04-20T02:26:00Z",
+    "updateDate": "2023-12-05T17:34:16Z"
+  },
+  "AWSMigrationHubOrchestratorInstanceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-04-20T02:43:50Z",
+    "updateDate": "2022-04-20T02:43:50Z"
+  },
+  "AWSMigrationHubOrchestratorPlugin": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-04-20T02:25:10Z",
+    "updateDate": "2022-04-20T02:25:10Z"
+  },
+  "AWSMigrationHubOrchestratorServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-04-20T02:24:00Z",
+    "updateDate": "2024-03-04T18:25:12Z"
+  },
+  "AWSMigrationHubRefactorSpaces-EnvironmentsWithoutBridgesFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-04-03T20:09:00Z",
+    "updateDate": "2024-04-11T18:16:48Z"
+  },
+  "AWSMigrationHubRefactorSpaces-SSMAutomationPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-08-10T15:08:14Z",
+    "updateDate": "2023-08-10T15:08:14Z"
+  },
+  "AWSMigrationHubRefactorSpacesFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2021-11-29T07:12:00Z",
+    "updateDate": "2024-04-11T17:45:46Z"
+  },
+  "AWSMigrationHubRefactorSpacesServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-29T06:50:00Z",
+    "updateDate": "2023-07-20T15:57:53Z"
+  },
+  "AWSMigrationHubSMSAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-08-14T13:57:00Z",
+    "updateDate": "2019-10-07T18:01:22Z"
+  },
+  "AWSMigrationHubStrategyCollector": {
+    "defaultVersionId": "v6",
+    "createDate": "2021-10-19T20:15:00Z",
+    "updateDate": "2024-04-01T16:21:02Z"
+  },
+  "AWSMigrationHubStrategyConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-10-19T20:13:00Z",
+    "updateDate": "2022-11-09T00:00:06Z"
+  },
+  "AWSMigrationHubStrategyServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-19T20:02:37Z",
+    "updateDate": "2021-10-19T20:02:37Z"
+  },
+  "AWSNATGatewayServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-11-14T17:19:07Z",
+    "updateDate": "2025-11-14T17:19:07Z"
+  },
+  "AWSNetworkFirewallFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-06-10T21:52:00Z",
+    "updateDate": "2026-02-12T18:02:53Z"
+  },
+  "AWSNetworkFirewallReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-06-10T21:52:00Z",
+    "updateDate": "2026-02-12T18:01:07Z"
+  },
+  "AWSNetworkFirewallServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-11-17T17:17:00Z",
+    "updateDate": "2026-06-01T21:57:07Z"
+  },
+  "AWSNetworkManagerCloudWANServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-07-12T12:17:49Z",
+    "updateDate": "2022-07-12T12:17:49Z"
+  },
+  "AWSNetworkManagerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T17:37:58Z",
+    "updateDate": "2019-12-03T17:37:58Z"
+  },
+  "AWSNetworkManagerReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T17:35:05Z",
+    "updateDate": "2019-12-03T17:35:05Z"
+  },
+  "AWSNetworkManagerServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2019-12-03T14:03:00Z",
+    "updateDate": "2022-07-27T19:41:29Z"
+  },
+  "AWSObservabilityAdminLogsCentralizationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-09-15T14:34:06Z",
+    "updateDate": "2025-09-15T14:34:06Z"
+  },
+  "AWSObservabilityAdminServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-11-27T19:36:00Z",
+    "updateDate": "2026-07-14T22:42:17Z"
+  },
+  "AWSObservabilityAdminTelemetryEnablementServiceRolePolicy": {
+    "defaultVersionId": "v14",
+    "createDate": "2025-08-01T18:04:00Z",
+    "updateDate": "2026-07-24T19:12:23Z"
+  },
+  "AWSOrganizationsFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-11-06T20:31:00Z",
+    "updateDate": "2026-02-12T17:59:07Z"
+  },
+  "AWSOrganizationsReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-11-06T20:32:00Z",
+    "updateDate": "2024-06-07T21:32:16Z"
+  },
+  "AWSOrganizationsServiceTrustPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-10-10T23:04:00Z",
+    "updateDate": "2026-03-05T19:12:09Z"
+  },
+  "AWSOutpostsAuthorizeServerPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-01-04T19:23:22Z",
+    "updateDate": "2023-01-04T19:23:22Z"
+  },
+  "AWSOutpostsServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-11-09T22:55:00Z",
+    "updateDate": "2025-04-17T17:37:07Z"
+  },
+  "AWSPCSComputeNodePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-06-23T18:07:00Z",
+    "updateDate": "2026-02-12T18:01:26Z"
+  },
+  "AWSPCSServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2024-08-27T16:01:00Z",
+    "updateDate": "2026-02-12T18:01:59Z"
+  },
+  "AWSPanoramaApplianceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-01T13:13:18Z",
+    "updateDate": "2020-12-01T13:13:18Z"
+  },
+  "AWSPanoramaApplianceServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2021-10-20T12:14:00Z",
+    "updateDate": "2026-02-12T18:02:05Z"
+  },
+  "AWSPanoramaFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2020-12-01T13:12:00Z",
+    "updateDate": "2026-02-12T18:00:40Z"
+  },
+  "AWSPanoramaGreengrassGroupRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-12-01T13:10:00Z",
+    "updateDate": "2021-01-06T19:30:35Z"
+  },
+  "AWSPanoramaSageMakerRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-01T13:13:54Z",
+    "updateDate": "2020-12-01T13:13:54Z"
+  },
+  "AWSPanoramaServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-20T12:12:50Z",
+    "updateDate": "2021-10-20T12:12:50Z"
+  },
+  "AWSPanoramaServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-01T13:14:43Z",
+    "updateDate": "2020-12-01T13:14:43Z"
+  },
+  "AWSPartnerCentralChannelHandshakeApprovalManagement": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-19T16:34:00Z",
+    "updateDate": "2026-02-12T17:59:23Z"
+  },
+  "AWSPartnerCentralChannelManagement": {
+    "defaultVersionId": "v7",
+    "createDate": "2025-11-19T16:34:00Z",
+    "updateDate": "2026-02-14T00:57:09Z"
+  },
+  "AWSPartnerCentralFullAccess": {
+    "defaultVersionId": "v14",
+    "createDate": "2024-11-18T23:33:00Z",
+    "updateDate": "2026-03-12T17:12:13Z"
+  },
+  "AWSPartnerCentralMarketingManagement": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-12-01T00:34:00Z",
+    "updateDate": "2026-02-14T00:57:08Z"
+  },
+  "AWSPartnerCentralOpportunityManagement": {
+    "defaultVersionId": "v10",
+    "createDate": "2024-11-14T19:09:00Z",
+    "updateDate": "2026-06-16T13:27:14Z"
+  },
+  "AWSPartnerCentralRevenueAttributionManagement": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-30T19:12:18Z",
+    "updateDate": "2026-06-30T19:12:18Z"
+  },
+  "AWSPartnerCentralSandboxFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2024-11-14T19:10:00Z",
+    "updateDate": "2026-03-12T17:12:12Z"
+  },
+  "AWSPartnerCentralSellingResourceSnapshotJobExecutionRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-10T18:21:00Z",
+    "updateDate": "2026-02-12T17:57:07Z"
+  },
+  "AWSPartnerLedSupportReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-11-22T20:06:00Z",
+    "updateDate": "2026-02-12T18:01:04Z"
+  },
+  "AWSPartnerProServeToolsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-23T21:57:10Z",
+    "updateDate": "2026-03-23T21:57:10Z"
+  },
+  "AWSPartnerProServeToolsIndividualContributor": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-23T21:57:09Z",
+    "updateDate": "2026-03-23T21:57:09Z"
+  },
+  "AWSPartnerProServeToolsOrganizationReaderIndividualContributor": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-23T22:12:10Z",
+    "updateDate": "2026-03-23T22:12:10Z"
+  },
+  "AWSPriceListServiceFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-11-22T00:36:00Z",
+    "updateDate": "2024-07-02T13:34:19Z"
+  },
+  "AWSPrivateCAAuditor": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-02-14T18:33:44Z",
+    "updateDate": "2023-02-14T18:33:44Z"
+  },
+  "AWSPrivateCAConnectorForKubernetesPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-05-19T19:22:00Z",
+    "updateDate": "2026-02-12T17:58:55Z"
+  },
+  "AWSPrivateCAFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-02-14T18:20:59Z",
+    "updateDate": "2023-02-14T18:20:59Z"
+  },
+  "AWSPrivateCAPrivilegedUser": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-02-14T18:26:00Z",
+    "updateDate": "2026-02-12T18:00:11Z"
+  },
+  "AWSPrivateCAReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-02-14T18:30:50Z",
+    "updateDate": "2023-02-14T18:30:50Z"
+  },
+  "AWSPrivateCAUser": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-02-14T18:16:00Z",
+    "updateDate": "2026-02-12T18:01:42Z"
+  },
+  "AWSPrivateMarketplaceAdminFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-11-27T16:32:00Z",
+    "updateDate": "2026-02-12T18:01:07Z"
+  },
+  "AWSPrivateMarketplaceRequests": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-10-28T21:44:00Z",
+    "updateDate": "2026-02-12T17:57:10Z"
+  },
+  "AWSPrivateNetworksServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-12-16T23:17:46Z",
+    "updateDate": "2021-12-16T23:17:46Z"
+  },
+  "AWSProtonCodeBuildProvisioningBasicAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-09T21:04:16Z",
+    "updateDate": "2022-11-09T21:04:16Z"
+  },
+  "AWSProtonCodeBuildProvisioningServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-09T21:32:00Z",
+    "updateDate": "2023-05-17T16:11:40Z"
+  },
+  "AWSProtonDeveloperAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-02-17T19:02:00Z",
+    "updateDate": "2024-06-06T18:26:38Z"
+  },
+  "AWSProtonFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-02-17T19:07:00Z",
+    "updateDate": "2024-06-06T18:29:00Z"
+  },
+  "AWSProtonReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-02-17T19:09:00Z",
+    "updateDate": "2022-11-18T18:28:24Z"
+  },
+  "AWSProtonServiceGitSyncServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-04T15:55:48Z",
+    "updateDate": "2023-04-04T15:55:48Z"
+  },
+  "AWSProtonSyncServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-11-23T21:14:00Z",
+    "updateDate": "2024-05-05T01:49:07Z"
+  },
+  "AWSPurchaseOrdersServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2020-05-06T18:15:00Z",
+    "updateDate": "2026-02-12T17:59:01Z"
+  },
+  "AWSQuickSetupCFGCPacksPermissionsBoundary": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:52:11Z",
+    "updateDate": "2024-06-26T09:52:11Z"
+  },
+  "AWSQuickSetupDeploymentRolePolicy": {
+    "defaultVersionId": "v14",
+    "createDate": "2024-06-26T09:55:00Z",
+    "updateDate": "2026-09-07T15:07:07Z"
+  },
+  "AWSQuickSetupDevOpsGuruPermissionsBoundary": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:44:42Z",
+    "updateDate": "2024-06-26T09:44:42Z"
+  },
+  "AWSQuickSetupDistributorPermissionsBoundary": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:50:21Z",
+    "updateDate": "2024-06-26T09:50:21Z"
+  },
+  "AWSQuickSetupEnableAREXExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-15T22:45:53Z",
+    "updateDate": "2024-11-15T22:45:53Z"
+  },
+  "AWSQuickSetupEnableDHMCExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-15T21:27:47Z",
+    "updateDate": "2024-11-15T21:27:47Z"
+  },
+  "AWSQuickSetupJITNADeploymentRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-04-17T09:07:00Z",
+    "updateDate": "2026-09-07T12:27:08Z"
+  },
+  "AWSQuickSetupManageJITNAResourcesExecutionPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-04-17T21:37:00Z",
+    "updateDate": "2026-02-12T17:57:30Z"
+  },
+  "AWSQuickSetupManagedInstanceProfileExecutionPolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2024-11-15T21:51:00Z",
+    "updateDate": "2026-06-03T14:12:12Z"
+  },
+  "AWSQuickSetupPatchPolicyBaselineAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:38:00Z",
+    "updateDate": "2024-06-26T09:38:00Z"
+  },
+  "AWSQuickSetupPatchPolicyDeploymentRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-06-26T09:57:00Z",
+    "updateDate": "2026-09-04T08:47:07Z"
+  },
+  "AWSQuickSetupPatchPolicyLambdaExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-03T14:12:26Z",
+    "updateDate": "2026-06-03T14:12:26Z"
+  },
+  "AWSQuickSetupPatchPolicyPermissionsBoundary": {
+    "defaultVersionId": "v5",
+    "createDate": "2024-06-26T09:46:00Z",
+    "updateDate": "2026-03-05T16:57:14Z"
+  },
+  "AWSQuickSetupPatchPolicyTagManagementExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-03T14:12:13Z",
+    "updateDate": "2026-06-03T14:12:13Z"
+  },
+  "AWSQuickSetupSSMDeploymentRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2024-11-15T22:53:00Z",
+    "updateDate": "2026-09-07T12:27:07Z"
+  },
+  "AWSQuickSetupSSMDeploymentS3BucketRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-15T22:01:44Z",
+    "updateDate": "2024-11-15T22:01:44Z"
+  },
+  "AWSQuickSetupSSMHostMgmtPermissionsBoundary": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:48:42Z",
+    "updateDate": "2024-06-26T09:48:42Z"
+  },
+  "AWSQuickSetupSSMLifecycleManagementExecutionPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-11-15T21:55:00Z",
+    "updateDate": "2026-02-12T18:01:58Z"
+  },
+  "AWSQuickSetupSSMManageResourcesExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-15T22:49:24Z",
+    "updateDate": "2024-11-15T22:49:24Z"
+  },
+  "AWSQuickSetupSchedulerPermissionsBoundary": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:53:37Z",
+    "updateDate": "2024-06-26T09:53:37Z"
+  },
+  "AWSQuickSetupStartSSMAssociationsExecutionPolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2025-08-08T12:04:00Z",
+    "updateDate": "2026-03-05T16:57:14Z"
+  },
+  "AWSQuickSetupStartStopInstancesExecutionPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-08-08T12:04:00Z",
+    "updateDate": "2026-02-12T17:57:46Z"
+  },
+  "AWSQuickSightAssetBundleExportPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-03-27T21:31:03Z",
+    "updateDate": "2024-03-27T21:31:03Z"
+  },
+  "AWSQuickSightAssetBundleImportPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-03-27T21:40:34Z",
+    "updateDate": "2024-03-27T21:40:34Z"
+  },
+  "AWSQuickSightDescribeRDS": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-11-10T23:24:50Z",
+    "updateDate": "2015-11-10T23:24:50Z"
+  },
+  "AWSQuickSightDescribeRedshift": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-11-10T23:25:01Z",
+    "updateDate": "2015-11-10T23:25:01Z"
+  },
+  "AWSQuickSightElasticsearchPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-09-09T17:27:00Z",
+    "updateDate": "2021-09-07T23:25:55Z"
+  },
+  "AWSQuickSightIoTAnalyticsAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-29T17:00:54Z",
+    "updateDate": "2017-11-29T17:00:54Z"
+  },
+  "AWSQuickSightListIAM": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-11-10T23:25:07Z",
+    "updateDate": "2015-11-10T23:25:07Z"
+  },
+  "AWSQuickSightSageMakerPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-01-17T17:18:00Z",
+    "updateDate": "2023-10-30T17:57:43Z"
+  },
+  "AWSQuickSightSecretsManagerWriteAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-05-22T01:22:00Z",
+    "updateDate": "2026-02-12T17:57:43Z"
+  },
+  "AWSQuickSightSecretsManagerWritePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-05-12T19:22:00Z",
+    "updateDate": "2026-02-12T17:59:36Z"
+  },
+  "AWSQuickSightTimestreamPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-09-30T21:47:03Z",
+    "updateDate": "2020-09-30T21:47:03Z"
+  },
+  "AWSQuicksightAthenaAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2016-12-09T02:31:00Z",
+    "updateDate": "2026-02-12T17:58:36Z"
+  },
+  "AWSQuicksightOpenSearchPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-07T23:26:19Z",
+    "updateDate": "2021-09-07T23:26:19Z"
+  },
+  "AWSReachabilityAnalyzerServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-11-23T17:12:00Z",
+    "updateDate": "2026-08-14T17:17:24Z"
+  },
+  "AWSRefactoringToolkitFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2022-10-25T16:41:00Z",
+    "updateDate": "2026-02-12T17:57:59Z"
+  },
+  "AWSRefactoringToolkitSidecarPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-10-25T16:41:00Z",
+    "updateDate": "2022-10-29T22:15:51Z"
+  },
+  "AWSRepostSpaceSupportOperationsPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-26T21:52:15Z",
+    "updateDate": "2023-11-26T21:52:15Z"
+  },
+  "AWSResilienceHubAsssessmentExecutionPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2023-06-27T12:32:00Z",
+    "updateDate": "2026-02-12T18:00:12Z"
+  },
+  "AWSResilienceHubResilienceTestingPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-31T22:27:21Z",
+    "updateDate": "2026-07-31T22:27:21Z"
+  },
+  "AWSResilienceHubServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-05-28T17:42:00Z",
+    "updateDate": "2026-07-06T18:12:14Z"
+  },
+  "AWSResilienceHubV2AssessmentExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-17T22:57:15Z",
+    "updateDate": "2026-06-17T22:57:15Z"
+  },
+  "AWSResourceAccessManagerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-06-04T17:28:22Z",
+    "updateDate": "2019-06-04T17:28:22Z"
+  },
+  "AWSResourceAccessManagerReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-09T20:58:37Z",
+    "updateDate": "2019-12-09T20:58:37Z"
+  },
+  "AWSResourceAccessManagerResourceShareParticipantAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-09T20:41:37Z",
+    "updateDate": "2019-12-09T20:41:37Z"
+  },
+  "AWSResourceAccessManagerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-14T19:28:28Z",
+    "updateDate": "2018-11-14T19:28:28Z"
+  },
+  "AWSResourceExplorerFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-07T20:01:00Z",
+    "updateDate": "2023-11-14T16:53:46Z"
+  },
+  "AWSResourceExplorerOrganizationsAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-14T17:01:12Z",
+    "updateDate": "2023-11-14T17:01:12Z"
+  },
+  "AWSResourceExplorerReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-07T19:56:00Z",
+    "updateDate": "2023-11-14T16:43:41Z"
+  },
+  "AWSResourceExplorerServiceRolePolicy": {
+    "defaultVersionId": "v53",
+    "createDate": "2022-10-25T20:35:00Z",
+    "updateDate": "2026-09-03T19:37:08Z"
+  },
+  "AWSResourceGroupsReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-03-07T10:27:00Z",
+    "updateDate": "2019-02-05T17:56:25Z"
+  },
+  "AWSRevenueAttributionManagement": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-30T16:57:13Z",
+    "updateDate": "2026-06-30T16:57:13Z"
+  },
+  "AWSRoboMakerReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-26T05:30:00Z",
+    "updateDate": "2020-08-28T23:10:18Z"
+  },
+  "AWSRoboMakerServicePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-11-26T06:30:00Z",
+    "updateDate": "2021-11-11T22:23:45Z"
+  },
+  "AWSRoboMakerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-26T05:33:19Z",
+    "updateDate": "2018-11-26T05:33:19Z"
+  },
+  "AWSRoboMaker_FullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-09-10T18:34:00Z",
+    "updateDate": "2021-09-16T21:06:10Z"
+  },
+  "AWSRolesAnywhereFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-07-16T14:52:00Z",
+    "updateDate": "2026-02-12T18:00:57Z"
+  },
+  "AWSRolesAnywhereReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-07-16T15:07:00Z",
+    "updateDate": "2026-02-12T18:00:43Z"
+  },
+  "AWSRolesAnywhereServicePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-07-05T15:26:11Z",
+    "updateDate": "2022-07-05T15:26:11Z"
+  },
+  "AWSS3OnOutpostsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-10-03T20:32:36Z",
+    "updateDate": "2023-10-03T20:32:36Z"
+  },
+  "AWSSDMPServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-07-24T20:57:00Z",
+    "updateDate": "2026-08-10T22:27:25Z"
+  },
+  "AWSSSMForSAPServiceLinkedRolePolicy": {
+    "defaultVersionId": "v21",
+    "createDate": "2022-11-16T01:18:00Z",
+    "updateDate": "2026-02-12T18:03:20Z"
+  },
+  "AWSSSMOpsInsightsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-06-16T20:12:52Z",
+    "updateDate": "2021-06-16T20:12:52Z"
+  },
+  "AWSSSODirectoryAdministrator": {
+    "defaultVersionId": "v7",
+    "createDate": "2018-10-31T23:54:00Z",
+    "updateDate": "2026-02-12T17:58:23Z"
+  },
+  "AWSSSODirectoryReadOnly": {
+    "defaultVersionId": "v7",
+    "createDate": "2018-10-31T23:49:00Z",
+    "updateDate": "2026-02-12T17:58:41Z"
+  },
+  "AWSSSOMasterAccountAdministrator": {
+    "defaultVersionId": "v13",
+    "createDate": "2018-06-27T20:36:00Z",
+    "updateDate": "2026-02-12T18:01:23Z"
+  },
+  "AWSSSOMemberAccountAdministrator": {
+    "defaultVersionId": "v11",
+    "createDate": "2018-06-27T20:45:00Z",
+    "updateDate": "2026-02-12T18:00:22Z"
+  },
+  "AWSSSOReadOnly": {
+    "defaultVersionId": "v12",
+    "createDate": "2018-06-27T20:24:00Z",
+    "updateDate": "2026-02-12T17:59:03Z"
+  },
+  "AWSSSOServiceRolePolicy": {
+    "defaultVersionId": "v18",
+    "createDate": "2017-12-05T18:36:00Z",
+    "updateDate": "2025-02-11T18:37:06Z"
+  },
+  "AWSSavingsPlansFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-06T22:45:18Z",
+    "updateDate": "2019-11-06T22:45:18Z"
+  },
+  "AWSSavingsPlansReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-06T22:45:10Z",
+    "updateDate": "2019-11-06T22:45:10Z"
+  },
+  "AWSSecretsManagerClientReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-11-05T20:04:00Z",
+    "updateDate": "2026-06-02T20:42:11Z"
+  },
+  "AWSSecurityAgentServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-11T23:42:19Z",
+    "updateDate": "2026-06-11T23:42:19Z"
+  },
+  "AWSSecurityAgentWebAppPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2026-02-05T23:19:00Z",
+    "updateDate": "2026-06-11T18:27:14Z"
+  },
+  "AWSSecurityHubFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-11-27T23:54:00Z",
+    "updateDate": "2026-02-12T17:58:23Z"
+  },
+  "AWSSecurityHubOrganizationsAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2021-03-15T20:53:00Z",
+    "updateDate": "2026-02-12T17:59:09Z"
+  },
+  "AWSSecurityHubReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2018-11-28T01:34:00Z",
+    "updateDate": "2024-02-22T23:45:59Z"
+  },
+  "AWSSecurityHubServiceRolePolicy": {
+    "defaultVersionId": "v16",
+    "createDate": "2018-11-27T23:47:00Z",
+    "updateDate": "2026-06-27T00:42:14Z"
+  },
+  "AWSSecurityHubV2ServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2025-06-10T17:37:00Z",
+    "updateDate": "2026-06-27T00:42:11Z"
+  },
+  "AWSSecurityIncidentResponseCaseFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-12-01T23:21:00Z",
+    "updateDate": "2026-04-22T15:57:11Z"
+  },
+  "AWSSecurityIncidentResponseFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-12-01T23:21:00Z",
+    "updateDate": "2026-04-22T16:12:08Z"
+  },
+  "AWSSecurityIncidentResponseReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-12-01T23:06:00Z",
+    "updateDate": "2026-04-22T16:12:20Z"
+  },
+  "AWSSecurityIncidentResponseServiceRolePolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2024-12-01T16:36:00Z",
+    "updateDate": "2026-02-12T17:59:48Z"
+  },
+  "AWSSecurityIncidentResponseTriageServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-01T16:36:00Z",
+    "updateDate": "2026-02-12T17:58:17Z"
+  },
+  "AWSServiceCatalogAdminFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-02-15T17:19:00Z",
+    "updateDate": "2026-08-04T18:12:22Z"
+  },
+  "AWSServiceCatalogAdminReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-10-25T18:53:38Z",
+    "updateDate": "2019-10-25T18:53:38Z"
+  },
+  "AWSServiceCatalogAppRegistryFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2020-11-12T22:25:00Z",
+    "updateDate": "2026-08-12T10:07:19Z"
+  },
+  "AWSServiceCatalogAppRegistryReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-11-12T22:34:00Z",
+    "updateDate": "2022-11-17T18:16:39Z"
+  },
+  "AWSServiceCatalogAppRegistryServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-05-18T22:18:00Z",
+    "updateDate": "2022-10-26T16:05:52Z"
+  },
+  "AWSServiceCatalogEndUserFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2018-02-15T17:22:00Z",
+    "updateDate": "2026-08-04T17:57:29Z"
+  },
+  "AWSServiceCatalogEndUserReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-10-25T18:49:34Z",
+    "updateDate": "2019-10-25T18:49:34Z"
+  },
+  "AWSServiceCatalogOrgsDataSyncServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-04-10T20:48:00Z",
+    "updateDate": "2025-12-08T19:04:09Z"
+  },
+  "AWSServiceCatalogSyncServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-15T21:20:00Z",
+    "updateDate": "2024-05-03T17:12:41Z"
+  },
+  "AWSServiceRoleForAIDevOpsPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-02-16T14:27:00Z",
+    "updateDate": "2026-03-27T00:42:09Z"
+  },
+  "AWSServiceRoleForAWSTransform": {
+    "defaultVersionId": "v12",
+    "createDate": "2025-05-15T13:37:00Z",
+    "updateDate": "2026-02-12T18:03:10Z"
+  },
+  "AWSServiceRoleForAWSTransformCustom": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-03-25T02:57:00Z",
+    "updateDate": "2026-05-05T19:42:14Z"
+  },
+  "AWSServiceRoleForAmazonEKSNodegroup": {
+    "defaultVersionId": "v11",
+    "createDate": "2019-11-07T01:34:00Z",
+    "updateDate": "2026-02-17T18:42:07Z"
+  },
+  "AWSServiceRoleForAmazonQDeveloper": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-04-25T07:40:00Z",
+    "updateDate": "2026-07-20T20:27:30Z"
+  },
+  "AWSServiceRoleForCloudWatchAlarmsActionSSMServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-10-01T09:49:01Z",
+    "updateDate": "2020-10-01T09:49:01Z"
+  },
+  "AWSServiceRoleForCloudWatchMetrics_DbPerfInsightsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-09-07T09:32:32Z",
+    "updateDate": "2023-09-07T09:32:32Z"
+  },
+  "AWSServiceRoleForCodeGuru-Profiler": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-26T22:04:26Z",
+    "updateDate": "2020-06-26T22:04:26Z"
+  },
+  "AWSServiceRoleForCodeWhispererPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2023-03-24T19:39:00Z",
+    "updateDate": "2026-04-09T18:27:19Z"
+  },
+  "AWSServiceRoleForEC2ScheduledInstances": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-10-12T18:31:55Z",
+    "updateDate": "2017-10-12T18:31:55Z"
+  },
+  "AWSServiceRoleForGroundStationDataflowEndpointGroupPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-12-13T23:52:45Z",
+    "updateDate": "2022-12-13T23:52:45Z"
+  },
+  "AWSServiceRoleForImageBuilder": {
+    "defaultVersionId": "v28",
+    "createDate": "2019-11-29T22:02:00Z",
+    "updateDate": "2026-07-09T15:27:28Z"
+  },
+  "AWSServiceRoleForIoTSiteWise": {
+    "defaultVersionId": "v8",
+    "createDate": "2018-11-14T19:19:00Z",
+    "updateDate": "2023-11-13T18:27:50Z"
+  },
+  "AWSServiceRoleForLogDeliveryPolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-10-04T17:31:00Z",
+    "updateDate": "2026-05-15T21:57:13Z"
+  },
+  "AWSServiceRoleForMonitronPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-12-02T19:06:00Z",
+    "updateDate": "2026-01-07T09:34:09Z"
+  },
+  "AWSServiceRoleForNeptuneGraphPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-29T14:03:36Z",
+    "updateDate": "2023-11-29T14:03:36Z"
+  },
+  "AWSServiceRoleForPrivateMarketplaceAdminPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-02-14T22:28:01Z",
+    "updateDate": "2024-02-14T22:28:01Z"
+  },
+  "AWSServiceRoleForProcurementInsightsPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-03T14:26:03Z",
+    "updateDate": "2024-10-03T14:26:03Z"
+  },
+  "AWSServiceRoleForSMS": {
+    "defaultVersionId": "v10",
+    "createDate": "2019-08-06T18:39:00Z",
+    "updateDate": "2020-10-15T17:28:13Z"
+  },
+  "AWSServiceRoleForUserSubscriptions": {
+    "defaultVersionId": "v8",
+    "createDate": "2024-04-25T16:14:00Z",
+    "updateDate": "2026-06-22T08:27:22Z"
+  },
+  "AWSServiceRolePolicyForBackupReports": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-08-19T21:16:00Z",
+    "updateDate": "2023-03-10T00:51:25Z"
+  },
+  "AWSServiceRolePolicyForBackupRestoreTesting": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-11-10T23:37:00Z",
+    "updateDate": "2026-03-18T22:12:13Z"
+  },
+  "AWSServiceRolePolicyForWorkspacesInstances": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-06-11T20:37:00Z",
+    "updateDate": "2026-08-27T18:57:07Z"
+  },
+  "AWSShieldDRTAccessPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-06-05T22:29:00Z",
+    "updateDate": "2020-12-15T17:28:15Z"
+  },
+  "AWSShieldServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-17T19:17:46Z",
+    "updateDate": "2021-11-17T19:17:46Z"
+  },
+  "AWSSocialMessagingServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-10T19:28:38Z",
+    "updateDate": "2024-10-10T19:28:38Z"
+  },
+  "AWSStepFunctionsConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-01-11T21:54:00Z",
+    "updateDate": "2017-01-12T00:19:34Z"
+  },
+  "AWSStepFunctionsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-01-11T21:51:32Z",
+    "updateDate": "2017-01-11T21:51:32Z"
+  },
+  "AWSStepFunctionsReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-01-11T21:46:00Z",
+    "updateDate": "2024-04-26T18:53:54Z"
+  },
+  "AWSStorageGatewayFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2022-09-06T20:26:09Z"
+  },
+  "AWSStorageGatewayReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2022-09-06T20:24:17Z"
+  },
+  "AWSStorageGatewayServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-02-17T19:03:19Z",
+    "updateDate": "2021-02-17T19:03:19Z"
+  },
+  "AWSSupplyChainFederationAdminAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2023-03-01T18:54:00Z",
+    "updateDate": "2026-08-14T21:07:21Z"
+  },
+  "AWSSupportAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2026-02-12T17:59:31Z"
+  },
+  "AWSSupportAppFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-08-22T16:53:41Z",
+    "updateDate": "2022-08-22T16:53:41Z"
+  },
+  "AWSSupportAppReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-08-22T17:01:15Z",
+    "updateDate": "2022-08-22T17:01:15Z"
+  },
+  "AWSSupportPlansFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-09-27T18:19:00Z",
+    "updateDate": "2026-08-24T18:27:14Z"
+  },
+  "AWSSupportPlansReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-09-27T18:08:00Z",
+    "updateDate": "2026-08-24T18:17:10Z"
+  },
+  "AWSSupportPlansServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-31T17:12:23Z",
+    "updateDate": "2026-07-31T17:12:23Z"
+  },
+  "AWSSupportServiceRolePolicy": {
+    "defaultVersionId": "v59",
+    "createDate": "2018-04-19T18:04:00Z",
+    "updateDate": "2026-08-19T17:37:19Z"
+  },
+  "AWSSystemsManagerAccountDiscoveryServicePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-10-24T17:21:00Z",
+    "updateDate": "2022-10-17T20:25:02Z"
+  },
+  "AWSSystemsManagerChangeManagementServicePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-12-07T22:21:00Z",
+    "updateDate": "2025-10-23T21:19:07Z"
+  },
+  "AWSSystemsManagerEnableConfigRecordingExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:40:20Z",
+    "updateDate": "2024-06-26T09:40:20Z"
+  },
+  "AWSSystemsManagerEnableExplorerExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-26T09:42:47Z",
+    "updateDate": "2024-06-26T09:42:47Z"
+  },
+  "AWSSystemsManagerForSAPFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-11-17T02:11:00Z",
+    "updateDate": "2024-07-10T21:54:54Z"
+  },
+  "AWSSystemsManagerForSAPReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-17T02:11:44Z",
+    "updateDate": "2022-11-17T02:11:44Z"
+  },
+  "AWSSystemsManagerJustInTimeAccessServicePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-04-21T20:07:00Z",
+    "updateDate": "2026-02-12T18:01:49Z"
+  },
+  "AWSSystemsManagerJustInTimeAccessTokenPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-04-17T21:07:00Z",
+    "updateDate": "2026-02-12T18:02:43Z"
+  },
+  "AWSSystemsManagerJustInTimeAccessTokenSessionPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-04-17T20:52:00Z",
+    "updateDate": "2026-02-12T18:03:06Z"
+  },
+  "AWSSystemsManagerJustInTimeNodeAccessRolePropagationPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-04-21T20:52:00Z",
+    "updateDate": "2026-02-12T17:59:46Z"
+  },
+  "AWSSystemsManagerNotificationsServicePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-04-17T20:52:07Z",
+    "updateDate": "2025-04-17T20:52:07Z"
+  },
+  "AWSSystemsManagerOpsDataSyncServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-04-26T20:42:00Z",
+    "updateDate": "2023-06-28T22:53:43Z"
+  },
+  "AWSThinkboxAWSPortalAdminPolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2020-05-27T19:41:00Z",
+    "updateDate": "2026-02-12T17:57:40Z"
+  },
+  "AWSThinkboxAWSPortalGatewayPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-05-27T19:05:00Z",
+    "updateDate": "2020-06-30T16:02:07Z"
+  },
+  "AWSThinkboxAWSPortalWorkerPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-05-27T19:15:00Z",
+    "updateDate": "2020-12-07T23:27:47Z"
+  },
+  "AWSThinkboxAssetServerPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-27T19:18:53Z",
+    "updateDate": "2020-05-27T19:18:53Z"
+  },
+  "AWSThinkboxDeadlineResourceTrackerAccessPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-27T19:25:05Z",
+    "updateDate": "2020-05-27T19:25:05Z"
+  },
+  "AWSThinkboxDeadlineResourceTrackerAdminPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2020-05-27T19:29:00Z",
+    "updateDate": "2026-07-16T17:42:11Z"
+  },
+  "AWSThinkboxDeadlineSpotEventPluginAdminPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-27T19:38:34Z",
+    "updateDate": "2020-05-27T19:38:34Z"
+  },
+  "AWSThinkboxDeadlineSpotEventPluginWorkerPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-05-27T19:35:00Z",
+    "updateDate": "2020-12-07T23:31:31Z"
+  },
+  "AWSTransferConsoleFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-14T19:33:25Z",
+    "updateDate": "2020-12-14T19:33:25Z"
+  },
+  "AWSTransferFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-14T19:37:23Z",
+    "updateDate": "2020-12-14T19:37:23Z"
+  },
+  "AWSTransferLoggingAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-14T15:32:50Z",
+    "updateDate": "2019-01-14T15:32:50Z"
+  },
+  "AWSTransferReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-27T17:54:51Z",
+    "updateDate": "2020-08-27T17:54:51Z"
+  },
+  "AWSTransformApplicationDeploymentPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-08-28T06:34:00Z",
+    "updateDate": "2026-02-12T17:59:09Z"
+  },
+  "AWSTransformApplicationECSDeploymentPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-09-29T22:49:00Z",
+    "updateDate": "2026-02-12T18:02:41Z"
+  },
+  "AWSTransformCustomExecuteTransformations": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-12-05T15:34:00Z",
+    "updateDate": "2026-04-27T19:42:16Z"
+  },
+  "AWSTransformCustomFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-12-05T15:19:00Z",
+    "updateDate": "2026-04-07T21:27:14Z"
+  },
+  "AWSTransformCustomManageTransformations": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-12-05T15:49:00Z",
+    "updateDate": "2026-04-27T19:27:10Z"
+  },
+  "AWSTransformInfrastructureExecutorAccessBatch": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-07-20T20:12:00Z",
+    "updateDate": "2026-09-02T21:27:07Z"
+  },
+  "AWSTransformInfrastructureExecutorAccessEC2": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-07-20T20:12:00Z",
+    "updateDate": "2026-09-02T21:27:07Z"
+  },
+  "AWSTransformLandingZoneAgentPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-06T15:12:00Z",
+    "updateDate": "2026-09-01T10:27:08Z"
+  },
+  "AWSTransformNetworkMigrationAgentPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-06T15:27:00Z",
+    "updateDate": "2026-09-01T10:37:07Z"
+  },
+  "AWSTransformRevenueAttributionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-07T16:42:19Z",
+    "updateDate": "2026-07-07T16:42:19Z"
+  },
+  "AWSTransformSecretsManagerConnectorPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-04T21:12:11Z",
+    "updateDate": "2026-03-04T21:12:11Z"
+  },
+  "AWSTransformSecurityAgentExecutorAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-06-30T21:27:00Z",
+    "updateDate": "2026-07-28T15:42:11Z"
+  },
+  "AWSTransformServerMigrationAgentPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-06T15:27:00Z",
+    "updateDate": "2026-09-01T10:37:08Z"
+  },
+  "AWSTrustedAdvisorPriorityFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-08-16T16:08:24Z",
+    "updateDate": "2022-08-16T16:08:24Z"
+  },
+  "AWSTrustedAdvisorPriorityReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-08-16T16:35:12Z",
+    "updateDate": "2022-08-16T16:35:12Z"
+  },
+  "AWSTrustedAdvisorReportingServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-11-19T17:41:00Z",
+    "updateDate": "2023-02-28T23:23:45Z"
+  },
+  "AWSTrustedAdvisorServiceRolePolicy": {
+    "defaultVersionId": "v15",
+    "createDate": "2018-02-22T21:24:00Z",
+    "updateDate": "2026-05-14T21:42:12Z"
+  },
+  "AWSUserAttributeCostAllocationPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-12-15T16:34:09Z",
+    "updateDate": "2025-12-15T16:34:09Z"
+  },
+  "AWSUserNotificationsServiceLinkedRolePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-04-19T13:28:00Z",
+    "updateDate": "2026-02-12T18:01:14Z"
+  },
+  "AWSVPCFlowLogsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-05-11T15:57:14Z",
+    "updateDate": "2026-05-11T15:57:14Z"
+  },
+  "AWSVPCS2SVpnServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-08-06T14:13:00Z",
+    "updateDate": "2025-05-15T16:52:07Z"
+  },
+  "AWSVPCTransitGatewayServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-26T16:21:00Z",
+    "updateDate": "2021-04-15T16:31:44Z"
+  },
+  "AWSVPCVerifiedAccessServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-11-29T03:35:00Z",
+    "updateDate": "2023-11-17T21:03:13Z"
+  },
+  "AWSVendorInsightsAssessorFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-07-26T15:05:00Z",
+    "updateDate": "2022-12-01T00:51:44Z"
+  },
+  "AWSVendorInsightsAssessorReadOnly": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-07-26T15:05:00Z",
+    "updateDate": "2022-12-01T00:55:16Z"
+  },
+  "AWSVendorInsightsVendorFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-07-26T15:05:00Z",
+    "updateDate": "2023-10-19T01:41:01Z"
+  },
+  "AWSVendorInsightsVendorReadOnly": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-07-26T15:05:00Z",
+    "updateDate": "2022-12-01T00:54:38Z"
+  },
+  "AWSVpcLatticeServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-30T20:47:00Z",
+    "updateDate": "2024-12-01T14:06:06Z"
+  },
+  "AWSWAFConsoleFullAccess": {
+    "defaultVersionId": "v22",
+    "createDate": "2020-04-06T18:38:00Z",
+    "updateDate": "2026-07-01T04:12:13Z"
+  },
+  "AWSWAFConsoleReadOnlyAccess": {
+    "defaultVersionId": "v21",
+    "createDate": "2020-04-06T18:43:00Z",
+    "updateDate": "2026-07-01T04:12:24Z"
+  },
+  "AWSWAFFullAccess": {
+    "defaultVersionId": "v17",
+    "createDate": "2015-10-06T20:44:00Z",
+    "updateDate": "2026-07-28T21:42:26Z"
+  },
+  "AWSWAFReadOnlyAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2015-10-06T20:43:00Z",
+    "updateDate": "2026-07-01T04:27:31Z"
+  },
+  "AWSWellArchitectedAgentResourceScanningServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-04T17:27:00Z",
+    "updateDate": "2026-08-13T00:27:19Z"
+  },
+  "AWSWellArchitectedDiscoveryServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-26T18:36:40Z",
+    "updateDate": "2023-04-26T18:36:40Z"
+  },
+  "AWSWellArchitectedOrganizationsServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-06-23T17:15:00Z",
+    "updateDate": "2022-07-25T18:03:31Z"
+  },
+  "AWSWickrFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-27T20:36:44Z",
+    "updateDate": "2022-11-27T20:36:44Z"
+  },
+  "AWSXRayDaemonWriteAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-08-28T23:00:00Z",
+    "updateDate": "2024-02-13T21:58:30Z"
+  },
+  "AWSXrayCrossAccountSharingConfiguration": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-27T13:46:35Z",
+    "updateDate": "2022-11-27T13:46:35Z"
+  },
+  "AWSXrayFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-12-01T18:30:00Z",
+    "updateDate": "2024-04-11T17:07:36Z"
+  },
+  "AWSXrayReadOnlyAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2016-12-01T18:27:00Z",
+    "updateDate": "2024-02-14T00:35:02Z"
+  },
+  "AWSXrayWriteOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-12-01T18:19:00Z",
+    "updateDate": "2018-08-28T23:03:04Z"
+  },
+  "AWSZonalAutoshiftPracticeRunSLRPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-11-29T17:34:00Z",
+    "updateDate": "2025-06-30T17:07:07Z"
+  },
+  "AWSZoneGroupAccessManagementServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-07-01T19:07:07Z",
+    "updateDate": "2025-07-01T19:07:07Z"
+  },
+  "AWS_ConfigRole": {
+    "defaultVersionId": "v72",
+    "createDate": "2020-09-15T20:30:00Z",
+    "updateDate": "2026-08-27T22:07:08Z"
+  },
+  "AWSrePostPrivateCloudWatchAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-15T16:37:33Z",
+    "updateDate": "2023-11-15T16:37:33Z"
+  },
+  "AccessAnalyzerServiceRolePolicy": {
+    "defaultVersionId": "v23",
+    "createDate": "2019-12-02T17:13:00Z",
+    "updateDate": "2026-02-12T17:59:49Z"
+  },
+  "AccountAccessManagerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-29T19:12:30Z",
+    "updateDate": "2026-06-29T19:12:30Z"
+  },
+  "AccountManagementFromVercel": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-12-11T16:34:00Z",
+    "updateDate": "2026-05-07T18:57:18Z"
+  },
+  "AdministratorAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:39:46Z",
+    "updateDate": "2015-02-06T18:39:46Z"
+  },
+  "AdministratorAccess-AWSElasticBeanstalk": {
+    "defaultVersionId": "v10",
+    "createDate": "2021-01-22T19:36:00Z",
+    "updateDate": "2026-05-19T20:12:27Z"
+  },
+  "AdministratorAccess-Amplify": {
+    "defaultVersionId": "v12",
+    "createDate": "2020-12-01T19:03:00Z",
+    "updateDate": "2024-04-04T20:35:31Z"
+  },
+  "AgentRegistryFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-06T18:12:00Z",
+    "updateDate": "2026-08-31T17:07:08Z"
+  },
+  "AgentRegistryReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-06T18:12:29Z",
+    "updateDate": "2026-08-06T18:12:29Z"
+  },
+  "AlexaForBusinessDeviceSetup": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-11-30T16:47:00Z",
+    "updateDate": "2019-05-20T21:05:39Z"
+  },
+  "AlexaForBusinessFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-11-30T16:47:00Z",
+    "updateDate": "2020-07-01T21:01:55Z"
+  },
+  "AlexaForBusinessGatewayExecution": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-30T16:47:19Z",
+    "updateDate": "2017-11-30T16:47:19Z"
+  },
+  "AlexaForBusinessLifesizeDelegatedAccessPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-06-04T19:46:00Z",
+    "updateDate": "2020-06-12T20:31:59Z"
+  },
+  "AlexaForBusinessNetworkProfileServicePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-03-13T00:53:00Z",
+    "updateDate": "2019-04-05T21:57:56Z"
+  },
+  "AlexaForBusinessPolyDelegatedAccessPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-10-16T19:48:45Z",
+    "updateDate": "2019-10-16T19:48:45Z"
+  },
+  "AlexaForBusinessReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-11-30T16:47:00Z",
+    "updateDate": "2019-11-20T00:25:33Z"
+  },
+  "AmazonAPIGatewayAdministrator": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-07-09T17:34:45Z",
+    "updateDate": "2015-07-09T17:34:45Z"
+  },
+  "AmazonAPIGatewayInvokeFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-07-09T17:36:00Z",
+    "updateDate": "2018-12-18T18:25:10Z"
+  },
+  "AmazonAPIGatewayPushToCloudWatchLogs": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-11-11T23:41:46Z",
+    "updateDate": "2015-11-11T23:41:46Z"
+  },
+  "AmazonAppFlowFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-06-02T23:30:00Z",
+    "updateDate": "2022-02-28T23:11:23Z"
+  },
+  "AmazonAppFlowReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-06-02T23:26:00Z",
+    "updateDate": "2022-02-28T20:42:58Z"
+  },
+  "AmazonAppStreamFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2020-08-28T17:24:35Z"
+  },
+  "AmazonAppStreamPCAAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-10-24T17:05:03Z",
+    "updateDate": "2022-10-24T17:05:03Z"
+  },
+  "AmazonAppStreamReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-02-12T18:02:02Z"
+  },
+  "AmazonAppStreamServiceAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2016-11-19T04:17:00Z",
+    "updateDate": "2026-09-03T16:57:06Z"
+  },
+  "AmazonApplicationRecoveryControllerRegionSwitchPlanExecutionPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-11-03T19:34:00Z",
+    "updateDate": "2026-03-05T19:27:12Z"
+  },
+  "AmazonAthenaFullAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2016-11-30T16:46:00Z",
+    "updateDate": "2026-02-12T18:03:09Z"
+  },
+  "AmazonAthenaServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-11-14T22:34:08Z",
+    "updateDate": "2025-11-14T22:34:08Z"
+  },
+  "AmazonAugmentedAIFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T16:21:56Z",
+    "updateDate": "2019-12-03T16:21:56Z"
+  },
+  "AmazonAugmentedAIHumanLoopFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T16:20:47Z",
+    "updateDate": "2019-12-03T16:20:47Z"
+  },
+  "AmazonAugmentedAIIntegratedAPIAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-04-22T20:47:32Z",
+    "updateDate": "2020-04-22T20:47:32Z"
+  },
+  "AmazonAuroraDSQLConsoleFullAccess": {
+    "defaultVersionId": "v16",
+    "createDate": "2024-12-03T15:36:00Z",
+    "updateDate": "2026-05-13T18:57:14Z"
+  },
+  "AmazonAuroraDSQLFullAccess": {
+    "defaultVersionId": "v16",
+    "createDate": "2024-12-03T15:36:00Z",
+    "updateDate": "2026-05-13T18:57:08Z"
+  },
+  "AmazonAuroraDSQLReadOnlyAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2024-12-03T15:21:00Z",
+    "updateDate": "2026-05-13T18:57:20Z"
+  },
+  "AmazonBedrockAgentCoreMemoryBedrockModelInferenceExecutionRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-07-16T13:37:00Z",
+    "updateDate": "2026-07-17T17:12:16Z"
+  },
+  "AmazonBedrockExternalWebSearchFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-03T16:57:20Z",
+    "updateDate": "2026-08-03T16:57:20Z"
+  },
+  "AmazonBedrockExternalWebSearchReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-03T16:57:15Z",
+    "updateDate": "2026-08-03T16:57:15Z"
+  },
+  "AmazonBedrockFullAccess": {
+    "defaultVersionId": "v11",
+    "createDate": "2023-12-06T15:47:00Z",
+    "updateDate": "2026-08-04T05:42:21Z"
+  },
+  "AmazonBedrockLimitedAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-06-29T22:22:00Z",
+    "updateDate": "2026-08-04T05:27:24Z"
+  },
+  "AmazonBedrockMantleFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2025-12-04T07:19:00Z",
+    "updateDate": "2026-08-04T04:42:21Z"
+  },
+  "AmazonBedrockMantleInferenceAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2025-12-04T07:19:00Z",
+    "updateDate": "2026-08-04T05:12:19Z"
+  },
+  "AmazonBedrockMantleReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-12-04T07:19:00Z",
+    "updateDate": "2026-02-12T17:58:26Z"
+  },
+  "AmazonBedrockMarketplaceAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-06-29T22:22:00Z",
+    "updateDate": "2026-02-12T17:57:09Z"
+  },
+  "AmazonBedrockReadOnly": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-12-06T15:48:00Z",
+    "updateDate": "2026-02-12T17:57:55Z"
+  },
+  "AmazonBedrockStudioPermissionsBoundary": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-08-01T00:24:40Z",
+    "updateDate": "2024-08-01T00:24:40Z"
+  },
+  "AmazonBedrockWebSearchFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-03T16:42:26Z",
+    "updateDate": "2026-08-03T16:42:26Z"
+  },
+  "AmazonBedrockWebSearchReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-03T16:57:25Z",
+    "updateDate": "2026-08-03T16:57:25Z"
+  },
+  "AmazonBraketFullAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2020-08-06T20:12:00Z",
+    "updateDate": "2026-07-06T19:57:33Z"
+  },
+  "AmazonBraketJobsExecutionPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-26T19:34:00Z",
+    "updateDate": "2026-07-06T19:12:15Z"
+  },
+  "AmazonBraketServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-08-04T17:12:00Z",
+    "updateDate": "2026-07-06T18:42:30Z"
+  },
+  "AmazonChimeFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-11-01T22:15:00Z",
+    "updateDate": "2020-12-14T21:00:52Z"
+  },
+  "AmazonChimeReadOnly": {
+    "defaultVersionId": "v10",
+    "createDate": "2017-11-01T22:04:00Z",
+    "updateDate": "2020-12-14T20:53:57Z"
+  },
+  "AmazonChimeSDK": {
+    "defaultVersionId": "v5",
+    "createDate": "2020-02-04T21:53:00Z",
+    "updateDate": "2023-01-10T18:05:12Z"
+  },
+  "AmazonChimeSDKMediaPipelinesServiceLinkedRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-04-04T22:02:00Z",
+    "updateDate": "2023-12-08T19:14:31Z"
+  },
+  "AmazonChimeSDKMessagingServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-03T01:43:49Z",
+    "updateDate": "2023-03-03T01:43:49Z"
+  },
+  "AmazonChimeServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-09-30T22:25:06Z",
+    "updateDate": "2019-09-30T22:25:06Z"
+  },
+  "AmazonChimeTranscriptionServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-08-04T21:47:41Z",
+    "updateDate": "2021-08-04T21:47:41Z"
+  },
+  "AmazonChimeUserManagement": {
+    "defaultVersionId": "v8",
+    "createDate": "2017-11-01T22:17:00Z",
+    "updateDate": "2020-02-18T19:26:10Z"
+  },
+  "AmazonChimeVoiceConnectorServiceLinkedRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-09-30T22:16:00Z",
+    "updateDate": "2023-04-14T21:49:14Z"
+  },
+  "AmazonCloudDirectoryFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-02-25T00:41:39Z",
+    "updateDate": "2017-02-25T00:41:39Z"
+  },
+  "AmazonCloudDirectoryReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-02-28T23:42:06Z",
+    "updateDate": "2017-02-28T23:42:06Z"
+  },
+  "AmazonCloudWatchEvidentlyFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-29T15:10:14Z",
+    "updateDate": "2021-11-29T15:10:14Z"
+  },
+  "AmazonCloudWatchEvidentlyReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-29T15:08:38Z",
+    "updateDate": "2021-11-29T15:08:38Z"
+  },
+  "AmazonCloudWatchEvidentlyServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-09-13T17:25:36Z",
+    "updateDate": "2022-09-13T17:25:36Z"
+  },
+  "AmazonCloudWatchRUMFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-29T15:46:12Z",
+    "updateDate": "2021-11-29T15:46:12Z"
+  },
+  "AmazonCloudWatchRUMReadOnlyAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2021-11-29T15:43:00Z",
+    "updateDate": "2026-02-12T18:02:30Z"
+  },
+  "AmazonCloudWatchRUMServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-11-17T23:17:00Z",
+    "updateDate": "2023-02-22T20:35:15Z"
+  },
+  "AmazonCodeCatalystFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-20T16:50:16Z",
+    "updateDate": "2023-04-20T16:50:16Z"
+  },
+  "AmazonCodeCatalystReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-20T16:49:12Z",
+    "updateDate": "2023-04-20T16:49:12Z"
+  },
+  "AmazonCodeCatalystSupportAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-20T12:34:44Z",
+    "updateDate": "2023-04-20T12:34:44Z"
+  },
+  "AmazonCodeGuruProfilerAgentAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-02-05T22:11:00Z",
+    "updateDate": "2022-05-05T18:11:03Z"
+  },
+  "AmazonCodeGuruProfilerFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-12-03T10:13:00Z",
+    "updateDate": "2020-07-15T03:23:08Z"
+  },
+  "AmazonCodeGuruProfilerReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-12-03T10:30:00Z",
+    "updateDate": "2020-06-27T23:52:52Z"
+  },
+  "AmazonCodeGuruReviewerFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-12-03T08:33:00Z",
+    "updateDate": "2020-08-29T04:16:08Z"
+  },
+  "AmazonCodeGuruReviewerReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-12-03T08:48:00Z",
+    "updateDate": "2020-08-29T04:15:32Z"
+  },
+  "AmazonCodeGuruReviewerServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-12-03T05:31:00Z",
+    "updateDate": "2020-11-27T15:09:46Z"
+  },
+  "AmazonCodeGuruSecurityFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-05-09T21:03:38Z",
+    "updateDate": "2023-05-09T21:03:38Z"
+  },
+  "AmazonCodeGuruSecurityScanAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-05-09T20:54:32Z",
+    "updateDate": "2023-05-09T20:54:32Z"
+  },
+  "AmazonCognitoDeveloperAuthenticatedIdentities": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-03-24T17:22:23Z",
+    "updateDate": "2015-03-24T17:22:23Z"
+  },
+  "AmazonCognitoIdpEmailServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-03-21T21:32:25Z",
+    "updateDate": "2019-03-21T21:32:25Z"
+  },
+  "AmazonCognitoIdpServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-26T22:30:20Z",
+    "updateDate": "2020-06-26T22:30:20Z"
+  },
+  "AmazonCognitoPowerUser": {
+    "defaultVersionId": "v9",
+    "createDate": "2015-03-24T17:14:00Z",
+    "updateDate": "2026-02-12T18:00:09Z"
+  },
+  "AmazonCognitoReadOnly": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-03-24T17:06:00Z",
+    "updateDate": "2019-08-01T19:21:04Z"
+  },
+  "AmazonCognitoUnAuthedIdentitiesSessionPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-07-19T23:04:00Z",
+    "updateDate": "2026-05-01T19:57:11Z"
+  },
+  "AmazonCognitoUnauthenticatedIdentities": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-02-01T22:36:27Z",
+    "updateDate": "2023-02-01T22:36:27Z"
+  },
+  "AmazonConnectCampaignsServiceLinkedRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2021-09-23T20:54:00Z",
+    "updateDate": "2026-06-18T23:12:23Z"
+  },
+  "AmazonConnectReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2018-10-17T21:00:00Z",
+    "updateDate": "2024-06-19T15:15:33Z"
+  },
+  "AmazonConnectServiceLinkedRolePolicy": {
+    "defaultVersionId": "v55",
+    "createDate": "2018-09-07T00:21:00Z",
+    "updateDate": "2026-05-27T21:57:16Z"
+  },
+  "AmazonConnectSynchronizationServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2023-10-27T22:38:00Z",
+    "updateDate": "2025-11-21T20:19:09Z"
+  },
+  "AmazonConnectVoiceIDFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-26T19:04:10Z",
+    "updateDate": "2021-09-26T19:04:10Z"
+  },
+  "AmazonConnect_FullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-11-20T19:54:00Z",
+    "updateDate": "2023-03-07T14:49:25Z"
+  },
+  "AmazonDMSCloudWatchLogsRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-01-07T23:44:00Z",
+    "updateDate": "2023-05-23T21:32:57Z"
+  },
+  "AmazonDMSRedshiftS3Role": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-04-20T17:05:00Z",
+    "updateDate": "2019-07-08T18:19:14Z"
+  },
+  "AmazonDMSVPCManagementRole": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-11-18T16:33:00Z",
+    "updateDate": "2024-07-25T15:19:01Z"
+  },
+  "AmazonDRSVPCManagement": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-09-02T00:09:20Z",
+    "updateDate": "2015-09-02T00:09:20Z"
+  },
+  "AmazonDataZoneBedrockModelConsumptionPolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-11-12T22:15:00Z",
+    "updateDate": "2026-02-12T18:01:13Z"
+  },
+  "AmazonDataZoneBedrockModelManagementPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-12T22:14:20Z",
+    "updateDate": "2024-11-12T22:14:20Z"
+  },
+  "AmazonDataZoneDomainExecutionRolePolicy": {
+    "defaultVersionId": "v13",
+    "createDate": "2023-09-27T21:55:00Z",
+    "updateDate": "2026-02-26T00:12:11Z"
+  },
+  "AmazonDataZoneEnvironmentRolePermissionsBoundary": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-09-11T23:38:00Z",
+    "updateDate": "2023-11-17T23:29:08Z"
+  },
+  "AmazonDataZoneFullAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2023-09-22T20:06:00Z",
+    "updateDate": "2026-02-12T17:59:29Z"
+  },
+  "AmazonDataZoneFullUserAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2023-09-22T21:06:00Z",
+    "updateDate": "2024-11-19T21:38:59Z"
+  },
+  "AmazonDataZoneGlueManageAccessRolePolicy": {
+    "defaultVersionId": "v18",
+    "createDate": "2023-09-22T20:21:00Z",
+    "updateDate": "2026-02-12T18:00:04Z"
+  },
+  "AmazonDataZoneRedshiftGlueProvisioningPolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2023-09-22T20:19:00Z",
+    "updateDate": "2026-08-21T22:27:22Z"
+  },
+  "AmazonDataZoneRedshiftManageAccessRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2023-09-22T20:15:00Z",
+    "updateDate": "2026-02-12T18:01:21Z"
+  },
+  "AmazonDataZoneSageMakerEnvironmentRolePermissionsBoundary": {
+    "defaultVersionId": "v13",
+    "createDate": "2024-04-23T23:01:00Z",
+    "updateDate": "2026-07-17T17:42:13Z"
+  },
+  "AmazonDataZoneSageMakerManageAccessRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-04-23T23:34:00Z",
+    "updateDate": "2026-02-12T18:03:09Z"
+  },
+  "AmazonDataZoneSageMakerProvisioningRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-04-23T23:32:00Z",
+    "updateDate": "2026-02-12T18:01:20Z"
+  },
+  "AmazonDetectiveFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-04-30T17:57:00Z",
+    "updateDate": "2023-05-17T19:39:57Z"
+  },
+  "AmazonDetectiveInvestigatorAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-01-17T15:24:00Z",
+    "updateDate": "2023-11-27T03:13:25Z"
+  },
+  "AmazonDetectiveMemberAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-01-17T15:16:14Z",
+    "updateDate": "2023-01-17T15:16:14Z"
+  },
+  "AmazonDetectiveOrganizationsAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-02T15:20:50Z",
+    "updateDate": "2023-03-02T15:20:50Z"
+  },
+  "AmazonDetectiveServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-18T19:47:32Z",
+    "updateDate": "2021-11-18T19:47:32Z"
+  },
+  "AmazonDevOpsGuruConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-12-17T18:43:00Z",
+    "updateDate": "2022-08-25T18:18:53Z"
+  },
+  "AmazonDevOpsGuruFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-12-01T16:38:00Z",
+    "updateDate": "2022-08-25T18:23:41Z"
+  },
+  "AmazonDevOpsGuruOrganizationsAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-15T23:50:52Z",
+    "updateDate": "2021-11-15T23:50:52Z"
+  },
+  "AmazonDevOpsGuruReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2020-12-01T16:34:00Z",
+    "updateDate": "2022-08-25T18:11:21Z"
+  },
+  "AmazonDevOpsGuruServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2020-12-01T10:24:00Z",
+    "updateDate": "2023-01-10T14:36:48Z"
+  },
+  "AmazonDocDB-ElasticServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-30T14:17:05Z",
+    "updateDate": "2022-11-30T14:17:05Z"
+  },
+  "AmazonDocDBConsoleFullAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2019-01-09T20:37:00Z",
+    "updateDate": "2026-02-12T17:59:53Z"
+  },
+  "AmazonDocDBElasticFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2023-06-05T13:51:00Z",
+    "updateDate": "2026-02-12T17:58:12Z"
+  },
+  "AmazonDocDBElasticReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-06-08T14:37:00Z",
+    "updateDate": "2023-06-21T16:57:09Z"
+  },
+  "AmazonDocDBFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-09T20:21:44Z",
+    "updateDate": "2019-01-09T20:21:44Z"
+  },
+  "AmazonDocDBReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-09T20:30:28Z",
+    "updateDate": "2019-01-09T20:30:28Z"
+  },
+  "AmazonDynamoDBFullAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2021-01-29T17:38:30Z"
+  },
+  "AmazonDynamoDBFullAccess_v2": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-05-22T14:52:00Z",
+    "updateDate": "2026-02-12T18:02:57Z"
+  },
+  "AmazonDynamoDBFullAccesswithDataPipeline": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2015-11-12T02:17:42Z"
+  },
+  "AmazonDynamoDBReadOnlyAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2024-11-18T17:38:15Z"
+  },
+  "AmazonEBSCSIDriverEKSClusterScopedPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-04-16T17:27:00Z",
+    "updateDate": "2026-05-28T17:27:10Z"
+  },
+  "AmazonEBSCSIDriverPolicy": {
+    "defaultVersionId": "v15",
+    "createDate": "2022-04-04T17:24:00Z",
+    "updateDate": "2026-05-13T17:42:22Z"
+  },
+  "AmazonEBSCSIDriverPolicyV2": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-16T17:27:15Z",
+    "updateDate": "2026-04-16T17:27:15Z"
+  },
+  "AmazonEC2ContainerRegistryFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-12-21T17:06:00Z",
+    "updateDate": "2020-12-05T00:04:19Z"
+  },
+  "AmazonEC2ContainerRegistryPowerUser": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-12-21T17:05:00Z",
+    "updateDate": "2019-12-10T20:48:08Z"
+  },
+  "AmazonEC2ContainerRegistryPullOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-04T16:58:49Z",
+    "updateDate": "2024-10-04T16:58:49Z"
+  },
+  "AmazonEC2ContainerRegistryReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-12-21T17:04:00Z",
+    "updateDate": "2019-12-10T20:56:32Z"
+  },
+  "AmazonEC2ContainerServiceAutoscaleRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-05-12T23:25:00Z",
+    "updateDate": "2018-02-05T19:15:15Z"
+  },
+  "AmazonEC2ContainerServiceEventsRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-05-30T16:51:00Z",
+    "updateDate": "2023-03-06T22:25:12Z"
+  },
+  "AmazonEC2ContainerServiceRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-04-09T16:14:00Z",
+    "updateDate": "2016-08-11T13:08:01Z"
+  },
+  "AmazonEC2ContainerServiceforEC2Role": {
+    "defaultVersionId": "v10",
+    "createDate": "2015-03-19T18:45:00Z",
+    "updateDate": "2026-02-12T17:59:52Z"
+  },
+  "AmazonEC2FullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2018-11-27T02:16:56Z"
+  },
+  "AmazonEC2ImageReferencesAccessPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-08-26T19:19:00Z",
+    "updateDate": "2026-02-12T17:59:36Z"
+  },
+  "AmazonEC2ReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-02-12T18:03:17Z"
+  },
+  "AmazonEC2RolePolicyForLaunchWizard": {
+    "defaultVersionId": "v12",
+    "createDate": "2019-11-13T08:05:00Z",
+    "updateDate": "2026-08-18T19:27:15Z"
+  },
+  "AmazonEC2RoleforAWSCodeDeploy": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-05-19T18:10:00Z",
+    "updateDate": "2017-03-20T17:14:10Z"
+  },
+  "AmazonEC2RoleforAWSCodeDeployLimited": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-08-24T17:55:00Z",
+    "updateDate": "2022-01-20T21:37:31Z"
+  },
+  "AmazonEC2RoleforDataPipelineRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2016-02-22T17:24:05Z"
+  },
+  "AmazonEC2RoleforSSM": {
+    "defaultVersionId": "v8",
+    "createDate": "2015-05-29T17:48:00Z",
+    "updateDate": "2019-01-24T19:20:51Z"
+  },
+  "AmazonEC2SpotFleetAutoscaleRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-08-19T18:27:00Z",
+    "updateDate": "2019-02-18T19:17:03Z"
+  },
+  "AmazonEC2SpotFleetTaggingRole": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-06-29T18:19:00Z",
+    "updateDate": "2020-04-23T19:30:49Z"
+  },
+  "AmazonECSComputeServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-03-24T17:37:00Z",
+    "updateDate": "2026-02-12T17:57:51Z"
+  },
+  "AmazonECSInfrastructureRolePolicyForLoadBalancers": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-07-17T16:37:00Z",
+    "updateDate": "2026-02-12T18:01:05Z"
+  },
+  "AmazonECSInfrastructureRolePolicyForManagedInstances": {
+    "defaultVersionId": "v11",
+    "createDate": "2025-09-26T18:04:00Z",
+    "updateDate": "2026-02-26T18:27:10Z"
+  },
+  "AmazonECSInfrastructureRolePolicyForServiceConnectTransportLayerSecurity": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-01-19T20:08:00Z",
+    "updateDate": "2026-02-12T18:02:05Z"
+  },
+  "AmazonECSInfrastructureRolePolicyForVolumes": {
+    "defaultVersionId": "v5",
+    "createDate": "2024-01-10T22:56:00Z",
+    "updateDate": "2026-02-12T18:02:34Z"
+  },
+  "AmazonECSInfrastructureRolePolicyForVpcLattice": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-15T20:02:55Z",
+    "updateDate": "2024-11-15T20:02:55Z"
+  },
+  "AmazonECSInfrastructureRoleforExpressGatewayServices": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-11-12T20:34:00Z",
+    "updateDate": "2026-02-12T18:01:54Z"
+  },
+  "AmazonECSInstanceRolePolicyForManagedInstances": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-09-26T23:49:00Z",
+    "updateDate": "2026-07-02T02:57:22Z"
+  },
+  "AmazonECSServiceRolePolicy": {
+    "defaultVersionId": "v24",
+    "createDate": "2017-10-14T01:18:00Z",
+    "updateDate": "2026-04-22T23:12:09Z"
+  },
+  "AmazonECSTaskExecutionRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-16T18:48:22Z",
+    "updateDate": "2017-11-16T18:48:22Z"
+  },
+  "AmazonECS_FullAccess": {
+    "defaultVersionId": "v22",
+    "createDate": "2017-11-07T21:36:00Z",
+    "updateDate": "2026-09-02T14:47:07Z"
+  },
+  "AmazonEFSCSIDriverPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-07-25T20:10:04Z",
+    "updateDate": "2023-07-25T20:10:04Z"
+  },
+  "AmazonEKSBlockStoragePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-30T20:18:13Z",
+    "updateDate": "2024-10-30T20:18:13Z"
+  },
+  "AmazonEKSBlockStoragePolicyV2": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-05-11T16:27:15Z",
+    "updateDate": "2026-05-11T16:27:15Z"
+  },
+  "AmazonEKSClusterPolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2018-05-27T21:06:00Z",
+    "updateDate": "2026-02-12T17:58:15Z"
+  },
+  "AmazonEKSComputePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-11-01T21:46:00Z",
+    "updateDate": "2026-05-18T21:12:10Z"
+  },
+  "AmazonEKSConnectorServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-09-04T20:31:00Z",
+    "updateDate": "2025-10-15T22:34:07Z"
+  },
+  "AmazonEKSDashboardConsoleReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-06-19T17:22:00Z",
+    "updateDate": "2026-02-12T17:59:13Z"
+  },
+  "AmazonEKSDashboardServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-05-08T19:07:07Z",
+    "updateDate": "2025-05-08T19:07:07Z"
+  },
+  "AmazonEKSFargatePodExecutionRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-22T04:34:29Z",
+    "updateDate": "2019-11-22T04:34:29Z"
+  },
+  "AmazonEKSForFargateServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-22T04:36:25Z",
+    "updateDate": "2019-11-22T04:36:25Z"
+  },
+  "AmazonEKSLoadBalancingPolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2024-10-30T20:18:00Z",
+    "updateDate": "2026-08-20T23:07:13Z"
+  },
+  "AmazonEKSLocalOutpostClusterPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-08-24T21:56:00Z",
+    "updateDate": "2024-10-24T17:59:05Z"
+  },
+  "AmazonEKSLocalOutpostServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-08-23T21:53:00Z",
+    "updateDate": "2025-06-26T18:22:07Z"
+  },
+  "AmazonEKSMCPReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-20T17:19:00Z",
+    "updateDate": "2026-02-12T18:02:10Z"
+  },
+  "AmazonEKSNetworkingPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-10-28T22:34:00Z",
+    "updateDate": "2026-08-21T17:27:32Z"
+  },
+  "AmazonEKSServicePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2018-05-27T21:08:00Z",
+    "updateDate": "2024-10-14T21:12:40Z"
+  },
+  "AmazonEKSServiceRolePolicy": {
+    "defaultVersionId": "v27",
+    "createDate": "2020-02-21T20:10:00Z",
+    "updateDate": "2026-08-21T17:17:09Z"
+  },
+  "AmazonEKSVPCResourceController": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-12T00:55:34Z",
+    "updateDate": "2020-08-12T00:55:34Z"
+  },
+  "AmazonEKSWorkerNodeMinimalPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-02T20:03:51Z",
+    "updateDate": "2024-10-02T20:03:51Z"
+  },
+  "AmazonEKSWorkerNodePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-05-27T21:09:00Z",
+    "updateDate": "2023-11-27T00:06:13Z"
+  },
+  "AmazonEKS_CNI_Policy": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-05-27T21:07:00Z",
+    "updateDate": "2026-03-04T19:12:14Z"
+  },
+  "AmazonEMRCleanupPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-09-26T23:54:00Z",
+    "updateDate": "2020-09-29T21:11:54Z"
+  },
+  "AmazonEMRContainersServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2020-12-09T00:38:00Z",
+    "updateDate": "2026-07-24T17:27:11Z"
+  },
+  "AmazonEMRFullAccessPolicy_v2": {
+    "defaultVersionId": "v7",
+    "createDate": "2021-03-12T01:50:00Z",
+    "updateDate": "2026-02-12T17:58:52Z"
+  },
+  "AmazonEMRReadOnlyAccessPolicy_v2": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-03-12T01:39:00Z",
+    "updateDate": "2023-08-02T19:15:33Z"
+  },
+  "AmazonEMRServerlessServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-05-20T23:15:00Z",
+    "updateDate": "2024-01-25T18:21:43Z"
+  },
+  "AmazonEMRServicePolicyForSessions": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-22T19:57:31Z",
+    "updateDate": "2026-06-22T19:57:31Z"
+  },
+  "AmazonEMRServicePolicy_v2": {
+    "defaultVersionId": "v6",
+    "createDate": "2021-03-12T01:11:00Z",
+    "updateDate": "2026-02-12T18:01:09Z"
+  },
+  "AmazonESCognitoAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-02-28T22:29:00Z",
+    "updateDate": "2021-12-20T14:04:44Z"
+  },
+  "AmazonESFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-10-01T19:14:00Z",
+    "updateDate": "2015-10-01T19:14:00Z"
+  },
+  "AmazonESReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-10-01T19:18:00Z",
+    "updateDate": "2018-10-03T03:32:56Z"
+  },
+  "AmazonEVSServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2025-05-16T23:37:00Z",
+    "updateDate": "2026-03-22T18:12:13Z"
+  },
+  "AmazonElastiCacheFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2023-11-28T03:49:56Z"
+  },
+  "AmazonElastiCacheReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:21Z",
+    "updateDate": "2015-02-06T18:40:21Z"
+  },
+  "AmazonElasticContainerRegistryPublicFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-01T17:25:52Z",
+    "updateDate": "2020-12-01T17:25:52Z"
+  },
+  "AmazonElasticContainerRegistryPublicPowerUser": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-01T16:16:54Z",
+    "updateDate": "2020-12-01T16:16:54Z"
+  },
+  "AmazonElasticContainerRegistryPublicReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-01T17:27:04Z",
+    "updateDate": "2020-12-01T17:27:04Z"
+  },
+  "AmazonElasticFileSystemClientFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-01-13T16:27:00Z",
+    "updateDate": "2020-01-13T16:27:00Z"
+  },
+  "AmazonElasticFileSystemClientReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-01-13T16:24:36Z",
+    "updateDate": "2020-01-13T16:24:36Z"
+  },
+  "AmazonElasticFileSystemClientReadWriteAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-01-13T16:21:55Z",
+    "updateDate": "2020-01-13T16:21:55Z"
+  },
+  "AmazonElasticFileSystemFullAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2015-05-27T16:22:00Z",
+    "updateDate": "2024-11-07T19:34:20Z"
+  },
+  "AmazonElasticFileSystemReadOnlyAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2015-05-27T16:25:00Z",
+    "updateDate": "2024-11-07T19:39:56Z"
+  },
+  "AmazonElasticFileSystemServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-11-05T16:52:00Z",
+    "updateDate": "2024-11-07T19:19:50Z"
+  },
+  "AmazonElasticFileSystemsUtils": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-09-29T15:16:00Z",
+    "updateDate": "2026-04-07T13:12:14Z"
+  },
+  "AmazonElasticMapReduceEditorsRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-16T21:55:00Z",
+    "updateDate": "2023-02-09T22:39:29Z"
+  },
+  "AmazonElasticMapReduceFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2019-10-11T15:19:30Z"
+  },
+  "AmazonElasticMapReducePlacementGroupPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-09-29T00:37:08Z",
+    "updateDate": "2020-09-29T00:37:08Z"
+  },
+  "AmazonElasticMapReduceReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2020-07-29T23:14:09Z"
+  },
+  "AmazonElasticMapReduceRole": {
+    "defaultVersionId": "v10",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2020-06-24T22:24:20Z"
+  },
+  "AmazonElasticMapReduceforAutoScalingRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-11-18T01:09:10Z",
+    "updateDate": "2016-11-18T01:09:10Z"
+  },
+  "AmazonElasticMapReduceforEC2Role": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2017-08-11T23:57:30Z"
+  },
+  "AmazonElasticTranscoderRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2019-06-13T22:48:22Z"
+  },
+  "AmazonElasticTranscoder_FullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-04-27T18:59:00Z",
+    "updateDate": "2019-06-10T22:51:51Z"
+  },
+  "AmazonElasticTranscoder_JobsSubmitter": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-06-07T21:12:00Z",
+    "updateDate": "2019-06-10T22:49:34Z"
+  },
+  "AmazonElasticTranscoder_ReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-06-07T21:09:00Z",
+    "updateDate": "2019-06-10T22:48:32Z"
+  },
+  "AmazonElasticsearchServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2017-07-07T00:15:00Z",
+    "updateDate": "2026-06-22T12:27:26Z"
+  },
+  "AmazonEventBridgeApiDestinationsServiceRolePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2021-02-11T20:52:00Z",
+    "updateDate": "2026-02-12T17:58:23Z"
+  },
+  "AmazonEventBridgeFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2019-07-11T14:08:00Z",
+    "updateDate": "2026-02-12T17:58:25Z"
+  },
+  "AmazonEventBridgePipesFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-12-01T17:03:20Z",
+    "updateDate": "2022-12-01T17:03:20Z"
+  },
+  "AmazonEventBridgePipesOperatorAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-12-01T17:04:32Z",
+    "updateDate": "2022-12-01T17:04:32Z"
+  },
+  "AmazonEventBridgePipesReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-12-01T17:04:03Z",
+    "updateDate": "2022-12-01T17:04:03Z"
+  },
+  "AmazonEventBridgeReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2019-07-11T13:59:00Z",
+    "updateDate": "2022-12-01T17:02:48Z"
+  },
+  "AmazonEventBridgeSchedulerFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-11-10T18:37:00Z",
+    "updateDate": "2026-02-12T18:03:15Z"
+  },
+  "AmazonEventBridgeSchedulerReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-11-10T18:50:00Z",
+    "updateDate": "2026-04-02T17:57:20Z"
+  },
+  "AmazonEventBridgeSchemasFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-28T23:12:53Z",
+    "updateDate": "2019-11-28T23:12:53Z"
+  },
+  "AmazonEventBridgeSchemasReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-11-28T23:05:00Z",
+    "updateDate": "2020-05-01T00:50:53Z"
+  },
+  "AmazonEventBridgeSchemasServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-27T01:10:40Z",
+    "updateDate": "2019-11-27T01:10:40Z"
+  },
+  "AmazonFISServiceRolePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2020-12-21T21:18:00Z",
+    "updateDate": "2022-10-25T09:05:23Z"
+  },
+  "AmazonFSxConsoleFullAccess": {
+    "defaultVersionId": "v20",
+    "createDate": "2018-11-28T16:36:00Z",
+    "updateDate": "2026-02-12T18:02:11Z"
+  },
+  "AmazonFSxConsoleReadOnlyAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2018-11-28T16:35:00Z",
+    "updateDate": "2026-02-12T17:59:08Z"
+  },
+  "AmazonFSxFullAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2018-11-28T16:34:00Z",
+    "updateDate": "2026-02-12T17:58:13Z"
+  },
+  "AmazonFSxReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-28T16:33:32Z",
+    "updateDate": "2018-11-28T16:33:32Z"
+  },
+  "AmazonFSxServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2018-11-28T10:38:00Z",
+    "updateDate": "2025-07-22T18:07:07Z"
+  },
+  "AmazonForecastFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-18T01:52:29Z",
+    "updateDate": "2019-01-18T01:52:29Z"
+  },
+  "AmazonFraudDetectorFullAccessPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T22:46:26Z",
+    "updateDate": "2019-12-03T22:46:26Z"
+  },
+  "AmazonFreeRTOSFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-29T15:32:51Z",
+    "updateDate": "2017-11-29T15:32:51Z"
+  },
+  "AmazonFreeRTOSOTAUpdate": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-08-27T22:43:00Z",
+    "updateDate": "2020-12-18T17:47:30Z"
+  },
+  "AmazonGlacierFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:28Z",
+    "updateDate": "2015-02-06T18:40:28Z"
+  },
+  "AmazonGlacierReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2016-05-05T18:46:10Z"
+  },
+  "AmazonGrafanaAthenaAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-22T17:11:11Z",
+    "updateDate": "2021-11-22T17:11:11Z"
+  },
+  "AmazonGrafanaCloudWatchAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-24T22:41:53Z",
+    "updateDate": "2023-03-24T22:41:53Z"
+  },
+  "AmazonGrafanaRedshiftAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-11-26T23:15:15Z",
+    "updateDate": "2021-11-26T23:15:15Z"
+  },
+  "AmazonGrafanaServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-08T23:10:33Z",
+    "updateDate": "2022-11-08T23:10:33Z"
+  },
+  "AmazonGuardDutyFullAccess_v2": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-06-04T20:22:00Z",
+    "updateDate": "2026-02-12T17:59:55Z"
+  },
+  "AmazonGuardDutyMalwareProtectionServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-07-19T19:06:00Z",
+    "updateDate": "2024-01-25T22:24:00Z"
+  },
+  "AmazonGuardDutyReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-11-28T22:29:00Z",
+    "updateDate": "2023-11-16T23:07:06Z"
+  },
+  "AmazonGuardDutyServiceRolePolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2017-11-28T20:12:00Z",
+    "updateDate": "2026-04-24T20:12:17Z"
+  },
+  "AmazonHealthLakeFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-02-17T01:07:05Z",
+    "updateDate": "2021-02-17T01:07:05Z"
+  },
+  "AmazonHealthLakeReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-02-17T02:43:00Z",
+    "updateDate": "2026-08-04T21:12:23Z"
+  },
+  "AmazonHoneycodeFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-24T20:28:11Z",
+    "updateDate": "2020-06-24T20:28:11Z"
+  },
+  "AmazonHoneycodeReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-06-24T20:28:00Z",
+    "updateDate": "2020-12-01T17:27:53Z"
+  },
+  "AmazonHoneycodeServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-18T18:03:08Z",
+    "updateDate": "2020-11-18T18:03:08Z"
+  },
+  "AmazonHoneycodeTeamAssociationFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-24T20:28:27Z",
+    "updateDate": "2020-06-24T20:28:27Z"
+  },
+  "AmazonHoneycodeTeamAssociationReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-24T20:27:46Z",
+    "updateDate": "2020-06-24T20:27:46Z"
+  },
+  "AmazonHoneycodeWorkbookFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-06-24T20:28:00Z",
+    "updateDate": "2020-12-01T17:30:06Z"
+  },
+  "AmazonHoneycodeWorkbookReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-06-24T20:28:00Z",
+    "updateDate": "2020-12-01T17:32:49Z"
+  },
+  "AmazonInspector2AgentlessServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-11-20T15:18:00Z",
+    "updateDate": "2026-08-20T19:17:13Z"
+  },
+  "AmazonInspector2AmiScanServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-30T17:57:10Z",
+    "updateDate": "2026-07-30T17:57:10Z"
+  },
+  "AmazonInspector2FullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-11-29T19:10:00Z",
+    "updateDate": "2024-04-25T13:21:03Z"
+  },
+  "AmazonInspector2FullAccess_v2": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-07-03T16:07:00Z",
+    "updateDate": "2026-07-08T19:12:18Z"
+  },
+  "AmazonInspector2ManagedCisPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-01-24T16:31:43Z",
+    "updateDate": "2024-01-24T16:31:43Z"
+  },
+  "AmazonInspector2ManagedTelemetryPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-02-13T17:12:06Z",
+    "updateDate": "2026-02-13T17:12:06Z"
+  },
+  "AmazonInspector2ReadOnlyAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2022-01-21T14:45:00Z",
+    "updateDate": "2026-07-07T18:57:19Z"
+  },
+  "AmazonInspector2ServiceRolePolicy": {
+    "defaultVersionId": "v27",
+    "createDate": "2021-11-16T20:27:00Z",
+    "updateDate": "2026-06-16T19:27:15Z"
+  },
+  "AmazonInspector2ThirdPartyServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-26T15:27:27Z",
+    "updateDate": "2026-06-26T15:27:27Z"
+  },
+  "AmazonInspectorFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2015-10-07T17:08:00Z",
+    "updateDate": "2017-12-21T14:53:31Z"
+  },
+  "AmazonInspectorReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-10-07T17:08:00Z",
+    "updateDate": "2019-10-01T15:17:54Z"
+  },
+  "AmazonInspectorServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-11-21T15:48:00Z",
+    "updateDate": "2020-09-11T17:12:02Z"
+  },
+  "AmazonKendraFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T16:15:37Z",
+    "updateDate": "2019-12-03T16:15:37Z"
+  },
+  "AmazonKendraReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-12-03T16:13:00Z",
+    "updateDate": "2021-05-27T17:01:20Z"
+  },
+  "AmazonKeyspacesFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2020-04-23T17:06:00Z",
+    "updateDate": "2026-02-12T18:00:58Z"
+  },
+  "AmazonKeyspacesReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2020-04-23T17:07:00Z",
+    "updateDate": "2026-02-12T18:00:32Z"
+  },
+  "AmazonKeyspacesReadOnlyAccess_v2": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-09-12T17:01:00Z",
+    "updateDate": "2026-02-12T18:02:57Z"
+  },
+  "AmazonKinesisAnalyticsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-09-21T19:01:14Z",
+    "updateDate": "2016-09-21T19:01:14Z"
+  },
+  "AmazonKinesisAnalyticsReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-09-21T18:16:43Z",
+    "updateDate": "2016-09-21T18:16:43Z"
+  },
+  "AmazonKinesisFirehoseFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-10-07T18:45:26Z",
+    "updateDate": "2015-10-07T18:45:26Z"
+  },
+  "AmazonKinesisFirehoseReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-10-07T18:43:39Z",
+    "updateDate": "2015-10-07T18:43:39Z"
+  },
+  "AmazonKinesisFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:29Z",
+    "updateDate": "2015-02-06T18:40:29Z"
+  },
+  "AmazonKinesisReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:30Z",
+    "updateDate": "2015-02-06T18:40:30Z"
+  },
+  "AmazonKinesisVideoStreamsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-12-01T23:27:18Z",
+    "updateDate": "2017-12-01T23:27:18Z"
+  },
+  "AmazonKinesisVideoStreamsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-12-01T23:14:32Z",
+    "updateDate": "2017-12-01T23:14:32Z"
+  },
+  "AmazonLaunchWizardFullAccessV2": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-09-01T17:14:00Z",
+    "updateDate": "2026-08-18T19:27:25Z"
+  },
+  "AmazonLexChannelsAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-01-13T20:12:46Z",
+    "updateDate": "2021-01-13T20:12:46Z"
+  },
+  "AmazonLexFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2017-04-11T23:20:00Z",
+    "updateDate": "2024-04-16T20:06:39Z"
+  },
+  "AmazonLexReadOnly": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-04-11T23:13:00Z",
+    "updateDate": "2024-05-13T16:58:13Z"
+  },
+  "AmazonLexReplicationPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-01-31T23:29:00Z",
+    "updateDate": "2025-06-24T21:52:07Z"
+  },
+  "AmazonLexRunBotsOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2017-04-11T23:06:00Z",
+    "updateDate": "2021-08-18T00:15:48Z"
+  },
+  "AmazonLexV2BotPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-01-13T20:10:29Z",
+    "updateDate": "2021-01-13T20:10:29Z"
+  },
+  "AmazonLookoutEquipmentFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-04-08T15:52:00Z",
+    "updateDate": "2021-11-24T21:00:13Z"
+  },
+  "AmazonLookoutEquipmentReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-05-05T16:47:00Z",
+    "updateDate": "2022-11-10T22:04:33Z"
+  },
+  "AmazonLookoutMetricsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-05-07T00:43:38Z",
+    "updateDate": "2021-05-07T00:43:38Z"
+  },
+  "AmazonLookoutMetricsReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-05-07T00:43:00Z",
+    "updateDate": "2022-01-04T18:19:27Z"
+  },
+  "AmazonLookoutVisionConsoleFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-05-11T19:37:17Z",
+    "updateDate": "2021-05-11T19:37:17Z"
+  },
+  "AmazonLookoutVisionConsoleReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-05-11T19:32:00Z",
+    "updateDate": "2021-12-09T02:46:29Z"
+  },
+  "AmazonLookoutVisionFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-05-11T19:24:54Z",
+    "updateDate": "2021-05-11T19:24:54Z"
+  },
+  "AmazonLookoutVisionReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-05-11T19:11:00Z",
+    "updateDate": "2021-12-09T03:01:51Z"
+  },
+  "AmazonMCSFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-12-03T13:45:00Z",
+    "updateDate": "2020-04-17T19:19:29Z"
+  },
+  "AmazonMCSReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-12-03T13:46:00Z",
+    "updateDate": "2020-04-17T19:21:34Z"
+  },
+  "AmazonMQApiFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-12-18T20:31:00Z",
+    "updateDate": "2020-11-04T16:45:35Z"
+  },
+  "AmazonMQApiReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-12-18T20:31:13Z",
+    "updateDate": "2018-12-18T20:31:13Z"
+  },
+  "AmazonMQFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2017-11-28T15:28:00Z",
+    "updateDate": "2026-09-03T22:47:07Z"
+  },
+  "AmazonMQReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-11-28T15:30:00Z",
+    "updateDate": "2017-11-28T19:02:03Z"
+  },
+  "AmazonMQServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-04T16:07:17Z",
+    "updateDate": "2020-11-04T16:07:17Z"
+  },
+  "AmazonMSKConnectReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-09-20T10:18:00Z",
+    "updateDate": "2021-10-18T09:16:26Z"
+  },
+  "AmazonMSKFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2019-01-14T22:07:00Z",
+    "updateDate": "2023-10-18T11:33:13Z"
+  },
+  "AmazonMSKReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-14T22:28:45Z",
+    "updateDate": "2019-01-14T22:28:45Z"
+  },
+  "AmazonMWAAServerlessServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-11-15T20:34:07Z",
+    "updateDate": "2025-11-15T20:34:07Z"
+  },
+  "AmazonMWAAServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-11-24T14:13:00Z",
+    "updateDate": "2022-11-17T00:56:25Z"
+  },
+  "AmazonMachineLearningBatchPredictionsAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T17:12:19Z",
+    "updateDate": "2015-04-09T17:12:19Z"
+  },
+  "AmazonMachineLearningCreateOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-04-09T17:18:00Z",
+    "updateDate": "2016-06-29T20:55:03Z"
+  },
+  "AmazonMachineLearningFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T17:25:41Z",
+    "updateDate": "2015-04-09T17:25:41Z"
+  },
+  "AmazonMachineLearningManageRealTimeEndpointOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T17:32:41Z",
+    "updateDate": "2015-04-09T17:32:41Z"
+  },
+  "AmazonMachineLearningReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T17:40:02Z",
+    "updateDate": "2015-04-09T17:40:02Z"
+  },
+  "AmazonMachineLearningRealTimePredictionOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T17:44:06Z",
+    "updateDate": "2015-04-09T17:44:06Z"
+  },
+  "AmazonMachineLearningRoleforRedshiftDataSourceV3": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-24T18:00:09Z",
+    "updateDate": "2020-06-24T18:00:09Z"
+  },
+  "AmazonMacieFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-08-14T14:54:00Z",
+    "updateDate": "2022-07-01T00:41:53Z"
+  },
+  "AmazonMacieHandshakeRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-06-28T15:46:10Z",
+    "updateDate": "2018-06-28T15:46:10Z"
+  },
+  "AmazonMacieReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-06-15T21:50:06Z",
+    "updateDate": "2023-06-15T21:50:06Z"
+  },
+  "AmazonMacieServiceRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-08-14T14:53:26Z",
+    "updateDate": "2017-08-14T14:53:26Z"
+  },
+  "AmazonMacieServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-06-19T22:17:00Z",
+    "updateDate": "2022-05-19T19:16:56Z"
+  },
+  "AmazonManagedBlockchainConsoleFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-04-29T21:23:25Z",
+    "updateDate": "2019-04-29T21:23:25Z"
+  },
+  "AmazonManagedBlockchainFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-04-29T21:39:29Z",
+    "updateDate": "2019-04-29T21:39:29Z"
+  },
+  "AmazonManagedBlockchainReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-04-30T18:17:31Z",
+    "updateDate": "2019-04-30T18:17:31Z"
+  },
+  "AmazonManagedBlockchainServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-01-17T19:51:28Z",
+    "updateDate": "2020-01-17T19:51:28Z"
+  },
+  "AmazonMechanicalTurkFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-12-11T19:08:19Z",
+    "updateDate": "2015-12-11T19:08:19Z"
+  },
+  "AmazonMechanicalTurkReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-12-11T19:08:00Z",
+    "updateDate": "2019-09-25T21:06:26Z"
+  },
+  "AmazonMemoryDBFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-08T19:24:16Z",
+    "updateDate": "2021-10-08T19:24:16Z"
+  },
+  "AmazonMemoryDBReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-10-08T19:27:28Z",
+    "updateDate": "2021-10-08T19:27:28Z"
+  },
+  "AmazonMobileAnalyticsFinancialReportAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:35Z",
+    "updateDate": "2015-02-06T18:40:35Z"
+  },
+  "AmazonMobileAnalyticsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:34Z",
+    "updateDate": "2015-02-06T18:40:34Z"
+  },
+  "AmazonMobileAnalyticsNon-financialReportAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:36Z",
+    "updateDate": "2015-02-06T18:40:36Z"
+  },
+  "AmazonMobileAnalyticsWriteOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:37Z",
+    "updateDate": "2015-02-06T18:40:37Z"
+  },
+  "AmazonMonitronFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-12-02T22:40:00Z",
+    "updateDate": "2022-06-08T16:27:42Z"
+  },
+  "AmazonNimbleStudio-LaunchProfileWorker": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-04-28T04:47:02Z",
+    "updateDate": "2021-04-28T04:47:02Z"
+  },
+  "AmazonNimbleStudio-StudioAdmin": {
+    "defaultVersionId": "v4",
+    "createDate": "2021-04-28T04:47:00Z",
+    "updateDate": "2023-09-22T17:40:41Z"
+  },
+  "AmazonNimbleStudio-StudioUser": {
+    "defaultVersionId": "v5",
+    "createDate": "2021-04-28T04:48:00Z",
+    "updateDate": "2023-09-22T17:45:14Z"
+  },
+  "AmazonODBAutonomousVmClusterAdmin": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-07T01:12:00Z",
+    "updateDate": "2026-09-04T21:17:07Z"
+  },
+  "AmazonODBExadataInfrastructureAdmin": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-07T01:12:00Z",
+    "updateDate": "2026-09-04T21:27:07Z"
+  },
+  "AmazonODBFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-07-23T22:57:00Z",
+    "updateDate": "2026-09-04T21:37:08Z"
+  },
+  "AmazonODBNetworkAdmin": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-07T01:12:00Z",
+    "updateDate": "2026-09-04T21:37:08Z"
+  },
+  "AmazonODBReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-07T01:12:00Z",
+    "updateDate": "2026-09-04T21:27:07Z"
+  },
+  "AmazonODBServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2024-11-13T18:21:00Z",
+    "updateDate": "2026-02-12T18:02:51Z"
+  },
+  "AmazonOmicsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-02-24T00:59:33Z",
+    "updateDate": "2023-02-24T00:59:33Z"
+  },
+  "AmazonOmicsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-29T04:17:07Z",
+    "updateDate": "2022-11-29T04:17:07Z"
+  },
+  "AmazonOneEnterpriseFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-28T04:58:21Z",
+    "updateDate": "2023-11-28T04:58:21Z"
+  },
+  "AmazonOneEnterpriseInstallerAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-28T05:00:39Z",
+    "updateDate": "2023-11-28T05:00:39Z"
+  },
+  "AmazonOneEnterpriseReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-28T04:59:23Z",
+    "updateDate": "2023-11-28T04:59:23Z"
+  },
+  "AmazonOpenSearchDashboardsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-12-22T19:38:16Z",
+    "updateDate": "2023-12-22T19:38:16Z"
+  },
+  "AmazonOpenSearchDirectQueryGlueCreateAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-05-06T12:24:38Z",
+    "updateDate": "2024-05-06T12:24:38Z"
+  },
+  "AmazonOpenSearchIngestionFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-26T18:11:38Z",
+    "updateDate": "2023-04-26T18:11:38Z"
+  },
+  "AmazonOpenSearchIngestionReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-26T18:09:52Z",
+    "updateDate": "2023-04-26T18:09:52Z"
+  },
+  "AmazonOpenSearchIngestionServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-18T16:49:00Z",
+    "updateDate": "2025-08-28T18:19:07Z"
+  },
+  "AmazonOpenSearchServerlessServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-24T19:50:00Z",
+    "updateDate": "2024-07-25T21:19:30Z"
+  },
+  "AmazonOpenSearchServiceCognitoAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-09-02T06:31:00Z",
+    "updateDate": "2021-12-20T14:04:18Z"
+  },
+  "AmazonOpenSearchServiceFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-08T05:33:47Z",
+    "updateDate": "2021-09-08T05:33:47Z"
+  },
+  "AmazonOpenSearchServiceReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-08T05:38:13Z",
+    "updateDate": "2021-09-08T05:38:13Z"
+  },
+  "AmazonOpenSearchServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2021-08-26T09:27:00Z",
+    "updateDate": "2025-03-27T22:52:06Z"
+  },
+  "AmazonPersonalizeFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-12-04T22:24:00Z",
+    "updateDate": "2019-05-30T23:46:59Z"
+  },
+  "AmazonPollyFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-11-30T18:59:06Z",
+    "updateDate": "2016-11-30T18:59:06Z"
+  },
+  "AmazonPollyReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-11-30T18:59:00Z",
+    "updateDate": "2026-04-01T08:12:15Z"
+  },
+  "AmazonPrometheusConsoleFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2020-12-15T18:11:00Z",
+    "updateDate": "2026-02-12T17:59:47Z"
+  },
+  "AmazonPrometheusFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-12-15T18:10:00Z",
+    "updateDate": "2023-11-26T20:16:13Z"
+  },
+  "AmazonPrometheusQueryAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-19T01:02:58Z",
+    "updateDate": "2020-12-19T01:02:58Z"
+  },
+  "AmazonPrometheusRemoteWriteAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-19T01:04:32Z",
+    "updateDate": "2020-12-19T01:04:32Z"
+  },
+  "AmazonPrometheusScraperServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-11-26T14:19:00Z",
+    "updateDate": "2026-07-17T08:27:27Z"
+  },
+  "AmazonQDeveloperAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-07-09T08:35:00Z",
+    "updateDate": "2026-05-20T23:12:16Z"
+  },
+  "AmazonQFullAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2023-11-28T16:00:00Z",
+    "updateDate": "2026-05-20T22:27:23Z"
+  },
+  "AmazonQLDBConsoleFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-09-05T18:24:00Z",
+    "updateDate": "2022-11-04T17:01:10Z"
+  },
+  "AmazonQLDBFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-09-05T18:23:00Z",
+    "updateDate": "2022-11-04T17:01:27Z"
+  },
+  "AmazonQLDBReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-09-05T18:19:00Z",
+    "updateDate": "2021-07-02T02:17:25Z"
+  },
+  "AmazonRDSBetaServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-05-02T19:41:00Z",
+    "updateDate": "2024-08-07T00:54:21Z"
+  },
+  "AmazonRDSCustomInstanceProfileRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-02-27T17:42:00Z",
+    "updateDate": "2026-02-12T18:00:17Z"
+  },
+  "AmazonRDSCustomPreviewServiceRolePolicy": {
+    "defaultVersionId": "v15",
+    "createDate": "2021-10-08T21:44:00Z",
+    "updateDate": "2026-02-12T17:58:02Z"
+  },
+  "AmazonRDSCustomServiceRolePolicy": {
+    "defaultVersionId": "v19",
+    "createDate": "2021-10-08T21:39:00Z",
+    "updateDate": "2026-02-12T17:57:39Z"
+  },
+  "AmazonRDSDataFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-11-20T21:29:00Z",
+    "updateDate": "2019-11-20T21:58:46Z"
+  },
+  "AmazonRDSDirectoryServiceAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2016-02-26T02:02:00Z",
+    "updateDate": "2019-05-15T16:51:50Z"
+  },
+  "AmazonRDSEnhancedMonitoringRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-11-11T19:58:29Z",
+    "updateDate": "2015-11-11T19:58:29Z"
+  },
+  "AmazonRDSFullAccess": {
+    "defaultVersionId": "v14",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2023-08-17T23:00:17Z"
+  },
+  "AmazonRDSPerformanceInsightsFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2023-08-15T23:41:00Z",
+    "updateDate": "2026-07-23T00:27:08Z"
+  },
+  "AmazonRDSPerformanceInsightsReadOnly": {
+    "defaultVersionId": "v7",
+    "createDate": "2022-04-05T00:02:00Z",
+    "updateDate": "2026-07-22T23:42:28Z"
+  },
+  "AmazonRDSPreviewServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-05-31T18:02:00Z",
+    "updateDate": "2024-08-07T01:02:38Z"
+  },
+  "AmazonRDSReadOnlyAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2023-04-14T12:32:09Z"
+  },
+  "AmazonRDSServiceRolePolicy": {
+    "defaultVersionId": "v14",
+    "createDate": "2018-01-08T18:17:00Z",
+    "updateDate": "2024-07-01T22:42:05Z"
+  },
+  "AmazonRedshiftAllCommandsFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-11-04T00:48:00Z",
+    "updateDate": "2021-11-25T02:27:31Z"
+  },
+  "AmazonRedshiftDataFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2020-09-09T19:23:00Z",
+    "updateDate": "2023-04-07T18:18:32Z"
+  },
+  "AmazonRedshiftFederatedAuthorization": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-22T00:04:00Z",
+    "updateDate": "2026-02-12T17:58:24Z"
+  },
+  "AmazonRedshiftFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2022-07-07T23:31:13Z"
+  },
+  "AmazonRedshiftQueryEditor": {
+    "defaultVersionId": "v4",
+    "createDate": "2018-10-04T22:50:00Z",
+    "updateDate": "2021-02-16T19:33:45Z"
+  },
+  "AmazonRedshiftQueryEditorV2FullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-09-24T14:06:00Z",
+    "updateDate": "2024-02-21T17:20:52Z"
+  },
+  "AmazonRedshiftQueryEditorV2NoSharing": {
+    "defaultVersionId": "v9",
+    "createDate": "2021-09-24T14:18:00Z",
+    "updateDate": "2024-02-21T17:25:07Z"
+  },
+  "AmazonRedshiftQueryEditorV2ReadSharing": {
+    "defaultVersionId": "v9",
+    "createDate": "2021-09-24T14:22:00Z",
+    "updateDate": "2024-02-21T17:27:40Z"
+  },
+  "AmazonRedshiftQueryEditorV2ReadWriteSharing": {
+    "defaultVersionId": "v9",
+    "createDate": "2021-09-24T14:25:00Z",
+    "updateDate": "2024-02-21T17:30:28Z"
+  },
+  "AmazonRedshiftReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2024-02-08T00:24:13Z"
+  },
+  "AmazonRedshiftServiceLinkedRolePolicy": {
+    "defaultVersionId": "v15",
+    "createDate": "2017-09-18T19:19:00Z",
+    "updateDate": "2025-02-19T17:22:07Z"
+  },
+  "AmazonRekognitionCustomLabelsFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-01-08T19:18:00Z",
+    "updateDate": "2022-08-16T20:20:43Z"
+  },
+  "AmazonRekognitionFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-11-30T14:40:44Z",
+    "updateDate": "2016-11-30T14:40:44Z"
+  },
+  "AmazonRekognitionReadOnlyAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2016-11-30T14:58:00Z",
+    "updateDate": "2023-11-08T18:30:22Z"
+  },
+  "AmazonRekognitionServiceRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-29T16:52:13Z",
+    "updateDate": "2017-11-29T16:52:13Z"
+  },
+  "AmazonRoute53AutoNamingFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-01-18T18:40:41Z",
+    "updateDate": "2018-01-18T18:40:41Z"
+  },
+  "AmazonRoute53AutoNamingReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-01-18T03:02:59Z",
+    "updateDate": "2018-01-18T03:02:59Z"
+  },
+  "AmazonRoute53AutoNamingRegistrantAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-03-12T22:33:20Z",
+    "updateDate": "2018-03-12T22:33:20Z"
+  },
+  "AmazonRoute53DomainsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:56Z",
+    "updateDate": "2015-02-06T18:40:56Z"
+  },
+  "AmazonRoute53DomainsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:40:57Z",
+    "updateDate": "2015-02-06T18:40:57Z"
+  },
+  "AmazonRoute53FullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-02-12T18:00:40Z"
+  },
+  "AmazonRoute53GlobalResolverFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-09T20:27:09Z",
+    "updateDate": "2026-03-09T20:27:09Z"
+  },
+  "AmazonRoute53GlobalResolverReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-09T20:27:11Z",
+    "updateDate": "2026-03-09T20:27:11Z"
+  },
+  "AmazonRoute53ProfilesFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-04-30T18:30:00Z",
+    "updateDate": "2024-08-27T19:18:18Z"
+  },
+  "AmazonRoute53ProfilesReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-04-30T18:29:00Z",
+    "updateDate": "2024-08-27T18:59:57Z"
+  },
+  "AmazonRoute53ReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2016-11-15T21:15:16Z"
+  },
+  "AmazonRoute53RecoveryClusterFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-08-18T18:37:00Z",
+    "updateDate": "2021-08-18T18:37:00Z"
+  },
+  "AmazonRoute53RecoveryClusterReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-08-18T17:36:00Z",
+    "updateDate": "2022-04-01T17:37:55Z"
+  },
+  "AmazonRoute53RecoveryControlConfigFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-08-18T17:48:35Z",
+    "updateDate": "2021-08-18T17:48:35Z"
+  },
+  "AmazonRoute53RecoveryControlConfigReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-08-18T18:01:00Z",
+    "updateDate": "2023-10-18T17:15:33Z"
+  },
+  "AmazonRoute53RecoveryReadinessFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-08-18T16:45:07Z",
+    "updateDate": "2021-08-18T16:45:07Z"
+  },
+  "AmazonRoute53RecoveryReadinessReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-08-18T18:11:00Z",
+    "updateDate": "2021-11-09T20:14:51Z"
+  },
+  "AmazonRoute53ResolverFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-05-30T18:10:00Z",
+    "updateDate": "2024-08-05T20:06:08Z"
+  },
+  "AmazonRoute53ResolverReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-05-30T18:11:00Z",
+    "updateDate": "2024-08-05T18:54:11Z"
+  },
+  "AmazonS3ExpressFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-03T20:42:13Z",
+    "updateDate": "2026-04-03T20:42:13Z"
+  },
+  "AmazonS3ExpressReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-03T20:42:10Z",
+    "updateDate": "2026-04-03T20:42:10Z"
+  },
+  "AmazonS3FilesCSIDriverPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-07T13:12:12Z",
+    "updateDate": "2026-04-07T13:12:12Z"
+  },
+  "AmazonS3FilesClientFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-07T12:57:21Z",
+    "updateDate": "2026-04-07T12:57:21Z"
+  },
+  "AmazonS3FilesClientReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-07T12:57:21Z",
+    "updateDate": "2026-04-07T12:57:21Z"
+  },
+  "AmazonS3FilesClientReadWriteAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-07T12:57:09Z",
+    "updateDate": "2026-04-07T12:57:09Z"
+  },
+  "AmazonS3FilesFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-07T12:42:08Z",
+    "updateDate": "2026-04-07T12:42:08Z"
+  },
+  "AmazonS3FilesReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-07T12:57:08Z",
+    "updateDate": "2026-04-07T12:57:08Z"
+  },
+  "AmazonS3FullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2021-09-27T20:16:37Z"
+  },
+  "AmazonS3ObjectLambdaExecutionRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-08-18T10:07:41Z",
+    "updateDate": "2021-08-18T10:07:41Z"
+  },
+  "AmazonS3OutpostsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-10-02T17:26:30Z",
+    "updateDate": "2020-10-02T17:26:30Z"
+  },
+  "AmazonS3OutpostsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-10-02T18:55:58Z",
+    "updateDate": "2020-10-02T18:55:58Z"
+  },
+  "AmazonS3ReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2023-08-10T21:31:39Z"
+  },
+  "AmazonS3TablesFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-03T15:21:00Z",
+    "updateDate": "2026-02-12T18:00:31Z"
+  },
+  "AmazonS3TablesLakeFormationServiceRole": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-06-19T19:07:00Z",
+    "updateDate": "2026-02-12T18:01:45Z"
+  },
+  "AmazonS3TablesReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-03T15:21:00Z",
+    "updateDate": "2026-02-12T18:02:34Z"
+  },
+  "AmazonSESFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:02Z",
+    "updateDate": "2015-02-06T18:41:02Z"
+  },
+  "AmazonSESReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2024-05-14T12:03:02Z"
+  },
+  "AmazonSESServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-05-21T16:02:20Z",
+    "updateDate": "2024-05-21T16:02:20Z"
+  },
+  "AmazonSNSFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2024-09-24T22:32:05Z"
+  },
+  "AmazonSNSReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2024-09-24T22:13:12Z"
+  },
+  "AmazonSNSRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:30Z",
+    "updateDate": "2015-02-06T18:41:30Z"
+  },
+  "AmazonSQSFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:07Z",
+    "updateDate": "2015-02-06T18:41:07Z"
+  },
+  "AmazonSQSReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2024-05-24T18:16:44Z"
+  },
+  "AmazonSSMAutomationApproverAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-08-07T23:07:28Z",
+    "updateDate": "2017-08-07T23:07:28Z"
+  },
+  "AmazonSSMAutomationRole": {
+    "defaultVersionId": "v9",
+    "createDate": "2016-12-05T22:09:00Z",
+    "updateDate": "2026-03-20T17:42:14Z"
+  },
+  "AmazonSSMDirectoryServiceAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-03-15T17:44:38Z",
+    "updateDate": "2019-03-15T17:44:38Z"
+  },
+  "AmazonSSMFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-05-29T17:39:00Z",
+    "updateDate": "2019-11-20T20:08:56Z"
+  },
+  "AmazonSSMMaintenanceWindowRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-12-01T15:57:00Z",
+    "updateDate": "2019-07-27T00:16:05Z"
+  },
+  "AmazonSSMManagedEC2InstanceDefaultPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-08-30T20:54:00Z",
+    "updateDate": "2024-07-16T18:14:07Z"
+  },
+  "AmazonSSMManagedInstanceCore": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-03-15T17:22:00Z",
+    "updateDate": "2019-05-23T16:54:21Z"
+  },
+  "AmazonSSMPatchAssociation": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-05-13T16:00:42Z",
+    "updateDate": "2020-05-13T16:00:42Z"
+  },
+  "AmazonSSMReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-05-29T17:44:19Z",
+    "updateDate": "2015-05-29T17:44:19Z"
+  },
+  "AmazonSSMServiceRolePolicy": {
+    "defaultVersionId": "v17",
+    "createDate": "2017-11-13T19:20:00Z",
+    "updateDate": "2026-06-26T19:12:18Z"
+  },
+  "AmazonSageMakerAdmin-ServiceCatalogProductsServiceRolePolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2020-11-27T18:48:00Z",
+    "updateDate": "2026-02-12T18:02:33Z"
+  },
+  "AmazonSageMakerCanvasAIServicesAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-03-23T22:36:00Z",
+    "updateDate": "2023-11-29T14:47:09Z"
+  },
+  "AmazonSageMakerCanvasBedrockAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-02-02T18:37:25Z",
+    "updateDate": "2024-02-02T18:37:25Z"
+  },
+  "AmazonSageMakerCanvasDataPrepFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-10-27T22:56:00Z",
+    "updateDate": "2024-08-16T18:11:13Z"
+  },
+  "AmazonSageMakerCanvasDirectDeployAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-10-06T18:11:53Z",
+    "updateDate": "2023-10-06T18:11:53Z"
+  },
+  "AmazonSageMakerCanvasEMRServerlessExecutionRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-07-27T00:35:42Z",
+    "updateDate": "2024-07-27T00:35:42Z"
+  },
+  "AmazonSageMakerCanvasForecastAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-08-24T20:04:20Z",
+    "updateDate": "2022-08-24T20:04:20Z"
+  },
+  "AmazonSageMakerCanvasFullAccess": {
+    "defaultVersionId": "v11",
+    "createDate": "2022-09-09T00:44:00Z",
+    "updateDate": "2024-08-16T04:35:23Z"
+  },
+  "AmazonSageMakerCanvasSMDataScienceAssistantAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-04T14:06:00Z",
+    "updateDate": "2026-02-12T18:02:13Z"
+  },
+  "AmazonSageMakerCapacityReservationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-04-08T20:27:08Z",
+    "updateDate": "2026-04-08T20:27:08Z"
+  },
+  "AmazonSageMakerClusterInstanceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-29T15:11:26Z",
+    "updateDate": "2023-11-29T15:11:26Z"
+  },
+  "AmazonSageMakerCoreServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-21T21:40:47Z",
+    "updateDate": "2020-12-21T21:40:47Z"
+  },
+  "AmazonSageMakerEdgeDeviceFleetPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-08T16:17:22Z",
+    "updateDate": "2020-12-08T16:17:22Z"
+  },
+  "AmazonSageMakerFeatureStoreAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-12-01T16:24:00Z",
+    "updateDate": "2022-12-05T14:19:58Z"
+  },
+  "AmazonSageMakerFullAccess": {
+    "defaultVersionId": "v29",
+    "createDate": "2017-11-29T13:07:00Z",
+    "updateDate": "2026-02-12T17:58:32Z"
+  },
+  "AmazonSageMakerGeospatialExecutionRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-30T10:08:00Z",
+    "updateDate": "2023-05-10T20:28:02Z"
+  },
+  "AmazonSageMakerGeospatialFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-30T10:06:48Z",
+    "updateDate": "2022-11-30T10:06:48Z"
+  },
+  "AmazonSageMakerGroundTruthExecution": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-07-09T19:30:00Z",
+    "updateDate": "2022-04-29T20:49:54Z"
+  },
+  "AmazonSageMakerHyperPodGatedModelAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-01-17T01:04:00Z",
+    "updateDate": "2026-02-12T18:00:37Z"
+  },
+  "AmazonSageMakerHyperPodInferenceAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2026-01-27T20:34:00Z",
+    "updateDate": "2026-07-20T20:57:13Z"
+  },
+  "AmazonSageMakerHyperPodObservabilityAdminAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-07-10T14:37:00Z",
+    "updateDate": "2026-02-12T17:57:37Z"
+  },
+  "AmazonSageMakerHyperPodServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-09-06T17:04:30Z",
+    "updateDate": "2024-09-06T17:04:30Z"
+  },
+  "AmazonSageMakerHyperPodTrainingOperatorAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-08-19T17:04:00Z",
+    "updateDate": "2026-02-12T17:58:35Z"
+  },
+  "AmazonSageMakerInferenceServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-07-30T19:42:00Z",
+    "updateDate": "2026-08-17T21:07:28Z"
+  },
+  "AmazonSageMakerJobFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-03T02:42:30Z",
+    "updateDate": "2026-06-03T02:42:30Z"
+  },
+  "AmazonSageMakerJobRuntimeAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-06-03T02:42:00Z",
+    "updateDate": "2026-08-07T18:42:15Z"
+  },
+  "AmazonSageMakerMechanicalTurkAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-03T16:19:36Z",
+    "updateDate": "2019-12-03T16:19:36Z"
+  },
+  "AmazonSageMakerModelCustomizationCoreAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-05-26T18:57:00Z",
+    "updateDate": "2026-07-21T19:57:28Z"
+  },
+  "AmazonSageMakerModelGovernanceUseAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-11-30T08:58:00Z",
+    "updateDate": "2024-06-04T21:48:12Z"
+  },
+  "AmazonSageMakerModelRegistryFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-04-13T05:20:00Z",
+    "updateDate": "2024-06-06T18:48:51Z"
+  },
+  "AmazonSageMakerNotebooksServiceRolePolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2019-10-18T20:27:00Z",
+    "updateDate": "2026-04-16T18:12:19Z"
+  },
+  "AmazonSageMakerPartnerAppsFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-01-17T18:37:00Z",
+    "updateDate": "2026-02-12T17:57:23Z"
+  },
+  "AmazonSageMakerPartnerServiceCatalogProductsApiGatewayServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-08-01T15:06:24Z",
+    "updateDate": "2023-08-01T15:06:24Z"
+  },
+  "AmazonSageMakerPartnerServiceCatalogProductsCloudFormationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-08-01T15:06:46Z",
+    "updateDate": "2023-08-01T15:06:46Z"
+  },
+  "AmazonSageMakerPartnerServiceCatalogProductsLambdaServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-08-01T15:05:51Z",
+    "updateDate": "2023-08-01T15:05:51Z"
+  },
+  "AmazonSageMakerPipelinesIntegrations": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-07-30T16:35:00Z",
+    "updateDate": "2023-02-17T21:28:19Z"
+  },
+  "AmazonSageMakerQuickSightVPCPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-06-03T17:37:00Z",
+    "updateDate": "2026-02-12T18:00:34Z"
+  },
+  "AmazonSageMakerReadOnly": {
+    "defaultVersionId": "v11",
+    "createDate": "2017-11-29T13:07:00Z",
+    "updateDate": "2021-12-01T16:29:20Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsApiGatewayServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-03-25T04:25:36Z",
+    "updateDate": "2022-03-25T04:25:36Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsCloudformationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-03-25T04:26:40Z",
+    "updateDate": "2022-03-25T04:26:40Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsCodeBuildServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-03-25T04:27:00Z",
+    "updateDate": "2026-02-12T18:00:10Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsCodePipelineServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2022-02-22T09:53:00Z",
+    "updateDate": "2026-02-12T18:00:38Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsEventsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-02-22T09:53:59Z",
+    "updateDate": "2022-02-22T09:53:59Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsFirehoseServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-02-22T09:54:35Z",
+    "updateDate": "2022-02-22T09:54:35Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsGlueServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-02-22T09:51:00Z",
+    "updateDate": "2022-08-26T19:13:02Z"
+  },
+  "AmazonSageMakerServiceCatalogProductsLambdaServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-04-04T16:34:00Z",
+    "updateDate": "2024-06-11T18:57:13Z"
+  },
+  "AmazonSageMakerSpacesControllerPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-19T04:34:00Z",
+    "updateDate": "2026-02-12T18:01:40Z"
+  },
+  "AmazonSageMakerSpacesRouterPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-19T04:34:00Z",
+    "updateDate": "2026-02-12T17:58:24Z"
+  },
+  "AmazonSageMakerTrainingPlanCreateAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-04T13:21:00Z",
+    "updateDate": "2026-02-12T18:03:21Z"
+  },
+  "AmazonSecurityLakeAdministrator": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-05-30T22:04:00Z",
+    "updateDate": "2024-02-23T16:01:57Z"
+  },
+  "AmazonSecurityLakeMetastoreManager": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-01-23T15:26:00Z",
+    "updateDate": "2024-04-01T20:04:24Z"
+  },
+  "AmazonSecurityLakePermissionsBoundary": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-29T14:11:00Z",
+    "updateDate": "2024-05-14T20:39:20Z"
+  },
+  "AmazonTextractFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-28T19:07:42Z",
+    "updateDate": "2018-11-28T19:07:42Z"
+  },
+  "AmazonTextractServiceRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-28T19:12:16Z",
+    "updateDate": "2018-11-28T19:12:16Z"
+  },
+  "AmazonTimestreamConsoleFullAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2020-09-30T21:47:00Z",
+    "updateDate": "2026-02-12T18:00:50Z"
+  },
+  "AmazonTimestreamFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-09-30T21:47:00Z",
+    "updateDate": "2021-11-26T23:42:00Z"
+  },
+  "AmazonTimestreamInfluxDBFullAccess": {
+    "defaultVersionId": "v18",
+    "createDate": "2024-03-14T22:53:00Z",
+    "updateDate": "2026-08-03T22:42:17Z"
+  },
+  "AmazonTimestreamInfluxDBFullAccessWithoutMarketplaceAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2025-04-17T17:52:00Z",
+    "updateDate": "2026-08-03T22:57:25Z"
+  },
+  "AmazonTimestreamInfluxDBServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-03-14T18:53:00Z",
+    "updateDate": "2026-07-20T18:27:24Z"
+  },
+  "AmazonTimestreamReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-09-30T21:47:00Z",
+    "updateDate": "2024-06-05T19:11:27Z"
+  },
+  "AmazonTranscribeFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-04-04T16:06:16Z",
+    "updateDate": "2018-04-04T16:06:16Z"
+  },
+  "AmazonTranscribeReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-04-04T16:05:06Z",
+    "updateDate": "2018-04-04T16:05:06Z"
+  },
+  "AmazonVPCCrossAccountNetworkInterfaceOperations": {
+    "defaultVersionId": "v5",
+    "createDate": "2017-07-18T20:47:00Z",
+    "updateDate": "2023-09-25T15:12:17Z"
+  },
+  "AmazonVPCFullAccess": {
+    "defaultVersionId": "v13",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2026-02-12T18:00:44Z"
+  },
+  "AmazonVPCNetworkAccessAnalyzerFullAccessPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-06-15T22:56:00Z",
+    "updateDate": "2026-08-14T17:17:25Z"
+  },
+  "AmazonVPCReachabilityAnalyzerFullAccessPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-06-14T20:12:00Z",
+    "updateDate": "2026-08-14T17:07:19Z"
+  },
+  "AmazonVPCReachabilityAnalyzerPathComponentReadPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-05-01T20:38:22Z",
+    "updateDate": "2023-05-01T20:38:22Z"
+  },
+  "AmazonVPCReadOnlyAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2026-02-12T17:58:19Z"
+  },
+  "AmazonVerifiedPermissionsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-11T18:19:31Z",
+    "updateDate": "2024-10-11T18:19:31Z"
+  },
+  "AmazonVerifiedPermissionsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-11T18:25:51Z",
+    "updateDate": "2024-10-11T18:25:51Z"
+  },
+  "AmazonWorkDocsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-04-16T23:05:11Z",
+    "updateDate": "2020-04-16T23:05:11Z"
+  },
+  "AmazonWorkDocsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-01-08T23:49:59Z",
+    "updateDate": "2020-01-08T23:49:59Z"
+  },
+  "AmazonWorkMailEventsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-04-16T16:52:43Z",
+    "updateDate": "2019-04-16T16:52:43Z"
+  },
+  "AmazonWorkMailFullAccess": {
+    "defaultVersionId": "v10",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2020-12-21T14:13:40Z"
+  },
+  "AmazonWorkMailMessageFlowFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-02-11T11:08:35Z",
+    "updateDate": "2021-02-11T11:08:35Z"
+  },
+  "AmazonWorkMailMessageFlowReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-01-28T12:40:08Z",
+    "updateDate": "2021-01-28T12:40:08Z"
+  },
+  "AmazonWorkMailReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2019-07-25T08:24:50Z"
+  },
+  "AmazonWorkSpacesAdmin": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-09-22T22:21:00Z",
+    "updateDate": "2024-06-27T17:16:27Z"
+  },
+  "AmazonWorkSpacesApplicationManagerAdminAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-04-09T14:03:18Z",
+    "updateDate": "2015-04-09T14:03:18Z"
+  },
+  "AmazonWorkSpacesPoolServiceAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-27T16:21:03Z",
+    "updateDate": "2024-06-27T16:21:03Z"
+  },
+  "AmazonWorkSpacesSecureBrowserReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-24T20:01:09Z",
+    "updateDate": "2024-06-24T20:01:09Z"
+  },
+  "AmazonWorkSpacesSelfServiceAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-06-27T19:22:52Z",
+    "updateDate": "2019-06-27T19:22:52Z"
+  },
+  "AmazonWorkSpacesServiceAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-06-27T19:19:00Z",
+    "updateDate": "2020-03-18T23:32:10Z"
+  },
+  "AmazonWorkSpacesThinClientFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-08-09T07:25:00Z",
+    "updateDate": "2026-02-12T17:59:25Z"
+  },
+  "AmazonWorkSpacesThinClientMonitoringServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-06-13T19:37:07Z",
+    "updateDate": "2025-06-13T19:37:07Z"
+  },
+  "AmazonWorkSpacesThinClientReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2024-07-19T08:50:00Z",
+    "updateDate": "2026-02-12T17:57:09Z"
+  },
+  "AmazonWorkSpacesWebReadOnly": {
+    "defaultVersionId": "v2",
+    "createDate": "2021-11-30T14:20:00Z",
+    "updateDate": "2022-11-02T20:20:44Z"
+  },
+  "AmazonWorkSpacesWebServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2021-11-30T13:15:00Z",
+    "updateDate": "2022-12-15T22:46:33Z"
+  },
+  "AmazonWorkspacesPCAAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-08T00:25:55Z",
+    "updateDate": "2022-11-08T00:25:55Z"
+  },
+  "AmazonZocaloFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:13Z",
+    "updateDate": "2015-02-06T18:41:13Z"
+  },
+  "AmazonZocaloReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:14Z",
+    "updateDate": "2015-02-06T18:41:14Z"
+  },
+  "AmplifyBackendDeployFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2023-10-06T21:32:00Z",
+    "updateDate": "2024-11-14T19:09:39Z"
+  },
+  "AnthropicFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-04-01T04:57:00Z",
+    "updateDate": "2026-04-01T22:42:19Z"
+  },
+  "AnthropicLimitedAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2026-04-01T04:57:00Z",
+    "updateDate": "2026-06-12T16:57:32Z"
+  },
+  "AnthropicReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-04-01T04:57:00Z",
+    "updateDate": "2026-04-01T22:42:18Z"
+  },
+  "AnthropicSelfHostedEnvironmentAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-12T17:12:29Z",
+    "updateDate": "2026-06-12T17:12:29Z"
+  },
+  "AppIntegrationsServiceLinkedRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-09-30T19:42:56Z",
+    "updateDate": "2022-09-30T19:42:56Z"
+  },
+  "AppRunnerNetworkingServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-01-12T21:02:40Z",
+    "updateDate": "2022-01-12T21:02:40Z"
+  },
+  "AppRunnerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-05-14T19:15:04Z",
+    "updateDate": "2021-05-14T19:15:04Z"
+  },
+  "AppStudioServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-07-10T05:01:00Z",
+    "updateDate": "2025-03-13T20:37:07Z"
+  },
+  "ApplicationAutoScalingForAmazonAppStreamAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-02-06T21:39:56Z",
+    "updateDate": "2017-02-06T21:39:56Z"
+  },
+  "ApplicationDiscoveryServiceContinuousExportServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-08-09T20:22:00Z",
+    "updateDate": "2018-08-13T22:31:21Z"
+  },
+  "AuroraDsqlServiceLinkedRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-03T15:06:00Z",
+    "updateDate": "2026-02-12T18:01:12Z"
+  },
+  "AutoScalingConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-01-12T19:43:00Z",
+    "updateDate": "2018-02-06T23:15:36Z"
+  },
+  "AutoScalingConsoleReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-01-12T19:48:53Z",
+    "updateDate": "2017-01-12T19:48:53Z"
+  },
+  "AutoScalingFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-01-12T19:31:00Z",
+    "updateDate": "2018-02-06T21:59:13Z"
+  },
+  "AutoScalingNotificationAccessRole": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:22Z",
+    "updateDate": "2015-02-06T18:41:22Z"
+  },
+  "AutoScalingReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-01-12T19:39:35Z",
+    "updateDate": "2017-01-12T19:39:35Z"
+  },
+  "AutoScalingServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2018-01-08T23:10:00Z",
+    "updateDate": "2025-11-12T18:19:06Z"
+  },
+  "AwsGlueDataBrewFullAccessPolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2020-11-11T16:51:00Z",
+    "updateDate": "2022-02-04T18:28:33Z"
+  },
+  "AwsGlueSessionUserRestrictedNotebookPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-04-18T15:24:00Z",
+    "updateDate": "2024-08-15T20:51:03Z"
+  },
+  "AwsGlueSessionUserRestrictedNotebookServiceRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-04-18T15:27:00Z",
+    "updateDate": "2024-08-15T20:51:58Z"
+  },
+  "AwsGlueSessionUserRestrictedPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-04-14T21:31:00Z",
+    "updateDate": "2024-08-05T23:06:45Z"
+  },
+  "AwsGlueSessionUserRestrictedServiceRole": {
+    "defaultVersionId": "v3",
+    "createDate": "2022-04-14T21:30:00Z",
+    "updateDate": "2024-08-05T23:14:07Z"
+  },
+  "BatchServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2021-03-10T06:55:00Z",
+    "updateDate": "2026-08-05T17:12:14Z"
+  },
+  "BedrockAgentCoreFullAccess": {
+    "defaultVersionId": "v21",
+    "createDate": "2025-07-16T13:37:00Z",
+    "updateDate": "2026-09-03T22:07:07Z"
+  },
+  "BedrockAgentCoreNetworkServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-09-19T22:04:06Z",
+    "updateDate": "2025-09-19T22:04:06Z"
+  },
+  "BedrockAgentCoreRuntimeIdentityServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-10-11T01:04:08Z",
+    "updateDate": "2025-10-11T01:04:08Z"
+  },
+  "BedrockAgentCoreRuntimeInstancesInstanceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-08-05T13:27:25Z",
+    "updateDate": "2026-08-05T13:27:25Z"
+  },
+  "BedrockAgentCoreRuntimeInstancesOperatorRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-08-05T11:27:00Z",
+    "updateDate": "2026-08-06T10:12:23Z"
+  },
+  "Billing": {
+    "defaultVersionId": "v30",
+    "createDate": "2016-11-10T17:33:00Z",
+    "updateDate": "2026-07-30T22:12:16Z"
+  },
+  "BudgetsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-07-30T21:07:06Z",
+    "updateDate": "2025-07-30T21:07:06Z"
+  },
+  "CertificateManagerServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-25T17:56:49Z",
+    "updateDate": "2020-06-25T17:56:49Z"
+  },
+  "ClientVPNServiceConnectionsRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-12T19:48:06Z",
+    "updateDate": "2020-08-12T19:48:06Z"
+  },
+  "ClientVPNServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2018-12-10T21:20:00Z",
+    "updateDate": "2020-08-12T19:39:34Z"
+  },
+  "CloudFormationStackSetsOrgAdminServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-10T00:20:05Z",
+    "updateDate": "2019-12-10T00:20:05Z"
+  },
+  "CloudFormationStackSetsOrgMemberServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-12-09T23:52:00Z",
+    "updateDate": "2026-07-22T20:12:14Z"
+  },
+  "CloudFrontFullAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2026-07-30T16:42:27Z"
+  },
+  "CloudFrontReadOnlyAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2026-02-12T17:59:06Z"
+  },
+  "CloudHSMServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-06T19:12:46Z",
+    "updateDate": "2017-11-06T19:12:46Z"
+  },
+  "CloudSearchFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:39:56Z",
+    "updateDate": "2015-02-06T18:39:56Z"
+  },
+  "CloudSearchReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:39:57Z",
+    "updateDate": "2015-02-06T18:39:57Z"
+  },
+  "CloudTrailEventContext": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-05-15T13:52:06Z",
+    "updateDate": "2025-05-15T13:52:06Z"
+  },
+  "CloudTrailServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-10-24T21:21:00Z",
+    "updateDate": "2023-11-27T01:18:10Z"
+  },
+  "CloudWatch-CrossAccountAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-07-23T09:59:27Z",
+    "updateDate": "2019-07-23T09:59:27Z"
+  },
+  "CloudWatchAPIKeyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-05-08T08:57:00Z",
+    "updateDate": "2026-06-04T20:42:29Z"
+  },
+  "CloudWatchActionsEC2Access": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-07-07T00:00:33Z",
+    "updateDate": "2015-07-07T00:00:33Z"
+  },
+  "CloudWatchAgentAdminPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-03-07T00:52:00Z",
+    "updateDate": "2024-02-05T20:59:57Z"
+  },
+  "CloudWatchAgentServerPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-03-07T01:06:00Z",
+    "updateDate": "2024-02-06T16:37:37Z"
+  },
+  "CloudWatchApplicationInsightsFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2020-11-24T18:44:00Z",
+    "updateDate": "2022-01-25T17:51:29Z"
+  },
+  "CloudWatchApplicationInsightsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-24T18:48:00Z",
+    "updateDate": "2020-11-24T18:48:00Z"
+  },
+  "CloudWatchApplicationSignalsFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-06-06T22:50:00Z",
+    "updateDate": "2026-02-12T17:57:47Z"
+  },
+  "CloudWatchApplicationSignalsReadOnlyAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-06-06T22:48:00Z",
+    "updateDate": "2026-02-12T17:57:56Z"
+  },
+  "CloudWatchApplicationSignalsServiceRolePolicy": {
+    "defaultVersionId": "v11",
+    "createDate": "2023-11-09T18:09:00Z",
+    "updateDate": "2026-02-12T18:00:05Z"
+  },
+  "CloudWatchAutomaticDashboardsAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-07-23T10:01:00Z",
+    "updateDate": "2026-08-07T10:42:17Z"
+  },
+  "CloudWatchCrossAccountSharingConfiguration": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-27T14:01:10Z",
+    "updateDate": "2022-11-27T14:01:10Z"
+  },
+  "CloudWatchEventsBuiltInTargetExecutionAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-01-14T18:35:49Z",
+    "updateDate": "2016-01-14T18:35:49Z"
+  },
+  "CloudWatchEventsFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2016-01-14T18:37:00Z",
+    "updateDate": "2026-02-12T18:00:32Z"
+  },
+  "CloudWatchEventsInvocationAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-01-14T18:36:33Z",
+    "updateDate": "2016-01-14T18:36:33Z"
+  },
+  "CloudWatchEventsReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2016-01-14T18:27:00Z",
+    "updateDate": "2022-12-01T16:29:31Z"
+  },
+  "CloudWatchEventsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-11-17T00:42:04Z",
+    "updateDate": "2017-11-17T00:42:04Z"
+  },
+  "CloudWatchFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2022-11-27T13:23:49Z"
+  },
+  "CloudWatchFullAccessV2": {
+    "defaultVersionId": "v16",
+    "createDate": "2023-08-01T11:32:00Z",
+    "updateDate": "2026-06-08T13:27:16Z"
+  },
+  "CloudWatchInternetMonitorFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-22T21:02:59Z",
+    "updateDate": "2024-10-22T21:02:59Z"
+  },
+  "CloudWatchInternetMonitorReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-12T23:11:17Z",
+    "updateDate": "2024-11-12T23:11:17Z"
+  },
+  "CloudWatchInternetMonitorServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-11-27T17:46:00Z",
+    "updateDate": "2023-07-20T04:46:37Z"
+  },
+  "CloudWatchLambdaApplicationSignalsExecutionRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-10-16T19:09:17Z",
+    "updateDate": "2024-10-16T19:09:17Z"
+  },
+  "CloudWatchLambdaInsightsExecutionRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-10-07T19:27:06Z",
+    "updateDate": "2020-10-07T19:27:06Z"
+  },
+  "CloudWatchLogsAPIKeyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-02-20T19:42:07Z",
+    "updateDate": "2026-02-20T19:42:07Z"
+  },
+  "CloudWatchLogsCrossAccountSharingConfiguration": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-27T13:55:22Z",
+    "updateDate": "2022-11-27T13:55:22Z"
+  },
+  "CloudWatchLogsFullAccess": {
+    "defaultVersionId": "v8",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-02-12T18:00:33Z"
+  },
+  "CloudWatchLogsReadOnlyAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-02-12T17:59:13Z"
+  },
+  "CloudWatchNetworkFlowMonitorAgentPublishPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-01T22:51:00Z",
+    "updateDate": "2026-02-12T18:00:08Z"
+  },
+  "CloudWatchNetworkFlowMonitorServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2024-12-01T22:36:00Z",
+    "updateDate": "2026-02-12T18:01:39Z"
+  },
+  "CloudWatchNetworkFlowMonitorTopologyServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2024-12-01T22:51:00Z",
+    "updateDate": "2026-09-01T01:47:07Z"
+  },
+  "CloudWatchNetworkMonitorServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-12-21T18:53:00Z",
+    "updateDate": "2026-08-25T13:27:18Z"
+  },
+  "CloudWatchOpenSearchDashboardAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-01T21:06:00Z",
+    "updateDate": "2026-02-12T17:59:06Z"
+  },
+  "CloudWatchOpenSearchDashboardsFullAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-01T21:06:00Z",
+    "updateDate": "2026-02-12T17:59:00Z"
+  },
+  "CloudWatchReadOnlyAccess": {
+    "defaultVersionId": "v24",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2026-02-12T18:01:50Z"
+  },
+  "CloudWatchSyntheticsFullAccess": {
+    "defaultVersionId": "v14",
+    "createDate": "2019-11-25T17:39:00Z",
+    "updateDate": "2026-03-31T21:12:14Z"
+  },
+  "CloudWatchSyntheticsReadOnlyAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-11-25T17:45:00Z",
+    "updateDate": "2020-03-06T19:26:01Z"
+  },
+  "CloudwatchApplicationInsightsServiceLinkedRolePolicy": {
+    "defaultVersionId": "v25",
+    "createDate": "2018-12-01T16:22:00Z",
+    "updateDate": "2024-07-25T16:24:03Z"
+  },
+  "ComprehendDataAccessRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-03-06T22:28:15Z",
+    "updateDate": "2019-03-06T22:28:15Z"
+  },
+  "ComprehendFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-11-29T18:08:00Z",
+    "updateDate": "2017-12-05T01:36:24Z"
+  },
+  "ComprehendMedicalFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-27T17:55:52Z",
+    "updateDate": "2018-11-27T17:55:52Z"
+  },
+  "ComprehendReadOnly": {
+    "defaultVersionId": "v11",
+    "createDate": "2017-11-29T18:10:00Z",
+    "updateDate": "2022-04-26T21:32:41Z"
+  },
+  "ComputeOptimizerAutomationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-11-15T01:19:07Z",
+    "updateDate": "2025-11-15T01:19:07Z"
+  },
+  "ComputeOptimizerReadOnlyAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2020-03-07T00:11:00Z",
+    "updateDate": "2024-11-20T21:08:59Z"
+  },
+  "ComputeOptimizerServiceRolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2019-12-03T08:45:00Z",
+    "updateDate": "2026-05-27T17:42:11Z"
+  },
+  "ConfigConformsServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2019-07-25T21:38:00Z",
+    "updateDate": "2023-01-12T04:17:34Z"
+  },
+  "ConsoleFullAccessFromVercel": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-12-11T16:49:00Z",
+    "updateDate": "2026-04-09T18:57:11Z"
+  },
+  "ConsoleViewOnlyAccessFromVercel": {
+    "defaultVersionId": "v5",
+    "createDate": "2025-12-11T16:49:00Z",
+    "updateDate": "2026-04-09T18:27:08Z"
+  },
+  "CostOptimizationHubAdminAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-12-19T00:03:00Z",
+    "updateDate": "2026-02-12T17:58:24Z"
+  },
+  "CostOptimizationHubReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-12-13T18:04:00Z",
+    "updateDate": "2026-02-12T18:00:33Z"
+  },
+  "CostOptimizationHubServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-11-26T08:03:00Z",
+    "updateDate": "2025-07-17T18:07:07Z"
+  },
+  "CustomerProfilesServiceLinkedRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2023-03-07T22:56:00Z",
+    "updateDate": "2026-03-05T21:12:08Z"
+  },
+  "DAXServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-03-05T17:51:25Z",
+    "updateDate": "2018-03-05T17:51:25Z"
+  },
+  "DBModDiscoveryAndAssessment": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-25T20:27:16Z",
+    "updateDate": "2026-03-25T20:27:16Z"
+  },
+  "DBModProvisioningAndMigration": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-03-25T20:42:12Z",
+    "updateDate": "2026-03-25T20:42:12Z"
+  },
+  "DBModVirtualSource": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-06T23:12:26Z",
+    "updateDate": "2026-07-06T23:12:26Z"
+  },
+  "DataScientist": {
+    "defaultVersionId": "v6",
+    "createDate": "2016-11-10T17:28:00Z",
+    "updateDate": "2026-09-02T23:37:07Z"
+  },
+  "DatabaseAdministrator": {
+    "defaultVersionId": "v5",
+    "createDate": "2016-11-10T17:25:00Z",
+    "updateDate": "2026-02-12T18:02:20Z"
+  },
+  "DeclarativePoliciesEC2Report": {
+    "defaultVersionId": "v2",
+    "createDate": "2024-11-30T13:21:00Z",
+    "updateDate": "2026-07-03T10:57:26Z"
+  },
+  "DynamoDBCloudWatchContributorInsightsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-11-15T21:13:58Z",
+    "updateDate": "2019-11-15T21:13:58Z"
+  },
+  "DynamoDBGlobalTableSettingsManagementServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-10-15T17:34:00Z",
+    "updateDate": "2026-02-12T17:58:01Z"
+  },
+  "DynamoDBKinesisReplicationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-12T00:43:25Z",
+    "updateDate": "2020-11-12T00:43:25Z"
+  },
+  "DynamoDBReplicationServiceRolePolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2017-11-09T23:55:00Z",
+    "updateDate": "2024-01-08T20:10:36Z"
+  },
+  "EC2ApplicationStatusChecksServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-04-27T23:42:00Z",
+    "updateDate": "2026-07-15T17:12:31Z"
+  },
+  "EC2FastLaunchFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2024-05-13T22:45:00Z",
+    "updateDate": "2026-08-04T20:27:26Z"
+  },
+  "EC2FastLaunchServiceRolePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2022-01-10T13:08:00Z",
+    "updateDate": "2026-02-12T17:57:11Z"
+  },
+  "EC2FleetTimeShiftableServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-23T19:47:15Z",
+    "updateDate": "2019-12-23T19:47:15Z"
+  },
+  "EC2ImageBuilderExecutionPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2026-06-04T17:12:00Z",
+    "updateDate": "2026-07-08T16:27:23Z"
+  },
+  "EC2ImageBuilderLifecycleExecutionPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-16T23:23:09Z",
+    "updateDate": "2023-11-16T23:23:09Z"
+  },
+  "EC2InstanceConnect": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-06-27T18:53:34Z",
+    "updateDate": "2019-06-27T18:53:34Z"
+  },
+  "EC2InstanceProfileForImageBuilder": {
+    "defaultVersionId": "v12",
+    "createDate": "2019-12-01T19:08:00Z",
+    "updateDate": "2026-02-12T17:58:59Z"
+  },
+  "EC2InstanceProfileForImageBuilderECRContainerBuilds": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-11T19:48:15Z",
+    "updateDate": "2020-12-11T19:48:15Z"
+  },
+  "ECRReplicationServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-04T22:11:28Z",
+    "updateDate": "2020-12-04T22:11:28Z"
+  },
+  "ECRTemplateServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-19T23:11:37Z",
+    "updateDate": "2024-06-19T23:11:37Z"
+  },
+  "EMRDescribeClusterPolicyForEMRWAL": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-06-15T23:30:22Z",
+    "updateDate": "2023-06-15T23:30:22Z"
+  },
+  "Ec2ImageBuilderCrossAccountDistributionAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-09-30T19:22:54Z",
+    "updateDate": "2020-09-30T19:22:54Z"
+  },
+  "Ec2InstanceConnectEndpoint": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-01-24T20:19:00Z",
+    "updateDate": "2025-07-31T17:49:06Z"
+  },
+  "ElastiCacheServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-12-07T17:50:00Z",
+    "updateDate": "2023-11-28T03:05:37Z"
+  },
+  "ElasticLoadBalancingFullAccess": {
+    "defaultVersionId": "v9",
+    "createDate": "2018-09-20T20:42:00Z",
+    "updateDate": "2026-02-23T18:57:07Z"
+  },
+  "ElasticLoadBalancingReadOnly": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-09-20T20:17:00Z",
+    "updateDate": "2023-11-26T18:15:46Z"
+  },
+  "ElementalActivationsDownloadSoftwareAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-09-08T17:26:09Z",
+    "updateDate": "2020-09-08T17:26:09Z"
+  },
+  "ElementalActivationsFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-06-04T21:00:13Z",
+    "updateDate": "2020-06-04T21:00:13Z"
+  },
+  "ElementalActivationsGenerateLicenses": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-28T18:28:58Z",
+    "updateDate": "2020-08-28T18:28:58Z"
+  },
+  "ElementalActivationsReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-28T16:51:01Z",
+    "updateDate": "2020-08-28T16:51:01Z"
+  },
+  "ElementalAppliancesSoftwareFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-07-31T16:28:00Z",
+    "updateDate": "2021-02-05T21:01:25Z"
+  },
+  "ElementalAppliancesSoftwareReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-04-01T22:31:09Z",
+    "updateDate": "2020-04-01T22:31:09Z"
+  },
+  "ElementalSupportCenterFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-11-25T18:08:00Z",
+    "updateDate": "2021-02-05T21:02:54Z"
+  },
+  "FMSServiceRolePolicy": {
+    "defaultVersionId": "v37",
+    "createDate": "2018-03-28T23:01:00Z",
+    "updateDate": "2026-04-06T21:57:08Z"
+  },
+  "FSxDeleteServiceLinkedRoleAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-28T10:40:24Z",
+    "updateDate": "2018-11-28T10:40:24Z"
+  },
+  "FinOpsAgentAgentPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-06-03T19:57:00Z",
+    "updateDate": "2026-09-01T16:27:06Z"
+  },
+  "FinOpsAgentOperatorPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-03T19:57:09Z",
+    "updateDate": "2026-06-03T19:57:09Z"
+  },
+  "GameLiftContainerFleetPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-11-12T19:28:00Z",
+    "updateDate": "2026-02-12T17:57:58Z"
+  },
+  "GameLiftGameServerGroupPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2020-04-03T23:12:00Z",
+    "updateDate": "2020-05-13T17:27:43Z"
+  },
+  "GitLabDuoWithAmazonQPermissionsPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-04-16T16:37:00Z",
+    "updateDate": "2026-02-12T18:00:18Z"
+  },
+  "GlobalAcceleratorFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-11-27T02:44:00Z",
+    "updateDate": "2020-12-04T19:17:26Z"
+  },
+  "GlobalAcceleratorReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2018-11-27T02:41:00Z",
+    "updateDate": "2018-11-27T02:41:00Z"
+  },
+  "GreengrassOTAUpdateArtifactAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-11-29T18:11:00Z",
+    "updateDate": "2018-12-18T00:59:43Z"
+  },
+  "Health_OrganizationsServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-12-16T13:28:00Z",
+    "updateDate": "2024-02-06T16:07:08Z"
+  },
+  "IAMAccessAdvisorReadOnly": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-06-21T19:33:45Z",
+    "updateDate": "2019-06-21T19:33:45Z"
+  },
+  "IAMAccessAnalyzerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-12-02T17:12:40Z",
+    "updateDate": "2019-12-02T17:12:40Z"
+  },
+  "IAMAccessAnalyzerReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-12-02T17:12:00Z",
+    "updateDate": "2024-07-18T17:49:04Z"
+  },
+  "IAMAuditRootUserCredentials": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-06T22:27:58Z",
+    "updateDate": "2024-11-06T22:27:58Z"
+  },
+  "IAMCreateRootUserPassword": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-06T22:32:59Z",
+    "updateDate": "2024-11-06T22:32:59Z"
+  },
+  "IAMDeleteRootUserCredentials": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-06T22:47:58Z",
+    "updateDate": "2024-11-06T22:47:58Z"
+  },
+  "IAMFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2019-06-21T19:40:00Z"
+  },
+  "IAMReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2015-02-06T18:40:00Z",
+    "updateDate": "2018-01-25T19:11:27Z"
+  },
+  "IAMSelfManageServiceSpecificCredentials": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-12-22T17:25:18Z",
+    "updateDate": "2016-12-22T17:25:18Z"
+  },
+  "IAMUserChangePassword": {
+    "defaultVersionId": "v5",
+    "createDate": "2016-11-15T00:25:00Z",
+    "updateDate": "2026-02-12T17:58:57Z"
+  },
+  "IAMUserSSHKeys": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-07-09T17:08:54Z",
+    "updateDate": "2015-07-09T17:08:54Z"
+  },
+  "IVSFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-12-13T21:20:21Z",
+    "updateDate": "2023-12-13T21:20:21Z"
+  },
+  "IVSReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2023-12-05T18:00:00Z",
+    "updateDate": "2026-02-12T18:03:11Z"
+  },
+  "IVSRecordToS3": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-12-05T00:10:43Z",
+    "updateDate": "2020-12-05T00:10:43Z"
+  },
+  "KafkaConnectServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2021-09-07T13:12:44Z",
+    "updateDate": "2021-09-07T13:12:44Z"
+  },
+  "KafkaServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2018-11-15T23:31:00Z",
+    "updateDate": "2025-11-10T23:19:09Z"
+  },
+  "KeyspacesCDCServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-06-21T00:22:07Z",
+    "updateDate": "2025-06-21T00:22:07Z"
+  },
+  "KeyspacesReplicationServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2023-05-02T16:15:00Z",
+    "updateDate": "2024-11-15T20:55:16Z"
+  },
+  "LakeFormationDataAccessServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-06-20T20:46:00Z",
+    "updateDate": "2024-02-06T18:37:31Z"
+  },
+  "LexBotPolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2017-02-17T22:18:00Z",
+    "updateDate": "2019-11-13T22:29:16Z"
+  },
+  "LexChannelPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2017-02-17T23:23:24Z",
+    "updateDate": "2017-02-17T23:23:24Z"
+  },
+  "LightsailExportAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-09-28T16:35:00Z",
+    "updateDate": "2022-01-15T01:45:33Z"
+  },
+  "MediaConnectGatewayInstanceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-22T20:43:25Z",
+    "updateDate": "2023-03-22T20:43:25Z"
+  },
+  "MediaPackageServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-09-18T17:45:47Z",
+    "updateDate": "2020-09-18T17:45:47Z"
+  },
+  "MemoryDBServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2021-08-17T22:34:00Z",
+    "updateDate": "2024-12-01T16:21:07Z"
+  },
+  "MigrationHubDMSAccessServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-06-12T17:50:00Z",
+    "updateDate": "2019-10-07T17:57:44Z"
+  },
+  "MigrationHubSMSAccessServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-06-12T18:30:00Z",
+    "updateDate": "2019-10-07T18:02:22Z"
+  },
+  "MigrationHubServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2019-06-12T17:22:00Z",
+    "updateDate": "2020-08-06T18:08:46Z"
+  },
+  "MonitronServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-05-02T19:22:03Z",
+    "updateDate": "2022-05-02T19:22:03Z"
+  },
+  "MultiPartyApprovalFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-06-18T20:22:00Z",
+    "updateDate": "2026-02-12T18:02:56Z"
+  },
+  "MultiPartyApprovalReadOnlyAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-06-18T20:07:00Z",
+    "updateDate": "2026-02-12T17:59:08Z"
+  },
+  "NeptuneConsoleFullAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2018-06-19T21:35:00Z",
+    "updateDate": "2023-11-30T07:32:44Z"
+  },
+  "NeptuneFullAccess": {
+    "defaultVersionId": "v7",
+    "createDate": "2018-05-30T19:17:00Z",
+    "updateDate": "2024-01-22T16:32:31Z"
+  },
+  "NeptuneGraphReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-30T07:32:17Z",
+    "updateDate": "2023-11-30T07:32:17Z"
+  },
+  "NeptuneReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-05-30T19:16:00Z",
+    "updateDate": "2024-01-22T16:33:46Z"
+  },
+  "NetworkAdministrator": {
+    "defaultVersionId": "v16",
+    "createDate": "2016-11-10T17:31:00Z",
+    "updateDate": "2026-07-09T14:42:15Z"
+  },
+  "NetworkSecurityDirectorServiceLinkedRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-06-13T20:07:00Z",
+    "updateDate": "2026-02-12T17:57:54Z"
+  },
+  "NovaActServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2025-11-26T16:19:08Z",
+    "updateDate": "2025-11-26T16:19:08Z"
+  },
+  "OAMFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-27T13:38:29Z",
+    "updateDate": "2022-11-27T13:38:29Z"
+  },
+  "OAMReadOnlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2022-11-27T13:29:39Z",
+    "updateDate": "2022-11-27T13:29:39Z"
+  },
+  "OpensearchIngestionSelfManagedVpcePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-06-10T19:59:40Z",
+    "updateDate": "2024-06-10T19:59:40Z"
+  },
+  "PartnerCentralAccountManagementUserRoleAssociation": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-11-10T02:03:40Z",
+    "updateDate": "2023-11-10T02:03:40Z"
+  },
+  "PartnerCentralIncentiveBenefitManagement": {
+    "defaultVersionId": "v4",
+    "createDate": "2026-02-11T16:42:00Z",
+    "updateDate": "2026-03-12T16:57:13Z"
+  },
+  "PowerUserAccess": {
+    "defaultVersionId": "v12",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2026-02-12T17:59:14Z"
+  },
+  "PricingPlanManagerFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-30T16:42:14Z",
+    "updateDate": "2026-07-30T16:42:14Z"
+  },
+  "PricingPlanManagerReadonlyAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-30T16:42:18Z",
+    "updateDate": "2026-07-30T16:42:18Z"
+  },
+  "QAppsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-09-26T19:22:22Z",
+    "updateDate": "2024-09-26T19:22:22Z"
+  },
+  "QBusinessQuicksightPluginPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-12-03T15:36:00Z",
+    "updateDate": "2026-02-12T17:58:27Z"
+  },
+  "QBusinessServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-04-29T16:05:44Z",
+    "updateDate": "2024-04-29T16:05:44Z"
+  },
+  "QuickSightAccessForS3StorageManagementAnalyticsReadOnly": {
+    "defaultVersionId": "v4",
+    "createDate": "2017-06-12T18:18:00Z",
+    "updateDate": "2019-10-08T23:53:11Z"
+  },
+  "RDSCloudHsmAuthorizationRole": {
+    "defaultVersionId": "v2",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2019-09-26T22:14:29Z"
+  },
+  "ROSAAmazonEBSCSIDriverOperatorPolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-04-20T22:36:00Z",
+    "updateDate": "2026-08-19T05:07:11Z"
+  },
+  "ROSACloudNetworkConfigOperatorPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-20T22:34:36Z",
+    "updateDate": "2023-04-20T22:34:36Z"
+  },
+  "ROSAControlPlaneOperatorPolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-04-24T23:02:00Z",
+    "updateDate": "2026-07-28T23:12:18Z"
+  },
+  "ROSAImageRegistryOperatorPolicy": {
+    "defaultVersionId": "v8",
+    "createDate": "2023-04-27T20:13:00Z",
+    "updateDate": "2026-02-12T18:01:17Z"
+  },
+  "ROSAIngressOperatorPolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-04-20T22:37:00Z",
+    "updateDate": "2026-02-12T17:58:27Z"
+  },
+  "ROSAInstallerPolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2023-06-06T21:00:00Z",
+    "updateDate": "2026-02-12T18:00:41Z"
+  },
+  "ROSAKMSProviderPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-04-27T20:10:20Z",
+    "updateDate": "2023-04-27T20:10:20Z"
+  },
+  "ROSAKarpenterControllerPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-27T16:42:18Z",
+    "updateDate": "2026-07-27T16:42:18Z"
+  },
+  "ROSAKubeControllerPolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2023-04-27T20:09:00Z",
+    "updateDate": "2026-04-10T16:12:08Z"
+  },
+  "ROSAManageSubscription": {
+    "defaultVersionId": "v2",
+    "createDate": "2022-04-11T20:58:00Z",
+    "updateDate": "2023-08-04T19:59:14Z"
+  },
+  "ROSANodePoolManagementPolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2023-06-08T20:48:00Z",
+    "updateDate": "2026-07-29T16:57:30Z"
+  },
+  "ROSASRESupportPolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2023-06-01T14:36:00Z",
+    "updateDate": "2026-02-12T17:59:23Z"
+  },
+  "ROSASharedVPCEndpointPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-08-11T17:19:00Z",
+    "updateDate": "2026-02-12T18:00:30Z"
+  },
+  "ROSASharedVPCRoute53Policy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-08-11T17:19:00Z",
+    "updateDate": "2026-02-12T17:58:57Z"
+  },
+  "ROSAWorkerInstancePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2023-04-20T22:35:00Z",
+    "updateDate": "2026-02-12T18:00:36Z"
+  },
+  "RTBFabricServiceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-10-16T16:49:00Z",
+    "updateDate": "2026-02-12T17:59:37Z"
+  },
+  "ReInventTicketApprovalAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-06-10T18:57:15Z",
+    "updateDate": "2026-06-10T18:57:15Z"
+  },
+  "ReadOnlyAccess": {
+    "defaultVersionId": "v188",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2026-07-21T18:42:30Z"
+  },
+  "ResourceGroupsServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-01-05T16:57:08Z",
+    "updateDate": "2023-01-05T16:57:08Z"
+  },
+  "ResourceGroupsTaggingAPITagUntagSupportedResources": {
+    "defaultVersionId": "v4",
+    "createDate": "2024-10-11T11:11:00Z",
+    "updateDate": "2026-02-12T18:00:08Z"
+  },
+  "ResourceGroupsandTagEditorFullAccess": {
+    "defaultVersionId": "v6",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2023-08-10T13:29:19Z"
+  },
+  "ResourceGroupsandTagEditorReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2015-02-06T18:39:00Z",
+    "updateDate": "2023-08-10T13:42:58Z"
+  },
+  "Route53RecoveryReadinessServiceRolePolicy": {
+    "defaultVersionId": "v5",
+    "createDate": "2021-07-15T16:06:00Z",
+    "updateDate": "2023-02-14T18:08:46Z"
+  },
+  "Route53ResolverServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-08-12T17:47:24Z",
+    "updateDate": "2020-08-12T17:47:24Z"
+  },
+  "S3StorageLensServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-11-18T18:15:40Z",
+    "updateDate": "2020-11-18T18:15:40Z"
+  },
+  "S3UnlockBucketPolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-06T21:55:56Z",
+    "updateDate": "2024-11-06T21:55:56Z"
+  },
+  "SMSVoiceServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-14T17:04:34Z",
+    "updateDate": "2024-11-14T17:04:34Z"
+  },
+  "SQSUnlockQueuePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-06T21:51:02Z",
+    "updateDate": "2024-11-06T21:51:02Z"
+  },
+  "SSMQuickSetupRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2024-06-25T15:20:00Z",
+    "updateDate": "2024-11-18T13:06:59Z"
+  },
+  "SageMakerStudioAdminIAMConsolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-08-18T22:49:00Z",
+    "updateDate": "2026-08-26T22:47:07Z"
+  },
+  "SageMakerStudioAdminIAMDefaultExecutionPolicy": {
+    "defaultVersionId": "v24",
+    "createDate": "2025-08-18T17:19:00Z",
+    "updateDate": "2026-07-14T18:57:22Z"
+  },
+  "SageMakerStudioAdminIAMPermissiveExecutionPolicy": {
+    "defaultVersionId": "v21",
+    "createDate": "2025-08-18T17:19:00Z",
+    "updateDate": "2026-07-14T18:57:27Z"
+  },
+  "SageMakerStudioAdminProjectUserRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-07-09T20:52:00Z",
+    "updateDate": "2026-02-12T17:59:34Z"
+  },
+  "SageMakerStudioBedrockAgentServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-13T23:37:00Z",
+    "updateDate": "2026-02-12T18:00:33Z"
+  },
+  "SageMakerStudioBedrockChatAgentUserRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-13T23:52:00Z",
+    "updateDate": "2026-02-12T17:57:44Z"
+  },
+  "SageMakerStudioBedrockEvaluationJobServiceRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-14T00:37:00Z",
+    "updateDate": "2026-02-12T18:00:09Z"
+  },
+  "SageMakerStudioBedrockFlowServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-02-14T00:07:00Z",
+    "updateDate": "2026-02-12T17:58:49Z"
+  },
+  "SageMakerStudioBedrockFunctionExecutionRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-25T03:52:00Z",
+    "updateDate": "2026-02-12T17:58:27Z"
+  },
+  "SageMakerStudioBedrockKnowledgeBaseCustomResourcePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-25T03:37:00Z",
+    "updateDate": "2026-02-12T18:02:56Z"
+  },
+  "SageMakerStudioBedrockKnowledgeBaseServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-02-25T02:52:00Z",
+    "updateDate": "2026-02-12T18:00:27Z"
+  },
+  "SageMakerStudioBedrockPromptUserRolePolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-02-14T00:22:00Z",
+    "updateDate": "2026-02-12T18:00:54Z"
+  },
+  "SageMakerStudioDomainExecutionRolePolicy": {
+    "defaultVersionId": "v23",
+    "createDate": "2024-11-20T21:56:00Z",
+    "updateDate": "2026-08-12T17:27:19Z"
+  },
+  "SageMakerStudioDomainServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-11-20T21:56:22Z",
+    "updateDate": "2024-11-20T21:56:22Z"
+  },
+  "SageMakerStudioEMRContainersSystemNamespaceRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-10-23T18:34:00Z",
+    "updateDate": "2026-02-12T18:01:48Z"
+  },
+  "SageMakerStudioEMRInstanceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2025-02-27T00:22:00Z",
+    "updateDate": "2026-06-01T23:27:10Z"
+  },
+  "SageMakerStudioEMRServiceRolePolicy": {
+    "defaultVersionId": "v9",
+    "createDate": "2025-01-31T19:52:00Z",
+    "updateDate": "2026-02-12T17:58:51Z"
+  },
+  "SageMakerStudioFullAccess": {
+    "defaultVersionId": "v15",
+    "createDate": "2024-11-28T00:06:00Z",
+    "updateDate": "2026-02-12T18:00:59Z"
+  },
+  "SageMakerStudioProjectProvisioningRolePolicy": {
+    "defaultVersionId": "v82",
+    "createDate": "2024-11-20T21:58:00Z",
+    "updateDate": "2026-08-24T20:37:11Z"
+  },
+  "SageMakerStudioProjectRoleMachineLearningPolicy": {
+    "defaultVersionId": "v43",
+    "createDate": "2024-11-20T21:55:00Z",
+    "updateDate": "2026-09-04T18:57:08Z"
+  },
+  "SageMakerStudioProjectUserRolePermissionsBoundary": {
+    "defaultVersionId": "v19",
+    "createDate": "2024-11-20T21:57:00Z",
+    "updateDate": "2026-02-12T17:58:21Z"
+  },
+  "SageMakerStudioProjectUserRolePolicy": {
+    "defaultVersionId": "v75",
+    "createDate": "2024-11-20T21:59:00Z",
+    "updateDate": "2026-08-27T20:57:08Z"
+  },
+  "SageMakerStudioQueryExecutionRolePolicy": {
+    "defaultVersionId": "v6",
+    "createDate": "2025-01-31T19:52:00Z",
+    "updateDate": "2026-02-12T18:02:00Z"
+  },
+  "SageMakerStudioUserIAMConsolePolicy": {
+    "defaultVersionId": "v10",
+    "createDate": "2025-08-18T22:49:00Z",
+    "updateDate": "2026-03-31T21:12:16Z"
+  },
+  "SageMakerStudioUserIAMDefaultExecutionPolicy": {
+    "defaultVersionId": "v29",
+    "createDate": "2025-08-18T17:19:00Z",
+    "updateDate": "2026-08-13T18:37:16Z"
+  },
+  "SageMakerStudioUserIAMPermissiveExecutionPolicy": {
+    "defaultVersionId": "v24",
+    "createDate": "2025-08-18T17:19:00Z",
+    "updateDate": "2026-08-13T18:37:09Z"
+  },
+  "SecretsManagerReadWrite": {
+    "defaultVersionId": "v6",
+    "createDate": "2018-04-04T18:05:00Z",
+    "updateDate": "2026-08-25T23:37:10Z"
+  },
+  "SecurityAgentWebAppAPIPolicy": {
+    "defaultVersionId": "v12",
+    "createDate": "2025-12-02T15:04:00Z",
+    "updateDate": "2026-02-12T18:02:14Z"
+  },
+  "SecurityAgentWebAppPolicy": {
+    "defaultVersionId": "v3",
+    "createDate": "2026-02-05T20:19:00Z",
+    "updateDate": "2026-02-12T18:01:23Z"
+  },
+  "SecurityAudit": {
+    "defaultVersionId": "v92",
+    "createDate": "2015-02-06T18:41:00Z",
+    "updateDate": "2026-08-17T15:27:26Z"
+  },
+  "SecurityLakeResourceManagementServiceRolePolicy": {
+    "defaultVersionId": "v7",
+    "createDate": "2024-11-14T22:10:00Z",
+    "updateDate": "2026-02-12T17:59:53Z"
+  },
+  "SecurityLakeServiceLinkedRole": {
+    "defaultVersionId": "v4",
+    "createDate": "2022-11-29T14:03:00Z",
+    "updateDate": "2026-07-15T17:57:16Z"
+  },
+  "ServerMigrationConnector": {
+    "defaultVersionId": "v1",
+    "createDate": "2016-10-24T21:45:56Z",
+    "updateDate": "2016-10-24T21:45:56Z"
+  },
+  "ServerMigrationServiceConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2020-05-09T17:18:00Z",
+    "updateDate": "2020-07-20T22:00:37Z"
+  },
+  "ServerMigrationServiceLaunchRole": {
+    "defaultVersionId": "v4",
+    "createDate": "2018-11-26T19:53:00Z",
+    "updateDate": "2020-10-15T17:29:00Z"
+  },
+  "ServerMigrationServiceRoleForInstanceValidation": {
+    "defaultVersionId": "v1",
+    "createDate": "2020-07-20T22:25:07Z",
+    "updateDate": "2020-07-20T22:25:07Z"
+  },
+  "ServiceQuotasFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-06-24T15:44:00Z",
+    "updateDate": "2021-02-04T21:29:43Z"
+  },
+  "ServiceQuotasReadOnlyAccess": {
+    "defaultVersionId": "v5",
+    "createDate": "2019-06-24T15:31:00Z",
+    "updateDate": "2026-02-12T18:00:30Z"
+  },
+  "ServiceQuotasServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2019-05-22T20:44:00Z",
+    "updateDate": "2019-06-24T14:52:56Z"
+  },
+  "SignInLocalDevelopmentAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2025-11-19T18:34:00Z",
+    "updateDate": "2026-02-12T17:59:05Z"
+  },
+  "SimpleWorkflowFullAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-02-06T18:41:04Z",
+    "updateDate": "2015-02-06T18:41:04Z"
+  },
+  "SplitCostAllocationDataServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2024-04-16T16:05:16Z",
+    "updateDate": "2024-04-16T16:05:16Z"
+  },
+  "SupportUser": {
+    "defaultVersionId": "v11",
+    "createDate": "2016-11-10T17:21:00Z",
+    "updateDate": "2026-02-12T18:03:12Z"
+  },
+  "SystemAdministrator": {
+    "defaultVersionId": "v12",
+    "createDate": "2016-11-10T17:23:00Z",
+    "updateDate": "2026-02-12T18:02:37Z"
+  },
+  "TranslateFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-27T23:36:00Z",
+    "updateDate": "2020-01-08T21:22:27Z"
+  },
+  "TranslateReadOnly": {
+    "defaultVersionId": "v7",
+    "createDate": "2017-11-29T18:22:00Z",
+    "updateDate": "2023-05-24T17:19:30Z"
+  },
+  "VMImportExportRoleForAWSConnector": {
+    "defaultVersionId": "v1",
+    "createDate": "2015-09-03T20:48:59Z",
+    "updateDate": "2015-09-03T20:48:59Z"
+  },
+  "VPCLatticeFullAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-03-30T02:49:00Z",
+    "updateDate": "2026-02-12T17:57:35Z"
+  },
+  "VPCLatticeReadOnlyAccess": {
+    "defaultVersionId": "v4",
+    "createDate": "2023-03-30T02:47:00Z",
+    "updateDate": "2026-02-12T17:58:25Z"
+  },
+  "VPCLatticeServicesInvokeAccess": {
+    "defaultVersionId": "v1",
+    "createDate": "2023-03-30T02:45:07Z",
+    "updateDate": "2023-03-30T02:45:07Z"
+  },
+  "ViewOnlyAccess": {
+    "defaultVersionId": "v45",
+    "createDate": "2016-11-10T17:20:00Z",
+    "updateDate": "2026-04-22T18:12:21Z"
+  },
+  "WAFLoggingServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-08-24T21:05:00Z",
+    "updateDate": "2026-05-20T19:12:17Z"
+  },
+  "WAFRegionalLoggingServiceRolePolicy": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-08-24T18:40:00Z",
+    "updateDate": "2026-05-20T18:42:25Z"
+  },
+  "WAFV2LoggingServiceRolePolicy": {
+    "defaultVersionId": "v4",
+    "createDate": "2019-11-07T00:40:00Z",
+    "updateDate": "2026-05-20T18:12:21Z"
+  },
+  "WellArchitectedAgentResourceScanning": {
+    "defaultVersionId": "v1",
+    "createDate": "2026-07-16T20:27:15Z",
+    "updateDate": "2026-07-16T20:27:15Z"
+  },
+  "WellArchitectedConsoleFullAccess": {
+    "defaultVersionId": "v2",
+    "createDate": "2018-11-29T18:19:00Z",
+    "updateDate": "2026-07-09T17:27:22Z"
+  },
+  "WellArchitectedConsoleReadOnlyAccess": {
+    "defaultVersionId": "v3",
+    "createDate": "2018-11-29T18:21:00Z",
+    "updateDate": "2026-07-09T17:27:19Z"
+  },
+  "WorkLinkServiceRolePolicy": {
+    "defaultVersionId": "v1",
+    "createDate": "2019-01-23T19:03:45Z",
+    "updateDate": "2019-01-23T19:03:45Z"
+  }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamManagedPolicyCatalogTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamManagedPolicyCatalogTest.java
@@ -4,13 +4,19 @@ import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.services.iam.model.IamPolicy;
+import io.github.hectorvent.floci.services.iam.model.PolicyVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Instant;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -19,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * subset, so that attaching a real policy succeeds and attaching an invented one still
  * fails the way it does on AWS.
  *
- * <p>A subset produced false negatives — {@code AttachRolePolicy} returned
+ * <p>A subset produced false negatives: {@code AttachRolePolicy} returned
  * {@code NoSuchEntity} for policies AWS genuinely publishes, breaking valid Terraform and
  * CloudFormation configurations. Resolving every well-formed ARN instead would produce
  * false positives, silently accepting typos that real AWS rejects and defeating stack
@@ -95,6 +101,77 @@ class IamManagedPolicyCatalogTest {
     @Test
     void policiesRetiredByAwsButPreviouslyResolvableAreRetained() {
         assertDoesNotThrow(() -> iamService.getPolicy("arn:aws:iam::aws:policy/AWSLambdaFullAccess"));
+    }
+
+    /**
+     * AWS revises managed policies in place, so their default version reflects that history
+     * rather than being {@code v1} for everything: {@code AmazonS3ReadOnlyAccess} is on
+     * {@code v3} (last revised August 2023) while {@code AdministratorAccess} genuinely never
+     * left {@code v1}. Reporting {@code v1} across the board only matched real AWS by accident.
+     */
+    @Test
+    void defaultVersionReflectsAwsRevisionHistory() {
+        IamPolicy s3ReadOnly = iamService.getPolicy("arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess");
+        IamPolicy administrator = iamService.getPolicy("arn:aws:iam::aws:policy/AdministratorAccess");
+
+        assertEquals("v3", s3ReadOnly.getDefaultVersionId());
+        // A revised policy keeps its original creation date; only UpdateDate moves with v3.
+        assertEquals(Instant.parse("2015-02-06T18:40:00Z"), s3ReadOnly.getCreateDate());
+        assertEquals(Instant.parse("2023-08-10T21:31:39Z"), s3ReadOnly.getUpdateDate());
+        assertEquals("v1", administrator.getDefaultVersionId());
+        assertEquals(Instant.parse("2015-02-06T18:39:46Z"), administrator.getCreateDate());
+        assertEquals(administrator.getCreateDate(), administrator.getUpdateDate());
+    }
+
+    @Test
+    void listedVersionsCarryTheDefaultVersionIdAndItsDocument() {
+        String arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess";
+        IamPolicy policy = iamService.getPolicy(arn);
+
+        List<PolicyVersion> versions = iamService.listPolicyVersions(arn);
+        assertEquals(1, versions.size(), "only the default version's document is bundled");
+        PolicyVersion listed = versions.get(0);
+        assertEquals("v3", listed.getVersionId());
+        assertTrue(listed.isDefaultVersion());
+        assertEquals(policy.getDefaultDocument(), listed.getDocument());
+        assertEquals(policy.getUpdateDate(), listed.getCreateDate());
+
+        PolicyVersion fetched = iamService.getPolicyVersion(arn, "v3");
+        assertEquals(listed.getDocument(), fetched.getDocument());
+        assertTrue(fetched.isDefaultVersion());
+    }
+
+    /**
+     * The dataset only carries each policy's current document, so a superseded version cannot
+     * be served. Answering {@code NoSuchEntity} matches what AWS returns for a version it has
+     * pruned, and is preferable to serving the current document under an old id.
+     */
+    @Test
+    void supersededVersionOfARevisedPolicyIsNotServedUnderTheWrongId() {
+        AwsException e = assertThrows(AwsException.class, () -> iamService.getPolicyVersion(
+                "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", "v1"));
+
+        assertEquals("NoSuchEntity", e.getErrorCode());
+        assertEquals(404, e.getHttpStatus());
+    }
+
+    @Test
+    void everyCatalogEntryHasAWellFormedVersionIdAndDates() {
+        for (AwsManagedPolicies.ManagedPolicyDef def : AwsManagedPolicies.POLICIES) {
+            assertTrue(def.defaultVersionId().matches("v[1-9][0-9]*"),
+                    def.name() + " has version id " + def.defaultVersionId());
+            assertNotNull(def.updateDate(), def.name() + " has no version date");
+            if (def.createDate() != null) {
+                assertFalse(def.createDate().isAfter(def.updateDate()),
+                        def.name() + " was created after its current version");
+            }
+        }
+        for (IamPolicy policy : iamService.listPolicies("AWS", null)) {
+            assertFalse(policy.getCreateDate().isAfter(policy.getUpdateDate()),
+                    policy.getPolicyName() + " reports CreateDate after UpdateDate");
+        }
+        assertTrue(AwsManagedPolicies.POLICIES.stream().anyMatch(p -> !"v1".equals(p.defaultVersionId())),
+                "the catalog should carry revised policies, not v1 everywhere");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iam/IamServiceTest.java
@@ -356,7 +356,7 @@ class IamServiceTest {
         IamPolicy policy = iamService.getPolicy(arn);
 
         assertEquals("AmazonS3ReadOnlyAccess", policy.getPolicyName());
-        assertEquals("v1", policy.getDefaultVersionId());
+        assertEquals("v3", policy.getDefaultVersionId());
         assertEquals(IamPolicyEvaluator.Decision.ALLOW,
                 new IamPolicyEvaluator(new com.fasterxml.jackson.databind.ObjectMapper())
                         .evaluate(List.of(policy.getDefaultDocument()), "s3:GetObject", "arn:aws:s3:::bucket/key"));
@@ -409,13 +409,21 @@ class IamServiceTest {
         IamPolicy policy = iamService.getPolicy(arn);
         assertEquals("AmazonS3ReadOnlyAccess", policy.getPolicyName());
         assertEquals(arn, policy.getArn());
-        assertEquals("v1", policy.getDefaultVersionId());
+        // AWS revised this policy twice; a real account reports v3, not v1.
+        assertEquals("v3", policy.getDefaultVersionId());
         assertTrue(policy.getDefaultDocument().contains("s3:Get*"));
 
-        AwsException error = assertThrows(AwsException.class,
-                () -> iamService.getPolicyVersion(arn, "v9"));
-        assertEquals("NoSuchEntity", error.getErrorCode());
-        assertEquals(404, error.getHttpStatus());
+        PolicyVersion current = iamService.getPolicyVersion(arn, "v3");
+        assertTrue(current.isDefaultVersion());
+        assertEquals(policy.getDefaultDocument(), current.getDocument());
+
+        // Neither a future version nor a superseded one whose document is not bundled resolves.
+        for (String versionId : new String[] {"v9", "v1"}) {
+            AwsException error = assertThrows(AwsException.class,
+                    () -> iamService.getPolicyVersion(arn, versionId));
+            assertEquals("NoSuchEntity", error.getErrorCode());
+            assertEquals(404, error.getHttpStatus());
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #3250

AWS-managed policies were always reported as `DefaultVersionId: v1`, regardless of how many times AWS has revised them. `AmazonS3ReadOnlyAccess` is on `v3` on real AWS (last revised August 2023); Floci only matched real AWS by coincidence for policies that were never revised, such as `AdministratorAccess`.

The catalog now bundles each policy's real default version id and that version's creation date, taken from the same public dataset (iann0036/iam-dataset) that already backs the policy documents. `GetPolicy`, `GetPolicyVersion` and `ListPolicyVersions` serve the bundled document under the version id AWS actually reports, with `CreateDate`/`UpdateDate` matching that version instead of the process start time.

- New resource `iam/managed-policy-versions.json` keyed by policy name (`defaultVersionId`, `createDate`), generated from the dataset's `version` and `updatedate` fields for all 1,566 catalog entries.
- `AwsManagedPolicies` loads it and carries the version on `ManagedPolicyDef`; a missing or malformed entry falls back to `v1` with a log line rather than dropping the policy.
- `IamPolicy` gains a constructor that accepts an arbitrary single default version; `PolicyVersion` gains a constructor with an explicit create date. Customer-managed policies still start at `v1`.
- Docs: new "Version numbers" section in `docs/services/iam.md`, and the stale sentence saying seeded policies use a wildcard document (obsolete since #3237) is replaced.

The dataset only publishes each policy's current document, so superseded versions (`v1`/`v2` of `AmazonS3ReadOnlyAccess`) return `NoSuchEntity`, which is what AWS returns once it prunes a managed policy's history. `ListPolicyVersions` lists only the default version. Bundling the full revision history would require mining the dataset's git history for every policy and is left out of scope.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `aws iam get-policy --policy-arn arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess` returned `DefaultVersionId: v1`, while real AWS returns `v3`. It now returns `v3` with `UpdateDate: 2023-08-10T21:31:39Z`; `AdministratorAccess` still returns `v1` with its real 2015 create date. Response shapes, policy names, paths, ARNs and descriptions are unchanged. AWS-managed policies remain read-only (`CreatePolicyVersion`, `SetDefaultPolicyVersion`, `DeletePolicyVersion` still return `AccessDenied`).

Added coverage in `IamManagedPolicyCatalogTest` and `IamServiceTest`:

- Default version reflects AWS's revision history (`v3` vs `v1`) with the published dates.
- `ListPolicyVersions` returns the single default version with the bundled document, and `GetPolicyVersion` serves it.
- A superseded version id returns `NoSuchEntity` instead of the current document under the wrong id.
- Every catalog entry has a well-formed version id and date.

## Checklist

- [X] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused runs of `IamManagedPolicyCatalogTest`, `IamServiceTest`, `IamManagedPolicyAccountScopeTest`, `IamPolicyEvaluatorTest`, `SsoAdminServiceTest`, `CloudFormationIamAttachmentProvisionerTest` and `CloudFormationManagedPolicyUpdateIntegrationTest` pass. The full Maven suite was not run on this machine.

