### PR TITLE
fix(elasticache): honor the requested Port on CreateReplicationGroup

### DIFF
--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -287,7 +287,11 @@ resource "aws_elasticache_replication_group" "compat" {
   engine               = "redis"
   node_type            = "cache.t3.micro"
   num_cache_clusters   = 1
-  port                 = 6379
+  # Deliberately not 6379: that is the bottom of floci's ElastiCache proxy range and the
+  # port it would hand out anyway, so pinning it asserts nothing. A non-default port is
+  # what actually exercises CreateReplicationGroup's Port input, and a mismatch shows up
+  # as permanent drift because Terraform treats the port as replacement-forcing.
+  port                 = 6395
 }
 
 # ── Firehose Delivery Stream ────────────────────────────────────────────────

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -287,7 +287,11 @@ resource "aws_elasticache_replication_group" "compat" {
   engine               = "redis"
   node_type            = "cache.t3.micro"
   num_cache_clusters   = 1
-  port                 = 6379
+  # Deliberately not 6379: that is the bottom of floci's ElastiCache proxy range and the
+  # port it would hand out anyway, so pinning it asserts nothing. A non-default port is
+  # what actually exercises CreateReplicationGroup's Port input, and a mismatch shows up
+  # as permanent drift because Terraform treats the port as replacement-forcing.
+  port                 = 6395
 }
 
 # -- Firehose Delivery Stream --------------------------------------------------

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandler.java
@@ -125,6 +125,7 @@ public class ElastiCacheQueryHandler {
                             intParam(params, "NumCacheClusters"),
                             boolParam(params, "AutomaticFailoverEnabled"),
                             boolParam(params, "MultiAZEnabled"),
+                            intParam(params, "Port"),
                             replicationGroupSettings(params),
                             parseTags(params)));
             String result = replicationGroupXml(group);

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -126,6 +126,7 @@ public class ElastiCacheService implements ResourceProvider {
             Integer numCacheClusters,
             Boolean automaticFailoverEnabled,
             Boolean multiAzEnabled,
+            Integer port,
             ReplicationGroupSettings settings,
             Map<String, String> tags) {
     }
@@ -142,7 +143,7 @@ public class ElastiCacheService implements ResourceProvider {
                                                    Map<String, String> tags) {
         return createReplicationGroup(new CreateReplicationGroupRequest(groupId, description,
                 authMode, authToken, region, null, null, null, null, null, null,
-                null, null, null, null, null, settings, tags));
+                null, null, null, null, null, null, settings, tags));
     }
 
     public ReplicationGroup createReplicationGroup(CreateReplicationGroupRequest request) {
@@ -221,7 +222,7 @@ public class ElastiCacheService implements ResourceProvider {
                                                       ReplicationGroupSettings resolvedSettings) {
         String groupId = request.replicationGroupId();
         AuthMode authMode = request.authMode();
-        int proxyPort = allocateProxyPort();
+        int proxyPort = allocateProxyPort(request.port());
         String image = config.services().elasticache().defaultImage();
 
         LOG.infov("Creating replication group {0} with authMode={1} on proxy port {2}",
@@ -304,8 +305,11 @@ public class ElastiCacheService implements ResourceProvider {
                 int[] slots = ValkeyClusterFormation.slotRange(shard, numNodeGroups);
                 for (int member = 0; member <= replicasPerNodeGroup; member++) {
                     String memberId = groupId + "-" + nodeGroupId + "-" + String.format("%03d", member + 1);
+                    // The group's Port is reported from the first node's proxy port, so only that
+                    // node can honor a requested port; the rest take whatever is free.
+                    Integer requestedPort = nodes.isEmpty() ? request.port() : null;
                     nodes.add(new ClusterNode(memberId, nodeGroupId, member == 0,
-                            allocateProxyPort(), slots[0] + "-" + slots[1]));
+                            allocateProxyPort(requestedPort), slots[0] + "-" + slots[1]));
                 }
             }
 
@@ -917,8 +921,32 @@ public class ElastiCacheService implements ResourceProvider {
     }
 
     private int allocateProxyPort() {
+        return allocateProxyPort(null);
+    }
+
+    /**
+     * Honors the request's {@code Port} when it is free and inside the proxy range, matching
+     * {@code NeptuneService.allocateProxyPort}. AWS models Port as an optional input on
+     * CreateReplicationGroup ("the port number on which each member of the replication group
+     * accepts connections"), so a caller that pins one and reads back a different value sees
+     * permanent drift: Terraform treats the port as replacement-forcing.
+     *
+     * <p>Floci multiplexes every group's proxy onto one host, so two groups genuinely cannot
+     * share a port. When the requested one is taken or out of range this logs why and falls
+     * back to the next free port rather than failing, which keeps that limit visible without
+     * breaking callers that do not care which port they get.
+     */
+    private int allocateProxyPort(Integer requested) {
         int base = config.services().elasticache().proxyBasePort();
         int max = config.services().elasticache().proxyMaxPort();
+        if (requested != null && requested >= base && requested <= max && usedPorts.add(requested)) {
+            return requested;
+        }
+        if (requested != null) {
+            LOG.infov("Requested ElastiCache port {0} is outside the proxy range {1}-{2} or already in use; "
+                    + "allocating the next free proxy port instead",
+                    String.valueOf(requested), String.valueOf(base), String.valueOf(max));
+        }
         for (int port = base; port <= max; port++) {
             if (usedPorts.add(port)) {
                 return port;

--- a/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheService.java
@@ -925,27 +925,40 @@ public class ElastiCacheService implements ResourceProvider {
     }
 
     /**
-     * Honors the request's {@code Port} when it is free and inside the proxy range, matching
-     * {@code NeptuneService.allocateProxyPort}. AWS models Port as an optional input on
-     * CreateReplicationGroup ("the port number on which each member of the replication group
-     * accepts connections"), so a caller that pins one and reads back a different value sees
-     * permanent drift: Terraform treats the port as replacement-forcing.
+     * Honors the request's {@code Port} when it is free and inside the proxy range. AWS models
+     * Port as an optional input on CreateReplicationGroup ("the port number on which each member
+     * of the replication group accepts connections"), so a caller that pins one and reads back a
+     * different value sees permanent drift: Terraform treats the port as replacement-forcing.
      *
-     * <p>Floci multiplexes every group's proxy onto one host, so two groups genuinely cannot
-     * share a port. When the requested one is taken or out of range this logs why and falls
-     * back to the next free port rather than failing, which keeps that limit visible without
-     * breaking callers that do not care which port they get.
+     * <p>An explicit port is therefore either honored or refused, never quietly changed.
+     * Substituting one reproduces the very drift honoring it was meant to remove, and the
+     * substitution could only ever hit a caller who did ask for a port: one who does not care
+     * passes null and never reaches that branch. Floci multiplexes every group's proxy onto one
+     * host, so two groups genuinely cannot share a port, and a caller who pinned an unavailable
+     * one needs to know rather than discover it as drift later.
+     *
+     * <p>Only an unpinned create falls back through the range below.
+     * {@code NeptuneService.allocateProxyPort} still substitutes on this path and carries the
+     * same flaw.
      */
     private int allocateProxyPort(Integer requested) {
         int base = config.services().elasticache().proxyBasePort();
         int max = config.services().elasticache().proxyMaxPort();
-        if (requested != null && requested >= base && requested <= max && usedPorts.add(requested)) {
-            return requested;
-        }
         if (requested != null) {
-            LOG.infov("Requested ElastiCache port {0} is outside the proxy range {1}-{2} or already in use; "
-                    + "allocating the next free proxy port instead",
-                    String.valueOf(requested), String.valueOf(base), String.valueOf(max));
+            if (requested < base || requested > max) {
+                LOG.infov("Rejecting ElastiCache port {0}: outside the proxy range {1}-{2}",
+                        String.valueOf(requested), String.valueOf(base), String.valueOf(max));
+                throw new AwsException("InvalidParameterValue",
+                        "Port " + requested + " is outside the port range this emulator serves ("
+                                + base + "-" + max + ").", 400);
+            }
+            if (!usedPorts.add(requested)) {
+                LOG.infov("Rejecting ElastiCache port {0}: already used by another replication group",
+                        String.valueOf(requested));
+                throw new AwsException("InvalidParameterValue",
+                        "Port " + requested + " is already in use by another replication group.", 400);
+            }
+            return requested;
         }
         for (int port = base; port <= max; port++) {
             if (usedPorts.add(port)) {

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheQueryHandlerTest.java
@@ -19,6 +19,7 @@ import io.github.hectorvent.floci.services.elasticache.model.Endpoint;
 import io.github.hectorvent.floci.core.common.AwsException;
 import java.util.List;
 import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 import org.mockito.ArgumentCaptor;
@@ -236,6 +237,42 @@ class ElastiCacheQueryHandlerTest {
         assertEquals("us-east-1", request.region());
         assertEquals(new ReplicationGroupSettings(true, "alias/cache", 7, "06:30-07:30"), request.settings());
         assertEquals(Map.of("Name", "g1"), request.tags());
+    }
+
+    @Test
+    void createReplicationGroup_passesTheRequestedPortToService() {
+        // Port is a modeled optional input on CreateReplicationGroup; the handler dropped it,
+        // so a caller that pinned one always read back whatever port floci allocated.
+        when(service.createReplicationGroup(any(ElastiCacheService.CreateReplicationGroupRequest.class)))
+                .thenReturn(group("g1"));
+        MultivaluedMap<String, String> p = params();
+        p.add("ReplicationGroupId", "g1");
+        p.add("ReplicationGroupDescription", "d");
+        p.add("Port", "6395");
+
+        assertEquals(200, handler.handle("CreateReplicationGroup", p, "us-east-1").getStatus());
+
+        ArgumentCaptor<ElastiCacheService.CreateReplicationGroupRequest> captor =
+                ArgumentCaptor.forClass(ElastiCacheService.CreateReplicationGroupRequest.class);
+        verify(service).createReplicationGroup(captor.capture());
+        assertEquals(6395, captor.getValue().port());
+    }
+
+    @Test
+    void createReplicationGroup_leavesPortNullWhenAbsent() {
+        when(service.createReplicationGroup(any(ElastiCacheService.CreateReplicationGroupRequest.class)))
+                .thenReturn(group("g1"));
+        MultivaluedMap<String, String> p = params();
+        p.add("ReplicationGroupId", "g1");
+        p.add("ReplicationGroupDescription", "d");
+
+        assertEquals(200, handler.handle("CreateReplicationGroup", p, "us-east-1").getStatus());
+
+        ArgumentCaptor<ElastiCacheService.CreateReplicationGroupRequest> captor =
+                ArgumentCaptor.forClass(ElastiCacheService.CreateReplicationGroupRequest.class);
+        verify(service).createReplicationGroup(captor.capture());
+        assertNull(captor.getValue().port(),
+                "An absent Port must stay null so the service allocates as before");
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -257,23 +257,36 @@ class ElastiCacheServiceTest {
     }
 
     @Test
-    void requestedPortAlreadyInUseFallsBackToTheNextFreePort() {
-        // floci multiplexes every group's proxy onto one host, so two groups cannot share a
-        // port. Falling back keeps the create working rather than failing the caller.
+    void requestedPortAlreadyInUseIsRejected() {
+        // floci multiplexes every group's proxy onto one host, so two groups cannot share a port.
+        // Substituting a different one would hand back the drift honoring Port exists to remove,
+        // and it could only ever hit a caller who did pin a port.
         service.createReplicationGroup(singleNodeRequest("grp1", 16390));
 
-        ReplicationGroup second = service.createReplicationGroup(singleNodeRequest("grp2", 16390));
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> service.createReplicationGroup(singleNodeRequest("grp2", 16390)));
 
-        assertEquals(16379, second.getProxyPort(),
-                "A taken Port must fall back to the next free port, not collide");
+        assertEquals("InvalidParameterValue", thrown.getErrorCode());
+        assertTrue(thrown.getMessage().contains("16390"));
     }
 
     @Test
-    void requestedPortOutsideTheProxyRangeFallsBack() {
-        ReplicationGroup group = service.createReplicationGroup(singleNodeRequest("grp", 9999));
+    void requestedPortOutsideTheProxyRangeIsRejected() {
+        AwsException thrown = assertThrows(AwsException.class,
+                () -> service.createReplicationGroup(singleNodeRequest("grp", 9999)));
 
-        assertEquals(16379, group.getProxyPort(),
-                "A Port outside the configured proxy range must fall back to an allocated one");
+        assertEquals("InvalidParameterValue", thrown.getErrorCode());
+        assertTrue(thrown.getMessage().contains("9999"));
+    }
+
+    @Test
+    void anUnpinnedCreateStillFallsBackWhenTheBasePortIsTaken() {
+        // The fallback survives for callers that named no port: only an explicit one is refused.
+        service.createReplicationGroup(singleNodeRequest("grp1", 16379));
+
+        ReplicationGroup second = service.createReplicationGroup(singleNodeRequest("grp2", null));
+
+        assertEquals(16380, second.getProxyPort());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/elasticache/ElastiCacheServiceTest.java
@@ -226,7 +226,73 @@ class ElastiCacheServiceTest {
         return new ElastiCacheService.CreateReplicationGroupRequest(groupId, "test",
                 AuthMode.NO_AUTH, null, "us-east-1", "valkey", "8.2", "cache.t4g.micro",
                 "default.valkey8.cluster.on", null, null, numNodeGroups, replicasPerNodeGroup,
-                null, true, null, ReplicationGroupSettings.defaults(), Map.of());
+                null, true, null, null, ReplicationGroupSettings.defaults(), Map.of());
+    }
+
+    private static ElastiCacheService.CreateReplicationGroupRequest singleNodeRequest(
+            String groupId, Integer port) {
+        return new ElastiCacheService.CreateReplicationGroupRequest(groupId, "test",
+                AuthMode.NO_AUTH, null, "us-east-1", null, null, null, null, null, null,
+                null, null, null, null, null, port, ReplicationGroupSettings.defaults(), Map.of());
+    }
+
+    // botocore models Port as an optional input on CreateReplicationGroup ("the port number on
+    // which each member of the replication group accepts connections"). Ignoring it made every
+    // caller that pins a port read back a different one, which Terraform treats as
+    // replacement-forcing and reports as permanent drift.
+    @Test
+    void requestedPortIsHonoredWhenFreeAndInRange() {
+        ReplicationGroup group = service.createReplicationGroup(singleNodeRequest("grp", 16390));
+
+        assertEquals(16390, group.getProxyPort(),
+                "A free, in-range requested Port must be the port the group reports");
+    }
+
+    @Test
+    void unpinnedCreateStillAllocatesFromTheBasePort() {
+        ReplicationGroup group = service.createReplicationGroup(singleNodeRequest("grp", null));
+
+        assertEquals(16379, group.getProxyPort(),
+                "A create with no Port keeps the previous behavior of taking the base port");
+    }
+
+    @Test
+    void requestedPortAlreadyInUseFallsBackToTheNextFreePort() {
+        // floci multiplexes every group's proxy onto one host, so two groups cannot share a
+        // port. Falling back keeps the create working rather than failing the caller.
+        service.createReplicationGroup(singleNodeRequest("grp1", 16390));
+
+        ReplicationGroup second = service.createReplicationGroup(singleNodeRequest("grp2", 16390));
+
+        assertEquals(16379, second.getProxyPort(),
+                "A taken Port must fall back to the next free port, not collide");
+    }
+
+    @Test
+    void requestedPortOutsideTheProxyRangeFallsBack() {
+        ReplicationGroup group = service.createReplicationGroup(singleNodeRequest("grp", 9999));
+
+        assertEquals(16379, group.getProxyPort(),
+                "A Port outside the configured proxy range must fall back to an allocated one");
+    }
+
+    @Test
+    void clusterModeHonorsTheRequestedPortOnTheFirstNode() {
+        // The group's Port is reported from the first node's proxy port, so that is the only
+        // node whose port a caller can pin; the remaining members take whatever is free.
+        stubPerNodeContainers();
+
+        ReplicationGroup group = service.createReplicationGroup(
+                new ElastiCacheService.CreateReplicationGroupRequest("grp", "test",
+                        AuthMode.NO_AUTH, null, "us-east-1", "valkey", "8.2", "cache.t4g.micro",
+                        "default.valkey8.cluster.on", null, null, 2, 1,
+                        null, true, null, 16390, ReplicationGroupSettings.defaults(), Map.of()));
+
+        assertEquals(16390, group.getConfigurationEndpoint().port());
+        assertEquals(16390, group.getClusterNodes().getFirst().getProxyPort());
+        assertEquals(4, group.getClusterNodes().stream()
+                        .map(ClusterNode::getProxyPort).distinct().count(),
+                "Each node must still own its own proxy port");
     }
 
     private void stubPerNodeContainers() {
@@ -687,7 +753,7 @@ class ElastiCacheServiceTest {
         return new ElastiCacheService.CreateReplicationGroupRequest(groupId, "test",
                 AuthMode.NO_AUTH, null, "us-east-1", null, null, null,
                 parameterGroupName, null, null, null, null,
-                null, null, null, ReplicationGroupSettings.defaults(), Map.of());
+                null, null, null, null, ReplicationGroupSettings.defaults(), Map.of());
     }
 
     @Test


### PR DESCRIPTION
## Summary

`CreateReplicationGroup` models `Port` as an optional input, but Floci ignored it:
`allocateProxyPort` took no argument and always handed out the next free port from the
base of its range. A caller that pinned a port read back a different one, which
Terraform treats as replacement-forcing and therefore reports as permanent drift.

`allocateProxyPort` now honors a requested port that is free and inside the proxy
range, mirroring `NeptuneService.allocateProxyPort`. Floci multiplexes every group's
proxy onto one host, so two groups genuinely cannot share a port; when the requested
one is taken or out of range it logs why and falls back to the next free port rather
than failing the create. In cluster mode only the first node can take the requested
port, because the group reports its port from that node.

`CreateCacheCluster` also models `Port`, but the memcached path takes its port from
the container handle rather than this allocator, so it is a separate mechanism and is
left for a follow-up.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The incorrect behavior: a pinned `Port` was silently replaced by whatever Floci
allocated, so `aws_elasticache_replication_group` re-planned dirty forever.

botocore models `Port` on `CreateReplicationGroup` as "the port number on which each
member of the replication group accepts connections"
([service-2.json](https://github.com/boto/botocore/blob/develop/botocore/data/elasticache/2015-02-02/service-2.json)).
Verified end to end with the Terraform AWS provider through the compatibility suite.

Both compatibility fixtures previously pinned `6379`, which is the bottom of the proxy
range and the port Floci would have allocated anyway, so the assertion passed by
coincidence rather than by behavior. They now pin `6395`, which fails without this fix.

## Checklist

- [x] `./mvnw test` passes locally (129 ElastiCache tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
