### PR TITLE
fix: align GuardDuty and RAM organization behavior

### DIFF
--- a/docs/services/ram.md
+++ b/docs/services/ram.md
@@ -16,7 +16,7 @@ below for what's simplified.
 <!-- floci:actions:start -->
 | Action | Description |
 | --- | --- |
-| `EnableSharingWithAwsOrganization` | Enables resource sharing within the organization; returns `{"returnValue": true}`. Idempotent, no disable counterpart, matching real AWS (`POST /enablesharingwithawsorganization`) |
+| `EnableSharingWithAwsOrganization` | Enables resource sharing within the organization; returns `{"returnValue": true}`. Also enables `ram.amazonaws.com` trusted access in Organizations and creates the `AWSServiceRoleForResourceAccessManager` IAM service-linked role when absent. Idempotent, no disable counterpart, matching real AWS (`POST /enablesharingwithawsorganization`) |
 | `CreateResourceShare` | Creates a resource share with the given name, principals, and resource ARNs (`POST /createresourceshare`) |
 | `GetResourceShares` | Lists resource shares visible to the caller, `SELF` owned or `OTHER-ACCOUNTS` shared in (`POST /getresourceshares`) |
 | `DeleteResourceShare` | Marks a share `DELETED`, a soft delete matching real AWS's async-then-terminal status (`DELETE /deleteresourceshare`) |

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
@@ -88,7 +88,7 @@ public class GuardDutyController {
             @QueryParam("maxResults") String maxResults,
             @QueryParam("nextToken") String nextToken) {
         GuardDutyService.Page<String> page = service.listDetectorIds(
-                regionResolver.resolveRegion(headers), maxResults, nextToken);
+                regionResolver.resolveRegion(headers), regionResolver.getAccountId(), maxResults, nextToken);
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode ids = response.putArray("detectorIds");
         page.items().forEach(ids::add);

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
@@ -33,10 +34,9 @@ import java.util.regex.Pattern;
  * GuardDuty detector lifecycle and organization configuration backed by the configured
  * Floci storage mode.
  *
- * <p>Organization semantics are readback-only: Floci has no Organizations service, so
- * {@code adminAccountId} membership is not validated, delegated-administrator permissions are
- * not enforced, and member accounts are not fanned out. Organization configuration is stored
- * per calling account and echoed back as submitted.
+ * <p>Organization state is shared across account partitions where AWS models it at organization
+ * scope. Delegated-administrator status is therefore visible to requests made with the delegated
+ * account's credentials, while detector and member resources remain scoped to their owning account.
  */
 @ApplicationScoped
 public class GuardDutyService {
@@ -109,7 +109,9 @@ public class GuardDutyService {
         List<DetectorFeature> features = readDetectorFeatures(request);
         Map<String, String> tags = readTags(request);
 
-        if (!detectorStore.scan(key -> key.startsWith(region + "::")).isEmpty()) {
+        boolean detectorExists = detectorStore.scan(key -> key.startsWith(region + "::")).stream()
+                .anyMatch(detector -> accountId.equals(accountIdFromServiceRole(detector.getServiceRole())));
+        if (detectorExists) {
             throw badRequest("The request is rejected because a detector already exists for the current account.");
         }
 
@@ -157,9 +159,11 @@ public class GuardDutyService {
         detectorStore.delete(key);
     }
 
-    public Page<String> listDetectorIds(String region, String maxResultsValue, String nextToken) {
+    public Page<String> listDetectorIds(String region, String accountId, String maxResultsValue, String nextToken) {
         int maxResults = parseMaxResults(maxResultsValue);
-        List<Detector> detectors = detectorStore.scan(key -> key.startsWith(region + "::"));
+        List<Detector> detectors = detectorStore.scan(key -> key.startsWith(region + "::")).stream()
+                .filter(detector -> accountId.equals(accountIdFromServiceRole(detector.getServiceRole())))
+                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
         detectors.sort(Comparator.comparing(Detector::getId));
         List<String> ids = detectors.stream().map(Detector::getId).toList();
 
@@ -207,7 +211,7 @@ public class GuardDutyService {
 
     public synchronized void enableOrganizationAdminAccount(String region, JsonNode request) {
         String adminAccountId = readAdminAccountId(request);
-        List<AdminAccount> existing = adminAccountStore.scan(key -> key.startsWith(region + "::"));
+        List<AdminAccount> existing = organizationAdminAccounts(region);
         if (!existing.isEmpty() && !existing.get(0).getAdminAccountId().equals(adminAccountId)) {
             throw badRequest("The request is rejected because the organization already has a "
                     + "delegated administrator account for GuardDuty.");
@@ -227,7 +231,7 @@ public class GuardDutyService {
     public Page<AdminAccount> listOrganizationAdminAccounts(
             String region, String maxResultsValue, String nextToken) {
         int maxResults = parseMaxResults(maxResultsValue);
-        List<AdminAccount> accounts = adminAccountStore.scan(key -> key.startsWith(region + "::"));
+        List<AdminAccount> accounts = new ArrayList<>(organizationAdminAccounts(region));
         accounts.sort(Comparator.comparing(AdminAccount::getAdminAccountId));
 
         int offset = decodeOffset(nextToken, accounts.size());
@@ -243,9 +247,9 @@ public class GuardDutyService {
             throw badRequest("accountDetails must contain between 1 and 50 accounts.");
         }
         String administratorId = accountIdFromServiceRole(detector.getServiceRole());
-        boolean organizationDelegatedAdministrator = adminAccountStore.get(storageKey(region, administratorId))
-                .map(account -> "ENABLED".equals(account.getAdminStatus()))
-                .orElse(false);
+        boolean organizationDelegatedAdministrator = organizationAdminAccounts(region).stream()
+                .anyMatch(account -> administratorId.equals(account.getAdminAccountId())
+                        && "ENABLED".equals(account.getAdminStatus()));
         String relationshipStatus = organizationDelegatedAdministrator ? "Enabled" : "Created";
         String now = Instant.now().toString();
         List<MemberWrite> writes = new ArrayList<>(details.size());
@@ -535,6 +539,16 @@ public class GuardDutyService {
             tags.put(entry.getKey(), valueNode.textValue());
         });
         return tags;
+    }
+
+    private List<AdminAccount> organizationAdminAccounts(String region) {
+        String prefix = region + "::";
+        if (adminAccountStore instanceof AccountAwareStorageBackend<AdminAccount> accountAware) {
+            return accountAware.scanAllAccountEntries(key -> key.startsWith(prefix)).stream()
+                    .map(AccountAwareStorageBackend.AccountEntry::value)
+                    .toList();
+        }
+        return adminAccountStore.scan(key -> key.startsWith(prefix));
     }
 
     private static String readAdminAccountId(JsonNode request) {

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -87,7 +87,8 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
     private static final String SERVICE_LINKED_ROLE_NAME_PREFIX = "AWSServiceRoleFor";
     private static final Map<String, String> SERVICE_LINKED_ROLE_NAMES = Map.of(
             "autoscaling.amazonaws.com", "AutoScaling",
-            "cloud9.amazonaws.com", "AWSCloud9"
+            "cloud9.amazonaws.com", "AWSCloud9",
+            "ram.amazonaws.com", "ResourceAccessManager"
     );
     private static final String AMAZONAWS_DOMAIN = ".amazonaws.com";
     /** AWSServiceName as AWS constrains it: 1-128 characters of {@code [\w+=,.@-]}. */

--- a/src/main/java/io/github/hectorvent/floci/services/ram/RamController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ram/RamController.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import io.github.hectorvent.floci.services.ram.model.PrincipalAssociation;
 import io.github.hectorvent.floci.services.ram.model.ResourceShare;
 import io.github.hectorvent.floci.services.ram.model.ResourceShareInvitation;
@@ -48,20 +50,31 @@ public class RamController {
     private final ObjectMapper objectMapper;
     private final ObjectReader requestReader;
     private final RegionResolver regionResolver;
+    private final OrganizationsService organizationsService;
+    private final IamService iamService;
 
     @Inject
-    public RamController(RamService service, ObjectMapper objectMapper, RegionResolver regionResolver) {
+    public RamController(RamService service, ObjectMapper objectMapper, RegionResolver regionResolver,
+                         OrganizationsService organizationsService, IamService iamService) {
         this.service = service;
         this.objectMapper = objectMapper;
         this.requestReader = objectMapper.reader()
                 .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         this.regionResolver = regionResolver;
+        this.organizationsService = organizationsService;
+        this.iamService = iamService;
     }
 
     @POST
     @Path("/enablesharingwithawsorganization")
     @Consumes(MediaType.WILDCARD)
     public Response enableSharingWithAwsOrganization() {
+        String callerAccountId = regionResolver.getAccountId();
+        organizationsService.enableAWSServiceAccess(callerAccountId, "ram.amazonaws.com");
+        if (iamService.findRole(callerAccountId, "AWSServiceRoleForResourceAccessManager").isEmpty()) {
+            iamService.createServiceLinkedRole("ram.amazonaws.com", null,
+                    "Allows AWS Resource Access Manager to access AWS Organizations on your behalf.");
+        }
         ObjectNode response = objectMapper.createObjectNode();
         response.put("returnValue", service.enableSharingWithAwsOrganization());
         return Response.ok(response).build();

--- a/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.PersistentStorage;
 import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
@@ -178,17 +179,27 @@ class GuardDutyServiceTest {
         AwsException error = assertThrows(
                 AwsException.class, () -> service.deleteDetector(REGION, detector.getId()));
         assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, error.getMessage());
-        assertTrue(service.listDetectorIds(REGION, null, null).items().isEmpty());
+        assertTrue(service.listDetectorIds(REGION, ACCOUNT, null, null).items().isEmpty());
     }
 
     @Test
     void listDetectorIdsReturnsTheRegionalDetector() throws Exception {
         Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
 
-        GuardDutyService.Page<String> page = service.listDetectorIds(REGION, null, null);
+        GuardDutyService.Page<String> page = service.listDetectorIds(REGION, ACCOUNT, null, null);
 
         assertEquals(List.of(detector.getId()), page.items());
         assertNull(page.nextToken());
+    }
+
+    @Test
+    void detectorsAreScopedByAccountWithinTheSameRegion() throws Exception {
+        String otherAccount = "222222222222";
+        Detector first = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+        Detector second = service.createDetector(REGION, otherAccount, request("{\"enable\":true}"));
+
+        assertEquals(List.of(first.getId()), service.listDetectorIds(REGION, ACCOUNT, null, null).items());
+        assertEquals(List.of(second.getId()), service.listDetectorIds(REGION, otherAccount, null, null).items());
     }
 
     @Test
@@ -260,6 +271,46 @@ class GuardDutyServiceTest {
                 () -> service.updateOrganizationConfiguration(REGION, detector.getId(), request(
                         "{\"autoEnableOrganizationMembers\":\"SOME\"}")));
         assertEquals("BadRequestException", badValue.getErrorCode());
+    }
+
+    @Test
+    void delegatedAdministratorCreatesEnabledOrganizationMembers() throws Exception {
+        String adminAccount = "111111111111";
+        String managementAccount = "222222222222";
+        service.enableOrganizationAdminAccount(REGION, request("{\"adminAccountId\":\"" + adminAccount + "\"}"));
+        Detector adminDetector = service.createDetector(REGION, adminAccount, request("{\"enable\":true}"));
+        service.createDetector(REGION, managementAccount, request("{\"enable\":true}"));
+
+        service.createMembers(REGION, adminDetector.getId(), request(
+                "{\"accountDetails\":[{\"accountId\":\"" + managementAccount
+                        + "\",\"email\":\"management@example.com\"}]}"));
+
+        List<MemberAccount> members = service.listMembers(REGION, adminDetector.getId(), null, null, "true").items();
+        assertEquals(1, members.size());
+        assertEquals(managementAccount, members.get(0).accountId());
+        assertEquals("Enabled", members.get(0).relationshipStatus());
+    }
+
+    @Test
+    void delegatedAdministratorIsVisibleAcrossAccountPartitions() throws Exception {
+        String adminAccount = "111111111111";
+        String managementAccount = "222222222222";
+        AccountAwareStorageBackend<Detector> detectors = AccountAwareStorageBackend.inMemory(adminAccount);
+        AccountAwareStorageBackend<AdminAccount> admins = AccountAwareStorageBackend.inMemory(adminAccount);
+        AccountAwareStorageBackend<MemberAccount> members = AccountAwareStorageBackend.inMemory(adminAccount);
+        admins.putForAccount(managementAccount, REGION + "::" + adminAccount,
+                new AdminAccount(adminAccount, "ENABLED"));
+        GuardDutyService partitioned = new GuardDutyService(detectors, admins, members);
+        Detector adminDetector = partitioned.createDetector(REGION, adminAccount, request("{\"enable\":true}"));
+
+        partitioned.createMembers(REGION, adminDetector.getId(), request(
+                "{\"accountDetails\":[{\"accountId\":\"" + managementAccount
+                        + "\",\"email\":\"management@example.com\"}]}"));
+
+        List<MemberAccount> listed = partitioned.listMembers(
+                REGION, adminDetector.getId(), null, null, "true").items();
+        assertEquals(1, listed.size());
+        assertEquals("Enabled", listed.get(0).relationshipStatus());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ram/RamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ram/RamIntegrationTest.java
@@ -3,16 +3,22 @@ package io.github.hectorvent.floci.services.ram;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * Verifies the RAM restJson1 organization-sharing opt-in:
  * {@code POST /enablesharingwithawsorganization} succeeds with or without a request body.
  */
 @QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class RamIntegrationTest {
 
     private static final String AUTH_HEADER =
@@ -24,6 +30,21 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(1)
+    void createOrganizationBeforeEnablingRamIntegration() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("Authorization", AUTH_HEADER)
+            .header("X-Amz-Target", "AWSOrganizationsV20161128.CreateOrganization")
+            .body("{\"FeatureSet\":\"ALL\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
     void enableSharingWithAwsOrganization_returnsTrue() {
         given()
             .contentType("application/json")
@@ -37,6 +58,7 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(5)
     void enableSharingWithAwsOrganization_withoutBody_returnsTrue() {
         given()
             .header("Authorization", AUTH_HEADER)
@@ -48,6 +70,42 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(6)
+    void enableSharingWithAwsOrganizationCreatesAwsSideEffects() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/enablesharingwithawsorganization")
+        .then()
+            .statusCode(200)
+            .body("returnValue", equalTo(true));
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("Authorization", AUTH_HEADER)
+            .header("X-Amz-Target", "AWSOrganizationsV20161128.ListAWSServiceAccessForOrganization")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("EnabledServicePrincipals.ServicePrincipal", hasItem("ram.amazonaws.com"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "GetRole")
+            .formParam("Version", "2010-05-08")
+            .formParam("RoleName", "AWSServiceRoleForResourceAccessManager")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("AWSServiceRoleForResourceAccessManager"));
+    }
+
+    @Test
+    @Order(2)
     void getResourceShareInvitations_returnsEmptyJson() {
         // LZA's Custom::GetResourceShare Lambda pages this first, before any share has been
         // created in this test's account. The response must be JSON (restJson1): an XML
@@ -348,6 +406,7 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(3)
     void acceptResourceShareInvitationOverHttp() {
         // A bare account-id principal (not an OU/organization ARN) gets a real PENDING
         // invitation; targeting this test's own account keeps the whole flow within one


### PR DESCRIPTION
## Summary

Fix two AWS-fidelity gaps found while running Cloud Launchpad Core flows against Floci:

- Scope GuardDuty detectors per caller account and make organization delegated-admin state visible across account partitions, so delegated administrators create active member relationships correctly.
- Make `ram:EnableSharingWithAwsOrganization` reproduce AWS side effects by enabling Organizations trusted access for `ram.amazonaws.com` and creating `AWSServiceRoleForResourceAccessManager` when needed.

Service Quotas is intentionally not changed in this PR; Floci's existing Organizations quota value remains unchanged.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

GuardDuty organization administration is organization-scoped even when the administrator operates from a different member-account partition. The previous Floci storage lookup made the delegated administrator invisible when `CreateMembers` was called from that account, leaving the relationship at `Created` instead of the active organization-admin/member state.

AWS RAM `EnableSharingWithAwsOrganization` also enables trusted access with AWS Organizations and creates the `AWSServiceRoleForResourceAccessManager` service-linked role. Floci previously returned success without those side effects.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused validation: `GuardDutyServiceTest`, `GuardDutyControllerIntegrationTest`, `RamIntegrationTest`, and `IamServiceTest`: 153 tests, 0 failures, 0 errors. `make docs-check` and `git diff --check origin/main...HEAD` also pass.