### PR TITLE
fix(guardduty): scope organization state across accounts

### DIFF
--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -887,10 +887,14 @@ public final class TestFixtures {
     }
 
     public static GuardDutyClient guardDutyClient() {
+        return guardDutyClient("test");
+    }
+
+    public static GuardDutyClient guardDutyClient(String accountId) {
         return GuardDutyClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
-                .credentialsProvider(CREDENTIALS)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))
                 .build();
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GuardDutyTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/GuardDutyTest.java
@@ -3,6 +3,7 @@ package com.floci.test;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.guardduty.GuardDutyClient;
+import software.amazon.awssdk.services.guardduty.model.AccountDetail;
 import software.amazon.awssdk.services.guardduty.model.AdminStatus;
 import software.amazon.awssdk.services.guardduty.model.AutoEnableMembers;
 import software.amazon.awssdk.services.guardduty.model.BadRequestException;
@@ -160,6 +161,45 @@ class GuardDutyTest {
                                 "ECS_FARGATE_AGENT_MANAGEMENT",
                                 "EC2_AGENT_MANAGEMENT",
                                 "EKS_ADDON_MANAGEMENT");
+            }
+        }
+    }
+
+    @Test
+    void crossAccountDetectorAndDelegatedAdministratorStateUsesAwsSdk() throws Exception {
+        String managementAccount = "222222222222";
+        String adminAccount = "111111111111";
+
+        try (GuardDutyClient management = TestFixtures.guardDutyClient(managementAccount);
+             GuardDutyClient administrator = TestFixtures.guardDutyClient(adminAccount)) {
+            String managementDetector = management.createDetector(request -> request.enable(true)).detectorId();
+            String adminDetector = administrator.createDetector(request -> request.enable(true)).detectorId();
+
+            assertThat(management.listDetectors(request -> {}).detectorIds()).containsExactly(managementDetector);
+            assertThat(administrator.listDetectors(request -> {}).detectorIds()).containsExactly(adminDetector);
+
+            management.enableOrganizationAdminAccount(request -> request.adminAccountId(adminAccount));
+            try {
+                administrator.createMembers(request -> request
+                        .detectorId(adminDetector)
+                        .accountDetails(AccountDetail.builder()
+                                .accountId(managementAccount)
+                                .email("management@example.com")
+                                .build()));
+
+                assertThat(administrator.listMembers(request -> request
+                        .detectorId(adminDetector)
+                        .onlyAssociated("true"))
+                        .members())
+                        .singleElement()
+                        .satisfies(member -> {
+                            assertThat(member.accountId()).isEqualTo(managementAccount);
+                            assertThat(member.relationshipStatus()).isEqualTo("Enabled");
+                        });
+            } finally {
+                management.disableOrganizationAdminAccount(request -> request.adminAccountId(adminAccount));
+                management.deleteDetector(request -> request.detectorId(managementDetector));
+                administrator.deleteDetector(request -> request.detectorId(adminDetector));
             }
         }
     }

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyController.java
@@ -88,7 +88,7 @@ public class GuardDutyController {
             @QueryParam("maxResults") String maxResults,
             @QueryParam("nextToken") String nextToken) {
         GuardDutyService.Page<String> page = service.listDetectorIds(
-                regionResolver.resolveRegion(headers), maxResults, nextToken);
+                regionResolver.resolveRegion(headers), regionResolver.getAccountId(), maxResults, nextToken);
         ObjectNode response = objectMapper.createObjectNode();
         ArrayNode ids = response.putArray("detectorIds");
         page.items().forEach(ids::add);

--- a/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/guardduty/GuardDutyService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
@@ -33,10 +34,9 @@ import java.util.regex.Pattern;
  * GuardDuty detector lifecycle and organization configuration backed by the configured
  * Floci storage mode.
  *
- * <p>Organization semantics are readback-only: Floci has no Organizations service, so
- * {@code adminAccountId} membership is not validated, delegated-administrator permissions are
- * not enforced, and member accounts are not fanned out. Organization configuration is stored
- * per calling account and echoed back as submitted.
+ * <p>Organization state is shared across account partitions where AWS models it at organization
+ * scope. Delegated-administrator status is therefore visible to requests made with the delegated
+ * account's credentials, while detector and member resources remain scoped to their owning account.
  */
 @ApplicationScoped
 public class GuardDutyService {
@@ -109,7 +109,9 @@ public class GuardDutyService {
         List<DetectorFeature> features = readDetectorFeatures(request);
         Map<String, String> tags = readTags(request);
 
-        if (!detectorStore.scan(key -> key.startsWith(region + "::")).isEmpty()) {
+        boolean detectorExists = detectorStore.scan(key -> key.startsWith(region + "::")).stream()
+                .anyMatch(detector -> accountId.equals(accountIdFromServiceRole(detector.getServiceRole())));
+        if (detectorExists) {
             throw badRequest("The request is rejected because a detector already exists for the current account.");
         }
 
@@ -157,9 +159,11 @@ public class GuardDutyService {
         detectorStore.delete(key);
     }
 
-    public Page<String> listDetectorIds(String region, String maxResultsValue, String nextToken) {
+    public Page<String> listDetectorIds(String region, String accountId, String maxResultsValue, String nextToken) {
         int maxResults = parseMaxResults(maxResultsValue);
-        List<Detector> detectors = detectorStore.scan(key -> key.startsWith(region + "::"));
+        List<Detector> detectors = detectorStore.scan(key -> key.startsWith(region + "::")).stream()
+                .filter(detector -> accountId.equals(accountIdFromServiceRole(detector.getServiceRole())))
+                .collect(java.util.stream.Collectors.toCollection(ArrayList::new));
         detectors.sort(Comparator.comparing(Detector::getId));
         List<String> ids = detectors.stream().map(Detector::getId).toList();
 
@@ -207,7 +211,7 @@ public class GuardDutyService {
 
     public synchronized void enableOrganizationAdminAccount(String region, JsonNode request) {
         String adminAccountId = readAdminAccountId(request);
-        List<AdminAccount> existing = adminAccountStore.scan(key -> key.startsWith(region + "::"));
+        List<AdminAccount> existing = organizationAdminAccounts(region);
         if (!existing.isEmpty() && !existing.get(0).getAdminAccountId().equals(adminAccountId)) {
             throw badRequest("The request is rejected because the organization already has a "
                     + "delegated administrator account for GuardDuty.");
@@ -227,7 +231,7 @@ public class GuardDutyService {
     public Page<AdminAccount> listOrganizationAdminAccounts(
             String region, String maxResultsValue, String nextToken) {
         int maxResults = parseMaxResults(maxResultsValue);
-        List<AdminAccount> accounts = adminAccountStore.scan(key -> key.startsWith(region + "::"));
+        List<AdminAccount> accounts = new ArrayList<>(organizationAdminAccounts(region));
         accounts.sort(Comparator.comparing(AdminAccount::getAdminAccountId));
 
         int offset = decodeOffset(nextToken, accounts.size());
@@ -243,9 +247,9 @@ public class GuardDutyService {
             throw badRequest("accountDetails must contain between 1 and 50 accounts.");
         }
         String administratorId = accountIdFromServiceRole(detector.getServiceRole());
-        boolean organizationDelegatedAdministrator = adminAccountStore.get(storageKey(region, administratorId))
-                .map(account -> "ENABLED".equals(account.getAdminStatus()))
-                .orElse(false);
+        boolean organizationDelegatedAdministrator = organizationAdminAccounts(region).stream()
+                .anyMatch(account -> administratorId.equals(account.getAdminAccountId())
+                        && "ENABLED".equals(account.getAdminStatus()));
         String relationshipStatus = organizationDelegatedAdministrator ? "Enabled" : "Created";
         String now = Instant.now().toString();
         List<MemberWrite> writes = new ArrayList<>(details.size());
@@ -535,6 +539,16 @@ public class GuardDutyService {
             tags.put(entry.getKey(), valueNode.textValue());
         });
         return tags;
+    }
+
+    private List<AdminAccount> organizationAdminAccounts(String region) {
+        String prefix = region + "::";
+        if (adminAccountStore instanceof AccountAwareStorageBackend<AdminAccount> accountAware) {
+            return accountAware.scanAllAccountEntries(key -> key.startsWith(prefix)).stream()
+                    .map(AccountAwareStorageBackend.AccountEntry::value)
+                    .toList();
+        }
+        return adminAccountStore.scan(key -> key.startsWith(prefix));
     }
 
     private static String readAdminAccountId(JsonNode request) {

--- a/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyServiceTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.InMemoryStorage;
 import io.github.hectorvent.floci.core.storage.PersistentStorage;
 import io.github.hectorvent.floci.services.guardduty.model.AdminAccount;
@@ -178,17 +179,27 @@ class GuardDutyServiceTest {
         AwsException error = assertThrows(
                 AwsException.class, () -> service.deleteDetector(REGION, detector.getId()));
         assertEquals(GuardDutyService.DETECTOR_NOT_FOUND_MESSAGE, error.getMessage());
-        assertTrue(service.listDetectorIds(REGION, null, null).items().isEmpty());
+        assertTrue(service.listDetectorIds(REGION, ACCOUNT, null, null).items().isEmpty());
     }
 
     @Test
     void listDetectorIdsReturnsTheRegionalDetector() throws Exception {
         Detector detector = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
 
-        GuardDutyService.Page<String> page = service.listDetectorIds(REGION, null, null);
+        GuardDutyService.Page<String> page = service.listDetectorIds(REGION, ACCOUNT, null, null);
 
         assertEquals(List.of(detector.getId()), page.items());
         assertNull(page.nextToken());
+    }
+
+    @Test
+    void detectorsAreScopedByAccountWithinTheSameRegion() throws Exception {
+        String otherAccount = "222222222222";
+        Detector first = service.createDetector(REGION, ACCOUNT, request("{\"enable\":true}"));
+        Detector second = service.createDetector(REGION, otherAccount, request("{\"enable\":true}"));
+
+        assertEquals(List.of(first.getId()), service.listDetectorIds(REGION, ACCOUNT, null, null).items());
+        assertEquals(List.of(second.getId()), service.listDetectorIds(REGION, otherAccount, null, null).items());
     }
 
     @Test
@@ -260,6 +271,46 @@ class GuardDutyServiceTest {
                 () -> service.updateOrganizationConfiguration(REGION, detector.getId(), request(
                         "{\"autoEnableOrganizationMembers\":\"SOME\"}")));
         assertEquals("BadRequestException", badValue.getErrorCode());
+    }
+
+    @Test
+    void delegatedAdministratorCreatesEnabledOrganizationMembers() throws Exception {
+        String adminAccount = "111111111111";
+        String managementAccount = "222222222222";
+        service.enableOrganizationAdminAccount(REGION, request("{\"adminAccountId\":\"" + adminAccount + "\"}"));
+        Detector adminDetector = service.createDetector(REGION, adminAccount, request("{\"enable\":true}"));
+        service.createDetector(REGION, managementAccount, request("{\"enable\":true}"));
+
+        service.createMembers(REGION, adminDetector.getId(), request(
+                "{\"accountDetails\":[{\"accountId\":\"" + managementAccount
+                        + "\",\"email\":\"management@example.com\"}]}"));
+
+        List<MemberAccount> members = service.listMembers(REGION, adminDetector.getId(), null, null, "true").items();
+        assertEquals(1, members.size());
+        assertEquals(managementAccount, members.get(0).accountId());
+        assertEquals("Enabled", members.get(0).relationshipStatus());
+    }
+
+    @Test
+    void delegatedAdministratorIsVisibleAcrossAccountPartitions() throws Exception {
+        String adminAccount = "111111111111";
+        String managementAccount = "222222222222";
+        AccountAwareStorageBackend<Detector> detectors = AccountAwareStorageBackend.inMemory(adminAccount);
+        AccountAwareStorageBackend<AdminAccount> admins = AccountAwareStorageBackend.inMemory(adminAccount);
+        AccountAwareStorageBackend<MemberAccount> members = AccountAwareStorageBackend.inMemory(adminAccount);
+        admins.putForAccount(managementAccount, REGION + "::" + adminAccount,
+                new AdminAccount(adminAccount, "ENABLED"));
+        GuardDutyService partitioned = new GuardDutyService(detectors, admins, members);
+        Detector adminDetector = partitioned.createDetector(REGION, adminAccount, request("{\"enable\":true}"));
+
+        partitioned.createMembers(REGION, adminDetector.getId(), request(
+                "{\"accountDetails\":[{\"accountId\":\"" + managementAccount
+                        + "\",\"email\":\"management@example.com\"}]}"));
+
+        List<MemberAccount> listed = partitioned.listMembers(
+                REGION, adminDetector.getId(), null, null, "true").items();
+        assertEquals(1, listed.size());
+        assertEquals("Enabled", listed.get(0).relationshipStatus());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fix GuardDuty account scoping so detectors remain account-local while organization delegated-administrator state is visible across account partitions, matching delegated administration flows.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

GuardDuty detector state must be scoped to the caller account and Region. Organization delegated-administrator state must remain visible when the delegated administrator calls member-management APIs from its own account context. Previously Floci could report a delegated admin as enabled from the management account while `CreateMembers` from the delegated-admin account could not see that organization state and left members in the wrong relationship state.

Verified with AWS SDK for Java v2 `GuardDutyClient` using separate management and delegated-administrator account credentials against the branch-local Floci endpoint. The SDK regression proves each account sees only its own detector, while delegated-administrator state remains visible across account partitions and `CreateMembers` yields an associated member with relationship status `Enabled`.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused validation: `./mvnw test -Dtest=GuardDutyServiceTest,GuardDutyControllerIntegrationTest` — 29 tests, 0 failures, 0 errors.

AWS SDK compatibility validation: `FLOCI_ENDPOINT=http://127.0.0.1:4696 ./mvnw -f compatibility-tests/sdk-test-java/pom.xml -Dtest=GuardDutyTest test` — 4 tests, 0 failures, 0 errors.

`make docs-check` and `git diff --check` pass.