### PR TITLE
fix(ram): emulate organization sharing side effects

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -341,6 +341,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>guardduty</artifactId>
         </dependency>
+        <!-- AWS Resource Access Manager client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>ram</artifactId>
+        </dependency>
         <!-- Secrets Manager client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.services.securityhub.SecurityHubClient;
 import software.amazon.awssdk.services.detective.DetectiveClient;
 import software.amazon.awssdk.services.rum.RumClient;
 import software.amazon.awssdk.services.resourceexplorer2.ResourceExplorer2Client;
+import software.amazon.awssdk.services.ram.RamClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.endpoints.Endpoint;
@@ -527,10 +528,14 @@ public final class TestFixtures {
     }
 
     public static IamClient iamClient() {
+        return iamClient("test");
+    }
+
+    public static IamClient iamClient(String accountId) {
         return IamClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
-                .credentialsProvider(CREDENTIALS)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))
                 .build();
     }
 
@@ -891,6 +896,18 @@ public final class TestFixtures {
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static RamClient ramClient() {
+        return ramClient("test");
+    }
+
+    public static RamClient ramClient(String accountId) {
+        return RamClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accountId, "test")))
                 .build();
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RamOrganizationSharingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/RamOrganizationSharingTest.java
@@ -1,0 +1,40 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.organizations.OrganizationsClient;
+import software.amazon.awssdk.services.ram.RamClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+
+@DisplayName("RAM organization sharing")
+class RamOrganizationSharingTest {
+    private static final String MANAGEMENT_ACCOUNT = "222222222222";
+
+    @Test
+    @DisplayName("enables Organizations trusted access and creates the RAM service-linked role")
+    void organizationSharingUsesAwsSdk() {
+        assumeFalse(TestFixtures.isRealAws(), "Avoids changing RAM organization sharing in real AWS");
+
+        try (OrganizationsClient organizations = TestFixtures.organizationsClient(MANAGEMENT_ACCOUNT);
+             RamClient ram = TestFixtures.ramClient(MANAGEMENT_ACCOUNT);
+             IamClient iam = TestFixtures.iamClient(MANAGEMENT_ACCOUNT)) {
+            try {
+                organizations.describeOrganization();
+            } catch (software.amazon.awssdk.services.organizations.model.AwsOrganizationsNotInUseException e) {
+                organizations.createOrganization(request -> request.featureSet("ALL"));
+            }
+
+            assertThat(ram.enableSharingWithAwsOrganization().returnValue()).isTrue();
+
+            assertThat(organizations.listAWSServiceAccessForOrganization().enabledServicePrincipals())
+                    .extracting(principal -> principal.servicePrincipal())
+                    .contains("ram.amazonaws.com");
+
+            assertThat(iam.getRole(request -> request.roleName("AWSServiceRoleForResourceAccessManager"))
+                    .role().roleName()).isEqualTo("AWSServiceRoleForResourceAccessManager");
+        }
+    }
+}

--- a/docs/services/ram.md
+++ b/docs/services/ram.md
@@ -16,7 +16,7 @@ below for what's simplified.
 <!-- floci:actions:start -->
 | Action | Description |
 | --- | --- |
-| `EnableSharingWithAwsOrganization` | Enables resource sharing within the organization; returns `{"returnValue": true}`. Idempotent, no disable counterpart, matching real AWS (`POST /enablesharingwithawsorganization`) |
+| `EnableSharingWithAwsOrganization` | Enables resource sharing within the organization; returns `{"returnValue": true}`. Also enables `ram.amazonaws.com` trusted access in Organizations and creates the `AWSServiceRoleForResourceAccessManager` IAM service-linked role when absent. Idempotent, no disable counterpart, matching real AWS (`POST /enablesharingwithawsorganization`) |
 | `CreateResourceShare` | Creates a resource share with the given name, principals, and resource ARNs (`POST /createresourceshare`) |
 | `GetResourceShares` | Lists resource shares visible to the caller, `SELF` owned or `OTHER-ACCOUNTS` shared in (`POST /getresourceshares`) |
 | `DeleteResourceShare` | Marks a share `DELETED`, a soft delete matching real AWS's async-then-terminal status (`DELETE /deleteresourceshare`) |

--- a/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iam/IamService.java
@@ -87,7 +87,8 @@ public class IamService implements SessionAccountLookup, ResourceProvider {
     private static final String SERVICE_LINKED_ROLE_NAME_PREFIX = "AWSServiceRoleFor";
     private static final Map<String, String> SERVICE_LINKED_ROLE_NAMES = Map.of(
             "autoscaling.amazonaws.com", "AutoScaling",
-            "cloud9.amazonaws.com", "AWSCloud9"
+            "cloud9.amazonaws.com", "AWSCloud9",
+            "ram.amazonaws.com", "ResourceAccessManager"
     );
     private static final String AMAZONAWS_DOMAIN = ".amazonaws.com";
     /** AWSServiceName as AWS constrains it: 1-128 characters of {@code [\w+=,.@-]}. */

--- a/src/main/java/io/github/hectorvent/floci/services/ram/RamController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ram/RamController.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.services.iam.IamService;
+import io.github.hectorvent.floci.services.organizations.OrganizationsService;
 import io.github.hectorvent.floci.services.ram.model.PrincipalAssociation;
 import io.github.hectorvent.floci.services.ram.model.ResourceShare;
 import io.github.hectorvent.floci.services.ram.model.ResourceShareInvitation;
@@ -48,20 +50,31 @@ public class RamController {
     private final ObjectMapper objectMapper;
     private final ObjectReader requestReader;
     private final RegionResolver regionResolver;
+    private final OrganizationsService organizationsService;
+    private final IamService iamService;
 
     @Inject
-    public RamController(RamService service, ObjectMapper objectMapper, RegionResolver regionResolver) {
+    public RamController(RamService service, ObjectMapper objectMapper, RegionResolver regionResolver,
+                         OrganizationsService organizationsService, IamService iamService) {
         this.service = service;
         this.objectMapper = objectMapper;
         this.requestReader = objectMapper.reader()
                 .with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         this.regionResolver = regionResolver;
+        this.organizationsService = organizationsService;
+        this.iamService = iamService;
     }
 
     @POST
     @Path("/enablesharingwithawsorganization")
     @Consumes(MediaType.WILDCARD)
     public Response enableSharingWithAwsOrganization() {
+        String callerAccountId = regionResolver.getAccountId();
+        organizationsService.enableAWSServiceAccess(callerAccountId, "ram.amazonaws.com");
+        if (iamService.findRole(callerAccountId, "AWSServiceRoleForResourceAccessManager").isEmpty()) {
+            iamService.createServiceLinkedRole("ram.amazonaws.com", null,
+                    "Allows AWS Resource Access Manager to access AWS Organizations on your behalf.");
+        }
         ObjectNode response = objectMapper.createObjectNode();
         response.put("returnValue", service.enableSharingWithAwsOrganization());
         return Response.ok(response).build();

--- a/src/test/java/io/github/hectorvent/floci/services/ram/RamIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ram/RamIntegrationTest.java
@@ -3,16 +3,22 @@ package io.github.hectorvent.floci.services.ram;
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 
 /**
  * Verifies the RAM restJson1 organization-sharing opt-in:
  * {@code POST /enablesharingwithawsorganization} succeeds with or without a request body.
  */
 @QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class RamIntegrationTest {
 
     private static final String AUTH_HEADER =
@@ -24,6 +30,21 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(1)
+    void createOrganizationBeforeEnablingRamIntegration() {
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("Authorization", AUTH_HEADER)
+            .header("X-Amz-Target", "AWSOrganizationsV20161128.CreateOrganization")
+            .body("{\"FeatureSet\":\"ALL\"}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+    }
+
+    @Test
+    @Order(4)
     void enableSharingWithAwsOrganization_returnsTrue() {
         given()
             .contentType("application/json")
@@ -37,6 +58,7 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(5)
     void enableSharingWithAwsOrganization_withoutBody_returnsTrue() {
         given()
             .header("Authorization", AUTH_HEADER)
@@ -48,6 +70,42 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(6)
+    void enableSharingWithAwsOrganizationCreatesAwsSideEffects() {
+        given()
+            .header("Authorization", AUTH_HEADER)
+        .when()
+            .post("/enablesharingwithawsorganization")
+        .then()
+            .statusCode(200)
+            .body("returnValue", equalTo(true));
+
+        given()
+            .contentType("application/x-amz-json-1.1")
+            .header("Authorization", AUTH_HEADER)
+            .header("X-Amz-Target", "AWSOrganizationsV20161128.ListAWSServiceAccessForOrganization")
+            .body("{}")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body("EnabledServicePrincipals.ServicePrincipal", hasItem("ram.amazonaws.com"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .header("Authorization", AUTH_HEADER)
+            .formParam("Action", "GetRole")
+            .formParam("Version", "2010-05-08")
+            .formParam("RoleName", "AWSServiceRoleForResourceAccessManager")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("AWSServiceRoleForResourceAccessManager"));
+    }
+
+    @Test
+    @Order(2)
     void getResourceShareInvitations_returnsEmptyJson() {
         // LZA's Custom::GetResourceShare Lambda pages this first, before any share has been
         // created in this test's account. The response must be JSON (restJson1): an XML
@@ -348,6 +406,7 @@ class RamIntegrationTest {
     }
 
     @Test
+    @Order(3)
     void acceptResourceShareInvitationOverHttp() {
         // A bare account-id principal (not an OU/organization ARN) gets a real PENDING
         // invitation; targeting this test's own account keeps the whole flow within one


### PR DESCRIPTION
## Summary

Fix AWS RAM `EnableSharingWithAwsOrganization` so Floci also enables Organizations trusted access for `ram.amazonaws.com` and creates the expected IAM service-linked role `AWSServiceRoleForResourceAccessManager`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS RAM organization sharing has side effects beyond returning success: trusted access is enabled in AWS Organizations and the RAM service-linked role is created. Previously Floci returned success without those effects, which forced consumers to pre-seed Organizations/IAM state.

Verified with AWS SDK for Java v2 `RamClient`, `OrganizationsClient`, and `IamClient` against the branch-local Floci endpoint. The SDK regression asserts that `EnableSharingWithAwsOrganization` returns success, `ram.amazonaws.com` appears in `ListAWSServiceAccessForOrganization`, and `AWSServiceRoleForResourceAccessManager` is retrievable through IAM.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused validation: `./mvnw test -Dtest=RamIntegrationTest,IamServiceTest` — 124 tests, 0 failures, 0 errors.

AWS SDK compatibility validation: `FLOCI_ENDPOINT=http://127.0.0.1:4695 ./mvnw -f compatibility-tests/sdk-test-java/pom.xml -Dtest=RamOrganizationSharingTest test` — 1 test, 0 failures, 0 errors.

`make docs-check` and `git diff --check` pass.