### PR TITLE
fix(ec2,ssm): explain missing IMDS registration for SSM-only managed instances

### DIFF
--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -138,6 +138,14 @@ curl -s -H "x-aws-ec2-metadata-token: $TOKEN" \
 
 IAM credentials are served when the instance has an `IamInstanceProfile.Arn` set at launch. The container can then call other Floci services with full SigV4 validation using the standard AWS SDK credential chain.
 
+### IMDS and SSM managed instances
+
+IMDS only knows about containers that Floci itself launched through `RunInstances`. That launch is what installs the link-local `169.254.169.254` proxy inside the container and maps the container's IP to its instance record.
+
+Registering a container with SSM is independent of this: an SSM agent that calls `UpdateInstanceInformation` becomes a managed instance, but that does not create an EC2 instance record, does not install the IMDS proxy, and does not register the container with IMDS. From such a container, `curl http://169.254.169.254/...` fails outright (no proxy), and a request sent straight to the host IMDS port returns `404` with a message explaining that no EC2 instance is registered for the source IP. Floci also logs a warning when an SSM agent registers from a container that is not backed by a Floci EC2 instance.
+
+To get a container that both answers IMDS (including instance profile credentials) and executes `SendCommand` directly, launch it with `RunInstances` first, then register that same container's SSM agent as a managed instance. Do not register an arbitrary or pre-existing container directly with SSM and expect IMDS to work. See [SSM](ssm.md#run-command-execution) for the SendCommand side of this.
+
 ## Default Resources
 
 Floci seeds the following resources on first use in each region so Terraform, the AWS CLI, and SDK clients work out of the box without any setup:

--- a/docs/services/ssm.md
+++ b/docs/services/ssm.md
@@ -28,7 +28,7 @@
 
 | Action | Description |
 |---|---|
-| `UpdateInstanceInformation` | Register or update an SSM agent record for an instance |
+| `UpdateInstanceInformation` | Register or update an SSM agent record for an instance. Does not create an EC2 instance or register the container with IMDS (see [Run Command Execution](#run-command-execution)) |
 | `DescribeInstanceInformation` | List registered SSM managed instances |
 | `SendCommand` | Create command invocations for target instances |
 | `GetCommandInvocation` | Return a command invocation result |
@@ -49,6 +49,11 @@
 `SendCommand` supports the `AWS-RunShellScript` document. For EC2 instances launched by Floci in real Docker mode, Floci creates the command invocation, returns the command response, and then runs the script asynchronously inside the target instance container. Callers observe completion through `GetCommandInvocation`. `stdout`, `stderr`, response code, start time, and end time are recorded on the invocation.
 
 If the target is not a Floci EC2 container, or if the document is not supported for direct execution, Floci falls back to the SSM agent polling flow. In that mode, `SendCommand` queues an ec2messages payload and the invocation completes after an agent calls `SendReply`.
+
+!!! note "Managed instance registration is independent of EC2 and IMDS"
+    Registering a container's SSM agent with `UpdateInstanceInformation` only creates the managed instance record. It does not create an EC2 instance, does not install the link-local `169.254.169.254` proxy in the container, and does not register the container with the [EC2 IMDS server](ec2.md#imds-and-ssm-managed-instances). A container that was only registered with SSM therefore has no working IMDS endpoint and no instance profile credentials, and `SendCommand` against it uses the agent polling flow rather than direct execution.
+
+    To get a container that both answers IMDS and runs `SendCommand` directly, launch it with EC2 `RunInstances` first and then register that same container's SSM agent. Floci logs a warning when an agent registers from a container that is not backed by a Floci EC2 instance.
 
 Direct command output follows the AWS inline output limits: first 24,000 characters of stdout and first 8,000 characters of stderr. Commands that exceed `TimeoutSeconds` are constrained inside the target container when the container has the `timeout` command available, and terminal timeout results are marked `TimedOut` with `StatusDetails` set to `Execution Timed Out`; commands with nonzero exit codes are marked `Failed`.
 

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServer.java
@@ -143,6 +143,10 @@ public class Ec2MetadataServer {
         if (inst != null) {
             tokenToInstance.put(token, inst);
         }
+        else {
+            LOG.debugv("IMDS: token requested from {0}, which is not a registered EC2 container; "
+                    + "metadata requests with this token will fail", ctx.request().remoteAddress().host());
+        }
 
         ctx.response()
                 .setStatusCode(200)
@@ -354,10 +358,28 @@ public class Ec2MetadataServer {
         String remoteIp = ctx.request().remoteAddress().host();
         Instance inst = containerIpToInstance.get(remoteIp);
         if (inst == null) {
-            LOG.warnv("IMDS: could not identify instance for request from {0}", remoteIp);
-            ctx.response().setStatusCode(404).end("Instance not found");
+            String message = unregisteredContainerMessage(remoteIp);
+            LOG.warnv("IMDS: {0}", message);
+            ctx.response().setStatusCode(404)
+                    .putHeader("content-type", "text/plain")
+                    .end(message);
         }
         return inst;
+    }
+
+    /**
+     * Explains why IMDS has nothing to serve for a request coming from {@code remoteIp}.
+     *
+     * <p>IMDS only knows about containers that {@link Ec2ContainerManager} launched through EC2
+     * {@code RunInstances}. Registering a container's SSM agent as a managed instance
+     * ({@code UpdateInstanceInformation}) does not create an EC2 instance record, so a container
+     * that was only registered with SSM ends up here.
+     */
+    static String unregisteredContainerMessage(String remoteIp) {
+        return "Instance not found: no EC2 instance is registered for source IP " + remoteIp + ". "
+                + "IMDS only serves containers launched through EC2 RunInstances; "
+                + "registering a container as an SSM managed instance does not register it with IMDS. "
+                + "Launch the container with RunInstances first, then register its SSM agent.";
     }
 
     // ── Utilities ─────────────────────────────────────────────────────────────

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmCommandService.java
@@ -114,12 +114,23 @@ public class SsmCommandService implements Resettable {
         info.setComputerName(request.path("Hostname").asText(instanceId));
         info.setRegion(region);
 
-        if (info.getRegistrationDate() == null) {
+        boolean firstRegistration = info.getRegistrationDate() == null;
+        if (firstRegistration) {
             info.setRegistrationDate(Instant.now());
         }
 
         instanceStore.put(instanceKey(region, instanceId), info);
         LOG.infov("SSM agent registered: instanceId={0} platform={1}/{2}", instanceId, info.getPlatformType(), info.getPlatformName());
+
+        // Registering with SSM does not create an EC2 instance record. Make it obvious when the
+        // agent lives in a container Floci did not launch through RunInstances: SendCommand falls
+        // back to agent polling and IMDS (169.254.169.254) has nothing to serve for that container.
+        if (firstRegistration && !directCommandExecutor.isContainerBacked(instanceId)) {
+            LOG.warnv("SSM managed instance {0} is not backed by a running Floci EC2 container. "
+                    + "SendCommand will use the agent polling flow and IMDS will not answer for it. "
+                    + "To get both, launch the container with EC2 RunInstances before registering its SSM agent.",
+                    instanceId);
+        }
     }
 
     public List<InstanceInformation> describeInstanceInformation(String region) {

--- a/src/main/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutor.java
@@ -69,7 +69,15 @@ public class SsmDirectCommandExecutor {
         if (!"AWS-RunShellScript".equals(documentName)) {
             return false;
         }
+        return isContainerBacked(instanceId);
+    }
 
+    /**
+     * Whether {@code instanceId} is a Floci EC2 instance whose Docker container is running.
+     * Only such instances get direct command execution and an IMDS registration; any other
+     * managed instance is served through the SSM agent polling flow.
+     */
+    public boolean isContainerBacked(String instanceId) {
         Instance instance = ec2Service.findInstanceById(instanceId);
         if (instance == null || instance.getDockerContainerId() == null || instance.getDockerContainerId().isBlank()) {
             return false;

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2MetadataServerTest.java
@@ -90,6 +90,16 @@ class Ec2MetadataServerTest {
     }
 
     @Test
+    void unregisteredContainerMessageExplainsMissingEc2Record() {
+        String message = Ec2MetadataServer.unregisteredContainerMessage("172.17.0.9");
+
+        assertTrue(message.startsWith("Instance not found"));
+        assertTrue(message.contains("172.17.0.9"));
+        assertTrue(message.contains("RunInstances"));
+        assertTrue(message.contains("SSM managed instance"));
+    }
+
+    @Test
     void iamCredentialRoleNameComesFromInstanceProfileRole() {
         IamService iamService = mock(IamService.class);
         InstanceProfile profile = new InstanceProfile();

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmCommandServiceDirectExecutionTest.java
@@ -32,12 +32,40 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class SsmCommandServiceDirectExecutionTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final RegionResolver regionResolver = mock(RegionResolver.class);
+
+    @Test
+    void agentRegistrationChecksEc2BackingOnFirstRegistrationOnly() throws Exception {
+        SsmDirectCommandExecutor executor = mock(SsmDirectCommandExecutor.class);
+        when(executor.isContainerBacked("mi-agent-only")).thenReturn(false);
+
+        SsmCommandService service = new SsmCommandService(
+                new InMemoryStorageFactory(),
+                objectMapper,
+                regionResolver,
+                executor);
+
+        String registration = """
+                {
+                  "InstanceId": "mi-agent-only",
+                  "AgentName": "amazon-ssm-agent",
+                  "IPAddress": "172.17.0.9"
+                }
+                """;
+        service.updateInstanceInformation(objectMapper.readTree(registration), "us-west-2");
+        service.updateInstanceInformation(objectMapper.readTree(registration), "us-west-2");
+
+        verify(executor, times(1)).isContainerBacked("mi-agent-only");
+        assertEquals(1, service.describeInstanceInformation("us-west-2").size());
+        assertEquals("mi-agent-only", service.describeInstanceInformation("us-west-2").getFirst().getInstanceId());
+    }
 
     @Test
     void directExecutionCompletesCommandWithoutQueuedAgentMessage() throws Exception {

--- a/src/test/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssm/SsmDirectCommandExecutorTest.java
@@ -134,6 +134,29 @@ class SsmDirectCommandExecutorTest {
     }
 
     @Test
+    void containerBackedRequiresRunningEc2Container() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        Ec2Service ec2Service = mock(Ec2Service.class);
+        Instance running = new Instance();
+        running.setInstanceId("i-running");
+        running.setDockerContainerId("container-1");
+        Instance stopped = new Instance();
+        stopped.setInstanceId("i-stopped");
+        stopped.setDockerContainerId("container-2");
+        when(ec2Service.findInstanceById("i-running")).thenReturn(running);
+        when(ec2Service.findInstanceById("i-stopped")).thenReturn(stopped);
+        when(ec2Service.findInstanceById("mi-agent-only")).thenReturn(null);
+        when(ec2Service.isInstanceContainerRunning("i-running")).thenReturn(true);
+        when(ec2Service.isInstanceContainerRunning("i-stopped")).thenReturn(false);
+
+        SsmDirectCommandExecutor executor = new SsmDirectCommandExecutor(dockerClient, ec2Service);
+
+        assertTrue(executor.isContainerBacked("i-running"));
+        assertFalse(executor.isContainerBacked("i-stopped"));
+        assertFalse(executor.isContainerBacked("mi-agent-only"));
+    }
+
+    @Test
     void returnsEmptyForUnsupportedDocument() {
         DockerClient dockerClient = mock(DockerClient.class);
         Ec2Service ec2Service = mock(Ec2Service.class);


### PR DESCRIPTION
## Summary

Fixes: #3280 

Closes #3280

`Ec2MetadataServer` only learns about a container when `Ec2ContainerManager` launches it through EC2 `RunInstances`; that is also the only place the link-local `169.254.169.254` proxy is installed. Registering a container's SSM agent as a managed instance (`UpdateInstanceInformation`) goes through a separate path that never touches EC2 or IMDS. A container that was only registered with SSM therefore had no working IMDS endpoint and got a bare `404 Instance not found` with no hint of why.

This PR documents that the two registrations are independent and makes the gap visible at runtime:

- `docs/services/ec2.md`: new "IMDS and SSM managed instances" subsection under the IMDS section explaining the dependency and the correct order (launch with `RunInstances`, then register that container's SSM agent).
- `docs/services/ssm.md`: note in "Run Command Execution" and in the `UpdateInstanceInformation` row saying it does not create an EC2 instance nor register the container with IMDS. Both pages cross-link.
- `Ec2MetadataServer`: the 404 for an unregistered source IP now says which IP was seen, that IMDS only serves containers launched via `RunInstances`, and that SSM registration does not register with IMDS. Same text goes to the warn log. An IMDSv2 token request from an unregistered IP logs at debug.
- `SsmDirectCommandExecutor`: extracted `isContainerBacked(instanceId)`, reused by `supports`.
- `SsmCommandService.updateInstanceInformation`: on the first registration of an instance that is not backed by a running Floci EC2 container, logs a warning that `SendCommand` will use the agent polling flow and IMDS will not answer for it. Only on first registration so periodic agent pings do not spam the log.

Registering an SSM-only container with IMDS automatically was not done: there is no EC2 `Instance` record to serve and no Docker container id to install the proxy into.

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## AWS Compatibility


On AWS, "the instance I registered with SSM" and "the instance IMDS answers for" are the same thing. In Floci they are only the same when the container was launched through EC2 `RunInstances`. Previously a container registered only through SSM got a well-formed `404 Instance not found` from IMDS with no explanation. The status code is unchanged; only the body and logs gained an explanation, so SDK credential-chain behavior is unaffected.

## Checklist

- [X] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

