### PR TITLE
fix(dynamodb): bind every PartiQL parameter type and reject unordered operands

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAttributeValueValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAttributeValueValidator.java
@@ -1,0 +1,89 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * Checks a wire-format AttributeValue the way AWS does before a request runs.
+ * Base64 is checked while the request is read, so a bad value is a
+ * SerializationException. The one-type rule is a ValidationException.
+ */
+final class DynamoDbAttributeValueValidator {
+
+    private static final List<String> TYPES = List.of("S", "N", "B", "BOOL", "NULL", "SS", "NS", "BS", "L", "M");
+
+    private DynamoDbAttributeValueValidator() {}
+
+    static void validate(JsonNode value) {
+        requireBase64(value);
+        requireOneType(value);
+    }
+
+    static String typeOf(JsonNode value) {
+        if (!value.isObject()) {
+            throw serializationEx("Unexpected value type in payload");
+        }
+        var types = TYPES.stream().filter(value::has).toList();
+        if (types.isEmpty()) {
+            throw validationEx("Supplied AttributeValue is empty, must contain exactly one of the supported datatypes");
+        }
+        if (types.size() > 1) {
+            throw validationEx("Supplied AttributeValue has more than one datatypes set, "
+                    + "must contain exactly one of the supported datatypes");
+        }
+        return types.getFirst();
+    }
+
+    private static void requireOneType(JsonNode value) {
+        switch (typeOf(value)) {
+            case "L" -> value.get("L").forEach(DynamoDbAttributeValueValidator::requireOneType);
+            case "M" -> value.get("M").forEach(DynamoDbAttributeValueValidator::requireOneType);
+            default -> { }
+        }
+    }
+
+    private static void requireBase64(JsonNode value) {
+        if (!value.isObject()) {
+            return;
+        }
+        if (value.has("B")) {
+            requireBase64Text(value.get("B"));
+        }
+        if (value.has("BS")) {
+            value.get("BS").forEach(DynamoDbAttributeValueValidator::requireBase64Text);
+        }
+        if (value.has("L")) {
+            value.get("L").forEach(DynamoDbAttributeValueValidator::requireBase64);
+        }
+        if (value.has("M")) {
+            value.get("M").forEach(DynamoDbAttributeValueValidator::requireBase64);
+        }
+    }
+
+    // AWS checks the length before the alphabet, and names only the length.
+    private static void requireBase64Text(JsonNode encoded) {
+        if (!encoded.isTextual()) {
+            throw serializationEx("only base-64-encoded strings are convertible to bytes");
+        }
+        var text = encoded.asText();
+        if (text.length() % 4 != 0) {
+            throw serializationEx("Base64 encoded length is expected a multiple of 4 bytes but found: " + text.length());
+        }
+        try {
+            Base64.getDecoder().decode(text);
+        } catch (IllegalArgumentException e) {
+            throw serializationEx("Unexpected value type in payload");
+        }
+    }
+
+    private static AwsException validationEx(String message) {
+        return new AwsException("ValidationException", message, 400);
+    }
+
+    private static AwsException serializationEx(String message) {
+        return new AwsException("SerializationException", message, 400);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLHandler.java
@@ -389,14 +389,13 @@ class DynamoDbPartiQLHandler {
     }
 
     JsonNode toTypedNode(PVal val) {
-        ObjectNode node = mapper.createObjectNode();
-        switch (val) {
-            case PVal.Str s  -> node.put("S", s.v());
-            case PVal.Num n  -> node.put("N", DynamoDbNumberUtils.validateAndNormalize(n.v()));
-            case PVal.Bool b -> node.put("BOOL", b.v());
-            case PVal.Null ignored -> node.put("NULL", true);
-        }
-        return node;
+        return switch (val) {
+            case PVal.Str s  -> mapper.createObjectNode().put("S", s.v());
+            case PVal.Num n  -> mapper.createObjectNode().put("N", DynamoDbNumberUtils.validateAndNormalize(n.v()));
+            case PVal.Bool b -> mapper.createObjectNode().put("BOOL", b.v());
+            case PVal.Null ignored -> mapper.createObjectNode().put("NULL", true);
+            case PVal.Av av -> av.node();
+        };
     }
 
     private ObjectNode emptyItemsResponse() {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParser.java
@@ -58,11 +58,13 @@ public class DynamoDbPartiQLParser {
         }
     }
 
-    sealed interface PVal permits PVal.Str, PVal.Num, PVal.Bool, PVal.Null {
+    sealed interface PVal permits PVal.Str, PVal.Num, PVal.Bool, PVal.Null, PVal.Av {
         record Str(String v)       implements PVal {}
         record Num(String v)       implements PVal {}
         record Bool(boolean v)     implements PVal {}
         record Null()              implements PVal {}
+        // A parameter of a type with no literal syntax, kept as its wire node.
+        record Av(String type, JsonNode node) implements PVal {}
     }
 
     sealed interface Cond permits Cond.Eq, Cond.Cmp, Cond.Between, Cond.BeginsWith {
@@ -257,6 +259,30 @@ public class DynamoDbPartiQLParser {
         return conds;
     }
 
+    // Types a parameter can carry that no PartiQL literal can express.
+    private static final List<String> NON_LITERAL_TYPES = List.of("B", "SS", "NS", "BS", "L", "M");
+
+    // S, N and B are the only types DynamoDB gives an ordering.
+    private static final Set<String> ORDERED_TYPES = Set.of("S", "N", "B");
+
+    private static String typeCode(PVal val) {
+        return switch (val) {
+            case PVal.Str ignored  -> "S";
+            case PVal.Num ignored  -> "N";
+            case PVal.Bool ignored -> "BOOL";
+            case PVal.Null ignored -> "NULL";
+            case PVal.Av av        -> av.type();
+        };
+    }
+
+    private static void requireOrdered(String op, PVal val) {
+        String type = typeCode(val);
+        if (!ORDERED_TYPES.contains(type)) {
+            throw validationEx("Incorrect operand type for operator or function; "
+                    + "operator or function: " + op + ", operand type: " + type);
+        }
+    }
+
     private Cond parseCond() {
         if (peek().type() == TType.IDENT && "begins_with".equalsIgnoreCase(peek().value())) {
             advance();
@@ -273,11 +299,19 @@ public class DynamoDbPartiQLParser {
             PVal lo = parseValue();
             consume(TType.AND);
             PVal hi = parseValue();
+            requireOrdered("BETWEEN", lo);
+            requireOrdered("BETWEEN", hi);
             return new Cond.Between(attr, lo, hi);
         }
         String op = parseOp();
         PVal val = parseValue();
-        return "=".equals(op) ? new Cond.Eq(attr, val) : new Cond.Cmp(attr, op, val);
+        if ("=".equals(op)) {
+            return new Cond.Eq(attr, val);
+        }
+        if (!"<>".equals(op)) {
+            requireOrdered(op, val);
+        }
+        return new Cond.Cmp(attr, op, val);
     }
 
     private String parseOp() {
@@ -317,6 +351,9 @@ public class DynamoDbPartiQLParser {
         if (p.has("N"))    return new PVal.Num(p.get("N").asText());
         if (p.has("BOOL")) return new PVal.Bool(p.get("BOOL").asBoolean());
         if (p.has("NULL")) return new PVal.Null();
+        for (String type : NON_LITERAL_TYPES) {
+            if (p.has(type)) return new PVal.Av(type, p);
+        }
         throw validationEx("Unsupported parameter type in parameters array");
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParser.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParser.java
@@ -169,6 +169,7 @@ public class DynamoDbPartiQLParser {
     }
 
     static Stmt parse(String statement, List<JsonNode> parameters) {
+        parameters.forEach(DynamoDbAttributeValueValidator::validate);
         return new DynamoDbPartiQLParser(tokenize(statement.trim()), parameters).parseStmt();
     }
 
@@ -259,9 +260,6 @@ public class DynamoDbPartiQLParser {
         return conds;
     }
 
-    // Types a parameter can carry that no PartiQL literal can express.
-    private static final List<String> NON_LITERAL_TYPES = List.of("B", "SS", "NS", "BS", "L", "M");
-
     // S, N and B are the only types DynamoDB gives an ordering.
     private static final Set<String> ORDERED_TYPES = Set.of("S", "N", "B");
 
@@ -347,14 +345,14 @@ public class DynamoDbPartiQLParser {
             throw validationEx("Not enough parameters supplied for ? placeholders");
         }
         JsonNode p = parameters.get(paramIdx++);
-        if (p.has("S"))    return new PVal.Str(p.get("S").asText());
-        if (p.has("N"))    return new PVal.Num(p.get("N").asText());
-        if (p.has("BOOL")) return new PVal.Bool(p.get("BOOL").asBoolean());
-        if (p.has("NULL")) return new PVal.Null();
-        for (String type : NON_LITERAL_TYPES) {
-            if (p.has(type)) return new PVal.Av(type, p);
-        }
-        throw validationEx("Unsupported parameter type in parameters array");
+        var type = DynamoDbAttributeValueValidator.typeOf(p);
+        return switch (type) {
+            case "S"    -> new PVal.Str(p.get("S").asText());
+            case "N"    -> new PVal.Num(p.get("N").asText());
+            case "BOOL" -> new PVal.Bool(p.get("BOOL").asBoolean());
+            case "NULL" -> new PVal.Null();
+            default     -> new PVal.Av(type, p);
+        };
     }
 
     private String expectIdent() {

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluator.java
@@ -1096,8 +1096,8 @@ final class ExpressionEvaluator {
             }
         }
         if (a.has("B") && b.has("B")) {
-            byte[] aBytes = Base64.getDecoder().decode(a.get("B").asText());
-            byte[] bBytes = Base64.getDecoder().decode(b.get("B").asText());
+            var aBytes = decodeBinaryBound(a);
+            var bBytes = decodeBinaryBound(b);
             int minLen = Math.min(aBytes.length, bBytes.length);
             for (int i = 0; i < minLen; i++) {
                 int diff = (aBytes[i] & 0xFF) - (bBytes[i] & 0xFF);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3781,6 +3781,107 @@ given()
         deleteTable(tableName);
     }
 
+    // Checked against real DynamoDB (ap-northeast-1, 2026-09-10): a binary that is not
+    // base64 fails the request as a SerializationException before anything runs, and an
+    // AttributeValue with zero or several type keys is a ValidationException.
+    @Test
+    void partiqlRejectsAParameterThatIsNotAWellFormedAttributeValue() {
+        var tableName = "PartiqlParameterShapeTable";
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {"pk": {"S": "row"}, "raw": {"B": "AQID"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        for (var op : List.of("=", "<")) {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+                .contentType(DYNAMODB_CONTENT_TYPE)
+                .body("""
+                    {
+                        "Statement": "SELECT pk FROM \\"%s\\" WHERE pk = ? AND raw %s ?",
+                        "Parameters": [{"S": "row"}, {"B": "not base64!!"}]
+                    }
+                    """.formatted(tableName, op))
+            .when().post("/")
+            .then()
+                .statusCode(400)
+                .body("__type", containsString("SerializationException"));
+        }
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "Statement": "SELECT pk FROM \\"%s\\" WHERE pk = ? AND raw = ?",
+                    "Parameters": [{"S": "row"}, {"B": "AQID", "SS": ["a"]}]
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Supplied AttributeValue has more than one datatypes set, "
+                    + "must contain exactly one of the supported datatypes"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "Statement": "SELECT pk FROM \\"%s\\" WHERE pk = ? AND raw = ?",
+                    "Parameters": [{"S": "row"}, {}]
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Supplied AttributeValue is empty, "
+                    + "must contain exactly one of the supported datatypes"));
+
+        // The same decode guards a FilterExpression, which reaches the comparison directly.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "FilterExpression": "#r < :v",
+                    "ExpressionAttributeNames": {"#r": "raw"},
+                    "ExpressionAttributeValues": {":v": {"B": "not base64!!"}}
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("SerializationException"));
+
+        deleteTable(tableName);
+    }
+
     @Test
     void partiqlSelectWithoutWhereClausePerformsScan() throws Exception {
         ObjectMapper mapper = new ObjectMapper();

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -3650,6 +3650,138 @@ given()
     }
 
     @Test
+    void partiqlBindsParametersOfEveryAttributeValueType() throws Exception {
+        var mapper = new ObjectMapper();
+        var tableName = "PartiqlOperandTypeTable";
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.PutItem")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "Item": {
+                        "pk": {"S": "row"},
+                        "tags": {"SS": ["b", "a"]},
+                        "scores": {"NS": ["2", "1"]},
+                        "blobs": {"BS": ["AQID"]},
+                        "items": {"L": [{"S": "a"}, {"N": "1"}]},
+                        "meta": {"M": {"k": {"S": "v"}}},
+                        "raw": {"B": "AQID"}
+                    }
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        // A set is unordered, so a permuted parameter is the same value.
+        assertEquals(1, partiqlMatchCount(mapper, tableName,
+                "tags", """
+                {"SS": ["a", "b"]}"""), "SS parameter should match regardless of member order");
+        assertEquals(1, partiqlMatchCount(mapper, tableName,
+                "scores", """
+                {"NS": ["1", "2"]}"""), "NS parameter should match regardless of member order");
+        assertEquals(1, partiqlMatchCount(mapper, tableName, "blobs", """
+                {"BS": ["AQID"]}"""));
+        assertEquals(1, partiqlMatchCount(mapper, tableName, "meta", """
+                {"M": {"k": {"S": "v"}}}"""));
+        assertEquals(1, partiqlMatchCount(mapper, tableName, "raw", """
+                {"B": "AQID"}"""));
+
+        // A list is ordered, so a permuted parameter is a different value.
+        assertEquals(1, partiqlMatchCount(mapper, tableName, "items", """
+                {"L": [{"S": "a"}, {"N": "1"}]}"""));
+        assertEquals(0, partiqlMatchCount(mapper, tableName, "items", """
+                {"L": [{"N": "1"}, {"S": "a"}]}"""), "A permuted list is a different value");
+
+        deleteTable(tableName);
+    }
+
+    private int partiqlMatchCount(ObjectMapper mapper, String tableName, String attribute, String parameter)
+            throws Exception {
+        var body = given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "Statement": "SELECT pk FROM \\"%s\\" WHERE pk = ? AND \\"%s\\" = ?",
+                    "Parameters": [{"S": "row"}, %s]
+                }
+                """.formatted(tableName, attribute, parameter))
+        .when().post("/")
+        .then()
+            .statusCode(200)
+            .extract().body().asString();
+
+        return mapper.readTree(body).path("Items").size();
+    }
+
+    // Only S, N and B have an ordering, so every other operand type is a
+    // ValidationException naming the operator as it was written.
+    @Test
+    void partiqlOrderingOperatorRejectsAnOperandTypeWithNoOrdering() {
+        var tableName = "PartiqlOrderingTable";
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "%s",
+                    "KeySchema": [{"AttributeName": "pk", "KeyType": "HASH"}],
+                    "AttributeDefinitions": [{"AttributeName": "pk", "AttributeType": "S"}],
+                    "BillingMode": "PAY_PER_REQUEST"
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "Statement": "SELECT pk FROM \\"%s\\" WHERE pk = ? AND val < ?",
+                    "Parameters": [{"S": "row"}, {"BOOL": true}]
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", containsString("ValidationException"))
+            .body("message", equalTo("Incorrect operand type for operator or function; "
+                    + "operator or function: <, operand type: BOOL"));
+
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.ExecuteStatement")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "Statement": "SELECT pk FROM \\"%s\\" WHERE pk = ? AND val = ?",
+                    "Parameters": [{"S": "row"}, {"BOOL": true}]
+                }
+                """.formatted(tableName))
+        .when().post("/")
+        .then().statusCode(200);
+
+        deleteTable(tableName);
+    }
+
+    @Test
     void partiqlSelectWithoutWhereClausePerformsScan() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         String tableName = "PartiqlScanTable";

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParserTest.java
@@ -1,0 +1,102 @@
+package io.github.hectorvent.floci.services.dynamodb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbPartiQLParser.Cond;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbPartiQLParser.PVal;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbPartiQLParser.Stmt;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DynamoDbPartiQLParserTest {
+
+    private static final String SELECT = "SELECT pk FROM \"t\" WHERE val ";
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private JsonNode json(String raw) {
+        try {
+            return mapper.readTree(raw);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private Cond firstCond(String statement, String... params) {
+        var stmt = DynamoDbPartiQLParser.parse(statement, Arrays.stream(params).map(this::json).toList());
+        return assertInstanceOf(Stmt.Select.class, stmt).where().get(0);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"B\":\"AQID\"}",
+            "{\"SS\":[\"a\",\"b\"]}",
+            "{\"NS\":[\"1\",\"2\"]}",
+            "{\"BS\":[\"AQID\"]}",
+            "{\"L\":[{\"S\":\"a\"}]}",
+            "{\"M\":{\"a\":{\"S\":\"b\"}}}"
+    })
+    void bindsAParameterOfATypeWithNoLiteralSyntax(String param) {
+        var cond = firstCond(SELECT + "= ?", param);
+
+        var val = assertInstanceOf(Cond.Eq.class, cond).val();
+        assertEquals(json(param), assertInstanceOf(PVal.Av.class, val).node());
+    }
+
+    @Test
+    void rejectsAParameterCarryingNoRecognisedType() {
+        assertEquals("Unsupported parameter type in parameters array",
+                assertThrows(AwsException.class, () -> firstCond(SELECT + "= ?", "{\"Q\":\"x\"}")).getMessage());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'<',  {\"BOOL\":true},          BOOL",
+            "'<=', {\"NULL\":true},          NULL",
+            "'>',  {\"L\":[]},               L",
+            "'>=', {\"M\":{}},               M",
+            "'<',  {\"SS\":[\"a\"]},         SS",
+            "'<',  {\"NS\":[\"1\"]},         NS",
+            "'<',  {\"BS\":[\"AQID\"]},      BS"
+    })
+    void rejectsAnOrderingOperatorOnATypeWithNoOrdering(String op, String param, String type) {
+        var e = assertThrows(AwsException.class, () -> firstCond(SELECT + op + " ?", param));
+
+        assertEquals("ValidationException", e.getErrorCode());
+        assertEquals("Incorrect operand type for operator or function; "
+                + "operator or function: " + op + ", operand type: " + type, e.getMessage());
+    }
+
+    @Test
+    void namesBetweenAsTheOperatorWhenItsBoundIsUnordered() {
+        var e = assertThrows(AwsException.class,
+                () -> firstCond(SELECT + "BETWEEN ? AND ?", "{\"BOOL\":true}", "{\"BOOL\":false}"));
+
+        assertEquals("Incorrect operand type for operator or function; "
+                + "operator or function: BETWEEN, operand type: BOOL", e.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"=", "<>"})
+    void acceptsEqualityOnATypeWithNoOrdering(String op) {
+        assertDoesNotThrow(() -> firstCond(SELECT + op + " ?", "{\"SS\":[\"a\"]}"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"{\"S\":\"a\"}", "{\"N\":\"1\"}", "{\"B\":\"AQID\"}"})
+    void acceptsAnOrderingOperatorOnAnOrderedType(String param) {
+        var cond = firstCond(SELECT + "< ?", param);
+
+        assertEquals("<", assertInstanceOf(Cond.Cmp.class, cond).op());
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLParserTest.java
@@ -53,10 +53,71 @@ class DynamoDbPartiQLParserTest {
         assertEquals(json(param), assertInstanceOf(PVal.Av.class, val).node());
     }
 
+    // Parameter shape and base64 rules below were checked against real DynamoDB
+    // (ap-northeast-1, 2026-09-10).
+    @ParameterizedTest
+    @ValueSource(strings = {"{\"Q\":\"x\"}", "{}"})
+    void rejectsAParameterCarryingNoRecognisedType(String param) {
+        var e = assertThrows(AwsException.class, () -> firstCond(SELECT + "= ?", param));
+
+        assertEquals("ValidationException", e.getErrorCode());
+        assertEquals("Supplied AttributeValue is empty, must contain exactly one of the supported datatypes",
+                e.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"S\":\"a\",\"N\":\"1\"}",
+            "{\"B\":\"AQID\",\"SS\":[\"a\"]}",
+            "{\"L\":[{\"S\":\"a\",\"N\":\"1\"}]}",
+            "{\"M\":{\"k\":{\"S\":\"a\",\"N\":\"1\"}}}"
+    })
+    void rejectsAParameterCarryingMoreThanOneType(String param) {
+        var e = assertThrows(AwsException.class, () -> firstCond(SELECT + "= ?", param));
+
+        assertEquals("ValidationException", e.getErrorCode());
+        assertEquals("Supplied AttributeValue has more than one datatypes set, "
+                + "must contain exactly one of the supported datatypes", e.getMessage());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "{\"B\":\"not base64!!\"}",
+            "{\"BS\":[\"AQID\",\"not base64!!\"]}",
+            "{\"L\":[{\"B\":\"not base64!!\"}]}",
+            "{\"M\":{\"k\":{\"B\":\"not base64!!\"}}}",
+            "{\"B\":123}"
+    })
+    void rejectsABinaryParameterThatIsNotBase64(String param) {
+        var e = assertThrows(AwsException.class, () -> firstCond(SELECT + "= ?", param));
+
+        assertEquals("SerializationException", e.getErrorCode());
+        assertEquals(400, e.getHttpStatus());
+    }
+
     @Test
-    void rejectsAParameterCarryingNoRecognisedType() {
-        assertEquals("Unsupported parameter type in parameters array",
-                assertThrows(AwsException.class, () -> firstCond(SELECT + "= ?", "{\"Q\":\"x\"}")).getMessage());
+    void namesTheLengthOfBase64ThatIsNotAMultipleOfFour() {
+        var e = assertThrows(AwsException.class, () -> firstCond(SELECT + "= ?", "{\"B\":\"AQI\"}"));
+
+        assertEquals("SerializationException", e.getErrorCode());
+        assertEquals("Base64 encoded length is expected a multiple of 4 bytes but found: 3", e.getMessage());
+    }
+
+    @Test
+    void acceptsAnEmptyBinaryParameter() {
+        var cond = firstCond(SELECT + "= ?", "{\"B\":\"\"}");
+
+        assertInstanceOf(PVal.Av.class, assertInstanceOf(Cond.Eq.class, cond).val());
+    }
+
+    // AWS reads every parameter before it looks at the statement, so one past the
+    // last placeholder still fails the request.
+    @Test
+    void rejectsAMalformedParameterBeyondThePlaceholders() {
+        var e = assertThrows(AwsException.class,
+                () -> firstCond(SELECT + "= ?", "{\"S\":\"a\"}", "{\"B\":\"not base64!!\"}"));
+
+        assertEquals("SerializationException", e.getErrorCode());
     }
 
     @ParameterizedTest

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/ExpressionEvaluatorTest.java
@@ -660,6 +660,20 @@ class ExpressionEvaluatorTest {
             assertEquals(400, serialization.getHttpStatus());
         }
 
+        // Checked against real DynamoDB (ap-northeast-1, 2026-09-10): a FilterExpression
+        // comparing against a binary that is not base64 fails the request with a 400
+        // SerializationException, so the comparison itself must never decode blindly.
+        @Test
+        void binaryComparisonRejectsMalformedBase64() {
+            var valid = mapper.createObjectNode().put("B", "AQID");
+            var malformed = mapper.createObjectNode().put("B", "not base64!!");
+
+            var e = assertThrows(AwsException.class,
+                    () -> ExpressionEvaluator.compareAttributeValues(valid, malformed));
+            assertEquals("SerializationException", e.getErrorCode());
+            assertEquals(400, e.getHttpStatus());
+        }
+
         // A FilterExpression carries the same text without the envelope on AWS.
         @Test
         void filterExpressionReportsTheReversedBoundsWithoutTheEnvelope() {


### PR DESCRIPTION
## Summary

Takes [tier2/partiql in the dynamodb-conformance suite](https://github.com/paritysuite/dynamodb-conformance/tree/bf21d8294275d88470d7f89b73ba0b640a242a8d/tests/tier2/partiql)from 70 to 113 of 186, with no regression elsewhere in the suite.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Verified in ap-northeast-1.

Currently, PartiQL parameters only bound S, N, BOOL and NULL. Every other type was rejected with "Unsupported parameter type in parameters array", so a statement could not compare against B, SS, NS, BS, L or M.
Keep those parameters as their wire node and pass them through unchanged.

Binding them makes the ordering operators reachable for types that have no ordering, so <, <=, >, >= and BETWEEN now reject any operand outside S, N and B. The message names the operator as it was written.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
