### PR TITLE
fix(sfn): apply state input and output paths

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -1931,16 +1931,19 @@ public class AslExecutor {
             throw new FailStateException("States.Runtime", NO_NEXT_STATE_CAUSE);
         }
 
+        JsonNode effectiveInput = applyInputPath(stateDef, input);
         JsonNode choices = stateDef.path("Choices");
         for (JsonNode choice : choices) {
-            if (evaluateCondition(choice, input)) {
-                return new StateResult(input, choice.path("Next").asText());
+            if (evaluateCondition(choice, effectiveInput)) {
+                JsonNode output = applyOutputPath(stateDef, input, effectiveInput);
+                return new StateResult(output, choice.path("Next").asText());
             }
         }
         // Default branch
         String defaultState = stateDef.path("Default").asText(null);
         if (defaultState != null) {
-            return new StateResult(input, defaultState);
+            JsonNode output = applyOutputPath(stateDef, input, effectiveInput);
+            return new StateResult(output, defaultState);
         }
         throw new FailStateException("States.Runtime", NO_NEXT_STATE_CAUSE);
     }
@@ -1961,6 +1964,7 @@ public class AslExecutor {
                                          ObjectNode variables, long executionDeadlineNanos)
             throws InterruptedException {
         int seconds = 0;
+        JsonNode effectiveInput = input;
         if (jsonata) {
             if (stateDef.has("Seconds")) {
                 JsonNode secondsNode = stateDef.get("Seconds");
@@ -1974,10 +1978,11 @@ public class AslExecutor {
                 }
             }
         } else {
+            effectiveInput = applyInputPath(stateDef, input);
             if (stateDef.has("Seconds")) {
                 seconds = Math.min(stateDef.get("Seconds").asInt(), MAX_WAIT_SECONDS);
             } else if (stateDef.has("SecondsPath")) {
-                JsonNode val = resolvePath(stateDef.get("SecondsPath").asText(), input);
+                JsonNode val = resolvePath(stateDef.get("SecondsPath").asText(), effectiveInput);
                 seconds = Math.min(val.asInt(), MAX_WAIT_SECONDS);
             }
         }
@@ -1989,7 +1994,8 @@ public class AslExecutor {
             JsonNode output = applyJsonataOutput(stateDef, input, null, context, variables);
             return new StateResult(output, stateDef.path("Next").asText(null));
         }
-        return new StateResult(input, stateDef.path("Next").asText(null));
+        JsonNode output = applyOutputPath(stateDef, input, effectiveInput);
+        return new StateResult(output, stateDef.path("Next").asText(null));
     }
 
     /**
@@ -2015,7 +2021,8 @@ public class AslExecutor {
             JsonNode output = applyJsonataOutput(stateDef, input, input, context, variables);
             return new StateResult(output, null);
         }
-        return new StateResult(applyOutputPath(stateDef, input, input), null);
+        JsonNode effectiveInput = applyInputPath(stateDef, input);
+        return new StateResult(applyOutputPath(stateDef, input, effectiveInput), null);
     }
 
     private StateResult executeFail(JsonNode stateDef, JsonNode input, boolean jsonata, JsonNode context,
@@ -2042,6 +2049,7 @@ public class AslExecutor {
                                               String topLevelQueryLanguage, JsonNode context,
                                               ObjectNode variables, long executionDeadlineNanos)
             throws Exception {
+        JsonNode effectiveInput = jsonata ? input : applyInputPath(stateDef, input);
         JsonNode branches = stateDef.path("Branches");
         chain.publish("ParallelStateStarted", null);
         var branchChains = new ArrayList<HistoryChain>();
@@ -2050,7 +2058,7 @@ public class AslExecutor {
         for (JsonNode branch : branches) {
             String startAt = branch.path("StartAt").asText();
             JsonNode branchStates = branch.path("States");
-            JsonNode capturedInput = input;
+            JsonNode capturedInput = effectiveInput;
             // Each branch gets an isolated copy of the current variables: assignments inside a
             // branch are scoped to that branch and do not leak back to the parent after the state.
             ObjectNode branchVariables = variables.deepCopy();

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
@@ -88,6 +88,20 @@ class AslExecutorStatePathTest {
     }
 
     @Test
+    void choiceDefaultRouteAppliesOutputPath() throws Exception {
+        assertOutput("""
+                {"StartAt":"Pick","States":{
+                  "Pick":{"Type":"Choice","OutputPath":"$.visible",
+                    "Choices":[{"Variable":"$.route","StringEquals":"yes","Next":"Wrong"}],
+                    "Default":"Done"},
+                  "Done":{"Type":"Pass","End":true},
+                  "Wrong":{"Type":"Fail","Error":"WrongBranch"}}}
+                """,
+                "{\"route\":\"no\",\"visible\":{\"kept\":true},\"hidden\":9}",
+                "{\"kept\":true}");
+    }
+
+    @Test
     void waitInputPathFeedsSecondsPath() throws Exception {
         assertOutput("""
                 {"StartAt":"Wait","States":{
@@ -127,6 +141,18 @@ class AslExecutorStatePathTest {
                 """,
                 "{\"scoped\":{\"value\":\"right\"},\"outside\":9}",
                 "{\"scoped\":{\"value\":\"right\"},\"outside\":9,\"branches\":[{\"value\":\"right\"}]}");
+    }
+
+    @Test
+    void parallelOutputPathFiltersMergedResult() throws Exception {
+        assertOutput("""
+                {"StartAt":"Parallel","States":{
+                  "Parallel":{"Type":"Parallel","ResultPath":"$.branches","OutputPath":"$.branches",
+                    "Branches":[{"StartAt":"Copy","States":{"Copy":{"Type":"Pass","End":true}}}],
+                    "End":true}}}
+                """,
+                "{\"value\":\"right\",\"outside\":9}",
+                "[{\"value\":\"right\",\"outside\":9}]");
     }
 
     private void assertOutput(String definition, String input, String expected) throws Exception {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
+import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
+import io.github.hectorvent.floci.services.ec2.Ec2Service;
+import io.github.hectorvent.floci.services.ecs.EcsJsonHandler;
+import io.github.hectorvent.floci.services.ecs.EcsService;
+import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
+import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
+import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
+import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
+import io.github.hectorvent.floci.services.stepfunctions.model.StateMachine;
+import jakarta.enterprise.inject.Instance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class AslExecutorStatePathTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private AslExecutor executor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        executor = new AslExecutor(
+                mock(LambdaExecutorService.class),
+                mock(LambdaFunctionStore.class),
+                mock(DynamoDbService.class),
+                mock(DynamoDbJsonHandler.class),
+                mock(SqsJsonHandler.class),
+                mock(CloudFormationQueryHandler.class),
+                mock(Ec2Service.class),
+                mock(S3Service.class),
+                mock(EcsService.class),
+                mock(EcsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerService.class),
+                mock(io.github.hectorvent.floci.services.scheduler.SchedulerController.class),
+                mapper,
+                new JsonataEvaluator(mapper),
+                mock(Instance.class),
+                mock(EmulatorConfig.class),
+                null, null);
+    }
+
+    @AfterEach
+    void tearDown() {
+        executor.stop();
+    }
+
+    @Test
+    void choiceInputPathControlsRuleEvaluation() throws Exception {
+        assertOutput("""
+                {"StartAt":"Pick","States":{
+                  "Pick":{"Type":"Choice","InputPath":"$.scoped",
+                    "Choices":[{"Variable":"$.route","StringEquals":"yes","Next":"Done"}],
+                    "Default":"Wrong"},
+                  "Done":{"Type":"Pass","End":true},
+                  "Wrong":{"Type":"Fail","Error":"WrongBranch"}}}
+                """,
+                "{\"scoped\":{\"route\":\"yes\",\"value\":1},\"route\":\"no\"}",
+                "{\"route\":\"yes\",\"value\":1}");
+    }
+
+    @Test
+    void choiceOutputPathFiltersSelectedInput() throws Exception {
+        assertOutput("""
+                {"StartAt":"Pick","States":{
+                  "Pick":{"Type":"Choice","OutputPath":"$.visible",
+                    "Choices":[{"Variable":"$.route","StringEquals":"yes","Next":"Done"}]},
+                  "Done":{"Type":"Pass","End":true}}}
+                """,
+                "{\"route\":\"yes\",\"visible\":{\"kept\":true},\"hidden\":9}",
+                "{\"kept\":true}");
+    }
+
+    @Test
+    void waitInputPathFeedsSecondsPath() throws Exception {
+        assertOutput("""
+                {"StartAt":"Wait","States":{
+                  "Wait":{"Type":"Wait","InputPath":"$.scoped","SecondsPath":"$.delay","End":true}}}
+                """,
+                "{\"scoped\":{\"delay\":0,\"value\":1},\"outside\":9}",
+                "{\"delay\":0,\"value\":1}");
+    }
+
+    @Test
+    void waitOutputPathFiltersStateOutput() throws Exception {
+        assertOutput("""
+                {"StartAt":"Wait","States":{
+                  "Wait":{"Type":"Wait","Seconds":0,"OutputPath":"$.visible","End":true}}}
+                """,
+                "{\"visible\":{\"kept\":true},\"hidden\":9}",
+                "{\"kept\":true}");
+    }
+
+    @Test
+    void succeedAppliesInputPathBeforeOutputPath() throws Exception {
+        assertOutput("""
+                {"StartAt":"Done","States":{
+                  "Done":{"Type":"Succeed","InputPath":"$.scoped","OutputPath":"$.visible"}}}
+                """,
+                "{\"visible\":{\"source\":\"wrong\"},\"scoped\":{\"visible\":{\"source\":\"right\"}}}",
+                "{\"source\":\"right\"}");
+    }
+
+    @Test
+    void parallelInputPathFeedsBranchesAndResultPathStillMergesIntoOriginalInput() throws Exception {
+        assertOutput("""
+                {"StartAt":"Parallel","States":{
+                  "Parallel":{"Type":"Parallel","InputPath":"$.scoped","ResultPath":"$.branches",
+                    "Branches":[{"StartAt":"Copy","States":{"Copy":{"Type":"Pass","End":true}}}],
+                    "End":true}}}
+                """,
+                "{\"scoped\":{\"value\":\"right\"},\"outside\":9}",
+                "{\"scoped\":{\"value\":\"right\"},\"outside\":9,\"branches\":[{\"value\":\"right\"}]}");
+    }
+
+    private void assertOutput(String definition, String input, String expected) throws Exception {
+        Execution execution = run(definition, input);
+        assertEquals("SUCCEEDED", execution.getStatus(), execution.getCause());
+        assertEquals(mapper.readTree(expected), mapper.readTree(execution.getOutput()));
+    }
+
+    private Execution run(String definition, String input) {
+        StateMachine stateMachine = new StateMachine();
+        stateMachine.setName("state-path-test");
+        stateMachine.setStateMachineArn("arn:aws:states:us-east-1:000000000000:stateMachine:state-path-test");
+        stateMachine.setRoleArn("arn:aws:iam::000000000000:role/test-role");
+        stateMachine.setDefinition(definition);
+
+        Execution execution = new Execution();
+        execution.setName("state-path-execution");
+        execution.setExecutionArn(
+                "arn:aws:states:us-east-1:000000000000:execution:state-path-test:state-path-execution");
+        execution.setStateMachineArn(stateMachine.getStateMachineArn());
+        execution.setInput(input);
+
+        List<HistoryEvent> history = new ArrayList<>();
+        executor.executeSync(stateMachine, execution, history, (updated, events) -> {
+        });
+        return execution;
+    }
+}


### PR DESCRIPTION
## Summary

- Apply the existing JSONPath input/output helpers to Choice, Wait, Succeed, and Parallel states.
- Preserve Parallel `ResultPath` behavior and leave JSONata execution unchanged.
- Add execution-level regression coverage for every affected state type.

Closes #3258

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, the four affected JSONPath state types either evaluated against raw input or returned unfiltered output. The corrected pipeline matches the behavior reported against AWS Step Functions Local: apply `InputPath`, execute the state, preserve original input only for Parallel result merging, then apply `OutputPath`.

## Checklist

- [ ] `./mvnw test` passes locally (all four CI shards ran; issue-related tests pass, while unrelated TUN/network and runtime-race failures also reproduce on the unmodified baseline)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `dev-loop-check.sh --phase final`: passed
- Focused new and related Step Functions tests: 100 passed, 0 failed
- `make docs-check`: passed
- `./mvnw clean package -DskipTests`: passed
