### PR TITLE
fix(cloudtrail): bound log flush memory

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriter.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -60,7 +61,7 @@ public class CloudTrailLogWriter {
     private final RegionResolver regionResolver;
     private final ObjectMapper mapper;
     private final SecureRandom rng = new SecureRandom();
-    private final ConcurrentHashMap<CloudTrailService.TrailKey, Object> flushLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<CloudTrailService.TrailKey, FlushLock> flushLocks = new ConcurrentHashMap<>();
 
     private ScheduledExecutorService executor;
 
@@ -125,8 +126,13 @@ public class CloudTrailLogWriter {
     }
 
     private void flushTrailBatches(CloudTrailService.TrailKey key) {
-        Object lock = flushLocks.computeIfAbsent(key, ignored -> new Object());
-        synchronized (lock) {
+        FlushLock lock = flushLocks.compute(key, (ignored, existing) -> {
+            FlushLock result = existing != null ? existing : new FlushLock();
+            result.users++;
+            return result;
+        });
+        lock.mutex.lock();
+        try {
             int remaining = cloudTrailService.pendingRecordCount(key);
             while (remaining > 0) {
                 int flushed = flushTrail(key);
@@ -135,7 +141,21 @@ public class CloudTrailLogWriter {
                 }
                 remaining -= flushed;
             }
+        } finally {
+            lock.mutex.unlock();
+            flushLocks.computeIfPresent(key, (ignored, current) -> {
+                if (current != lock) {
+                    return current;
+                }
+                current.users--;
+                return current.users == 0 ? null : current;
+            });
         }
+    }
+
+    private static final class FlushLock {
+        private final ReentrantLock mutex = new ReentrantLock();
+        private int users;
     }
 
     private int flushTrail(CloudTrailService.TrailKey key) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriter.java
@@ -23,6 +23,7 @@ import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +60,7 @@ public class CloudTrailLogWriter {
     private final RegionResolver regionResolver;
     private final ObjectMapper mapper;
     private final SecureRandom rng = new SecureRandom();
+    private final ConcurrentHashMap<CloudTrailService.TrailKey, Object> flushLocks = new ConcurrentHashMap<>();
 
     private ScheduledExecutorService executor;
 
@@ -111,7 +113,7 @@ public class CloudTrailLogWriter {
         try {
             for (CloudTrailService.TrailKey key : cloudTrailService.trailsWithPendingRecords()) {
                 try {
-                    flushTrail(key);
+                    flushTrailBatches(key);
                 } catch (RuntimeException e) {
                     LOG.warnv(e, "CloudTrail log flush failed for trail {0} in {1}",
                             key.trailName(), key.region());
@@ -122,17 +124,31 @@ public class CloudTrailLogWriter {
         }
     }
 
-    private void flushTrail(CloudTrailService.TrailKey key) {
+    private void flushTrailBatches(CloudTrailService.TrailKey key) {
+        Object lock = flushLocks.computeIfAbsent(key, ignored -> new Object());
+        synchronized (lock) {
+            int remaining = cloudTrailService.pendingRecordCount(key);
+            while (remaining > 0) {
+                int flushed = flushTrail(key);
+                if (flushed == 0) {
+                    return;
+                }
+                remaining -= flushed;
+            }
+        }
+    }
+
+    private int flushTrail(CloudTrailService.TrailKey key) {
         Trail trail = cloudTrailService.getTrail(key.region(), key.trailName());
         if (trail == null) {
-            // Trail was deleted while records were pending — drop them.
-            cloudTrailService.drainPendingRecords(key);
-            return;
+            // Trail was deleted while records were pending. Drop only the
+            // records that existed when this flush cycle started.
+            return cloudTrailService.drainPendingRecords(key, MAX_RECORDS_PER_LOG_FILE).size();
         }
 
         List<ObjectNode> records = cloudTrailService.drainPendingRecords(key, MAX_RECORDS_PER_LOG_FILE);
         if (records.isEmpty()) {
-            return;
+            return 0;
         }
 
         byte[] payload;
@@ -182,6 +198,7 @@ public class CloudTrailLogWriter {
             LOG.warnv(e, "CloudTrail self-delivery event emission failed for trail {0} "
                     + "(write already succeeded, records not re-queued)", key.trailName());
         }
+        return records.size();
     }
 
     private byte[] serializeAndGzip(List<ObjectNode> records) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriter.java
@@ -1,7 +1,7 @@
 package io.github.hectorvent.floci.services.cloudtrail;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.RegionResolver;
@@ -49,6 +49,7 @@ public class CloudTrailLogWriter {
 
     private static final DateTimeFormatter PATH_DATE = DateTimeFormatter.ofPattern("yyyy/MM/dd");
     private static final DateTimeFormatter FILE_TS = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmm'Z'");
+    static final int MAX_RECORDS_PER_LOG_FILE = 1_000;
     private static final String FILENAME_RAND_ALPHABET =
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -129,7 +130,7 @@ public class CloudTrailLogWriter {
             return;
         }
 
-        List<ObjectNode> records = cloudTrailService.drainPendingRecords(key);
+        List<ObjectNode> records = cloudTrailService.drainPendingRecords(key, MAX_RECORDS_PER_LOG_FILE);
         if (records.isEmpty()) {
             return;
         }
@@ -184,16 +185,18 @@ public class CloudTrailLogWriter {
     }
 
     private byte[] serializeAndGzip(List<ObjectNode> records) {
-        ObjectNode envelope = mapper.createObjectNode();
-        ArrayNode arr = envelope.putArray("Records");
-        for (ObjectNode r : records) {
-            arr.add(r);
-        }
         try {
-            byte[] json = mapper.writeValueAsBytes(envelope);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream(Math.max(64, json.length / 4));
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
             try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
-                gz.write(json);
+                try (JsonGenerator generator = mapper.getFactory().createGenerator(gz)) {
+                    generator.writeStartObject();
+                    generator.writeArrayFieldStart("Records");
+                    for (ObjectNode record : records) {
+                        generator.writeTree(record);
+                    }
+                    generator.writeEndArray();
+                    generator.writeEndObject();
+                }
             }
             return baos.toByteArray();
         } catch (Exception e) {

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
@@ -27,10 +27,11 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Supplier;
 
 @ApplicationScoped
@@ -47,7 +48,7 @@ public class CloudTrailService {
     private final ObjectMapper mapper;
 
     /** Per-trail pending record buffers — ephemeral, never persisted. */
-    private final ConcurrentHashMap<TrailKey, ConcurrentLinkedQueue<ObjectNode>> pendingRecordsByTrail =
+    private final ConcurrentHashMap<TrailKey, ConcurrentLinkedDeque<ObjectNode>> pendingRecordsByTrail =
             new ConcurrentHashMap<>();
 
     /**
@@ -364,17 +365,32 @@ public class CloudTrailService {
     }
 
     public void requeueRecords(TrailKey key, List<ObjectNode> records) {
-        if (!records.isEmpty()) {
-            queueFor(key).addAll(records);
+        if (records.isEmpty()) {
+            return;
+        }
+        ConcurrentLinkedDeque<ObjectNode> q = queueFor(key);
+        ListIterator<ObjectNode> it = records.listIterator(records.size());
+        // Add in reverse so the first failed record remains first.
+        while (it.hasPrevious()) {
+            q.addFirst(it.previous());
         }
     }
 
     public List<ObjectNode> drainPendingRecords(TrailKey key) {
-        ConcurrentLinkedQueue<ObjectNode> q = pendingRecordsByTrail.get(key);
-        if (q == null) return List.of();
+        return drainPendingRecords(key, Integer.MAX_VALUE);
+    }
+
+    public List<ObjectNode> drainPendingRecords(TrailKey key, int maxRecords) {
+        if (maxRecords <= 0) {
+            return List.of();
+        }
+        ConcurrentLinkedDeque<ObjectNode> q = pendingRecordsByTrail.get(key);
+        if (q == null) {
+            return List.of();
+        }
         List<ObjectNode> drained = new ArrayList<>();
         ObjectNode r;
-        while ((r = q.poll()) != null) {
+        while (drained.size() < maxRecords && (r = q.pollFirst()) != null) {
             drained.add(r);
         }
         return drained;
@@ -382,7 +398,7 @@ public class CloudTrailService {
 
     public List<TrailKey> trailsWithPendingRecords() {
         List<TrailKey> result = new ArrayList<>();
-        for (Map.Entry<TrailKey, ConcurrentLinkedQueue<ObjectNode>> e : pendingRecordsByTrail.entrySet()) {
+        for (Map.Entry<TrailKey, ConcurrentLinkedDeque<ObjectNode>> e : pendingRecordsByTrail.entrySet()) {
             if (!e.getValue().isEmpty()) {
                 result.add(e.getKey());
             }
@@ -396,8 +412,8 @@ public class CloudTrailService {
                 .orElse(null);
     }
 
-    private ConcurrentLinkedQueue<ObjectNode> queueFor(TrailKey key) {
-        return pendingRecordsByTrail.computeIfAbsent(key, k -> new ConcurrentLinkedQueue<>());
+    private ConcurrentLinkedDeque<ObjectNode> queueFor(TrailKey key) {
+        return pendingRecordsByTrail.computeIfAbsent(key, k -> new ConcurrentLinkedDeque<>());
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailService.java
@@ -396,6 +396,11 @@ public class CloudTrailService {
         return drained;
     }
 
+    public int pendingRecordCount(TrailKey key) {
+        ConcurrentLinkedDeque<ObjectNode> q = pendingRecordsByTrail.get(key);
+        return q == null ? 0 : q.size();
+    }
+
     public List<TrailKey> trailsWithPendingRecords() {
         List<TrailKey> result = new ArrayList<>();
         for (Map.Entry<TrailKey, ConcurrentLinkedDeque<ObjectNode>> e : pendingRecordsByTrail.entrySet()) {

--- a/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerService.java
@@ -225,7 +225,13 @@ public class IotMqttBrokerService {
         server = null;
         tlsServer = null;
         keyManager = null;
-        sessionsByClient.values().forEach(session -> session.endpoint().close());
+        sessionsByClient.values().forEach(session -> {
+            try {
+                session.endpoint().close();
+            } catch (IllegalStateException e) {
+                LOG.debugv("IoT MQTT client {0} was already closed during broker shutdown", session.clientId());
+            }
+        });
         sessionsByClient.clear();
         subscriptionsByClient.clear();
         if (mqttServer != null) {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBatchingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBatchingIntegrationTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @QuarkusTest
-class CloudTrailLogWriterBatchingTest {
+class CloudTrailLogWriterBatchingIntegrationTest {
 
     @Inject
     CloudTrailLogWriter writer;
@@ -91,7 +91,7 @@ class CloudTrailLogWriterBatchingTest {
         List<List<JsonNode>> allObjects = readCloudTrailRecordGroups(bucket);
         assertEquals(2, allObjects.size());
         allObjects = new ArrayList<>(allObjects);
-        allObjects.sort(Comparator.comparingInt(CloudTrailLogWriterBatchingTest::firstRecordIndex));
+        allObjects.sort(Comparator.comparingInt(CloudTrailLogWriterBatchingIntegrationTest::firstRecordIndex));
         assertRecordRange(allObjects.get(0), 0, 999);
         assertRecordRange(allObjects.get(1), 1_000, 1_000);
     }
@@ -112,7 +112,7 @@ class CloudTrailLogWriterBatchingTest {
         writer.flushNow();
 
         List<List<JsonNode>> recordGroups = readCloudTrailRecordGroups(bucket).stream()
-                .sorted(Comparator.comparingInt(CloudTrailLogWriterBatchingTest::firstRecordIndex))
+                .sorted(Comparator.comparingInt(CloudTrailLogWriterBatchingIntegrationTest::firstRecordIndex))
                 .toList();
 
         assertEquals(3, recordGroups.size());
@@ -148,7 +148,7 @@ class CloudTrailLogWriterBatchingTest {
         writer.flushNow();
 
         List<List<JsonNode>> recordGroups = new ArrayList<>(readCloudTrailRecordGroups(destinationBucket));
-        recordGroups.sort(Comparator.comparingInt(CloudTrailLogWriterBatchingTest::firstRecordIndex));
+        recordGroups.sort(Comparator.comparingInt(CloudTrailLogWriterBatchingIntegrationTest::firstRecordIndex));
         assertEquals(2, recordGroups.size());
         assertRecordRange(recordGroups.get(0), 0, 999);
         assertRecordRange(recordGroups.get(1), 1_000, 1_005);

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBatchingTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBatchingTest.java
@@ -1,0 +1,293 @@
+package io.github.hectorvent.floci.services.cloudtrail;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.cloudtrail.model.DataResource;
+import io.github.hectorvent.floci.services.cloudtrail.model.EventSelector;
+import io.github.hectorvent.floci.services.cloudtrail.model.Trail;
+import io.quarkus.test.junit.QuarkusMock;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Deque;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.GZIPInputStream;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@QuarkusTest
+class CloudTrailLogWriterBatchingTest {
+
+    @Inject
+    CloudTrailLogWriter writer;
+
+    @Inject
+    CloudTrailService realService;
+
+    @AfterEach
+    void restoreRealService() {
+        QuarkusMock.installMockForType(realService, CloudTrailService.class);
+    }
+
+    @Test
+    void maximumSizedFlushWritesOneValidOrderedGzipObject() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String bucket = "batch-max-logs-" + suffix;
+        String trailName = "batch-max-trail-" + suffix;
+        String region = "us-east-1";
+
+        createBucket(bucket);
+
+        CloudTrailService.TrailKey key = new CloudTrailService.TrailKey(region, trailName, region);
+        Deque<ObjectNode> pending = records(CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE);
+        installMockCloudTrailService(bucket, trailName, region, key, pending);
+
+        writer.flushNow();
+
+        List<CloudTrailLogObject> objects = readCloudTrailObjects(bucket);
+        assertEquals(1, objects.size());
+        JsonNode envelope = objects.getFirst().envelope();
+        assertEquals(1, envelope.size(), "Expected only the Records envelope field");
+        assertTrue(envelope.path("Records").isArray(), "Records is not an array");
+        assertRecordRange(toList(envelope.path("Records")), 0, 999);
+    }
+
+    @Test
+    void flushWritesAtMostOneThousandRecordsAndLeavesTheRestForLater() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String bucket = "batch-logs-" + suffix;
+        String trailName = "batch-trail-" + suffix;
+        String region = "us-east-1";
+
+        createBucket(bucket);
+
+        CloudTrailService.TrailKey key = new CloudTrailService.TrailKey(region, trailName, region);
+        Deque<ObjectNode> pending = records(1_001);
+        installMockCloudTrailService(bucket, trailName, region, key, pending);
+
+        writer.flushNow();
+
+        List<List<JsonNode>> firstFlushObjects = readCloudTrailRecordGroups(bucket);
+        assertEquals(1, firstFlushObjects.size());
+        assertRecordRange(firstFlushObjects.getFirst(), 0, 999);
+
+        writer.flushNow();
+
+        List<List<JsonNode>> allObjects = readCloudTrailRecordGroups(bucket);
+        assertEquals(2, allObjects.size());
+        List<JsonNode> secondObject = allObjects.stream()
+                .filter(records -> records.size() == 1)
+                .findFirst()
+                .orElseThrow();
+        assertRecordRange(secondObject, 1_000, 1_000);
+    }
+
+    @Test
+    void sustainedBacklogDrainsIncrementallyInOrder() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String bucket = "batch-backlog-logs-" + suffix;
+        String trailName = "batch-backlog-trail-" + suffix;
+        String region = "us-east-1";
+
+        createBucket(bucket);
+
+        CloudTrailService.TrailKey key = new CloudTrailService.TrailKey(region, trailName, region);
+        Deque<ObjectNode> pending = records(2_500);
+        installMockCloudTrailService(bucket, trailName, region, key, pending);
+
+        writer.flushNow();
+        writer.flushNow();
+        writer.flushNow();
+
+        List<List<JsonNode>> recordGroups = readCloudTrailRecordGroups(bucket).stream()
+                .sorted(Comparator.comparingInt(CloudTrailLogWriterBatchingTest::firstRecordIndex))
+                .toList();
+
+        assertEquals(3, recordGroups.size());
+        assertRecordRange(recordGroups.get(0), 0, 999);
+        assertRecordRange(recordGroups.get(1), 1_000, 1_999);
+        assertRecordRange(recordGroups.get(2), 2_000, 2_499);
+    }
+
+    @Test
+    void failedBoundedBatchRetriesBeforeNewerQueuedRecords() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String sourceBucket = "batch-source-" + suffix;
+        String destinationBucket = "batch-retry-logs-" + suffix;
+        String trailName = "batch-retry-trail-" + suffix;
+        String region = "us-east-1";
+
+        realService.createTrail(region, trailName, destinationBucket, null,
+                null, true, false, false, false);
+        realService.putEventSelectors(region, trailName, List.of(new EventSelector(
+                "All",
+                false,
+                List.of(new DataResource("AWS::S3::Object",
+                        List.of("arn:aws:s3:::" + sourceBucket + "/"))),
+                List.of())));
+        realService.startLogging(region, trailName);
+        emitS3Events(sourceBucket, region, 0, 1_000);
+
+        writer.flushNow();
+
+        createBucket(destinationBucket);
+        emitS3Events(sourceBucket, region, 1_001, 1_005);
+
+        writer.flushNow();
+
+        List<List<JsonNode>> recordGroups = readCloudTrailRecordGroups(destinationBucket);
+        assertEquals(1, recordGroups.size());
+        assertRecordRange(recordGroups.getFirst(), 0, 999);
+    }
+
+    private void installMockCloudTrailService(String bucket, String trailName, String region,
+                                              CloudTrailService.TrailKey key,
+                                              Deque<ObjectNode> pending) {
+        Trail trail = new Trail(trailName,
+                "arn:aws:cloudtrail:" + region + ":000000000000:trail/" + trailName,
+                bucket, null, null, true, false, region, false, false, false, false);
+
+        CloudTrailService mockService = mock(CloudTrailService.class);
+        when(mockService.trailsWithPendingRecords())
+                .thenAnswer(inv -> pending.isEmpty() ? List.of() : List.of(key));
+        when(mockService.getTrail(region, trailName)).thenReturn(trail);
+        when(mockService.drainPendingRecords(eq(key), eq(CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE)))
+                .thenAnswer(inv -> drain(pending, CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE));
+        doAnswer(inv -> null).when(mockService).emitS3DataEvent(any());
+
+        QuarkusMock.installMockForType(mockService, CloudTrailService.class);
+    }
+
+    private void emitS3Events(String bucket, String region, int first, int last) {
+        for (int i = first; i <= last; i++) {
+            realService.emitS3DataEvent(CloudTrailService.S3EventInput.builder()
+                    .region(region)
+                    .eventName("PutObject")
+                    .bucketName(bucket)
+                    .key(objectKey(i))
+                    .accessKeyId(null)
+                    .sourceIp(null)
+                    .userAgent("test")
+                    .bytesIn(0)
+                    .bytesOut(0)
+                    .errorCode(null)
+                    .errorMessage(null)
+                    .eventTimeMillis(System.currentTimeMillis())
+                    .build());
+        }
+    }
+
+    private static List<ObjectNode> drain(Deque<ObjectNode> pending, int maxRecords) {
+        List<ObjectNode> drained = new ArrayList<>();
+        while (drained.size() < maxRecords && !pending.isEmpty()) {
+            drained.add(pending.removeFirst());
+        }
+        return drained;
+    }
+
+    private static Deque<ObjectNode> records(int count) {
+        ObjectMapper mapper = new ObjectMapper();
+        Deque<ObjectNode> records = new ArrayDeque<>();
+        for (int i = 0; i < count; i++) {
+            ObjectNode record = mapper.createObjectNode();
+            record.put("eventName", "PutObject");
+            record.putObject("requestParameters").put("key", objectKey(i));
+            records.add(record);
+        }
+        return records;
+    }
+
+    private static void assertRecordRange(List<JsonNode> records, int first, int last) {
+        assertEquals(last - first + 1, records.size());
+        for (int i = first; i <= last; i++) {
+            JsonNode record = records.get(i - first);
+            assertEquals(objectKey(i), record.path("requestParameters").path("key").asText());
+        }
+    }
+
+    private static String objectKey(int index) {
+        return "object-" + String.format("%04d", index);
+    }
+
+    private static int firstRecordIndex(List<JsonNode> records) {
+        return recordIndex(records.getFirst());
+    }
+
+    private static int recordIndex(JsonNode record) {
+        String key = record.path("requestParameters").path("key").asText();
+        return Integer.parseInt(key.substring("object-".length()));
+    }
+
+    private static void createBucket(String name) {
+        given().when().put("/" + name).then().statusCode(200);
+    }
+
+    private static List<List<JsonNode>> readCloudTrailRecordGroups(String bucket) throws Exception {
+        return readCloudTrailObjects(bucket).stream()
+                .map(logObject -> toList(logObject.envelope().path("Records")))
+                .toList();
+    }
+
+    private static List<CloudTrailLogObject> readCloudTrailObjects(String bucket) throws Exception {
+        List<CloudTrailLogObject> objects = new ArrayList<>();
+        ObjectMapper mapper = new ObjectMapper();
+        for (String key : listCloudTrailKeys(bucket)) {
+            byte[] gz = given().when().get("/" + bucket + "/" + key)
+                    .then().statusCode(200).extract().asByteArray();
+            try (GZIPInputStream gzin = new GZIPInputStream(new ByteArrayInputStream(gz))) {
+                JsonNode envelope = mapper.readTree(gzin);
+                JsonNode records = envelope.get("Records");
+                assertNotNull(records, "Missing Records[] in " + key);
+                assertTrue(records.isArray(), "Records is not an array in " + key);
+                objects.add(new CloudTrailLogObject(key, envelope));
+            }
+        }
+        return objects;
+    }
+
+    private static List<JsonNode> toList(JsonNode records) {
+        List<JsonNode> result = new ArrayList<>();
+        records.forEach(result::add);
+        return result;
+    }
+
+    private static List<String> listCloudTrailKeys(String bucket) {
+        String xml = given().when().get("/" + bucket + "?list-type=2")
+                .then().statusCode(200).extract().asString();
+        List<String> keys = new ArrayList<>();
+        int from = 0;
+        while (true) {
+            int open = xml.indexOf("<Key>", from);
+            if (open < 0) {
+                break;
+            }
+            int close = xml.indexOf("</Key>", open);
+            String key = xml.substring(open + 5, close);
+            if (key.contains("/CloudTrail/") && key.endsWith(".json.gz")) {
+                keys.add(key);
+            }
+            from = close + 6;
+        }
+        keys.sort(Comparator.naturalOrder());
+        return keys;
+    }
+
+    private record CloudTrailLogObject(String key, JsonNode envelope) {
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBatchingTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBatchingTest.java
@@ -19,10 +19,15 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.zip.GZIPInputStream;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +74,7 @@ class CloudTrailLogWriterBatchingTest {
     }
 
     @Test
-    void flushWritesAtMostOneThousandRecordsAndLeavesTheRestForLater() throws Exception {
+    void flushWritesAllQueuedRecordsInBoundedObjects() throws Exception {
         String suffix = UUID.randomUUID().toString().substring(0, 8);
         String bucket = "batch-logs-" + suffix;
         String trailName = "batch-trail-" + suffix;
@@ -83,19 +88,12 @@ class CloudTrailLogWriterBatchingTest {
 
         writer.flushNow();
 
-        List<List<JsonNode>> firstFlushObjects = readCloudTrailRecordGroups(bucket);
-        assertEquals(1, firstFlushObjects.size());
-        assertRecordRange(firstFlushObjects.getFirst(), 0, 999);
-
-        writer.flushNow();
-
         List<List<JsonNode>> allObjects = readCloudTrailRecordGroups(bucket);
         assertEquals(2, allObjects.size());
-        List<JsonNode> secondObject = allObjects.stream()
-                .filter(records -> records.size() == 1)
-                .findFirst()
-                .orElseThrow();
-        assertRecordRange(secondObject, 1_000, 1_000);
+        allObjects = new ArrayList<>(allObjects);
+        allObjects.sort(Comparator.comparingInt(CloudTrailLogWriterBatchingTest::firstRecordIndex));
+        assertRecordRange(allObjects.get(0), 0, 999);
+        assertRecordRange(allObjects.get(1), 1_000, 1_000);
     }
 
     @Test
@@ -111,8 +109,6 @@ class CloudTrailLogWriterBatchingTest {
         Deque<ObjectNode> pending = records(2_500);
         installMockCloudTrailService(bucket, trailName, region, key, pending);
 
-        writer.flushNow();
-        writer.flushNow();
         writer.flushNow();
 
         List<List<JsonNode>> recordGroups = readCloudTrailRecordGroups(bucket).stream()
@@ -151,9 +147,74 @@ class CloudTrailLogWriterBatchingTest {
 
         writer.flushNow();
 
-        List<List<JsonNode>> recordGroups = readCloudTrailRecordGroups(destinationBucket);
-        assertEquals(1, recordGroups.size());
-        assertRecordRange(recordGroups.getFirst(), 0, 999);
+        List<List<JsonNode>> recordGroups = new ArrayList<>(readCloudTrailRecordGroups(destinationBucket));
+        recordGroups.sort(Comparator.comparingInt(CloudTrailLogWriterBatchingTest::firstRecordIndex));
+        assertEquals(2, recordGroups.size());
+        assertRecordRange(recordGroups.get(0), 0, 999);
+        assertRecordRange(recordGroups.get(1), 1_000, 1_005);
+    }
+
+    @Test
+    void overlappingFlushesForOneTrailAreSerialized() throws Exception {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        String bucket = "serialized-logs-" + suffix;
+        String trailName = "serialized-trail-" + suffix;
+        String region = "us-east-1";
+
+        createBucket(bucket);
+
+        CloudTrailService.TrailKey key = new CloudTrailService.TrailKey(region, trailName, region);
+        Deque<ObjectNode> pending = records(2);
+        Trail trail = new Trail(trailName,
+                "arn:aws:cloudtrail:" + region + ":000000000000:trail/" + trailName,
+                bucket, null, null, true, false, region, false, false, false, false);
+        CountDownLatch firstDrainEntered = new CountDownLatch(1);
+        CountDownLatch releaseFirstDrain = new CountDownLatch(1);
+        CountDownLatch secondDrainEntered = new CountDownLatch(1);
+        AtomicBoolean inDrain = new AtomicBoolean();
+        AtomicBoolean overlap = new AtomicBoolean();
+        AtomicInteger drainCalls = new AtomicInteger();
+
+        CloudTrailService mockService = mock(CloudTrailService.class);
+        when(mockService.trailsWithPendingRecords())
+                .thenAnswer(inv -> pending.isEmpty() ? List.of() : List.of(key));
+        when(mockService.pendingRecordCount(eq(key))).thenAnswer(inv -> pending.size());
+        when(mockService.getTrail(region, trailName)).thenReturn(trail);
+        when(mockService.drainPendingRecords(eq(key), eq(CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE)))
+                .thenAnswer(inv -> {
+                    if (!inDrain.compareAndSet(false, true)) {
+                        overlap.set(true);
+                    }
+                    try {
+                        if (drainCalls.getAndIncrement() == 0) {
+                            firstDrainEntered.countDown();
+                            releaseFirstDrain.await(5, TimeUnit.SECONDS);
+                        } else {
+                            secondDrainEntered.countDown();
+                        }
+                        return drain(pending, CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE);
+                    } finally {
+                        inDrain.set(false);
+                    }
+                });
+        doAnswer(inv -> null).when(mockService).emitS3DataEvent(any());
+        QuarkusMock.installMockForType(mockService, CloudTrailService.class);
+
+        Thread first = new Thread(writer::flushNow);
+        Thread second = new Thread(writer::flushNow);
+        first.start();
+        assertTrue(firstDrainEntered.await(5, TimeUnit.SECONDS));
+        second.start();
+
+        assertFalse(secondDrainEntered.await(200, TimeUnit.MILLISECONDS),
+                "A second flush must wait for the first trail flush to finish");
+        releaseFirstDrain.countDown();
+        first.join(5_000);
+        second.join(5_000);
+
+        assertFalse(first.isAlive(), "First flush did not finish");
+        assertFalse(second.isAlive(), "Second flush did not finish");
+        assertFalse(overlap.get(), "Flushes for one trail overlapped");
     }
 
     private void installMockCloudTrailService(String bucket, String trailName, String region,
@@ -166,6 +227,7 @@ class CloudTrailLogWriterBatchingTest {
         CloudTrailService mockService = mock(CloudTrailService.class);
         when(mockService.trailsWithPendingRecords())
                 .thenAnswer(inv -> pending.isEmpty() ? List.of() : List.of(key));
+        when(mockService.pendingRecordCount(eq(key))).thenAnswer(inv -> pending.size());
         when(mockService.getTrail(region, trailName)).thenReturn(trail);
         when(mockService.drainPendingRecords(eq(key), eq(CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE)))
                 .thenAnswer(inv -> drain(pending, CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE));

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterRequeueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterRequeueTest.java
@@ -68,6 +68,7 @@ class CloudTrailLogWriterRequeueTest {
         CloudTrailService mockService = mock(CloudTrailService.class);
         when(mockService.trailsWithPendingRecords())
                 .thenAnswer(inv -> pending.isEmpty() ? List.of() : List.of(key));
+        when(mockService.pendingRecordCount(eq(key))).thenAnswer(inv -> pending.size());
         when(mockService.getTrail(region, trailName)).thenReturn(trail);
         when(mockService.drainPendingRecords(eq(key), eq(CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE)))
                 .thenAnswer(inv -> {

--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterRequeueTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterRequeueTest.java
@@ -69,11 +69,12 @@ class CloudTrailLogWriterRequeueTest {
         when(mockService.trailsWithPendingRecords())
                 .thenAnswer(inv -> pending.isEmpty() ? List.of() : List.of(key));
         when(mockService.getTrail(region, trailName)).thenReturn(trail);
-        when(mockService.drainPendingRecords(key)).thenAnswer(inv -> {
-            List<ObjectNode> drained = new ArrayList<>(pending);
-            pending.clear();
-            return drained;
-        });
+        when(mockService.drainPendingRecords(eq(key), eq(CloudTrailLogWriter.MAX_RECORDS_PER_LOG_FILE)))
+                .thenAnswer(inv -> {
+                    List<ObjectNode> drained = new ArrayList<>(pending);
+                    pending.clear();
+                    return drained;
+                });
         doAnswer(inv -> {
             List<ObjectNode> records = inv.getArgument(1);
             pending.addAll(records);

--- a/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerDeviceVerificationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/iot/IotMqttBrokerDeviceVerificationTest.java
@@ -263,6 +263,19 @@ class IotMqttBrokerDeviceVerificationTest {
         }
     }
 
+    @Test
+    void stoppingAfterClientDisconnectDoesNotFail() throws Exception {
+        RegisteredDevice device = registered(deviceLeaf);
+        when(service.findRegisteredCertificate(certificate(deviceLeaf))).thenReturn(Optional.of(device));
+        when(service.isConnectAllowed(eq(device), eq("sensor-1"), eq("127.0.0.1"), isNull())).thenReturn(true);
+
+        MqttClient client = connectTls("sensor-1", deviceLeaf, null);
+        client.disconnect();
+        client.close();
+
+        broker.stop();
+    }
+
     /** Dials {@code host}, which Paho also sends as the TLS server name; MQTT 3.1.1 pinned so a refusal is not retried as 3.1. */
     private MqttClient connectTls(String clientId, CertificateGenerator.GeneratedCertificate leaf, String host) throws Exception {
         MqttClient client = new MqttClient("ssl://" + (host == null ? "127.0.0.1" : host) + ":" + tlsPort, clientId, new MemoryPersistence());


### PR DESCRIPTION
## Summary

Reduce peak CloudTrail flush memory by draining at most 1,000 records per flush batch and streaming JSON directly into gzip. Failed batches are returned to the front of the queue, so event order is preserved. The CloudTrail wire format and S3 layout are unchanged.

Also fix a CI-exposed MQTT broker shutdown race. Broker shutdown now tolerates client endpoints that have already closed, with regression coverage for disconnect and shutdown ordering.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

CloudTrail documentation defines log files as gzip-compressed JSON with one or more records. It does not define a record-count limit. The 1,000-record bound is internal and preserves the `Records` envelope, `.json.gz` format, S3 key layout, event fields, and event order.

The incorrect CloudTrail behavior was unbounded draining during a flush. A large pending queue created several simultaneous in-memory representations of the same records.

CI also exposed an MQTT lifecycle race: a client endpoint could close before broker shutdown attempted to close it. The fix only makes local broker cleanup tolerant of an already-closed endpoint. It does not change MQTT request or response behavior.

## Validation

- `./mvnw -q -Dtest=CloudTrailLogWriterBatchingTest,CloudTrailLogWriterRequeueTest,CloudTrailSelfDeliveryTest,CloudTrailIntegrationTest test` passed.
- `./mvnw -q -Dtest='CloudTrail*Test' test` passed: 61 tests, 0 failures, errors, or skips.
- `./mvnw -q -Dtest=IotMqttBrokerDeviceVerificationTest test` passed: 11 tests, 0 failures, errors, or skips.
- `./mvnw -q -DskipTests compile` passed.
- `../../mvnw -q -Dtest=CloudTrailTest test` passed against a live Floci endpoint: 6 AWS SDK tests, 0 failures, errors, or skips.
- `git diff --check` passed.
- The full `./mvnw -q test` run was started but stopped after about 17 minutes because the repository has 1,374 test classes and many isolated Quarkus profiles. No failure appeared before it was stopped.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
