### PR TITLE
test(ec2): cover launch template not found behavior

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2DescribeLaunchTemplatesTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2DescribeLaunchTemplatesTest.java
@@ -1,0 +1,67 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.RequestLaunchTemplateData;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Ec2DescribeLaunchTemplatesTest {
+
+    @Test
+    void missingNameCanTriggerCreateThenDescribe() {
+        String name = "sdk-describe-" + UUID.randomUUID();
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            Ec2Exception error = assertThrows(Ec2Exception.class,
+                    () -> ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name)));
+            assertThat(error.statusCode()).isEqualTo(400);
+            assertThat(error.awsErrorDetails().errorCode())
+                    .isEqualTo("InvalidLaunchTemplateName.NotFoundException");
+
+            String id = ec2.createLaunchTemplate(r -> r.launchTemplateName(name)
+                    .launchTemplateData(RequestLaunchTemplateData.builder()
+                            .imageId("ami-0abcdef1234567890").build()))
+                    .launchTemplate().launchTemplateId();
+            try {
+                assertThat(ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name)).launchTemplates())
+                        .singleElement().satisfies(t -> assertThat(t.launchTemplateId()).isEqualTo(id));
+                assertThat(ec2.describeLaunchTemplates(r -> r.launchTemplateIds(id)).launchTemplates())
+                        .singleElement().satisfies(t -> assertThat(t.launchTemplateName()).isEqualTo(name));
+                Ec2Exception mixed = assertThrows(Ec2Exception.class,
+                        () -> ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name, name + "-missing")));
+                assertThat(mixed.awsErrorDetails().errorCode())
+                        .isEqualTo("InvalidLaunchTemplateName.NotFoundException");
+                Ec2Exception mixedIds = assertThrows(Ec2Exception.class,
+                        () -> ec2.describeLaunchTemplates(r -> r.launchTemplateIds(id, "lt-00000000000000000")));
+                assertThat(mixedIds.awsErrorDetails().errorCode()).isEqualTo("InvalidLaunchTemplateId.NotFound");
+                assertThat(ec2.describeLaunchTemplates(r -> r.launchTemplateNames(name)
+                        .filters(f -> f.name("launch-template-name").values(name + "-missing"))).launchTemplates())
+                        .isEmpty();
+            } finally {
+                ec2.deleteLaunchTemplate(r -> r.launchTemplateId(id));
+            }
+        }
+    }
+
+    @Test
+    void missingIdIsAnSdkError() {
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            Ec2Exception error = assertThrows(Ec2Exception.class,
+                    () -> ec2.describeLaunchTemplates(r -> r.launchTemplateIds("lt-00000000000000000")));
+            assertThat(error.statusCode()).isEqualTo(400);
+            assertThat(error.awsErrorDetails().errorCode()).isEqualTo("InvalidLaunchTemplateId.NotFound");
+        }
+    }
+
+    @Test
+    void unmatchedFilterStillReturnsAnEmptyList() {
+        try (Ec2Client ec2 = TestFixtures.ec2Client()) {
+            assertThat(ec2.describeLaunchTemplates(r -> r.filters(f -> f.name("launch-template-name")
+                    .values("missing-" + UUID.randomUUID()))).launchTemplates()).isEmpty();
+        }
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2DescribeLaunchTemplatesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2DescribeLaunchTemplatesIntegrationTest.java
@@ -1,0 +1,113 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class Ec2DescribeLaunchTemplatesIntegrationTest {
+
+    private RequestSpecification request(String action, String region) {
+        return given().formParam("Action", action)
+                .header("Authorization", "AWS4-HMAC-SHA256 Credential=test/20260908/"
+                        + region + "/ec2/aws4_request");
+    }
+
+    private String create(String name) {
+        return request("CreateLaunchTemplate", "us-east-1")
+                .formParam("LaunchTemplateName", name)
+                .formParam("LaunchTemplateData.ImageId", "ami-0abcdef1234567890")
+                .post("/").then().statusCode(200)
+                .extract().xmlPath().getString("CreateLaunchTemplateResponse.launchTemplate.launchTemplateId");
+    }
+
+    @Test
+    void missingNameReturnsAwsNotFound() {
+        request("DescribeLaunchTemplates", "us-east-1")
+                .formParam("LaunchTemplateName.1", "missing-" + UUID.randomUUID())
+                .post("/").then().statusCode(400)
+                .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateName.NotFoundException"));
+    }
+
+    @Test
+    void missingIdReturnsAwsNotFound() {
+        request("DescribeLaunchTemplates", "us-east-1")
+                .formParam("LaunchTemplateId.1", "lt-00000000000000000")
+                .post("/").then().statusCode(400)
+                .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateId.NotFound"));
+    }
+
+    @Test
+    void existingTemplatesRoundTripAndMixedRequestsFail() {
+        String name = "describe-" + UUID.randomUUID();
+        String id = create(name);
+        try {
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateName.1", name)
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.launchTemplateId", equalTo(id));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateId.1", id)
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.launchTemplateName", equalTo(name));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateName.1", name)
+                    .formParam("LaunchTemplateName.2", name + "-missing")
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateName.NotFoundException"));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateId.1", id)
+                    .formParam("LaunchTemplateId.2", "lt-00000000000000000")
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateId.NotFound"));
+            request("DescribeLaunchTemplates", "us-west-2")
+                    .formParam("LaunchTemplateName.1", name)
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateName.NotFoundException"));
+            request("DescribeLaunchTemplates", "us-west-2")
+                    .formParam("LaunchTemplateId.1", id)
+                    .post("/").then().statusCode(400)
+                    .body("Response.Errors.Error.Code", equalTo("InvalidLaunchTemplateId.NotFound"));
+        } finally {
+            request("DeleteLaunchTemplate", "us-east-1").formParam("LaunchTemplateId", id)
+                    .post("/").then().statusCode(200);
+        }
+    }
+
+    @Test
+    void filtersDoNotTurnExistingResourcesIntoNotFoundErrors() {
+        String name = "filter-" + UUID.randomUUID();
+        String id = create(name);
+        try {
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.find { it.launchTemplateId == '"
+                            + id + "' }.launchTemplateId", equalTo(id));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("Filter.1.Name", "launch-template-name")
+                    .formParam("Filter.1.Value.1", name + "-missing")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.size()", equalTo(0));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateName.1", name)
+                    .formParam("Filter.1.Name", "launch-template-name")
+                    .formParam("Filter.1.Value.1", name + "-missing")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.size()", equalTo(0));
+            request("DescribeLaunchTemplates", "us-east-1")
+                    .formParam("LaunchTemplateId.1", id)
+                    .formParam("Filter.1.Name", "launch-template-name")
+                    .formParam("Filter.1.Value.1", name + "-missing")
+                    .post("/").then().statusCode(200)
+                    .body("DescribeLaunchTemplatesResponse.launchTemplates.item.size()", equalTo(0));
+        } finally {
+            request("DeleteLaunchTemplate", "us-east-1").formParam("LaunchTemplateId", id)
+                    .post("/").then().statusCode(200);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3234. Add the two regression test files requested after #3245 was superseded by #3246.

This PR is based on the current upstream `main` and contains no production changes. The merged implementation already returns AWS-compatible errors for missing explicit launch-template IDs and names while preserving filter-only empty results.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Adds coverage for the EC2 Query protocol and AWS SDK for Java 2.52.0:

- missing explicit names return `InvalidLaunchTemplateName.NotFoundException`;
- missing explicit IDs return `InvalidLaunchTemplateId.NotFound`;
- existing and mixed requests behave correctly;
- cross-region lookups return the appropriate not-found error;
- unmatched filter queries continue to return an empty successful list;
- an existing template can be created and then described through the SDK.

## Checklist

- [x] `./mvnw test` passes locally for the new AWS Query integration test
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
