### PR TITLE
fix(cloudfront): emit origin timeout fields

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
@@ -40,6 +40,21 @@ public class CloudFrontController {
     private static final String DEFAULT_GEO_RESTRICTION_TYPE = "none";
     private static final int EMPTY_QUANTITY = 0;
 
+    /**
+     * Origin timeout constraints from the CloudFront {@code CustomOriginConfig} and
+     * {@code Origin} API references. {@code OriginReadTimeout} accepts 1-120 seconds, default 30.
+     * {@code OriginKeepaliveTimeout} accepts 1-300 seconds, default 5. {@code ResponseCompletionTimeout}
+     * has no enforced maximum when unset (represented here as 0), but when set must be at least
+     * {@code OriginReadTimeout}.
+     */
+    private static final int DEFAULT_ORIGIN_READ_TIMEOUT_SECONDS = 30;
+    private static final int MIN_ORIGIN_READ_TIMEOUT_SECONDS = 1;
+    private static final int MAX_ORIGIN_READ_TIMEOUT_SECONDS = 120;
+    private static final int DEFAULT_ORIGIN_KEEPALIVE_TIMEOUT_SECONDS = 5;
+    private static final int MIN_ORIGIN_KEEPALIVE_TIMEOUT_SECONDS = 1;
+    private static final int MAX_ORIGIN_KEEPALIVE_TIMEOUT_SECONDS = 300;
+    private static final int DEFAULT_RESPONSE_COMPLETION_TIMEOUT_SECONDS = 0;
+
     private final CloudFrontService service;
 
     @Inject
@@ -1920,7 +1935,11 @@ public class CloudFrontController {
                 .elem("DomainName", o.getDomainName())
                 .elem("OriginPath", o.getOriginPath() != null ? o.getOriginPath() : "")
                 .elem("ConnectionAttempts", o.getConnectionAttempts())
-                .elem("ConnectionTimeout", o.getConnectionTimeout());
+                .elem("ConnectionTimeout", o.getConnectionTimeout())
+                .elem("ResponseCompletionTimeout",
+                        o.getResponseCompletionTimeout() != null
+                                ? o.getResponseCompletionTimeout()
+                                : DEFAULT_RESPONSE_COMPLETION_TIMEOUT_SECONDS);
 
         if (o.getOriginAccessControlId() != null && !o.getOriginAccessControlId().isEmpty()) {
             xml.elem("OriginAccessControlId", o.getOriginAccessControlId());
@@ -1942,6 +1961,11 @@ public class CloudFrontController {
                     .elem("HTTPSPort", coc.getOrDefault("HTTPSPort", "443").toString())
                     .elem("OriginProtocolPolicy",
                             coc.getOrDefault("OriginProtocolPolicy", "https-only").toString())
+                    .elem("OriginReadTimeout",
+                            coc.getOrDefault("OriginReadTimeout", DEFAULT_ORIGIN_READ_TIMEOUT_SECONDS).toString())
+                    .elem("OriginKeepaliveTimeout",
+                            coc.getOrDefault("OriginKeepaliveTimeout", DEFAULT_ORIGIN_KEEPALIVE_TIMEOUT_SECONDS)
+                                    .toString())
                     .raw(xmlOriginSslProtocols(coc.get("OriginSslProtocols")))
                     .end("CustomOriginConfig");
         }
@@ -2673,6 +2697,8 @@ public class CloudFrontController {
             Map<String, String> s3Config = null;
             Map<String, Object> customConfig = null;
             List<String> sslProtocols = null;
+            Integer sslProtocolsQuantity = null;
+            Integer originReadTimeoutSeconds = null;
             boolean inCustomHeaders = false;
             boolean inCustomHeaderItems = false;
             boolean customHeaderItemsSeen = false;
@@ -2773,6 +2799,12 @@ public class CloudFrontController {
                                 }
                             }
                         }
+                        case "ResponseCompletionTimeout" -> {
+                            if (inOrigin && !inS3OriginConfig && !inCustomOriginConfig && current != null) {
+                                current.setResponseCompletionTimeout(
+                                        parseNonNegativeTimeout("ResponseCompletionTimeout", r.getElementText()));
+                            }
+                        }
                         case "OriginAccessIdentity" -> {
                             if (inS3OriginConfig && s3Config != null) {
                                 s3Config.put("OriginAccessIdentity", r.getElementText());
@@ -2793,6 +2825,23 @@ public class CloudFrontController {
                                 customConfig.put("OriginProtocolPolicy", r.getElementText());
                             }
                         }
+                        case "OriginKeepaliveTimeout" -> {
+                            if (inCustomOriginConfig && customConfig != null) {
+                                customConfig.put("OriginKeepaliveTimeout", parseBoundedTimeout(
+                                        "InvalidOriginKeepaliveTimeout", "OriginKeepaliveTimeout",
+                                        r.getElementText(), MIN_ORIGIN_KEEPALIVE_TIMEOUT_SECONDS,
+                                        MAX_ORIGIN_KEEPALIVE_TIMEOUT_SECONDS));
+                            }
+                        }
+                        case "OriginReadTimeout" -> {
+                            if (inCustomOriginConfig && customConfig != null) {
+                                originReadTimeoutSeconds = parseBoundedTimeout(
+                                        "InvalidOriginReadTimeout", "OriginReadTimeout",
+                                        r.getElementText(), MIN_ORIGIN_READ_TIMEOUT_SECONDS,
+                                        MAX_ORIGIN_READ_TIMEOUT_SECONDS);
+                                customConfig.put("OriginReadTimeout", originReadTimeoutSeconds);
+                            }
+                        }
                         case "CustomHeaders" -> {
                             if (inOrigin) {
                                 inCustomHeaders = true;
@@ -2806,6 +2855,12 @@ public class CloudFrontController {
                             if (inCustomHeaders && currentHeader == null) {
                                 try {
                                     customHeadersQuantity = Integer.parseInt(r.getElementText());
+                                } catch (NumberFormatException e) {
+                                    throw inconsistentQuantities();
+                                }
+                            } else if (inOriginSslProtocols) {
+                                try {
+                                    sslProtocolsQuantity = Integer.parseInt(r.getElementText());
                                 } catch (NumberFormatException e) {
                                     throw inconsistentQuantities();
                                 }
@@ -2846,10 +2901,14 @@ public class CloudFrontController {
                         }
                         case "OriginSslProtocols" -> {
                             if (inCustomOriginConfig && customConfig != null && sslProtocols != null) {
+                                if (sslProtocolsQuantity == null || sslProtocolsQuantity != sslProtocols.size()) {
+                                    throw inconsistentQuantities();
+                                }
                                 customConfig.put("OriginSslProtocols", sslProtocols);
                             }
                             inOriginSslProtocols = false;
                             sslProtocols = null;
+                            sslProtocolsQuantity = null;
                         }
                         case "CustomOriginConfig" -> {
                             if (inCustomOriginConfig && current != null) {
@@ -2891,10 +2950,23 @@ public class CloudFrontController {
                         }
                         case "Origin" -> {
                             if (inOrigin && current != null) {
+                                Integer completionTimeout = current.getResponseCompletionTimeout();
+                                int effectiveReadTimeout = originReadTimeoutSeconds != null
+                                        ? originReadTimeoutSeconds
+                                        : DEFAULT_ORIGIN_READ_TIMEOUT_SECONDS;
+                                if (completionTimeout != null && completionTimeout > 0
+                                        && completionTimeout < effectiveReadTimeout) {
+                                    throw new AwsException(
+                                            "InvalidArgument",
+                                            "The parameter ResponseCompletionTimeout must be greater than or "
+                                                    + "equal to OriginReadTimeout.",
+                                            400);
+                                }
                                 result.add(current);
                             }
                             inOrigin = false;
                             current = null;
+                            originReadTimeoutSeconds = null;
                         }
                         case "Origins" -> inOrigins = false;
                         default -> {
@@ -2927,6 +2999,36 @@ public class CloudFrontController {
                 "InvalidArgument",
                 "The origin custom headers structure is invalid.",
                 400);
+    }
+
+    private static int parseBoundedTimeout(String errorCode, String field, String rawValue, int min, int max) {
+        int value = parseNonNegativeTimeout(errorCode, field, rawValue);
+        if (value < min || value > max) {
+            throw new AwsException(
+                    errorCode,
+                    "The parameter " + field + " must be between " + min + " and " + max + " seconds.",
+                    400);
+        }
+        return value;
+    }
+
+    private static int parseNonNegativeTimeout(String field, String rawValue) {
+        return parseNonNegativeTimeout("InvalidArgument", field, rawValue);
+    }
+
+    private static int parseNonNegativeTimeout(String errorCode, String field, String rawValue) {
+        try {
+            int value = Integer.parseInt(rawValue);
+            if (value < 0) {
+                throw new NumberFormatException(rawValue);
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            throw new AwsException(
+                    errorCode,
+                    "The parameter " + field + " must be a non-negative integer.",
+                    400);
+        }
     }
 
     // Event types accepted by AWS for each association kind. Lambda@Edge runs at all

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Origin.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/model/Origin.java
@@ -16,6 +16,7 @@ public class Origin {
     private Map<String, Object> customOriginConfig;
     private int connectionAttempts = 3;
     private int connectionTimeout = 10;
+    private Integer responseCompletionTimeout;
     private List<Map<String, String>> customHeaders;
 
     public Origin() {}
@@ -43,6 +44,9 @@ public class Origin {
 
     public int getConnectionTimeout() { return connectionTimeout; }
     public void setConnectionTimeout(int connectionTimeout) { this.connectionTimeout = connectionTimeout; }
+
+    public Integer getResponseCompletionTimeout() { return responseCompletionTimeout; }
+    public void setResponseCompletionTimeout(Integer responseCompletionTimeout) { this.responseCompletionTimeout = responseCompletionTimeout; }
 
     public List<Map<String, String>> getCustomHeaders() { return customHeaders; }
     public void setCustomHeaders(List<Map<String, String>> customHeaders) { this.customHeaders = customHeaders; }

--- a/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontControllerTest.java
@@ -387,6 +387,122 @@ class CloudFrontControllerTest {
     }
 
     @Test
+    void originSslProtocolsQuantityMismatchIsRejected() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginSslProtocols><Quantity>2</Quantity><Items>"
+                        + "<SslProtocol>TLSv1.2</SslProtocol>"
+                        + "</Items></OriginSslProtocols></CustomOriginConfig>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(400, created.getStatus());
+            assertTrue(((String) created.getEntity()).contains("InconsistentQuantities"));
+        }
+    }
+
+    @Test
+    void originReadTimeoutAboveTheAwsMaximumIsRejected() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginReadTimeout>121</OriginReadTimeout></CustomOriginConfig>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(400, created.getStatus());
+            assertTrue(((String) created.getEntity()).contains("InvalidOriginReadTimeout"));
+        }
+    }
+
+    @Test
+    void originKeepaliveTimeoutOfZeroIsRejected() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginKeepaliveTimeout>0</OriginKeepaliveTimeout></CustomOriginConfig>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(400, created.getStatus());
+            assertTrue(((String) created.getEntity()).contains("InvalidOriginKeepaliveTimeout"));
+        }
+    }
+
+    @Test
+    void nonNumericOriginReadTimeoutIsRejected() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginReadTimeout>fast</OriginReadTimeout></CustomOriginConfig>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(400, created.getStatus());
+            assertTrue(((String) created.getEntity()).contains("InvalidOriginReadTimeout"));
+        }
+    }
+
+    @Test
+    void responseCompletionTimeoutBelowOriginReadTimeoutIsRejected() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginReadTimeout>60</OriginReadTimeout></CustomOriginConfig>"
+                        + "<ResponseCompletionTimeout>30</ResponseCompletionTimeout>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(400, created.getStatus());
+            assertTrue(((String) created.getEntity()).contains("InvalidArgument"));
+        }
+    }
+
+    @Test
+    void responseCompletionTimeoutAtLeastOriginReadTimeoutIsAccepted() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+        when(service.createDistribution(any(), any())).thenReturn(distribution("dist-rct"));
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy>"
+                        + "<OriginReadTimeout>60</OriginReadTimeout></CustomOriginConfig>"
+                        + "<ResponseCompletionTimeout>60</ResponseCompletionTimeout>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+    }
+
+    @Test
+    void responseCompletionTimeoutBelowTheImplicitOriginReadTimeoutDefaultIsRejected() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("").replace(
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>",
+                "<OriginProtocolPolicy>https-only</OriginProtocolPolicy></CustomOriginConfig>"
+                        + "<ResponseCompletionTimeout>10</ResponseCompletionTimeout>");
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(400, created.getStatus());
+            assertTrue(((String) created.getEntity()).contains("InvalidArgument"));
+        }
+    }
+
+    @Test
     void defaultCacheBehaviorRoundTripsForwardedValues() {
         CloudFrontService service = mock(CloudFrontService.class);
         CloudFrontController controller = new CloudFrontController(service);
@@ -532,6 +648,93 @@ class CloudFrontControllerTest {
         }
     }
 
+
+    @Test
+    void customOriginConfigRoundTripsTimeoutsAndSslProtocols() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = """
+                <DistributionConfig xmlns="http://cloudfront.amazonaws.com/doc/2020-05-31/">
+                  <CallerReference>ref-timeouts</CallerReference>
+                  <Enabled>true</Enabled>
+                  <Comment>probe</Comment>
+                  <Origins><Quantity>1</Quantity><Items><Origin>
+                    <Id>o1</Id><DomainName>example.com</DomainName>
+                    <CustomOriginConfig>
+                      <HTTPPort>80</HTTPPort><HTTPSPort>443</HTTPSPort>
+                      <OriginProtocolPolicy>https-only</OriginProtocolPolicy>
+                      <OriginKeepaliveTimeout>45</OriginKeepaliveTimeout>
+                      <OriginReadTimeout>60</OriginReadTimeout>
+                      <OriginSslProtocols><Quantity>2</Quantity><Items>
+                        <SslProtocol>TLSv1.1</SslProtocol><SslProtocol>TLSv1.2</SslProtocol>
+                      </Items></OriginSslProtocols>
+                    </CustomOriginConfig>
+                    <ResponseCompletionTimeout>90</ResponseCompletionTimeout>
+                  </Origin></Items></Origins>
+                  <DefaultCacheBehavior>
+                    <TargetOriginId>o1</TargetOriginId>
+                    <ViewerProtocolPolicy>redirect-to-https</ViewerProtocolPolicy>
+                    <AllowedMethods><Quantity>2</Quantity><Items>
+                      <Method>GET</Method><Method>HEAD</Method></Items></AllowedMethods>
+                  </DefaultCacheBehavior>
+                </DistributionConfig>
+                """;
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-timeouts");
+            d.setEtag("etag-timeouts");
+            return d;
+        });
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+
+        when(service.getDistribution("dist-timeouts")).thenReturn(captor.getValue());
+
+        try (Response cfg = controller.getDistributionConfig("dist-timeouts")) {
+            String xml = (String) cfg.getEntity();
+
+            assertEquals("45", XmlParser.extractFirst(xml, "OriginKeepaliveTimeout", null));
+            assertEquals("60", XmlParser.extractFirst(xml, "OriginReadTimeout", null));
+            assertEquals("90", XmlParser.extractFirst(xml, "ResponseCompletionTimeout", null));
+            assertEquals(List.of("TLSv1.1", "TLSv1.2"), XmlParser.extractAll(xml, "SslProtocol"));
+        }
+    }
+
+    @Test
+    void customOriginConfigDefaultsTimeoutsWhenUnspecified() {
+        CloudFrontService service = mock(CloudFrontService.class);
+        CloudFrontController controller = new CloudFrontController(service);
+
+        String body = distributionConfigBody("");
+
+        ArgumentCaptor<Distribution> captor = ArgumentCaptor.forClass(Distribution.class);
+        when(service.createDistribution(captor.capture(), any())).thenAnswer(inv -> {
+            Distribution d = inv.getArgument(0);
+            d.setId("dist-defaults");
+            d.setEtag("etag-defaults");
+            return d;
+        });
+
+        try (Response created = controller.createDistribution(null, body)) {
+            assertEquals(201, created.getStatus());
+        }
+
+        when(service.getDistribution("dist-defaults")).thenReturn(captor.getValue());
+
+        try (Response cfg = controller.getDistributionConfig("dist-defaults")) {
+            String xml = (String) cfg.getEntity();
+
+            assertEquals("5", XmlParser.extractFirst(xml, "OriginKeepaliveTimeout", null));
+            assertEquals("30", XmlParser.extractFirst(xml, "OriginReadTimeout", null));
+            assertEquals("0", XmlParser.extractFirst(xml, "ResponseCompletionTimeout", null));
+            assertEquals(List.of("TLSv1.2"), XmlParser.extractAll(xml, "SslProtocol"));
+        }
+    }
 
     private static String distributionConfigBody(String defaultCacheBehaviorExtra) {
         return """


### PR DESCRIPTION
## Summary

The CloudFront Origin response serializer dropped optional timeout fields that AWS accepts on create/update but never echoes back, causing perpetual terraform plan diffs on aws_cloudfront_distribution origins.

Closes #3221

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior before this fix: CustomOriginConfig responses omitted OriginKeepaliveTimeout and OriginReadTimeout entirely, and Origin never emitted ResponseCompletionTimeout, even though AWS always echoes these per the CloudFront API reference.

- Origin now carries a responseCompletionTimeout and xmlOrigin always emits ResponseCompletionTimeout at the Origin level (0 when unset, matching CloudFront's "no maximum enforced" behavior).
- CustomOriginConfig responses now include OriginKeepaliveTimeout (default 5s) and OriginReadTimeout (default 30s) per the CloudFront API reference defaults.
- Added parsing for OriginKeepaliveTimeout and OriginReadTimeout in CreateDistribution/UpdateDistribution request bodies, since neither was previously captured despite being accepted in the XML schema.

OriginSslProtocols round-tripping is already handled on main (#3182), so this PR only covers the remaining timeout fields from #3221.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)