### PR TITLE
fix(lambda): reject dotted and over-length function names

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtils.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtils.java
@@ -13,8 +13,17 @@ import java.util.regex.Pattern;
  */
 public final class LambdaArnUtils {
 
-    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_.]+");
-    private static final int MAX_NAME_LENGTH = 256;
+    /**
+     * FunctionName constraints from the Lambda API reference (CreateFunction, FunctionName):
+     * {@code [a-zA-Z0-9-_]+}, with no dot. A bare name (no ARN prefix) is capped at 64
+     * characters; the ARN and partial-ARN forms embed the same character class but are
+     * bounded instead by {@link #MAX_TOTAL_LENGTH} on the full string.
+     */
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_]+");
+    private static final int MAX_NAME_LENGTH = 64;
+    private static final int MAX_TOTAL_LENGTH = 140;
+    private static final String NAME_REGEX = "(arn:(aws[a-zA-Z-]*)?:lambda:)?([a-z]{2}(-gov)?-[a-z]+-\\d{1}:)?"
+            + "(\\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\\$LATEST|[a-zA-Z0-9-_]+))?";
     private static final Pattern ACCOUNT_PATTERN = Pattern.compile("\\d{12}");
     private static final Pattern QUALIFIER_PATTERN = Pattern.compile("\\$LATEST|[a-zA-Z0-9-_]+");
 
@@ -31,13 +40,18 @@ public final class LambdaArnUtils {
     public record ResolvedFunctionRef(String name, String qualifier, String region) {}
 
     /**
-     * Parses a {@code FunctionName} path parameter. Throws
-     * {@link AwsException} ({@code InvalidParameterValueException}, HTTP 400)
-     * on any malformed input.
+     * Parses a {@code FunctionName} path parameter. Throws {@link AwsException}, HTTP 400,
+     * on any malformed input: {@code ValidationException} when the name fails the
+     * {@code FunctionName} pattern or length constraint, {@code InvalidParameterValueException}
+     * for other malformed forms (bad ARN structure, mismatched qualifiers, and the like).
      */
     public static ResolvedFunctionRef resolve(String input) {
         if (input == null || input.isBlank()) {
             throw invalid("FunctionName must not be blank");
+        }
+        if (input.length() > MAX_TOTAL_LENGTH) {
+            throw validationFailure(input,
+                    "Member must have length less than or equal to " + MAX_TOTAL_LENGTH);
         }
 
         if (input.startsWith("arn:")) {
@@ -96,7 +110,7 @@ public final class LambdaArnUtils {
             throw invalid("ARN resource type must be 'function': " + input);
         }
         String name = resParts[1];
-        validateName(name);
+        validateNamePattern(name);
         String qualifier = resParts.length == 3 ? resParts[2] : null;
         if (qualifier != null) {
             validateQualifier(qualifier);
@@ -118,7 +132,7 @@ public final class LambdaArnUtils {
             throw invalid("Partial ARN has invalid account id: " + input);
         }
         String name = parts[2];
-        validateName(name);
+        validateNamePattern(name);
         String qualifier = parts.length == 4 ? parts[3] : null;
         if (qualifier != null) {
             validateQualifier(qualifier);
@@ -133,7 +147,7 @@ public final class LambdaArnUtils {
             throw invalid("Invalid FunctionName: " + input);
         }
         String name = parts[0];
-        validateName(name);
+        validateBareName(name);
         String qualifier = parts.length == 2 ? parts[1] : null;
         if (qualifier != null) {
             validateQualifier(qualifier);
@@ -141,15 +155,19 @@ public final class LambdaArnUtils {
         return new ResolvedFunctionRef(name, qualifier, null);
     }
 
-    private static void validateName(String name) {
+    private static void validateNamePattern(String name) {
         if (name == null || name.isEmpty()) {
             throw invalid("FunctionName segment is empty");
         }
-        if (name.length() > MAX_NAME_LENGTH) {
-            throw invalid("FunctionName exceeds maximum length of " + MAX_NAME_LENGTH + ": " + name);
-        }
         if (!NAME_PATTERN.matcher(name).matches()) {
-            throw invalid("FunctionName contains invalid characters: " + name);
+            throw validationFailure(name, "Member must satisfy regular expression pattern: " + NAME_REGEX);
+        }
+    }
+
+    private static void validateBareName(String name) {
+        validateNamePattern(name);
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw validationFailure(name, "Member must have length less than or equal to " + MAX_NAME_LENGTH);
         }
     }
 
@@ -164,6 +182,12 @@ public final class LambdaArnUtils {
 
     private static AwsException invalid(String message) {
         return new AwsException("InvalidParameterValueException", message, 400);
+    }
+
+    private static AwsException validationFailure(String value, String constraint) {
+        return new AwsException("ValidationException",
+                "1 validation error detected: Value '" + value + "' at 'functionName' failed to satisfy "
+                        + "constraint: " + constraint, 400);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtilsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaArnUtilsTest.java
@@ -24,8 +24,6 @@ class LambdaArnUtilsTest {
             "arn:aws:lambda:us-east-1:000000000000:function:my-fn:prod, my-fn, prod, us-east-1",
             "arn:aws:lambda:us-east-1:000000000000:function:my-fn:$LATEST, my-fn, $LATEST, us-east-1",
             "arn:aws:lambda:us-east-1:000000000000:function:my_fn-1, my_fn-1, , us-east-1",
-            "my.fn.v2, my.fn.v2, , ",
-            "arn:aws:lambda:us-east-1:000000000000:function:my.fn.v2, my.fn.v2, , us-east-1",
     })
     void resolveAcceptsValidForms(String input, String expectedName, String expectedQualifier, String expectedRegion) {
         LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(input);
@@ -49,8 +47,6 @@ class LambdaArnUtilsTest {
             "arn:aws:lambda:us-east-1:000000000000:function:my-fn:q1:q2",
             "my-fn:bad/qualifier",
             "my:fn:extra:segments",
-            "name with spaces",
-            "name!bang",
     })
     void resolveRejectsMalformedInputs(String input) {
         AwsException ex = assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(input));
@@ -58,19 +54,75 @@ class LambdaArnUtilsTest {
         assertEquals(400, ex.getHttpStatus());
     }
 
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "name with spaces",
+            "name!bang",
+            "foo.v1",
+            "..",
+    })
+    void resolveRejectsNamesFailingTheFunctionNamePattern(String input) {
+        AwsException ex = assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(input));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+        assertTrue(ex.getMessage().contains("failed to satisfy constraint"));
+    }
+
     @Test
-    void resolveRejectsNameLongerThan256Chars() {
-        String tooLong = "a".repeat(257);
+    void resolveRejectsNameLongerThan64Chars() {
+        String tooLong = "a".repeat(65);
         AwsException ex = assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(tooLong));
-        assertEquals("InvalidParameterValueException", ex.getErrorCode());
+        assertEquals("ValidationException", ex.getErrorCode());
         assertEquals(400, ex.getHttpStatus());
     }
 
     @Test
-    void resolveAccepts256CharName() {
-        String maxLen = "a".repeat(256);
+    void resolveAccepts64CharName() {
+        String maxLen = "a".repeat(64);
         LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(maxLen);
         assertEquals(maxLen, ref.name());
+    }
+
+    @Test
+    void resolveAccepts140CharPartialArn() {
+        String name = "a".repeat(118);
+        String partialArn = "000000000000:function:" + name;
+        assertEquals(140, partialArn.length());
+
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(partialArn);
+        assertEquals(name, ref.name());
+    }
+
+    @Test
+    void resolveAccepts140CharFullArn() {
+        String name = "a".repeat(93);
+        String fullArn = "arn:aws:lambda:us-east-1:000000000000:function:" + name;
+        assertEquals(140, fullArn.length());
+
+        LambdaArnUtils.ResolvedFunctionRef ref = LambdaArnUtils.resolve(fullArn);
+        assertEquals(name, ref.name());
+    }
+
+    @Test
+    void resolveRejectsFullArnLongerThan140Chars() {
+        String name = "a".repeat(94);
+        String fullArn = "arn:aws:lambda:us-east-1:000000000000:function:" + name;
+        assertEquals(141, fullArn.length());
+
+        AwsException ex = assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(fullArn));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
+    }
+
+    @Test
+    void resolveRejectsPartialArnLongerThan140Chars() {
+        String name = "a".repeat(119);
+        String partialArn = "000000000000:function:" + name;
+        assertEquals(141, partialArn.length());
+
+        AwsException ex = assertThrows(AwsException.class, () -> LambdaArnUtils.resolve(partialArn));
+        assertEquals("ValidationException", ex.getErrorCode());
+        assertEquals(400, ex.getHttpStatus());
     }
 
     @Test


### PR DESCRIPTION
## Summary

LambdaArnUtils validated FunctionName more permissively than the live service: NAME_PATTERN allowed a dot and MAX_NAME_LENGTH capped a bare name at 256 characters.

Closes #3238

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Real AWS's CreateFunction FunctionName pattern is `[a-zA-Z0-9-_]+` (no dot), and a name-only FunctionName is limited to 64 characters (the 140-character ceiling documented in the API reference applies to the full ARN string, not the bare name).

Changes in `LambdaArnUtils`:
- `NAME_PATTERN` no longer allows `.`
- `MAX_NAME_LENGTH` corrected from 256 to 64, applied only to a bare (non-ARN) name
- Added a 140-character ceiling on the full input string, matching AWS's full-ARN constraint
- A name that fails the character-set or length constraint now surfaces as `ValidationException` with a message resembling AWS's own wording, instead of a generic `InvalidParameterValueException`

`CreateFunction`, `GetFunction`, `UpdateFunctionConfiguration` and the other Lambda name-resolving APIs all route through this same `LambdaArnUtils.resolve`/`resolveWithQualifier`, so the fix applies uniformly; no other resource type (layers, aliases, versions) shares this pattern/constant.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)