### PR TITLE
fix(cloudformation): resolve dynamic references for all template values

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationResourceProvisioner.java
@@ -477,7 +477,8 @@ public class CloudFormationResourceProvisioner {
     public StackResource provisionStandalone(String resourceType, JsonNode properties, String region, String accountId) {
         CloudFormationTemplateEngine engine = new CloudFormationTemplateEngine(
                 accountId, region, "cloudcontrol", "cloudcontrol",
-                Map.of(), new HashMap<>(), new HashMap<>(), Map.of(), Map.of(), objectMapper, name -> null);
+                Map.of(), new HashMap<>(), new HashMap<>(), Map.of(), Map.of(), objectMapper, name -> null,
+                value -> dynamicReferences.resolveDynamicReferences(value, region, false));
         return provision("resource", resourceType, properties, engine, region, accountId, "cloudcontrol");
     }
 
@@ -1391,7 +1392,7 @@ public class CloudFormationResourceProvisioner {
         if (instance != null) {
             instance = rdsService.modifyDbInstance(
                     id,
-                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    resolveDynamicReferences(resolveOptionalWithoutDynamicReferences(props, "MasterUserPassword", engine), region, true),
                     parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
                     resolveOptional(props, "DBSubnetGroupName", engine));
         } else {
@@ -1399,8 +1400,8 @@ public class CloudFormationResourceProvisioner {
                     id,
                     resolveOptional(props, "Engine", engine),
                     resolveOptional(props, "EngineVersion", engine),
-                    resolveDynamicReferences(resolveOptional(props, "MasterUsername", engine), region, false),
-                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    resolveDynamicReferences(resolveOptionalWithoutDynamicReferences(props, "MasterUsername", engine), region, false),
+                    resolveDynamicReferences(resolveOptionalWithoutDynamicReferences(props, "MasterUserPassword", engine), region, true),
                     resolveOptional(props, "DBName", engine),
                     firstNonBlank(resolveOptional(props, "DBInstanceClass", engine), "db.t3.micro"),
                     parseIntProp(props, "AllocatedStorage", engine, 20),
@@ -1441,7 +1442,7 @@ public class CloudFormationResourceProvisioner {
         if (cluster != null) {
             cluster = rdsService.modifyDbCluster(
                     id,
-                    resolveDynamicReferences(resolveOptional(props, "MasterUserPassword", engine), region, true),
+                    resolveDynamicReferences(resolveOptionalWithoutDynamicReferences(props, "MasterUserPassword", engine), region, true),
                     parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine),
                     parseServerlessV2Capacity(props, "MinCapacity", engine),
                     parseServerlessV2Capacity(props, "MaxCapacity", engine),
@@ -1454,9 +1455,9 @@ public class CloudFormationResourceProvisioner {
             String engineName = resolveOptional(props, "Engine", engine);
             String engineVersion = resolveOptional(props, "EngineVersion", engine);
             String masterUsername = resolveDynamicReferences(
-                    resolveOptional(props, "MasterUsername", engine), region, false);
+                    resolveOptionalWithoutDynamicReferences(props, "MasterUsername", engine), region, false);
             String masterPassword = resolveDynamicReferences(
-                    resolveOptional(props, "MasterUserPassword", engine), region, true);
+                    resolveOptionalWithoutDynamicReferences(props, "MasterUserPassword", engine), region, true);
             String databaseName = resolveOptional(props, "DatabaseName", engine);
             boolean iamEnabled = parseBoolProp(props, "EnableIAMDatabaseAuthentication", engine);
             String parameterGroup = resolveOptional(props, "DBClusterParameterGroupName", engine);
@@ -5690,8 +5691,27 @@ public class CloudFormationResourceProvisioner {
     }
 
     /**
+     * Like {@link #resolveOptional}, but skips the general dynamic-reference stage that
+     * {@link CloudFormationTemplateEngine#resolve} applies. RDS {@code MasterUsername}/
+     * {@code MasterUserPassword} are the only properties where {@code ssm-secure} is a valid
+     * dynamic reference service, and the general stage rejects {@code ssm-secure} outright since
+     * it is invalid everywhere else; the caller resolves the intrinsic-only result itself via
+     * {@link #resolveDynamicReferences} with the permission only these two properties are allowed.
+     */
+    private String resolveOptionalWithoutDynamicReferences(JsonNode props, String name,
+                                                            CloudFormationTemplateEngine engine) {
+        if (props == null || !props.has(name) || props.get(name).isNull()) {
+            return null;
+        }
+        return engine.resolveWithoutDynamicReferences(props.get(name));
+    }
+
+    /**
      * Resolves CloudFormation dynamic references in a provisioned property value. Delegates to
-     * {@link CfnDynamicReferences}; the RDS master-credential paths are its only callers today.
+     * {@link CfnDynamicReferences}. {@code allowSsmSecure} is {@code true} only for the RDS
+     * master-credential properties resolved here directly; every other property value reaches
+     * {@link CfnDynamicReferences} through {@link CloudFormationTemplateEngine#resolveNode}, which
+     * disallows {@code ssm-secure} the same way the general path does.
      */
     private String resolveDynamicReferences(String value, String region, boolean allowSsmSecure) {
         return dynamicReferences.resolveDynamicReferences(value, region, allowSsmSecure);

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationService.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.cloudformation.model.Stack;
 import io.github.hectorvent.floci.services.cloudformation.model.StackEvent;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
 import io.github.hectorvent.floci.services.cloudformation.model.TemplateSummary;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnDynamicReferences;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnRollback;
 import io.github.hectorvent.floci.services.cloudformation.provisioners.UpdateCleanupResult;
 import io.github.hectorvent.floci.services.s3.S3Service;
@@ -65,6 +66,7 @@ public class CloudFormationService implements ResourceProvider {
     private final CloudFormationResourceProvisioner provisioner;
     private final S3Service s3Service;
     private final SsmService ssmService;
+    private final CfnDynamicReferences dynamicReferences;
     private final ObjectMapper objectMapper;
     private final EmulatorConfig config;
     private final RegionResolver regionResolver;
@@ -81,12 +83,14 @@ public class CloudFormationService implements ResourceProvider {
 
     @Inject
     public CloudFormationService(CloudFormationResourceProvisioner provisioner, S3Service s3Service,
-                                 SsmService ssmService, ObjectMapper objectMapper, EmulatorConfig config,
+                                 SsmService ssmService, CfnDynamicReferences dynamicReferences,
+                                 ObjectMapper objectMapper, EmulatorConfig config,
                                  RegionResolver regionResolver, Clock clock,
                                  StorageFactory storageFactory) {
         this.provisioner = provisioner;
         this.s3Service = s3Service;
         this.ssmService = ssmService;
+        this.dynamicReferences = dynamicReferences;
         this.objectMapper = objectMapper;
         this.config = config;
         this.regionResolver = regionResolver;
@@ -1135,7 +1139,8 @@ public class CloudFormationService implements ResourceProvider {
                     CloudFormationTemplateEngine engine = new CloudFormationTemplateEngine(
                             accountId, region, stack.getStackName(),
                             stack.getStackId(), resolvedParams, physicalIds, resourceAttrs, conditions, mappings, objectMapper,
-                            name -> exports.get(accountExportKey(accountId, exportKey(region, name))));
+                            name -> exports.get(accountExportKey(accountId, exportKey(region, name))),
+                            value -> dynamicReferences.resolveDynamicReferences(value, region, false));
 
                     StackResource resource = stack.getResources().get(logicalId);
                     StackResource previousResource = resource;
@@ -1233,7 +1238,8 @@ public class CloudFormationService implements ResourceProvider {
             CloudFormationTemplateEngine finalEngine = new CloudFormationTemplateEngine(
                     accountId, region, stack.getStackName(),
                     stack.getStackId(), resolvedParams, physicalIds, resourceAttrs, conditions, mappings, objectMapper,
-                    name -> exports.get(accountExportKey(accountId, exportKey(region, name))));
+                    name -> exports.get(accountExportKey(accountId, exportKey(region, name))),
+                    value -> dynamicReferences.resolveDynamicReferences(value, region, false));
 
             // Resolve outputs before mutating stack/global export state, so failed updates do not
             // leave stale or partially registered exports behind.

--- a/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationTemplateEngine.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationTemplateEngine.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 import java.util.regex.Pattern;
 
 /**
@@ -36,6 +37,7 @@ public class CloudFormationTemplateEngine {
     private final Map<String, JsonNode> mappings;
     private final ObjectMapper objectMapper;
     private final Function<String, String> importValueResolver;
+    private final UnaryOperator<String> dynamicReferenceResolver;
 
     CloudFormationTemplateEngine(String accountId, String region, String stackName, String stackId,
                                  Map<String, String> parameters,
@@ -45,6 +47,29 @@ public class CloudFormationTemplateEngine {
                                  Map<String, JsonNode> mappings,
                                  ObjectMapper objectMapper,
                                  Function<String, String> importValueResolver) {
+        this(accountId, region, stackName, stackId, parameters, physicalIds, resourceAttributes,
+                conditions, mappings, objectMapper, importValueResolver, null);
+    }
+
+    /**
+     * @param dynamicReferenceResolver resolves a value that may contain CloudFormation dynamic
+     *                                 references ({@code {{resolve:ssm:...}}},
+     *                                 {@code {{resolve:secretsmanager:...}}}) against the live
+     *                                 services, leaving a value with no dynamic reference syntax
+     *                                 untouched. {@code null} skips this stage entirely, which
+     *                                 keeps template values that only ever contain intrinsics
+     *                                 (tests, Cloud Control desired-state resolution) free of the
+     *                                 dependency.
+     */
+    CloudFormationTemplateEngine(String accountId, String region, String stackName, String stackId,
+                                 Map<String, String> parameters,
+                                 Map<String, String> physicalIds,
+                                 Map<String, Map<String, String>> resourceAttributes,
+                                 Map<String, Boolean> conditions,
+                                 Map<String, JsonNode> mappings,
+                                 ObjectMapper objectMapper,
+                                 Function<String, String> importValueResolver,
+                                 UnaryOperator<String> dynamicReferenceResolver) {
         this.accountId = accountId;
         this.region = region;
         this.stackName = stackName;
@@ -56,9 +81,33 @@ public class CloudFormationTemplateEngine {
         this.mappings = mappings;
         this.objectMapper = objectMapper;
         this.importValueResolver = importValueResolver;
+        this.dynamicReferenceResolver = dynamicReferenceResolver;
     }
 
+    /**
+     * Resolves a property value, including CloudFormation dynamic reference syntax
+     * ({@code {{resolve:ssm:...}}}, {@code {{resolve:secretsmanager:...}}}) in the result, the same
+     * way {@link #resolveNode} does. This is the entry point every scalar-property resolution in
+     * this codebase goes through, directly or via {@link #resolveNode}, so a dynamic reference is
+     * substituted regardless of which of the two a caller uses.
+     */
     public String resolve(JsonNode node) {
+        return resolveDynamicReferences(resolveIntrinsic(node)).asText();
+    }
+
+    /**
+     * Resolves intrinsics only, leaving any {@code {{resolve:...}}} dynamic reference syntax in the
+     * result untouched. For the one property family where {@code ssm-secure} is a valid dynamic
+     * reference service (RDS {@code MasterUsername}/{@code MasterUserPassword}): {@link #resolve}
+     * rejects {@code ssm-secure} outright since it is invalid everywhere else, so that property has
+     * to skip the general dynamic-reference stage and resolve it separately, with the permission
+     * only that property is allowed.
+     */
+    public String resolveWithoutDynamicReferences(JsonNode node) {
+        return resolveIntrinsic(node);
+    }
+
+    private String resolveIntrinsic(JsonNode node) {
         if (node == null || node.isNull() || node.isMissingNode()) {
             return "";
         }
@@ -116,7 +165,10 @@ public class CloudFormationTemplateEngine {
         if (node == null || node.isNull() || node.isMissingNode()) {
             return node;
         }
-        if (node.isTextual() || node.isNumber() || node.isBoolean()) {
+        if (node.isTextual()) {
+            return resolveDynamicReferences(node.textValue());
+        }
+        if (node.isNumber() || node.isBoolean()) {
             return node;
         }
         if (node.isObject()) {
@@ -154,6 +206,22 @@ public class CloudFormationTemplateEngine {
             return arr;
         }
         return node;
+    }
+
+    /**
+     * Resolves a value against {@link #dynamicReferenceResolver} when it carries CloudFormation
+     * dynamic reference syntax ({@code {{resolve:ssm:...}}}, {@code {{resolve:secretsmanager:...}}}).
+     * CloudFormation substitutes these for any string property in a template, not only the RDS
+     * master-credential properties that first needed them (see
+     * <a href="https://github.com/floci-io/floci/issues/2213">#2213</a>), so {@link #resolveNode}
+     * applies this to every textual result: a literal string carrying the syntax outright, and the
+     * text an intrinsic function (e.g. {@code Fn::Sub}) produces.
+     */
+    private TextNode resolveDynamicReferences(String value) {
+        if (dynamicReferenceResolver == null || value == null || !value.contains("{{resolve:")) {
+            return TextNode.valueOf(value);
+        }
+        return TextNode.valueOf(dynamicReferenceResolver.apply(value));
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamicReferenceIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationDynamicReferenceIntegrationTest.java
@@ -1,0 +1,317 @@
+package io.github.hectorvent.floci.services.cloudformation;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * CloudFormation resolves {@code {{resolve:...}}} dynamic references for any string property in a
+ * template, not only the RDS master-credential properties that first needed them (issue #2213).
+ * These tests exercise that general path end to end through a real stack deploy, using a Lambda
+ * {@code Environment.Variables} entry the way the AWS documentation's own example does.
+ */
+@QuarkusTest
+class CloudFormationDynamicReferenceIntegrationTest {
+
+    private static final String SSM_CONTENT_TYPE = "application/x-amz-json-1.1";
+    private static final String SM_CONTENT_TYPE = "application/x-amz-json-1.1";
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void createStack_lambdaEnvironmentVariableResolvesSsmDynamicReference() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.PutParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Name": "/cfn-dynref/url",
+                    "Value": "https://real.example.com",
+                    "Type": "String",
+                    "Overwrite": true
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String template = """
+            {
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "cfn-dynref-ssm-func",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/cfn-test-lambda-role",
+                    "Environment": {
+                      "Variables": {
+                        "URL": "{{resolve:ssm:/cfn-dynref/url}}"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-dynref-ssm-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-dynref-ssm-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/cfn-dynref-ssm-func")
+        .then()
+            .statusCode(200)
+            .body("Configuration.Environment.Variables.URL", equalTo("https://real.example.com"));
+    }
+
+    @Test
+    void createStack_lambdaEnvironmentVariableResolvesSecretsManagerDynamicReference() {
+        given()
+            .header("X-Amz-Target", "secretsmanager.CreateSecret")
+            .contentType(SM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Name": "cfn-dynref-secret",
+                    "SecretString": "{\\"apiKey\\":\\"s3cr3t-value\\"}"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String template = """
+            {
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "cfn-dynref-sm-func",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/cfn-test-lambda-role",
+                    "Environment": {
+                      "Variables": {
+                        "API_KEY": "{{resolve:secretsmanager:cfn-dynref-secret:SecretString:apiKey}}"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-dynref-sm-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-dynref-sm-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/cfn-dynref-sm-func")
+        .then()
+            .statusCode(200)
+            .body("Configuration.Environment.Variables.API_KEY", equalTo("s3cr3t-value"));
+    }
+
+    @Test
+    void createStack_snsTopicNameResolvesSsmDynamicReferenceThroughResolveOptional() {
+        given()
+            .header("X-Amz-Target", "AmazonSSM.PutParameter")
+            .contentType(SSM_CONTENT_TYPE)
+            .body("""
+                {
+                    "Name": "/cfn-dynref/topic-name",
+                    "Value": "cfn-dynref-resolved-topic",
+                    "Type": "String",
+                    "Overwrite": true
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+
+        String template = """
+            {
+              "Resources": {
+                "MyTopic": {
+                  "Type": "AWS::SNS::Topic",
+                  "Properties": {
+                    "TopicName": "{{resolve:ssm:/cfn-dynref/topic-name}}"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-dynref-sns-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-dynref-sns-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "ListTopics")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("cfn-dynref-resolved-topic"))
+            .body(org.hamcrest.Matchers.not(containsString("{{resolve:ssm:")));
+    }
+
+    @Test
+    void createStack_ssmSecureDynamicReferenceOnANonRdsResourceFailsResourceCreation() {
+        String template = """
+            {
+              "Resources": {
+                "MyTopic": {
+                  "Type": "AWS::SNS::Topic",
+                  "Properties": {
+                    "TopicName": "{{resolve:ssm-secure:/cfn-dynref/topic-name}}"
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-dynref-ssm-secure-non-rds-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-dynref-ssm-secure-non-rds-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>ROLLBACK_COMPLETE</StackStatus>"));
+    }
+
+    @Test
+    void createStack_lambdaEnvironmentVariableLeavesPlainLiteralStringUntouched() {
+        String template = """
+            {
+              "Resources": {
+                "MyFunction": {
+                  "Type": "AWS::Lambda::Function",
+                  "Properties": {
+                    "FunctionName": "cfn-dynref-literal-func",
+                    "Runtime": "nodejs20.x",
+                    "Handler": "index.handler",
+                    "Role": "arn:aws:iam::000000000000:role/cfn-test-lambda-role",
+                    "Environment": {
+                      "Variables": {
+                        "PLAIN": "just-a-normal-value",
+                        "BRACES": "not-a-dynamic-reference-{{example}}"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """;
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "CreateStack")
+            .formParam("StackName", "cfn-dynref-literal-stack")
+            .formParam("TemplateBody", template)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackId>"));
+
+        given()
+            .contentType("application/x-www-form-urlencoded")
+            .formParam("Action", "DescribeStacks")
+            .formParam("StackName", "cfn-dynref-literal-stack")
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200)
+            .body(containsString("<StackStatus>CREATE_COMPLETE</StackStatus>"));
+
+        given()
+        .when()
+            .get("/2015-03-31/functions/cfn-dynref-literal-func")
+        .then()
+            .statusCode(200)
+            .body("Configuration.Environment.Variables.PLAIN", equalTo("just-a-normal-value"))
+            .body("Configuration.Environment.Variables.BRACES",
+                    equalTo("not-a-dynamic-reference-{{example}}"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceRollbackTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationServiceRollbackTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.cloudformation.model.Stack;
 import io.github.hectorvent.floci.services.cloudformation.model.StackResource;
+import io.github.hectorvent.floci.services.cloudformation.provisioners.CfnDynamicReferences;
 import io.github.hectorvent.floci.services.s3.S3Service;
 import io.github.hectorvent.floci.services.ssm.SsmService;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ class CloudFormationServiceRollbackTest {
                 provisioner,
                 mock(S3Service.class),
                 mock(SsmService.class),
+                mock(CfnDynamicReferences.class),
                 new ObjectMapper(),
                 config,
                 mock(RegionResolver.class),

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationTemplateEngineTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationTemplateEngineTest.java
@@ -10,10 +10,12 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class CloudFormationTemplateEngineTest {
 
@@ -369,5 +371,70 @@ class CloudFormationTemplateEngineTest {
 
         assertEquals(java.util.List.of("subnet-default"),
                 eFalse.resolveStringList(json("{\"Fn::If\":[\"UseCustom\",[\"subnet-prefix\",{\"Fn::Split\":[\",\",{\"Fn::ImportValue\":\"Subnets\"}]}],[\"subnet-default\"]]}")));
+    }
+
+    /**
+     * Reproduces #2213: a Lambda {@code Environment.Variables} entry (or any other plain string
+     * template value) carrying {@code {{resolve:...}}} syntax reached the deployed resource as the
+     * literal text because {@code resolveNode}, the general-purpose path every non-RDS property goes
+     * through, had no dynamic-reference stage.
+     */
+    @Test
+    void resolveNodeResolvesDynamicReferenceInPlainStringValue() {
+        UnaryOperator<String> resolver = value -> {
+            assertEquals("{{resolve:ssm:/demo/url}}", value);
+            return "https://real.example.com";
+        };
+        CloudFormationTemplateEngine e = new CloudFormationTemplateEngine("000000000000",
+                "us-east-1", "my-stack", "stack/id", Map.of(), Map.of(), Map.of(), Map.of(),
+                Map.of(), mapper, (Function<String, String>) name -> null, resolver);
+
+        assertEquals("https://real.example.com",
+                e.resolveNode(json("\"{{resolve:ssm:/demo/url}}\"")).asText());
+    }
+
+    /**
+     * The same dynamic-reference stage applies to the text an intrinsic function produces, since a
+     * literal {@code {{resolve:...}}} embedded in an {@code Fn::Sub} template survives substitution
+     * untouched and reaches resolveNode's final string.
+     */
+    @Test
+    void resolveNodeResolvesDynamicReferenceProducedByIntrinsic() {
+        UnaryOperator<String> resolver = value -> {
+            assertEquals("prefix-{{resolve:ssm:/demo/url}}", value);
+            return "prefix-https://real.example.com";
+        };
+        CloudFormationTemplateEngine e = new CloudFormationTemplateEngine("000000000000",
+                "us-east-1", "my-stack", "stack/id", Map.of(), Map.of(), Map.of(), Map.of(),
+                Map.of(), mapper, (Function<String, String>) name -> null, resolver);
+
+        assertEquals("prefix-https://real.example.com", e.resolveNode(
+                json("{\"Fn::Sub\": \"prefix-{{resolve:ssm:/demo/url}}\"}")).asText());
+    }
+
+    /**
+     * A plain literal with no dynamic reference syntax must never reach the resolver: it is left
+     * exactly as written, and a resolver that throws proves it was not invoked.
+     */
+    @Test
+    void resolveNodeLeavesPlainLiteralStringUntouched() {
+        UnaryOperator<String> resolver = value -> fail("dynamic reference resolver must not be "
+                + "invoked for a value with no {{resolve:...}} syntax: " + value);
+        CloudFormationTemplateEngine e = new CloudFormationTemplateEngine("000000000000",
+                "us-east-1", "my-stack", "stack/id", Map.of(), Map.of(), Map.of(), Map.of(),
+                Map.of(), mapper, (Function<String, String>) name -> null, resolver);
+
+        assertEquals("just-a-normal-value", e.resolveNode(json("\"just-a-normal-value\"")).asText());
+    }
+
+    /**
+     * With no dynamic-reference resolver configured (the 11-argument constructor every other test
+     * in this class uses), resolveNode leaves {@code {{resolve:...}}} syntax exactly as written
+     * instead of failing: callers that never need dynamic references stay decoupled from them.
+     */
+    @Test
+    void resolveNodeWithNoResolverLeavesDynamicReferenceSyntaxVerbatim() {
+        assertEquals("{{resolve:ssm:/demo/url}}",
+                engine().resolveNode(json("\"{{resolve:ssm:/demo/url}}\"")).asText());
     }
 }


### PR DESCRIPTION
## Summary

CloudFormation dynamic references (`{{resolve:ssm:...}}`, `{{resolve:secretsmanager:...}}`) were only resolved for the RDS MasterUsername/MasterUserPassword properties, which call CfnDynamicReferences directly. Every other property value goes through CloudFormationTemplateEngine#resolveNode, which had no dynamic-reference stage at all, so a value such as a Lambda Environment.Variables entry reached the deployed resource as the literal `{{resolve:ssm:...}}` text instead of the resolved value.

Closes #2213

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`resolveNode` now runs the same CfnDynamicReferences resolution over every textual result it produces: a plain string literal carrying the syntax outright, and the text an intrinsic function (e.g. Fn::Sub) produces. `ssm-secure` stays restricted to the RDS master-credential path, matching the existing behavior there. The RDS code path is unchanged, since it resolves MasterUsername/MasterUserPassword directly rather than through resolveNode.

- `CloudFormationTemplateEngine`: added an optional dynamicReferenceResolver collaborator (a UnaryOperator<String>, following the same nullable-functional-collaborator pattern already used for importValueResolver) and applied it in resolveNode for both plain string values and the output of resolved intrinsics.
- `CloudFormationService` / `CloudFormationResourceProvisioner`: wired the new resolver into every place a CloudFormationTemplateEngine is constructed, backed by the existing CfnDynamicReferences bean.
- Tests: unit tests in CloudFormationTemplateEngineTest covering the resolver wiring (dynamic reference in a plain string, in an Fn::Sub result, a plain literal left untouched, and no-resolver backward compatibility), plus a new CloudFormationDynamicReferenceIntegrationTest that deploys a real stack with a Lambda Environment.Variables entry using `{{resolve:ssm:...}}` and `{{resolve:secretsmanager:...}}` and asserts the deployed function has the resolved value, alongside a regression case for plain literal strings.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)