### PR TITLE
fix(ec2): generate real key material in CreateKeyPair and fingerprint imported keys

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterial.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterial.java
@@ -1,0 +1,150 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.HexFormat;
+
+/**
+ * Real key material for EC2 key pairs.
+ *
+ * <p>CreateKeyPair is the only time AWS ever discloses a private key, and callers are
+ * expected to write the response straight to a file and use it: the Packer amazon-ebs
+ * builder, for one, creates a temporary key pair, saves the returned material, and SSHes
+ * in with it. A placeholder string cannot serve that, so the key is generated here.
+ *
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateKeyPair.html">CreateKeyPair</a>
+ * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportKeyPair.html">ImportKeyPair</a>
+ */
+public final class Ec2KeyMaterial {
+
+    /** AWS generates 2048-bit RSA keys for KeyType=rsa, which is the default. */
+    private static final int RSA_KEY_SIZE = 2048;
+
+    private Ec2KeyMaterial() {}
+
+    /**
+     * @param privateKeyPem   PKCS#1 PEM, the "BEGIN RSA PRIVATE KEY" form AWS returns
+     * @param openSshPublicKey the matching "ssh-rsa AAAA..." line, for authorized_keys
+     * @param fingerprint     SHA-1 of the DER private key, colon-separated hex
+     */
+    public record Generated(String privateKeyPem, String openSshPublicKey, String fingerprint) {}
+
+    public static Generated generateRsa() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(RSA_KEY_SIZE);
+            java.security.KeyPair pair = generator.generateKeyPair();
+
+            StringWriter out = new StringWriter();
+            try (JcaPEMWriter pem = new JcaPEMWriter(out)) {
+                // Writes the traditional PKCS#1 "RSA PRIVATE KEY" block rather than Java's
+                // native PKCS#8 "PRIVATE KEY", matching what AWS actually returns. OpenSSH
+                // reads both, but tooling that pattern-matches the header only reads the former.
+                pem.writeObject(pair.getPrivate());
+            }
+
+            // "The SHA-1 digest of the DER encoded private key" for a key pair AWS created.
+            // (Imported keys use the MD5 of the public key instead -- see fingerprintOf.)
+            String fingerprint = colonHex(
+                    MessageDigest.getInstance("SHA-1").digest(pair.getPrivate().getEncoded()));
+
+            return new Generated(
+                    out.toString(),
+                    openSshPublicKey((RSAPublicKey) pair.getPublic()),
+                    fingerprint);
+        } catch (NoSuchAlgorithmException | IOException e) {
+            throw new IllegalStateException("Could not generate an EC2 key pair", e);
+        }
+    }
+
+    /**
+     * Fingerprint for an imported public key: the MD5 digest of its DER encoding, which is
+     * what AWS reports for ImportKeyPair.
+     *
+     * <p>Only ssh-rsa is decoded back to a DER SubjectPublicKeyInfo. For any other key type
+     * (ssh-ed25519 and friends) the digest is taken over the wire-format blob instead: still
+     * stable and distinct per key, which is what callers actually depend on, but not
+     * byte-identical to what AWS would report. Returns null for material that does not parse,
+     * so the caller can decide rather than getting a fingerprint of garbage.
+     */
+    public static String fingerprintOf(String openSshPublicKey) {
+        byte[] blob = decodeOpenSshBlob(openSshPublicKey);
+        if (blob == null) {
+            return null;
+        }
+        try {
+            byte[] der = blob;
+            SshReader reader = new SshReader(blob);
+            String type = new String(reader.readBytes(), StandardCharsets.UTF_8);
+            if ("ssh-rsa".equals(type)) {
+                BigInteger exponent = new BigInteger(reader.readBytes());
+                BigInteger modulus = new BigInteger(reader.readBytes());
+                der = KeyFactory.getInstance("RSA")
+                        .generatePublic(new RSAPublicKeySpec(modulus, exponent))
+                        .getEncoded();
+            }
+            return colonHex(MessageDigest.getInstance("MD5").digest(der));
+        } catch (Exception e) {  // malformed material is the caller's problem, not a crash
+            return null;
+        }
+    }
+
+    static String openSshPublicKey(RSAPublicKey key) {
+        byte[] type = "ssh-rsa".getBytes(StandardCharsets.US_ASCII);
+        byte[] exponent = key.getPublicExponent().toByteArray();
+        byte[] modulus = key.getModulus().toByteArray();
+        ByteBuffer blob = ByteBuffer.allocate(
+                12 + type.length + exponent.length + modulus.length);
+        for (byte[] field : new byte[][]{type, exponent, modulus}) {
+            blob.putInt(field.length).put(field);
+        }
+        return "ssh-rsa " + Base64.getEncoder().encodeToString(blob.array());
+    }
+
+    private static byte[] decodeOpenSshBlob(String openSshPublicKey) {
+        if (openSshPublicKey == null) {
+            return null;
+        }
+        // "ssh-rsa AAAAB3Nza... comment" -- the middle field is the blob.
+        String[] fields = openSshPublicKey.trim().split("\\s+");
+        if (fields.length < 2) {
+            return null;
+        }
+        try {
+            return Base64.getDecoder().decode(fields[1]);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String colonHex(byte[] digest) {
+        return HexFormat.of().withDelimiter(":").formatHex(digest);
+    }
+
+    /** Reads the length-prefixed fields of an OpenSSH public key blob. */
+    private static final class SshReader {
+        private final ByteBuffer buffer;
+
+        SshReader(byte[] blob) {
+            this.buffer = ByteBuffer.wrap(blob);
+        }
+
+        byte[] readBytes() {
+            byte[] field = new byte[buffer.getInt()];
+            buffer.get(field);
+            return field;
+        }
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterial.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterial.java
@@ -32,6 +32,9 @@ public final class Ec2KeyMaterial {
     /** AWS generates 2048-bit RSA keys for KeyType=rsa, which is the default. */
     private static final int RSA_KEY_SIZE = 2048;
 
+    /** An ed25519 public key is a fixed 32-byte value, so any other length is not one. */
+    private static final int ED25519_KEY_LENGTH = 32;
+
     private Ec2KeyMaterial() {}
 
     /**
@@ -70,14 +73,31 @@ public final class Ec2KeyMaterial {
     }
 
     /**
-     * Fingerprint for an imported public key: the MD5 digest of its DER encoding, which is
-     * what AWS reports for ImportKeyPair.
+     * Fingerprint for an imported public key, in the scheme AWS uses for that key type.
      *
-     * <p>Only ssh-rsa is decoded back to a DER SubjectPublicKeyInfo. For any other key type
-     * (ssh-ed25519 and friends) the digest is taken over the wire-format blob instead: still
-     * stable and distinct per key, which is what callers actually depend on, but not
-     * byte-identical to what AWS would report. Returns null for material that does not parse,
-     * so the caller can decide rather than getting a fingerprint of garbage.
+     * <p>ImportKeyPair does not fingerprint every key the same way, and it does not agree
+     * with CreateKeyPair either:
+     *
+     * <ul>
+     *   <li><b>ssh-rsa</b>: "the MD5 public key fingerprint", taken over the DER
+     *       SubjectPublicKeyInfo rather than over the SSH wire blob. AWS documents the check
+     *       as {@code openssl rsa -in key -pubout -outform DER | openssl md5 -c}, and
+     *       {@link java.security.Key#getEncoded()} produces exactly that DER, so the blob is
+     *       decoded back to a public key first. Colon-separated hex, as AWS reports it.</li>
+     *   <li><b>ssh-ed25519</b>: the base64-encoded SHA-256 digest of the wire blob, "which is
+     *       the default for OpenSSH". This is the {@code ssh-keygen -l} value without its
+     *       {@code SHA256:} prefix, and padded: AWS keeps the trailing {@code =} that
+     *       ssh-keygen drops.</li>
+     * </ul>
+     *
+     * <p>Any other key type keeps the MD5 of the wire blob: stable and distinct per key,
+     * which is what callers depend on, but not a value AWS would report. AWS accepts only
+     * RSA and ed25519 material for import, so nothing else has a documented answer to match.
+     *
+     * <p>Returns null for material that does not parse, so the caller can decide rather than
+     * getting a fingerprint of garbage.
+     *
+     * @see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/verify-keys.html">Verify the fingerprint of your key pair</a>
      */
     public static String fingerprintOf(String openSshPublicKey) {
         byte[] blob = decodeOpenSshBlob(openSshPublicKey);
@@ -88,6 +108,13 @@ public final class Ec2KeyMaterial {
             byte[] der = blob;
             SshReader reader = new SshReader(blob);
             String type = new String(reader.readBytes(), StandardCharsets.UTF_8);
+            if ("ssh-ed25519".equals(type)) {
+                if (reader.readBytes().length != ED25519_KEY_LENGTH) {
+                    return null;
+                }
+                return Base64.getEncoder().encodeToString(
+                        MessageDigest.getInstance("SHA-256").digest(blob));
+            }
             if ("ssh-rsa".equals(type)) {
                 BigInteger exponent = new BigInteger(reader.readBytes());
                 BigInteger modulus = new BigInteger(reader.readBytes());
@@ -135,6 +162,13 @@ public final class Ec2KeyMaterial {
 
     /** Reads the length-prefixed fields of an OpenSSH public key blob. */
     private static final class SshReader {
+
+        /**
+         * Absolute ceiling on a single field, well clear of anything a real key carries: the
+         * largest is the modulus of a 16384-bit RSA key, 2049 bytes with its sign byte.
+         */
+        private static final int MAX_FIELD_LENGTH = 64 * 1024;
+
         private final ByteBuffer buffer;
 
         SshReader(byte[] blob) {
@@ -142,7 +176,21 @@ public final class Ec2KeyMaterial {
         }
 
         byte[] readBytes() {
-            byte[] field = new byte[buffer.getInt()];
+            if (buffer.remaining() < Integer.BYTES) {
+                throw new IllegalArgumentException("truncated OpenSSH key blob");
+            }
+            int length = buffer.getInt();
+            // ImportKeyPair hands the caller's PublicKeyMaterial straight to this parser, so
+            // the declared length is attacker-controlled and has to be checked before it is
+            // allocated. Reading it first meant an eleven-byte blob could declare a
+            // two-gigabyte field and the array was built before anything noticed the bytes
+            // were not there; the resulting OutOfMemoryError is an Error, so the catch around
+            // fingerprintOf did not contain it either. Bounding by what is left in the buffer
+            // ties the allocation to the size of the request that carried it.
+            if (length < 0 || length > MAX_FIELD_LENGTH || length > buffer.remaining()) {
+                throw new IllegalArgumentException("invalid OpenSSH key field length: " + length);
+            }
+            byte[] field = new byte[length];
             buffer.get(field);
             return field;
         }

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2Service.java
@@ -3936,8 +3936,12 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         KeyPair kp = new KeyPair();
         kp.setKeyPairId(keyPairId);
         kp.setKeyName(keyName);
-        kp.setKeyFingerprint("00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00");
-        kp.setKeyMaterial("-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA0Z3VS5JJcds3xHn/ygWep4Ib/ue7YiKbCIZgYpYDe0+FAKE\n-----END RSA PRIVATE KEY-----");
+        Ec2KeyMaterial.Generated generated = Ec2KeyMaterial.generateRsa();
+        kp.setKeyFingerprint(generated.fingerprint());
+        kp.setKeyMaterial(generated.privateKeyPem());
+        // The public half is what RunInstances injects into the guest's authorized_keys.
+        // Without storing it, a key pair created here could never authenticate anything.
+        kp.setPublicKey(generated.openSshPublicKey());
         kp.setRegion(region);
         keyPairs.put(key(region, keyPairId), kp);
         return kp;
@@ -3997,7 +4001,13 @@ public class Ec2Service implements ContainerTeardown, ResourceProvider {
         KeyPair kp = new KeyPair();
         kp.setKeyPairId(keyPairId);
         kp.setKeyName(keyName);
-        kp.setKeyFingerprint("00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00");
+        // A per-key fingerprint, not a constant: callers compare it to detect that the key
+        // under a given name has been replaced. Falls back to the old placeholder only when
+        // the material does not parse, rather than reporting a digest of garbage.
+        String fingerprint = Ec2KeyMaterial.fingerprintOf(publicKeyMaterial);
+        kp.setKeyFingerprint(fingerprint != null
+                ? fingerprint
+                : "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00");
         kp.setPublicKey(publicKeyMaterial);
         kp.setRegion(region);
         keyPairs.put(key(region, keyPairId), kp);

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterialTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterialTest.java
@@ -1,0 +1,139 @@
+package io.github.hectorvent.floci.services.ec2;
+
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.junit.jupiter.api.Test;
+
+import java.io.StringReader;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * CreateKeyPair previously returned a fixed 63-character string literal as KeyMaterial. It
+ * looked like a PEM but did not parse ("ssh-keygen -y -f key.pem: invalid format"), so no
+ * caller could ever use it -- and it was byte-identical for every key pair.
+ *
+ * <p>These tests deliberately parse and use the material rather than matching it against a
+ * pattern: a placeholder passes any shape check, which is how the original went unnoticed.
+ */
+class Ec2KeyMaterialTest {
+
+    @Test
+    void generatedPrivateKeyParsesAsA2048BitRsaKey() throws Exception {
+        Ec2KeyMaterial.Generated generated = Ec2KeyMaterial.generateRsa();
+
+        Object parsed = new PEMParser(new StringReader(generated.privateKeyPem())).readObject();
+        assertTrue(parsed instanceof PEMKeyPair, "expected a PEM key pair, got: " + parsed);
+        RSAPrivateCrtKey privateKey = (RSAPrivateCrtKey) new JcaPEMKeyConverter()
+                .getKeyPair((PEMKeyPair) parsed).getPrivate();
+
+        assertEquals(2048, privateKey.getModulus().bitLength());
+    }
+
+    @Test
+    void generatedPrivateKeyUsesThePkcs1HeaderAwsReturns() {
+        // AWS returns the traditional "BEGIN RSA PRIVATE KEY" block. Java's own encoding is
+        // PKCS#8 ("BEGIN PRIVATE KEY"); OpenSSH reads both, but tooling that matches on the
+        // header only reads the former.
+        String pem = Ec2KeyMaterial.generateRsa().privateKeyPem();
+        assertTrue(pem.startsWith("-----BEGIN RSA PRIVATE KEY-----"), pem.lines().findFirst().orElse(""));
+        assertTrue(pem.contains("-----END RSA PRIVATE KEY-----"));
+    }
+
+    @Test
+    void publicKeyMatchesThePrivateKeyItWasGeneratedWith() throws Exception {
+        // The whole point of the pair: what gets written to authorized_keys has to be the
+        // other half of what the caller receives, or SSH still fails.
+        Ec2KeyMaterial.Generated generated = Ec2KeyMaterial.generateRsa();
+
+        PEMKeyPair parsed = (PEMKeyPair) new PEMParser(
+                new StringReader(generated.privateKeyPem())).readObject();
+        RSAPrivateCrtKey privateKey = (RSAPrivateCrtKey) new JcaPEMKeyConverter()
+                .getKeyPair(parsed).getPrivate();
+
+        String[] fields = generated.openSshPublicKey().split(" ");
+        assertEquals("ssh-rsa", fields[0]);
+        ByteBuffer blob = ByteBuffer.wrap(Base64.getDecoder().decode(fields[1]));
+
+        assertEquals("ssh-rsa", new String(read(blob), StandardCharsets.UTF_8));
+        assertEquals(privateKey.getPublicExponent(), new BigInteger(read(blob)));
+        assertEquals(privateKey.getModulus(), new BigInteger(read(blob)));
+    }
+
+    @Test
+    void everyKeyPairIsDistinct() {
+        // The literal made all key pairs identical, so a second key silently authenticated
+        // as the first.
+        Ec2KeyMaterial.Generated first = Ec2KeyMaterial.generateRsa();
+        Ec2KeyMaterial.Generated second = Ec2KeyMaterial.generateRsa();
+
+        assertNotEquals(first.privateKeyPem(), second.privateKeyPem());
+        assertNotEquals(first.openSshPublicKey(), second.openSshPublicKey());
+        assertNotEquals(first.fingerprint(), second.fingerprint());
+    }
+
+    @Test
+    void fingerprintIsTheColonSeparatedSha1OfTheDerPrivateKey() {
+        // "The SHA-1 digest of the DER encoded private key" -- 20 bytes, so 20 hex pairs.
+        String fingerprint = Ec2KeyMaterial.generateRsa().fingerprint();
+
+        assertTrue(fingerprint.matches("([0-9a-f]{2}:){19}[0-9a-f]{2}"), fingerprint);
+    }
+
+    @Test
+    void importedKeyFingerprintIsPerKeyRatherThanAConstant() {
+        String first = Ec2KeyMaterial.fingerprintOf(Ec2KeyMaterial.generateRsa().openSshPublicKey());
+        String second = Ec2KeyMaterial.fingerprintOf(Ec2KeyMaterial.generateRsa().openSshPublicKey());
+
+        assertNotNull(first);
+        // MD5 of the DER public key: 16 bytes.
+        assertTrue(first.matches("([0-9a-f]{2}:){15}[0-9a-f]{2}"), first);
+        assertNotEquals(first, second);
+    }
+
+    @Test
+    void importedKeyFingerprintIsStableAndIgnoresTheTrailingComment() {
+        // ssh-keygen writes "ssh-rsa AAAA... user@host"; the comment is not part of the key,
+        // so re-importing the same key under a different comment must not change its identity.
+        String publicKey = Ec2KeyMaterial.generateRsa().openSshPublicKey();
+
+        assertEquals(Ec2KeyMaterial.fingerprintOf(publicKey),
+                Ec2KeyMaterial.fingerprintOf(publicKey + " someone@example.com"));
+    }
+
+    @Test
+    void unparseableImportedMaterialYieldsNoFingerprintRatherThanADigestOfGarbage() {
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf("not-a-key"));
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf(""));
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf(null));
+    }
+
+    @Test
+    void openSshEncodingRoundTripsAnArbitraryRsaPublicKey() throws Exception {
+        // Guards the length-prefixed framing: a wrong length here produces a line that looks
+        // right and that sshd silently ignores.
+        Ec2KeyMaterial.Generated generated = Ec2KeyMaterial.generateRsa();
+        PEMKeyPair parsed = (PEMKeyPair) new PEMParser(
+                new StringReader(generated.privateKeyPem())).readObject();
+        RSAPublicKey publicKey = (RSAPublicKey) new JcaPEMKeyConverter()
+                .getKeyPair(parsed).getPublic();
+
+        assertEquals(generated.openSshPublicKey(), Ec2KeyMaterial.openSshPublicKey(publicKey));
+    }
+
+    private static byte[] read(ByteBuffer blob) {
+        byte[] field = new byte[blob.getInt()];
+        blob.get(field);
+        return field;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterialTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2KeyMaterialTest.java
@@ -28,6 +28,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class Ec2KeyMaterialTest {
 
+    /** Throwaway keys, kept fixed so their fingerprints can be pinned to known good values. */
+    private static final String RSA_PUBLIC_KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCp7mGC9"
+            + "NkQI+loxf1G9bM6HnCs9iR1nnzZA/f/o7hx/Wv1oDhx03k6H83I+Q49eE1XO56WBPxnr8/2G6UmS9D0R"
+            + "FKe9L+HJrfiZF7oLQ09JwEK91VLNSkD0Bq2zhnfWJe/ULkaPQ7FgHEghRi8aI5PsATH6VCaJDKWxl+2b"
+            + "zM7MWlbKRAo8uuu2evnGrgnu+RmuXJQCRYz6lG+JESVzm6MnHXYxme+UD+7c/tTYwzoswfXh8VN8QVzX"
+            + "mjfHi2Ve3PJ+YuF2X2gKpRMNMf7cLWMCTOhZI2AgXX+NLDlCG0dEUm/DXdSKRTDhm3mIJmF67eGYuff+"
+            + "zHusBZ9cSBkW9i9";
+
+    private static final String ED25519_PUBLIC_KEY =
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII0fBPBUZHaEOBc2mySfmI5btu4mkvFfNRujmF7RH2fj";
+
     @Test
     void generatedPrivateKeyParsesAsA2048BitRsaKey() throws Exception {
         Ec2KeyMaterial.Generated generated = Ec2KeyMaterial.generateRsa();
@@ -129,6 +140,78 @@ class Ec2KeyMaterialTest {
                 .getKeyPair(parsed).getPublic();
 
         assertEquals(generated.openSshPublicKey(), Ec2KeyMaterial.openSshPublicKey(publicKey));
+    }
+
+    @Test
+    void importedRsaFingerprintMatchesTheSchemeAwsDocuments() {
+        // Pinned against a value derived outside this code, from a throwaway key:
+        //   openssl rsa -in rsa.pem -pubout -outform DER | openssl md5 -c
+        // which is the command AWS gives for verifying an imported RSA key pair. A test that
+        // compared the service against fingerprintOf, or that only checked the digest shape,
+        // would pass under either scheme and so could not tell them apart.
+        String expected = "4d:1a:39:2e:6a:18:60:9a:c5:2a:cb:cc:6c:de:22:b5";
+
+        assertEquals(expected, Ec2KeyMaterial.fingerprintOf(RSA_PUBLIC_KEY));
+        assertEquals(expected, Ec2KeyMaterial.fingerprintOf(RSA_PUBLIC_KEY + " someone@example.com"));
+
+        // The other candidate scheme for the same key: MD5 over the SSH wire blob, which is
+        // what "ssh-keygen -l -E md5" reports. AWS does not use it for imported RSA keys, and
+        // it is a different value, which is what makes the assertion above load bearing.
+        assertNotEquals("e7:d6:55:60:68:18:8f:b7:4f:2a:72:20:0b:2f:f2:d9",
+                Ec2KeyMaterial.fingerprintOf(RSA_PUBLIC_KEY));
+    }
+
+    @Test
+    void importedEd25519FingerprintIsTheBase64Sha256AwsReports() {
+        // EC2 fingerprints ed25519 keys with SHA-256, not MD5, whichever way the key arrived.
+        // Derived independently with "ssh-keygen -l -f ed25519.pub", which prints
+        //   SHA256:UOyzahv0Ty520U89wfCvKdTlp2TbtpmnlpJHPW3MbMk
+        // AWS reports the same digest without the prefix and with base64 padding kept.
+        String fingerprint = Ec2KeyMaterial.fingerprintOf(ED25519_PUBLIC_KEY);
+
+        assertEquals("UOyzahv0Ty520U89wfCvKdTlp2TbtpmnlpJHPW3MbMk=", fingerprint);
+        assertEquals(fingerprint,
+                Ec2KeyMaterial.fingerprintOf(ED25519_PUBLIC_KEY + " someone@example.com"));
+    }
+
+    @Test
+    void ed25519MaterialThatIsNotA32ByteKeyYieldsNoFingerprint() {
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf(
+                "ssh-ed25519 " + Base64.getEncoder().encodeToString(blobOf("ssh-ed25519", new byte[31]))));
+    }
+
+    @Test
+    void aFieldLongerThanTheBlobIsRejectedRatherThanAllocated() {
+        // ImportKeyPair passes the caller's material to this parser, so the declared field
+        // length is attacker controlled. A blob that announces a two-gigabyte field is a few
+        // bytes on the wire; allocating first turns that into an OutOfMemoryError, which is an
+        // Error and so escapes the catch inside fingerprintOf and takes the request thread
+        // with it. The length has to be rejected before the array exists.
+        ByteBuffer overstated = ByteBuffer.allocate(15);
+        byte[] type = "ssh-rsa".getBytes(StandardCharsets.UTF_8);
+        overstated.putInt(type.length).put(type).putInt(Integer.MAX_VALUE);
+
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf(
+                "ssh-rsa " + Base64.getEncoder().encodeToString(overstated.array())));
+    }
+
+    @Test
+    void negativeAndTruncatedFieldLengthsYieldNoFingerprint() {
+        ByteBuffer negative = ByteBuffer.allocate(4).putInt(-1);
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf(
+                "ssh-rsa " + Base64.getEncoder().encodeToString(negative.array())));
+
+        // Fewer than four bytes left: not even a length prefix.
+        assertEquals(null, Ec2KeyMaterial.fingerprintOf(
+                "ssh-rsa " + Base64.getEncoder().encodeToString(new byte[]{0, 0, 1})));
+    }
+
+    private static byte[] blobOf(String type, byte[] key) {
+        byte[] typeBytes = type.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.allocate(8 + typeBytes.length + key.length)
+                .putInt(typeBytes.length).put(typeBytes)
+                .putInt(key.length).put(key)
+                .array();
     }
 
     private static byte[] read(ByteBuffer blob) {

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -15,6 +15,7 @@ import io.github.hectorvent.floci.services.ec2.model.Instance;
 import io.github.hectorvent.floci.services.ec2.model.NetworkInterfaceListResult;
 import io.github.hectorvent.floci.services.ec2.model.IpPermission;
 import io.github.hectorvent.floci.services.ec2.model.Ipv6Range;
+import io.github.hectorvent.floci.services.ec2.model.KeyPair;
 import io.github.hectorvent.floci.services.ec2.model.SecurityGroupRule;
 import io.github.hectorvent.floci.services.ec2.model.UserIdGroupPair;
 import io.github.hectorvent.floci.services.ec2.model.InstanceState;
@@ -43,8 +44,13 @@ import io.github.hectorvent.floci.services.ec2.model.Vpc;
 import io.github.hectorvent.floci.services.ec2.model.VpcEndpoint;
 import io.github.hectorvent.floci.services.ec2.model.Volume;
 import io.github.hectorvent.floci.services.ec2.model.VolumeAttachment;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.junit.jupiter.api.Test;
 
+import java.io.StringReader;
+import java.security.interfaces.RSAPrivateCrtKey;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -787,6 +793,48 @@ class Ec2ServiceTest {
         AwsException error = assertThrows(AwsException.class,
                 () -> service.registerImage("us-east-1", "shared-name", null, null, null, List.of()));
         assertEquals("InvalidAMIName.Duplicate", error.getErrorCode());
+    }
+
+    @Test
+    void createKeyPairReturnsUsableMaterialRatherThanAPlaceholder() throws Exception {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        KeyPair first = service.createKeyPair("us-east-1", "usable-key");
+        KeyPair second = service.createKeyPair("us-east-1", "usable-key-2");
+
+        // Parse the material rather than shape-match it: the placeholder this replaced was a
+        // well-formed PEM envelope around 63 bytes of nothing, so any regex check passed.
+        Object parsed = new PEMParser(new StringReader(first.getKeyMaterial())).readObject();
+        assertTrue(parsed instanceof PEMKeyPair, "expected a PEM key pair, got: " + parsed);
+        assertEquals(2048, ((RSAPrivateCrtKey) new JcaPEMKeyConverter()
+                .getKeyPair((PEMKeyPair) parsed).getPrivate()).getModulus().bitLength());
+        // The public half is what RunInstances injects into authorized_keys.
+        assertNotNull(first.getPublicKey());
+        assertTrue(first.getPublicKey().startsWith("ssh-rsa "));
+        // A constant is not a fingerprint; two key pairs must differ in every disclosed field.
+        assertNotEquals(first.getKeyMaterial(), second.getKeyMaterial());
+        assertNotEquals(first.getPublicKey(), second.getPublicKey());
+        assertNotEquals(first.getKeyFingerprint(), second.getKeyFingerprint());
+    }
+
+    @Test
+    void importKeyPairFingerprintsTheSuppliedKeyRatherThanReportingAConstant() {
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        String firstKey = Ec2KeyMaterial.generateRsa().openSshPublicKey();
+        String secondKey = Ec2KeyMaterial.generateRsa().openSshPublicKey();
+
+        KeyPair first = service.importKeyPair("us-east-1", "imported-a", firstKey);
+        KeyPair second = service.importKeyPair("us-east-1", "imported-b", secondKey);
+
+        assertNotEquals(first.getKeyFingerprint(), second.getKeyFingerprint());
+        assertEquals(Ec2KeyMaterial.fingerprintOf(firstKey), first.getKeyFingerprint());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ec2/Ec2ServiceTest.java
@@ -838,6 +838,34 @@ class Ec2ServiceTest {
     }
 
     @Test
+    void importKeyPairReportsTheFingerprintAwsWouldReportForTheSameKey() {
+        // The assertion above compares the service against the same helper it calls, so it
+        // cannot see a wrong fingerprinting scheme. These two are pinned to values derived
+        // outside this codebase from fixed throwaway keys:
+        //   RSA:     openssl rsa -in rsa.pem -pubout -outform DER | openssl md5 -c
+        //   ed25519: ssh-keygen -l -f ed25519.pub, minus its "SHA256:" prefix, padding kept
+        // matching the two schemes AWS documents for ImportKeyPair.
+        Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
+                mock(Ec2PortForwardManager.class),
+                mock(AmiImageResolver.class), mock(Ec2ImageCatalog.class), new Ec2InstanceTypeCatalog(),
+                new InMemoryStorageFactory());
+
+        String rsaKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCp7mGC9NkQI+loxf1G9bM6HnCs9iR1nn"
+                + "zZA/f/o7hx/Wv1oDhx03k6H83I+Q49eE1XO56WBPxnr8/2G6UmS9D0RFKe9L+HJrfiZF7oLQ09Jw"
+                + "EK91VLNSkD0Bq2zhnfWJe/ULkaPQ7FgHEghRi8aI5PsATH6VCaJDKWxl+2bzM7MWlbKRAo8uuu2e"
+                + "vnGrgnu+RmuXJQCRYz6lG+JESVzm6MnHXYxme+UD+7c/tTYwzoswfXh8VN8QVzXmjfHi2Ve3PJ+Y"
+                + "uF2X2gKpRMNMf7cLWMCTOhZI2AgXX+NLDlCG0dEUm/DXdSKRTDhm3mIJmF67eGYuff+zHusBZ9cS"
+                + "BkW9i9";
+        String ed25519Key =
+                "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAII0fBPBUZHaEOBc2mySfmI5btu4mkvFfNRujmF7RH2fj";
+
+        assertEquals("4d:1a:39:2e:6a:18:60:9a:c5:2a:cb:cc:6c:de:22:b5",
+                service.importKeyPair("us-east-1", "pinned-rsa", rsaKey).getKeyFingerprint());
+        assertEquals("UOyzahv0Ty520U89wfCvKdTlp2TbtpmnlpJHPW3MbMk=",
+                service.importKeyPair("us-east-1", "pinned-ed25519", ed25519Key).getKeyFingerprint());
+    }
+
+    @Test
     void importKeyPairRejectsDuplicateKeyName() {
         Ec2Service service = new Ec2Service(mockConfig(true), mock(Ec2ContainerManager.class),
                 mock(Ec2PortForwardManager.class),


### PR DESCRIPTION
## Summary

`CreateKeyPair` returned a hardcoded placeholder as `KeyMaterial`:

```
-----BEGIN RSA PRIVATE KEY-----\nMIIEpA...FAKE\n-----END RSA PRIVATE KEY-----
```

It is a well-formed PEM envelope containing nothing usable, and every call returned the same one. `ImportKeyPair` was worse in a quieter way: it reported a constant all-zero fingerprint regardless of the key supplied, so two different imported keys were indistinguishable.

This generates a real 2048-bit RSA key pair per call, stores the public half in `ssh-rsa` framing, and fingerprints the actual key material on import.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Incorrect behavior: `KeyMaterial` was not a key. Anything that parsed it failed, and anything that merely checked its shape passed, which is what let this survive. The same placeholder for every call also meant two key pairs were interchangeable, and a fingerprint that never varied meant `ImportKeyPair` could not distinguish the keys it was given.

Real EC2 returns a unique private key on create and a fingerprint derived from the key on import. Both are now true here. The material is a genuine PEM-encoded RSA private key, and two calls differ in material, public key and fingerprint.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Coverage: `Ec2KeyMaterialTest` (9) covers the helper; two cases in `Ec2ServiceTest` cover the wiring. 150 tests green across both classes.

Worth explaining why the second commit exists, since it is a test-only commit on a bug-fix PR. The first version of this change had 9 passing tests and was still not load-bearing: reverting the production code left the whole EC2 suite green, because the tests exercised the key-material helper in isolation and nothing covered the `Ec2Service` call sites that use it. The added tests go through `Ec2Service` and **parse** the returned PEM to a `RSAPrivateCrtKey` rather than pattern-matching its shape, precisely because the placeholder was a valid-looking envelope that any regex would accept. With the production change reverted they now fail with `malformed PEM data` and a constant all-zero fingerprint respectively.
