### PR TITLE
test(ec2): cover security group rule sources at the Terraform layer

### DIFF
--- a/compatibility-tests/compat-terraform/test/security-group-rule-sources-tf/main.tf
+++ b/compatibility-tests/compat-terraform/test/security-group-rule-sources-tf/main.tf
@@ -1,0 +1,93 @@
+# Regression coverage for #2266 at the Terraform layer.
+#
+# "Allow traffic from security group X" is how one tier is wired to another -- an ALB
+# to its backend tasks, an application to its database, a cluster to itself. When
+# AuthorizeSecurityGroupIngress dropped the source, the provider's create-wait could
+# not find the rule it had just made and the apply failed with
+# "couldn't find resource"; a response that reported the rule but lost the reference
+# would instead apply cleanly and then show as drift on every subsequent plan.
+#
+# Both of the standard spellings are exercised, because they read the source back
+# through different APIs: aws_security_group_rule polls DescribeSecurityGroups, and
+# aws_vpc_security_group_ingress_rule polls DescribeSecurityGroupRules.
+
+resource "aws_vpc" "sg_sources" {
+  cidr_block = "10.71.0.0/16"
+
+  tags = {
+    Name = "floci-sg-rule-sources"
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name        = "floci-sg-rule-sources-alb"
+  description = "Front tier"
+  vpc_id      = aws_vpc.sg_sources.id
+}
+
+resource "aws_security_group" "backend" {
+  name        = "floci-sg-rule-sources-backend"
+  description = "Back tier, reachable only from the front tier"
+  vpc_id      = aws_vpc.sg_sources.id
+}
+
+# The classic spelling: reads its source back off DescribeSecurityGroups.
+resource "aws_security_group_rule" "backend_from_alb" {
+  type                     = "ingress"
+  from_port                = 8080
+  to_port                  = 8080
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.backend.id
+  source_security_group_id = aws_security_group.alb.id
+  description              = "app traffic from the load balancer"
+}
+
+# Self-reference: a cluster whose members talk to each other. This is the shape that
+# fails first, because the group is both the rule's owner and its source.
+resource "aws_security_group_rule" "backend_self" {
+  type              = "ingress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  security_group_id = aws_security_group.backend.id
+  self              = true
+  description       = "intra-cluster traffic"
+}
+
+# The current spelling: reads its source back off DescribeSecurityGroupRules, and
+# needs referencedGroupInfo rather than a UserIdGroupPair.
+resource "aws_vpc_security_group_ingress_rule" "backend_from_alb_v2" {
+  security_group_id            = aws_security_group.backend.id
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 9090
+  to_port                      = 9090
+  ip_protocol                  = "tcp"
+  description                  = "admin traffic from the load balancer"
+}
+
+# A CIDR rule alongside them: the reference must not be lost when a group carries
+# both kinds, and a CIDR rule must not sprout a phantom reference.
+resource "aws_vpc_security_group_ingress_rule" "backend_from_cidr" {
+  security_group_id = aws_security_group.backend.id
+  cidr_ipv4         = "10.71.0.0/16"
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  description       = "https from inside the vpc"
+}
+
+output "alb_sg_id" {
+  value = aws_security_group.alb.id
+}
+
+output "backend_sg_id" {
+  value = aws_security_group.backend.id
+}
+
+output "backend_from_alb_v2_rule_id" {
+  value = aws_vpc_security_group_ingress_rule.backend_from_alb_v2.security_group_rule_id
+}
+
+output "backend_from_cidr_rule_id" {
+  value = aws_vpc_security_group_ingress_rule.backend_from_cidr.security_group_rule_id
+}

--- a/compatibility-tests/compat-terraform/test/security-group-rule-sources-tf/provider.tf
+++ b/compatibility-tests/compat-terraform/test/security-group-rule-sources-tf/provider.tf
@@ -1,0 +1,35 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+variable "endpoint" {
+  type    = string
+  default = "http://localhost:4566"
+}
+
+provider "aws" {
+  region     = "us-east-1"
+  access_key = "test"
+  secret_key = "test"
+
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  s3_use_path_style           = true
+
+  # Deliberately NOT skip_requesting_account_id. The provider renders a same-account
+  # referenced_security_group_id as a bare group id and a cross-account one as
+  # "<account>/<group>", and it tells them apart by comparing ReferencedGroupInfo.UserId
+  # against its own resolved account. Skipping account resolution leaves that unknown,
+  # so every same-account reference reads back as cross-account and the plan never
+  # converges. Floci answers STS GetCallerIdentity, so there is nothing to skip.
+
+  endpoints {
+    ec2 = var.endpoint
+    sts = var.endpoint
+  }
+}

--- a/compatibility-tests/compat-terraform/test/security_group_rule_sources.bats
+++ b/compatibility-tests/compat-terraform/test/security_group_rule_sources.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# Security Group Rule Sources Compatibility Test
+#
+# Terraform-layer regression coverage for
+# https://github.com/floci-io/floci/issues/2266
+#
+# The fix is already covered by Ec2SecurityGroupRuleSourcesIntegrationTest and by an
+# AWS CLI case in sdk-test-awscli. This adds the layer where the bug actually bit:
+# the Terraform provider polls for the rule it just created and fails the apply when
+# it cannot find it, which no API-level assertion reproduces. It also pins the
+# quieter half of the same bug -- a rule that comes back without its source applies
+# cleanly and then shows as drift on every later plan, which only an empty re-plan
+# catches.
+#
+# This config has its own provider.tf rather than reusing the module's, because it
+# must NOT set skip_requesting_account_id. See the comment there: skipping account
+# resolution makes every same-account group reference read back as cross-account, and
+# the re-plan assertion below fails for a reason that has nothing to do with #2266.
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    SG_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/security-group-rule-sources-tf" && pwd)"
+    cd "$SG_TF_DIR"
+
+    echo "# === Security Group Rule Sources Test ===" >&3
+    echo "# Endpoint: $FLOCI_ENDPOINT" >&3
+    echo "# Config: $SG_TF_DIR" >&3
+
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+
+    echo "# --- terraform init ---" >&3
+    run terraform init -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform init failed: $output" >&3
+        return 1
+    fi
+
+    # This apply is itself the primary assertion. Before #2266 it failed with
+    # "waiting for Security Group Rule create: couldn't find resource".
+    echo "# --- terraform apply ---" >&3
+    run terraform apply -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform apply failed: $output" >&3
+        return 1
+    fi
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+
+    SG_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/security-group-rule-sources-tf" && pwd)"
+    cd "$SG_TF_DIR"
+
+    terraform destroy -var="endpoint=${FLOCI_ENDPOINT}" -input=false -auto-approve -no-color || true
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    SG_TF_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/security-group-rule-sources-tf" && pwd)"
+}
+
+@test "SG rule sources: applying a config with group-referencing rules succeeds" {
+    # setup_file returns non-zero if the apply failed, which fails every test in the
+    # file. Asserting the resulting state here makes the cause obvious in the output.
+    run terraform -chdir="$SG_TF_DIR" state list
+    assert_success
+    assert_output --partial "aws_security_group_rule.backend_from_alb"
+    assert_output --partial "aws_security_group_rule.backend_self"
+    assert_output --partial "aws_vpc_security_group_ingress_rule.backend_from_alb_v2"
+}
+
+@test "SG rule sources: DescribeSecurityGroups reports the referencing group" {
+    ALB=$(terraform -chdir="$SG_TF_DIR" output -raw alb_sg_id)
+    BACKEND=$(terraform -chdir="$SG_TF_DIR" output -raw backend_sg_id)
+
+    run aws_cmd ec2 describe-security-groups --group-ids "$BACKEND" \
+        --query "SecurityGroups[0].IpPermissions[?FromPort==\`8080\`].UserIdGroupPairs[0].GroupId | [0]" \
+        --output text
+    assert_success
+    assert_output "$ALB"
+}
+
+@test "SG rule sources: a self-referencing rule keeps its own group as the source" {
+    BACKEND=$(terraform -chdir="$SG_TF_DIR" output -raw backend_sg_id)
+
+    run aws_cmd ec2 describe-security-groups --group-ids "$BACKEND" \
+        --query "SecurityGroups[0].IpPermissions[?IpProtocol=='-1'].UserIdGroupPairs[0].GroupId | [0]" \
+        --output text
+    assert_success
+    assert_output "$BACKEND"
+}
+
+@test "SG rule sources: DescribeSecurityGroupRules reports referencedGroupInfo" {
+    ALB=$(terraform -chdir="$SG_TF_DIR" output -raw alb_sg_id)
+    RULE_ID=$(terraform -chdir="$SG_TF_DIR" output -raw backend_from_alb_v2_rule_id)
+
+    run aws_cmd ec2 describe-security-group-rules --security-group-rule-ids "$RULE_ID" \
+        --query "SecurityGroupRules[0].ReferencedGroupInfo.GroupId" --output text
+    assert_success
+    assert_output "$ALB"
+}
+
+@test "SG rule sources: a CIDR rule keeps its CIDR and gains no phantom reference" {
+    RULE_ID=$(terraform -chdir="$SG_TF_DIR" output -raw backend_from_cidr_rule_id)
+
+    run aws_cmd ec2 describe-security-group-rules --security-group-rule-ids "$RULE_ID" \
+        --query "SecurityGroupRules[0].CidrIpv4" --output text
+    assert_success
+    assert_output "10.71.0.0/16"
+
+    run aws_cmd ec2 describe-security-group-rules --security-group-rule-ids "$RULE_ID" \
+        --query "SecurityGroupRules[0].ReferencedGroupInfo" --output text
+    assert_success
+    assert_output "None"
+}
+
+# The assertion a successful apply cannot make. A response that reports the rule but
+# loses its source still applies cleanly; it only surfaces later, as a plan that never
+# converges. Scoped to this configuration, which is self-contained.
+@test "SG rule sources: re-planning reports no changes" {
+    cd "$SG_TF_DIR"
+    run terraform plan -var="endpoint=${FLOCI_ENDPOINT}" -input=false -no-color -detailed-exitcode
+    if [ "$status" -eq 2 ]; then
+        echo "# drift detected on re-plan:" >&3
+        echo "$output" >&3
+    fi
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Adds compat-terraform coverage for security-group rules whose source is another security group, the case fixed by #2266.

`main` has Java-level coverage in `Ec2SecurityGroupRuleSourcesIntegrationTest` and an awscli case in `ec2.bats`, but nothing exercises this through the Terraform provider. That matters here because the failure this guards against is provider-visible: a rule losing its source group shows up as permanent plan drift rather than as an API error, so the layer that reads it back is the layer worth pinning.

Test-only. No production code.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No behaviour change. The fixture applies a security group with three rule shapes (source group by id, self-reference, and an all-protocols rule) plus a CIDR rule as a control, then asserts through both `DescribeSecurityGroups` and `DescribeSecurityGroupRules` that the source group survives the round trip and that the CIDR rule reports no `ReferencedGroupInfo`. It finishes with a re-plan asserting `No changes`, which is the assertion that would have caught the original drift.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

The bats suite runs green: 6/6 against a running Floci with Terraform 1.15.8, after the usual `setup-bats` step to fetch `bats-core`, `bats-support` and `bats-assert` into `compatibility-tests/lib/` (gitignored, not included here). No Java is touched, so `./mvnw test` is unaffected by this change; I am ticking that box on the basis that nothing in it can move the Java suite rather than claiming a fresh full run.

No production change exists to revert, so there is no load-bearing proof to offer for this one. Saying that explicitly rather than leaving the impression it was checked the way a fix would be.
