### PR TITLE
fix(dynamodb): read every attribute through an ALL-projection index in PartiQL

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbPartiQLTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/DynamoDbPartiQLTest.java
@@ -349,4 +349,20 @@ class DynamoDbPartiQLTest {
                             .isEqualTo("NextToken does not match request");
                 });
     }
+
+    @Test
+    @Order(20)
+    void executeStatementReadsEveryAttributeThroughAllProjectionIndex() {
+        // status-index projects ALL, so a qualified read returns attributes that
+        // belong to no key, and naming one explicitly stays legal.
+        ExecuteStatementResponse all = ddb.executeStatement(r -> r
+                .statement("SELECT * FROM \"" + INDEX_TABLE + "\".\"status-index\" WHERE status = 'active'"));
+        assertThat(all.items()).hasSize(2);
+        assertThat(all.items().get(0)).containsKey("alternate");
+
+        ExecuteStatementResponse explicit = ddb.executeStatement(r -> r
+                .statement("SELECT alternate FROM \"" + INDEX_TABLE + "\".\"status-index\" WHERE status = 'active'"));
+        assertThat(explicit.items()).hasSize(2);
+        assertThat(explicit.items().get(0).get("alternate").s()).startsWith("alt-");
+    }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbPartiQLHandler.java
@@ -56,7 +56,7 @@ class DynamoDbPartiQLHandler {
         // projects; the message preserves statement order (characterised on
         // real AWS, eu-west-1, 2026-09-02). An LSI read reaches the co-located
         // base item, so non-projected columns stay legal there.
-        if (accessPath.isGlobalSecondaryIndex()) {
+        if (accessPath.isGlobalSecondaryIndex() && !"ALL".equals(accessPath.projectionType())) {
             Set<String> projected = accessPath.projectedAttributeNames(table);
             List<String> unprojected = stmt.columns().stream()
                     .filter(c -> !"*".equals(c))
@@ -151,8 +151,10 @@ class DynamoDbPartiQLHandler {
                     .toList();
         }
 
-        // SELECT * over an index reads the projection, not the whole item.
-        if (stmt.columns().isEmpty() && accessPath.isIndex()) {
+        // SELECT * over an index reads the projection, not the whole item. An
+        // ALL projection stores every base attribute, so nothing is trimmed.
+        if (stmt.columns().isEmpty() && accessPath.isIndex()
+                && !"ALL".equals(accessPath.projectionType())) {
             Set<String> projected = accessPath.projectedAttributeNames(table);
             items = items.stream()
                     .map(item -> (JsonNode) ProjectionEvaluator.trimToAttributes((ObjectNode) item, projected))

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
@@ -23,6 +23,7 @@ class DynamoDbAccessPathIntegrationTest {
     private static final String CONTENT_TYPE = "application/x-amz-json-1.0";
     private static final String TABLE = "access-path-validation";
     private static final String SIBLING_TABLE = "access-path-validation-sibling";
+    private static final String ALL_PROJECTION_TABLE = "access-path-validation-all-projection";
 
     @BeforeAll
     static void configureRestAssured() {
@@ -748,6 +749,85 @@ class DynamoDbAccessPathIntegrationTest {
                 .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
                 .contentType(CONTENT_TYPE)
                 .body("{\"TableName\":\"" + SIBLING_TABLE + "\"}")
+            .when()
+                .post("/")
+            .then()
+                .statusCode(200);
+        }
+    }
+
+    @Test
+    @Order(29)
+    void executeStatementReadsEveryAttributeThroughAllProjectionIndex() {
+        // An ALL projection stores every base attribute, so a qualified read
+        // returns them all and an explicit non-key column stays legal. Query
+        // and Scan already skip the projection trim for ALL; ExecuteStatement
+        // kept only the key attributes, so a caller reading its own data
+        // through an ALL-projection index silently lost every non-key
+        // attribute.
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.CreateTable")
+            .contentType(CONTENT_TYPE)
+            .body("""
+                {
+                  "TableName":"%s",
+                  "AttributeDefinitions":[
+                    {"AttributeName":"pk","AttributeType":"S"},
+                    {"AttributeName":"runId","AttributeType":"S"}
+                  ],
+                  "KeySchema":[{"AttributeName":"pk","KeyType":"HASH"}],
+                  "GlobalSecondaryIndexes":[{
+                    "IndexName":"all-projection-index",
+                    "KeySchema":[{"AttributeName":"runId","KeyType":"HASH"}],
+                    "Projection":{"ProjectionType":"ALL"}
+                  }],
+                  "BillingMode":"PAY_PER_REQUEST"
+                }
+                """.formatted(ALL_PROJECTION_TABLE))
+        .when()
+            .post("/")
+        .then()
+            .statusCode(200);
+        try {
+            request("DynamoDB_20120810.PutItem", """
+                    {
+                      "TableName":"%s",
+                      "Item":{"pk":{"S":"p1"},"runId":{"S":"run-1"},"rowsInserted":{"N":"7"}}
+                    }
+                    """.formatted(ALL_PROJECTION_TABLE))
+                .statusCode(200);
+
+            request("DynamoDB_20120810.ExecuteStatement", """
+                    {"Statement":"SELECT * FROM \\"%s\\".\\"all-projection-index\\" WHERE runId = 'run-1'"}
+                    """.formatted(ALL_PROJECTION_TABLE))
+                .statusCode(200)
+                .body("Items.size()", equalTo(1))
+                .body("Items[0].rowsInserted.N", equalTo("7"));
+
+            request("DynamoDB_20120810.ExecuteStatement", """
+                    {"Statement":"SELECT rowsInserted FROM \\"%s\\".\\"all-projection-index\\" WHERE runId = 'run-1'"}
+                    """.formatted(ALL_PROJECTION_TABLE))
+                .statusCode(200)
+                .body("Items.size()", equalTo(1))
+                .body("Items[0].rowsInserted.N", equalTo("7"));
+
+            // Query over the same index is the behaviour ExecuteStatement must match.
+            request("DynamoDB_20120810.Query", """
+                    {
+                      "TableName":"%s",
+                      "IndexName":"all-projection-index",
+                      "KeyConditionExpression":"runId = :r",
+                      "ExpressionAttributeValues":{":r":{"S":"run-1"}}
+                    }
+                    """.formatted(ALL_PROJECTION_TABLE))
+                .statusCode(200)
+                .body("Items.size()", equalTo(1))
+                .body("Items[0].rowsInserted.N", equalTo("7"));
+        } finally {
+            given()
+                .header("X-Amz-Target", "DynamoDB_20120810.DeleteTable")
+                .contentType(CONTENT_TYPE)
+                .body("{\"TableName\":\"" + ALL_PROJECTION_TABLE + "\"}")
             .when()
                 .post("/")
             .then()


### PR DESCRIPTION
## Summary

A PartiQL read qualified with a secondary index returns the wrong item when the index projects `ALL`: `SELECT *` drops every attribute that is not part of a key, and naming one of those attributes explicitly is rejected as unprojected. Both are wrong answers rather than errors, and `Query` against the same index already returns the whole item, so the two read paths disagree.

### What it looks like

Table `queue`, partition key `id`, GSI `idx-queue-run_id` on `run_id` with `"ProjectionType": "ALL"`, holding one item.

```
SELECT * FROM "queue"."idx-queue-run_id" WHERE "run_id" = 'abc123'
```

Before, on `main` at 520568ef. `rows_inserted` and `status` are gone, with no error:

```json
{"Items":[{"id":{"S":"r1"},"run_id":{"S":"abc123"}}]}
```

After:

```json
{"Items":[{"id":{"S":"r1"},"run_id":{"S":"abc123"},"rows_inserted":{"N":"7"},"status":{"S":"done"}}]}
```

`Query` on that same index returns the full item both before and after, which is what makes the disagreement visible:

```json
[{"id":{"S":"r1"},"run_id":{"S":"abc123"},"rows_inserted":{"N":"7"},"status":{"S":"done"}}]
```

Naming a non-key attribute fails outright before the change:

```
SELECT rows_inserted FROM "queue"."idx-queue-run_id" WHERE "run_id" = 'abc123'
```

Before: `ValidationException: One or more parameter values were invalid: Global secondary index idx-queue-run_id does not project [rows_inserted]`

After: `{"Items":[{"rows_inserted":{"N":"7"}}]}`

### Why it happens

`DynamoDbAccessPath.projectedAttributeNames` builds its set from the table key schema, the index key schema, and, for an `INCLUDE` projection, `NonKeyAttributes`. It has no `ALL` arm, because the full attribute set of a schemaless table cannot be derived from its schema. For an `ALL` projection it therefore returns the key attributes and nothing else.

Every other caller already accounts for that by short-circuiting before it reads the set:

- `DynamoDbService.readItemSize`: `if (!accessPath.isIndex() || "ALL".equals(accessPath.projectionType()))`
- `DynamoDbJsonHandler.applyIndexProjection`: `if ("ALL_ATTRIBUTES".equals(select) || "ALL".equals(accessPath.projectionType()))`
- `DynamoDbAccessPathValidator.validateSelection`: `if (!accessPath.isGlobalSecondaryIndex() || "ALL".equals(accessPath.projectionType()))`

`DynamoDbPartiQLHandler.executeSelect` is the only caller without it, at both points where it uses the set: the unprojected-column rejection and the `SELECT *` trim. That is why `Query` and `Scan` are correct and `ExecuteStatement` is not.

### The change

Adds the same guard at those two points. `INCLUDE` and `KEYS_ONLY` indexes trim and reject exactly as before, and base-table reads never reached this code.

The existing coverage used only `INCLUDE` and `KEYS_ONLY` indexes, which is why neither case surfaced. `DynamoDbAccessPathIntegrationTest` gains an `ALL`-projection index and asserts `SELECT *`, an explicit non-key column, and `Query` over the same index agreeing; `DynamoDbPartiQLTest` in the Java SDK compatibility suite asserts the same two reads through the AWS SDK against the existing `ALL`-projection `status-index`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`Projection.ProjectionType` documents `ALL` as "All of the table attributes are projected into the index", and notes that `ALL` projects "all attributes from the source table, even if the table has more than 100 attributes" ([API_Projection](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Projection.html), read 2026-09-09). The `Query` API reference is where the reachable-attribute rule is stated: a global secondary index query "can only request attributes that are projected into the index", which for an `ALL` projection is every attribute.

This change is derived from those documented projection semantics and from Floci's own `Query`, `Scan` and selection-validator behaviour against an `ALL` index. It is not backed by a fresh probe against a live account, so I have not quoted a characterisation run for it; the before and after above are against a packaged build of `main` and of this branch.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
