### PR TITLE
docs(lambda): correct the FunctionName charset claim in CodeStore

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/zip/CodeStore.java
@@ -70,11 +70,12 @@ public class CodeStore {
      *
      * <p>The {@link #VERSIONS_DIR_SUFFIX} is what keeps that sibling from colliding with a real
      * function. {@link #sanitizeName} maps every name into {@code [a-zA-Z0-9_.-]}, so no function
-     * can produce a directory name containing {@code @}, whatever it is called. Floci does not
-     * restrict the character set of {@code FunctionName} today, only that it is non-blank, so a
-     * plainer {@code <name>.v<n>} sibling carried no such guarantee: a function genuinely named
-     * {@code foo.v1} owns the exact directory {@code foo}'s version 1 would otherwise claim, and
-     * deleting either one silently corrupts the other.
+     * can produce a directory name containing {@code @}, whatever it is called. A plainer
+     * {@code <name>.v<n>} sibling carried no such guarantee, because a dot is an accepted character
+     * in a function name: {@code LambdaArnUtils} validates against {@code [a-zA-Z0-9-_.]+}, which is
+     * wider than the live service (issue #3238). So a function genuinely named {@code foo.v1} owns
+     * the exact directory {@code foo}'s version 1 would otherwise claim, and deleting either one
+     * silently corrupts the other.
      */
     public Path getVersionsPath(String accountId, String region, String functionName) {
         return baseDir.resolve(sanitizeName(accountId))

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/zip/CodeStoreTest.java
@@ -122,12 +122,13 @@ class CodeStoreTest {
     @Test
     void aVersionDirectoryCannotCollideWithAnotherFunctionsOwnDirectory(@TempDir Path baseDir)
             throws IOException {
-        // Floci does not restrict the character set of FunctionName today, only that it is
-        // non-blank, so "foo.v1" is a function a user can genuinely create. A "<name>.v<n>" sibling
-        // naming scheme handed it the exact directory version 1 of "foo" would claim, so deleting
-        // either function silently corrupted the other. The suffix used instead is outside the
-        // character set sanitizeName can emit, which makes the two namespaces disjoint by
-        // construction rather than by a prefix match that has to guess where the name ends.
+        // A dot is an accepted character in a function name: LambdaArnUtils validates against
+        // [a-zA-Z0-9-_.]+, which is wider than the live service (issue #3238), so "foo.v1" is a
+        // function a user can genuinely create. A "<name>.v<n>" sibling naming scheme handed it the
+        // exact directory version 1 of "foo" would claim, so deleting either function silently
+        // corrupted the other. The suffix used instead is outside the character set sanitizeName
+        // can emit, which makes the two namespaces disjoint by construction rather than by a prefix
+        // match that has to guess where the name ends.
         CodeStore store = new CodeStore(baseDir);
         writeHandler(store.getVersionCodePath(ACCOUNT_A, REGION, "foo", "1"), "foo-v1");
         writeHandler(store.getCodePath(ACCOUNT_A, REGION, "foo.v1"), "other-function");


### PR DESCRIPTION
## Summary

Refs #3238. Corrects two comments I wrote in #3041 that misdescribe the codebase.

The Javadoc on `CodeStore.getVersionsPath`, and the matching comment in `CodeStoreTest`, both say
Floci "does not restrict the character set of `FunctionName` today, only that it is non-blank".
That is wrong. `LambdaArnUtils.validateName` has validated the name since #450:

```java
private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9-_.]+");
private static final int MAX_NAME_LENGTH = 256;
```

The conclusion both comments draw is unaffected and still correct: a dot **is** an accepted
character, so `foo.v1` really is a function a user can create, and it really would have collided with
a `<name>.v<n>` sibling directory. That is why the `@versions` suffix exists and it should stay.
Only the stated reason was wrong.

It is worth correcting rather than leaving because of how it misleads. A reader who takes the comment
at face value goes looking for a validation that the comment says is not there, finds it, and now has
to work out which of the two to believe. Both comments now name the actual pattern and point at
\#3238, which tracks the divergence from the live service.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No behaviour change, so nothing moves toward or away from the live service here. The divergence the
corrected comments now describe accurately is real and is filed separately as #3238: Floci accepts
`FunctionName` values AWS rejects, specifically a dot in the name and a ceiling of 256 characters
against the live service's 64 for the name-only form. Measured against `main`, `foo.v1`, `..`, and a
200 character name are all accepted with `201 Created`. Changing that is a behaviour change with a
migration question attached, which is why it is an issue for a maintainer to direct rather than
something folded in here.

## How it was tested

Comment text only. No production statement, signature, or control flow is touched, and the diff is
entirely inside a Javadoc block and a `//` comment.

- `CodeStoreTest`: 11 run, 0 failures, 0 errors, on this branch
- A full `./mvnw test` is running locally as I open this; I will confirm the result in a comment
  rather than assert it here before it lands. CI covers it either way.

I re-checked `NAME_PATTERN` against this branch rather than relying on the earlier measurement, since
`CodeStore` has changed on `main` since #3041 and now carries a `region` parameter.

No new test. Per the project's Testing Policy, a change with no observable behaviour does not require
one, and there is nothing here to assert against.

## Checklist

- [ ] `./mvnw test` passes locally (affected class green, full run in progress, see above)
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
