### PR TITLE
feat(stepfunctions): add SNS Publish service integration

### DIFF
--- a/docs/services/step-functions.md
+++ b/docs/services/step-functions.md
@@ -357,10 +357,40 @@ the wire and the task fails with `Sfn.StateMachineDoesNotExistException`.
 | `arn:aws:states:::aws-sdk:sfn:sendTaskFailure` | `{}` | `Sfn.InvalidTokenException` |
 | `arn:aws:states:::aws-sdk:scheduler:createSchedule` | `{ScheduleArn}` | `Scheduler.ConflictException` when the name is taken |
 | `arn:aws:states:::aws-sdk:scheduler:updateSchedule` | `{ScheduleArn}` | `Scheduler.ResourceNotFoundException` |
+| `arn:aws:states:::aws-sdk:sns:publish` | `{MessageId}` | `Sns.NotFoundException` when the topic does not exist |
 
 `sendTaskSuccess` and `sendTaskFailure` resolve a token a `.waitForTaskToken` task is parked on. A
 token nobody is waiting for fails the calling task rather than reporting a delivery that never
 happened.
+
+## Publishing to SNS
+
+`arn:aws:states:::sns:publish` calls the SNS Publish API with the task's parameters and returns the
+Publish response, `{MessageId}`. `TopicArn`, `TargetArn`, `PhoneNumber`, `Message`, `Subject`,
+`MessageStructure`, `MessageAttributes`, `MessageGroupId` and `MessageDeduplicationId` are the API's
+own fields, so a FIFO topic needs a `MessageGroupId` here just as it does from the SDK. A `Message`
+given as an object rather than a string is published as its JSON text, which is how a
+`.waitForTaskToken` task hands its token to the subscriber:
+
+```json
+{
+  "Type": "Task",
+  "Resource": "arn:aws:states:::sns:publish.waitForTaskToken",
+  "Parameters": {
+    "TopicArn": "arn:aws:sns:us-east-1:000000000000:myTopic",
+    "Message": {
+      "Input.$": "$.message",
+      "TaskToken.$": "$$.Task.Token"
+    }
+  },
+  "End": true
+}
+```
+
+A failure names the SDK exception class under the `SNS.` prefix, so a topic that does not exist
+fails the task with `SNS.NotFoundException` and a missing `Message` with
+`SNS.InvalidParameterException`. `arn:aws:states:::aws-sdk:sns:publish` is the same call under the
+`Sns.` prefix, as the AWS SDK integration table above shows.
 
 ## Publishing events
 

--- a/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/sns/SnsJsonHandler.java
@@ -170,11 +170,13 @@ public class SnsJsonHandler {
         String message = request.path("Message").asText(null);
         String subject = request.path("Subject").asText(null);
         String messageStructure = request.path("MessageStructure").asText(null);
+        String messageGroupId = request.path("MessageGroupId").asText(null);
+        String messageDeduplicationId = request.path("MessageDeduplicationId").asText(null);
 
         Map<String, MessageAttributeValue> attributes = SnsMessageAttributes.parse(request.path("MessageAttributes"));
 
         String messageId = snsService.publish(topicArn, targetArn, phoneNumber, message, subject,
-                messageStructure, attributes, null, null, region);
+                messageStructure, attributes, messageGroupId, messageDeduplicationId, region);
         ObjectNode response = objectMapper.createObjectNode();
         response.put("MessageId", messageId);
         return Response.ok(response).build();

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -31,6 +31,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.s3.model.S3Object;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -202,6 +203,7 @@ public class AslExecutor {
     private final DynamoDbService dynamoDbService;
     private final DynamoDbJsonHandler dynamoDbJsonHandler;
     private final SqsJsonHandler sqsJsonHandler;
+    private final SnsJsonHandler snsJsonHandler;
     private final CloudFormationQueryHandler cloudFormationHandler;
     private final Ec2Service ec2Service;
     private final S3Service s3Service;
@@ -226,7 +228,8 @@ public class AslExecutor {
     @Inject
     public AslExecutor(LambdaExecutorService lambdaExecutor, LambdaFunctionStore functionStore,
                        DynamoDbService dynamoDbService, DynamoDbJsonHandler dynamoDbJsonHandler,
-                       SqsJsonHandler sqsJsonHandler, CloudFormationQueryHandler cloudFormationHandler,
+                       SqsJsonHandler sqsJsonHandler, SnsJsonHandler snsJsonHandler,
+                       CloudFormationQueryHandler cloudFormationHandler,
                        Ec2Service ec2Service, S3Service s3Service,
                        EcsService ecsService, EcsJsonHandler ecsJsonHandler,
                        EventBridgeHandler eventBridgeHandler, SchedulerService schedulerService,
@@ -240,6 +243,7 @@ public class AslExecutor {
         this.dynamoDbService = dynamoDbService;
         this.dynamoDbJsonHandler = dynamoDbJsonHandler;
         this.sqsJsonHandler = sqsJsonHandler;
+        this.snsJsonHandler = snsJsonHandler;
         this.cloudFormationHandler = cloudFormationHandler;
         this.ec2Service = ec2Service;
         this.s3Service = s3Service;
@@ -983,6 +987,18 @@ public class AslExecutor {
         if (resource.equals("arn:aws:states:::aws-sdk:sqs:sendMessage")) {
             String region = extractRegionFromArn(sm.getStateMachineArn());
             return invokeAwsSdkSqsSendMessage(input, region);
+        }
+
+        // SNS optimized integration
+        if (resource.equals("arn:aws:states:::sns:publish")) {
+            String region = extractRegionFromArn(sm.getStateMachineArn());
+            return invokeSnsPublish(input, region, "SNS.");
+        }
+
+        // AWS SDK service integration: SNS Publish
+        if (resource.equals("arn:aws:states:::aws-sdk:sns:publish")) {
+            String region = extractRegionFromArn(sm.getStateMachineArn());
+            return invokeSnsPublish(input, region, "Sns.");
         }
 
         // AWS SDK service integration: CloudFormation (query protocol → JSON)
@@ -1882,6 +1898,60 @@ public class AslExecutor {
             return jsonNode;
         }
         return objectMapper.createObjectNode();
+    }
+
+    /**
+     * {@code sns:publish} and {@code aws-sdk:sns:publish} share the SNS Publish API and differ only
+     * in the prefix of the error name a failure carries. A non-string {@code Message}, such as the
+     * object carrying {@code $$.Task.Token} in a {@code .waitForTaskToken} task, is serialized to
+     * its JSON text the way AWS does before the API sees it.
+     */
+    private JsonNode invokeSnsPublish(JsonNode input, String region, String errorPrefix) {
+        ObjectNode request = input != null && input.isObject()
+                ? ((ObjectNode) input.deepCopy())
+                : objectMapper.createObjectNode();
+
+        JsonNode message = request.get("Message");
+        if (message != null && !message.isTextual() && !message.isNull()) {
+            request.put("Message", message.toString());
+        }
+
+        jakarta.ws.rs.core.Response response;
+        try {
+            response = snsJsonHandler.handle("Publish", request, region);
+        } catch (AwsException e) {
+            throw new FailStateException(errorPrefix + snsExceptionName(e.getErrorCode()), e.getMessage());
+        } catch (Exception e) {
+            throw new FailStateException(errorPrefix + "InternalErrorException",
+                    e.getMessage() != null ? e.getMessage() : "SNS error");
+        }
+
+        Object entity = response.getEntity();
+        if (response.getStatus() >= 400) {
+            if (entity instanceof AwsErrorResponse err) {
+                throw new FailStateException(errorPrefix + snsExceptionName(err.type()), err.message());
+            }
+            if (entity instanceof JsonNode errorNode) {
+                String errorName = snsExceptionName(errorNode.path("__type").asText("UnknownError"));
+                String errorMessage = errorNode.path("message").asText(
+                        errorNode.path("Message").asText("SNS operation failed"));
+                throw new FailStateException(errorPrefix + errorName, errorMessage);
+            }
+            throw new FailStateException(errorPrefix + "InternalErrorException", "SNS operation failed");
+        }
+
+        if (entity instanceof JsonNode jsonNode) {
+            return jsonNode;
+        }
+        return objectMapper.createObjectNode();
+    }
+
+    /** The SDK exception class for an SNS wire error code: {@code NotFound} is {@code NotFoundException}. */
+    private static String snsExceptionName(String errorCode) {
+        if (errorCode == null || errorCode.isBlank()) {
+            return "InternalErrorException";
+        }
+        return errorCode.endsWith("Exception") ? errorCode : errorCode + "Exception";
     }
 
     private String normalizeSqsErrorCode(String errorCode, boolean awsSdkStyleErrors) {

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorArrayAndMathIntrinsicsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorArrayAndMathIntrinsicsTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -54,7 +55,7 @@ class AslExecutorArrayAndMathIntrinsicsTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class),
                 mock(Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorArrayParamsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorArrayParamsTest.java
@@ -18,7 +18,7 @@ class AslExecutorArrayParamsTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     private AslExecutor newExecutor() {
-        return new AslExecutor(null, null, null, null, null, null, null, null,
+        return new AslExecutor(null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, mapper, null, null, null, null, null);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorBranchHistoryEventsTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -65,7 +66,7 @@ class AslExecutorBranchHistoryEventsTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCatchTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -82,7 +83,7 @@ class AslExecutorCatchTest {
                 functionStore,
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorChoiceRuntimeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorChoiceRuntimeTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -47,7 +48,7 @@ class AslExecutorChoiceRuntimeTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class),
                 mock(Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCustomResourceLivenessTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorCustomResourceLivenessTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -77,7 +78,7 @@ class AslExecutorCustomResourceLivenessTest {
                 functionStore,
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorEcsRunTaskModeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorEcsRunTaskModeTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.ecs.model.NetworkConfiguration;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -63,7 +64,7 @@ class AslExecutorEcsRunTaskModeTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(io.github.hectorvent.floci.services.s3.S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorErrorTerminationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorErrorTerminationTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -76,7 +77,7 @@ class AslExecutorErrorTerminationTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHistoryEventLimitTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -191,7 +192,7 @@ class AslExecutorHistoryEventLimitTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHttpInvokeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorHttpInvokeTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.ecs.EcsJsonHandler;
 import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -163,7 +164,7 @@ class AslExecutorHttpInvokeTest {
             mock(LambdaFunctionStore.class),
             mock(DynamoDbService.class),
             mock(DynamoDbJsonHandler.class),
-            mock(SqsJsonHandler.class),
+            mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
             mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
             mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
             mock(io.github.hectorvent.floci.services.s3.S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicContextTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicContextTest.java
@@ -22,7 +22,7 @@ class AslExecutorIntrinsicContextTest {
 
     /** Only ObjectMapper is exercised by the path/intrinsic resolution methods under test. */
     private AslExecutor newExecutor() {
-        return new AslExecutor(null, null, null, null, null, null, null, null,
+        return new AslExecutor(null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, mapper, null, null, null, null, null);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicFunctionsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicFunctionsTest.java
@@ -13,6 +13,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -57,7 +58,7 @@ class AslExecutorIntrinsicFunctionsTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class),
                 mock(Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicMissingArgumentTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorIntrinsicMissingArgumentTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,7 @@ class AslExecutorIntrinsicMissingArgumentTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(io.github.hectorvent.floci.services.s3.S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorJsonMergeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorJsonMergeTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +43,7 @@ class AslExecutorJsonMergeTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class),
                 mock(Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaInvokeResultTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorLambdaInvokeResultTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -80,7 +81,7 @@ class AslExecutorLambdaInvokeResultTest {
                 functionStore,
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorMockedResponsesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorMockedResponsesTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -53,7 +54,7 @@ class AslExecutorMockedResponsesTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorNestedQueryLanguageTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorNestedQueryLanguageTest.java
@@ -8,6 +8,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -61,7 +62,7 @@ class AslExecutorNestedQueryLanguageTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorNestedStartExecutionTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorNestedStartExecutionTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -69,7 +70,7 @@ class AslExecutorNestedStartExecutionTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class),
                 mock(Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbJsonHandler;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import jakarta.enterprise.inject.Instance;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,7 @@ class AslExecutorPathIntrinsicsTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(io.github.hectorvent.floci.services.s3.S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultPathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultPathTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -42,7 +43,7 @@ class AslExecutorResultPathTest {
     void setUp() {
         executor = new AslExecutor(
                 mock(LambdaExecutorService.class), mock(LambdaFunctionStore.class),
-                mock(DynamoDbService.class), mock(DynamoDbJsonHandler.class), mock(SqsJsonHandler.class),
+                mock(DynamoDbService.class), mock(DynamoDbJsonHandler.class), mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class), mock(Ec2Service.class), mock(S3Service.class),
                 mock(EcsService.class), mock(EcsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultWriterTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorResultWriterTest.java
@@ -11,6 +11,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -62,7 +63,7 @@ class AslExecutorResultWriterTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 s3Service,

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorRetryTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorRetryTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -70,7 +71,7 @@ class AslExecutorRetryTest {
                 functionStore,
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
@@ -12,6 +12,7 @@ import io.github.hectorvent.floci.services.ecs.EcsService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -40,7 +41,7 @@ class AslExecutorStatePathTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(CloudFormationQueryHandler.class),
                 mock(Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTaskHistoryEventsTest.java
@@ -10,6 +10,7 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -66,7 +67,7 @@ class AslExecutorTaskHistoryEventsTest {
                 functionStore,
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTerminalStateTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorTerminalStateTest.java
@@ -7,6 +7,7 @@ import io.github.hectorvent.floci.services.dynamodb.DynamoDbService;
 import io.github.hectorvent.floci.services.lambda.LambdaExecutorService;
 import io.github.hectorvent.floci.services.lambda.LambdaFunctionStore;
 import io.github.hectorvent.floci.services.s3.S3Service;
+import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.model.Execution;
 import io.github.hectorvent.floci.services.stepfunctions.model.HistoryEvent;
@@ -54,7 +55,7 @@ class AslExecutorTerminalStateTest {
                 mock(LambdaFunctionStore.class),
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
-                mock(SqsJsonHandler.class),
+                mock(SqsJsonHandler.class), mock(SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorUnresolvableJsonPathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorUnresolvableJsonPathTest.java
@@ -22,7 +22,7 @@ class AslExecutorUnresolvableJsonPathTest {
     private final ObjectMapper mapper = new ObjectMapper();
 
     private AslExecutor newExecutor() {
-        return new AslExecutor(null, null, null, null, null, null, null, null,
+        return new AslExecutor(null, null, null, null, null, null, null, null, null,
                 null, null, null, null, null, mapper, null, null, null, null, null);
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsServicePersistenceTest.java
@@ -379,7 +379,7 @@ class StepFunctionsServicePersistenceTest {
         private final CountDownLatch completion = new CountDownLatch(1);
 
         private RestartableAslExecutor(Instance<StepFunctionsService> serviceInstance) {
-            super(null, null, null, null, null, null, null, null, null, null,
+            super(null, null, null, null, null, null, null, null, null, null, null,
                 null, null, null, new ObjectMapper(), null, serviceInstance, null, null, null);
         }
 

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSnsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/StepFunctionsSnsIntegrationTest.java
@@ -1,0 +1,453 @@
+package io.github.hectorvent.floci.services.stepfunctions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * The {@code arn:aws:states:::sns:publish} and {@code arn:aws:states:::aws-sdk:sns:publish}
+ * integrations, observed through an SQS queue subscribed to the topic with raw delivery so the
+ * queue body is exactly the published {@code Message}.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class StepFunctionsSnsIntegrationTest {
+
+    private static final String SFN_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String SQS_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String SNS_CONTENT_TYPE = "application/x-amz-json-1.0";
+    private static final String ROLE_ARN = "arn:aws:iam::000000000000:role/test-role";
+    private static final String MISSING_TOPIC_ARN = "arn:aws:sns:us-east-1:000000000000:sfn-sns-does-not-exist";
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static String queueUrl;
+    private static String topicArn;
+
+    @BeforeAll
+    static void configureRestAssured() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    @Order(0)
+    void setup_createTopicAndSubscribedQueue() {
+        queueUrl = createQueue("sfn-sns-integration-queue");
+        topicArn = createTopic("sfn-sns-integration-topic");
+        String subscriptionArn = subscribeQueue(topicArn, queueUrl);
+        setSubscriptionAttribute(subscriptionArn, "RawMessageDelivery", "true");
+    }
+
+    @Test
+    @Order(1)
+    void optimized_publish() throws Exception {
+        String output = executeSfn("optimized-publish", "arn:aws:states:::sns:publish", """
+                {
+                    "TopicArn": "%s",
+                    "Message": "hello optimized"
+                }
+                """.formatted(topicArn));
+
+        JsonNode result = mapper.readTree(output);
+        assertFalse(result.path("MessageId").asText().isBlank());
+
+        JsonNode message = receiveSingleMessage(queueUrl);
+        assertEquals("hello optimized", message.path("Body").asText());
+        deleteMessage(queueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(2)
+    void awsSdk_publish_withMessageAttributes() throws Exception {
+        String output = executeSfn("aws-sdk-publish", "arn:aws:states:::aws-sdk:sns:publish", """
+                {
+                    "TopicArn": "%s",
+                    "Message": "hello aws-sdk",
+                    "Subject": "greeting",
+                    "MessageAttributes": {
+                        "my_attribute_no_1": {
+                            "DataType": "String",
+                            "StringValue": "value of my_attribute_no_1"
+                        }
+                    }
+                }
+                """.formatted(topicArn));
+
+        JsonNode result = mapper.readTree(output);
+        assertFalse(result.path("MessageId").asText().isBlank());
+
+        JsonNode message = receiveSingleMessage(queueUrl);
+        assertEquals("hello aws-sdk", message.path("Body").asText());
+        assertEquals("value of my_attribute_no_1",
+                message.path("MessageAttributes").path("my_attribute_no_1").path("StringValue").asText());
+        deleteMessage(queueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(3)
+    void optimized_waitForTaskToken_serializesMessageObject() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::sns:publish.waitForTaskToken", """
+                {
+                    "TopicArn": "%s",
+                    "Message": {
+                        "Input": "callback requested",
+                        "TaskToken.$": "$$.Task.Token"
+                    }
+                }
+                """.formatted(topicArn));
+
+        String smArn = createStateMachine("sns-wait-token-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{}");
+
+        JsonNode message = receiveSingleMessage(queueUrl);
+        JsonNode body = mapper.readTree(message.path("Body").asText());
+        assertEquals("callback requested", body.path("Input").asText());
+        String taskToken = body.path("TaskToken").asText();
+        assertFalse(taskToken.isBlank());
+
+        sendTaskSuccess(taskToken, "{\"delivered\":true}");
+        String output = waitForExecution(execArn);
+        assertTrue(mapper.readTree(output).path("delivered").asBoolean());
+
+        deleteMessage(queueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(4)
+    void jsonata_publish_resolvesArguments() throws Exception {
+        String definition = """
+                {
+                    "QueryLanguage": "JSONata",
+                    "StartAt": "Publish",
+                    "States": {
+                        "Publish": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::sns:publish",
+                            "Arguments": {
+                                "TopicArn": "%s",
+                                "Message": "{%% $states.input.message %%}"
+                            },
+                            "End": true
+                        }
+                    }
+                }
+                """.formatted(topicArn);
+
+        String smArn = createStateMachine("sns-jsonata-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{\"message\":\"hello jsonata\"}");
+        String output = waitForExecution(execArn);
+        assertFalse(mapper.readTree(output).path("MessageId").asText().isBlank());
+
+        JsonNode message = receiveSingleMessage(queueUrl);
+        assertEquals("hello jsonata", message.path("Body").asText());
+        deleteMessage(queueUrl, message.path("ReceiptHandle").asText());
+    }
+
+    @Test
+    @Order(5)
+    void optimized_missingTopic_failsWithSnsErrorName() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::sns:publish", """
+                {
+                    "TopicArn": "%s",
+                    "Message": "noop"
+                }
+                """.formatted(MISSING_TOPIC_ARN));
+
+        String smArn = createStateMachine("sns-missing-topic-" + System.currentTimeMillis(), definition);
+        Response failed = waitForFailedExecution(startExecution(smArn, "{}"));
+        assertEquals("SNS.NotFoundException", failed.jsonPath().getString("error"));
+        assertEquals("Topic does not exist.", failed.jsonPath().getString("cause"));
+    }
+
+    @Test
+    @Order(6)
+    void awsSdk_missingTopic_failsWithSdkStyleErrorName() throws Exception {
+        String definition = buildStateMachineDefinition("arn:aws:states:::aws-sdk:sns:publish", """
+                {
+                    "TopicArn": "%s",
+                    "Message": "noop"
+                }
+                """.formatted(MISSING_TOPIC_ARN));
+
+        String smArn = createStateMachine("aws-sdk-sns-missing-topic-" + System.currentTimeMillis(), definition);
+        Response failed = waitForFailedExecution(startExecution(smArn, "{}"));
+        assertEquals("Sns.NotFoundException", failed.jsonPath().getString("error"));
+    }
+
+    @Test
+    @Order(7)
+    void optimized_missingMessage_isCatchable() throws Exception {
+        String definition = """
+                {
+                    "StartAt": "Publish",
+                    "States": {
+                        "Publish": {
+                            "Type": "Task",
+                            "Resource": "arn:aws:states:::sns:publish",
+                            "Parameters": {"TopicArn": "%s"},
+                            "Catch": [{"ErrorEquals": ["SNS.InvalidParameterException"], "Next": "Recovered"}],
+                            "End": true
+                        },
+                        "Recovered": {"Type": "Pass", "Result": {"recovered": true}, "End": true}
+                    }
+                }
+                """.formatted(topicArn);
+
+        String smArn = createStateMachine("sns-catch-" + System.currentTimeMillis(), definition);
+        String output = waitForExecution(startExecution(smArn, "{}"));
+        assertTrue(mapper.readTree(output).path("recovered").asBoolean());
+    }
+
+    @Test
+    @Order(8)
+    void cleanup() {
+        deleteTopic(topicArn);
+        deleteQueue(queueUrl);
+    }
+
+    private static String createQueue(String queueName) {
+        Response resp = given()
+                .header("X-Amz-Target", "AmazonSQS.CreateQueue")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueName":"%s"}
+                        """.formatted(queueName))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("QueueUrl");
+    }
+
+    private static String createTopic(String name) {
+        Response resp = given()
+                .header("X-Amz-Target", "SNS_20100331.CreateTopic")
+                .contentType(SNS_CONTENT_TYPE)
+                .body("""
+                        {"Name":"%s"}
+                        """.formatted(name))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("TopicArn");
+    }
+
+    private static String subscribeQueue(String topic, String queue) {
+        Response resp = given()
+                .header("X-Amz-Target", "SNS_20100331.Subscribe")
+                .contentType(SNS_CONTENT_TYPE)
+                .body("""
+                        {"TopicArn":"%s","Protocol":"sqs","Endpoint":"%s"}
+                        """.formatted(topic, queue))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("SubscriptionArn");
+    }
+
+    private static void setSubscriptionAttribute(String subscriptionArn, String name, String value) {
+        given()
+                .header("X-Amz-Target", "SNS_20100331.SetSubscriptionAttributes")
+                .contentType(SNS_CONTENT_TYPE)
+                .body("""
+                        {"SubscriptionArn":"%s","AttributeName":"%s","AttributeValue":"%s"}
+                        """.formatted(subscriptionArn, name, value))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private static void deleteTopic(String topic) {
+        if (topic == null) {
+            return;
+        }
+        given()
+                .header("X-Amz-Target", "SNS_20100331.DeleteTopic")
+                .contentType(SNS_CONTENT_TYPE)
+                .body("""
+                        {"TopicArn":"%s"}
+                        """.formatted(topic))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private JsonNode receiveSingleMessage(String queue) throws Exception {
+        Response resp = given()
+                .header("X-Amz-Target", "AmazonSQS.ReceiveMessage")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s","MaxNumberOfMessages":1,"WaitTimeSeconds":1,"MessageAttributeNames":["All"]}
+                        """.formatted(queue))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        JsonNode messages = mapper.readTree(resp.body().asString()).path("Messages");
+        assertEquals(1, messages.size(), "Expected one message");
+        return messages.get(0);
+    }
+
+    private static void deleteMessage(String queue, String receiptHandle) {
+        given()
+                .header("X-Amz-Target", "AmazonSQS.DeleteMessage")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s","ReceiptHandle":"%s"}
+                        """.formatted(queue, receiptHandle))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private static void deleteQueue(String queue) {
+        if (queue == null) {
+            return;
+        }
+        given()
+                .header("X-Amz-Target", "AmazonSQS.DeleteQueue")
+                .contentType(SQS_CONTENT_TYPE)
+                .body("""
+                        {"QueueUrl":"%s"}
+                        """.formatted(queue))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private String executeSfn(String nameSuffix, String resource, String parameters) throws Exception {
+        String definition = buildStateMachineDefinition(resource, parameters);
+        String smArn = createStateMachine(nameSuffix + "-" + System.currentTimeMillis(), definition);
+        String execArn = startExecution(smArn, "{}");
+        return waitForExecution(execArn);
+    }
+
+    private String buildStateMachineDefinition(String resource, String parameters) {
+        return """
+                {
+                    "StartAt": "Action",
+                    "States": {
+                        "Action": {
+                            "Type": "Task",
+                            "Resource": "%s",
+                            "Parameters": %s,
+                            "End": true
+                        }
+                    }
+                }
+                """.formatted(resource, parameters.strip());
+    }
+
+    private String createStateMachine(String name, String definition) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.CreateStateMachine")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {
+                            "name": "%s",
+                            "definition": %s,
+                            "roleArn": "%s"
+                        }
+                        """.formatted(name, quote(definition), ROLE_ARN))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("stateMachineArn");
+    }
+
+    private String startExecution(String smArn, String input) {
+        Response resp = given()
+                .header("X-Amz-Target", "AWSStepFunctions.StartExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {
+                            "stateMachineArn": "%s",
+                            "input": %s
+                        }
+                        """.formatted(smArn, quote(input)))
+                .when()
+                .post("/");
+        resp.then().statusCode(200);
+        return resp.jsonPath().getString("executionArn");
+    }
+
+    private void sendTaskSuccess(String taskToken, String output) {
+        given()
+                .header("X-Amz-Target", "AWSStepFunctions.SendTaskSuccess")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {
+                            "taskToken": %s,
+                            "output": %s
+                        }
+                        """.formatted(quote(taskToken), quote(output)))
+                .when()
+                .post("/")
+                .then()
+                .statusCode(200);
+    }
+
+    private String waitForExecution(String execArn) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            Response resp = describeExecution(execArn);
+            String status = resp.jsonPath().getString("status");
+            if ("SUCCEEDED".equals(status)) {
+                return resp.jsonPath().getString("output");
+            }
+            if ("FAILED".equals(status) || "ABORTED".equals(status)) {
+                fail("Execution " + status + ": " + resp.body().asString());
+            }
+            Thread.sleep(100);
+        }
+        fail("Execution did not complete within timeout");
+        return null;
+    }
+
+    private Response waitForFailedExecution(String execArn) throws InterruptedException {
+        for (int i = 0; i < 50; i++) {
+            Response resp = describeExecution(execArn);
+            String status = resp.jsonPath().getString("status");
+            if ("FAILED".equals(status)) {
+                return resp;
+            }
+            if ("SUCCEEDED".equals(status)) {
+                fail("Execution should have failed but succeeded: " + resp.body().asString());
+            }
+            Thread.sleep(100);
+        }
+        fail("Execution did not complete within timeout");
+        return null;
+    }
+
+    private Response describeExecution(String execArn) {
+        return given()
+                .header("X-Amz-Target", "AWSStepFunctions.DescribeExecution")
+                .contentType(SFN_CONTENT_TYPE)
+                .body("""
+                        {"executionArn": "%s"}
+                        """.formatted(execArn))
+                .when()
+                .post("/");
+    }
+
+    private static String quote(String raw) {
+        return "\"" + raw
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                + "\"";
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Step Functions SNS service integration described in
https://docs.aws.amazon.com/step-functions/latest/dg/connect-sns.html.

- `arn:aws:states:::sns:publish` (optimized) and `arn:aws:states:::aws-sdk:sns:publish`
  call the SNS Publish API through `SnsJsonHandler` and return the Publish response (`{MessageId}`).
- `.waitForTaskToken` works through the existing generic suffix handling; a `Message` given as an
  object (e.g. carrying `$$.Task.Token`) is serialized to its JSON text before publishing, as AWS does.
- Failures use the SDK exception class name: `SNS.NotFoundException` / `SNS.InvalidParameterException`
  on the optimized integration and `Sns.NotFoundException` on the `aws-sdk` one, so they are
  catchable via `Catch`/`Retry`.
- Both `Parameters` (JSONPath) and `Arguments` (JSONata) are supported.
- `SnsJsonHandler.Publish` now forwards `MessageGroupId` and `MessageDeduplicationId`; it was
  dropping them, which would have broken publishing to FIFO topics from a state machine
  (and from any JSON-protocol client).
- Docs: new "Publishing to SNS" section and an `aws-sdk:sns:publish` row in
  `docs/services/step-functions.md`.

Closes #2093

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Resource ARNs, parameter names (PascalCase `TopicArn`, `Message`, `Subject`, `MessageAttributes`,
`MessageGroupId`, `MessageDeduplicationId`, …), the `{MessageId}` result and the object-`Message`
serialization follow the AWS developer guide linked above. The optimized integration has no special
behavior beyond request/response and `.waitForTaskToken`, matching the guide. Error names follow
the `<Service>.<SdkExceptionClass>` convention already used by the `aws-sdk:*` integrations in this
repo.

Verified with the Step Functions JSON 1.0 protocol (`AWSStepFunctions.*` targets) and SQS/SNS
JSON protocols in the integration test; no new wire endpoints were added.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

