### PR TITLE
fix(compat): avoid CloudWatch statistics time race

### DIFF
--- a/compatibility-tests/sdk-test-node/tests/cloudwatch.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/cloudwatch.test.ts
@@ -77,8 +77,7 @@ describe('CloudWatch Metrics', () => {
   });
 
   it('should put metric data with statistic values', async () => {
-    const now = new Date();
-    const start = new Date(now.getTime() - 3600000);
+    const start = new Date(Date.now() - 3600000);
 
     // Put metric data with pre-calculated statistics
     await cw.send(
@@ -100,12 +99,13 @@ describe('CloudWatch Metrics', () => {
     );
 
     // Query back the statistics
+    const end = new Date();
     const response = await cw.send(
       new GetMetricStatisticsCommand({
         Namespace: namespace,
         MetricName: 'AggregatedMetric',
         StartTime: start,
-        EndTime: now,
+        EndTime: end,
         Period: 3600,
         Statistics: ['Sum', 'Average', 'Minimum', 'Maximum', 'SampleCount'],
       })


### PR DESCRIPTION
## Summary

Make the CloudWatch statistics compatibility test use an end time captured after `PutMetricData` completes. This prevents a one-second boundary race from producing an empty datapoint response and blocking unrelated pull requests.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The test previously captured `EndTime` before sending `PutMetricData`. If the request crossed a second boundary, Floci assigned the metric a timestamp later than that end time, so `GetMetricStatistics` returned no datapoints. The test now captures the end time after the write completes. This changes test timing only and does not change Floci's AWS wire behavior.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
