### PR TITLE
fix(compat): require Kinesis stream details

### DIFF
--- a/compatibility-tests/sdk-test-go/tests/kinesis_test.go
+++ b/compatibility-tests/sdk-test-go/tests/kinesis_test.go
@@ -43,11 +43,13 @@ func TestKinesis(t *testing.T) {
 	t.Run("DescribeStream", func(t *testing.T) {
 		r, err := svc.DescribeStream(ctx, &kinesis.DescribeStreamInput{StreamName: aws.String(streamName)})
 		require.NoError(t, err)
+		require.NotNil(t, r.StreamDescription)
 		assert.Equal(t, kinesistypes.StreamStatusActive, r.StreamDescription.StreamStatus)
-		if len(r.StreamDescription.Shards) > 0 {
-			shardID = aws.ToString(r.StreamDescription.Shards[0].ShardId)
-		}
+		require.NotEmpty(t, r.StreamDescription.Shards)
+		shardID = aws.ToString(r.StreamDescription.Shards[0].ShardId)
+		require.NotEmpty(t, shardID)
 		streamARN = aws.ToString(r.StreamDescription.StreamARN)
+		require.NotEmpty(t, streamARN)
 	})
 
 	t.Run("PutRecord", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Make the Kinesis Go compatibility test fail when `DescribeStream` omits the stream description, shards, shard ID, or stream ARN. Previously, missing fields could skip dependent checks and allow an invalid response to pass.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The test now validates the required `DescribeStream` response fields before using them. This improves compatibility coverage only and does not change Floci production behavior or AWS wire responses.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
