### PR TITLE
fix(docker): produce a working native image from Dockerfile.native

### DIFF
--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -38,6 +38,9 @@ ARG VERSION=latest
 ENV FLOCI_VERSION=${VERSION}
 ENV FLOCI_STORAGE_PERSISTENT_PATH=/app/data
 
+# The builder image has no zlib-static, so native-image links zlib dynamically and the
+# runner needs libz.so.1, which ubi9-micro does not ship. Take it from the builder image.
+COPY --from=build /usr/lib64/libz.so.1 /usr/lib64/libz.so.1
 COPY --chmod=755 --from=build /app/target/*-runner /app/application
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 COPY --chmod=755 docker/localstack-parity.sh docker/healthcheck.sh /usr/local/bin/

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -11,7 +11,14 @@ COPY pom.xml .
 RUN mvn dependency:go-offline -B
 COPY src ./src
 
-RUN mvn clean package -Dnative -DskipTests -B
+# Quarkus 3.39 switches on -H:+AOTSingleCallsiteInline for Mandrel 25.0.4+. The generated
+# REST invokers for AwsQueryController.dispatch and AwsJson11Controller.handle are each the
+# single call site of a very large method; inlined, the method outgrows the aarch64
+# conditional-branch range and the build dies with BranchTargetOutOfBoundsException.
+# The flag only exists on Mandrel, so it is passed here rather than in application.yml,
+# the same way the workflow native builds pass it.
+RUN mvn clean package -Dnative -DskipTests -B \
+    -Dquarkus.native.additional-build-args-append=-H:-AOTSingleCallsiteInline
 
 # Stage 2: Minimal runtime. Same base and user setup as Dockerfile.native-package.
 FROM registry.access.redhat.com/ubi9-micro:9.7


### PR DESCRIPTION
## Summary

Two separate problems stop `docker/Dockerfile.native` from producing a usable image. Both are fixed here. Only that file changes: no application code, no configuration, no docs.

**1. The build fails on arm64.**

```
Fatal error: BranchTargetOutOfBoundsException: Branch target 1208412 out of bounds
  at method: AwsQueryController$quarkusrestinvoker$dispatch_...invoke(Object, Object[])
```

The native build turns on `-H:+AOTSingleCallsiteInline`. That option inlines a method that is reached from exactly one call site, whatever its size. Each Query handler is reached from one switch case, each switch from one `handle()`, and each `handle()` from the single `AwsQueryController.dispatch` call site, so the whole handler tree ends up in one generated method of about 1.2 MB. An arm64 conditional branch can only jump 1 MB, so the jump cannot be encoded. On x86_64 the limit is 2 GB, which is why amd64 builds.

This was the only native build in the repository that did not pass `-H:-AOTSingleCallsiteInline`. The workflow builds have passed it since #3175, so this Dockerfile now passes it the same way, with the same comment. `application.yml` stays untouched, so a native build with a compiler that does not have this Mandrel option is unaffected.

**2. The image it builds cannot start.**

```
/app/application: error while loading shared libraries: libz.so.1: cannot open shared object file
```

The builder image carries zlib as a shared library only, so `native-image` links zlib dynamically and the binary needs `libz.so.1` at run time. The runtime base `ubi9-micro` does not ship it. The image now copies the library out of the builder stage. This one is not architecture specific: amd64 has the same gap. The published images are not affected, because their binaries are compiled on the CI runners, where zlib is available as a static library and gets compiled in.

## AWS Compatibility

No change in behaviour. `-H:-AOTSingleCallsiteInline` is the GraalVM default and the same setting every published binary is already built with, so this binary matches them. Nothing about request parsing, responses or errors is touched.

## What is covered

Legend: ✅ full, 🟡 partial, ❌ not implemented

| Area | Item | Status | Note |
| --- | --- | :-: | --- |
| Build | `docker/Dockerfile.native` on arm64 | ✅ | Compiles, and the image starts and answers requests |
| Build | `docker/Dockerfile.native` on amd64 | 🟡 | The compile already worked. The libz fix applies here too, but an amd64 build was not run: emulating it on this machine takes hours |
| Build | Workflow native builds (`build-images`, `nightly`, `release`, `compatibility`) | ✅ | Unchanged. They already pass the flag and their runtime image is `Dockerfile.native-package` |
| Build | `./mvnw package -Dnative` run directly on an arm64 machine | ❌ | Still fails. It needs `-Dquarkus.native.additional-build-args-append=-H:-AOTSingleCallsiteInline` on the command line. Putting the flag in `application.yml` would cover this too, but that is the case your comment rules out, so I left it alone. Happy to add it if you would rather have one place |
| Runtime | Image starts | ✅ | 0.023 s, `/_floci/health` returns 200 |
| Runtime | Query, JSON 1.1, REST XML, REST JSON requests | ✅ | Checked against the built image, see below |

## How this was checked

On an arm64 machine, with `docker buildx build --platform linux/arm64 -f docker/Dockerfile.native .`

| Step | Before | After |
| --- | --- | --- |
| Compile phase | 82.4 s, then `BranchTargetOutOfBoundsException` | 21.6 s |
| Build stage | fails | native executable produced in 1 m 22 s |
| Container start | `libz.so.1` missing, exit 127 | started in 0.023 s, health check 200 |

Requests against that image, covering each protocol the emulator serves:

- SQS `CreateQueue` and `SendMessage`, Query. This is the path that could not be compiled
- SNS `CreateTopic`, Query
- SSM `PutParameter`, JSON 1.1
- S3 create bucket, put object, get object, REST XML
- Lambda `ListFunctions`, REST JSON

All answered correctly.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [ ] `./mvnw test` passes locally. Not run, and `ci.yml` does not trigger for this path: the change is two lines in a Dockerfile, with no source, resource or configuration file touched. The native build was run instead, before and after, and the image it produces was started and exercised as listed above
- [ ] New or updated integration test added. Nothing to add: no test harness builds this Dockerfile
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
