### PR TITLE
fix(lambda): defer handler validation to invocation

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -2773,30 +2773,6 @@ public class LambdaService implements ResourceProvider {
                 }
             }
 
-            // For file-based runtimes, verify handler file exists (skip Java and .NET which use different handler formats)
-            if (fn.getRuntime() != null && !fn.getRuntime().startsWith("java") && !fn.getRuntime().startsWith("dotnet")) {
-                String handlerFile = resolveHandlerFilePath(fn);
-                boolean pythonRuntime = fn.getRuntime().startsWith("python");
-                boolean found;
-                try (var walk = Files.walk(codePath)) {
-                    found = walk
-                            .filter(Files::isRegularFile)
-                            .anyMatch(p -> {
-                                String relative = codePath.relativize(p).toString();
-                                String withoutExt = relative.contains(".")
-                                        ? relative.substring(0, relative.lastIndexOf('.'))
-                                        : relative;
-                                String normalized = withoutExt.replace('\\', '/');
-                                return normalized.equals(handlerFile)
-                                        || (pythonRuntime && normalized.equals(handlerFile + "/__init__"));
-                            });
-                }
-                if (!found) {
-                    throw new AwsException("InvalidParameterValueException",
-                            "Handler file '" + handlerFile + "' not found in deployment package", 400);
-                }
-            }
-
             // Deploy succeeded: keep the exact package so GetFunction can serve
             // a real Code.Location.
             storeDeploymentPackage(fn, zipBytes, region);
@@ -2893,22 +2869,6 @@ public class LambdaService implements ResourceProvider {
                     "Unable to fetch code from s3://" + s3Bucket + "/" + s3Key + ": " + e.getMessage(), 400);
         }
         extractZipCodeBytes(fn, obj.getData(), region);
-    }
-
-    private String resolveHandlerFilePath(LambdaFunction fn) {
-        String handler = fn.getHandler();
-        int lastDot = handler.lastIndexOf('.');
-        String modulePath = lastDot >= 0 ? handler.substring(0, lastDot) : handler;
-        if (fn.getRuntime().startsWith("python")) {
-            return modulePath.replace('.', '/');
-        }
-        // A file-based handler may be given with a leading "./" (e.g.
-        // "./v1/lambda-handlers/entry.handler"); deployment-package entries are stored without
-        // it, so normalize the prefix away before matching.
-        if (modulePath.startsWith("./")) {
-            modulePath = modulePath.substring(2);
-        }
-        return modulePath;
     }
 
     private void applyHotReload(LambdaFunction fn, String hostPath) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaLayerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaLayerIntegrationTest.java
@@ -34,6 +34,9 @@ class LambdaLayerIntegrationTest {
             zos.putNextEntry(new ZipEntry("nodejs/node_modules/my-lib/index.js"));
             zos.write("module.exports = { hello: () => 'world' };".getBytes());
             zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("python/entrypoint.py"));
+            zos.write("def lambda_handler(event, context): return {'from': 'layer'}".getBytes());
+            zos.closeEntry();
         }
         return Base64.getEncoder().encodeToString(baos.toByteArray());
     }
@@ -58,7 +61,7 @@ class LambdaLayerIntegrationTest {
             .body("""
                 {
                     "Content": { "ZipFile": "%s" },
-                    "CompatibleRuntimes": ["nodejs20.x", "nodejs22.x"],
+                    "CompatibleRuntimes": ["nodejs20.x", "nodejs22.x", "python3.12"],
                     "CompatibleArchitectures": ["x86_64"],
                     "Description": "Shared utilities v1",
                     "LicenseInfo": "MIT"
@@ -73,7 +76,7 @@ class LambdaLayerIntegrationTest {
             .body("LayerVersionArn", containsString(":layer:" + LAYER_NAME + ":1"))
             .body("Description", equalTo("Shared utilities v1"))
             .body("LicenseInfo", equalTo("MIT"))
-            .body("CompatibleRuntimes", hasItems("nodejs20.x", "nodejs22.x"))
+            .body("CompatibleRuntimes", hasItems("nodejs20.x", "nodejs22.x", "python3.12"))
             .body("CompatibleArchitectures", hasItem("x86_64"))
             .body("Content.CodeSize", greaterThan(0))
             .body("Content.CodeSha256", not(emptyString()))
@@ -188,15 +191,15 @@ class LambdaLayerIntegrationTest {
 
     @Test
     @Order(9)
-    void createFunction_withLayers_storesLayerArns() throws Exception {
+    void createFunction_acceptsHandlerProvidedByLayer() throws Exception {
         given()
             .contentType("application/json")
             .body("""
                 {
                     "FunctionName": "%s",
-                    "Runtime": "nodejs20.x",
+                    "Runtime": "python3.12",
                     "Role": "arn:aws:iam::000000000000:role/lambda-role",
-                    "Handler": "index.handler",
+                    "Handler": "entrypoint.lambda_handler",
                     "Code": { "ZipFile": "%s" },
                     "Layers": ["arn:aws:lambda:us-east-1:000000000000:layer:%s:1"]
                 }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/LambdaServiceTest.java
@@ -538,7 +538,7 @@ class LambdaServiceTest {
     }
 
     @Test
-    void createFunctionWithMissingHandler() throws Exception {
+    void createFunctionDoesNotValidateHandlerAtDeployTime() throws Exception {
         Map<String, Object> req = new java.util.HashMap<>(Map.of(
                 "FunctionName", "missing-handler-fn",
                 "Runtime", "nodejs20.x",
@@ -546,22 +546,24 @@ class LambdaServiceTest {
                 "Handler", "src/index.handler",
                 "Code", Map.of("ZipFile", createZipBase64("other.js"))
         ));
-        AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
-        assertEquals("InvalidParameterValueException", ex.getErrorCode());
+        LambdaFunction fn = service.createFunction(REGION, req);
+        assertEquals("src/index.handler", fn.getHandler());
     }
 
     @Test
-    void createFunctionWithMissingNestedPythonModuleHandler() throws Exception {
+    void updateFunctionCodeDoesNotValidateHandlerAtDeployTime() throws Exception {
         Map<String, Object> req = new java.util.HashMap<>(Map.of(
                 "FunctionName", "missing-nested-python-handler-fn",
                 "Runtime", "python3.11",
                 "Role", "arn:aws:iam::000000000000:role/test-role",
                 "Handler", "apps.foo.src.lambda_handler.lambda_handler",
-                "Code", Map.of("ZipFile", createZipBase64("apps/foo/src/other.py"))
+                "Code", Map.of("ZipFile", createZipBase64("apps/foo/src/lambda_handler.py"))
         ));
-        AwsException ex = assertThrows(AwsException.class, () -> service.createFunction(REGION, req));
-        assertEquals("InvalidParameterValueException", ex.getErrorCode());
-        assertTrue(ex.getMessage().contains("apps/foo/src/lambda_handler"));
+        service.createFunction(REGION, req);
+
+        LambdaFunction fn = service.updateFunctionCode(REGION, "missing-nested-python-handler-fn",
+                Map.of("ZipFile", createZipBase64("apps/foo/src/other.py")));
+        assertEquals("apps.foo.src.lambda_handler.lambda_handler", fn.getHandler());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Defer Lambda handler resolution from deployment to invocation time.
- Allow Python handlers supplied exclusively by Lambda layers.
- Cover `CreateFunction`, `UpdateFunctionCode`, and a layer-backed Python handler.

Fixes #3311

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously rejected ZIP deployments when the configured handler was not in the function archive. AWS accepts these deployments and resolves the handler at invocation time, which also permits handlers supplied by layers.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Verification

- Full Maven suite: 19,080 tests, 0 failures, 0 errors, 9 conditional skips
- `make docs-check` and docs tests: 53 passed
- `./mvnw -B -DskipTests clean test-compile`
- `./mvnw -B -DskipTests package`
- `git diff --check`

The full suite was partitioned with the repository's CI helper. Two wildcard-hostname tests ran with `floci.hostname=localhost`, and `ContainerNetworkReachabilityTest` ran in an isolated Linux network to avoid macOS TUN interception.
