### PR TITLE
feat(core): derive ARN partition from the region

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsArnUtils.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsArnUtils.java
@@ -19,11 +19,21 @@ public final class AwsArnUtils {
     public record Arn(String partition, String service, String region, String accountId, String resource) {
 
         /**
-         * Factory for standard AWS ARNs using the {@code aws} partition.
-         * Produces: {@code arn:aws:<service>:<region>:<accountId>:<resource>}
+         * Factory for AWS ARNs, deriving the partition from the region.
+         * Produces: {@code arn:<partition>:<service>:<region>:<accountId>:<resource>}
+         *
+         * <p>A resource in {@code cn-north-1} gets {@code aws-cn}, one in {@code us-gov-west-1}
+         * gets {@code aws-us-gov}, and everything else gets {@code aws}. See
+         * {@link AwsRegions#partitionFor}.
+         *
+         * <p>Global services pass an empty region and therefore keep {@code aws}. That is a known
+         * gap rather than a decision: an IAM ARN in a GovCloud deployment really is
+         * {@code arn:aws-us-gov:iam::…}, but nothing in the region argument can say so. Those call
+         * sites need a partition from the deployment, not from the resource, and they are left
+         * alone until there is one.
          */
         public static Arn of(String service, String region, String accountId, String resource) {
-            return new Arn("aws", service, region, accountId, resource);
+            return new Arn(AwsRegions.partitionFor(region), service, region, accountId, resource);
         }
 
         @Override

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsRegions.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsRegions.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.core.common;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Catalog of AWS regions the emulator advertises. Single source of truth for
@@ -52,6 +53,76 @@ public final class AwsRegions {
     /** True when {@code label} is exactly an AWS region id, case-insensitively. */
     public static boolean isRegionId(String label) {
         return label != null && KNOWN_IDS.contains(label.toLowerCase(Locale.ROOT));
+    }
+
+    /** The partition every region falls back to: the commercial one. */
+    public static final String DEFAULT_PARTITION = "aws";
+
+    /** The DNS suffix of the commercial partition, shared with {@code aws-us-gov}. */
+    public static final String DEFAULT_DNS_SUFFIX = "amazonaws.com";
+
+    private record PartitionRule(Pattern regionPattern, String partition, String dnsSuffix) {
+    }
+
+    /**
+     * Region-to-partition rules, transcribed from the AWS SDKs' own public partition metadata
+     * (botocore's {@code partitions.json}, MIT-licensed and openly published at
+     * https://github.com/boto/botocore/blob/develop/botocore/data/partitions.json). The patterns
+     * are that file's {@code regionRegex} values verbatim, so they stay comparable against it.
+     *
+     * <p>Only the non-commercial partitions need a rule: the commercial {@code aws} partition is
+     * the fallback, and {@code aws-us-gov} shares its DNS suffix, which is why GovCloud carries a
+     * rule for the partition id alone. The rules are mutually exclusive by construction (nothing
+     * matching {@code us-gov-*}, {@code us-iso-*} or {@code us-isob-*} matches the commercial
+     * shape, because {@code \w} does not cross a hyphen), so evaluation order is not load-bearing.
+     *
+     * <p>An unrecognised region resolves to {@code aws}. That is what the SDKs themselves do, and
+     * it keeps a region AWS launches tomorrow working rather than failing closed.
+     */
+    private static final List<PartitionRule> PARTITION_RULES = List.of(
+            new PartitionRule(Pattern.compile("^cn-\\w+-\\d+$"), "aws-cn", "amazonaws.com.cn"),
+            new PartitionRule(Pattern.compile("^us-gov-\\w+-\\d+$"), "aws-us-gov", DEFAULT_DNS_SUFFIX),
+            new PartitionRule(Pattern.compile("^us-iso-\\w+-\\d+$"), "aws-iso", "c2s.ic.gov"),
+            new PartitionRule(Pattern.compile("^us-isob-\\w+-\\d+$"), "aws-iso-b", "sc2s.sgov.gov"),
+            new PartitionRule(Pattern.compile("^eu-isoe-\\w+-\\d+$"), "aws-iso-e", "cloud.adc-e.uk"),
+            new PartitionRule(Pattern.compile("^us-isof-\\w+-\\d+$"), "aws-iso-f", "csp.hci.ic.gov"),
+            new PartitionRule(Pattern.compile("^eusc-de-\\w+-\\d+$"), "aws-eusc", "amazonaws.eu"));
+
+    /**
+     * The partition id a region belongs to: {@code aws}, {@code aws-us-gov}, {@code aws-cn}, or
+     * one of the classified partitions. This is the second segment of every ARN minted for a
+     * resource in that region.
+     *
+     * <p>A null, blank or unrecognised region gives {@code aws}. Blank is not an error case: many
+     * ARNs are global and carry no region at all ({@code arn:aws:iam::…}), and those keep the
+     * commercial partition because the resource's own region cannot say otherwise.
+     */
+    public static String partitionFor(String region) {
+        PartitionRule rule = ruleFor(region);
+        return rule == null ? DEFAULT_PARTITION : rule.partition();
+    }
+
+    /**
+     * The DNS suffix endpoints in a region's partition are served under, e.g.
+     * {@code amazonaws.com.cn} for {@code cn-north-1}. Same fallback rule as
+     * {@link #partitionFor}.
+     */
+    public static String dnsSuffixFor(String region) {
+        PartitionRule rule = ruleFor(region);
+        return rule == null ? DEFAULT_DNS_SUFFIX : rule.dnsSuffix();
+    }
+
+    private static PartitionRule ruleFor(String region) {
+        if (region == null || region.isBlank()) {
+            return null;
+        }
+        String normalized = region.trim().toLowerCase(Locale.ROOT);
+        for (PartitionRule rule : PARTITION_RULES) {
+            if (rule.regionPattern().matcher(normalized).matches()) {
+                return rule;
+            }
+        }
+        return null;
     }
 
     private AwsRegions() {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/EksTokenMinter.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/kubernetes/EksTokenMinter.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.lambda.launcher.kubernetes;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import io.github.hectorvent.floci.core.common.AwsRegions;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -305,41 +306,13 @@ final class EksTokenMinter {
     record AwsCredentials(String accessKeyId, String secretAccessKey, String sessionToken) {
     }
 
-    /** Maps a region to its STS hostname, honoring the region's actual partition. */
-    private static String stsHost(String region) {
-        return "sts." + region + "." + partitionDnsSuffix(region);
-    }
-
     /**
-     * Sourced from the AWS SDKs' own public partition metadata (e.g. botocore's
-     * {@code partitions.json}, MIT-licensed and openly published at
-     * https://github.com/boto/botocore/blob/develop/botocore/data/partitions.json), rather than
-     * assumed. Covers every partition that metadata currently defines: the commercial
-     * {@code aws} partition and {@code aws-us-gov} share {@code amazonaws.com} so neither needs
-     * a case of its own, {@code aws-cn} is the one commonly-hit split, and the classified
-     * ISO/ISOB/ISOE/ISOF partitions (regions matching {@code us-iso-*}, {@code us-isob-*},
-     * {@code eu-isoe-*}, {@code us-isof-*}) each resolve under their own distinct domain.
+     * Maps a region to its STS hostname, honoring the region's actual partition. The partition
+     * table lives in {@link AwsRegions}, shared with ARN construction, so a region added in one
+     * place cannot be missing from the other.
      */
-    private static String partitionDnsSuffix(String region) {
-        if (region.matches("cn-\\w+-\\d+")) {
-            return "amazonaws.com.cn";
-        }
-        if (region.matches("us-iso-\\w+-\\d+")) {
-            return "c2s.ic.gov";
-        }
-        if (region.matches("us-isob-\\w+-\\d+")) {
-            return "sc2s.sgov.gov";
-        }
-        if (region.matches("eu-isoe-\\w+-\\d+")) {
-            return "cloud.adc-e.uk";
-        }
-        if (region.matches("us-isof-\\w+-\\d+")) {
-            return "csp.hci.ic.gov";
-        }
-        if (region.matches("eusc-de-\\w+-\\d+")) {
-            return "amazonaws.eu";
-        }
-        return "amazonaws.com";
+    private static String stsHost(String region) {
+        return "sts." + region + "." + AwsRegions.dnsSuffixFor(region);
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsArnUtilsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsArnUtilsTest.java
@@ -1,0 +1,170 @@
+package io.github.hectorvent.floci.core.common;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * {@link AwsArnUtils} is the emulator's shared ARN helper and had no test of its own, despite
+ * routing the whole cross-service tagging API through {@code TagDispatcher}. These pin the
+ * parsing contract the callers depend on, most of it in the resource field: the helper splits
+ * six segments and deliberately hands the resource back whole, because its structure is
+ * service-specific.
+ */
+class AwsArnUtilsTest {
+
+    @Test
+    void parsesTheSixSegments() {
+        AwsArnUtils.Arn arn = AwsArnUtils.parse("arn:aws:sqs:us-east-1:000000000000:my-queue");
+
+        assertEquals("aws", arn.partition());
+        assertEquals("sqs", arn.service());
+        assertEquals("us-east-1", arn.region());
+        assertEquals("000000000000", arn.accountId());
+        assertEquals("my-queue", arn.resource());
+    }
+
+    /**
+     * The resource keeps its own colons. {@code split(":", 6)} is what makes a Lambda qualified
+     * ARN survive; a plain {@code split(":")} would strip the alias off the end.
+     */
+    @Test
+    void resourceKeepsItsOwnColons() {
+        AwsArnUtils.Arn arn = AwsArnUtils.parse(
+                "arn:aws:lambda:us-east-1:000000000000:function:order-processor:PROD");
+
+        assertEquals("function:order-processor:PROD", arn.resource());
+    }
+
+    /** Global services omit region and account, and those arrive as empty strings, never null. */
+    @Test
+    void omittedRegionAndAccountAreEmptyNotNull() {
+        AwsArnUtils.Arn arn = AwsArnUtils.parse("arn:aws:s3:::my-bucket");
+
+        assertEquals("", arn.region());
+        assertEquals("", arn.accountId());
+        assertEquals("my-bucket", arn.resource());
+    }
+
+    /** An empty resource is legal input and must not collapse the segment count. */
+    @Test
+    void emptyResourceStillParses() {
+        AwsArnUtils.Arn arn = AwsArnUtils.parse("arn:aws:glue:us-east-1:000000000000:");
+
+        assertEquals("glue", arn.service());
+        assertEquals("", arn.resource());
+    }
+
+    @Test
+    void parseIsTheInverseOfToString() {
+        String text = "arn:aws:iam::000000000000:role/service-role/my-role";
+
+        assertEquals(text, AwsArnUtils.parse(text).toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "arn:aws:sqs:us-east-1:000000000000",
+            "arn:aws:sqs",
+            "my-queue",
+            "urn:aws:sqs:us-east-1:000000000000:my-queue",
+            "  "})
+    void malformedArnsAreRejected(String value) {
+        assertThrows(IllegalArgumentException.class, () -> AwsArnUtils.parse(value));
+    }
+
+    @Test
+    void nullIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> AwsArnUtils.parse(null));
+    }
+
+    /**
+     * Non-commercial partitions parse like any other. Only construction pinned the partition,
+     * never parsing.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "arn:aws-us-gov:kms:us-gov-west-1:000000000000:key/abc, aws-us-gov, us-gov-west-1",
+            "arn:aws-cn:s3:cn-north-1:000000000000:bucket,          aws-cn,     cn-north-1",
+            "arn:aws-iso:sns:us-iso-east-1:000000000000:topic,      aws-iso,    us-iso-east-1"})
+    void foreignPartitionsParse(String text, String partition, String region) {
+        AwsArnUtils.Arn arn = AwsArnUtils.parse(text);
+
+        assertEquals(partition, arn.partition());
+        assertEquals(region, arn.region());
+    }
+
+    @Test
+    void regionOrDefaultFallsBackOnEveryFailureMode() {
+        assertEquals("us-east-1", AwsArnUtils.regionOrDefault(null, "us-east-1"));
+        assertEquals("us-east-1", AwsArnUtils.regionOrDefault("not-an-arn", "us-east-1"));
+        assertEquals("us-east-1", AwsArnUtils.regionOrDefault("arn:aws:s3:::bucket", "us-east-1"));
+        assertEquals("eu-west-1",
+                AwsArnUtils.regionOrDefault("arn:aws:sqs:eu-west-1:000000000000:q", "us-east-1"));
+    }
+
+    @Test
+    void accountOrDefaultFallsBackOnEveryFailureMode() {
+        assertEquals("000000000000", AwsArnUtils.accountOrDefault(null, "000000000000"));
+        assertEquals("000000000000", AwsArnUtils.accountOrDefault("not-an-arn", "000000000000"));
+        assertEquals("000000000000",
+                AwsArnUtils.accountOrDefault("arn:aws:s3:::bucket", "000000000000"));
+        assertEquals("123456789012",
+                AwsArnUtils.accountOrDefault("arn:aws:sqs:eu-west-1:123456789012:q", "000000000000"));
+    }
+
+    /**
+     * The partition is derived from the region, so a resource in GovCloud or China is named with
+     * the partition it actually lives in rather than always {@code aws}.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "us-east-1,      arn:aws:sqs:us-east-1:000000000000:q",
+            "eu-west-1,      arn:aws:sqs:eu-west-1:000000000000:q",
+            "us-gov-west-1,  arn:aws-us-gov:sqs:us-gov-west-1:000000000000:q",
+            "cn-north-1,     arn:aws-cn:sqs:cn-north-1:000000000000:q",
+            "us-iso-east-1,  arn:aws-iso:sqs:us-iso-east-1:000000000000:q",
+            "us-isob-east-1, arn:aws-iso-b:sqs:us-isob-east-1:000000000000:q",
+            "eu-isoe-west-1, arn:aws-iso-e:sqs:eu-isoe-west-1:000000000000:q",
+            "us-isof-south-1,arn:aws-iso-f:sqs:us-isof-south-1:000000000000:q",
+            "eusc-de-east-1, arn:aws-eusc:sqs:eusc-de-east-1:000000000000:q"})
+    void partitionIsDerivedFromTheRegion(String region, String expected) {
+        assertEquals(expected, AwsArnUtils.Arn.of("sqs", region, "000000000000", "q").toString());
+    }
+
+    /**
+     * Global services pass no region, and they keep the commercial partition. Thirty call sites
+     * do this; anything else would rewrite every IAM, S3 and CloudFront ARN the emulator mints.
+     */
+    @Test
+    void aRegionlessArnStaysInTheCommercialPartition() {
+        assertEquals("arn:aws:iam::000000000000:role/r",
+                AwsArnUtils.Arn.of("iam", "", "000000000000", "role/r").toString());
+    }
+
+    /** A region AWS has not launched yet must not fail closed. */
+    @Test
+    void anUnrecognisedRegionFallsBackToTheCommercialPartition() {
+        assertEquals("arn:aws:sqs:xx-nowhere-9:000000000000:q",
+                AwsArnUtils.Arn.of("sqs", "xx-nowhere-9", "000000000000", "q").toString());
+    }
+
+    /** The record constructor still takes an explicit partition, for echoing a caller's own. */
+    @Test
+    void theRecordConstructorKeepsAnExplicitPartition() {
+        assertEquals("arn:aws-cn:secretsmanager:us-east-1:000000000000:secret:s",
+                new AwsArnUtils.Arn("aws-cn", "secretsmanager", "us-east-1", "000000000000",
+                        "secret:s").toString());
+    }
+
+    @Test
+    void queueUrlIsAccountThenQueueName() {
+        assertEquals("http://localhost:4566/000000000000/my-queue",
+                AwsArnUtils.arnToQueueUrl("arn:aws:sqs:us-east-1:000000000000:my-queue",
+                        "http://localhost:4566"));
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/core/common/AwsRegionsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/AwsRegionsTest.java
@@ -2,8 +2,11 @@ package io.github.hectorvent.floci.core.common;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -43,5 +46,68 @@ class AwsRegionsTest {
     @Test
     void nullIsNotARegionId() {
         assertFalse(AwsRegions.isRegionId(null));
+    }
+
+    /**
+     * One row per partition botocore defines, so a partition going missing is a failing test
+     * rather than a silently commercial ARN.
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "us-east-1,       aws,        amazonaws.com",
+            "eu-west-1,       aws,        amazonaws.com",
+            "us-gov-west-1,   aws-us-gov, amazonaws.com",
+            "us-gov-east-1,   aws-us-gov, amazonaws.com",
+            "cn-north-1,      aws-cn,     amazonaws.com.cn",
+            "cn-northwest-1,  aws-cn,     amazonaws.com.cn",
+            "us-iso-east-1,   aws-iso,    c2s.ic.gov",
+            "us-isob-east-1,  aws-iso-b,  sc2s.sgov.gov",
+            "eu-isoe-west-1,  aws-iso-e,  cloud.adc-e.uk",
+            "us-isof-south-1, aws-iso-f,  csp.hci.ic.gov",
+            "eusc-de-east-1,  aws-eusc,   amazonaws.eu"})
+    void everyPartitionResolvesFromItsRegion(String region, String partition, String dnsSuffix) {
+        assertEquals(partition, AwsRegions.partitionFor(region));
+        assertEquals(dnsSuffix, AwsRegions.dnsSuffixFor(region));
+    }
+
+    /**
+     * The pair that would collide under a naive prefix check: {@code us-isob-east-1} is
+     * {@code aws-iso-b}, not {@code aws-iso}.
+     */
+    @Test
+    void isobIsNotIso() {
+        assertEquals("aws-iso", AwsRegions.partitionFor("us-iso-west-1"));
+        assertEquals("aws-iso-b", AwsRegions.partitionFor("us-isob-west-1"));
+    }
+
+    /**
+     * Blank is the common case, not an error: a global-service ARN carries no region and keeps
+     * the commercial partition.
+     */
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "xx-nowhere-9", "not-a-region", "us-gov", "cn-north"})
+    void blankAndUnrecognisedRegionsFallBackToCommercial(String region) {
+        assertEquals("aws", AwsRegions.partitionFor(region));
+        assertEquals("amazonaws.com", AwsRegions.dnsSuffixFor(region));
+    }
+
+    @Test
+    void regionMatchingIsCaseInsensitive() {
+        assertEquals("aws-cn", AwsRegions.partitionFor("CN-NORTH-1"));
+    }
+
+    /** Every GovCloud and China id the emulator recognises must land outside {@code aws}. */
+    @Test
+    void knownNonCommercialIdsAreNotCommercial() {
+        for (String region : AwsRegions.KNOWN_IDS) {
+            if (region.startsWith("us-gov-")) {
+                assertEquals("aws-us-gov", AwsRegions.partitionFor(region), region);
+            } else if (region.startsWith("cn-")) {
+                assertEquals("aws-cn", AwsRegions.partitionFor(region), region);
+            } else {
+                assertEquals("aws", AwsRegions.partitionFor(region), region);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

`AwsArnUtils.Arn.of` hardcoded the `aws` partition, so every ARN the emulator minted for a GovCloud or China region named the wrong partition. Correctness here was not a property of the call site: all 115 `Arn.of` callers and the 132 that reach it through `RegionResolver.buildArn` were equally wrong, including the ones following the documented pattern.

`AwsRegions` gains `partitionFor` and `dnsSuffixFor`, with the region patterns transcribed from botocore's `partitions.json` `regionRegex` values so they stay comparable against it. Only the non-commercial partitions need a rule; an unrecognised region resolves to `aws`, which is what the SDKs themselves do and which keeps a region AWS launches tomorrow working rather than failing closed.

`EksTokenMinter` already carried the same table for STS hostnames and now delegates to it, so a partition cannot go missing from one and not the other.

Global services pass an empty region and keep `aws`. That gap is documented on `Arn.of` rather than closed: an IAM ARN in a GovCloud deployment really is `arn:aws-us-gov:iam::...`, but nothing in the region argument can say so, and those call sites need a partition from the deployment instead.

This is the first of a short series. It only changes what the emulator emits; the matching work to accept those ARNs back on the inbound side follows separately.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The partition rules are transcribed from botocore's `partitions.json` (`regionRegex` and `outputs.dnsSuffix`), the same source `EksTokenMinter.partitionDnsSuffix` was already using, so the two tables cannot drift apart. No request or response shape changes.

No test in `src/test` or `compatibility-tests` constructs an ARN from a non-commercial region: the six test files that mention one are parsing a hostname or validating a supplied ARN. Emitted ARNs are therefore unchanged across the whole suite.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Notes on the checklist:

- `AwsArnUtils` is referenced from 120 files and had no test of its own. This adds `AwsArnUtilsTest`, written against the previous behaviour *before* the change, covering the resource field's colon handling that callers depend on. `AwsRegionsTest` is extended with one case per partition botocore defines, so a partition going missing is a failing test rather than a silently commercial ARN.
- `./mvnw test` is left unticked deliberately: it does not complete on my machine. It exhausts the configured `-Xmx6g` partway through `S3IntegrationTest` and reports ~5,679 tests over 543 classes, which looks like a clean full run but is 39% of the suite. Verified instead with this repo's own CI shard mechanism (`.github/ci/partition.sh` plus `surefire:test -Dsurefire.includesFile`), which covers all 1,465 classes and 19,050 tests. The only failures there are pre-existing and unrelated: three ElastiCache classes (port 6379 held by another container locally), `ContainerPlatformDockerIntegrationTest`, and `CfnSchemaCoverageTest`, the last of which I confirmed fails identically on a clean `origin/main` worktree.
