### PR TITLE
chore(tls): pin the certificate path against backslash mangling

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsConfigSource.java
@@ -45,6 +45,14 @@ public class TlsConfigSource implements ConfigSource {
 
     private static final Logger LOG = Logger.getLogger(TlsConfigSource.class);
 
+    /**
+     * Internal ports Quarkus binds when TLS is enabled. {@link TlsProxyServer} listens on the
+     * public Floci port and routes to these by protocol, so the two classes must agree; they are
+     * declared here, next to the properties that set them, and referenced from the proxy.
+     */
+    static final int HTTP_INTERNAL_PORT = 4510;
+    static final int HTTPS_INTERNAL_PORT = 4511;
+
     private static final String SERVER_CERT_NAME = "floci-server.crt";
     private static final String SERVER_KEY_NAME = "floci-server.key";
     private static final String SERVER_METADATA_NAME = "floci-server.metadata.json";
@@ -136,8 +144,8 @@ public class TlsConfigSource implements ConfigSource {
         // and does protocol detection to route HTTP and HTTPS to the correct backend.
         properties.put("quarkus.http.insecure-requests", "enabled");
         properties.put("quarkus.http.host", "127.0.0.1");
-        properties.put("quarkus.http.port", "4510");
-        properties.put("quarkus.http.ssl-port", "4511");
+        properties.put("quarkus.http.port", String.valueOf(HTTP_INTERNAL_PORT));
+        properties.put("quarkus.http.ssl-port", String.valueOf(HTTPS_INTERNAL_PORT));
 
         LOG.infov("TLS: HTTPS enabled, proxy will listen on port {0} (HTTP+HTTPS), cert={1}",
                 resolveProperty("floci.port", "4566"), certPath);

--- a/src/main/java/io/github/hectorvent/floci/config/TlsProxyServer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsProxyServer.java
@@ -51,8 +51,8 @@ public class TlsProxyServer {
     /** TLS record content type for Handshake (ClientHello). */
     private static final byte TLS_HANDSHAKE = 0x16;
 
-    private static final int HTTP_BACKEND_PORT = 4510;
-    private static final int HTTPS_BACKEND_PORT = 4511;
+    private static final int HTTP_BACKEND_PORT = TlsConfigSource.HTTP_INTERNAL_PORT;
+    private static final int HTTPS_BACKEND_PORT = TlsConfigSource.HTTPS_INTERNAL_PORT;
 
     private final Vertx vertx;
     private final EmulatorConfig config;

--- a/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsConfigSourceCertificatePathTest.java
@@ -1,0 +1,125 @@
+package io.github.hectorvent.floci.config;
+
+import io.smallrye.config.PropertiesConfigSource;
+import io.smallrye.config.SmallRyeConfig;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Guards the certificate path against the backslash-mangling that broke TLS startup on Windows
+ * in the sibling Azure emulator (floci-az #142), where a path such as
+ * {@code D:\Dev\floci\data\tls\cert.crt} reached the HTTP server as
+ * {@code D:Devflocidatatlscert.crt} and startup died with {@code NoSuchFileException}.
+ *
+ * <p>The mangling is not general SmallRye behaviour. Expression handling leaves a value with no
+ * {@code $} untouched, and it deliberately compiles without escape processing. The damage comes
+ * from {@code StringUtil.split}, which is reached only by the converter for collection-typed
+ * properties, and which consumes each backslash.
+ *
+ * <p>That makes the property's declared type the whole defence. floci-aws is safe today only
+ * because it writes {@code quarkus.tls.key-store.pem.0.cert}, a scalar {@code Path}. The key it
+ * used to write, {@code quarkus.http.ssl.certificate.files}, is an {@code Optional<List<Path>>}
+ * and is mangled. Nothing else records that distinction, so switching back would silently
+ * reintroduce the bug; these tests fail if that happens.
+ */
+class TlsConfigSourceCertificatePathTest {
+
+    /** A Windows path with no {@code $}, the shape that broke floci-az. */
+    private static final String WINDOWS_PATH = "D:\\Dev\\floci\\data\\tls\\floci-server.crt";
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setup() {
+        System.setProperty("floci.tls.enabled", "true");
+        System.setProperty("floci.tls.self-signed", "true");
+        System.setProperty("floci.storage.persistent-path", tempDir.toString());
+    }
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty("floci.tls.enabled");
+        System.clearProperty("floci.tls.self-signed");
+        System.clearProperty("floci.storage.persistent-path");
+    }
+
+    private static SmallRyeConfig config(String key, String value) {
+        return new SmallRyeConfigBuilder()
+                .addDefaultInterceptors()
+                .withSources(new PropertiesConfigSource(Map.of(key, value), "test", 300))
+                .build();
+    }
+
+    @Test
+    void aWindowsPathSurvivesAsAScalarPathProperty() {
+        SmallRyeConfig config = config("quarkus.tls.key-store.pem.0.cert", WINDOWS_PATH);
+
+        assertEquals(WINDOWS_PATH, config.getValue("quarkus.tls.key-store.pem.0.cert", String.class),
+                "a scalar property must round-trip a Windows path unchanged");
+        assertEquals(Path.of(WINDOWS_PATH),
+                config.getValue("quarkus.tls.key-store.pem.0.cert", Path.class),
+                "converting to Path must not lose the separators either");
+    }
+
+    @Test
+    void theSamePathIsMangledWhenReadAsACollection() {
+        // Not a wish, a demonstration: this is exactly what floci-az hit, and it is why the
+        // property's type is what protects us rather than anything in our own code.
+        SmallRyeConfig config = config("quarkus.tls.key-store.pem.0.cert", WINDOWS_PATH);
+
+        List<String> asList = config.getValues("quarkus.tls.key-store.pem.0.cert", String.class);
+
+        assertEquals(1, asList.size());
+        assertNotEquals(WINDOWS_PATH, asList.getFirst(),
+                "if this ever stops mangling, the collection converter changed and the guard below "
+                        + "can be relaxed");
+        assertEquals("D:Devflocidatatlsfloci-server.crt", asList.getFirst(),
+                "the collection converter consumes every backslash");
+    }
+
+    @Test
+    void theEmittedCertificateKeysAreScalarNotCollectionTyped() {
+        // The actual regression guard. Quarkus types `...pem.0.cert` as a scalar Path and
+        // `quarkus.http.ssl.certificate.files` as Optional<List<Path>>, so emitting the latter
+        // would put the certificate path back through the splitter that broke floci-az.
+        TlsConfigSource source = new TlsConfigSource();
+
+        String certKey = "quarkus.tls.key-store.pem.0.cert";
+        String keyKey = "quarkus.tls.key-store.pem.0.key";
+
+        assertNotNull(source.getValue(certKey), "the scalar PEM cert key must be the one emitted");
+        assertNotNull(source.getValue(keyKey), "the scalar PEM key key must be the one emitted");
+
+        for (String plural : List.of("quarkus.http.ssl.certificate.files",
+                "quarkus.http.ssl.certificate.key-files")) {
+            assertTrue(source.getValue(plural) == null,
+                    "must not emit " + plural + ": it is collection-typed, so a Windows path "
+                            + "would be mangled by the collection converter");
+        }
+    }
+
+    @Test
+    void theGeneratedPathIsAbsoluteAndUsableAsWritten() {
+        TlsConfigSource source = new TlsConfigSource();
+
+        String certPath = source.getValue("quarkus.tls.key-store.pem.0.cert");
+
+        assertNotNull(certPath);
+        assertTrue(Path.of(certPath).isAbsolute(), "the emitted path must be absolute: " + certPath);
+        assertTrue(java.nio.file.Files.exists(Path.of(certPath)),
+                "the emitted path must resolve to the generated certificate: " + certPath);
+    }
+}


### PR DESCRIPTION
## Summary

The sibling Azure emulator lost TLS startup on Windows: a path such as `D:\Dev\floci\data\tls\cert.crt` reached the HTTP server as `D:Devflocidatatlscert.crt` and died with `NoSuchFileException`.

That is not general SmallRye behaviour, which is what makes it easy to reintroduce. Expression handling leaves a value with no `$` untouched and deliberately compiles without escape processing. The damage comes from `StringUtil.split`, reached only by the converter for **collection-typed** properties, which consumes every backslash.

So the property's declared type is the entire defence. This emitter is safe today only because it writes `quarkus.tls.key-store.pem.0.cert`, a scalar `Path`. The key it wrote before the TLS registry migration, `quarkus.http.ssl.certificate.files`, is an `Optional<List<Path>>` and is mangled. Nothing in the code recorded that distinction, so moving back to a plural key would silently break Windows again.

This PR adds no behaviour change. It pins the property that is load-bearing, and tidies one adjacent duplication: the internal HTTP and HTTPS port literals are hoisted into constants on `TlsConfigSource`, because `TlsProxyServer` routes to those ports and had its own independent copies that could drift apart silently.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

N/A. This touches only how Floci configures its own HTTP server for TLS; no emulated AWS surface, request parsing or response shape is involved.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Notes on the checklist:

- `TlsConfigSourceCertificatePathTest` asserts a Windows-shaped path round-trips through a scalar property, **demonstrates the mangling on the collection path** so the reasoning above is evidence rather than assertion, and fails if the collection-typed keys are ever emitted again. That last test is the point of the PR.
- `./mvnw test` is unticked deliberately: it does not complete on my machine, exhausting the configured `-Xmx6g` partway through `S3IntegrationTest` while reporting what looks like a clean full run at roughly 39% of the suite. I verify with this repo's own CI shard mechanism (`.github/ci/partition.sh` plus `surefire:test -Dsurefire.includesFile`) instead.
