### PR TITLE
refactor(core): parse XML through one hardened factory, not four

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/XmlParser.java
@@ -43,6 +43,18 @@ public final class XmlParser {
     private XmlParser() {}
 
     /**
+     * A stream reader over {@code xml} using this class's hardened settings: namespace-aware,
+     * with DTDs and external entities disabled.
+     *
+     * <p>For callers whose parsing goes beyond the extraction helpers here, typically because
+     * they read attributes. Reaching for {@link XMLInputFactory} directly means restating the
+     * hardening, and a copy that forgets a property is an XXE hole that nothing would catch.
+     */
+    public static XMLStreamReader newStreamReader(String xml) throws XMLStreamException {
+        return FACTORY.createXMLStreamReader(new StringReader(xml));
+    }
+
+    /**
      * Parses XML into a namespace-aware DOM document with external entities and
      * DTD processing disabled. DOM is required by the JDK XML-DSig API.
      */

--- a/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/cloudfront/CloudFrontController.java
@@ -11,10 +11,8 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
-import java.io.StringReader;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -41,15 +39,6 @@ public class CloudFrontController {
     private static final String RESTRICTIONS = "Restrictions";
     private static final String DEFAULT_GEO_RESTRICTION_TYPE = "none";
     private static final int EMPTY_QUANTITY = 0;
-
-    private static final XMLInputFactory XML_FACTORY;
-
-    static {
-        XML_FACTORY = XMLInputFactory.newInstance();
-        XML_FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
-        XML_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        XML_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-    }
 
     private final CloudFrontService service;
 
@@ -2500,8 +2489,7 @@ public class CloudFrontController {
             return values;
         }
         try {
-            XMLStreamReader reader = XML_FACTORY.createXMLStreamReader(
-                    new StringReader(body));
+            XMLStreamReader reader = XmlParser.newStreamReader(body);
             boolean inDistributionConfig = false;
             int nestedDepth = 0;
             while (reader.hasNext()) {
@@ -2574,7 +2562,7 @@ public class CloudFrontController {
             return result;
         }
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inBlock = false;
             boolean inItem = false;
             Map<String, Object> current = null;
@@ -2641,7 +2629,7 @@ public class CloudFrontController {
             return result;
         }
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inOrigins = false;
             boolean inOrigin = false;
             boolean inS3OriginConfig = false;
@@ -2999,7 +2987,7 @@ public class CloudFrontController {
             return dcb;
         }
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inDcb = false;
             boolean inAllowedMethods = false;
             boolean inCachedMethods = false;
@@ -3282,7 +3270,7 @@ public class CloudFrontController {
             return result;
         }
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inCacheBehaviors = false;
             boolean inCacheBehavior = false;
             boolean inAllowedMethods = false;
@@ -3666,7 +3654,7 @@ public class CloudFrontController {
             return result;
         }
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inAliases = false;
             while (r.hasNext()) {
                 int event = r.next();
@@ -3695,7 +3683,7 @@ public class CloudFrontController {
             return result;
         }
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inVc = false;
             while (r.hasNext()) {
                 int event = r.next();

--- a/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/route53/Route53Controller.java
@@ -23,10 +23,8 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.Response;
 
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
-import java.io.StringReader;
 import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -62,15 +60,6 @@ public class Route53Controller {
             "cn-north-1", "cn-northwest-1",
             "af-south-1", "eu-south-1", "eu-south-2",
             "il-central-1", "mx-central-1");
-
-    private static final XMLInputFactory XML_FACTORY;
-
-    static {
-        XML_FACTORY = XMLInputFactory.newInstance();
-        XML_FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
-        XML_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        XML_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-    }
 
     @Inject
     Route53Service service;
@@ -913,7 +902,7 @@ public class Route53Controller {
         if (body == null || body.isEmpty()) return result;
 
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             String currentAction = null;
             ResourceRecordSet currentRrs = null;
             List<ResourceRecord> currentRecords = null;
@@ -1078,7 +1067,7 @@ public class Route53Controller {
         List<String> keys = new ArrayList<>();
         if (body == null || body.isEmpty()) return keys;
         try {
-            XMLStreamReader r = XML_FACTORY.createXMLStreamReader(new StringReader(body));
+            XMLStreamReader r = XmlParser.newStreamReader(body);
             boolean inRemove = false;
             while (r.hasNext()) {
                 int event = r.next();

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -42,7 +42,6 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 import jakarta.ws.rs.core.UriInfo;
 import java.io.ByteArrayOutputStream;
-import java.io.StringReader;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -59,7 +58,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
@@ -83,16 +81,7 @@ public class S3Controller {
     private static final DateTimeFormatter RFC_822 = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss z", Locale.US)
             .withZone(ZoneId.of("GMT"));
-    private static final XMLInputFactory NOTIFICATION_XML_FACTORY;
-
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
-    static {
-        NOTIFICATION_XML_FACTORY = XMLInputFactory.newInstance();
-        NOTIFICATION_XML_FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
-        NOTIFICATION_XML_FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        NOTIFICATION_XML_FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-    }
 
     private final S3Service s3Service;
     private final S3SelectService s3SelectService;
@@ -1760,7 +1749,7 @@ public class S3Controller {
             return result;
         }
         try {
-            XMLStreamReader reader = NOTIFICATION_XML_FACTORY.createXMLStreamReader(new StringReader(xml));
+            XMLStreamReader reader = XmlParser.newStreamReader(xml);
             while (reader.hasNext()) {
                 int event = reader.next();
                 if (event == XMLStreamConstants.START_ELEMENT && groupElement.equals(reader.getLocalName())) {

--- a/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/XmlParserTest.java
@@ -2,12 +2,92 @@ package io.github.hectorvent.floci.core.common;
 
 import org.junit.jupiter.api.Test;
 
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class XmlParserTest {
+
+    // --- newStreamReader: the hardening this centralises ---
+
+    /**
+     * The reason three controllers stopped standing up their own XMLInputFactory. Each restated
+     * these settings, and a copy that forgot one would be an XXE hole nothing would catch.
+     */
+    @Test
+    void newStreamReaderIgnoresEntitiesDeclaredInADoctype() throws Exception {
+        // The DTD is skipped rather than rejected, so the document itself still parses. What
+        // protects us is that nothing in it takes effect: an entity it declares stays undefined,
+        // so any reference to one fails instead of expanding.
+        String declaredButUnused = """
+                <!DOCTYPE root [ <!ENTITY x "expanded"> ]>
+                <Root><Value>plain</Value></Root>
+                """;
+
+        XMLStreamReader r = XmlParser.newStreamReader(declaredButUnused);
+        StringBuilder text = new StringBuilder();
+        while (r.hasNext()) {
+            if (r.next() == XMLStreamConstants.CHARACTERS) {
+                text.append(r.getText());
+            }
+        }
+        assertEquals("plain", text.toString().trim(), "the document parses, the DTD is ignored");
+
+        String referenced = """
+                <!DOCTYPE root [ <!ENTITY x "expanded"> ]>
+                <Root><Value>&x;</Value></Root>
+                """;
+
+        XMLStreamException e = assertThrows(XMLStreamException.class, () -> {
+            XMLStreamReader r2 = XmlParser.newStreamReader(referenced);
+            while (r2.hasNext()) {
+                r2.next();
+            }
+        }, "an entity from the skipped DTD must not expand");
+        assertTrue(e.getMessage().contains("not declared"),
+                "should fail because the DTD never took effect, was: " + e.getMessage());
+    }
+
+    @Test
+    void newStreamReaderDoesNotExpandAnExternalEntity() {
+        // Pointing at a path that does not exist: if the entity were resolved this would fail
+        // by trying to read it. Refusing the DTD outright is the behaviour we want.
+        String xml = """
+                <!DOCTYPE root [ <!ENTITY secret SYSTEM "file:///nonexistent/secret"> ]>
+                <Root><Value>&secret;</Value></Root>
+                """;
+
+        XMLStreamException e = assertThrows(XMLStreamException.class, () -> {
+            XMLStreamReader r = XmlParser.newStreamReader(xml);
+            while (r.hasNext()) {
+                r.next();
+            }
+        }, "an external entity must never be resolved");
+        assertTrue(e.getMessage().contains("not declared"),
+                "must fail without reading the file at all, was: " + e.getMessage());
+    }
+
+    @Test
+    void newStreamReaderIsNamespaceAwareAndReadsAttributes() throws Exception {
+        // Attributes are why a caller reaches for a raw reader instead of the helpers here.
+        String xml = "<Root xmlns=\"http://example.com/ns\"><Item id=\"7\" name=\"x\"/></Root>";
+
+        XMLStreamReader r = XmlParser.newStreamReader(xml);
+        String id = null;
+        while (r.hasNext()) {
+            if (r.next() == XMLStreamConstants.START_ELEMENT && "Item".equals(r.getLocalName())) {
+                id = r.getAttributeValue(null, "id");
+                assertEquals("http://example.com/ns", r.getNamespaceURI(),
+                        "the reader must be namespace-aware");
+            }
+        }
+        assertEquals("7", id);
+    }
 
     // --- extractGroupsMulti: nested element resilience ---
 


### PR DESCRIPTION
## Summary

CloudFront, Route 53 and S3 each stood up a private `XMLInputFactory` and each restated the same three hardening properties: namespace-aware, DTDs off, external entities off. `XmlParser` already held a fourth copy.

Four copies of security-relevant configuration is three too many, and a copy that one day forgets a property is an XXE hole with nothing to catch it.

`XmlParser` gains `newStreamReader`, exposing the factory it already holds, for the callers whose parsing goes past the extraction helpers because they read attributes. The three controllers drop their own factories and their ten call sites (CloudFront 7, Route 53 2, S3 1) go through it.

Behaviour is unchanged by construction: the four factories were byte-identical beforehand, same properties and same values, so no existing test needed touching. That was the check, not an afterthought.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

No wire-format change. The same parser configuration handles the same documents; only the number of places that configuration is written changes. `AGENTS.md` already requires XML parsing to go through `XmlParser` rather than ad-hoc parsers, so this brings the three controllers in line with the documented rule.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Notes on the checklist:

- `XmlParserTest` pins what is being centralised, which nothing covered before. Worth recording what writing it turned up: **`SUPPORT_DTD=false` does not reject a document type declaration, it silently skips it.** The protection is that nothing declared inside takes effect, so an entity referenced from it fails as undeclared rather than expanding, and an external one is never read. The tests assert that behaviour rather than the refusal I first assumed and wrote, which failed.
- Ran `XmlParserTest` plus the suites for all three affected controllers (`CloudFrontControllerTest`, `CloudFrontManagementProtocolTest`, `CloudFrontServiceTest`, `Route53IntegrationTest`, `S3NotificationModelTest`, `S3EventBridgeIntegrationTest`): 140 tests green.
- `./mvnw test` is unticked deliberately: it does not complete on my machine, exhausting the configured `-Xmx6g` partway through `S3IntegrationTest` while reporting what looks like a clean full run at roughly 39% of the suite. I verify with this repo's own CI shard mechanism (`.github/ci/partition.sh` plus `surefire:test -Dsurefire.includesFile`) instead.
