### PR TITLE
feat(marketplace-entitlement): emulate AWS Marketplace Entitlement API

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -292,6 +292,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>marketplaceagreement</artifactId>
         </dependency>
+        <!-- AWS Marketplace Entitlement client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>marketplaceentitlement</artifactId>
+        </dependency>
         <!-- IAM Access Analyzer client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.macie2.Macie2Client;
 import software.amazon.awssdk.services.controlcatalog.ControlCatalogClient;
 import software.amazon.awssdk.services.marketplacecatalog.MarketplaceCatalogClient;
 import software.amazon.awssdk.services.marketplaceagreement.MarketplaceAgreementClient;
+import software.amazon.awssdk.services.marketplaceentitlement.MarketplaceEntitlementClient;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
 import software.amazon.awssdk.services.securityhub.SecurityHubClient;
 import software.amazon.awssdk.services.detective.DetectiveClient;
@@ -371,6 +372,14 @@ public final class TestFixtures {
 
     public static MarketplaceAgreementClient marketplaceAgreementClient() {
         return MarketplaceAgreementClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static MarketplaceEntitlementClient marketplaceEntitlementClient() {
+        return MarketplaceEntitlementClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MarketplaceEntitlementTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MarketplaceEntitlementTest.java
@@ -1,0 +1,19 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.marketplaceentitlement.MarketplaceEntitlementClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MarketplaceEntitlementTest {
+
+    @Test
+    void usesAwsSdkWireContract() {
+        try (MarketplaceEntitlementClient client = TestFixtures.marketplaceEntitlementClient()) {
+            var response = client.getEntitlements(r -> r.productCode("product-local"));
+            assertNotNull(response.entitlements());
+            assertTrue(response.entitlements().isEmpty());
+        }
+    }
+}

--- a/docs/services/marketplace.md
+++ b/docs/services/marketplace.md
@@ -47,6 +47,7 @@ Floci emulates AWS Marketplace APIs under the shared `aws-marketplace` SigV4 sig
 | `SendAgreementCancellationRequest` | Sends an agreement cancellation request |
 | `SendAgreementPaymentRequest` | Sends an agreement payment request |
 | `UpdatePurchaseOrders` | Updates purchase orders for an agreement |
+| `GetEntitlements` | - |
 <!-- floci:actions:end -->
 
 ## Marketplace Catalog
@@ -61,6 +62,11 @@ Agreement request acceptance persists the resulting agreement and exposes it thr
 
 - Accepted agreements use a local 365-day duration instead of deriving the end time from requested terms.
 - `PartyType` is validated for AWS-compatible values but does not otherwise change which locally stored agreements match.
+
+## Marketplace Entitlement
+
+AWS exposes this service as read-only: `GetEntitlements` is the only public operation. Floci therefore does not add a non-AWS mutation endpoint. Entitlement records are loaded from the shared `StorageFactory` backend (`marketplace-entitlements.json` in persistent mode), so tests and local environments can pre-seed AWS-shaped entitlement state while preserving account isolation.
+
 
 ## Configuration
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -42,6 +42,7 @@ import io.github.hectorvent.floci.services.cloudmap.CloudMapHandler;
 import io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler;
 import io.github.hectorvent.floci.services.emr.EmrHandler;
 import io.github.hectorvent.floci.services.memorydb.MemoryDbHandler;
+import io.github.hectorvent.floci.services.marketplace.MarketplaceEntitlementController;
 import io.github.hectorvent.floci.services.wafv2.WafV2Handler;
 import io.github.hectorvent.floci.services.kinesis.KinesisJsonHandler;
 import io.github.hectorvent.floci.services.kinesisanalytics.KinesisAnalyticsV2JsonHandler;
@@ -131,6 +132,7 @@ public class AwsJson11Controller {
     private final IdentityStoreJsonHandler identityStoreJsonHandler;
     private final BudgetsJsonHandler budgetsJsonHandler;
     private final ServiceQuotasJsonHandler serviceQuotasJsonHandler;
+    private final MarketplaceEntitlementController marketplaceEntitlementController;
 
     @Inject
     public AwsJson11Controller(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -180,7 +182,8 @@ public class AwsJson11Controller {
                                SsoAdminJsonHandler ssoAdminJsonHandler,
                                IdentityStoreJsonHandler identityStoreJsonHandler,
                                BudgetsJsonHandler budgetsJsonHandler,
-                               ServiceQuotasJsonHandler serviceQuotasJsonHandler) {
+                               ServiceQuotasJsonHandler serviceQuotasJsonHandler,
+                               MarketplaceEntitlementController marketplaceEntitlementController) {
         this.objectMapper = objectMapper;
         this.strictBodyReader = objectMapper.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         this.catalog = catalog;
@@ -235,6 +238,7 @@ public class AwsJson11Controller {
         this.identityStoreJsonHandler = identityStoreJsonHandler;
         this.budgetsJsonHandler = budgetsJsonHandler;
         this.serviceQuotasJsonHandler = serviceQuotasJsonHandler;
+        this.marketplaceEntitlementController = marketplaceEntitlementController;
     }
 
     @POST
@@ -327,6 +331,7 @@ public class AwsJson11Controller {
                 case "budgets" -> budgetsJsonHandler.handle(action, request, regionResolver.getAccountId());
                 case "servicequotas" -> serviceQuotasJsonHandler.handle(
                         action, request, region, regionResolver.getAccountId());
+                case "marketplace" -> marketplaceEntitlementController.handle(action, request, region);
                 default -> null;
             };
             // catalog.matchTarget is protocol-agnostic: a JSON 1.0 target

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJsonCborController.java
@@ -16,6 +16,7 @@ import io.github.hectorvent.floci.services.kinesis.KinesisJsonHandler;
 import io.github.hectorvent.floci.services.sns.SnsJsonHandler;
 import io.github.hectorvent.floci.services.sqs.SqsJsonHandler;
 import io.github.hectorvent.floci.services.stepfunctions.StepFunctionsJsonHandler;
+import io.github.hectorvent.floci.services.marketplace.MarketplaceEntitlementController;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
@@ -57,6 +58,7 @@ public class AwsJsonCborController {
     private final KinesisJsonHandler kinesisJsonHandler;
     private final StepFunctionsJsonHandler sfnJsonHandler;
     private final CloudWatchMetricsJsonHandler cloudWatchMetricsJsonHandler;
+    private final MarketplaceEntitlementController marketplaceEntitlementController;
 
     @Inject
     public AwsJsonCborController(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -66,7 +68,8 @@ public class AwsJsonCborController {
                                  SqsJsonHandler sqsJsonHandler, SnsJsonHandler snsJsonHandler,
                                  KinesisJsonHandler kinesisJsonHandler,
                                  StepFunctionsJsonHandler sfnJsonHandler,
-                                 CloudWatchMetricsJsonHandler cloudWatchMetricsJsonHandler) {
+                                 CloudWatchMetricsJsonHandler cloudWatchMetricsJsonHandler,
+                                 MarketplaceEntitlementController marketplaceEntitlementController) {
         this.objectMapper = objectMapper;
         this.catalog = catalog;
         this.regionResolver = regionResolver;
@@ -77,6 +80,7 @@ public class AwsJsonCborController {
         this.kinesisJsonHandler = kinesisJsonHandler;
         this.sfnJsonHandler = sfnJsonHandler;
         this.cloudWatchMetricsJsonHandler = cloudWatchMetricsJsonHandler;
+        this.marketplaceEntitlementController = marketplaceEntitlementController;
     }
 
 
@@ -482,6 +486,7 @@ public class AwsJsonCborController {
             case "kinesis" -> kinesisJsonHandler.handle(operation, request, region);
             case "states" -> sfnJsonHandler.handle(operation, request, region);
             case "monitoring" -> cloudWatchMetricsJsonHandler.handle(operation, request, region);
+            case "marketplace" -> marketplaceEntitlementController.handle(operation, request, region);
             default -> null;
         };
     }

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -644,8 +644,8 @@ public class ResolvedServiceCatalog {
                         Set.of(io.github.hectorvent.floci.services.codegurureviewer.CodeGuruReviewerController.class)),
                 descriptor("marketplace", "marketplace", config.services().marketplace().enabled(), true,
                         "marketplace", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
-                        protocols(ServiceProtocol.REST_JSON, ServiceProtocol.JSON),
-                        Set.of("AWSMPCommerceService_v20200301."), Set.of("aws-marketplace"), Set.of(),
+                        protocols(ServiceProtocol.REST_JSON, ServiceProtocol.JSON, ServiceProtocol.CBOR),
+                        Set.of("AWSMPCommerceService_v20200301.", "AWSMPEntitlementService."), Set.of("aws-marketplace"), Set.of("AWS Marketplace Entitlement Service"),
                         Set.of(MarketplaceCatalogController.class))
         ));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementController.java
@@ -1,0 +1,24 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+/** Service-specific controller invoked by the shared AWS JSON 1.1 protocol handler. */
+@ApplicationScoped
+public class MarketplaceEntitlementController {
+    private final MarketplaceEntitlementService service;
+
+    @Inject
+    public MarketplaceEntitlementController(MarketplaceEntitlementService service) {
+        this.service = service;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        return switch (action) {
+            case "GetEntitlements" -> Response.ok(service.getEntitlements(request, region)).build();
+            default -> null;
+        };
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementService.java
@@ -1,0 +1,185 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.Resettable;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.marketplace.model.MarketplaceEntitlementRecord;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@ApplicationScoped
+public class MarketplaceEntitlementService implements Resettable {
+    private static final Set<String> FILTER_KEYS = Set.of(
+            "CUSTOMER_IDENTIFIER", "DIMENSION", "CUSTOMER_AWS_ACCOUNT_ID", "LICENSE_ARN");
+
+    private final ObjectMapper mapper;
+    private final AccountAwareStorageBackend<JsonNode> entitlements;
+
+    @Inject
+    public MarketplaceEntitlementService(StorageFactory factory, ObjectMapper mapper) {
+        this(mapper, factory.create("marketplace", "marketplace-entitlements.json",
+                new TypeReference<Map<String, JsonNode>>() {}));
+    }
+
+    MarketplaceEntitlementService(ObjectMapper mapper, AccountAwareStorageBackend<JsonNode> entitlements) {
+        this.mapper = mapper;
+        this.entitlements = entitlements;
+    }
+
+    ObjectNode getEntitlements(JsonNode request, String region) {
+        if (region != null && !region.isBlank() && !"us-east-1".equals(region)) {
+            throw new AwsException("InvalidParameterException",
+                    "AWS Marketplace Entitlement Service is available only in us-east-1.", 400);
+        }
+        String productCode = requireText(request, "ProductCode", 1, 255);
+        JsonNode filter = request == null ? null : request.get("Filter");
+        validateFilter(filter);
+
+        int maxResults = 25;
+        if (request != null && request.has("MaxResults")) {
+            if (!request.get("MaxResults").isIntegralNumber()
+                    || !request.get("MaxResults").canConvertToInt()) {
+                throw invalid("MaxResults must be an integer between 1 and 25.");
+            }
+            maxResults = request.get("MaxResults").asInt();
+            if (maxResults < 1 || maxResults > 25) {
+                throw invalid("MaxResults must be between 1 and 25.");
+            }
+        }
+        int offset = parseToken(request == null ? null : request.path("NextToken").asText(null));
+
+        List<StoredEntitlement> matches = new ArrayList<>();
+        for (JsonNode value : entitlements.scan(key -> key.startsWith(productCode + "/"))) {
+            matches.add(new StoredEntitlement(value, MarketplaceEntitlementRecord.fromJson(value)));
+        }
+        matches.removeIf(value -> !matchesFilter(value.record(), filter));
+        matches.sort(Comparator.comparing(value -> sortKey(value.record())));
+        if (offset > matches.size()) {
+            throw invalid("NextToken is invalid.");
+        }
+        int end = Math.min(matches.size(), offset + maxResults);
+        ObjectNode response = mapper.createObjectNode();
+        ArrayNode out = response.putArray("Entitlements");
+        matches.subList(offset, end).forEach(value -> out.add(value.raw().deepCopy()));
+        if (end < matches.size()) {
+            response.put("NextToken", Integer.toString(end));
+        }
+        return response;
+    }
+
+    private void validateFilter(JsonNode filter) {
+        if (filter == null || filter.isNull()) {
+            return;
+        }
+        if (!filter.isObject()) {
+            throw invalid("Filter must be an object.");
+        }
+        if (filter.has("CUSTOMER_IDENTIFIER") && filter.has("CUSTOMER_AWS_ACCOUNT_ID")) {
+            throw invalid("CustomerIdentifier and CustomerAWSAccountId are mutually exclusive.");
+        }
+        filter.fields().forEachRemaining(entry -> {
+            if (!FILTER_KEYS.contains(entry.getKey())) {
+                throw invalid("Unsupported filter key: " + entry.getKey());
+            }
+            JsonNode values = entry.getValue();
+            if (!values.isArray() || values.isEmpty()) {
+                throw invalid("Filter values for " + entry.getKey() + " must be a non-empty list.");
+            }
+            for (JsonNode value : values) {
+                if (!value.isTextual() || value.asText().isBlank()) {
+                    throw invalid("Filter values for " + entry.getKey() + " must be non-empty strings.");
+                }
+            }
+        });
+    }
+
+    private boolean matchesFilter(MarketplaceEntitlementRecord entitlement, JsonNode filter) {
+        if (filter == null || filter.isNull()) {
+            return true;
+        }
+        var fields = filter.fields();
+        while (fields.hasNext()) {
+            var entry = fields.next();
+            String actual = switch (entry.getKey()) {
+                case "CUSTOMER_IDENTIFIER" -> entitlement.customerIdentifier();
+                case "CUSTOMER_AWS_ACCOUNT_ID" -> entitlement.customerAwsAccountId();
+                case "DIMENSION" -> entitlement.dimension();
+                case "LICENSE_ARN" -> entitlement.licenseArn();
+                default -> throw invalid("Unsupported filter key: " + entry.getKey());
+            };
+            boolean matched = false;
+            for (JsonNode wanted : entry.getValue()) {
+                if (wanted.asText().equals(actual)) {
+                    matched = true;
+                    break;
+                }
+            }
+            if (!matched) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String sortKey(MarketplaceEntitlementRecord value) {
+        return textOrEmpty(value.customerAwsAccountId()) + "|"
+                + textOrEmpty(value.customerIdentifier()) + "|"
+                + textOrEmpty(value.dimension()) + "|"
+                + textOrEmpty(value.licenseArn());
+    }
+
+    private static String textOrEmpty(String value) {
+        return value == null ? "" : value;
+    }
+
+    private record StoredEntitlement(JsonNode raw, MarketplaceEntitlementRecord record) {
+    }
+
+    private static int parseToken(String token) {
+        if (token == null || token.isBlank()) {
+            return 0;
+        }
+        try {
+            int value = Integer.parseInt(token);
+            if (value < 0) {
+                throw new NumberFormatException();
+            }
+            return value;
+        } catch (NumberFormatException e) {
+            throw invalid("NextToken is invalid.");
+        }
+    }
+
+    private static String requireText(JsonNode request, String field, int min, int max) {
+        JsonNode value = request == null ? null : request.get(field);
+        if (value == null || !value.isTextual()) {
+            throw invalid(field + " is required.");
+        }
+        String text = value.asText();
+        if (text.length() < min || text.length() > max) {
+            throw invalid(field + " must be between " + min + " and " + max + " characters.");
+        }
+        return text;
+    }
+
+    private static AwsException invalid(String message) {
+        return new AwsException("InvalidParameterException", message, 400);
+    }
+
+    @Override
+    public void clear() {
+        entitlements.clear();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/model/MarketplaceEntitlementRecord.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/model/MarketplaceEntitlementRecord.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.marketplace.model;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Read-only entitlement record returned by the AWS Marketplace Entitlement Service. */
+public record MarketplaceEntitlementRecord(
+        String productCode,
+        String dimension,
+        String customerIdentifier,
+        String customerAwsAccountId,
+        String licenseArn,
+        JsonNode value,
+        Double expirationDate) {
+
+    public MarketplaceEntitlementRecord {
+        value = value == null ? null : value.deepCopy();
+    }
+
+    public static MarketplaceEntitlementRecord fromJson(JsonNode node) {
+        return new MarketplaceEntitlementRecord(
+                text(node, "ProductCode"),
+                text(node, "Dimension"),
+                text(node, "CustomerIdentifier"),
+                text(node, "CustomerAWSAccountId"),
+                text(node, "LicenseArn"),
+                node.get("Value"),
+                node.hasNonNull("ExpirationDate") ? node.path("ExpirationDate").asDouble() : null);
+    }
+
+    private static String text(JsonNode node, String field) {
+        return node.hasNonNull(field) ? node.path(field).asText() : null;
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementIntegrationTest.java
@@ -1,0 +1,61 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+
+@QuarkusTest
+class MarketplaceEntitlementIntegrationTest {
+    @BeforeAll
+    static void configure() {
+        RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    @Test
+    void getEntitlementsReturnsEmptySetForUnknownProduct() {
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("Authorization", auth("us-east-1"))
+                .header("X-Amz-Target", "AWSMPEntitlementService.GetEntitlements")
+                .body("{\"ProductCode\":\"product-local\"}")
+                .post("/")
+                .then()
+                .statusCode(200)
+                .body("Entitlements", empty());
+    }
+
+    @Test
+    void getEntitlementsRejectsMutuallyExclusiveCustomerFilters() {
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("Authorization", auth("us-east-1"))
+                .header("X-Amz-Target", "AWSMPEntitlementService.GetEntitlements")
+                .body("{\"ProductCode\":\"product-local\",\"Filter\":{\"CUSTOMER_IDENTIFIER\":[\"customer\"],\"CUSTOMER_AWS_ACCOUNT_ID\":[\"123456789012\"]}}")
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("InvalidParameterException"));
+    }
+
+    @Test
+    void entitlementEndpointRejectsUnsupportedRegion() {
+        given()
+                .contentType("application/x-amz-json-1.1")
+                .header("Authorization", auth("us-west-2"))
+                .header("X-Amz-Target", "AWSMPEntitlementService.GetEntitlements")
+                .body("{\"ProductCode\":\"product-local\"}")
+                .post("/")
+                .then()
+                .statusCode(400)
+                .body("__type", containsString("InvalidParameterException"));
+    }
+
+    private static String auth(String region) {
+        return "AWS4-HMAC-SHA256 Credential=000000000000/20260908/" + region + "/aws-marketplace/aws4_request";
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementServiceTest.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MarketplaceEntitlementServiceTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private AccountAwareStorageBackend<JsonNode> storage;
+    private MarketplaceEntitlementService service;
+
+    @BeforeEach
+    void setUp() {
+        storage = AccountAwareStorageBackend.inMemory("000000000000");
+        service = new MarketplaceEntitlementService(mapper, storage);
+    }
+
+    @Test
+    void getEntitlementsReadsSharedReadOnlyStateAndAppliesFilters() throws Exception {
+        storage.put("product-local/ent-1", mapper.readTree("""
+                {"ProductCode":"product-local","Dimension":"users","CustomerAWSAccountId":"123456789012",
+                "LicenseArn":"arn:aws:license-manager:us-east-1:123456789012:license:l-local",
+                "Value":{"IntegerValue":10}}
+                """));
+        storage.put("product-local/ent-2", mapper.readTree("""
+                {"ProductCode":"product-local","Dimension":"storage","CustomerAWSAccountId":"999999999999",
+                "Value":{"IntegerValue":5}}
+                """));
+
+        JsonNode response = service.getEntitlements(mapper.readTree("""
+                {"ProductCode":"product-local","Filter":{"CUSTOMER_AWS_ACCOUNT_ID":["123456789012"]}}
+                """), "us-east-1");
+        assertEquals(1, response.path("Entitlements").size());
+        assertEquals("users", response.path("Entitlements").get(0).path("Dimension").asText());
+        assertEquals("123456789012",
+                response.path("Entitlements").get(0).path("CustomerAWSAccountId").asText());
+    }
+
+    @Test
+    void maxResultsMustBeIntegral() throws Exception {
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.getEntitlements(mapper.readTree(
+                        "{\"ProductCode\":\"product-local\",\"MaxResults\":1.5}"), "us-east-1"));
+        assertEquals("InvalidParameterException", error.getErrorCode());
+    }
+
+    @Test
+    void maxResultsRejectsIntegralOverflow() throws Exception {
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.getEntitlements(mapper.readTree(
+                        "{\"ProductCode\":\"product-local\",\"MaxResults\":4294967297}"), "us-east-1"));
+        assertEquals("InvalidParameterException", error.getErrorCode());
+    }
+
+    @Test
+    void productCodeAndRegionFollowAwsConstraints() throws Exception {
+        assertThrows(AwsException.class,
+                () -> service.getEntitlements(mapper.readTree("{\"ProductCode\":\"\"}"), "us-east-1"));
+        assertThrows(AwsException.class,
+                () -> service.getEntitlements(mapper.readTree("{\"ProductCode\":\"product-local\"}"), "us-west-2"));
+    }
+}

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -86,6 +86,7 @@ services:
     sources:
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceCatalogController.java, mode: rest }
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceAgreementService.java, mode: switch }
+      - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementController.java, mode: switch }
     exclude_actions:
       - AgreementType
       - Status


### PR DESCRIPTION
## Summary

Adds AWS Marketplace Entitlement Service emulation as an independent Marketplace API-family contribution. Includes GetEntitlements routing, filters, pagination, account-aware persistence, us-east-1 restriction, integration coverage, docs, and an AWS SDK compatibility smoke test.

This is one of the API-family splits of the previous combined Marketplace contribution (#3303).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reviewed against the current AWS Marketplace Entitlement Service API reference and SDK wire contract. The handler exposes only `GetEntitlements` and preserves the documented regional restriction. `make docs-check` and `git diff --check` pass. Heavy local Maven execution was intentionally not run on this machine; CI is expected to execute the full test suite.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
