### PR TITLE
feat(marketplace-reporting): emulate AWS Marketplace Reporting API

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -302,6 +302,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>marketplacedeployment</artifactId>
         </dependency>
+        <!-- AWS Marketplace Reporting client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>marketplacereporting</artifactId>
+        </dependency>
         <!-- IAM Access Analyzer client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.services.marketplaceagreement.MarketplaceAgreement
 import software.amazon.awssdk.services.marketplaceentitlement.MarketplaceEntitlementClient;
 import software.amazon.awssdk.services.verifiedpermissions.VerifiedPermissionsClient;
 import software.amazon.awssdk.services.marketplacedeployment.MarketplaceDeploymentClient;
+import software.amazon.awssdk.services.marketplacereporting.MarketplaceReportingClient;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
 import software.amazon.awssdk.services.securityhub.SecurityHubClient;
 import software.amazon.awssdk.services.detective.DetectiveClient;
@@ -458,6 +459,14 @@ public final class TestFixtures {
 
     public static MarketplaceDeploymentClient marketplaceDeploymentClient() {
         return MarketplaceDeploymentClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static MarketplaceReportingClient marketplaceReportingClient() {
+        return MarketplaceReportingClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MarketplaceReportingTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MarketplaceReportingTest.java
@@ -1,0 +1,21 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.marketplacereporting.MarketplaceReportingClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class MarketplaceReportingTest {
+
+    @Test
+    void usesAwsSdkWireContract() {
+        try (MarketplaceReportingClient client = TestFixtures.marketplaceReportingClient()) {
+            String arn = "arn:aws:aws-marketplace::000000000000:AWSMarketplace/ReportingData/Agreement_V1/Dashboard/AgreementSummary_V1";
+            var response = client.getBuyerDashboard(r -> r.dashboardIdentifier(arn).embeddingDomains("https://example.com"));
+            assertEquals(arn, response.dashboardIdentifier());
+            assertFalse(response.embedUrl().isBlank());
+        }
+    }
+}

--- a/docs/services/marketplace.md
+++ b/docs/services/marketplace.md
@@ -49,6 +49,7 @@ Floci emulates AWS Marketplace APIs under the shared `aws-marketplace` SigV4 sig
 | `UpdatePurchaseOrders` | Updates purchase orders for an agreement |
 | `GetEntitlements` | - |
 | `PutDeploymentParameter` | Creates or updates an AWS Marketplace deployment parameter |
+| `GetBuyerDashboard` | Returns an embeddable AWS Marketplace buyer dashboard URL |
 <!-- floci:actions:end -->
 
 ## Marketplace Catalog
@@ -72,6 +73,14 @@ AWS exposes this service as read-only: `GetEntitlements` is the only public oper
 ## Marketplace Deployment
 
 Deployment parameters and idempotency records are persisted through `StorageFactory` and isolated by AWS account.
+
+## Marketplace Reporting
+
+Marketplace Reporting validates buyer dashboard requests and returns account-scoped local embed URLs for supported dashboard identifiers.
+
+### Known deviations
+
+- AWS limits `GetBuyerDashboard` to an AWS Organizations management account or a delegated administrator registered for procurement insights. Floci does not currently enforce that Organizations-role prerequisite.
 
 
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -53,6 +53,7 @@ import io.github.hectorvent.floci.services.s3tables.S3TablesController;
 import io.github.hectorvent.floci.services.efs.EfsController;
 import io.github.hectorvent.floci.services.marketplace.MarketplaceCatalogController;
 import io.github.hectorvent.floci.services.marketplace.MarketplaceDeploymentController;
+import io.github.hectorvent.floci.services.marketplace.MarketplaceReportingController;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -658,7 +659,7 @@ public class ResolvedServiceCatalog {
                         "marketplace", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON, ServiceProtocol.JSON, ServiceProtocol.CBOR),
                         Set.of("AWSMPCommerceService_v20200301.", "AWSMPEntitlementService."), Set.of("aws-marketplace"), Set.of("AWS Marketplace Entitlement Service"),
-                        Set.of(MarketplaceCatalogController.class, MarketplaceDeploymentController.class))
+                        Set.of(MarketplaceCatalogController.class, MarketplaceDeploymentController.class, MarketplaceReportingController.class))
         ));
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingController.java
@@ -1,0 +1,51 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RequestContext;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class MarketplaceReportingController {
+    private final MarketplaceReportingService service;
+    private final ObjectReader strictReader;
+    private final RequestContext context;
+
+    @Inject
+    public MarketplaceReportingController(MarketplaceReportingService service, ObjectMapper mapper, RequestContext context) {
+        this.service = service;
+        this.strictReader = mapper.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+        this.context = context;
+    }
+
+    @POST
+    @Path("/getBuyerDashboard")
+    public Response getBuyerDashboard(String body) {
+        return Response.ok(service.getBuyerDashboard(parse(body), accountId())).build();
+    }
+
+    private JsonNode parse(String body) {
+        try {
+            JsonNode node = strictReader.readTree(body == null || body.isBlank() ? "{}" : body);
+            if (node == null || !node.isObject()) {
+                throw badRequest("Request body must be a JSON object.");
+            }
+            return node;
+        } catch (AwsException e) { throw e; }
+        catch (Exception e) { throw badRequest("Request body is not valid JSON."); }
+    }
+
+    private String accountId() { return context.getAccountId() == null ? "000000000000" : context.getAccountId(); }
+    private static AwsException badRequest(String message) { return new AwsException("BadRequestException", message, 400); }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingService.java
@@ -1,0 +1,68 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.services.marketplace.model.MarketplaceBuyerDashboard;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class MarketplaceReportingService {
+    private static final Pattern DASHBOARD = Pattern.compile(
+            "arn:aws:aws-marketplace::[0-9]{12}:AWSMarketplace/ReportingData/(Agreement_V1/Dashboard/AgreementSummary_V1|BillingEvent_V1/Dashboard/CostAnalysis_V1)");
+    private static final Pattern DOMAIN = Pattern.compile(
+            "(https://[a-zA-Z.*0-9_-]+[.][a-zA-Z]+[a-zA-Z0-9&?/_=-]*[a-zA-Z*0-9/]+|https?://localhost(:[0-9]{1,5})?)");
+    private final ObjectMapper mapper;
+
+    @Inject
+    public MarketplaceReportingService(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    public ObjectNode getBuyerDashboard(JsonNode request, String accountId) {
+        String dashboard = text(request, "dashboardIdentifier");
+        if (!DASHBOARD.matcher(dashboard).matches()) {
+            throw badRequest("dashboardIdentifier must be a supported AWS Marketplace procurement insights dashboard ARN.");
+        }
+        JsonNode domains = request.get("embeddingDomains");
+        if (domains == null || !domains.isArray() || domains.size() < 1 || domains.size() > 2) {
+            throw badRequest("embeddingDomains must contain one or two domains.");
+        }
+        List<String> copiedDomains = new ArrayList<>(domains.size());
+        for (JsonNode domain : domains) {
+            if (!domain.isTextual() || domain.asText().length() > 2000 || !DOMAIN.matcher(domain.asText()).matches()) {
+                throw badRequest("embeddingDomains contains an invalid domain.");
+            }
+            copiedDomains.add(domain.asText());
+        }
+        String token = UUID.randomUUID().toString().replace("-", "");
+        String dashboardName = dashboard.substring(dashboard.lastIndexOf('/') + 1);
+        String embedUrl = "https://us-east-1.quicksight.aws.amazon.com/sn/embed/share/accounts/"
+                + accountId + "/dashboards/" + URLEncoder.encode(dashboardName, StandardCharsets.UTF_8)
+                + "?code=" + token;
+        MarketplaceBuyerDashboard result = new MarketplaceBuyerDashboard(
+                dashboard, embedUrl, copiedDomains);
+        return mapper.valueToTree(result);
+    }
+
+    private static String text(JsonNode request, String field) {
+        JsonNode value = request == null ? null : request.get(field);
+        if (value == null || !value.isTextual() || value.asText().isBlank()) {
+            throw badRequest(field + " is required.");
+        }
+        return value.asText();
+    }
+
+    private static AwsException badRequest(String message) {
+        return new AwsException("BadRequestException", message, 400);
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/model/MarketplaceBuyerDashboard.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/model/MarketplaceBuyerDashboard.java
@@ -1,0 +1,16 @@
+package io.github.hectorvent.floci.services.marketplace.model;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/** Buyer dashboard embed result returned by Marketplace Reporting. */
+@RegisterForReflection
+public record MarketplaceBuyerDashboard(
+        String dashboardIdentifier,
+        String embedUrl,
+        List<String> embeddingDomains) {
+    public MarketplaceBuyerDashboard {
+        embeddingDomains = embeddingDomains == null ? List.of() : List.copyOf(embeddingDomains);
+    }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingIntegrationTest.java
@@ -1,0 +1,44 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class MarketplaceReportingIntegrationTest {
+    @BeforeAll static void configure() { RestAssuredJsonUtils.configureAwsContentTypes(); }
+
+    @Test
+    void getBuyerDashboardReturnsEmbeddingUrl() {
+        String dashboard = "arn:aws:aws-marketplace::000000000000:AWSMarketplace/ReportingData/Agreement_V1/Dashboard/AgreementSummary_V1";
+        given().contentType("application/json").header("Authorization", auth())
+                .body("{\"dashboardIdentifier\":\"" + dashboard + "\",\"embeddingDomains\":[\"https://example.com\"]}")
+                .post("/getBuyerDashboard").then().statusCode(200)
+                .body("dashboardIdentifier", equalTo(dashboard)).body("embedUrl", notNullValue())
+                .body("embeddingDomains[0]", equalTo("https://example.com"));
+    }
+
+    @Test
+    void rejectsTrailingJson() {
+        given().contentType("application/json").header("Authorization", auth())
+                .body("{} {}")
+                .post("/getBuyerDashboard").then().statusCode(400)
+                .body("__type", containsString("BadRequestException"));
+    }
+
+    @Test
+    void rejectsUnsupportedDashboardArn() {
+        given().contentType("application/json").header("Authorization", auth())
+                .body("{\"dashboardIdentifier\":\"bad\",\"embeddingDomains\":[\"https://example.com\"]}")
+                .post("/getBuyerDashboard").then().statusCode(400)
+                .body("__type", containsString("BadRequestException"));
+    }
+
+    private static String auth() { return "AWS4-HMAC-SHA256 Credential=000000000000/20260908/us-east-1/aws-marketplace/aws4_request"; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingServiceTest.java
@@ -1,0 +1,33 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MarketplaceReportingServiceTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final MarketplaceReportingService service = new MarketplaceReportingService(mapper);
+
+    @Test
+    void getBuyerDashboardBuildsAccountScopedEmbedUrl() throws Exception {
+        var response = service.getBuyerDashboard(mapper.readTree("""
+                {"dashboardIdentifier":"arn:aws:aws-marketplace::123456789012:AWSMarketplace/ReportingData/Agreement_V1/Dashboard/AgreementSummary_V1",
+                "embeddingDomains":["https://example.com"]}
+                """), "123456789012");
+        assertTrue(response.path("embedUrl").asText().contains("accounts/123456789012/dashboards/AgreementSummary_V1"));
+        assertEquals("https://example.com", response.path("embeddingDomains").get(0).asText());
+    }
+
+    @Test
+    void invalidDomainsAreRejected() throws Exception {
+        AwsException error = assertThrows(AwsException.class, () -> service.getBuyerDashboard(mapper.readTree("""
+                {"dashboardIdentifier":"arn:aws:aws-marketplace::123456789012:AWSMarketplace/ReportingData/Agreement_V1/Dashboard/AgreementSummary_V1",
+                "embeddingDomains":["javascript:alert(1)"]}
+                """), "123456789012"));
+        assertEquals("BadRequestException", error.getErrorCode());
+    }
+}

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -88,6 +88,7 @@ services:
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceAgreementService.java, mode: switch }
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementController.java, mode: switch }
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceDeploymentController.java, mode: rest }
+      - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingController.java, mode: rest }
     exclude_actions:
       - AgreementType
       - Status


### PR DESCRIPTION
## Summary

Adds AWS Marketplace Reporting Service emulation as an independent Marketplace API-family contribution. Includes GetBuyerDashboard request validation, response shaping, integration coverage, docs, and an AWS SDK compatibility smoke test.

This is one of the API-family splits of the previous combined Marketplace contribution (#3303).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reviewed against the current AWS Marketplace Reporting Service GetBuyerDashboard API contract, including dashboard identifier and embedding-domain constraints. `make docs-check` and `git diff --check` pass. Heavy local Maven execution was intentionally not run on this machine; CI is expected to execute the full test suite.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
