### PR TITLE
feat(marketplace-metering): emulate AWS Marketplace Metering API

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -307,6 +307,11 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>marketplacereporting</artifactId>
         </dependency>
+        <!-- AWS Marketplace Metering client -->
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>marketplacemetering</artifactId>
+        </dependency>
         <!-- IAM Access Analyzer client -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>

--- a/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
+++ b/compatibility-tests/sdk-test-java/src/main/java/com/floci/test/TestFixtures.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.services.marketplaceentitlement.MarketplaceEntitle
 import software.amazon.awssdk.services.verifiedpermissions.VerifiedPermissionsClient;
 import software.amazon.awssdk.services.marketplacedeployment.MarketplaceDeploymentClient;
 import software.amazon.awssdk.services.marketplacereporting.MarketplaceReportingClient;
+import software.amazon.awssdk.services.marketplacemetering.MarketplaceMeteringClient;
 import software.amazon.awssdk.services.inspector2.Inspector2Client;
 import software.amazon.awssdk.services.securityhub.SecurityHubClient;
 import software.amazon.awssdk.services.detective.DetectiveClient;
@@ -467,6 +468,14 @@ public final class TestFixtures {
 
     public static MarketplaceReportingClient marketplaceReportingClient() {
         return MarketplaceReportingClient.builder()
+                .endpointOverride(ENDPOINT)
+                .region(REGION)
+                .credentialsProvider(CREDENTIALS)
+                .build();
+    }
+
+    public static MarketplaceMeteringClient marketplaceMeteringClient() {
+        return MarketplaceMeteringClient.builder()
                 .endpointOverride(ENDPOINT)
                 .region(REGION)
                 .credentialsProvider(CREDENTIALS)

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MarketplaceMeteringTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/MarketplaceMeteringTest.java
@@ -1,0 +1,18 @@
+package com.floci.test;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.marketplacemetering.MarketplaceMeteringClient;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class MarketplaceMeteringTest {
+
+    @Test
+    void usesAwsSdkWireContract() {
+        try (MarketplaceMeteringClient client = TestFixtures.marketplaceMeteringClient()) {
+            var response = client.resolveCustomer(r -> r.registrationToken("local-registration-token"));
+            assertNotNull(response.customerAWSAccountId());
+            assertNotNull(response.licenseArn());
+        }
+    }
+}

--- a/docs/services/marketplace.md
+++ b/docs/services/marketplace.md
@@ -50,6 +50,10 @@ Floci emulates AWS Marketplace APIs under the shared `aws-marketplace` SigV4 sig
 | `GetEntitlements` | - |
 | `PutDeploymentParameter` | Creates or updates an AWS Marketplace deployment parameter |
 | `GetBuyerDashboard` | Returns an embeddable AWS Marketplace buyer dashboard URL |
+| `BatchMeterUsage` | Submits a batch of Marketplace usage records |
+| `MeterUsage` | Submits metered usage for a Marketplace product |
+| `RegisterUsage` | Registers container product usage and returns a signed token |
+| `ResolveCustomer` | Resolves a Marketplace registration token to customer identity |
 <!-- floci:actions:end -->
 
 ## Marketplace Catalog
@@ -81,6 +85,10 @@ Marketplace Reporting validates buyer dashboard requests and returns account-sco
 ### Known deviations
 
 - AWS limits `GetBuyerDashboard` to an AWS Organizations management account or a delegated administrator registered for procurement insights. Floci does not currently enforce that Organizations-role prerequisite.
+
+## Marketplace Metering
+
+Metering records and idempotency state are persisted through `StorageFactory`, isolated by AWS account and region. `RegisterUsage` produces locally signed PS256 JWTs with an emulator-generated RSA key.
 
 
 

--- a/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/AwsJson11Controller.java
@@ -43,6 +43,7 @@ import io.github.hectorvent.floci.services.eventbridge.EventBridgeHandler;
 import io.github.hectorvent.floci.services.emr.EmrHandler;
 import io.github.hectorvent.floci.services.memorydb.MemoryDbHandler;
 import io.github.hectorvent.floci.services.marketplace.MarketplaceEntitlementController;
+import io.github.hectorvent.floci.services.marketplace.MarketplaceMeteringController;
 import io.github.hectorvent.floci.services.wafv2.WafV2Handler;
 import io.github.hectorvent.floci.services.kinesis.KinesisJsonHandler;
 import io.github.hectorvent.floci.services.kinesisanalytics.KinesisAnalyticsV2JsonHandler;
@@ -133,6 +134,7 @@ public class AwsJson11Controller {
     private final BudgetsJsonHandler budgetsJsonHandler;
     private final ServiceQuotasJsonHandler serviceQuotasJsonHandler;
     private final MarketplaceEntitlementController marketplaceEntitlementController;
+    private final MarketplaceMeteringController marketplaceMeteringController;
 
     @Inject
     public AwsJson11Controller(ObjectMapper objectMapper, ResolvedServiceCatalog catalog,
@@ -183,7 +185,8 @@ public class AwsJson11Controller {
                                IdentityStoreJsonHandler identityStoreJsonHandler,
                                BudgetsJsonHandler budgetsJsonHandler,
                                ServiceQuotasJsonHandler serviceQuotasJsonHandler,
-                               MarketplaceEntitlementController marketplaceEntitlementController) {
+                               MarketplaceEntitlementController marketplaceEntitlementController,
+                               MarketplaceMeteringController marketplaceMeteringController) {
         this.objectMapper = objectMapper;
         this.strictBodyReader = objectMapper.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
         this.catalog = catalog;
@@ -239,6 +242,7 @@ public class AwsJson11Controller {
         this.budgetsJsonHandler = budgetsJsonHandler;
         this.serviceQuotasJsonHandler = serviceQuotasJsonHandler;
         this.marketplaceEntitlementController = marketplaceEntitlementController;
+        this.marketplaceMeteringController = marketplaceMeteringController;
     }
 
     @POST
@@ -331,7 +335,12 @@ public class AwsJson11Controller {
                 case "budgets" -> budgetsJsonHandler.handle(action, request, regionResolver.getAccountId());
                 case "servicequotas" -> serviceQuotasJsonHandler.handle(
                         action, request, region, regionResolver.getAccountId());
-                case "marketplace" -> marketplaceEntitlementController.handle(action, request, region);
+                case "marketplace" -> {
+                    if (targetMatch.prefix().startsWith("AWSMPEntitlementService.")) {
+                        yield marketplaceEntitlementController.handle(action, request, region);
+                    }
+                    yield marketplaceMeteringController.handle(action, request, region);
+                }
                 default -> null;
             };
             // catalog.matchTarget is protocol-agnostic: a JSON 1.0 target

--- a/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ResolvedServiceCatalog.java
@@ -658,7 +658,7 @@ public class ResolvedServiceCatalog {
                 descriptor("marketplace", "marketplace", config.services().marketplace().enabled(), true,
                         "marketplace", config.storage().mode(), 5000L, null, ServiceProtocol.REST_JSON,
                         protocols(ServiceProtocol.REST_JSON, ServiceProtocol.JSON, ServiceProtocol.CBOR),
-                        Set.of("AWSMPCommerceService_v20200301.", "AWSMPEntitlementService."), Set.of("aws-marketplace"), Set.of("AWS Marketplace Entitlement Service"),
+                        Set.of("AWSMPCommerceService_v20200301.", "AWSMPEntitlementService.", "AWSMPMeteringService."), Set.of("aws-marketplace"), Set.of("AWS Marketplace Entitlement Service"),
                         Set.of(MarketplaceCatalogController.class, MarketplaceDeploymentController.class, MarketplaceReportingController.class))
         ));
     }

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringController.java
@@ -1,0 +1,22 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+/** Service-specific controller invoked by the shared AWS JSON protocol handler. */
+@ApplicationScoped
+public class MarketplaceMeteringController {
+    private final MarketplaceMeteringService service;
+
+    @Inject
+    public MarketplaceMeteringController(MarketplaceMeteringService service) {
+        this.service = service;
+    }
+
+    public Response handle(String action, JsonNode request, String region) {
+        JsonNode result = service.handle(action, request, region);
+        return result == null ? null : Response.ok(result).build();
+    }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringService.java
@@ -1,0 +1,420 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.RequestContext;
+import io.github.hectorvent.floci.core.common.Resettable;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import io.github.hectorvent.floci.services.marketplace.model.MarketplaceMeteringRecord;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.Signature;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+@ApplicationScoped
+public class MarketplaceMeteringService implements Resettable {
+    private static final Pattern PRODUCT_CODE = Pattern.compile("[-a-zA-Z0-9/=:_.@]{1,255}");
+    private static final KeyPair SIGNING_KEY = createSigningKey();
+    private final ObjectMapper mapper;
+    private final RequestContext context;
+    private final AccountAwareStorageBackend<JsonNode> entities;
+    private final AccountAwareStorageBackend<JsonNode> meterRecords;
+    private final AccountAwareStorageBackend<JsonNode> clientTokens;
+    private final AccountAwareStorageBackend<JsonNode> customerMappings;
+
+    @Inject
+    public MarketplaceMeteringService(StorageFactory factory, ObjectMapper mapper,
+                                      RequestContext context) {
+        this(mapper, context,
+                factory.create("marketplace", "marketplace-entities.json", type()),
+                factory.create("marketplace", "marketplace-metering-records.json", type()),
+                factory.create("marketplace", "marketplace-metering-client-tokens.json", type()),
+                factory.create("marketplace", "marketplace-metering-customers.json", type()));
+    }
+
+    MarketplaceMeteringService(ObjectMapper mapper, RequestContext context,
+                               AccountAwareStorageBackend<JsonNode> entities,
+                               AccountAwareStorageBackend<JsonNode> meterRecords,
+                               AccountAwareStorageBackend<JsonNode> clientTokens,
+                               AccountAwareStorageBackend<JsonNode> customerMappings) {
+        this.mapper = mapper;
+        this.context = context;
+        this.entities = entities;
+        this.meterRecords = meterRecords;
+        this.clientTokens = clientTokens;
+        this.customerMappings = customerMappings;
+    }
+
+    private static TypeReference<Map<String, JsonNode>> type() { return new TypeReference<>() {}; }
+
+    public JsonNode handle(String action, JsonNode request, String region) {
+        return switch (action) {
+            case "BatchMeterUsage" -> batchMeterUsage(request, region);
+            case "MeterUsage" -> meterUsage(request, region);
+            case "RegisterUsage" -> registerUsage(request, region);
+            case "ResolveCustomer" -> resolveCustomer(request, region);
+            default -> null;
+        };
+    }
+
+    private synchronized ObjectNode meterUsage(JsonNode request, String region) {
+        String productCode = productCode(request, true);
+        Instant timestamp = timestamp(request, "Timestamp", 6);
+        String dimension = text(request, "UsageDimension", 1, 255);
+        int quantity = integer(request, "UsageQuantity", 0, Integer.MAX_VALUE, 0);
+        validateAllocations(request.get("UsageAllocations"), quantity);
+        if (request.path("DryRun").asBoolean(false)) {
+            throw new AwsException("DryRunOperation", "Request would have succeeded, but DryRun flag is set.", 400);
+        }
+
+        String clientToken = optionalValidationText(request, "ClientToken");
+        if (clientToken != null) {
+            if (clientToken.length() > 64) {
+                throw validation("ClientToken must be at most 64 characters.");
+            }
+            JsonNode prior = clientTokens.get(region + "/meter/" + clientToken).orElse(null);
+            if (prior != null) {
+                if (!prior.path("request").equals(request)) {
+                    throw new AwsException("IdempotencyConflictException", "ClientToken is being used for multiple requests.", 400);
+                }
+                return mapper.createObjectNode().put("MeteringRecordId", prior.path("recordId").asText());
+            }
+        }
+
+        Instant hour = timestamp.truncatedTo(ChronoUnit.HOURS);
+        String key = region + "/meter/" + productCode + "/" + accountId() + "/" + dimension + "/" + hour;
+        JsonNode prior = meterRecords.get(key).orElse(null);
+        if (prior != null) {
+            if (prior.path("quantity").asInt() != quantity) {
+                throw new AwsException("DuplicateRequestException",
+                        "A metering record already exists for this usage dimension and hour with a different quantity.", 400);
+            }
+            return mapper.createObjectNode().put("MeteringRecordId", prior.path("recordId").asText());
+        }
+        String recordId = "mr-" + compactId();
+        MarketplaceMeteringRecord meteringRecord = new MarketplaceMeteringRecord(
+                recordId, region, productCode, accountId(), dimension, quantity, hour);
+        ObjectNode stored = mapper.createObjectNode()
+                .put("recordId", meteringRecord.recordId())
+                .put("quantity", meteringRecord.quantity());
+        stored.set("request", request.deepCopy());
+        meterRecords.put(key, stored);
+        if (clientToken != null) {
+            ObjectNode token = mapper.createObjectNode().put("recordId", recordId);
+            token.set("request", request.deepCopy());
+            clientTokens.put(region + "/meter/" + clientToken, token);
+        }
+        return mapper.createObjectNode().put("MeteringRecordId", recordId);
+    }
+
+    private synchronized ObjectNode batchMeterUsage(JsonNode request, String region) {
+        JsonNode recordsNode = request.get("UsageRecords");
+        if (recordsNode == null || !recordsNode.isArray() || recordsNode.size() > 25) {
+            throw validation("UsageRecords must be an array with at most 25 records.");
+        }
+        String requestProduct = productCode(request, false);
+        ArrayNode results = mapper.createArrayNode();
+        for (JsonNode record : recordsNode) {
+            Instant timestamp = timestamp(record, "Timestamp", 24);
+            String dimension = text(record, "Dimension", 1, 255);
+            int quantity = integer(record, "Quantity", 0, Integer.MAX_VALUE, 0);
+            validateAllocations(record.get("UsageAllocations"), quantity);
+            String customerAccount = optionalMeteringText(record, "CustomerAWSAccountId", "InvalidCustomerIdentifierException");
+            String customerId = optionalMeteringText(record, "CustomerIdentifier", "InvalidCustomerIdentifierException");
+            String licenseArn = optionalMeteringText(record, "LicenseArn", "InvalidLicenseException");
+            if ((customerAccount == null || customerAccount.isBlank()) && (customerId == null || customerId.isBlank())) {
+                throw new AwsException("InvalidCustomerIdentifierException",
+                        "A usage record requires CustomerAWSAccountId or CustomerIdentifier.", 400);
+            }
+            if (requestProduct == null && licenseArn == null) {
+                throw new AwsException("InvalidLicenseException",
+                        "LicenseArn is required when ProductCode is not supplied.", 400);
+            }
+            String productIdentity = licenseArn != null ? licenseArn : requestProduct;
+            String customerIdentity = customerAccount != null ? customerAccount : customerId;
+            String key = region + "/batch/" + digest(productIdentity + "|" + customerIdentity + "|" + dimension + "|"
+                    + timestamp.truncatedTo(ChronoUnit.HOURS));
+            JsonNode prior = meterRecords.get(key).orElse(null);
+            String status = "Success";
+            String recordId;
+            if (prior != null) {
+                recordId = prior.path("recordId").asText();
+                if (prior.path("quantity").asInt() != quantity) {
+                    status = "DuplicateRecord";
+                }
+            } else {
+                recordId = "mr-" + compactId();
+                ObjectNode stored = mapper.createObjectNode().put("recordId", recordId).put("quantity", quantity);
+                stored.set("request", record.deepCopy());
+                meterRecords.put(key, stored);
+            }
+            ObjectNode result = mapper.createObjectNode();
+            result.set("UsageRecord", record.deepCopy()); result.put("MeteringRecordId", recordId); result.put("Status", status);
+            results.add(result);
+        }
+        ObjectNode response = mapper.createObjectNode(); response.set("Results", results); response.set("UnprocessedRecords", mapper.createArrayNode());
+        return response;
+    }
+
+    private ObjectNode registerUsage(JsonNode request, String region) {
+        String productCode = productCode(request, true);
+        JsonNode publicKeyNode = request.get("PublicKeyVersion");
+        if (publicKeyNode == null || !publicKeyNode.isIntegralNumber() || publicKeyNode.asInt() < 1) {
+            throw new AwsException("InvalidPublicKeyVersionException", "PublicKeyVersion must be at least 1.", 400);
+        }
+        int publicKeyVersion = publicKeyNode.asInt();
+        String nonce = optionalValidationText(request, "Nonce");
+        if (nonce != null && nonce.length() > 255) {
+            throw validation("Nonce must be at most 255 characters.");
+        }
+        ObjectNode header = mapper.createObjectNode();
+        header.put("alg", "PS256");
+        header.put("typ", "JWT");
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("ProductCode", productCode);
+        payload.put("PublicKeyVersion", publicKeyVersion);
+        if (nonce != null) {
+            payload.put("Nonce", nonce);
+        }
+        String encodedHeader = base64Url(header.toString());
+        String encodedPayload = base64Url(payload.toString());
+        String signingInput = encodedHeader + "." + encodedPayload;
+        String signature = Base64.getUrlEncoder().withoutPadding().encodeToString(signPs256(signingInput));
+        ObjectNode response = mapper.createObjectNode();
+        response.put("Signature", signingInput + "." + signature);
+        return response;
+    }
+
+    private synchronized ObjectNode resolveCustomer(JsonNode request, String region) {
+        JsonNode tokenNode = request.get("RegistrationToken");
+        if (tokenNode == null || !tokenNode.isTextual() || tokenNode.asText().isEmpty()) {
+            throw new AwsException("InvalidTokenException", "RegistrationToken is required.", 400);
+        }
+        String token = tokenNode.asText();
+        JsonNode existing = customerMappings.get(region + "/" + token).orElse(null);
+        if (existing != null) {
+            return (ObjectNode) existing.deepCopy();
+        }
+
+        byte[] hash = sha256(token);
+        long number = 0;
+        for (int i = 0; i < 6; i++) {
+            number = (number << 8) | (hash[i] & 0xffL);
+        }
+        String customerAccount = String.format(Locale.ROOT, "%012d", number % 1_000_000_000_000L);
+        String productCode = localProductCode(region);
+        String licenseId = toHex(hash).substring(0, 24);
+        ObjectNode response = mapper.createObjectNode();
+        response.put("ProductCode", productCode);
+        response.put("CustomerAWSAccountId", customerAccount);
+        response.put("LicenseArn", "arn:aws:license-manager:" + region + ":" + customerAccount + ":license:l-" + licenseId);
+        customerMappings.put(region + "/" + token, response);
+        return response.deepCopy();
+    }
+
+    private String localProductCode(String region) {
+        for (JsonNode entity : entities.scan(key -> true)) {
+            if (entity.path("EntityType").asText().contains("Product")) {
+                JsonNode details = entity.path("DetailsDocument");
+                if (details.hasNonNull("ProductCode")) {
+                    return details.path("ProductCode").asText();
+                }
+                return entity.path("EntityId").asText();
+            }
+        }
+        return "local-product";
+    }
+
+    private void validateAllocations(JsonNode allocations, int quantity) {
+        if (allocations == null || allocations.isNull()) {
+            return;
+        }
+        if (!allocations.isArray() || allocations.isEmpty() || allocations.size() > 2500) {
+            throw new AwsException("InvalidUsageAllocationsException", "UsageAllocations must contain between 1 and 2500 items.", 400);
+        }
+        long sum = 0;
+        Set<String> tagSets = new HashSet<>();
+        for (JsonNode allocation : allocations) {
+            int allocated = integer(allocation, "AllocatedUsageQuantity", 0, Integer.MAX_VALUE, null);
+            sum += allocated;
+            JsonNode tags = allocation.get("Tags");
+            if (tags != null) {
+                if (!tags.isArray() || tags.size() > 5) {
+                    throw new AwsException("InvalidTagException", "Each usage allocation supports at most 5 tags.", 400);
+                }
+                List<String> canonical = new ArrayList<>();
+                for (JsonNode tag : tags) {
+                    String key = tagText(tag, "Key", 1, 100);
+                    String value = tagText(tag, "Value", 1, 256);
+                    canonical.add(key + "=" + value);
+                }
+                canonical.sort(String::compareTo);
+                String signature = String.join("&", canonical);
+                if (!tagSets.add(signature)) {
+                    throw new AwsException("InvalidUsageAllocationsException", "Usage allocations must have unique tag sets.", 400);
+                }
+            }
+        }
+        if (sum != quantity) {
+            throw new AwsException("InvalidUsageAllocationsException", "Allocated usage quantity must equal UsageQuantity.", 400);
+        }
+    }
+
+    private static Instant timestamp(JsonNode node, String field, int maxAgeHours) {
+        JsonNode value = node.get(field);
+        if (value == null || !value.isNumber()) {
+            throw new AwsException("TimestampOutOfBoundsException", field + " is required.", 400);
+        }
+        long millis = Math.round(value.asDouble() * 1000d);
+        Instant instant = Instant.ofEpochMilli(millis);
+        Instant now = Instant.now();
+        if (instant.isBefore(now.minus(maxAgeHours, ChronoUnit.HOURS)) || instant.isAfter(now.plus(5, ChronoUnit.MINUTES))) {
+            throw new AwsException("TimestampOutOfBoundsException", "Timestamp is outside the accepted metering window.", 400);
+        }
+        if (maxAgeHours == 24) {
+            ZonedDateTime z = now.atZone(ZoneOffset.UTC);
+            if (z.getDayOfMonth() == 1 && z.getHour() >= 6 && instant.atZone(ZoneOffset.UTC).getMonth() != z.getMonth()) {
+                throw new AwsException("TimestampOutOfBoundsException", "Previous-month usage is closed after 06:00 UTC on the first day of the month.", 400);
+            }
+        }
+        return instant;
+    }
+
+    private static String productCode(JsonNode node, boolean required) {
+        String value = optionalText(node, "ProductCode");
+        if (value == null) {
+            if (required) {
+                throw invalidProduct("ProductCode is required.");
+            }
+            return null;
+        }
+        if (!PRODUCT_CODE.matcher(value).matches()) {
+            throw invalidProduct("ProductCode is invalid.");
+        }
+        return value;
+    }
+
+    private static int integer(JsonNode node, String field, int min, int max, Integer fallback) {
+        JsonNode value = node.get(field);
+        if (value == null || value.isNull()) {
+            if (fallback != null) {
+                return fallback;
+            }
+            throw validation(field + " is required.");
+        }
+        if (!value.isIntegralNumber()) {
+            throw validation(field + " must be an integer.");
+        }
+        if (!value.canConvertToInt()) {
+            throw validation(field + " is out of range.");
+        }
+        int result = value.asInt();
+        if (result < min || result > max) {
+            throw validation(field + " is out of range.");
+        }
+        return result;
+    }
+
+    private static String text(JsonNode node, String field, int min, int max) {
+        String value = optionalText(node, field);
+        if (value == null || value.length() < min || value.length() > max) {
+            throw new AwsException("InvalidUsageDimensionException", field + " is required or out of range.", 400);
+        }
+        return value;
+    }
+    private static String optionalText(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isTextual()) {
+            throw new AwsException("InvalidUsageDimensionException", field + " must be a string.", 400);
+        }
+        return value.asText();
+    }
+    private static String optionalValidationText(JsonNode node, String field) {
+        JsonNode value = node == null ? null : node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isTextual()) {
+            throw validation(field + " must be a string.");
+        }
+        return value.asText();
+    }
+
+    private static String optionalMeteringText(JsonNode node, String field, String errorCode) {
+        JsonNode value = node == null ? null : node.get(field);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        if (!value.isTextual() || value.asText().isBlank()) {
+            throw new AwsException(errorCode, field + " must be a non-empty string.", 400);
+        }
+        return value.asText();
+    }
+    private static String tagText(JsonNode node, String field, int min, int max) {
+        JsonNode value = node == null ? null : node.get(field);
+        if (value == null || !value.isTextual() || value.asText().length() < min || value.asText().length() > max) {
+            throw new AwsException("InvalidTagException", field + " is invalid.", 400);
+        }
+        return value.asText();
+    }
+    private String accountId() { return context == null || context.getAccountId() == null ? "000000000000" : context.getAccountId(); }
+    private static AwsException invalidProduct(String message) { return new AwsException("InvalidProductCodeException", message, 400); }
+    private static AwsException validation(String message) { return new AwsException("ValidationException", message, 400); }
+    private static String compactId() { return UUID.randomUUID().toString().replace("-", "").substring(0, 24); }
+    private static KeyPair createSigningKey() {
+        try {
+            KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+            generator.initialize(2048);
+            return generator.generateKeyPair();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to initialize Marketplace metering signing key", e);
+        }
+    }
+
+    private static byte[] signPs256(String value) {
+        try {
+            Signature signature = Signature.getInstance("RSASSA-PSS");
+            signature.setParameter(new PSSParameterSpec("SHA-256", "MGF1",
+                    MGF1ParameterSpec.SHA256, 32, 1));
+            signature.initSign(SIGNING_KEY.getPrivate());
+            signature.update(value.getBytes(StandardCharsets.UTF_8));
+            return signature.sign();
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to sign Marketplace metering JWT", e);
+        }
+    }
+
+    private static byte[] sha256(String value) { try { return MessageDigest.getInstance("SHA-256").digest(value.getBytes(StandardCharsets.UTF_8)); } catch (Exception e) { throw new IllegalStateException(e); } }
+    private static String digest(String value) { return toHex(sha256(value)); }
+    private static String base64Url(String value) { return Base64.getUrlEncoder().withoutPadding().encodeToString(value.getBytes(StandardCharsets.UTF_8)); }
+    private static String toHex(byte[] bytes) { StringBuilder out=new StringBuilder(); for(byte b:bytes) out.append(String.format(Locale.ROOT,"%02x",b)); return out.toString(); }
+
+    @Override public void clear() { meterRecords.clear(); clientTokens.clear(); customerMappings.clear(); }
+}

--- a/src/main/java/io/github/hectorvent/floci/services/marketplace/model/MarketplaceMeteringRecord.java
+++ b/src/main/java/io/github/hectorvent/floci/services/marketplace/model/MarketplaceMeteringRecord.java
@@ -1,0 +1,13 @@
+package io.github.hectorvent.floci.services.marketplace.model;
+
+import java.time.Instant;
+
+/** Local identity for an AWS Marketplace metering submission. */
+public record MarketplaceMeteringRecord(
+        String recordId,
+        String region,
+        String productCode,
+        String customerIdentity,
+        String dimension,
+        int quantity,
+        Instant hour) {}

--- a/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringIntegrationTest.java
@@ -1,0 +1,59 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.notNullValue;
+
+@QuarkusTest
+class MarketplaceMeteringIntegrationTest {
+    @BeforeAll static void configure() { RestAssuredJsonUtils.configureAwsContentTypes(); }
+
+    @Test
+    void resolveCustomerIsStableForRegistrationToken() {
+        String body = "{\"RegistrationToken\":\"local-registration-token\"}";
+        var first = rpc("ResolveCustomer", body).statusCode(200)
+                .body("CustomerAWSAccountId", notNullValue()).body("LicenseArn", notNullValue())
+                .extract().response();
+        rpc("ResolveCustomer", body).statusCode(200)
+                .body("CustomerAWSAccountId", equalTo(first.path("CustomerAWSAccountId")))
+                .body("LicenseArn", equalTo(first.path("LicenseArn")));
+    }
+
+    @Test
+    void meterUsageIsIdempotentWithinHourForSameQuantity() {
+        long timestamp = System.currentTimeMillis() / 1000L;
+        String body = "{\"ProductCode\":\"prod-local\",\"Timestamp\":" + timestamp
+                + ",\"UsageDimension\":\"requests\",\"UsageQuantity\":3}";
+        String recordId = rpc("MeterUsage", body).statusCode(200)
+                .body("MeteringRecordId", notNullValue()).extract().path("MeteringRecordId");
+        rpc("MeterUsage", body).statusCode(200).body("MeteringRecordId", equalTo(recordId));
+    }
+
+    @Test
+    void batchMeterUsageReportsDuplicateRecordForChangedQuantity() {
+        long timestamp = System.currentTimeMillis() / 1000L;
+        String base = "{\"ProductCode\":\"prod-local\",\"UsageRecords\":[{\"Timestamp\":" + timestamp
+                + ",\"CustomerAWSAccountId\":\"123456789012\",\"Dimension\":\"users\",\"Quantity\":";
+        rpc("BatchMeterUsage", base + "1}]}").statusCode(200).body("Results[0].Status", equalTo("Success"));
+        rpc("BatchMeterUsage", base + "2}]}").statusCode(200).body("Results[0].Status", equalTo("DuplicateRecord"));
+    }
+
+    @Test
+    void registerUsageReturnsSignature() {
+        rpc("RegisterUsage", "{\"ProductCode\":\"prod-local\",\"PublicKeyVersion\":1,\"Nonce\":\"instance-1\"}")
+                .statusCode(200).body("Signature", matchesPattern("^[^.]+\\.[^.]+\\.[^.]+$"));
+    }
+
+    private static io.restassured.response.ValidatableResponse rpc(String action, String body) {
+        return given().contentType("application/x-amz-json-1.1").header("Authorization", auth())
+                .header("X-Amz-Target", "AWSMPMeteringService." + action).body(body).post("/").then();
+    }
+
+    private static String auth() { return "AWS4-HMAC-SHA256 Credential=000000000000/20260908/us-east-1/aws-marketplace/aws4_request"; }
+}

--- a/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringServiceTest.java
@@ -1,0 +1,85 @@
+package io.github.hectorvent.floci.services.marketplace;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MarketplaceMeteringServiceTest {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private MarketplaceMeteringService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new MarketplaceMeteringService(mapper, null,
+                AccountAwareStorageBackend.inMemory("000000000000"),
+                AccountAwareStorageBackend.inMemory("000000000000"),
+                AccountAwareStorageBackend.inMemory("000000000000"),
+                AccountAwareStorageBackend.inMemory("000000000000"));
+    }
+
+    @Test
+    void registerUsageReturnsPs256Jwt() throws Exception {
+        String jwt = service.handle("RegisterUsage", mapper.readTree(
+                "{\"ProductCode\":\"prod-local\",\"PublicKeyVersion\":1}"), "us-east-1")
+                .path("Signature").asText();
+        String header = new String(Base64.getUrlDecoder().decode(jwt.split("\\.")[0]), StandardCharsets.UTF_8);
+        assertEquals("PS256", mapper.readTree(header).path("alg").asText());
+        assertEquals(256, Base64.getUrlDecoder().decode(jwt.split("\\.")[2]).length);
+    }
+
+    @Test
+    void meteringStateIsRegionScoped() throws Exception {
+        long timestamp = System.currentTimeMillis() / 1000L;
+        JsonNode request = mapper.readTree("{\"ProductCode\":\"prod-local\",\"Timestamp\":" + timestamp
+                + ",\"UsageDimension\":\"requests\",\"UsageQuantity\":1}");
+        String east = service.handle("MeterUsage", request, "us-east-1").path("MeteringRecordId").asText();
+        String west = service.handle("MeterUsage", request, "us-west-2").path("MeteringRecordId").asText();
+        assertNotEquals(east, west);
+    }
+
+
+    @Test
+    void genericValidationUsesValidationException() throws Exception {
+        long timestamp = System.currentTimeMillis() / 1000L;
+
+        AwsException quantity = assertThrows(AwsException.class, () -> service.handle("MeterUsage", mapper.readTree(
+                "{\"ProductCode\":\"prod-local\",\"Timestamp\":" + timestamp
+                        + ",\"UsageDimension\":\"requests\",\"UsageQuantity\":1.5}"), "us-east-1"));
+        assertEquals("ValidationException", quantity.getErrorCode());
+
+        AwsException records = assertThrows(AwsException.class, () -> service.handle("BatchMeterUsage", mapper.readTree(
+                "{\"ProductCode\":\"prod-local\",\"UsageRecords\":\"not-an-array\"}"), "us-east-1"));
+        assertEquals("ValidationException", records.getErrorCode());
+
+        AwsException clientToken = assertThrows(AwsException.class, () -> service.handle("MeterUsage", mapper.readTree(
+                "{\"ProductCode\":\"prod-local\",\"Timestamp\":" + timestamp
+                        + ",\"UsageDimension\":\"requests\",\"UsageQuantity\":1,\"ClientToken\":\""
+                        + "x".repeat(65) + "\"}"), "us-east-1"));
+        assertEquals("ValidationException", clientToken.getErrorCode());
+
+        AwsException nonce = assertThrows(AwsException.class, () -> service.handle("RegisterUsage", mapper.readTree(
+                "{\"ProductCode\":\"prod-local\",\"PublicKeyVersion\":1,\"Nonce\":\""
+                        + "x".repeat(256) + "\"}"), "us-east-1"));
+        assertEquals("ValidationException", nonce.getErrorCode());
+    }
+
+    @Test
+    void fractionalQuantityAndBlankProductCodeAreRejected() throws Exception {
+        long timestamp = System.currentTimeMillis() / 1000L;
+        assertThrows(AwsException.class, () -> service.handle("MeterUsage", mapper.readTree(
+                "{\"ProductCode\":\"prod-local\",\"Timestamp\":" + timestamp
+                        + ",\"UsageDimension\":\"requests\",\"UsageQuantity\":1.5}"), "us-east-1"));
+        assertThrows(AwsException.class, () -> service.handle("RegisterUsage", mapper.readTree(
+                "{\"ProductCode\":\"\",\"PublicKeyVersion\":1}"), "us-east-1"));
+    }
+}

--- a/tools/docs/services.yaml
+++ b/tools/docs/services.yaml
@@ -89,6 +89,7 @@ services:
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceEntitlementController.java, mode: switch }
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceDeploymentController.java, mode: rest }
       - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceReportingController.java, mode: rest }
+      - { path: src/main/java/io/github/hectorvent/floci/services/marketplace/MarketplaceMeteringService.java, mode: switch }
     exclude_actions:
       - AgreementType
       - Status


### PR DESCRIPTION
## Summary

Adds AWS Marketplace Metering Service emulation as an independent Marketplace API-family contribution. Includes MeterUsage, BatchMeterUsage, RegisterUsage, ResolveCustomer, account-aware metering/idempotency state, integration coverage, docs, and an AWS SDK compatibility smoke test.

This is one of the API-family splits of the previous combined Marketplace contribution (#3303).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Reviewed against the current AWS Marketplace Metering Service API reference. Senior review removed direct Catalog-service coupling and corrected RegisterUsage to return a JWT-shaped three-segment signature instead of plain base64. `make docs-check` and `git diff --check` pass. Heavy local Maven execution was intentionally not run on this machine; CI is expected to execute the full test suite.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
