### PR TITLE
test(stepfunctions): pass the SNS handler when constructing AslExecutor in tests

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorFailStateErrorCauseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorFailStateErrorCauseTest.java
@@ -52,6 +52,7 @@ class AslExecutorFailStateErrorCauseTest {
                 mock(DynamoDbService.class),
                 mock(DynamoDbJsonHandler.class),
                 mock(SqsJsonHandler.class),
+                mock(io.github.hectorvent.floci.services.sns.SnsJsonHandler.class),
                 mock(io.github.hectorvent.floci.services.cloudformation.CloudFormationQueryHandler.class),
                 mock(io.github.hectorvent.floci.services.ec2.Ec2Service.class),
                 mock(S3Service.class),


### PR DESCRIPTION
## Summary

`main` does not compile. `AslExecutorFailStateErrorCauseTest` constructs `AslExecutor` by hand and is missing the `SnsJsonHandler` argument, so Build and Test fails at the **Compile** step before any test runs.

A merge-order race put it there, and neither PR was wrong on its own:

- **#3302** added this test class, which constructs `AslExecutor` directly.
- **#3316** then added an `SnsJsonHandler` parameter to that constructor and updated the 26 test classes that constructed it. That set was taken from a base predating #3302, so this class was never in it.

Git merged both cleanly, because neither touched the other's lines. Nothing surfaced until `test-compile` ran on `main`.

One argument, in the position the constructor declares it and the position its sibling `AslExecutorCatchTest` already uses. Fully qualified to match this file, which spells out eight of its other mocks the same way.

No other class needs it. Three further `AslExecutor` tests carry no `SnsJsonHandler` either, but they pass their arguments as positional `null`s, so the added parameter was absorbed and they compile unchanged.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

Titled `test(stepfunctions):` rather than `fix:` deliberately. It touches one test file and changes no emulator behaviour, so it should not produce a release note. There is no `test:` box on this template, hence the chore tick.

## AWS Compatibility

No emulated surface changes. No request parsing, response shape, error code, ARN or URL generation is touched, and no production file is modified. This restores the build only.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Verified at `483dfb4`, which is current `main` including #3317: `./mvnw test-compile` is clean, and that is the exact step currently red on `main`, so the one line is the complete fix rather than the first of several. `AslExecutorFailStateErrorCauseTest` and `StepFunctionsFailErrorPathValidationIntegrationTest` run 14 green.

The full suite box is unticked rather than claimed: I ran the focused tests plus a full `test-compile`, which is what proves this particular breakage fixed. No behaviour changed, so nothing else in the suite can be affected by it.
