### PR TITLE
fix(ec2): include supported usage classes in DescribeInstanceTypes

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -278,6 +278,7 @@ class Ec2Tests {
                 .containsExactly("arm64");
     }
 
+    /** Regression coverage for the Karpenter instance-type compatibility contract. */
     @Test
     @Order(7)
     @DisplayName("DescribeInstanceTypes - supported usage classes")

--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/Ec2Tests.java
@@ -280,6 +280,21 @@ class Ec2Tests {
 
     @Test
     @Order(7)
+    @DisplayName("DescribeInstanceTypes - supported usage classes")
+    void describeInstanceTypeSupportedUsageClasses() {
+        DescribeInstanceTypesResponse resp = ec2.describeInstanceTypes(DescribeInstanceTypesRequest.builder()
+                .instanceTypes(InstanceType.M5_LARGE, InstanceType.fromValue("t4g.medium"),
+                        InstanceType.fromValue("m6gd.large"))
+                .build());
+
+        assertThat(resp.instanceTypes()).hasSize(3);
+        assertThat(resp.instanceTypes()).allSatisfy(instanceType ->
+                assertThat(instanceType.supportedUsageClassesAsStrings())
+                        .containsExactlyInAnyOrder("on-demand", "spot"));
+    }
+
+    @Test
+    @Order(7)
     @DisplayName("CreateFleet - dry-run and instant on-demand launch")
     void createFleetDryRunAndLaunch() {
         String launchTemplateId = ec2.createLaunchTemplate(CreateLaunchTemplateRequest.builder()

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalog.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2InstanceTypeCatalog.java
@@ -95,6 +95,9 @@ public class Ec2InstanceTypeCatalog {
             if (instanceType.supportedArchitectures == null || instanceType.supportedArchitectures.isEmpty()) {
                 throw new IllegalStateException("EC2 instance type catalog entry is missing supportedArchitectures: " + name);
             }
+            if (instanceType.supportedUsageClasses == null || instanceType.supportedUsageClasses.isEmpty()) {
+                throw new IllegalStateException("EC2 instance type catalog entry is missing supportedUsageClasses: " + name);
+            }
             if (instanceType.encryptionInTransitSupported == null) {
                 throw new IllegalStateException(
                         "EC2 instance type catalog entry is missing encryptionInTransitSupported: " + name);
@@ -156,6 +159,7 @@ public class Ec2InstanceTypeCatalog {
         public int memoryMib;
         public int localStorageGiB;
         public List<String> supportedArchitectures = List.of();
+        public List<String> supportedUsageClasses = List.of("on-demand", "spot");
         public Boolean currentGeneration;
         public Boolean encryptionInTransitSupported;
         public Integer defaultNetworkCardIndex;
@@ -170,6 +174,7 @@ public class Ec2InstanceTypeCatalog {
             type.put("instanceStorageSupported", localStorageGiB > 0);
             type.put("localStorageGiB", localStorageGiB);
             type.put("supportedArchitectures", List.copyOf(supportedArchitectures));
+            type.put("supportedUsageClasses", List.copyOf(supportedUsageClasses));
             type.put("currentGeneration", currentGeneration == null || currentGeneration);
             Map<String, Object> networkInfo = new LinkedHashMap<>();
             networkInfo.put("encryptionInTransitSupported", encryptionInTransitSupported);

--- a/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ec2/Ec2QueryHandler.java
@@ -3849,7 +3849,12 @@ public class Ec2QueryHandler {
             for (String arch : (List<String>) t.get("supportedArchitectures")) {
                 xml.elem("item", arch);
             }
-            xml.end("supportedArchitectures").end("processorInfo");
+            xml.end("supportedArchitectures").end("processorInfo")
+                    .start("supportedUsageClasses");
+            for (String usageClass : (List<String>) t.get("supportedUsageClasses")) {
+                xml.elem("item", usageClass);
+            }
+            xml.end("supportedUsageClasses");
             Map<String, Object> networkInfo = (Map<String, Object>) t.get("networkInfo");
             xml.start("networkInfo")
                     .elem("encryptionInTransitSupported",

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorFailStateErrorCauseTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorFailStateErrorCauseTest.java
@@ -31,6 +31,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * <p>Both fields are resolved through the same reference-path resolver a {@code ".$"} payload
  * template field uses, so an unresolvable path fails with {@code States.Runtime}, matching the
  * precedent set for issue #2521 in {@link AslExecutorUnresolvableJsonPathTest}.
+ *
+ * <p>The fixture supplies all service handlers required by the production executor, including
+ * the SNS handler introduced by the Step Functions SNS integration.
  */
 @QuarkusTest
 class AslExecutorFailStateErrorCauseTest {


### PR DESCRIPTION
## Summary

Fixes the EC2 `DescribeInstanceTypes` response so it includes the supported usage classes required by Karpenter and other AWS-compatible clients. Fixes #3346.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously omitted `supportedUsageClasses` from `DescribeInstanceTypes`. Karpenter 1.8.8 interprets the missing field as no compatible capacity types and rejects on-demand NodeClaims before `CreateFleet`; the same direct `CreateFleet` request succeeds. The catalog now returns `on-demand` and `spot`, and the query handler serializes both values using the AWS EC2 Query response shape.

The change covers `m5.large`, `t4g.medium`, and `m6gd.large`, the instance types exercised by the compatibility gate.

## Changes

- Add validated `supportedUsageClasses` data to the instance-type catalog, defaulting to `on-demand` and `spot`.
- Serialize the list as `<supportedUsageClasses><item>...</item></supportedUsageClasses>` in `DescribeInstanceTypes`.
- Add an SDK integration test asserting the values for representative amd64 and arm64 instance types.

## Validation

- `./mvnw -q -DskipTests package`
- `./mvnw -q -Dtest=Ec2IntegrationTest test`

## Checklist

- [ ] `./mvnw test` passes locally (targeted EC2 integration test and package build pass; full suite not run)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->
