### PR TITLE
fix(test): disable the GuardDuty organization admin GuardDutyMembersIntegrationTest enables

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyMembersIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyMembersIntegrationTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.guardduty;
 
 import io.github.hectorvent.floci.testing.RestAssuredJsonUtils;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -11,9 +12,29 @@ import static org.hamcrest.Matchers.hasSize;
 
 @QuarkusTest
 class GuardDutyMembersIntegrationTest {
+    private boolean enabledOrganizationAdmin;
+
     @BeforeAll
     static void configureRestAssured() {
         RestAssuredJsonUtils.configureAwsContentTypes();
+    }
+
+    /**
+     * GuardDuty's organization admin accounts are shared by every test in the JVM, and Macie
+     * answers the same {@code /admin} route, so an admin left behind here makes
+     * {@code MacieOrganizationIntegrationTest.sharedAdminRouteKeepsGuardDutyBehavior} see one
+     * where it expects none. The flag keeps the teardown to the test that enabled it, so a
+     * single-method run of this class still works.
+     */
+    @AfterEach
+    void disableTheOrganizationAdminThisTestEnabled() {
+        if (enabledOrganizationAdmin) {
+            given().contentType("application/json")
+                    .header("Authorization", auth("444444444444"))
+                    .body("{\"adminAccountId\":\"444444444444\"}")
+                    .post("/admin/disable")
+                    .then().statusCode(200);
+        }
     }
 
     @Test
@@ -49,6 +70,7 @@ class GuardDutyMembersIntegrationTest {
                 .body("{\"adminAccountId\":\"444444444444\"}")
                 .post("/admin/enable")
                 .then().statusCode(200);
+        enabledOrganizationAdmin = true;
 
         String detectorId = createDetector("444444444444");
 

--- a/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyMembersIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/guardduty/GuardDutyMembersIntegrationTest.java
@@ -34,6 +34,7 @@ class GuardDutyMembersIntegrationTest {
                     .body("{\"adminAccountId\":\"444444444444\"}")
                     .post("/admin/disable")
                     .then().statusCode(200);
+            enabledOrganizationAdmin = false;
         }
     }
 


### PR DESCRIPTION
## Summary

`GuardDutyMembersIntegrationTest` enables account 444444444444 as a GuardDuty
organization admin and never disables it. Those admin accounts live in a store
shared by every `@QuarkusTest` class in the same Surefire fork, and Macie
answers the same `/admin` route, so
`MacieOrganizationIntegrationTest.sharedAdminRouteKeepsGuardDutyBehavior` fails
whenever it runs after this class: it asks for an empty admin list on the
GuardDuty credential scope and gets 444444444444 back.

```
MacieOrganizationIntegrationTest.sharedAdminRouteKeepsGuardDutyBehavior:57
  JSON path adminAccounts doesn't match.
  Expected: a collection with size <0>
    Actual: <[{adminAccountId=444444444444, adminStatus=ENABLED}]>
```

The admin is now disabled in `@AfterEach`, guarded by a flag so the teardown
runs only for the test that enabled one and a single-method run of the class
still works. The teardown goes through `/admin/disable`, the same route the test
used to create the state, rather than reaching for the service.
`GuardDutyControllerIntegrationTest` already disables what it enables, so this
was the only class leaving one behind.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No product code changes: this is test state that leaks between classes, in the
same shape as the DetectiveIntegrationTest teardown, and the fix follows that
one's flag-guarded `@AfterEach` pattern.

Reproduced and verified locally. `GuardDutyMembersIntegrationTest` plus
`MacieOrganizationIntegrationTest` in one fork fails before this change on the
assertion above and passes after (7 tests). The org-admin neighbourhood is green
as well: `GuardDuty*`, `Macie*`, `Detective*`, `Inspector2*` and `SecurityHub*`
run to 74 tests, no failures.

A full local `./mvnw test` on this branch runs 19120 tests with one error left,
and it is not this one: `ContainerPlatformDockerIntegrationTest` fails on this
host because Docker 29's containerd image store reports an empty Os and
Architecture for a foreign-platform image, which is unrelated to this change.
Before the change, that same run had this Macie failure alongside it.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
