### PR TITLE
fix(s3): parse namespaced S3 EventBridge notifications

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1741,13 +1741,27 @@ public class S3Controller {
                         new LambdaNotification(parsed.id, parsed.arn, parsed.events, parsed.filterRules));
             }
 
-            config.setEventBridgeEnabled(xml.contains("<EventBridgeConfiguration"));
+            config.setEventBridgeEnabled(parseEventBridgeConfiguration(xml));
 
             s3Service.putBucketNotificationConfiguration(bucket, config);
             return Response.ok().build();
         } catch (AwsException e) {
             return xmlErrorResponse(e);
         }
+    }
+
+    private static boolean parseEventBridgeConfiguration(String xml) {
+        if (!"NotificationConfiguration".equals(XmlParser.rootElementName(xml))) {
+            throw new AwsException("MalformedXML", "The XML you provided was not well-formed.", 400);
+        }
+        List<String> children = XmlParser.childElementNames(xml, "NotificationConfiguration");
+        long eventBridgeConfigurations = children.stream()
+                .filter("EventBridgeConfiguration"::equals)
+                .count();
+        if (eventBridgeConfigurations > 1) {
+            throw new AwsException("MalformedXML", "The XML you provided was not well-formed.", 400);
+        }
+        return eventBridgeConfigurations == 1;
     }
 
     private record ParsedNotificationGroup(String id, String arn, List<String> events,

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3EventBridgeNotificationValidationIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3EventBridgeNotificationValidationIntegrationTest.java
@@ -1,0 +1,116 @@
+package io.github.hectorvent.floci.services.s3;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+class S3EventBridgeNotificationValidationIntegrationTest {
+
+    @Test
+    void namespacedEventBridgeConfigurationIsAccepted() {
+        String bucket = createBucket("namespaced");
+
+        given()
+                .contentType("application/xml")
+                .body("""
+                        <s3:NotificationConfiguration xmlns:s3="http://s3.amazonaws.com/doc/2006-03-01/">
+                            <s3:EventBridgeConfiguration/>
+                        </s3:NotificationConfiguration>
+                        """)
+                .when()
+                .put("/" + bucket + "?notification")
+                .then()
+                .statusCode(200);
+
+        given()
+                .when()
+                .get("/" + bucket + "?notification")
+                .then()
+                .statusCode(200)
+                .body(containsString("<EventBridgeConfiguration"));
+    }
+
+    @Test
+    void malformedNotificationConfigurationIsRejected() {
+        String bucket = createBucket("malformed");
+
+        putNotification(bucket, "<NotificationConfiguration><EventBridgeConfiguration></NotificationConfiguration>")
+                .statusCode(400)
+                .body(containsString("<Code>MalformedXML</Code>"));
+    }
+
+    @Test
+    void eventBridgeTextInCommentDoesNotEnableEventBridge() {
+        String bucket = createBucket("comment");
+
+        putNotification(bucket, """
+                <NotificationConfiguration>
+                    <!-- <EventBridgeConfiguration/> -->
+                </NotificationConfiguration>
+        """).statusCode(200);
+
+        getNotification(bucket)
+                .statusCode(200)
+                .body(not(containsString("<EventBridgeConfiguration")));
+    }
+
+    @Test
+    void wrongNotificationConfigurationRootIsRejected() {
+        String bucket = createBucket("wrong-root");
+
+        putNotification(bucket, "<OtherConfiguration><EventBridgeConfiguration/></OtherConfiguration>")
+                .statusCode(400)
+                .body(containsString("<Code>MalformedXML</Code>"));
+    }
+
+    @Test
+    void duplicateEventBridgeConfigurationsAreRejected() {
+        String bucket = createBucket("duplicate");
+
+        putNotification(bucket, """
+                <NotificationConfiguration>
+                    <EventBridgeConfiguration/>
+                    <EventBridgeConfiguration/>
+                </NotificationConfiguration>
+                """)
+                .statusCode(400)
+                .body(containsString("<Code>MalformedXML</Code>"));
+    }
+
+    @Test
+    void emptyNotificationConfigurationDisablesEventBridge() {
+        String bucket = createBucket("empty");
+
+        putNotification(bucket, "<NotificationConfiguration/>").statusCode(200);
+
+        getNotification(bucket)
+                .statusCode(200)
+                .body(not(containsString("<EventBridgeConfiguration")));
+    }
+
+    private static String createBucket(String suffix) {
+        String bucket = "eventbridge-validation-" + suffix;
+        given().when().put("/" + bucket).then().statusCode(200);
+        return bucket;
+    }
+
+    private static io.restassured.response.ValidatableResponse putNotification(String bucket, String body) {
+        return given()
+                .contentType("application/xml")
+                .body(body)
+                .when()
+                .put("/" + bucket + "?notification")
+                .then();
+    }
+
+    private static io.restassured.response.ValidatableResponse getNotification(String bucket) {
+        return given()
+                .when()
+                .get("/" + bucket + "?notification")
+                .then();
+    }
+}


### PR DESCRIPTION
## Summary

S3 bucket notification configuration now handles namespaced EventBridge XML correctly and ignores matching text inside comments. Invalid roots and duplicate EventBridge elements return the AWS-compatible `MalformedXML` error.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

S3 notification configuration uses XML namespaces, so element names must be matched by their local names rather than raw text. This keeps valid EventBridge configurations enabled and prevents comments or malformed structures from changing the stored configuration.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
