### PR TITLE
fix(cdk): parse CDK endpoint URLs safely

### DIFF
--- a/compatibility-tests/README.md
+++ b/compatibility-tests/README.md
@@ -61,6 +61,7 @@ Per-module requirements:
 | `sdk-test-awscli` | AWS CLI v2, bash, jq                |
 | `sdk-test-java`   | Java 17+, Maven                     |
 | `sdk-test-go`     | Go 1.24+                            |
+| `compat-cdk`      | Node.js 20+, npm, Python 3, bats-core |
 
 ## Setup
 

--- a/compatibility-tests/compat-cdk/run.sh
+++ b/compatibility-tests/compat-cdk/run.sh
@@ -9,10 +9,25 @@ export AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-test}"
 export FLOCI_ENDPOINT="${FLOCI_ENDPOINT:-http://localhost:4566}"
 export AWS_ENDPOINT_URL="$FLOCI_ENDPOINT"
 export AWS_ENDPOINT_URL_S3="$FLOCI_ENDPOINT"
-# CDK-specific: derive hostname and port from endpoint
-export LOCALSTACK_HOSTNAME="${FLOCI_ENDPOINT#http://}"
-export LOCALSTACK_HOSTNAME="${LOCALSTACK_HOSTNAME%:*}"
-export EDGE_PORT="${FLOCI_ENDPOINT##*:}"
+
+# CDK-specific: derive hostname and port from the endpoint URL.
+read -r LOCALSTACK_HOSTNAME EDGE_PORT < <(python3 - "$FLOCI_ENDPOINT" <<'PY'
+import sys
+from urllib.parse import urlsplit
+
+endpoint = sys.argv[1]
+parsed = urlsplit(endpoint if "://" in endpoint else "//" + endpoint)
+hostname = parsed.hostname
+if not hostname:
+    raise SystemExit(f"Cannot determine hostname from FLOCI_ENDPOINT: {endpoint}")
+try:
+    port = parsed.port or 4566
+except ValueError as error:
+    raise SystemExit(f"Invalid port in FLOCI_ENDPOINT: {endpoint}") from error
+print(hostname, port)
+PY
+)
+export LOCALSTACK_HOSTNAME EDGE_PORT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/compatibility-tests/compat-cdk/test/endpoint-parsing.bats
+++ b/compatibility-tests/compat-cdk/test/endpoint-parsing.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+@test "run.sh derives CDK host and port from a URL endpoint" {
+    workdir=$(mktemp -d)
+    trap 'rm -rf "$workdir"' EXIT
+    mkdir -p "$workdir/compat-cdk" "$workdir/lib/bats-core"
+    cp "$BATS_TEST_DIRNAME/../run.sh" "$workdir/compat-cdk/run.sh"
+    cat > "$workdir/lib/run-bats-with-junit.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$LOCALSTACK_HOSTNAME" "$EDGE_PORT"
+EOF
+    chmod +x "$workdir/lib/run-bats-with-junit.sh"
+
+    run env FLOCI_ENDPOINT="https://[::1]:8443/floci" bash "$workdir/compat-cdk/run.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "::1|8443" ]
+}
+
+@test "run.sh uses the default port for an endpoint without one" {
+    workdir=$(mktemp -d)
+    trap 'rm -rf "$workdir"' EXIT
+    mkdir -p "$workdir/compat-cdk" "$workdir/lib/bats-core"
+    cp "$BATS_TEST_DIRNAME/../run.sh" "$workdir/compat-cdk/run.sh"
+    cat > "$workdir/lib/run-bats-with-junit.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s|%s\n' "$LOCALSTACK_HOSTNAME" "$EDGE_PORT"
+EOF
+    chmod +x "$workdir/lib/run-bats-with-junit.sh"
+
+    run env FLOCI_ENDPOINT="floci" bash "$workdir/compat-cdk/run.sh"
+
+    [ "$status" -eq 0 ]
+    [ "$output" = "floci|4566" ]
+}

--- a/compatibility-tests/justfile
+++ b/compatibility-tests/justfile
@@ -47,7 +47,7 @@ test-java:
 # Run Go SDK tests (JUnit XML output via gotestsum)
 [working-directory: 'sdk-test-go']
 test-go:
-    gotestsum --junitfile test-results.xml ./tests/...
+    gotestsum --junitfile test-results.xml ./tests/... ./internal/testutil/...
 
 # Install all test dependencies
 setup: setup-python setup-typescript setup-awscli setup-java setup-go

--- a/compatibility-tests/sdk-test-go/Dockerfile
+++ b/compatibility-tests/sdk-test-go/Dockerfile
@@ -16,4 +16,4 @@ ENV AWS_ACCESS_KEY_ID=test
 ENV AWS_SECRET_ACCESS_KEY=test
 ENV AWS_DEFAULT_REGION=us-east-1
 
-ENTRYPOINT ["gotestsum", "--format", "testname", "--junitfile", "/results/junit.xml", "./tests/..."]
+ENTRYPOINT ["gotestsum", "--format", "testname", "--junitfile", "/results/junit.xml", "./tests/...", "./internal/testutil/..."]

--- a/compatibility-tests/sdk-test-go/README.md
+++ b/compatibility-tests/sdk-test-go/README.md
@@ -30,10 +30,10 @@ Compatibility tests for [Floci](https://github.com/hectorvent/floci) using the *
 
 ```bash
 # All groups
-gotestsum --junitfile test-results.xml ./tests/...
+gotestsum --junitfile test-results.xml ./tests/... ./internal/testutil/...
 
 # Specific tests
-go test ./tests/ -run TestSsm
+go test ./tests/... ./internal/testutil/... -run TestSsm
 
 # Via just (from compatibility-tests/)
 just test-go

--- a/compatibility-tests/sdk-test-go/internal/testutil/fixtures.go
+++ b/compatibility-tests/sdk-test-go/internal/testutil/fixtures.go
@@ -5,7 +5,9 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -177,18 +179,15 @@ func CognitoClient() *cognitoidentityprovider.Client {
 // ProxyHost returns the host to use for direct TCP connections to RDS/ElastiCache proxies.
 func ProxyHost() string {
 	ep := Endpoint()
-	// Strip scheme — ep is "http://host:port" or "http://host"
-	if len(ep) > 7 && ep[:7] == "http://" {
-		ep = ep[7:]
+	parsed, err := url.Parse(ep)
+	if err != nil {
+		return ep
 	}
-	// Strip port if present
-	if i := len(ep) - 1; i > 0 {
-		for i >= 0 && ep[i] != ':' {
-			i--
-		}
-		if i > 0 {
-			return ep[:i]
-		}
+	if parsed.Hostname() == "" && !strings.Contains(ep, "://") {
+		parsed, err = url.Parse("//" + ep)
+	}
+	if err == nil && parsed.Hostname() != "" {
+		return parsed.Hostname()
 	}
 	return ep
 }

--- a/compatibility-tests/sdk-test-go/internal/testutil/fixtures_test.go
+++ b/compatibility-tests/sdk-test-go/internal/testutil/fixtures_test.go
@@ -1,0 +1,52 @@
+package testutil
+
+import "testing"
+
+func TestProxyHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     string
+	}{
+		{
+			name:     "http endpoint with port",
+			endpoint: "http://localhost:4566",
+			want:     "localhost",
+		},
+		{
+			name:     "https endpoint with port",
+			endpoint: "https://example.test:8443",
+			want:     "example.test",
+		},
+		{
+			name:     "ipv6 endpoint with port",
+			endpoint: "http://[::1]:4566",
+			want:     "::1",
+		},
+		{
+			name:     "endpoint with path",
+			endpoint: "https://example.test:4566/floci",
+			want:     "example.test",
+		},
+		{
+			name:     "endpoint without scheme",
+			endpoint: "localhost:4566",
+			want:     "localhost",
+		},
+		{
+			name:     "invalid endpoint",
+			endpoint: "http://[::1",
+			want:     "http://[::1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("FLOCI_ENDPOINT", tt.endpoint)
+
+			if got := ProxyHost(); got != tt.want {
+				t.Fatalf("ProxyHost() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The CDK compatibility runner now derives its host and port from `FLOCI_ENDPOINT` using URL parsing. This supports schemes, paths, IPv6 addresses, and endpoints without an explicit port.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The change only affects compatibility-test environment setup. It preserves the AWS endpoint variables while preventing malformed host and port values from being passed to the CDK test container.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
