### PR TITLE
fix(msk): isolate MSK resources by account and region

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -132,6 +132,7 @@ public class MskService implements ResourceProvider {
         MskCluster cluster = new MskCluster(clusterArn, clusterName, resolvedKafkaVersion);
         cluster.setClusterType(PROVISIONED_CLUSTER_TYPE);
         cluster.setAccountId(accountId);
+        cluster.setResourceRegion(regionResolver.getRegion());
         cluster.setVolumeId(String.format("%06x", new SecureRandom().nextInt(0xFFFFFF)));
 
         if (request.getNumberOfBrokerNodes() != null) {
@@ -342,6 +343,7 @@ public class MskService implements ResourceProvider {
         cluster.setServerless(request.getServerless());
         cluster.setTags(request.getTags());
         cluster.setAccountId(accountId);
+        cluster.setResourceRegion(regionResolver.getRegion());
         cluster.setVolumeId(String.format("%06x", new SecureRandom().nextInt(0xFFFFFF)));
 
         // Provisioned-only members must not surface on a serverless cluster.
@@ -667,7 +669,12 @@ public class MskService implements ResourceProvider {
     }
 
     private boolean isCurrentRegion(MskCluster cluster) {
-        return regionResolver.getRegion().equals(AwsArnUtils.regionOrDefault(
-                cluster.getClusterArn(), config.defaultRegion()));
+        if (cluster.getResourceRegion() != null) {
+            return regionResolver.getRegion().equals(cluster.getResourceRegion());
+        }
+        // Older records have no request-region marker and their ARN always used the configured
+        // default. Keep them visible until they are recreated so an upgrade does not hide or
+        // strand persisted clusters whose original request region was not stored.
+        return true;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/MskService.java
@@ -118,12 +118,14 @@ public class MskService implements ResourceProvider {
     public MskCluster createCluster(CreateClusterRequest request) {
         validateCreateRequest(request);
         String clusterName = request.getClusterName();
-        if (storage.scan(k -> true).stream().anyMatch(c -> c.getClusterName().equals(clusterName))) {
+        if (storage.scan(k -> true).stream().anyMatch(c -> isCurrentRegion(c)
+                && c.getClusterName().equals(clusterName))) {
             throw new AwsException("ConflictException", "Cluster already exists: " + clusterName, 409);
         }
 
         String accountId = regionResolver.getAccountId();
-        String clusterArn = AwsArnUtils.Arn.of("kafka", config.defaultRegion(), accountId, "cluster/" + clusterName + "/" + java.util.UUID.randomUUID()).toString();
+        String clusterArn = AwsArnUtils.Arn.of("kafka", regionResolver.getRegion(), accountId,
+                "cluster/" + clusterName + "/" + java.util.UUID.randomUUID()).toString();
 
         String kafkaVersion = request.getKafkaVersion();
         String resolvedKafkaVersion = (kafkaVersion == null || kafkaVersion.isBlank()) ? DEFAULT_KAFKA_VERSION : kafkaVersion;
@@ -326,12 +328,13 @@ public class MskService implements ResourceProvider {
             throw badRequest("clusterName",
                     "clusterName must be between 1 and " + MAX_CLUSTER_NAME_LENGTH + " characters.");
         }
-        if (storage.scan(k -> true).stream().anyMatch(c -> c.getClusterName().equals(clusterName))) {
+        if (storage.scan(k -> true).stream().anyMatch(c -> isCurrentRegion(c)
+                && c.getClusterName().equals(clusterName))) {
             throw new AwsException("ConflictException", "Cluster already exists: " + clusterName, 409);
         }
 
         String accountId = regionResolver.getAccountId();
-        String clusterArn = AwsArnUtils.Arn.of("kafka", config.defaultRegion(), accountId,
+        String clusterArn = AwsArnUtils.Arn.of("kafka", regionResolver.getRegion(), accountId,
                 "cluster/" + clusterName + "/" + UUID.randomUUID()).toString();
 
         MskCluster cluster = new MskCluster(clusterArn, clusterName, DEFAULT_KAFKA_VERSION);
@@ -377,21 +380,21 @@ public class MskService implements ResourceProvider {
 
     /** ListClusters for the v1 API, which likewise cannot represent serverless clusters. */
     public List<MskCluster> listProvisionedClusters() {
-        return storage.scan(k -> true).stream().filter(c -> !isServerless(c)).toList();
+        return storage.scan(k -> true).stream().filter(this::isCurrentRegion)
+                .filter(c -> !isServerless(c)).toList();
     }
 
     public MskCluster describeCluster(String clusterArn) {
-        return storage.get(clusterArn)
+        return storage.get(clusterArn).filter(this::isCurrentRegion)
                 .orElseThrow(() -> new AwsException("NotFoundException", "Cluster not found: " + clusterArn, 404));
     }
 
     public List<MskCluster> listClusters() {
-        return storage.scan(k -> true);
+        return storage.scan(k -> true).stream().filter(this::isCurrentRegion).toList();
     }
 
     public void deleteCluster(String clusterArn) {
-        MskCluster cluster = storage.get(clusterArn)
-                .orElseThrow(() -> new AwsException("NotFoundException", "Cluster not found: " + clusterArn, 404));
+        MskCluster cluster = describeCluster(clusterArn);
 
         cluster.setState(ClusterState.DELETING);
         if (!config.services().msk().mock()) {
@@ -541,7 +544,7 @@ public class MskService implements ResourceProvider {
     // DescribeConfiguration, whose 400 is a deliberate terraform-provider contract.
 
     public Map<String, String> listTagsForResource(String arn) {
-        MskCluster cluster = storage.get(arn).orElse(null);
+        MskCluster cluster = storage.get(arn).filter(this::isCurrentRegion).orElse(null);
         if (cluster != null) {
             return cluster.getTags() != null ? cluster.getTags() : Map.of();
         }
@@ -553,7 +556,7 @@ public class MskService implements ResourceProvider {
     }
 
     public void tagResource(String arn, Map<String, String> tags) {
-        MskCluster cluster = storage.get(arn).orElse(null);
+        MskCluster cluster = storage.get(arn).filter(this::isCurrentRegion).orElse(null);
         if (cluster != null) {
             cluster.setTags(merged(cluster.getTags(), tags));
             storage.put(arn, cluster);
@@ -569,7 +572,7 @@ public class MskService implements ResourceProvider {
     }
 
     public void untagResource(String arn, List<String> tagKeys) {
-        MskCluster cluster = storage.get(arn).orElse(null);
+        MskCluster cluster = storage.get(arn).filter(this::isCurrentRegion).orElse(null);
         if (cluster != null) {
             cluster.setTags(without(cluster.getTags(), tagKeys));
             storage.put(arn, cluster);
@@ -643,7 +646,7 @@ public class MskService implements ResourceProvider {
     @Override
     public List<ExplorerResource> getResources() {
         List<ExplorerResource> resources = new ArrayList<>();
-        for (MskCluster cluster : storage.scan(k -> true)) {
+        for (MskCluster cluster : storage.scan(k -> true).stream().filter(this::isCurrentRegion).toList()) {
             String arn = cluster.getClusterArn();
             if (arn == null) {
                 continue;
@@ -661,5 +664,10 @@ public class MskService implements ResourceProvider {
     @Override
     public Set<SupportedResourceType> getSupportedResourceTypes() {
         return Set.of(new SupportedResourceType("kafka:cluster", "kafka", true));
+    }
+
+    private boolean isCurrentRegion(MskCluster cluster) {
+        return regionResolver.getRegion().equals(AwsArnUtils.regionOrDefault(
+                cluster.getClusterArn(), config.defaultRegion()));
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -1,6 +1,7 @@
 package io.github.hectorvent.floci.services.msk;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
@@ -149,8 +150,9 @@ public class RedpandaManager {
                 .withDockerNetwork(config.services().dockerNetwork())
                 .withLogRotation()
                 .withLabels(ContainerStorageHelper.resourceIdentityLabels(
-                        "msk", cluster.getClusterName(), regionResolver.getAccountId(),
-                        regionResolver.getDefaultRegion()));
+                        "msk", cluster.getClusterName(),
+                        AwsArnUtils.accountOrDefault(cluster.getClusterArn(), regionResolver.getAccountId()),
+                        AwsArnUtils.regionOrDefault(cluster.getClusterArn(), regionResolver.getDefaultRegion())));
 
         if (!containerDetector.isRunningInContainer()) {
             specBuilder.withPortBinding(KAFKA_PORT, kafkaHostPort).withDynamicPort(ADMIN_PORT);
@@ -200,12 +202,12 @@ public class RedpandaManager {
                 : info.containerId();
         String logGroup = "/aws/msk/cluster/" + cluster.getClusterName();
         String logStream = logStreamer.generateLogStreamName(shortId);
-        String region = regionResolver.getDefaultRegion();
+        String region = AwsArnUtils.regionOrDefault(cluster.getClusterArn(), regionResolver.getDefaultRegion());
 
         Closeable logHandle = logStreamer.attach(
                 info.containerId(), logGroup, logStream, region, "msk:" + cluster.getClusterName());
         if (logHandle != null) {
-            logStreams.put(cluster.getClusterName(), logHandle);
+            logStreams.put(clusterIdentityKey(cluster), logHandle);
         }
     }
 
@@ -249,7 +251,7 @@ public class RedpandaManager {
         }
 
         // Close log stream
-        Closeable logHandle = logStreams.remove(cluster.getClusterName());
+        Closeable logHandle = logStreams.remove(clusterIdentityKey(cluster));
 
         lifecycleManager.stopAndRemove(cluster.getContainerId(), logHandle);
         LOG.infov("Redpanda container {0} stopped and removed", cluster.getContainerId());
@@ -279,5 +281,9 @@ public class RedpandaManager {
     public void removeClusterStorage(MskCluster cluster) {
         ContainerStorageHelper.removeStorage(config, lifecycleManager,
                 "msk", cluster.getVolumeId(), cluster.getClusterName());
+    }
+
+    private String clusterIdentityKey(MskCluster cluster) {
+        return cluster.getClusterArn() != null ? cluster.getClusterArn() : cluster.getClusterName();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -298,8 +298,8 @@ public class RedpandaManager {
     private Path legacyCompatibleHostPath(MskCluster cluster) {
         Path scopedPath = ContainerStorageHelper.hostResourcePath(config, "msk", clusterStorageId(cluster));
         Path legacyPath = ContainerStorageHelper.hostResourcePath(config, "msk", cluster.getClusterName());
-        return Files.exists(scopedPath) || !Files.exists(legacyPath)
-                ? scopedPath
-                : legacyPath;
+        return cluster.getResourceRegion() == null && Files.exists(legacyPath)
+                ? legacyPath
+                : scopedPath;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -167,7 +167,7 @@ public class RedpandaManager {
                     "/var/lib/redpanda/data");
         } else {
             // Legacy host-path mode: host-persistent-path is an absolute path
-            String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "msk", cluster.getClusterName())
+            String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "msk", clusterStorageId(cluster))
                     .toAbsolutePath().toString();
             if (!containerDetector.isRunningInContainer()) {
                 ContainerStorageHelper.ensureHostDir(hostDataPath);
@@ -204,8 +204,9 @@ public class RedpandaManager {
         String logStream = logStreamer.generateLogStreamName(shortId);
         String region = AwsArnUtils.regionOrDefault(cluster.getClusterArn(), regionResolver.getDefaultRegion());
 
-        Closeable logHandle = logStreamer.attach(
-                info.containerId(), logGroup, logStream, region, "msk:" + cluster.getClusterName());
+        String account = AwsArnUtils.accountOrDefault(cluster.getClusterArn(), regionResolver.getDefaultAccountId());
+        Closeable logHandle = logStreamer.attachForAccount(
+                account, info.containerId(), logGroup, logStream, region, "msk:" + cluster.getClusterName());
         if (logHandle != null) {
             logStreams.put(clusterIdentityKey(cluster), logHandle);
         }
@@ -285,5 +286,12 @@ public class RedpandaManager {
 
     private String clusterIdentityKey(MskCluster cluster) {
         return cluster.getClusterArn() != null ? cluster.getClusterArn() : cluster.getClusterName();
+    }
+
+    private String clusterStorageId(MskCluster cluster) {
+        String account = AwsArnUtils.accountOrDefault(cluster.getClusterArn(), regionResolver.getDefaultAccountId());
+        String region = AwsArnUtils.regionOrDefault(cluster.getClusterArn(), regionResolver.getDefaultRegion());
+        return ContainerStorageHelper.dockerName(config,
+                "msk-" + account + "-" + region + "-" + cluster.getClusterName());
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/RedpandaManager.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 import java.io.Closeable;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -167,8 +168,7 @@ public class RedpandaManager {
                     "/var/lib/redpanda/data");
         } else {
             // Legacy host-path mode: host-persistent-path is an absolute path
-            String hostDataPath = ContainerStorageHelper.hostResourcePath(config, "msk", clusterStorageId(cluster))
-                    .toAbsolutePath().toString();
+            String hostDataPath = legacyCompatibleHostPath(cluster).toAbsolutePath().toString();
             if (!containerDetector.isRunningInContainer()) {
                 ContainerStorageHelper.ensureHostDir(hostDataPath);
             }
@@ -293,5 +293,13 @@ public class RedpandaManager {
         String region = AwsArnUtils.regionOrDefault(cluster.getClusterArn(), regionResolver.getDefaultRegion());
         return ContainerStorageHelper.dockerName(config,
                 "msk-" + account + "-" + region + "-" + cluster.getClusterName());
+    }
+
+    private Path legacyCompatibleHostPath(MskCluster cluster) {
+        Path scopedPath = ContainerStorageHelper.hostResourcePath(config, "msk", clusterStorageId(cluster));
+        Path legacyPath = ContainerStorageHelper.hostResourcePath(config, "msk", cluster.getClusterName());
+        return Files.exists(scopedPath) || !Files.exists(legacyPath)
+                ? scopedPath
+                : legacyPath;
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/msk/model/MskCluster.java
+++ b/src/main/java/io/github/hectorvent/floci/services/msk/model/MskCluster.java
@@ -97,6 +97,10 @@ public class MskCluster {
     @JsonProperty("accountId")
     private String accountId;
 
+    // Region is persisted separately so records created before regional ARNs remain identifiable.
+    @JsonProperty("resourceRegion")
+    private String resourceRegion;
+
     // 6-char hex generated once at creation for stable, collision-free volume/container naming
     @JsonProperty("volumeId")
     private String volumeId;
@@ -179,6 +183,9 @@ public class MskCluster {
 
     public String getAccountId() { return accountId; }
     public void setAccountId(String accountId) { this.accountId = accountId; }
+
+    public String getResourceRegion() { return resourceRegion; }
+    public void setResourceRegion(String resourceRegion) { this.resourceRegion = resourceRegion; }
 
     public String getVolumeId() { return volumeId; }
     public void setVolumeId(String volumeId) { this.volumeId = volumeId; }

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -150,6 +150,17 @@ class MskServiceTest {
     }
 
     @Test
+    void legacyClusterWithoutResourceRegionRemainsVisibleAfterRegionalIsolation() {
+        MskCluster legacy = mskService.createCluster("legacy-cluster");
+        legacy.setResourceRegion(null);
+
+        when(regionResolver.getRegion()).thenReturn("eu-west-1");
+
+        assertEquals(List.of(legacy), mskService.listClusters());
+        assertEquals(legacy, mskService.describeCluster(legacy.getClusterArn()));
+    }
+
+    @Test
     void sameClusterNameIsRejectedWithinOneRegion() {
         mskService.createCluster("shared-name");
 
@@ -395,6 +406,8 @@ class MskServiceTest {
         assertNotNull(reloaded.getVolumeId());
         assertEquals(cluster.getAccountId(), reloaded.getAccountId());
         assertNotNull(reloaded.getAccountId());
+        assertEquals(cluster.getResourceRegion(), reloaded.getResourceRegion());
+        assertNotNull(reloaded.getResourceRegion());
 
         // and the client-facing metadata survives too
         assertEquals(3, reloaded.getNumberOfBrokerNodes());

--- a/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/MskServiceTest.java
@@ -56,6 +56,7 @@ class MskServiceTest {
     private StorageFactory storageFactory;
     private EmulatorConfig config;
     private RedpandaManager redpandaManager;
+    private RegionResolver regionResolver;
     // MskService's constructor creates the cluster backend first and the configuration backend
     // second; captured here so tests can seed raw entries directly into the configuration store
     // (e.g. to simulate a pre-revision-history persisted entry) without exposing it from MskService.
@@ -87,7 +88,10 @@ class MskServiceTest {
         when(config.defaultRegion()).thenReturn("us-east-1");
 
         redpandaManager = Mockito.mock(RedpandaManager.class);
-        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        regionResolver = Mockito.mock(RegionResolver.class);
+        when(regionResolver.getRegion()).thenReturn("us-east-1");
+        when(regionResolver.getAccountId()).thenReturn("000000000000");
+        when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
         mskService = new MskService(storageFactory, config, regionResolver, redpandaManager);
     }
 
@@ -127,6 +131,42 @@ class MskServiceTest {
         mskService.createCluster("cluster-2");
         List<MskCluster> clusters = mskService.listClusters();
         assertEquals(2, clusters.size());
+    }
+
+    @Test
+    void sameClusterNameIsAllowedInDifferentRegionsAndListsOnlyCurrentRegion() {
+        MskCluster east = mskService.createCluster("shared-name");
+
+        when(regionResolver.getRegion()).thenReturn("eu-west-1");
+        MskCluster west = mskService.createCluster("shared-name");
+
+        assertNotEquals(east.getClusterArn(), west.getClusterArn());
+        assertTrue(east.getClusterArn().contains(":us-east-1:"));
+        assertTrue(west.getClusterArn().contains(":eu-west-1:"));
+        assertEquals(List.of(west), mskService.listClusters());
+
+        when(regionResolver.getRegion()).thenReturn("us-east-1");
+        assertEquals(List.of(east), mskService.listClusters());
+    }
+
+    @Test
+    void sameClusterNameIsRejectedWithinOneRegion() {
+        mskService.createCluster("shared-name");
+
+        AwsException error = assertThrows(AwsException.class, () -> mskService.createCluster("shared-name"));
+
+        assertEquals("ConflictException", error.getErrorCode());
+    }
+
+    @Test
+    void clusterCannotBeDescribedOrDeletedFromAnotherRegion() {
+        MskCluster east = mskService.createCluster("regional-cluster");
+
+        when(regionResolver.getRegion()).thenReturn("eu-west-1");
+
+        assertThrows(AwsException.class, () -> mskService.describeCluster(east.getClusterArn()));
+        assertThrows(AwsException.class, () -> mskService.deleteCluster(east.getClusterArn()));
+        assertEquals(0, mskService.listClusters().size());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
@@ -259,16 +259,40 @@ class RedpandaManagerTest {
         when(portAllocator.allocate(9300, 9399)).thenReturn(54321);
         Files.createDirectories(tempDir.resolve("msk").resolve("test-cluster"));
 
+        MskCluster cluster = newCluster();
+        cluster.setResourceRegion(null);
         ContainerInfo info = new ContainerInfo("container-legacy",
                 Map.of(KAFKA_PORT, new EndpointInfo("localhost", 54321)));
         when(lifecycleManager.createAndStart(any())).thenReturn(info);
 
         ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
-        manager.startContainer(newCluster());
+        manager.startContainer(cluster);
 
         verify(lifecycleManager).createAndStart(specCaptor.capture());
         assertEquals(tempDir.resolve("msk").resolve("test-cluster").toAbsolutePath(),
                 Path.of(specCaptor.getValue().binds().get(0).getPath()).toAbsolutePath());
+    }
+
+    @Test
+    void startContainerDoesNotReuseLegacyPathForScopedCluster() throws Exception {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(portAllocator.allocate(9300, 9399)).thenReturn(54321);
+        Files.createDirectories(tempDir.resolve("msk").resolve("test-cluster"));
+
+        MskCluster cluster = newCluster();
+        cluster.setResourceRegion("us-east-1");
+        ContainerInfo info = new ContainerInfo("container-scoped",
+                Map.of(KAFKA_PORT, new EndpointInfo("localhost", 54321)));
+        when(lifecycleManager.createAndStart(any())).thenReturn(info);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        manager.startContainer(cluster);
+
+        verify(lifecycleManager).createAndStart(specCaptor.capture());
+        assertTrue(Path.of(specCaptor.getValue().binds().get(0).getPath()).toAbsolutePath()
+                .toString().contains("000000000000"));
+        assertTrue(Path.of(specCaptor.getValue().binds().get(0).getPath()).toAbsolutePath()
+                .toString().contains("us-east-1"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
@@ -38,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -102,6 +103,7 @@ class RedpandaManagerTest {
         lenient().when(logStreamer.generateLogStreamName(any())).thenReturn("log-stream");
         lenient().when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
         lenient().when(regionResolver.getAccountId()).thenReturn("000000000000");
+        lenient().when(regionResolver.getDefaultAccountId()).thenReturn("000000000000");
     }
 
     @AfterEach
@@ -228,6 +230,27 @@ class RedpandaManagerTest {
                         "io.floci.account", "000000000000",
                         "io.floci.region", "us-east-1"),
                 specCaptor.getValue().labels());
+    }
+
+    @Test
+    void startContainerUsesAccountAwareLogsAndScopedHostPath() {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(portAllocator.allocate(9300, 9399)).thenReturn(54321);
+
+        ContainerInfo info = new ContainerInfo("container-789",
+                Map.of(KAFKA_PORT, new EndpointInfo("localhost", 54321)));
+        when(lifecycleManager.createAndStart(any())).thenReturn(info);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        manager.startContainer(newCluster());
+
+        verify(logStreamer).attachForAccount(eq("000000000000"), eq("container-789"),
+                eq("/aws/msk/cluster/test-cluster"), eq("log-stream"), eq("us-east-1"),
+                eq("msk:test-cluster"));
+        verify(lifecycleManager).createAndStart(specCaptor.capture());
+        String hostPath = specCaptor.getValue().binds().get(0).getPath().toString();
+        assertTrue(hostPath.contains("000000000000"));
+        assertTrue(hostPath.contains("us-east-1"));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/msk/RedpandaManagerTest.java
@@ -254,6 +254,24 @@ class RedpandaManagerTest {
     }
 
     @Test
+    void startContainerReusesLegacyHostPathWhenScopedPathIsMissing() throws Exception {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(portAllocator.allocate(9300, 9399)).thenReturn(54321);
+        Files.createDirectories(tempDir.resolve("msk").resolve("test-cluster"));
+
+        ContainerInfo info = new ContainerInfo("container-legacy",
+                Map.of(KAFKA_PORT, new EndpointInfo("localhost", 54321)));
+        when(lifecycleManager.createAndStart(any())).thenReturn(info);
+
+        ArgumentCaptor<ContainerSpec> specCaptor = ArgumentCaptor.forClass(ContainerSpec.class);
+        manager.startContainer(newCluster());
+
+        verify(lifecycleManager).createAndStart(specCaptor.capture());
+        assertEquals(tempDir.resolve("msk").resolve("test-cluster").toAbsolutePath(),
+                Path.of(specCaptor.getValue().binds().get(0).getPath()).toAbsolutePath());
+    }
+
+    @Test
     void stopContainerReleasesAllocatedKafkaHostPort() {
         when(containerDetector.isRunningInContainer()).thenReturn(false);
 


### PR DESCRIPTION
## Summary

MSK broker logs and legacy host-persistent storage are now isolated by AWS account and region. This prevents resources with the same cluster name in different environments from sharing log streams or data directories.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

MSK cluster identity includes the account and region. Floci now uses that identity when attaching broker logs and constructing the legacy host storage path, while preserving the existing cluster name in user-facing log labels and container labels.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
