### PR TITLE
fix(lambda): stop rejecting a foreign-platform image the daemon cannot describe

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheService.java
@@ -63,7 +63,7 @@ public class ImageCacheService {
             }
             InspectImageResponse localImage = inspectLocalImage(imageUri);
             if (matchesPlatform(localImage, requestedPlatform)) {
-                resolvedImage = resolvedImageReference(imageUri, requestedPlatform, localImage);
+                resolvedImage = resolvedImageReference(imageUri, localImage);
                 resolvedImages.put(imageKey, resolvedImage);
                 LOG.infov("Image already present locally, skipping pull: {0}", imageUri);
                 return resolvedImage;
@@ -79,8 +79,7 @@ public class ImageCacheService {
                     pullImage.exec(new PullImageResultCallback())
                             .awaitCompletion(5, TimeUnit.MINUTES);
                 });
-                resolvedImage = resolvedImageReference(imageUri, requestedPlatform,
-                        inspectLocalImage(imageUri));
+                resolvedImage = resolvedImageReference(imageUri, inspectLocalImage(imageUri));
                 resolvedImages.put(imageKey, resolvedImage);
                 LOG.infov("Image pulled successfully: {0}", imageUri);
                 return resolvedImage;
@@ -198,11 +197,19 @@ public class ImageCacheService {
                 && parts[1].equals(image.getArch());
     }
 
-    private static String resolvedImageReference(String imageUri, String platform,
-                                                  InspectImageResponse image) {
-        if (!matchesPlatform(image, platform)) {
-            throw new DockerClientException(
-                    "Docker image does not match requested platform " + platform + ": " + imageUri);
+    /**
+     * Resolves the reference the container is created from. Inspecting the image cannot confirm
+     * the platform on Docker 29, whose containerd image store is the default: for an image whose
+     * platform is not the host's it answers with an empty Os and Architecture until another
+     * variant of the same tag is present, and with the host's variant once one is, because the
+     * tag and its id both name the index rather than the variant that will run. Neither answer
+     * says anything about the variant the daemon selected. The platform is enforced by the daemon
+     * itself at both points that matter, choosing the variant to pull and choosing the variant to
+     * create the container from, so this only has to hand back an id.
+     */
+    private static String resolvedImageReference(String imageUri, InspectImageResponse image) {
+        if (image == null) {
+            throw new DockerClientException("Docker did not report the image: " + imageUri);
         }
         String imageId = image.getId();
         if (imageId == null || imageId.isBlank()) {

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerPlatformDockerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerPlatformDockerIntegrationTest.java
@@ -1,6 +1,9 @@
 package io.github.hectorvent.floci.core.common.docker;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.core.command.WaitContainerResultCallback;
+import com.github.dockerjava.api.model.Frame;
 import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -8,8 +11,11 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -43,20 +49,88 @@ class ContainerPlatformDockerIntegrationTest {
         String platform = "linux/" + requestedArchitecture;
         ContainerSpec spec = containerBuilder.newContainer(IMAGE)
                 .withName("floci-platform-test-" + UUID.randomUUID())
+                .withCmd(List.of("uname", "-m"))
                 .build();
 
         String containerId = null;
         try {
             containerId = lifecycleManager.create(spec, platform);
-            String imageId = dockerClient.inspectContainerCmd(containerId).exec().getImageId();
 
-            assertEquals(requestedArchitecture,
-                    dockerClient.inspectImageCmd(imageId).exec().getArch());
+            String machine = architectureReportedByContainer(containerId);
+            if (machine != null) {
+                assertEquals(armHost ? "x86_64" : "aarch64", machine);
+                return;
+            }
+            assertEquals(requestedArchitecture, architectureReportedByDaemon(containerId, hostArchitecture));
         } finally {
             if (containerId != null) {
                 dockerClient.removeContainerCmd(containerId).withForce(true).exec();
             }
         }
+    }
+
+    /**
+     * Runs the created container, whose command is {@code uname -m}, and returns what it printed.
+     * This is the only reading that holds on every engine, because the container is the variant
+     * the daemon actually selected. Running one built for another architecture needs emulation on
+     * the host, which not every machine has: without it the start either throws or the container
+     * exits nonzero on an exec-format error, and both return {@code null} for the caller to fall
+     * back on.
+     */
+    private String architectureReportedByContainer(String containerId) {
+        try {
+            dockerClient.startContainerCmd(containerId).exec();
+        } catch (RuntimeException e) {
+            LOG.warnv(e, "Could not start the foreign-platform container, falling back to inspect");
+            return null;
+        }
+        Integer status = dockerClient.waitContainerCmd(containerId)
+                .exec(new WaitContainerResultCallback())
+                .awaitStatusCode(60, TimeUnit.SECONDS);
+        if (status == null || status != 0) {
+            LOG.warnv("The foreign-platform container exited with {0}, falling back to inspect: {1}",
+                    status, logs(containerId));
+            return null;
+        }
+        return logs(containerId).trim();
+    }
+
+    /**
+     * The architecture the daemon reports for the image the container was created from. Docker 29's
+     * containerd image store, its default, answers for the index rather than the selected variant:
+     * an empty string until a second variant of the tag is local, and the host's architecture once
+     * one is. Neither can confirm anything here, so both skip the test instead of failing it.
+     */
+    private String architectureReportedByDaemon(String containerId, String hostArchitecture) {
+        String imageId = dockerClient.inspectContainerCmd(containerId).exec().getImageId();
+        String reported = dockerClient.inspectImageCmd(imageId).exec().getArch();
+        if (reported == null || reported.isBlank()) {
+            return Assumptions.abort("this daemon reports no architecture for a foreign-platform image");
+        }
+        if (reported.equalsIgnoreCase(hostArchitecture)
+                || (hostArchitecture.equals("aarch64") && reported.equals("arm64"))
+                || (hostArchitecture.equals("x86_64") && reported.equals("amd64"))) {
+            return Assumptions.abort(
+                    "this daemon reports the host architecture for a foreign-platform image");
+        }
+        return reported;
+    }
+
+    private String logs(String containerId) {
+        StringBuilder out = new StringBuilder();
+        try {
+            dockerClient.logContainerCmd(containerId).withStdOut(true).withStdErr(true)
+                    .exec(new ResultCallback.Adapter<Frame>() {
+                        @Override
+                        public void onNext(Frame frame) {
+                            out.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
+                        }
+                    }).awaitCompletion(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while reading container logs", e);
+        }
+        return out.toString();
     }
 
     private boolean isDockerAvailable() {

--- a/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerPlatformDockerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/common/docker/ContainerPlatformDockerIntegrationTest.java
@@ -84,9 +84,15 @@ class ContainerPlatformDockerIntegrationTest {
             LOG.warnv(e, "Could not start the foreign-platform container, falling back to inspect");
             return null;
         }
-        Integer status = dockerClient.waitContainerCmd(containerId)
-                .exec(new WaitContainerResultCallback())
-                .awaitStatusCode(60, TimeUnit.SECONDS);
+        Integer status;
+        try {
+            status = dockerClient.waitContainerCmd(containerId)
+                    .exec(new WaitContainerResultCallback())
+                    .awaitStatusCode(60, TimeUnit.SECONDS);
+        } catch (RuntimeException e) {
+            LOG.warnv(e, "Waiting on the foreign-platform container failed, falling back to inspect");
+            return null;
+        }
         if (status == null || status != 0) {
             LOG.warnv("The foreign-platform container exited with {0}, falling back to inspect: {1}",
                     status, logs(containerId));
@@ -116,6 +122,7 @@ class ContainerPlatformDockerIntegrationTest {
         return reported;
     }
 
+    /** Best effort, as in the sibling Docker tests: a read that fails reports itself in the text. */
     private String logs(String containerId) {
         StringBuilder out = new StringBuilder();
         try {
@@ -128,7 +135,9 @@ class ContainerPlatformDockerIntegrationTest {
                     }).awaitCompletion(10, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while reading container logs", e);
+            out.append("(interrupted while reading logs)");
+        } catch (Exception e) {
+            out.append("(could not read logs: ").append(e.getMessage()).append(')');
         }
         return out.toString();
     }

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/launcher/ImageCacheServiceTest.java
@@ -97,6 +97,53 @@ class ImageCacheServiceTest {
     }
 
     @Test
+    void acceptsThePulledImageWhenInspectionReportsTheHostVariant() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        // Docker 29's containerd image store answers for the index, so with the host's variant
+        // already local it keeps reporting that architecture after the foreign pull.
+        when(inspectImage.exec()).thenReturn(
+                new InspectImageResponse().withOs("linux").withArch("arm64"),
+                new InspectImageResponse().withId("sha256:index").withOs("linux").withArch("arm64"));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/amd64")).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        String resolvedImage = newService(dockerClient)
+                .ensureImageExists(IMAGE, "linux/amd64");
+
+        assertEquals("sha256:index", resolvedImage);
+        verify(pullImage).withPlatform("linux/amd64");
+    }
+
+    @Test
+    void acceptsThePulledImageWhenInspectionReportsNoPlatform() throws Exception {
+        DockerClient dockerClient = mock(DockerClient.class);
+        InspectImageCmd inspectImage = mock(InspectImageCmd.class);
+        PullImageCmd pullImage = mock(PullImageCmd.class);
+        PullImageResultCallback callback = mock(PullImageResultCallback.class);
+        when(dockerClient.inspectImageCmd(IMAGE)).thenReturn(inspectImage);
+        // The same store with no other variant local: the index it pulled describes no platform
+        // at all.
+        when(inspectImage.exec()).thenThrow(new NotFoundException("image not found"))
+                .thenReturn(new InspectImageResponse().withId("sha256:index").withOs("").withArch(""));
+        when(dockerClient.pullImageCmd(IMAGE)).thenReturn(pullImage);
+        when(pullImage.withAuthConfig(any())).thenReturn(pullImage);
+        when(pullImage.withPlatform("linux/amd64")).thenReturn(pullImage);
+        when(pullImage.exec(any(PullImageResultCallback.class))).thenReturn(callback);
+
+        String resolvedImage = newService(dockerClient)
+                .ensureImageExists(IMAGE, "linux/amd64");
+
+        assertEquals("sha256:index", resolvedImage);
+        verify(pullImage).withPlatform("linux/amd64");
+    }
+
+    @Test
     void skipsPullWhenLocalImageMatchesRequestedPlatform() {
         DockerClient dockerClient = mock(DockerClient.class);
         InspectImageCmd inspectImage = mock(InspectImageCmd.class);


### PR DESCRIPTION
## Summary

Fixes #3304.

Docker 29 makes the containerd image store its default, and there an image
inspect answers for the index rather than for the variant that will run. For an
image pulled for another architecture it reports an empty Os and Architecture
while no other variant of that tag is local, and the host's variant once one is.
`ImageCacheService` compared that answer with the requested platform and threw,
so every container started for a non-host architecture failed even though the
pull had already selected the right variant:

```
DockerClientException: Docker image does not match requested platform linux/amd64:
  public.ecr.aws/docker/library/busybox:1.36
```

- The comparison is gone. The daemon enforces the platform at both points that
  decide anything, `pullImageCmd.withPlatform` choosing the variant to fetch and
  `createContainerCmd.withPlatform` in `ContainerLifecycleManager` choosing the
  variant to run, so resolving the reference only has to hand back an id and say
  so plainly when the daemon reports no image at all.
- The local-reuse check is untouched. An inspect that cannot confirm the platform
  still means "pull it", which is the safe direction and costs only a pull.
- `ContainerPlatformDockerIntegrationTest` verified the platform through the same
  inspect, so it would have compared `amd64` against an empty string. It now runs
  the container, whose command is `uname -m`, and reads what the selected variant
  reports. Running a container built for another architecture needs emulation on
  the host, so where the start fails the test falls back to the inspect
  assertion, and skips when that reading is the empty or host-variant answer that
  cannot confirm anything.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No wire behavior changes. This is the container launcher that every
Docker-backed service shares, and the fix restores `Architectures: [arm64]` on
an amd64 host, and an amd64 image on Apple Silicon, on Docker 29.

Measured on Docker 29.7.2 (macOS, Apple Silicon, containerd image store):

| Reading | Answer |
|---|---|
| `docker image inspect <tag>` right after `pull --platform linux/amd64` | empty Os and Architecture |
| the same inspect once the arm64 variant is also local | `linux` / `arm64`, the host's variant |
| `docker inspect <container>` created with `--platform linux/amd64` | `Platform: linux`, no architecture |
| `uname -m` inside that container | `x86_64` |

So the only reading that describes the variant the daemon selected is the
running container, which is what the integration test now uses.

`ImageCacheServiceTest` gains a regression test for each of the two readings
above, both of which the old implementation rejects: the pull that comes back
described as the host's variant, and the one that comes back described as
nothing. Docker-backed classes are green together: `ImageCache*`,
`ContainerLauncher*`, `ContainerPlatform*`, `ContainerCaBundle*`,
`LambdaExecutionRoleDocker*`, `ElbV2LambdaTargetDataPlane*`, `SwfLambda*` and
`RdsContainerManager*`, 161 tests.

A full `./mvnw test` on this host, with #3348 applied for the unrelated Macie
failure it fixes, runs 19150 tests with no failures. Before this change that run
ends on the exception above, since `ContainerPlatformDockerIntegrationTest` is
the test that exercises it.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
