### PR TITLE
fix(tls): fail startup when public listener cannot bind

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/config/TlsProxyServer.java
+++ b/src/main/java/io/github/hectorvent/floci/config/TlsProxyServer.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletionException;
 
 /**
  * A TCP proxy server that enables HTTP and HTTPS on the same port (LocalStack parity).
@@ -109,7 +110,8 @@ public class TlsProxyServer {
             NetServer server = vertx.createNetServer(options);
             server.connectHandler(connectHandler);
             proxyServers.add(server);
-            server.listen().onComplete(ar -> {
+            var bind = server.listen();
+            bind.onComplete(ar -> {
                 if (ar.succeeded()) {
                     failedPorts.remove(port);
                     LOG.infov("TLS proxy: listening on port {0} (HTTP→{1}, HTTPS→{2})",
@@ -128,6 +130,16 @@ public class TlsProxyServer {
                             String.valueOf(port), ar.cause().getMessage());
                 }
             });
+            if (port == config.port()) {
+                try {
+                    bind.toCompletionStage().toCompletableFuture().join();
+                } catch (CompletionException e) {
+                    stop();
+                    Throwable cause = e.getCause() != null ? e.getCause() : e;
+                    throw new IllegalStateException(
+                            "TLS proxy failed to bind public port " + port, cause);
+                }
+            }
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/config/TlsProxyServerReservedPortTest.java
+++ b/src/test/java/io/github/hectorvent/floci/config/TlsProxyServerReservedPortTest.java
@@ -9,9 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -38,7 +37,7 @@ class TlsProxyServerReservedPortTest {
         // stage it directly on failedPorts.
         NetServer server = mock(NetServer.class);
         when(server.connectHandler(any())).thenReturn(server);
-        when(server.listen()).thenReturn(Promise.<NetServer>promise().future());
+        when(server.listen()).thenReturn(Future.succeededFuture(server), Promise.<NetServer>promise().future());
 
         Vertx vertx = mock(Vertx.class);
         when(vertx.createNetClient()).thenReturn(mock(NetClient.class));
@@ -54,6 +53,14 @@ class TlsProxyServerReservedPortTest {
     private static TlsProxyServer proxyWith(int flociPort, boolean tlsEnabled, int awsHttpsPort,
                                             Future<NetServer> outcome,
                                             java.util.function.Consumer<TlsProxyServer> beforeStart) {
+        return proxyWith(flociPort, tlsEnabled, awsHttpsPort,
+                Future.succeededFuture(mock(NetServer.class)), outcome, beforeStart);
+    }
+
+    private static TlsProxyServer proxyWith(int flociPort, boolean tlsEnabled, int awsHttpsPort,
+                                            Future<NetServer> publicOutcome,
+                                            Future<NetServer> awsHttpsOutcome,
+                                            java.util.function.Consumer<TlsProxyServer> beforeStart) {
         EmulatorConfig.TlsConfig tls = mock(EmulatorConfig.TlsConfig.class);
         when(tls.enabled()).thenReturn(tlsEnabled);
         when(tls.awsHttpsPort()).thenReturn(awsHttpsPort);
@@ -63,7 +70,7 @@ class TlsProxyServerReservedPortTest {
 
         NetServer server = mock(NetServer.class);
         when(server.connectHandler(any())).thenReturn(server);
-        when(server.listen()).thenReturn(outcome);
+        when(server.listen()).thenReturn(publicOutcome, awsHttpsOutcome);
 
         Vertx vertx = mock(Vertx.class);
         when(vertx.createNetClient()).thenReturn(mock(NetClient.class));
@@ -112,6 +119,15 @@ class TlsProxyServerReservedPortTest {
         assertTrue(released.contains(443),
                 "a listener that yielded 443 has no other way to learn the bind failed");
         assertFalse(proxy.reservesPort(443));
+    }
+
+    @Test
+    void failsStartupWhenThePublicPortCannotBind() {
+        assertThrows(IllegalStateException.class, () -> proxyWith(4566, true, 443,
+                Future.failedFuture(new RuntimeException("address already in use")),
+                Future.succeededFuture(mock(NetServer.class)),
+                ignored -> {
+                }));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fail startup when the required public TLS listener cannot bind. Keep the optional AWS HTTPS listener best-effort for unprivileged environments.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

When the public TLS listener failed to bind, Floci could continue startup and report readiness without serving its configured public endpoint. Floci now propagates that bind failure during startup and closes the partially initialized proxy. The optional `floci.tls.aws-https-port` listener keeps its existing best-effort behavior.

The change does not alter AWS request or response formats. AWS SDK endpoint configuration and CloudFormation custom-resource response handling remain unchanged.

## CI note

The initial CI run also exposed an unrelated intermittent CloudTrail integration-test failure. Merged PR [#3363](https://github.com/floci-io/floci/pull/3363) fixed that test on `main` by sorting records by their event sequence instead of random S3 log-key order. No CloudTrail code is included in this PR.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->
