### PR TITLE
fix(cloudtrail): stop CloudTrailLogWriterBoundedRetryIntegrationTest relying on S3 key order

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBoundedRetryIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudtrail/CloudTrailLogWriterBoundedRetryIntegrationTest.java
@@ -12,10 +12,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import static io.restassured.RestAssured.given;
@@ -301,6 +304,14 @@ class CloudTrailLogWriterBoundedRetryIntegrationTest {
         return String.format("events/%04d.txt", index);
     }
 
+    // Two log files written in the same flush cycle can land in the same delivery
+    // minute, leaving only a random filename suffix (CloudTrailLogWriter#randomFilenameSuffix)
+    // to distinguish their S3 keys. That suffix carries no relationship to write order, so
+    // relying on S3 listing order across files (as real CloudTrail's own key layout would
+    // also not support) is not a reliable way to reconstruct delivery order. Each event's
+    // own key already encodes its original sequence, so sort on that instead.
+    private static final Pattern EVENT_INDEX = Pattern.compile("(\\d+)\\.txt$");
+
     private static List<JsonNode> deliveredRecords(String bucket) throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         List<JsonNode> records = new ArrayList<>();
@@ -313,7 +324,13 @@ class CloudTrailLogWriterBoundedRetryIntegrationTest {
             }
         mapper.readTree(json).path("Records").forEach(records::add);
         }
+        records.sort(Comparator.comparingInt(CloudTrailLogWriterBoundedRetryIntegrationTest::sourceEventIndex));
         return records;
+    }
+
+    private static int sourceEventIndex(JsonNode record) {
+        Matcher m = EVENT_INDEX.matcher(record.path("requestParameters").path("key").asText(""));
+        return m.find() ? Integer.parseInt(m.group(1)) : Integer.MAX_VALUE;
     }
 
     private static List<String> listLogKeys(String bucket) {


### PR DESCRIPTION
## Summary

`CloudTrailLogWriterBoundedRetryIntegrationTest#retryStateStaysBoundedAndDeliversRetainedPrefixAfterDestinationRecovery` failed intermittently because it inferred the write order of two CloudTrail log files from their S3 listing (lexicographic key) order. `RETRY_RECORD_LIMIT` (1024) sits just above `MAX_RECORDS_PER_LOG_FILE` (1000), so recovery always splits the retained records into two files written in the same delivery minute, distinguished only by a random 16 character filename suffix that carries no relationship to write order. Whichever suffix happened to sort first determined whether the test passed.

`deliveredRecords()` now sorts the records it reads back by the sequence already embedded in each event's own key (`events/NNNN.txt`) instead of trusting S3 key order. Ran the affected test class locally 5 times in a row after the change, all green.

Introduced by #3298.

Closes #3361

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not applicable. This is a test harness bug in Floci's own integration suite, not a discrepancy with real CloudTrail behavior. Real CloudTrail's own delivered filenames have the same minute resolution plus random suffix shape, so key listing order isn't a reliable ordering signal there either, the fix avoids depending on it.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
