### PR TITLE
fix(s3): honor x-amz-bypass-governance-retention in batch DeleteObjects

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Controller.java
@@ -1414,6 +1414,9 @@ public class S3Controller {
         }
         boolean quiet = XmlParser.containsValue(xml, "Quiet", "true");
 
+        boolean bypass = "true".equalsIgnoreCase(
+                httpHeaders.getHeaderString("x-amz-bypass-governance-retention"));
+
         S3Service.RequestAuthorization authorization = S3RequestAuthorizationParser.parseIfRequired(
                 s3Service.isAuthEnforced(), httpHeaders, uriInfo);
         s3Service.authorizeSignedRequest(authorization);
@@ -1422,13 +1425,17 @@ public class S3Controller {
         for (XmlParser.KeyVersion entry : entries) {
             try {
                 s3Service.authorizeDeleteObject(bucket, entry.key(), entry.versionId(), authorization);
+                if (bypass) {
+                    s3Service.authorizeObjectWrite(bucket, entry.key(),
+                            "s3:BypassGovernanceRetention", authorization);
+                }
                 authorizedEntries.add(entry);
             } catch (AwsException e) {
                 authorizationErrors.add(new S3Service.DeleteError(entry.key(), e.getErrorCode(), e.getMessage()));
             }
         }
 
-        S3Service.DeleteObjectsResult result = s3Service.deleteObjects(bucket, authorizedEntries);
+        S3Service.DeleteObjectsResult result = s3Service.deleteObjects(bucket, authorizedEntries, bypass);
 
         XmlBuilder builder = new XmlBuilder()
                 .raw("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")

--- a/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/s3/S3Service.java
@@ -1601,17 +1601,24 @@ public class S3Service implements Resettable, ResourceProvider {
     }
 
     public DeleteObjectsResult deleteObjects(String bucketName, List<XmlParser.KeyVersion> entries) {
+        return deleteObjects(bucketName, entries, false);
+    }
+
+    public DeleteObjectsResult deleteObjects(String bucketName, List<XmlParser.KeyVersion> entries,
+                                             boolean bypassGovernance) {
         ensureBucketExists(bucketName);
         List<DeleteResult> deleted = new ArrayList<>();
         List<DeleteError> errors = new ArrayList<>();
         for (XmlParser.KeyVersion entry : entries) {
             try {
-                S3Object result = deleteObject(bucketName, entry.key(), entry.versionId());
+                S3Object result = deleteObject(bucketName, entry.key(), entry.versionId(), bypassGovernance);
                 if (result != null && result.isDeleteMarker()) {
                     deleted.add(new DeleteResult(entry.key(), entry.versionId(), true, result.getVersionId()));
                 } else {
                     deleted.add(new DeleteResult(entry.key(), entry.versionId(), false, null));
                 }
+            } catch (AwsException e) {
+                errors.add(new DeleteError(entry.key(), e.getErrorCode(), e.getMessage()));
             } catch (Exception e) {
                 errors.add(new DeleteError(entry.key(), "InternalError", e.getMessage()));
             }

--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3DeleteObjectsIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3DeleteObjectsIntegrationTest.java
@@ -96,6 +96,56 @@ class S3DeleteObjectsIntegrationTest {
             .statusCode(404);
     }
 
+    @Test
+    void deleteObjects_governanceRetentionVersionIdHonorsBypassHeader() {
+        String bucket = createBucket();
+        enableVersioning(bucket);
+
+        String key = "governance.txt";
+        String versionId = putGovernanceLockedObject(bucket, key);
+
+        String deleteBody = """
+                <Delete>
+                  <Object><Key>%s</Key><VersionId>%s</VersionId></Object>
+                </Delete>
+                """.formatted(key, versionId);
+
+        given()
+            .contentType("application/xml")
+            .body(deleteBody)
+        .when()
+            .post("/" + bucket + "?delete")
+        .then()
+            .statusCode(200)
+            .body(containsString("<Error>"))
+            .body(containsString("<Key>" + key + "</Key>"))
+            .body(containsString("<Code>AccessDenied</Code>"));
+
+        given()
+        .when()
+            .get("/" + bucket + "?versions&prefix=" + key)
+        .then()
+            .statusCode(200)
+            .body(containsString(versionId));
+
+        given()
+            .header("x-amz-bypass-governance-retention", "true")
+            .contentType("application/xml")
+            .body(deleteBody)
+        .when()
+            .post("/" + bucket + "?delete")
+        .then()
+            .statusCode(200)
+            .body(containsString("<VersionId>" + versionId + "</VersionId>"));
+
+        given()
+        .when()
+            .get("/" + bucket + "?versions&prefix=" + key)
+        .then()
+            .statusCode(200)
+            .body(not(containsString(versionId)));
+    }
+
     private static String createBucket() {
         String bucket = "delete-objects-" + UUID.randomUUID().toString().substring(0, 8);
         given()
@@ -122,6 +172,19 @@ class S3DeleteObjectsIntegrationTest {
             .put("/" + bucket + "?versioning")
         .then()
             .statusCode(200);
+    }
+
+    private static String putGovernanceLockedObject(String bucket, String key) {
+        return given()
+            .header("x-amz-object-lock-mode", "GOVERNANCE")
+            .header("x-amz-object-lock-retain-until-date", "2030-01-01T00:00:00Z")
+            .body("locked")
+        .when()
+            .put("/" + bucket + "/" + key)
+        .then()
+            .statusCode(200)
+            .extract()
+            .header("x-amz-version-id");
     }
 
     private static String putVersionedObject(String bucket, String key) {


### PR DESCRIPTION
## Summary

Fixes the S3 `DeleteObjects` batch path so `x-amz-bypass-governance-retention` is authorized and propagated consistently with `DeleteObject`. Per-object `AwsException` codes are also preserved instead of being flattened to `InternalError`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS documents the governance bypass header and the `s3:BypassGovernanceRetention` permission for `DeleteObjects`. The integration regression covers a GOVERNANCE-retained version both without the header and with an authorized bypass, including the per-object `AccessDenied` result.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused verification: `./mvnw test -Dtest=S3DeleteObjectsIntegrationTest,S3ObjectLockIntegrationTest,S3AuthEnforcementIntegrationTest` passed 66 tests with the enforcer skipped because the local JDK is newer than the repository's required JDK 25.
