### PR TITLE
test(cloudformation): wait for the async stack delete before asserting it

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationCloudFrontPoliciesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationCloudFrontPoliciesIntegrationTest.java
@@ -9,6 +9,7 @@ import io.github.hectorvent.floci.services.cloudfront.model.OriginAccessControl;
 import io.github.hectorvent.floci.services.cloudfront.model.OriginRequestPolicy;
 import io.github.hectorvent.floci.services.cloudfront.model.ResponseHeadersPolicy;
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
@@ -275,14 +276,18 @@ class CloudFormationCloudFrontPoliciesIntegrationTest {
             .atMost(STACK_DELETE_TIMEOUT)
             .pollInterval(STACK_DELETE_POLL_INTERVAL)
             .untilAsserted(() -> {
-                given()
+                Response response = given()
                     .contentType("application/x-www-form-urlencoded")
                     .header("Authorization", CFN_AUTH)
                     .formParam("Action", "DescribeStacks")
                     .formParam("StackName", stackName)
                 .when()
-                    .post("/")
-                .then()
+                    .post("/");
+                if (response.statusCode() == 200
+                        && response.asString().contains("<StackStatus>DELETE_FAILED</StackStatus>")) {
+                    fail("Stack deletion failed: " + response.asString());
+                }
+                response.then()
                     .statusCode(400)
                     .body(containsString("Stack with id " + stackName + " does not exist"));
             });

--- a/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationCloudFrontPoliciesIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/cloudformation/CloudFormationCloudFrontPoliciesIntegrationTest.java
@@ -12,11 +12,13 @@ import io.quarkus.test.junit.QuarkusTest;
 import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -34,6 +36,8 @@ class CloudFormationCloudFrontPoliciesIntegrationTest {
 
     private static final String CFN_AUTH =
             "AWS4-HMAC-SHA256 Credential=test/20260205/us-east-1/cloudformation/aws4_request";
+    private static final Duration STACK_DELETE_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration STACK_DELETE_POLL_INTERVAL = Duration.ofMillis(50);
 
     @Inject
     CloudFrontService cloudFrontService;
@@ -267,16 +271,21 @@ class CloudFormationCloudFrontPoliciesIntegrationTest {
             .post("/")
         .then()
             .statusCode(200);
-        given()
-            .contentType("application/x-www-form-urlencoded")
-            .header("Authorization", CFN_AUTH)
-            .formParam("Action", "DescribeStacks")
-            .formParam("StackName", stackName)
-        .when()
-            .post("/")
-        .then()
-            .statusCode(400)
-            .body(containsString("Stack with id " + stackName + " does not exist"));
+        await()
+            .atMost(STACK_DELETE_TIMEOUT)
+            .pollInterval(STACK_DELETE_POLL_INTERVAL)
+            .untilAsserted(() -> {
+                given()
+                    .contentType("application/x-www-form-urlencoded")
+                    .header("Authorization", CFN_AUTH)
+                    .formParam("Action", "DescribeStacks")
+                    .formParam("StackName", stackName)
+                .when()
+                    .post("/")
+                .then()
+                    .statusCode(400)
+                    .body(containsString("Stack with id " + stackName + " does not exist"));
+            });
     }
 
     private static String describeStacks(String stackName) {


### PR DESCRIPTION
`CloudFormationCloudFrontPoliciesIntegrationTest.deleteStack` asserted that `DescribeStacks` returns 400 on the very next request after `DeleteStack` returned 200. The teardown runs on a background executor and the Query handler discards the returned future, so the stack is still describable while it is being removed. The status is set to `DELETE_IN_PROGRESS` before `DeleteStack` returns, which is what real CloudFormation reports too. The assertion was racing the teardown.

## Change

`deleteStack` now waits for the deletion to become visible, using the same Awaitility pattern its sibling in this package already uses (`CloudFormationDynamoDbReplicaIntegrationTest.awaitStackGone`): 30s bound, 50ms poll, and a `DELETE_FAILED` check so a failed delete reports the stack body rather than timing out silently. The assertion that the stack disappears is unchanged, only the timing assumption is gone.

This also removes the same race from the two CloudFront service assertions that follow the delete in the first test, which read `CloudFrontService` directly.

Only the test changes; no runtime behavior is touched, hence the `test` type rather than `fix`.

## Evidence

`CloudFormationService.deleteStack` documents the async contract itself:

> a future that completes when the resources have been removed; already-gone stacks complete immediately. Callers that need synchronous deletion (e.g. StackSet instance removal) can await it.

`CloudFormationQueryHandler.deleteStack` calls the two-argument overload, which ignores that future.

I could **not** reproduce the flake locally, and I want to be explicit about that rather than imply a reproduction. Probing the window directly, the teardown for the reported template finished in under 46 ms on an idle machine, so the immediate `DescribeStacks` already returned 400 and no window was observed. A loaded CI runner widens that window, which fits the issue describing it as intermittent. So this fixes the incorrect timing assumption the issue identifies as the cause, and the async contract above is the evidence, not a local repro.

## Tests

`./mvnw test -Dtest=CloudFormationCloudFrontPoliciesIntegrationTest` passes, 2 tests, 0 failures.

The repository requires JDK 25 and the machine I used has JDK 26, so I ran with `-Denforcer.skip=true`; CI's JDK 25 toolchain is the authority.

Closes #3365.

## Summary

Fix the asynchronous CloudFormation stack-deletion race in the CloudFront policies integration test by waiting for the stack and related resources to disappear.

## Type of change

- [x] Test
- [ ] Feature
- [ ] Bug fix

## Checklist

- [x] Tests added or updated
- [x] Focused tests pass locally
- [x] No runtime behavior changes