### PR TITLE
docs: name the pinned Quarkus version in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Floci acts as an open-source alternative to LocalStack Community.
 - Port: 4566
 - Stack:
   - Java 25
-  - Quarkus 3.32.3
+  - Quarkus 3.39.2
   - JUnit 5
   - RestAssured
   - Jackson


### PR DESCRIPTION
## Summary

`AGENTS.md` listed the stack as `Quarkus 3.32.3`. The build pins `quarkus.platform.version` to `3.39.2`, set by #3175 (`50836bbd`), and that dependency bump did not update the line. `AGENTS.md` is the canonical agent instructions file that CONTRIBUTING.md points coding agents at, so it was naming a platform seven minor releases behind the one the build resolves.

Closes #3368.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## AWS Compatibility

Not applicable: no wire protocol, handler, or service behavior is touched.

## Verification

The neighbouring entries in the same list were checked against their source of truth and are correct, so the Quarkus line was the only stale one:

| Claim | Source of truth | Status |
|---|---|---|
| Port 4566 | `src/main/resources/application.yml` | correct |
| Java 25 | `pom.xml` `maven.compiler.release` | correct |
| Java 25 in CI | `.github/workflows/*.yml` | correct |
| Quarkus 3.32.3 | `pom.xml` `quarkus.platform.version` | stale, corrected here |

`grep -rnE "Quarkus [0-9]+\.[0-9]+" --include=*.md` returns this one line, so nothing else in the tree states a Quarkus version.

## Checklist

- [x] `./mvnw test` passes locally (no code path is touched; the existing suite is unaffected)
- [ ] New or updated integration test added: not applicable, this changes one line of documentation and CONTRIBUTING.md says docs changes that alter no observable behavior do not need new tests
- [x] Commit messages follow Conventional Commits
