### PR TITLE
fix(wafv2): reject IP set addresses that are not CIDR blocks

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/wafv2/WafV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/wafv2/WafV2Service.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.CidrCanonicalizer;
 import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
@@ -127,6 +128,7 @@ public class WafV2Service {
     public IpSet createIpSet(IpSet ipSet, String scope, String name, String region) {
         validateScope(scope);
         requireName(name);
+        requireCidrAddresses(ipSet.getAddresses());
         if (findByName(ipSetStore, scope, name) != null) {
             throw new AwsException("WAFDuplicateItemException", "Duplicate IPSet name: " + name, 400);
         }
@@ -148,6 +150,7 @@ public class WafV2Service {
                               List<String> addresses, String name, String lockToken) {
         IpSet existing = require(ipSetStore, scope, id, name);
         checkLock(existing.getLockToken(), lockToken);
+        requireCidrAddresses(addresses);
         existing.setDescription(description);
         existing.setAddresses(addresses);
         return rotate(existing, ipSetStore, scope);
@@ -478,6 +481,25 @@ public class WafV2Service {
     private void requireName(String name) {
         if (name == null || name.isBlank()) {
             throw new AwsException("WAFInvalidParameterException", "Name is required.", 400);
+        }
+    }
+
+    /**
+     * An IP set member is a block, not a single address: AWS requires CIDR notation and rejects a
+     * bare address such as {@code 203.0.113.10}, because the prefix length is what defines the
+     * range the set matches. {@link CidrCanonicalizer} supplies exactly the accepted forms (IPv4
+     * and IPv6, prefix in range for the family), so anything it cannot parse is rejected rather
+     * than stored verbatim.
+     */
+    private void requireCidrAddresses(List<String> addresses) {
+        if (addresses == null) {
+            return;
+        }
+        for (String address : addresses) {
+            if (CidrCanonicalizer.canonicalize(address).isEmpty()) {
+                throw new AwsException("WAFInvalidParameterException",
+                        "Address is not a valid CIDR block: " + address, 400);
+            }
         }
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/wafv2/WafV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/wafv2/WafV2IntegrationTest.java
@@ -357,12 +357,30 @@ class WafV2IntegrationTest {
                         + "\"Addresses\":[\"10.0.0.0/24\",\"203.0.113.10\"]}")
                 .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
 
+        // A rejected create must not leave a partially persisted IP set behind.
+        call("ListIPSets", "{\"Scope\":\"REGIONAL\"}")
+                .then().statusCode(200)
+                .body("IPSets.findAll { it.Name == 'floci-waf-mixed' }", hasSize(0));
+
         // The guard must not reject well-formed blocks, IPv6 included.
         Response created = call("CreateIPSet",
                 "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"IPAddressVersion\":\"IPV4\","
                         + "\"Addresses\":[\"10.1.0.0/16\",\"192.0.2.0/24\"]}");
         created.then().statusCode(200);
         String id = created.jsonPath().getString("Summary.Id");
+
+        Response ipv6Created = call("CreateIPSet",
+                "{\"Name\":\"floci-waf-cidr-ipv6\",\"Scope\":\"REGIONAL\","
+                        + "\"IPAddressVersion\":\"IPV6\",\"Addresses\":[\"2001:db8::/32\"]}");
+        ipv6Created.then().statusCode(200);
+        String ipv6Id = ipv6Created.jsonPath().getString("Summary.Id");
+        String ipv6LockToken = call("GetIPSet",
+                "{\"Name\":\"floci-waf-cidr-ipv6\",\"Scope\":\"REGIONAL\",\"Id\":\"" + ipv6Id + "\"}")
+                .then().statusCode(200).extract().jsonPath().getString("LockToken");
+        call("DeleteIPSet",
+                "{\"Name\":\"floci-waf-cidr-ipv6\",\"Scope\":\"REGIONAL\",\"Id\":\"" + ipv6Id
+                        + "\",\"LockToken\":\"" + ipv6LockToken + "\"}")
+                .then().statusCode(200);
 
         String lockToken = call("GetIPSet",
                 "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\"}")

--- a/src/test/java/io/github/hectorvent/floci/services/wafv2/WafV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/wafv2/WafV2IntegrationTest.java
@@ -332,4 +332,68 @@ class WafV2IntegrationTest {
                 .then().statusCode(404)
                 .body("__type", equalTo("WAFNonexistentItemException"));
     }
+
+    @Test
+    @Order(17)
+    void ipSetAddressesMustBeCidrBlocks() {
+        // Issue #3328: an IP set member is a block, not a single address. AWS rejects a bare
+        // address because the prefix length is what defines the range the set matches, so
+        // accepting one silently stored a value that could never match as intended.
+        call("CreateIPSet",
+                "{\"Name\":\"floci-waf-bad-ipv4\",\"Scope\":\"REGIONAL\",\"IPAddressVersion\":\"IPV4\","
+                        + "\"Addresses\":[\"203.0.113.10\"]}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("CreateIPSet",
+                "{\"Name\":\"floci-waf-bad-ipv6\",\"Scope\":\"REGIONAL\",\"IPAddressVersion\":\"IPV6\","
+                        + "\"Addresses\":[\"2001:db8::1\"]}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        call("CreateIPSet",
+                "{\"Name\":\"floci-waf-bad-prefix\",\"Scope\":\"REGIONAL\",\"IPAddressVersion\":\"IPV4\","
+                        + "\"Addresses\":[\"10.0.0.0/33\"]}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+        // A single malformed member rejects the whole call, including when it is not the first.
+        call("CreateIPSet",
+                "{\"Name\":\"floci-waf-mixed\",\"Scope\":\"REGIONAL\",\"IPAddressVersion\":\"IPV4\","
+                        + "\"Addresses\":[\"10.0.0.0/24\",\"203.0.113.10\"]}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+
+        // The guard must not reject well-formed blocks, IPv6 included.
+        Response created = call("CreateIPSet",
+                "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"IPAddressVersion\":\"IPV4\","
+                        + "\"Addresses\":[\"10.1.0.0/16\",\"192.0.2.0/24\"]}");
+        created.then().statusCode(200);
+        String id = created.jsonPath().getString("Summary.Id");
+
+        String lockToken = call("GetIPSet",
+                "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\"}")
+                .jsonPath().getString("LockToken");
+
+        call("UpdateIPSet",
+                "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\","
+                        + "\"LockToken\":\"" + lockToken + "\",\"Addresses\":[\"198.51.100.7\"]}")
+                .then().statusCode(400).body("__type", equalTo("WAFInvalidParameterException"));
+
+        // The rejected update must leave the stored addresses untouched.
+        call("GetIPSet", "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\"}")
+                .then().statusCode(200)
+                .body("IPSet.Addresses", hasSize(2))
+                .body("IPSet.Addresses[0]", equalTo("10.1.0.0/16"));
+
+        call("UpdateIPSet",
+                "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\","
+                        + "\"LockToken\":\"" + lockToken + "\",\"Addresses\":[\"198.51.100.0/24\"]}")
+                .then().statusCode(200);
+        call("GetIPSet", "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\"}")
+                .then().statusCode(200)
+                .body("IPSet.Addresses", hasSize(1))
+                .body("IPSet.Addresses[0]", equalTo("198.51.100.0/24"));
+
+        String finalLock = call("GetIPSet",
+                "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\"}")
+                .jsonPath().getString("LockToken");
+        call("DeleteIPSet",
+                "{\"Name\":\"floci-waf-cidr\",\"Scope\":\"REGIONAL\",\"Id\":\"" + id + "\","
+                        + "\"LockToken\":\"" + finalLock + "\"}")
+                .then().statusCode(200);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #3328

Validate WAFv2 IP set members as CIDR blocks before create or update persistence. The WAF-specific validator now rejects `/0` ranges and members whose IPv4 or IPv6 family differs from `IPAddressVersion`, while preserving atomic rejected updates.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS WAF requires CIDR notation and rejects `/0` ranges. Bare addresses, malformed members, out-of-range prefixes, `/0` ranges, and family mismatches now return `WAFInvalidParameterException` without mutating stored state. Valid IPv4 and IPv6 CIDRs remain accepted.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused verification: `./mvnw.cmd -q test -Dtest=WafV2IntegrationTest -Denforcer.skip=true` passed 17 tests. The enforcer was skipped because the local JDK is not the repository's required JDK 25.
