### PR TITLE
fix(sfn): return empty objects for null state paths

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -3013,7 +3013,7 @@ public class AslExecutor {
         }
         String path = stateDef.get("InputPath").asText();
         if (path == null || path.equals("null")) {
-            return NullNode.getInstance();
+            return objectMapper.createObjectNode();
         }
         return resolvePath(path, input);
     }
@@ -3038,7 +3038,7 @@ public class AslExecutor {
         }
         String path = stateDef.get("OutputPath").asText();
         if (path == null || path.equals("null")) {
-            return NullNode.getInstance();
+            return objectMapper.createObjectNode();
         }
         return resolvePath(path, output);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
@@ -133,6 +133,39 @@ class AslExecutorStatePathTest {
     }
 
     @Test
+    void passInputPathNullDiscardsInputAsEmptyObject() throws Exception {
+        assertOutput("""
+                {"StartAt":"Pass","States":{
+                  "Pass":{"Type":"Pass","InputPath":null,"End":true}}}
+                """,
+                "{\"discarded\":true}",
+                "{}");
+    }
+
+    @Test
+    void passOutputPathNullDiscardsOutputAsEmptyObject() throws Exception {
+        assertOutput("""
+                {"StartAt":"Pass","States":{
+                  "Pass":{"Type":"Pass","OutputPath":null,"End":true}}}
+                """,
+                "{\"discarded\":true}",
+                "{}");
+    }
+
+    @Test
+    void mapIteratorOutputPathNullProducesEmptyObjects() throws Exception {
+        assertOutput("""
+                {"StartAt":"Each","States":{
+                  "Each":{"Type":"Map","ItemsPath":"$.ids","MaxConcurrency":1,
+                    "Iterator":{"StartAt":"Pass","States":{
+                      "Pass":{"Type":"Pass","OutputPath":null,"End":true}}},
+                    "End":true}}}
+                """,
+                "{\"ids\":[1,2]}",
+                "[{},{}]");
+    }
+
+    @Test
     void parallelInputPathFeedsBranchesAndResultPathStillMergesIntoOriginalInput() throws Exception {
         assertOutput("""
                 {"StartAt":"Parallel","States":{


### PR DESCRIPTION
## Summary

- return an empty JSON object when InputPath is explicitly null
- return an empty JSON object when OutputPath is explicitly null
- cover Pass states and Map iterator output with execution-level regression tests

Closes #3259

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Floci previously returned JSON null for explicit null input/output paths. The ASL contract requires an empty JSON object ({}), matching the AWS Step Functions Local behavior documented in #3259.

## Checklist

- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

## Testing

- mvn -Dtest=AslExecutorStatePathTest test (11 tests)
- mvn -Dtest=AslExecutorStatePathTest,AslExecutorResultPathTest,AslExecutorUnresolvableJsonPathTest test (28 tests)
- mvn -Dtest=AslExecutor*Test test (303 tests)
- git diff --check