### PR TITLE
fix(opensearch): keep readiness polling after errors

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -347,20 +347,22 @@ public class OpenSearchService implements ResourceProvider {
     }
 
     private void startReadinessPoller() {
-        poller.scheduleWithFixedDelay(() -> {
-            try {
-                for (Domain domain : allDomains()) {
-                    if (domain.isProcessing() && domainManager.isReady(domain)) {
-                        domain.setProcessing(false);
-                        putDomain(domain);
-                        LOG.infov("OpenSearch domain {0} is ready at {1}",
-                                domain.getDomainName(), domain.getEndpoint());
-                    }
+        poller.scheduleWithFixedDelay(this::pollReadiness, 3, 3, TimeUnit.SECONDS);
+    }
+
+    void pollReadiness() {
+        try {
+            for (Domain domain : allDomains()) {
+                if (domain.isProcessing() && domainManager.isReady(domain)) {
+                    domain.setProcessing(false);
+                    putDomain(domain);
+                    LOG.infov("OpenSearch domain {0} is ready at {1}",
+                            domain.getDomainName(), domain.getEndpoint());
                 }
-            } catch (RuntimeException e) {
-                LOG.warn("OpenSearch readiness poll failed; will retry", e);
             }
-        }, 3, 3, TimeUnit.SECONDS);
+        } catch (RuntimeException e) {
+            LOG.warn("OpenSearch readiness poll failed; will retry", e);
+        }
     }
 
     private List<Domain> allDomains() {

--- a/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/opensearch/OpenSearchService.java
@@ -348,13 +348,17 @@ public class OpenSearchService implements ResourceProvider {
 
     private void startReadinessPoller() {
         poller.scheduleWithFixedDelay(() -> {
-            for (Domain domain : allDomains()) {
-                if (domain.isProcessing() && domainManager.isReady(domain)) {
-                    domain.setProcessing(false);
-                    putDomain(domain);
-                    LOG.infov("OpenSearch domain {0} is ready at {1}",
-                            domain.getDomainName(), domain.getEndpoint());
+            try {
+                for (Domain domain : allDomains()) {
+                    if (domain.isProcessing() && domainManager.isReady(domain)) {
+                        domain.setProcessing(false);
+                        putDomain(domain);
+                        LOG.infov("OpenSearch domain {0} is ready at {1}",
+                                domain.getDomainName(), domain.getEndpoint());
+                    }
                 }
+            } catch (RuntimeException e) {
+                LOG.warn("OpenSearch readiness poll failed; will retry", e);
             }
         }, 3, 3, TimeUnit.SECONDS);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchServiceTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -78,5 +79,30 @@ class OpenSearchServiceTest {
 
         assertFalse(domain.isProcessing());
         verify(domainManager, Mockito.never()).tryStartDomain(any());
+    }
+
+    @Test
+    void readinessPollerContinuesAfterOneReadinessFailure() throws InterruptedException {
+        when(domainManager.tryStartDomain(any())).thenReturn(true);
+        when(domainManager.isReady(any()))
+                .thenThrow(new RuntimeException("temporary readiness failure"))
+                .thenReturn(true);
+
+        service.init();
+        try {
+            service.createDomain("ready-recovery", "OpenSearch_2.11",
+                    null, null, null, "us-east-1");
+
+            long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(8);
+            while (service.describeDomain("ready-recovery").isProcessing()
+                    && System.nanoTime() < deadline) {
+                Thread.sleep(50);
+            }
+
+            assertFalse(service.describeDomain("ready-recovery").isProcessing());
+            verify(domainManager, atLeast(2)).isReady(any());
+        } finally {
+            service.shutdown();
+        }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/opensearch/OpenSearchServiceTest.java
@@ -82,27 +82,20 @@ class OpenSearchServiceTest {
     }
 
     @Test
-    void readinessPollerContinuesAfterOneReadinessFailure() throws InterruptedException {
+    void readinessPollerContinuesAfterOneReadinessFailure() {
         when(domainManager.tryStartDomain(any())).thenReturn(true);
         when(domainManager.isReady(any()))
                 .thenThrow(new RuntimeException("temporary readiness failure"))
                 .thenReturn(true);
 
-        service.init();
-        try {
-            service.createDomain("ready-recovery", "OpenSearch_2.11",
-                    null, null, null, "us-east-1");
+        service.createDomain("ready-recovery", "OpenSearch_2.11",
+                null, null, null, "us-east-1");
 
-            long deadline = System.nanoTime() + java.util.concurrent.TimeUnit.SECONDS.toNanos(8);
-            while (service.describeDomain("ready-recovery").isProcessing()
-                    && System.nanoTime() < deadline) {
-                Thread.sleep(50);
-            }
+        service.pollReadiness();
+        assertTrue(service.describeDomain("ready-recovery").isProcessing());
 
-            assertFalse(service.describeDomain("ready-recovery").isProcessing());
-            verify(domainManager, atLeast(2)).isReady(any());
-        } finally {
-            service.shutdown();
-        }
+        service.pollReadiness();
+        assertFalse(service.describeDomain("ready-recovery").isProcessing());
+        verify(domainManager, atLeast(2)).isReady(any());
     }
 }


### PR DESCRIPTION
## Summary

Keep the OpenSearch readiness poller running after a transient storage or Docker readiness failure. The failed poll is logged and retried, so a later successful check can still mark the domain as ready.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The readiness task previously stopped permanently when a domain scan or readiness check raised a runtime exception. Domains could remain in a processing state even after the backing service recovered.

The change adds an exception boundary around each scheduled poll cycle without changing the polling interval or domain response shape. Focused unit tests cover one failed readiness check followed by successful recovery. The related OpenSearch integration test also passes.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->
