### PR TITLE
fix(identity-center): restore bootstrap identity store safely

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
@@ -224,6 +224,9 @@ public class SsoAdminService implements Resettable {
         if (identityStoreId == null) {
             return false;
         }
+        if (IDENTITY_STORE_ID.equals(identityStoreId)) {
+            ensureBootstrapInstance(defaultAccountId, defaultRegion);
+        }
         if (instances.scan(key -> true).stream()
                 .anyMatch(instance -> identityStoreId.equals(instance.identityStoreId()))) {
             return true;

--- a/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryDuplicateBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/StorageFactoryDuplicateBackendTest.java
@@ -32,10 +32,12 @@ class StorageFactoryDuplicateBackendTest {
 
     @BeforeEach
     void reset() throws IOException {
-        // StorageFactory is an application-scoped singleton, so a backend for this file may already
-        // exist and hold in-memory state from app startup. Clear all backends (wipes memory + disk),
-        // then remove the file so both create() calls below start from an empty store.
-        storageFactory.clearAll();
+        // StorageFactory is application-scoped and may already hold this DynamoDB backend from
+        // application startup. Clear only the store exercised by this regression test. Calling
+        // clearAll() here also wipes bootstrap state owned by unrelated services, including IAM
+        // Identity Center, which makes later SCIM integration tests fail with 401 in the same JVM.
+        TypeReference<Map<String, String>> typeRef = new TypeReference<>() {};
+        storageFactory.create("dynamodb", FILE_NAME, typeRef).clear();
         Files.deleteIfExists(Path.of(STORAGE_PATH, FILE_NAME));
     }
 

--- a/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminServiceTest.java
@@ -46,6 +46,7 @@ class SsoAdminServiceTest {
     private InMemoryStorage<String, ApplicationAccessScope> applicationAccessScopes;
     private InMemoryStorage<String, ApplicationAuthenticationMethod> applicationAuthenticationMethods;
     private InMemoryStorage<String, ApplicationGrant> applicationGrants;
+    private InMemoryStorage<String, SsoInstance> instances;
 
     @BeforeEach
     void setUp() {
@@ -54,6 +55,7 @@ class SsoAdminServiceTest {
         applicationAccessScopes = new InMemoryStorage<>();
         applicationAuthenticationMethods = new InMemoryStorage<>();
         applicationGrants = new InMemoryStorage<>();
+        instances = new InMemoryStorage<>();
         service = new SsoAdminService(
                 new InMemoryStorage<String, PermissionSet>(),
                 new InMemoryStorage<String, Assignment>(),
@@ -72,7 +74,7 @@ class SsoAdminServiceTest {
                 applicationGrants,
                 new InMemoryStorage<String, String>(),
                 new InMemoryStorage<String, Map<String, String>>(),
-                new InMemoryStorage<String, SsoInstance>(),
+                instances,
                 new InMemoryStorage<String, InstanceUpdateState>(),
                 new InMemoryStorage<String, String>(),
                 new InMemoryStorage<String, Boolean>(),
@@ -85,6 +87,18 @@ class SsoAdminServiceTest {
                 ACCOUNT_ID,
                 "us-east-1");
         service.ensureBootstrapInstance(ACCOUNT_ID, "us-east-1");
+    }
+
+    @Test
+    void hasIdentityStoreRestoresBootstrapUnlessInstanceWasDeleted() {
+        String identityStoreId = service.getIdentityStoreId();
+        instances.clear();
+
+        assertTrue(service.hasIdentityStore(identityStoreId));
+
+        ObjectNode delete = mapper.createObjectNode().put("InstanceArn", service.getInstanceArn());
+        service.deleteInstance(delete, ACCOUNT_ID);
+        assertFalse(service.hasIdentityStore(identityStoreId));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- make IAM Identity Center restore its default bootstrap identity store on demand when shared storage was cleared out-of-band
- preserve explicit `DeleteInstance` semantics by honoring the existing deletion marker before recreating bootstrap state
- keep `StorageFactoryDuplicateBackendTest` scoped to the DynamoDB backend it owns so it no longer wipes unrelated application state
- add regression coverage proving bootstrap recovery and non-recreation after explicit deletion

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The regression was test-suite state corruption, not an AWS wire-protocol mismatch. `StorageFactoryDuplicateBackendTest` cleared every registered backend in the shared Quarkus JVM. That removed IAM Identity Center's bootstrap instance, so later SCIM requests used a valid bearer token and tenant ID but received 401 because the identity store no longer existed.

The fix limits that storage regression test to its DynamoDB backend and makes lookup of the built-in identity store recover the bootstrap instance if storage was cleared unexpectedly. An explicit `DeleteInstance` still prevents recreation through the existing deletion marker.

Focused validation passes for `SsoAdminServiceTest`, `ScimIntegrationTest`, and `StorageFactoryDuplicateBackendTest` together.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
