### PR TITLE
fix(rds): map Aurora MySQL engine versions to the MySQL image tag

### DIFF
--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -236,6 +236,7 @@ mysql -h 127.0.0.1 -P 7002 -u root -psecret123
 | `mariadb` | `mariadb:11` |
 
 Override the image per-instance with the `--engine-version` flag or globally via environment variables.
+Aurora MySQL versions such as `8.0.mysql_aurora.3.08.0` use the MySQL version in front, so that example runs `mysql:8.0`.
 
 ## Option Groups
 

--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -3791,6 +3791,11 @@ public class RdsService implements Resettable, ResourceProvider {
         }
 
         String requestedTag = engineVersion.trim();
+        // Aurora MySQL versions read 8.0.mysql_aurora.3.08.0. The MySQL image tag is the part in front.
+        var auroraSuffix = requestedTag.indexOf(".mysql_aurora.");
+        if (auroraSuffix > 0) {
+            requestedTag = requestedTag.substring(0, auroraSuffix);
+        }
         if (!SAFE_IMAGE_TAG_PATTERN.matcher(requestedTag).matches()) {
             throw new AwsException("InvalidParameterValue",
                     "Unsupported engine version tag: " + engineVersion, 400);

--- a/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/RdsServiceTest.java
@@ -212,6 +212,18 @@ class RdsServiceTest {
     }
 
     @Test
+    void auroraMysqlImageUsesTheMysqlVersionInFrontOfTheAuroraSuffix() {
+        assertEquals("mysql:8.0",
+                RdsService.imageForRequestedVersion("mysql:8.0", "8.0.mysql_aurora.3.08.0"));
+        assertEquals("mysql:5.7",
+                RdsService.imageForRequestedVersion("mysql:8.0", "5.7.mysql_aurora.2.12.5"));
+        assertEquals("mysql:8.4",
+                RdsService.imageForRequestedVersion("mysql:8.0", "8.4.mysql_aurora.3.10.0"));
+        assertEquals("mysql:8.0.36",
+                RdsService.imageForRequestedVersion("mysql:8.0", "8.0.36"));
+    }
+
+    @Test
     void createDbClusterRejectsADuplicateIdentifier() {
         rdsService.createDbCluster("dup-cluster", "postgres", "17.5",
                 "admin", "password", "dbname", false, null, null, null, false);


### PR DESCRIPTION
## Summary

`CreateDBCluster` with Engine aurora-mysql and an Aurora version such as `8.0.mysql_aurora.3.08.0` used the version **literally** as the container image tag. MySQL Docker image has no such tag, leading the pull to 404.

Take the MySQL version in front of the Aurora suffix, so that example runs `mysql:8.0`. Plain mysql versions still map to their own tag.

The Go compatibility tests for the RDS Data API on aurora-mysql [skip when the cluster cannot be created](https://github.com/floci-io/floci/actions/runs/34535182525/job/103067300255#step:10:242), so this failure never showed in CI. They now run with the mapping fixed.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No change.
Just floci internal for CI.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

