### PR TITLE
fix(identitystore): self-heal the bootstrap identity store on hasIdentityStore

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminService.java
@@ -224,6 +224,9 @@ public class SsoAdminService implements Resettable {
         if (identityStoreId == null) {
             return false;
         }
+        // Self-heals like listInstances(): storageFactory.clearAll() wipes `instances` right after
+        // clear() re-seeds it, so /state/reset otherwise leaves the bootstrap instance missing.
+        ensureBootstrapInstance(defaultAccountId, defaultRegion);
         if (instances.scan(key -> true).stream()
                 .anyMatch(instance -> identityStoreId.equals(instance.identityStoreId()))) {
             return true;

--- a/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ssoadmin/SsoAdminServiceTest.java
@@ -46,6 +46,7 @@ class SsoAdminServiceTest {
     private InMemoryStorage<String, ApplicationAccessScope> applicationAccessScopes;
     private InMemoryStorage<String, ApplicationAuthenticationMethod> applicationAuthenticationMethods;
     private InMemoryStorage<String, ApplicationGrant> applicationGrants;
+    private InMemoryStorage<String, SsoInstance> instances;
 
     @BeforeEach
     void setUp() {
@@ -54,6 +55,7 @@ class SsoAdminServiceTest {
         applicationAccessScopes = new InMemoryStorage<>();
         applicationAuthenticationMethods = new InMemoryStorage<>();
         applicationGrants = new InMemoryStorage<>();
+        instances = new InMemoryStorage<>();
         service = new SsoAdminService(
                 new InMemoryStorage<String, PermissionSet>(),
                 new InMemoryStorage<String, Assignment>(),
@@ -72,7 +74,7 @@ class SsoAdminServiceTest {
                 applicationGrants,
                 new InMemoryStorage<String, String>(),
                 new InMemoryStorage<String, Map<String, String>>(),
-                new InMemoryStorage<String, SsoInstance>(),
+                instances,
                 new InMemoryStorage<String, InstanceUpdateState>(),
                 new InMemoryStorage<String, String>(),
                 new InMemoryStorage<String, Boolean>(),
@@ -85,6 +87,19 @@ class SsoAdminServiceTest {
                 ACCOUNT_ID,
                 "us-east-1");
         service.ensureBootstrapInstance(ACCOUNT_ID, "us-east-1");
+    }
+
+    @Test
+    void hasIdentityStoreSelfHealsAfterStorageFactoryClearsInstancesPostReset() {
+        // Mirrors EmulatorInfoController.performReset(): every Resettable.clear() (including
+        // this service's, which re-seeds the bootstrap instance) runs, then
+        // StorageFactory.clearAll() wipes every backing store again, including `instances`.
+        service.clear();
+        instances.clear();
+        assertTrue(instances.get(ACCOUNT_ID).isEmpty());
+
+        assertTrue(service.hasIdentityStore(service.getIdentityStoreId()));
+        assertTrue(instances.get(ACCOUNT_ID).isPresent());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #3386. `ScimIntegrationTest` passes in isolation but ~20/22 cases return 401 when run as part of the full suite (shard 3 on main).

Root cause: `EmulatorInfoController.performReset()` runs every `Resettable.clear()` first — `SsoAdminService.clear()` re-seeds the default `d-9067f2a3c1` identity center instance as part of that — then calls `storageFactory.clearAll()`, which wipes the `instances` backend again right after, undoing the re-seed with nothing to restore it. Once any test in the same JVM fork hits `/state/reset` or `/state/nuke` (e.g. `EmulatorInfoControllerIntegrationTest`), the default identity store never comes back for the rest of that fork, so `ScimController.resolveIdentityStore` → `ssoAdminService.hasIdentityStore("d-9067f2a3c1")` 401s on every later SCIM request.

`hasIdentityStore` now self-heals the bootstrap instance before checking, the same way `listInstances()` already does.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Not an AWS wire-protocol change — this is an emulator-internal test-isolation bug in the SCIM bearer-token/tenant-resolution path (`ScimController.resolveIdentityStore`), not a change to any AWS API's request/response shape.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)