### PR TITLE
fix(lifecycle): clear storage before services clear on state reset

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
+++ b/src/main/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoController.java
@@ -146,10 +146,12 @@ public class EmulatorInfoController {
     }
 
     private void performReset() {
+        // Storage first. Services re-create their bootstrap state in clear(), and a wipe
+        // afterwards would remove it again until the next restart.
+        storageFactory.clearAll();
         for (Resettable r : resettables) {
             r.clear();
         }
-        storageFactory.clearAll();
     }
 
     static String resolveVersion() {

--- a/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoControllerIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/lifecycle/EmulatorInfoControllerIntegrationTest.java
@@ -135,6 +135,24 @@ class EmulatorInfoControllerIntegrationTest {
     }
 
     @Test
+    void stateReset_keepsBootstrapStateOfServicesThatReseedOnClear() {
+        // IAM Identity Center recreates its bootstrap instance in clear(). A reset that wiped
+        // storage after that step left every SCIM call answering 401 until a restart.
+        given()
+            .when().post("/_floci/state/reset")
+            .then()
+                .statusCode(200);
+
+        given()
+            .header("Authorization", "Bearer floci-scim-token")
+        .when()
+            .get("/9067f2a3c1-00000000-0000-0000-0000-000000000000/scim/v2/ServiceProviderConfig")
+        .then()
+            .statusCode(200)
+            .body("schemas[0]", equalTo("urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig"));
+    }
+
+    @Test
     void stateReset_clearsDatabaseState() {
         // 1. Put SSM parameter
         given()


### PR DESCRIPTION
## Summary

> [!NOTE]
> #3387 fixed the symptom for Identity Center. The cause is still in `performReset()` in which every `Resettable.clear()` runs before `storageFactory.clearAll()`. So anything a service re-seeds in `clear()` is wiped right after.
>
> This PR fixes that order, so future services with default state do not hit the same bug, and adds a regression test on the reset endpoint. Both fix can coexist.


Fixes #3385

`performReset()` ran every `Resettable.clear()` first and `storageFactory.clearAll()` last, so any service that recreates its bootstrap state in `clear()` lost it again until the next restart. Today only `SsoAdminService` does this, which is why SCIM answered 401 after a reset, but every future service with default state would hit the same bug. Wiping storage first and letting services clear and re-seed afterwards closes the trap for all of them.

This is what broke `ScimIntegrationTest` in CI shard 3 since #3331. `EmulatorInfoControllerIntegrationTest` runs in the same test application before it and posts the reset endpoints.

Clear storage first, then let services clear and re-seed. The `clear()` implementations that iterate state to stop timers or sockets read in-memory maps, not storage, so the order change does not affect them.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No change.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
