### PR TITLE
fix(dynamodb): reject cursors outside query boundaries

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbService.java
@@ -944,6 +944,8 @@ public class DynamoDbService implements ResourceProvider {
         String partitionKeyValuePlaceholder = DynamoDbAccessPathValidator.validateQuery(
                 table, accessPath, keyConditions, keyConditionExpression, filterExpression,
                 null, exprAttrNames, expressionAttrValues);
+        validateExclusiveStartKeyWithinQuery(exclusiveStartKey, table, accessPath, keyConditions,
+                keyConditionExpression, expressionAttrValues, exprAttrNames);
         String pkName = accessPath.partitionKeyName();
         List<String> pkNames = accessPath.partitionKeyNames();
         String skName = accessPath.sortKeyName();
@@ -3369,6 +3371,26 @@ public class DynamoDbService implements ResourceProvider {
             }
             default -> true;
         };
+    }
+
+    private void validateExclusiveStartKeyWithinQuery(JsonNode exclusiveStartKey, TableDefinition table,
+                                                      DynamoDbAccessPath accessPath, JsonNode keyConditions,
+                                                      String keyConditionExpression, JsonNode expressionAttrValues,
+                                                      JsonNode expressionAttrNames) {
+        if (exclusiveStartKey == null || exclusiveStartKey.isNull()) {
+            return;
+        }
+        DynamoDbAccessPathValidator.validateExclusiveStartKey(exclusiveStartKey, table, accessPath, false);
+
+        boolean withinBounds = keyConditionExpression != null
+                ? ExpressionEvaluator.matches(keyConditionExpression, exclusiveStartKey,
+                        expressionAttrNames, expressionAttrValues)
+                : keyConditions.properties().stream().allMatch(entry ->
+                        matchesKeyCondition(exclusiveStartKey.get(entry.getKey()), entry.getValue()));
+        if (!withinBounds) {
+            throw new AwsException("ValidationException",
+                    "The provided starting key is outside query boundaries based on provided condition", 400);
+        }
     }
 
     private List<JsonNode> queryWithExpression(ConcurrentSkipListMap<String, JsonNode> items,

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathIntegrationTest.java
@@ -368,6 +368,48 @@ class DynamoDbAccessPathIntegrationTest {
 
     @Test
     @Order(10)
+    void queryRejectsExclusiveStartKeyOutsideKeyCondition() {
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "KeyConditionExpression":"pk = :pk",
+                  "ExpressionAttributeValues":{":pk":{"S":"p2"}},
+                  "ExclusiveStartKey":{"pk":{"S":"p1"},"sk":{"S":"s1"}}
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo(
+                    "The provided starting key is outside query boundaries based on provided condition"));
+
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "KeyConditions":{
+                    "pk":{"ComparisonOperator":"EQ","AttributeValueList":[{"S":"p2"}]}
+                  },
+                  "ExclusiveStartKey":{"pk":{"S":"p1"},"sk":{"S":"s1"}}
+                }
+                """.formatted(TABLE))
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo(
+                    "The provided starting key is outside query boundaries based on provided condition"));
+
+        request("DynamoDB_20120810.Query", """
+                {
+                  "TableName":"%s",
+                  "KeyConditionExpression":"pk = :pk",
+                  "ExpressionAttributeValues":{":pk":{"S":"p1"}},
+                  "ExclusiveStartKey":{"pk":{"S":"p1"},"sk":{"S":"s1"}}
+                }
+                """.formatted(TABLE))
+            .statusCode(200)
+            .body("Count", equalTo(0));
+    }
+
+    @Test
+    @Order(10)
     void queryRejectsMalformedNumericExclusiveStartKey() {
         String numericTable = TABLE + "-numeric";
         request("DynamoDB_20120810.CreateTable", """


### PR DESCRIPTION
## Summary

Closes #3322.

Reject DynamoDB Query requests when `ExclusiveStartKey` falls outside the supplied key condition. This prevents a cursor from another partition from being silently ignored and restarting pagination from the first item.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously returned HTTP 200 and duplicated the first page when the cursor belonged to a different partition. AWS returns HTTP 400 `ValidationException` with `The provided starting key is outside query boundaries based on provided condition`.

The shared Query service now validates both expression and legacy key conditions against the cursor. The regression test covers both invalid forms plus a valid cursor control.

## Checklist

- [x] `./mvnw test` passes locally using the repository's four CI shards; host DNS-sensitive tests were run separately with the documented localhost setting or an isolated Linux network
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Verification

- Target regression: 25 tests, 0 failures/errors
- Related DynamoDB suite: 279 tests, 0 failures/errors
- Full CI-equivalent suite: 1,413 classes, 19,537 tests, 0 failures/errors, 9 conditional skips
- `git diff --check`, `make docs-check`, Java 25 test compilation, and Maven package passed
