### PR TITLE
fix(sfn): resolve context reference paths

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -2004,7 +2004,7 @@ public class AslExecutor {
         JsonNode effectiveInput = applyInputPath(stateDef, input);
         JsonNode choices = stateDef.path("Choices");
         for (JsonNode choice : choices) {
-            if (evaluateCondition(choice, effectiveInput)) {
+            if (evaluateCondition(choice, effectiveInput, context)) {
                 JsonNode output = applyOutputPath(stateDef, input, effectiveInput);
                 return new StateResult(output, choice.path("Next").asText());
             }
@@ -2018,13 +2018,13 @@ public class AslExecutor {
         throw new FailStateException("States.Runtime", NO_NEXT_STATE_CAUSE);
     }
 
-    private boolean evaluateCondition(JsonNode rule, JsonNode input) throws Exception {
+    private boolean evaluateCondition(JsonNode rule, JsonNode input, JsonNode context) throws Exception {
         // Comparator inventory, type-strict evaluation, and the missing-path/unknown-operator rules
         // live in ChoiceOperators so the runtime and the CreateStateMachine validator share one source
         // of truth. An undefined reference path or an unsupported comparator is a runtime error on AWS,
         // not a silently-false fallthrough to the Default branch.
         try {
-            return ChoiceOperators.evaluate(rule, path -> resolvePathNode(path, input));
+            return ChoiceOperators.evaluate(rule, path -> resolvePathNode(path, input, context));
         } catch (ChoiceOperators.ChoiceEvaluationException e) {
             throw new FailStateException("States.Runtime", e.getMessage());
         }
@@ -2746,7 +2746,8 @@ public class AslExecutor {
         }
 
         JsonNode itemsPath = stateDef.path("ItemsPath");
-        return new ResolvedMapItems(itemsPath.isMissingNode() ? input : resolvePath(itemsPath.asText("$"), input),
+        return new ResolvedMapItems(
+                itemsPath.isMissingNode() ? input : resolvePath(itemsPath.asText("$"), input, context),
                 MapItemsSource.DEFAULT);
     }
 
@@ -3115,7 +3116,7 @@ public class AslExecutor {
      * (returns a {@link NullNode}) and a missing/absent path (returns a {@link MissingNode}).
      * {@link #resolvePath} collapses both to null; only callers that care about presence
      * (e.g. {@code IsPresent}) should use this variant. When {@code context} is non-null it is the
-     * Context Object ({@code $$}) available to {@code States.*} intrinsic arguments.
+     * Context Object available to direct {@code $$} references and {@code States.*} intrinsic arguments.
      */
     JsonNode resolvePathNode(String path, JsonNode root, JsonNode context) {
         if (path == null || "$".equals(path)) {
@@ -3123,6 +3124,16 @@ public class AslExecutor {
         }
         if (path.startsWith("States.")) {
             return evaluateIntrinsic(path, root, context);
+        }
+        if ("$$".equals(path)) {
+            return context == null ? MissingNode.getInstance() : context;
+        }
+        if (path.startsWith("$$.") || path.startsWith("$$[")) {
+            if (context == null || !ChoiceOperators.isReferencePath(path)) {
+                return MissingNode.getInstance();
+            }
+            path = "$" + path.substring(2);
+            root = context;
         }
         // Support dotted ($.a.b) and root-bracket ($[*], $[0]) forms; anything else is unsupported.
         if (!path.startsWith("$.") && !path.startsWith("$[")) {

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/ChoiceOperators.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/ChoiceOperators.java
@@ -457,13 +457,17 @@ public final class ChoiceOperators {
     }
 
     /**
-     * Pragmatic ASL reference-path syntax check: must start with {@code $}; {@code $} alone is valid; a
-     * longer path must be a sequence of non-empty {@code .segment} steps and balanced non-empty
-     * {@code [..]} steps. Rejects the common malformations ({@code not-a-path}, {@code $.}, {@code $[}).
+     * Pragmatic ASL reference-path syntax check: must start with {@code $} or {@code $$}; either root
+     * alone is valid; a longer path must be a sequence of non-empty {@code .segment} steps and balanced
+     * non-empty {@code [..]} steps. Rejects common malformations ({@code not-a-path}, {@code $.},
+     * {@code $$.}, {@code $[}).
      */
     static boolean isReferencePath(String p) {
         if (p == null || p.isEmpty() || p.charAt(0) != '$') {
             return false;
+        }
+        if (p.startsWith("$$")) {
+            p = "$" + p.substring(2);
         }
         if (p.equals("$")) {
             return true;

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorChoiceRuntimeTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorChoiceRuntimeTest.java
@@ -93,6 +93,54 @@ class AslExecutorChoiceRuntimeTest {
     }
 
     @Test
+    void contextObjectVariableRoutesUsingOriginalExecutionInput() {
+        Execution exec = run("""
+                {
+                  "StartAt": "Pick",
+                  "States": {
+                    "Pick": {
+                      "Type": "Choice",
+                      "InputPath": "$.scoped",
+                      "Choices": [{
+                        "Variable": "$$.Execution.Input.token",
+                        "StringEquals": "keep",
+                        "Next": "TAKEN"
+                      }],
+                      "Default": "FELL"
+                    },
+                    "TAKEN": {"Type": "Pass", "End": true},
+                    "FELL": {"Type": "Fail", "Error": "FELL"}
+                  }
+                }
+                """, "{\"token\":\"keep\",\"scoped\":{\"token\":\"wrong\"}}");
+        assertEquals("SUCCEEDED", exec.getStatus());
+    }
+
+    @Test
+    void contextObjectPathOperandRoutesUsingOriginalExecutionInput() {
+        Execution exec = run("""
+                {
+                  "StartAt": "Pick",
+                  "States": {
+                    "Pick": {
+                      "Type": "Choice",
+                      "InputPath": "$.scoped",
+                      "Choices": [{
+                        "Variable": "$.district_id",
+                        "StringEqualsPath": "$$.Execution.Input.expected_district_id",
+                        "Next": "TAKEN"
+                      }],
+                      "Default": "FELL"
+                    },
+                    "TAKEN": {"Type": "Pass", "End": true},
+                    "FELL": {"Type": "Fail", "Error": "FELL"}
+                  }
+                }
+                """, "{\"expected_district_id\":\"42\",\"scoped\":{\"district_id\":\"42\"}}");
+        assertEquals("SUCCEEDED", exec.getStatus());
+    }
+
+    @Test
     void unknownComparatorFailsExecutionWithStatesRuntime() {
         // executeSync bypasses create-time validation, so the runtime backstop must fire loudly.
         Execution exec = run("""

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
@@ -166,6 +166,21 @@ class AslExecutorStatePathTest {
     }
 
     @Test
+    void mapItemsPathCanReadOriginalExecutionInputFromContext() throws Exception {
+        assertOutput("""
+                {"StartAt":"Each","States":{
+                  "Each":{"Type":"Map","InputPath":"$.scoped",
+                    "ItemsPath":"$$.Execution.Input.ids","MaxConcurrency":1,
+                    "ItemSelector":{"id.$":"$$.Map.Item.Value"},
+                    "Iterator":{"StartAt":"Pass","States":{
+                      "Pass":{"Type":"Pass","End":true}}},
+                    "End":true}}}
+                """,
+                "{\"ids\":[1,2],\"scoped\":{\"ignored\":true}}",
+                "[{\"id\":1},{\"id\":2}]");
+    }
+
+    @Test
     void parallelInputPathFeedsBranchesAndResultPathStillMergesIntoOriginalInput() throws Exception {
         assertOutput("""
                 {"StartAt":"Parallel","States":{

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/ChoiceOperatorsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/ChoiceOperatorsTest.java
@@ -418,10 +418,18 @@ class ChoiceOperatorsTest {
                 "Assign must be an object");
         assertTrue(validate(j("{'Variable':'$.a[0].b','NumericEquals':1,'Next':'X'}")).isEmpty(),
                 "valid indexed reference path accepted");
+        assertTrue(validate(j("{'Variable':'$$.Execution.Input.token',"
+                + "'StringEqualsPath':'$$.Execution.Input.expected','Next':'X'}")).isEmpty(),
+                "context reference paths are valid for variables and path operands");
         assertTrue(ChoiceOperators.isReferencePath("$"));
         assertTrue(ChoiceOperators.isReferencePath("$.a.b"));
         assertTrue(ChoiceOperators.isReferencePath("$[0]"));
+        assertTrue(ChoiceOperators.isReferencePath("$$"));
+        assertTrue(ChoiceOperators.isReferencePath("$$.Execution.Input.token"));
+        assertTrue(ChoiceOperators.isReferencePath("$$[0]"));
         assertFalse(ChoiceOperators.isReferencePath("$."));
+        assertFalse(ChoiceOperators.isReferencePath("$$."));
+        assertFalse(ChoiceOperators.isReferencePath("$$foo"));
         assertFalse(ChoiceOperators.isReferencePath("$["));
         assertFalse(ChoiceOperators.isReferencePath("nope"));
     }


### PR DESCRIPTION
## Summary

- accept `$$` as a valid ASL reference-path root while still rejecting malformed paths
- resolve Choice variables and `*Path` operands against the execution Context Object
- resolve Map `ItemsPath` against the same Context Object
- add end-to-end regression coverage for all three affected cases

Closes #3253

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Choice `Variable` and `*Path` operands rooted at `$$` were rejected during state machine validation, while Map `ItemsPath` references rooted at `$$` resolved against the state input and failed at runtime. This restores Context Object reference-path behavior consistent with AWS Step Functions Local for the three affected fields.

## Testing

- `mvn -Dtest=ChoiceOperatorsTest,AslExecutorChoiceRuntimeTest,AslExecutorStatePathTest test`: 41 tests passed
- `mvn -Dtest=AslExecutor*Test,ChoiceOperatorsTest test`: 329 tests passed
- Full `mvn test` was attempted. It reached unrelated Docker-backed API Gateway integration tests and reported four timeouts in `ApiGatewayApiKeyRevocationIntegrationTest` because the local Docker daemon pipe was unavailable (`\\.\pipe\docker_engine`).

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)