### PR TITLE
fix(sfn): preserve mocked response indexes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -114,6 +114,22 @@ public class AslExecutor {
     private record ResolvedMapItems(JsonNode items, MapItemsSource source) {
     }
 
+    private record ActiveMockExecution(
+            MockedTestCase testCase,
+            ConcurrentHashMap<String, AtomicInteger> responseIndexes) {
+
+        private ActiveMockExecution(MockedTestCase testCase) {
+            this(testCase, new ConcurrentHashMap<>());
+        }
+
+        private int nextResponseIndex(String stateName) {
+            return responseIndexes.computeIfAbsent(stateName, ignored -> new AtomicInteger()).getAndIncrement();
+        }
+    }
+
+    private record MockedTaskInvocation(List<MockedResponseStep> steps, int responseIndex) {
+    }
+
     private static final Logger LOG = Logger.getLogger(AslExecutor.class);
     private static final int MAX_WAIT_SECONDS = 30;
     // How long a Task waits for its token when the state declares no TimeoutSeconds. AWS lets it
@@ -218,7 +234,7 @@ public class AslExecutor {
     private final WebClient webClient;
     private final EmulatorConfig config;
     private final CustomResourceLiveness customResourceLiveness;
-    private final Map<String, MockedTestCase> activeMocks = new ConcurrentHashMap<>();
+    private final Map<String, ActiveMockExecution> activeMocks = new ConcurrentHashMap<>();
     private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "sfn-executor");
         t.setDaemon(true);
@@ -526,7 +542,7 @@ public class AslExecutor {
 
     private void registerMocks(Execution exec, MockedTestCase mockedTestCase) {
         if (mockedTestCase != null) {
-            activeMocks.put(exec.getExecutionArn(), mockedTestCase);
+            activeMocks.put(exec.getExecutionArn(), new ActiveMockExecution(mockedTestCase));
         }
     }
 
@@ -547,7 +563,7 @@ public class AslExecutor {
         while (true) {
             try {
                 return executeState(name, type, stateDef, input, chain, sm, jsonata,
-                        topLevelQueryLanguage, context, variables, attempt, executionDeadlineNanos);
+                        topLevelQueryLanguage, context, variables, executionDeadlineNanos);
             } catch (FailStateException raised) {
                 var e = raised.attributedTo(name, enteredEventId);
                 if (!raised.hasFinalCause()) {
@@ -621,11 +637,11 @@ public class AslExecutor {
     private StateResult executeState(String name, String type, JsonNode stateDef, JsonNode input,
                                      HistoryChain chain, StateMachine sm, boolean jsonata,
                                      String topLevelQueryLanguage, JsonNode context, ObjectNode variables,
-                                     int attempt, long executionDeadlineNanos) throws Exception {
+                                     long executionDeadlineNanos) throws Exception {
         return switch (type) {
             case "Pass" -> executePassState(stateDef, input, jsonata, context, variables);
             case "Task" -> executeTaskState(name, stateDef, input, chain, sm,
-                    jsonata, context, variables, attempt, executionDeadlineNanos);
+                    jsonata, context, variables, executionDeadlineNanos);
             case "Choice" -> executeChoiceState(stateDef, input, jsonata, context, variables);
             case "Wait" -> executeWaitState(stateDef, input, jsonata, context, variables, executionDeadlineNanos);
             case "Succeed" -> executeSucceedState(stateDef, input, jsonata, context, variables);
@@ -665,7 +681,7 @@ public class AslExecutor {
 
     private StateResult executeTaskState(String stateName, JsonNode stateDef, JsonNode input,
                                          HistoryChain chain, StateMachine sm, boolean jsonata,
-                                         JsonNode context, ObjectNode variables, int attempt,
+                                         JsonNode context, ObjectNode variables,
                                          long executionDeadlineNanos) throws Exception {
         var resource = stateDef.path("Resource").asText();
         var isWaitForToken = resource.endsWith(".waitForTaskToken");
@@ -673,10 +689,10 @@ public class AslExecutor {
                 ? resource.substring(0, resource.length() - ".waitForTaskToken".length())
                 : resource;
         var isActivity = isActivityArn(effectiveResource);
-        var mockedSteps = findMockedResponses(context, stateName);
+        var mockedInvocation = findMockedInvocation(context, stateName);
         // A mocked task never calls the integrated service, so it neither registers a task token
         // nor waits for one; the mocked response stands in for the whole interaction.
-        var needsToken = mockedSteps == null && (isWaitForToken || isActivity);
+        var needsToken = mockedInvocation == null && (isWaitForToken || isActivity);
 
         String taskToken = null;
         if (needsToken) {
@@ -707,8 +723,8 @@ public class AslExecutor {
             addTaskScheduledEvent(chain, profile, stateDef, effectiveInput, sm);
             addTaskStartedEvent(chain, profile);
             try {
-                taskResult = mockedSteps != null
-                        ? mockedTaskResult(mockedSteps, stateName, attempt)
+                taskResult = mockedInvocation != null
+                        ? mockedTaskResult(mockedInvocation.steps(), stateName, mockedInvocation.responseIndex())
                         : invokeResource(effectiveResource, effectiveInput, sm, taskToken,
                                 executionDeadlineNanos, jsonata ? null : stateDef.path("Parameters"));
                 if (tokenFuture != null) {
@@ -760,7 +776,7 @@ public class AslExecutor {
         }
     }
 
-    private List<MockedResponseStep> findMockedResponses(JsonNode context, String stateName) {
+    private MockedTaskInvocation findMockedInvocation(JsonNode context, String stateName) {
         if (activeMocks.isEmpty()) {
             return null;
         }
@@ -768,13 +784,19 @@ public class AslExecutor {
         if (executionArn == null) {
             return null;
         }
-        var testCase = activeMocks.get(executionArn);
-        return testCase != null ? testCase.stateResponses().get(stateName) : null;
+        var activeMock = activeMocks.get(executionArn);
+        if (activeMock == null) {
+            return null;
+        }
+        var steps = activeMock.testCase().stateResponses().get(stateName);
+        return steps != null
+                ? new MockedTaskInvocation(steps, activeMock.nextResponseIndex(stateName))
+                : null;
     }
 
-    private JsonNode mockedTaskResult(List<MockedResponseStep> steps, String stateName, int attempt) {
+    private JsonNode mockedTaskResult(List<MockedResponseStep> steps, String stateName, int responseIndex) {
         for (var step : steps) {
-            if (step.covers(attempt)) {
+            if (step.covers(responseIndex)) {
                 if (step.isThrow()) {
                     // The mocked Error and Cause must reach Retry/Catch unchanged; routing them
                     // through integration error translation would rewrite the error name that
@@ -785,7 +807,7 @@ public class AslExecutor {
             }
         }
         throw new FailStateException("States.Runtime",
-                "No mocked response defined for attempt " + attempt + " of state '" + stateName + "'");
+                "No mocked response defined for attempt " + responseIndex + " of state '" + stateName + "'");
     }
 
     /**

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorMockedResponsesTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorMockedResponsesTest.java
@@ -155,6 +155,67 @@ class AslExecutorMockedResponsesTest {
     }
 
     @Test
+    void mockedResponseIndexContinuesAcrossMapIterations() throws Exception {
+        var mocks = testCase(Map.of("Call API", List.of(
+                returnStep(0, 0, "{\"Payload\": \"first\"}"),
+                returnStep(1, 1, "{\"Payload\": \"second\"}"))));
+
+        var execution = run("""
+                {
+                  "StartAt": "Each",
+                  "States": {
+                    "Each": {
+                      "Type": "Map",
+                      "ItemsPath": "$.ids",
+                      "MaxConcurrency": 1,
+                      "ItemProcessor": {
+                        "StartAt": "Call API",
+                        "States": {
+                          "Call API": {
+                            "Type": "Task",
+                            "Resource": "%s",
+                            "OutputPath": "$.Payload",
+                            "End": true
+                          }
+                        }
+                      },
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(UNSUPPORTED_RESOURCE), mocks, "{\"ids\": [1, 2]}");
+
+        assertEquals("SUCCEEDED", execution.getStatus());
+        assertEquals(List.of("first", "second"),
+                objectMapper.readValue(execution.getOutput(), List.class));
+    }
+
+    @Test
+    void mockedResponseIndexRestartsForEachExecution() throws Exception {
+        var mocks = testCase(Map.of("Call API", List.of(
+                returnStep(0, 0, "{\"value\": \"first\"}"),
+                returnStep(1, 1, "{\"value\": \"second\"}"))));
+        var definition = """
+                {
+                  "StartAt": "Call API",
+                  "States": {
+                    "Call API": {
+                      "Type": "Task",
+                      "Resource": "%s",
+                      "End": true
+                    }
+                  }
+                }
+                """.formatted(UNSUPPORTED_RESOURCE);
+
+        var firstExecution = run(definition, mocks, "{}", "first-execution");
+        var secondExecution = run(definition, mocks, "{}", "second-execution");
+
+        assertEquals("first", objectMapper.readTree(firstExecution.getOutput()).path("value").asText());
+        assertEquals("first", objectMapper.readTree(secondExecution.getOutput()).path("value").asText());
+    }
+
+    @Test
     void missingAttemptEntryFailsExecution() throws Exception {
         var mocks = testCase(Map.of("Call API", List.of(
                 throwStep(0, 0, "ApiGateway.429", "Too many requests"))));
@@ -236,6 +297,14 @@ class AslExecutorMockedResponsesTest {
     }
 
     private Execution run(String definition, MockedTestCase mocks) {
+        return run(definition, mocks, "{}");
+    }
+
+    private Execution run(String definition, MockedTestCase mocks, String input) {
+        return run(definition, mocks, input, "mock-test-execution");
+    }
+
+    private Execution run(String definition, MockedTestCase mocks, String input, String executionName) {
         var stateMachine = new StateMachine();
         stateMachine.setName("mock-test");
         stateMachine.setStateMachineArn("arn:aws:states:%s:%s:stateMachine:mock-test".formatted(REGION, ACCOUNT));
@@ -243,11 +312,11 @@ class AslExecutorMockedResponsesTest {
         stateMachine.setDefinition(definition);
 
         var execution = new Execution();
-        execution.setName("mock-test-execution");
+        execution.setName(executionName);
         execution.setExecutionArn(
-                "arn:aws:states:%s:%s:execution:mock-test:mock-test-execution".formatted(REGION, ACCOUNT));
+                "arn:aws:states:%s:%s:execution:mock-test:%s".formatted(REGION, ACCOUNT, executionName));
         execution.setStateMachineArn(stateMachine.getStateMachineArn());
-        execution.setInput("{}");
+        execution.setInput(input);
 
         var history = new ArrayList<HistoryEvent>();
         executor.executeSync(stateMachine, execution, history, mocks, (updated, events) -> {


### PR DESCRIPTION
## Summary

- track mocked response indexes per state for each execution
- advance the index for every mocked Task invocation, including retries and repeated Map or loop entries
- keep index allocation thread-safe for concurrent Map execution

Fixes #3254

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Previously, every fresh entry into a mocked Task reset its response index to 0. Map iterations and loops therefore replayed the first response instead of consuming the next configured response. This change keeps one monotonic counter per state and execution and advances it on every mocked invocation, including retries, matching the Step Functions Local behavior reproduced in #3254.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated regression test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] `mvn -Dtest=AslExecutorMockedResponsesTest test` (7 tests)
- [x] `mvn -Dtest=AslExecutor*Test,SfnMockLoaderTest test` (316 tests)