### PR TITLE
feat(rds): accept AWS IAM DB auth users on MySQL

### DIFF
--- a/docs/services/rds.md
+++ b/docs/services/rds.md
@@ -328,6 +328,21 @@ On PostgreSQL, the token names a database role (`DBUser`) and the session runs a
 
 Underneath, the proxy reaches the container as the master user and hands the session over to the token's role, so an IAM session that talks its way back to the master role, via `RESET SESSION AUTHORIZATION` and its variants, is terminated with `FATAL: permission denied to set session authorization` rather than being allowed to regain superuser. `SET ROLE` is untouched: PostgreSQL still permission-checks it against the token's role, exactly as on RDS. One difference from RDS: the proxy learns of the switch from PostgreSQL's own report, so when several statements are batched into a single query after the switch, their results are returned before the session is closed.
 
+On MySQL, `AWSAuthenticationPlugin` is proprietary to RDS and ships in no public MySQL build, so
+`CREATE USER ... IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'` would fail against the container
+with `ERROR 1524 (HY000): Plugin 'AWSAuthenticationPlugin' is not loaded`. The proxy rewrites that
+clause to `IDENTIFIED WITH mysql_native_password AS '*000...0'`, an authentication string no
+password hashes to. The account is therefore created, can be granted to and can be dropped, but
+holds no password of its own, which is what an IAM DB user is: an account whose credentials come
+from IAM rather than from MySQL. This is the MySQL counterpart of the empty `rds_iam` role Floci
+pre-creates for PostgreSQL.
+
+Two limits follow from that. `SHOW CREATE USER` reports the substituted plugin rather than
+`AWSAuthenticationPlugin`, so a Terraform or Pulumi refresh sees drift on `auth_plugin`. And
+connecting with a token is not yet emulated for MySQL: unlike PostgreSQL, which receives the
+password in cleartext, MySQL sends a scramble, so the proxy would have to drive the
+`mysql_clear_password` auth switch that real RDS triggers before it could see a token to validate.
+
 ## TLS / SSL
 
 The RDS auth proxy terminates TLS itself (the backend container stays plaintext) using a

--- a/src/main/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/proxy/MySqlProtocolHandler.java
@@ -12,6 +12,8 @@ import java.net.Socket;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Handles the MySQL wire protocol auth intercept using a transparent relay.
@@ -60,6 +62,18 @@ public class MySqlProtocolHandler {
 
     // 4-byte capabilities + 4-byte max-packet-size + 1-byte charset + 23 reserved bytes.
     private static final int SSL_REQUEST_PAYLOAD_LENGTH = 32;
+
+    private static final int COM_QUERY = 0x03;
+    private static final int MAX_PACKET_PAYLOAD = 0xFFFFFF;
+
+    private static final Pattern IAM_AUTH_PLUGIN = Pattern.compile(
+            "IDENTIFIED\\s+WITH\\s+`?AWSAuthenticationPlugin`?"
+                    + "(?:\\s+AS\\s+(?:'[^']*'|\"[^\"]*\"|0x[0-9A-Fa-f]+))?",
+            Pattern.CASE_INSENSITIVE);
+    private static final String NO_MATCHING_PASSWORD_HASH =
+            "*0000000000000000000000000000000000000000";
+    private static final String IAM_AUTH_PLUGIN_REPLACEMENT =
+            "IDENTIFIED WITH mysql_native_password AS '" + NO_MATCHING_PASSWORD_HASH + "'";
 
     public static void handleAuth(Socket client, Socket backend,
                                   String masterUsername, String masterPassword,
@@ -586,7 +600,7 @@ public class MySqlProtocolHandler {
         }
 
         Thread t1 = Thread.ofVirtual().name("rds-mysql-c2b")
-                .start(() -> relay(clientIn, backendOut));
+                .start(() -> relayClientCommands(clientIn, backendOut));
         Thread t2 = Thread.ofVirtual().name("rds-mysql-b2c")
                 .start(() -> relay(backendIn, clientOut));
         try {
@@ -598,6 +612,35 @@ public class MySqlProtocolHandler {
             closeQuietly(client);
             closeQuietly(backend);
         }
+    }
+
+    private static void relayClientCommands(InputStream from, OutputStream to) {
+        try {
+            byte[] raw;
+            while ((raw = readMysqlPacketRaw(from)) != null) {
+                int length = (raw[0] & 0xFF) | ((raw[1] & 0xFF) << 8) | ((raw[2] & 0xFF) << 16);
+                byte[] rewritten = length == MAX_PACKET_PAYLOAD || raw.length < 5
+                        || (raw[4] & 0xFF) != COM_QUERY
+                        ? null
+                        : rewriteIamAuthPlugin(Arrays.copyOfRange(raw, 4, raw.length));
+                if (rewritten == null) {
+                    to.write(raw);
+                } else {
+                    writeMysqlPacket(to, raw[3] & 0xFF, rewritten);
+                }
+                to.flush();
+            }
+        } catch (IOException ignored) {}
+    }
+
+    static byte[] rewriteIamAuthPlugin(byte[] payload) {
+        String text = new String(payload, StandardCharsets.ISO_8859_1);
+        Matcher matcher = IAM_AUTH_PLUGIN.matcher(text);
+        if (!matcher.find()) {
+            return null;
+        }
+        return matcher.replaceAll(Matcher.quoteReplacement(IAM_AUTH_PLUGIN_REPLACEMENT))
+                .getBytes(StandardCharsets.ISO_8859_1);
     }
 
     private static void relay(InputStream from, OutputStream to) {

--- a/src/test/java/io/github/hectorvent/floci/services/rds/proxy/MySqlIamAuthPluginRewriteTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/proxy/MySqlIamAuthPluginRewriteTest.java
@@ -1,0 +1,67 @@
+package io.github.hectorvent.floci.services.rds.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class MySqlIamAuthPluginRewriteTest {
+
+    private static final String HASH = "*0000000000000000000000000000000000000000";
+
+    private static String rewrite(String sql) {
+        byte[] rewritten = MySqlProtocolHandler.rewriteIamAuthPlugin(
+                sql.getBytes(StandardCharsets.ISO_8859_1));
+        return rewritten == null ? null : new String(rewritten, StandardCharsets.ISO_8859_1);
+    }
+
+    @Test
+    void rewritesTheClauseTheTerraformProviderEmits() {
+        assertEquals("CREATE USER 'app'@'%' IDENTIFIED WITH mysql_native_password AS '" + HASH + "'",
+                rewrite("CREATE USER 'app'@'%' IDENTIFIED WITH AWSAuthenticationPlugin as 'RDS'"));
+    }
+
+    @Test
+    void rewritesBackquotedUppercasedAndAlterForms() {
+        assertEquals("ALTER USER 'app'@'%' IDENTIFIED WITH mysql_native_password AS '" + HASH + "'",
+                rewrite("ALTER USER 'app'@'%' IDENTIFIED WITH `AWSAuthenticationPlugin` AS 'RDS'"));
+        assertEquals("CREATE USER a IDENTIFIED WITH mysql_native_password AS '" + HASH + "'",
+                rewrite("CREATE USER a identified   with AWSAUTHENTICATIONPLUGIN"));
+        assertEquals("CREATE USER a IDENTIFIED WITH mysql_native_password AS '" + HASH + "'",
+                rewrite("CREATE USER a IDENTIFIED WITH AWSAuthenticationPlugin AS 0xDEADBEEF"));
+    }
+
+    @Test
+    void rewritesEveryOccurrenceInOneStatement() {
+        assertEquals("CREATE USER a IDENTIFIED WITH mysql_native_password AS '" + HASH + "', b IDENTIFIED WITH mysql_native_password AS '" + HASH + "'",
+                rewrite("CREATE USER a IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS',"
+                        + " b IDENTIFIED WITH AWSAuthenticationPlugin AS 'RDS'"));
+    }
+
+    @Test
+    void leavesEveryOtherStatementUntouched() {
+        assertNull(rewrite("SELECT 1"));
+        assertNull(rewrite("CREATE USER 'app'@'%' IDENTIFIED BY 'secret'"));
+        assertNull(rewrite("CREATE USER 'app'@'%' IDENTIFIED WITH caching_sha2_password BY 'x'"));
+    }
+
+    @Test
+    void findsTheClauseBehindQueryAttributeMetadata() {
+        byte[] payload = new byte[]{0x03, 0x00, 0x01};
+        byte[] sql = "CREATE USER a IDENTIFIED WITH AWSAuthenticationPlugin as 'RDS'"
+                .getBytes(StandardCharsets.ISO_8859_1);
+        byte[] packet = new byte[payload.length + sql.length];
+        System.arraycopy(payload, 0, packet, 0, payload.length);
+        System.arraycopy(sql, 0, packet, payload.length, sql.length);
+
+        byte[] rewritten = MySqlProtocolHandler.rewriteIamAuthPlugin(packet);
+
+        assertEquals(0x03, rewritten[0]);
+        assertEquals(0x00, rewritten[1]);
+        assertEquals(0x01, rewritten[2]);
+        assertEquals("CREATE USER a IDENTIFIED WITH mysql_native_password AS '" + HASH + "'",
+                new String(rewritten, 3, rewritten.length - 3, StandardCharsets.ISO_8859_1));
+    }
+}


### PR DESCRIPTION
## Summary

Makes `CREATE USER ... IDENTIFIED WITH AWSAuthenticationPlugin` work on MySQL, so Terraform's `mysql_user` and Pulumi's `mysql.User` can declare AWS IAM DB auth users against floci instead of failing with `ERROR 1524 (HY000): Plugin 'AWSAuthenticationPlugin' is not loaded`.

Closes #3394

`AWSAuthenticationPlugin` is proprietary to RDS and ships in no public MySQL build, so the plugin itself can never be present. The proxy rewrites the clause on its way to the container:

```sql
CREATE USER 'app'@'%' IDENTIFIED WITH AWSAuthenticationPlugin as 'RDS'
-- becomes
CREATE USER 'app'@'%' IDENTIFIED WITH mysql_native_password AS '*0000000000000000000000000000000000000000'
```

That is a format-valid `mysql_native_password` authentication string that no password hashes to. The account is created, can be granted to and dropped, and holds no password of its own, which is what an IAM DB user is. It is the MySQL counterpart of the empty `rds_iam` role `RdsContainerManager` already pre-creates for PostgreSQL.

Details worth calling out:

1. **Nothing else changes on the container.** `mysql_no_login` would state the intent better, but it is not loaded in `mysql:8.0` and `INSTALL PLUGIN` would mean an init script on every MySQL start. The unmatchable hash needs no plugin, no init script and no startup change.
2. **The match is byte-level, anywhere in the packet.** A client that negotiated `CLIENT_QUERY_ATTRIBUTES` puts parameter metadata between the `COM_QUERY` byte and the statement, so a fixed offset would miss it. The payload is decoded as ISO-8859-1 so the round trip preserves bytes whatever encoding the client used.
3. **Only `COM_QUERY` is touched**, and packets at the `0xFFFFFF` continuation length are passed through untouched.
4. **The clause is matched as the providers emit it**: optional backticks, case-insensitive, and the optional `AS '...'` or `AS 0x...` suffix, on `ALTER USER` as well as `CREATE USER`.

### Known limits, stated rather than papered over

- `SHOW CREATE USER` reports the substituted plugin, so a Terraform or Pulumi refresh sees drift on `auth_plugin`. Same class of fidelity gap as the empty `rds_iam` role.
- Connecting with a token is still unimplemented for MySQL. `MySqlProtocolHandler` already takes `iamEnabled` and `sigV4` and references neither. It is not a copy of the Postgres branch: PostgreSQL gets the password in cleartext, MySQL sends a scramble, so the proxy would have to drive the `mysql_clear_password` auth switch real RDS triggers before there is a token to validate. Noted as a follow-up in #3394, happy to take it separately.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

The rewritten statement was verified directly against `mysql:8.0` before any code was written: `CREATE USER` succeeds, `GRANT SELECT ON *.* ` succeeds, `mysql.user` shows a 41-character authentication string, and a login attempt is refused with `ERROR 1045 (28000): Access denied`.

Verified end to end with Pulumi against a JVM image built from this branch. The suite creates a real MySQL RDS instance through floci and an IAM applicative user through the proxy, then destroys all 12 resources:

```
PASS tests/aurax/mysql-rds.int.test.ts (157.581 s)
  ✓ provisions a mysql RDS instance + IAM applicative user in floci (150598 ms)
```

The same spec cannot get past user creation on `floci/floci:2.0.0-compat`, which is why it was skipped in my suite until now.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

50 RDS tests green (`MySqlIamAuthPluginRewriteTest` 5 new, `MySqlProtocolHandlerTest` 4, `RdsContainerManagerTest` 41 unchanged; I checked that 41 against clean `main` first). `docs/services/rds.md` gains an emulation note covering both the rewrite and the two limits above; no new AWS actions, and the three `tools/docs` generators run clean.

One thing you may want to know separately: `docker/Dockerfile` does not currently build on `main`. Its `mvn clean package -DskipTests` still compiles tests, and `VerifiedPermissionsIntegrationTest` cannot resolve `io.github.hectorvent.floci.cedar` in that build. I built my image with `-Dmaven.test.skip=true` to work around it and have not touched the Dockerfile here.
