### PR TITLE
fix(test): relax S3 concurrent write stress timeout

### DIFF
--- a/src/test/java/io/github/hectorvent/floci/services/s3/S3ConcurrentWriteReadTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/s3/S3ConcurrentWriteReadTest.java
@@ -79,7 +79,7 @@ class S3ConcurrentWriteReadTest {
         }
         for (Thread t : threads) t.start();
         for (Thread t : threads) {
-            t.join(30_000);
+            t.join(120_000);
             assertFalse(t.isAlive(), "thread did not finish within the join timeout");
         }
 


### PR DESCRIPTION
## Summary

Stabilizes `S3ConcurrentWriteReadTest.concurrentOverwriteNeverYieldsTornRead` on slower CI runners by allowing its writer/reader stress threads up to 120 seconds to finish instead of 30 seconds.

The test deliberately performs about 1.6 GiB of same-key overwrite traffic to exercise torn-read protection. A recent PR CI run hit the 30-second thread join limit even though the exact upstream `main` SHA passed its own full CI. This change keeps the workload and every atomicity assertion unchanged; it only removes the machine-speed-sensitive deadline.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No AWS protocol or runtime behavior changes. The existing regression still verifies that concurrent same-key overwrites never expose null, partial, or torn object data. Only the test execution deadline changes.

Validated with three consecutive runs of:

`./mvnw -q -Dtest=S3ConcurrentWriteReadTest test`

and `git diff --check`.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
