### PR TITLE
fix(sfn): support advanced JSONPath expressions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,12 @@
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
+        <!-- Filter expressions and recursive descent for Step Functions JSONPath evaluation. -->
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.9.0</version>
+        </dependency>
 
         <!-- Vert.x for per-container Lambda Runtime API servers -->
         <dependency>

--- a/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
+++ b/src/main/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutor.java
@@ -46,6 +46,12 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.InvalidPathException;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.impl.NoStackTraceTimeoutException;
@@ -213,6 +219,7 @@ public class AslExecutor {
     private final SchedulerService schedulerService;
     private final SchedulerController schedulerController;
     private final ObjectMapper objectMapper;
+    private final Configuration jsonPathConfiguration;
     private final JsonataEvaluator jsonataEvaluator;
     private final Instance<StepFunctionsService> sfnService;
     private final WebClient webClient;
@@ -253,6 +260,12 @@ public class AslExecutor {
         this.schedulerService = schedulerService;
         this.schedulerController = schedulerController;
         this.objectMapper = objectMapper;
+        this.jsonPathConfiguration = objectMapper == null
+                ? null
+                : Configuration.builder()
+                        .jsonProvider(new JacksonJsonNodeJsonProvider(objectMapper))
+                        .mappingProvider(new JacksonMappingProvider(objectMapper))
+                        .build();
         this.jsonataEvaluator = jsonataEvaluator;
         this.sfnService = sfnService;
         this.config = config;
@@ -3139,6 +3152,9 @@ public class AslExecutor {
         if (!path.startsWith("$.") && !path.startsWith("$[")) {
             return MissingNode.getInstance();
         }
+        if (isAdvancedJsonPath(path)) {
+            return resolveAdvancedJsonPath(path, root);
+        }
         return walkPath(splitPathSegments(path), 0, root);
     }
 
@@ -3172,6 +3188,13 @@ public class AslExecutor {
         if (!path.startsWith("$.") && !path.startsWith("$[")) {
             return NullNode.getInstance();
         }
+        if (isAdvancedJsonPath(path)) {
+            JsonNode value = resolveAdvancedJsonPath(path, searchRoot);
+            if (!value.isMissingNode()) {
+                return value;
+            }
+            throw unresolvedPayloadTemplateReference(path, fieldKey, reportedInput);
+        }
         String[] parts = splitPathSegments(path);
         if (containsWildcard(parts)) {
             JsonNode value = walkPath(parts, 0, searchRoot);
@@ -3184,7 +3207,50 @@ public class AslExecutor {
         if (lookup.outOfRangeArrayIndex) {
             return NullNode.getInstance();
         }
-        throw new FailStateException("States.Runtime",
+        throw unresolvedPayloadTemplateReference(path, fieldKey, reportedInput);
+    }
+
+    private static boolean isAdvancedJsonPath(String path) {
+        char quote = 0;
+        boolean escaped = false;
+        for (int i = 0; i < path.length(); i++) {
+            char current = path.charAt(i);
+            if (quote != 0) {
+                if (escaped) {
+                    escaped = false;
+                } else if (current == '\\') {
+                    escaped = true;
+                } else if (current == quote) {
+                    quote = 0;
+                }
+                continue;
+            }
+            if (current == '\'' || current == '"') {
+                quote = current;
+            } else if (current == '.' && i + 1 < path.length() && path.charAt(i + 1) == '.') {
+                return true;
+            } else if (current == '[' && i + 2 < path.length()
+                    && path.charAt(i + 1) == '?' && path.charAt(i + 2) == '(') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private JsonNode resolveAdvancedJsonPath(String path, JsonNode root) {
+        try {
+            Object result = JsonPath.using(jsonPathConfiguration).parse(root).read(path);
+            return result instanceof JsonNode jsonNode ? jsonNode : objectMapper.valueToTree(result);
+        } catch (PathNotFoundException e) {
+            return MissingNode.getInstance();
+        } catch (InvalidPathException e) {
+            throw new FailStateException("States.Runtime", "Invalid JSONPath '" + path + "': " + e.getMessage());
+        }
+    }
+
+    private static FailStateException unresolvedPayloadTemplateReference(String path, String fieldKey,
+                                                                           JsonNode reportedInput) {
+        return new FailStateException("States.Runtime",
                 "The JSONPath '" + path + "' specified for the field '" + fieldKey
                         + "' could not be found in the input '" + reportedInput + "'");
     }

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorPathIntrinsicsTest.java
@@ -101,10 +101,49 @@ class AslExecutorPathIntrinsicsTest {
 
     @Test
     void bracketQuotedMembersSupportNamesOutsideDotShorthand() throws Exception {
-        JsonNode root = mapper.readTree("{\"config\":{\"max-limit\":2},\"a.b\":3}");
+        JsonNode root = mapper.readTree(
+                "{\"config\":{\"max-limit\":2},\"a.b\":3,\"a..b\":4,\"[?(\":5}");
 
         assertEquals(2, executor.resolvePath("$['config']['max-limit']", root).asInt());
         assertEquals(3, executor.resolvePath("$['a.b']", root).asInt());
+        assertEquals(4, executor.resolvePath("$['a..b']", root).asInt());
+        assertEquals(5, executor.resolvePath("$['[?(']", root).asInt());
+    }
+
+    @Test
+    void filterExpressionsSupportExistenceAndComparisonPredicates() throws Exception {
+        JsonNode root = mapper.readTree("""
+                {"list":[{"keep":true,"id":1},{"keep":false,"id":2},{"id":3}]}
+                """);
+
+        assertEquals(mapper.readTree("[{\"keep\":true,\"id\":1},{\"keep\":false,\"id\":2}]"),
+                executor.resolvePath("$.list[?(@.keep)]", root));
+        assertEquals(mapper.readTree("[{\"keep\":true,\"id\":1}]"),
+                executor.resolvePath("$.list[?(@.keep == true)]", root));
+    }
+
+    @Test
+    void recursiveDescentPreservesAndFlattensNestedArrayMatches() throws Exception {
+        JsonNode root = mapper.readTree("{\"d\":{\"x\":{\"a\":[1,2]}}}");
+
+        assertEquals(mapper.readTree("[[1,2]]"), executor.resolvePath("$.d..a", root));
+        assertEquals(mapper.readTree("[1,2]"), executor.resolvePath("$.d..a[*]", root));
+    }
+
+    @Test
+    void advancedPathsWorkInPayloadTemplatesAndIntrinsics() throws Exception {
+        JsonNode root = mapper.readTree("{\"list\":[1,null,2]}");
+        JsonNode parameters = mapper.readTree("""
+                {
+                  "filtered.$": "$.list[?(@ != null)]",
+                  "count.$": "States.ArrayLength($.list[?(@ != null)])"
+                }
+                """);
+
+        JsonNode resolved = executor.resolveParameters(parameters, root, mapper.createObjectNode());
+
+        assertEquals(mapper.readTree("[1,2]"), resolved.path("filtered"));
+        assertEquals(2, resolved.path("count").asInt());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/stepfunctions/AslExecutorStatePathTest.java
@@ -123,6 +123,16 @@ class AslExecutorStatePathTest {
     }
 
     @Test
+    void passOutputPathSupportsFilterExpressions() throws Exception {
+        assertOutput("""
+                {"StartAt":"Pass","States":{
+                  "Pass":{"Type":"Pass","OutputPath":"$.Payload[?(@.title)]","End":true}}}
+                """,
+                "{\"Payload\":[{\"title\":\"first\"},{\"title\":false},{\"other\":1}]}",
+                "[{\"title\":\"first\"},{\"title\":false}]");
+    }
+
+    @Test
     void succeedAppliesInputPathBeforeOutputPath() throws Exception {
         assertOutput("""
                 {"StartAt":"Done","States":{


### PR DESCRIPTION
## Summary

- add advanced JSONPath evaluation for filter expressions and recursive descent
- reuse Floci's Jackson mapper while preserving the existing resolver for simple paths
- cover payload templates, intrinsic arguments, state output paths, and quoted member-name regressions

Fixes #3260

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Floci previously rejected filter expressions with `States.Runtime` and silently returned `null` for recursive descent paths containing a wildcard. Advanced paths now match the Step Functions Local results documented in #3260, including existence predicates retaining `false` values, comparison predicates, recursive descent, and null filtering inside intrinsic arguments.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

### Verification

- `mvn -Dtest=AslExecutorPathIntrinsicsTest,AslExecutorStatePathTest test` (30 tests)
- `mvn -Dtest=AslExecutor*Test,SfnMockLoaderTest test` (321 tests)
- `git diff --check`