### PR TITLE
fix(apigateway): fall back to a parameterised sibling on method mismatch

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayExecuteController.java
@@ -335,20 +335,35 @@ public class ApiGatewayExecuteController {
 
         ApiGatewayResource matched = null;
         MethodConfig method = null;
+        boolean concreteWithMethodsSeen = false;
         for (ApiGatewayResource r : matchedResources) {
-            if (r.getResourceMethods() != null && !r.getResourceMethods().isEmpty()) {
-                MethodConfig m = r.getResourceMethods().get(httpMethod.toUpperCase());
-                if (m == null) {
-                    m = r.getResourceMethods().get("ANY");
-                }
-                if (m != null) {
-                    matched = r;
-                    method = m;
-                }
-                // Once we match a path that has methods configured, we must not fall back
-                // to less specific sibling resources (e.g. /{proxy+}), even on method mismatch.
+            Map<String, MethodConfig> resourceMethods = r.getResourceMethods();
+            if (resourceMethods == null || resourceMethods.isEmpty()) {
+                continue;
+            }
+
+            boolean greedy = r.getPath() != null && r.getPath().contains("{proxy+}");
+            // A concrete resource that declares methods but not this one is a method
+            // mismatch, not an invitation for a greedy catch-all to absorb the request.
+            if (greedy && concreteWithMethodsSeen) {
                 break;
             }
+
+            MethodConfig m = resourceMethods.get(httpMethod.toUpperCase());
+            if (m == null) {
+                m = resourceMethods.get("ANY");
+            }
+            if (m != null) {
+                matched = r;
+                method = m;
+                break;
+            }
+
+            // Candidates are ordered exact, then parameterised, then greedy. A literal
+            // segment that cannot serve the method yields to a parameterised sibling that
+            // can: /users/me declaring only PATCH must not hide GET /users/{userId}, since
+            // "me" is an ordinary parameter value there.
+            concreteWithMethodsSeen = true;
         }
 
         if (matched == null) {

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayRoutingFallthroughIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayRoutingFallthroughIntegrationTest.java
@@ -128,6 +128,70 @@ class ApiGatewayRoutingFallthroughIntegrationTest {
                 .when().put("/restapis/" + apiId + "/resources/" + devicesResourceId + "/methods/POST/integration/responses/200")
                 .then()
                 .statusCode(201);
+
+        // Create /users, then a parameterised /users/{userId} with GET and a literal
+        // /users/me carrying only PATCH. A request for GET /users/me matches the literal
+        // first, which cannot serve it; AWS resolves it against the {userId} sibling.
+        String usersResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"users\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + rootId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        String userIdResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"{userId}\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + usersResourceId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        createMockMethod(userIdResourceId, "GET", "users-get");
+
+        String usersMeResourceId = given()
+                .contentType(ContentType.JSON)
+                .body("{\"pathPart\":\"me\"}")
+                .when().post("/restapis/" + apiId + "/resources/" + usersResourceId)
+                .then()
+                .statusCode(201)
+                .extract().path("id");
+
+        createMockMethod(usersMeResourceId, "PATCH", "users-me-patch");
+    }
+
+    /** Wires {@code httpMethod} on {@code resourceId} to a MOCK integration echoing {@code marker}. */
+    private static void createMockMethod(String resourceId, String httpMethod, String marker) {
+        String base = "/restapis/" + apiId + "/resources/" + resourceId + "/methods/" + httpMethod;
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"authorizationType\":\"NONE\"}")
+                .when().put(base)
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"responseParameters\":{}}")
+                .when().put(base + "/responses/200")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"type\":\"MOCK\",\"requestTemplates\":{\"application/json\":\"{\\\"statusCode\\\": 200}\"}}")
+                .when().put(base + "/integration")
+                .then()
+                .statusCode(201);
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("{\"selectionPattern\":\"\",\"responseTemplates\":{\"application/json\":\"{\\\"matched\\\":\\\"" + marker + "\\\"}\"}}")
+                .when().put(base + "/integration/responses/200")
+                .then()
+                .statusCode(201);
     }
 
     @Test @Order(3)
@@ -207,6 +271,37 @@ class ApiGatewayRoutingFallthroughIntegrationTest {
     }
 
     @Test @Order(9)
+    void getUsersMeFallsBackToTheParameterisedSibling() {
+        // /users/me exists but declares only PATCH. GET must resolve against
+        // /users/{userId} rather than 405 - "me" is an ordinary parameter value.
+        given()
+                .when().get("/execute-api/" + apiId + "/test/users/me")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("users-get"));
+    }
+
+    @Test @Order(10)
+    void patchUsersMeStillPrefersTheLiteralResource() {
+        // The literal keeps priority for the method it does declare.
+        given()
+                .contentType(ContentType.JSON)
+                .when().patch("/execute-api/" + apiId + "/test/users/me")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("users-me-patch"));
+    }
+
+    @Test @Order(11)
+    void getUsersOtherIdUsesTheParameterisedResource() {
+        given()
+                .when().get("/execute-api/" + apiId + "/test/users/abc123")
+                .then()
+                .statusCode(200)
+                .body("matched", equalTo("users-get"));
+    }
+
+    @Test @Order(12)
     void cleanup() {
         given().when().delete("/restapis/" + apiId).then().statusCode(202);
     }


### PR DESCRIPTION
## Summary

A literal resource that declares some methods but not the requested one returns `405`, even when a parameterised sibling could serve it.

`matchResources` returns candidates ordered exact → parameterised → greedy, but the selection loop stopped at the first candidate with any methods configured:

```java
for (ApiGatewayResource r : matchedResources) {
    if (r.getResourceMethods() != null && !r.getResourceMethods().isEmpty()) {
        MethodConfig m = r.getResourceMethods().get(httpMethod.toUpperCase());
        if (m == null) m = r.getResourceMethods().get("ANY");
        if (m != null) { matched = r; method = m; }
        // Once we match a path that has methods configured, we must not fall back
        // to less specific sibling resources (e.g. /{proxy+}), even on method mismatch.
        break;
    }
}
```

Given `/users/{userId}` with `GET` and a literal `/users/me` with only `PATCH`, `GET /users/me` selects the literal, finds no `GET`, and breaks — never reaching `/users/{userId}`, where `me` is an ordinary parameter value.

The stop exists for a narrower reason that this repo's tests already pin: a method mismatch on a concrete resource must not be absorbed by a greedy `/{proxy+}` catch-all. **That rule is kept.** Only the concrete-to-concrete case changes: a literal now yields to a parameterised sibling that can serve the method, tracked with a `concreteWithMethodsSeen` flag so a greedy candidate is still refused once any concrete resource with methods has been passed.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** with `/users/{userId}` (GET) and `/users/me` (PATCH only) both deployed,

| Request | floci before | AWS |
|---|---|---|
| `GET /users/me` | `405 Method Not Allowed` | resolves to `/users/{userId}`, `userId=me` |
| `PATCH /users/me` | literal resource | literal resource |
| `GET /users/abc123` | `/users/{userId}` | `/users/{userId}` |

Only the first row differs.

This was found porting an application from LocalStack to floci. `/users/me` had long been served by `/users/{userId}`; a later feature added a literal `/users/me` for a self-service `PATCH`, which on floci silently removed `GET` from that path while it kept working on deployed AWS. Adding a literal child for one method should not remove every other method a parameterised sibling already served.

I do not have an AWS account to hand to capture a wire trace, so the AWS column reflects the reported behaviour of a deployed API with exactly this resource layout rather than a capture I can attach. If a maintainer would like this pinned in `compatibility-tests/` before merging, I am happy to add a case there — it seems the right home for it.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

`ApiGatewayRoutingFallthroughIntegrationTest` already covers the greedy cases, so the new cases live alongside them. It gains `/users/{userId}` with `GET` and a literal `/users/me` with `PATCH`, plus a small `createMockMethod` helper to avoid repeating the four-call MOCK wiring:

| Case | Asserts |
|---|---|
| `GET /users/me` | resolves to `/users/{userId}` (fails on `main` with 405) |
| `PATCH /users/me` | still prefers the literal resource |
| `GET /users/abc123` | ordinary id unaffected |

The pre-existing assertions are unchanged and still pass — in particular `getDevicesReturns405`, which is the case the `break` was protecting, and the three `/{proxy+}` fallthrough cases.

Ran 204 tests across the routing and execute-path suites: `ApiGatewayRoutingFallthroughIntegrationTest`, `ApiGatewayProxyMatchTest`, `ApiGatewayExecuteControllerTest`, `ApiGatewayUserRequestIntegrationTest`, `ApiGatewayAnyMethodIntegrationTest`, `ApiGatewayPreflightRoutingIntegrationTest`, `ApiGatewaySqsPathIntegrationTest`, `ApiGatewayAwsExecuteIntegrationTest`, `ApiGatewayAwsLambdaIntegrationTest`, `ApiGatewayCustomDomainIntegrationTest`, `ApiGatewayRequestAuthorizerIntegrationTest`, `ApiGatewayAuthorizerContextIntegrationTest`, `ApiGatewayIntegrationTest`, `ApiGatewayMockCorsHeadersTest`. All passing.

End to end against the application that surfaced this, on an image built from this branch: `GET /users/me` returns `200` with the user document instead of `405`.

---

Independent of #3397 — different code path, branched from `main`, no overlap in the diff. Either can merge first.
