### PR TITLE
fix(mwaa): isolate environments by account and region

### DIFF
--- a/docs/services/mwaa.md
+++ b/docs/services/mwaa.md
@@ -30,8 +30,11 @@ Environment metadata is stored in-process. No Docker containers are started. The
 
 Floci starts two containers per environment:
 
-- `floci-mwaa-<name>-db` — a private `postgres` metadata database, never given a published host port; it's only ever reached by the sibling Airflow container over the Docker network.
-- `floci-mwaa-<name>-airflow` — a real `apache/airflow` container running **LocalExecutor** (webserver + scheduler in one process tree). `AirflowVersion` genuinely selects the image tag (`apache/airflow:<version>-python3.12`), validated against `supported-versions` — unlike some Floci services where a requested version is echoed back but not actually applied, MWAA always runs the exact Airflow version requested.
+- `floci-mwaa-<account>.<region>.<name>-db` — a private `postgres` metadata database, never given a published host port; it's only ever reached by the sibling Airflow container over the Docker network.
+- `floci-mwaa-<account>.<region>.<name>-airflow` — a real `apache/airflow` container running **LocalExecutor** (webserver + scheduler in one process tree). `AirflowVersion` genuinely selects the image tag (`apache/airflow:<version>-python3.12`), validated against `supported-versions` — unlike some Floci services where a requested version is echoed back but not actually applied, MWAA always runs the exact Airflow version requested.
+
+Legacy environments retain the region recorded in their ARN. A request in another region does not
+adopt that environment; recreate it in the requested region instead.
 
 Once Airflow's unauthenticated `/health` endpoint reports both `metadatabase` and `scheduler` as `"healthy"`, the environment transitions to `AVAILABLE`.
 

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
@@ -1,7 +1,7 @@
 package io.github.hectorvent.floci.services.mwaa;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
-import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
@@ -66,21 +66,18 @@ public class MwaaEnvironmentManager {
     private final ContainerDetector containerDetector;
     private final EmulatorConfig config;
     private final LaunchedContainerAwsEnv awsEnv;
-    private final RegionResolver regionResolver;
 
     @Inject
     public MwaaEnvironmentManager(ContainerBuilder containerBuilder,
                                   ContainerLifecycleManager lifecycleManager,
                                   ContainerDetector containerDetector,
                                   EmulatorConfig config,
-                                  LaunchedContainerAwsEnv awsEnv,
-                                  RegionResolver regionResolver) {
+                                  LaunchedContainerAwsEnv awsEnv) {
         this.containerBuilder = containerBuilder;
         this.lifecycleManager = lifecycleManager;
         this.containerDetector = containerDetector;
         this.config = config;
         this.awsEnv = awsEnv;
-        this.regionResolver = regionResolver;
     }
 
     /**
@@ -98,7 +95,7 @@ public class MwaaEnvironmentManager {
         String dbPassword = generateSecret(24);
         environment.setDbPassword(dbPassword);
 
-        String dbContainerName = dbContainerName(config, name);
+        String dbContainerName = dbContainerName(config, environment);
         String dbVolume = dbContainerName;
         lifecycleManager.removeIfExists(dbContainerName);
         lifecycleManager.ensureVolume(dbVolume);
@@ -114,7 +111,7 @@ public class MwaaEnvironmentManager {
                 .withExposedPort(POSTGRES_PORT)
                 .withLogRotation()
                 .withLabels(ContainerStorageHelper.resourceIdentityLabels(
-                        "mwaa", name, regionResolver.getAccountId(), regionResolver.getDefaultRegion()))
+                        "mwaa", name, environmentAccount(environment), environmentRegion(environment)))
                 .build();
 
         String dbContainerId = lifecycleManager.create(dbSpec);
@@ -135,7 +132,7 @@ public class MwaaEnvironmentManager {
     void startAirflowContainer(Environment environment, String airflowVersion, String dbIp, String dbPassword,
                                byte[] startupScriptContent) {
         String name = environment.getName();
-        String airflowContainerName = airflowContainerName(config, name);
+        String airflowContainerName = airflowContainerName(config, environment);
         String dagsVolume = airflowContainerName + "-dags";
         String logsVolume = airflowContainerName + "-logs";
 
@@ -151,7 +148,7 @@ public class MwaaEnvironmentManager {
         // Points DAG code's own AWS SDK calls (boto3, botocore) at Floci itself, the same way
         // Lambda/ECS containers already do via LaunchedContainerAwsEnv — otherwise a real DAG's
         // boto3.client("s3") etc. would target real AWS instead of this emulator.
-        List<String> env = new ArrayList<>(awsEnv.sdkBaselineEnv(config.defaultRegion(), Optional.empty()));
+        List<String> env = new ArrayList<>(awsEnv.sdkBaselineEnv(environmentRegion(environment), Optional.empty()));
         env.addAll(List.of(
                 "AIRFLOW__CORE__EXECUTOR=LocalExecutor",
                 "AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=" + sqlAlchemyConn,
@@ -177,7 +174,7 @@ public class MwaaEnvironmentManager {
                 .withDockerNetwork(config.services().mwaa().dockerNetwork())
                 .withLogRotation()
                 .withLabels(ContainerStorageHelper.resourceIdentityLabels(
-                        "mwaa", name, regionResolver.getAccountId(), regionResolver.getDefaultRegion()));
+                        "mwaa", name, environmentAccount(environment), environmentRegion(environment)));
 
         if (!containerDetector.isRunningInContainer()) {
             specBuilder.withDynamicPort(AIRFLOW_WEBSERVER_PORT);
@@ -293,8 +290,8 @@ public class MwaaEnvironmentManager {
         if (environment.getDbContainerId() != null) {
             lifecycleManager.stopAndRemove(environment.getDbContainerId(), null);
         }
-        String airflowContainerName = airflowContainerName(config, name);
-        lifecycleManager.removeVolume(dbContainerName(config, name));
+        String airflowContainerName = airflowContainerName(config, environment);
+        lifecycleManager.removeVolume(dbContainerName(config, environment));
         lifecycleManager.removeVolume(airflowContainerName + "-dags");
         lifecycleManager.removeVolume(airflowContainerName + "-logs");
         LOG.infov("Stopped MWAA containers for environment {0}", name);
@@ -351,6 +348,29 @@ public class MwaaEnvironmentManager {
 
     static String airflowContainerName(EmulatorConfig config, String environmentName) {
         return ContainerStorageHelper.dockerName(config, "floci-mwaa-" + environmentName + "-airflow");
+    }
+
+    static String dbContainerName(EmulatorConfig config, Environment environment) {
+        return ContainerStorageHelper.dockerName(config, "floci-mwaa-" + environmentIdentity(environment) + "-db");
+    }
+
+    static String airflowContainerName(EmulatorConfig config, Environment environment) {
+        return ContainerStorageHelper.dockerName(config,
+                "floci-mwaa-" + environmentIdentity(environment) + "-airflow");
+    }
+
+    private static String environmentIdentity(Environment environment) {
+        return environmentAccount(environment) + "-" + environmentRegion(environment) + "-" + environment.getName();
+    }
+
+    private static String environmentAccount(Environment environment) {
+        return environment.getAccountId() != null
+                ? environment.getAccountId()
+                : AwsArnUtils.accountOrDefault(environment.getArn(), "000000000000");
+    }
+
+    private static String environmentRegion(Environment environment) {
+        return AwsArnUtils.regionOrDefault(environment.getArn(), "us-east-1");
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
@@ -342,14 +342,6 @@ public class MwaaEnvironmentManager {
      *  daemon (via {@code FLOCI_DOCKER_RESOURCE_NAMESPACE}) don't collide, same as every other
      *  Docker-backed service (EKS, RDS, ...). {@code config} may be {@code null} — the helper treats
      *  that as "no namespace configured" and returns the base name unchanged. */
-    static String dbContainerName(EmulatorConfig config, String environmentName) {
-        return ContainerStorageHelper.dockerName(config, "floci-mwaa-" + environmentName + "-db");
-    }
-
-    static String airflowContainerName(EmulatorConfig config, String environmentName) {
-        return ContainerStorageHelper.dockerName(config, "floci-mwaa-" + environmentName + "-airflow");
-    }
-
     static String dbContainerName(EmulatorConfig config, Environment environment) {
         return ContainerStorageHelper.dockerName(config, "floci-mwaa-" + environmentIdentity(environment) + "-db");
     }
@@ -360,16 +352,16 @@ public class MwaaEnvironmentManager {
     }
 
     private static String environmentIdentity(Environment environment) {
-        return environmentAccount(environment) + "-" + environmentRegion(environment) + "-" + environment.getName();
+        return environmentAccount(environment) + "." + environmentRegion(environment) + "." + environment.getName();
     }
 
-    private static String environmentAccount(Environment environment) {
+    static String environmentAccount(Environment environment) {
         return environment.getAccountId() != null
                 ? environment.getAccountId()
                 : AwsArnUtils.accountOrDefault(environment.getArn(), "000000000000");
     }
 
-    private static String environmentRegion(Environment environment) {
+    static String environmentRegion(Environment environment) {
         return AwsArnUtils.regionOrDefault(environment.getArn(), "us-east-1");
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
@@ -214,6 +214,9 @@ public class MwaaService implements TagHandler {
     public List<String> listEnvironments() {
         String accountId = regionResolver.getAccountId();
         String region = regionResolver.getRegion();
+        if (storage instanceof AccountAwareStorageBackend<Environment> aware) {
+            migrateLegacyEnvironments(aware, accountId, region);
+        }
         List<Environment> environments = storage instanceof AccountAwareStorageBackend<Environment> aware
                 ? aware.scanForAccount(accountId, k -> true)
                 : storage.scan(k -> true);
@@ -412,6 +415,11 @@ public class MwaaService implements TagHandler {
                     || !"airflow".equals(arn.service())) {
                 throw new IllegalArgumentException("not an MWAA environment ARN");
             }
+            if (!arn.accountId().equals(regionResolver.getAccountId())
+                    || !arn.region().equals(regionResolver.getRegion())) {
+                throw new AwsException("ResourceNotFoundException",
+                        "No environment found for name: " + name, 404);
+            }
             return getStoredEnvironment(arn.accountId(), arn.region(), name)
                     .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                             "No environment found for name: " + name, 404));
@@ -555,10 +563,14 @@ public class MwaaService implements TagHandler {
         return storage.scan(k -> true);
     }
 
-    private void putEnvironment(Environment environment) {
+    void putEnvironment(Environment environment) {
         String key = environmentKey(environmentRegion(environment), environment.getName());
         String accountId = environmentAccount(environment);
         if (accountId != null && storage instanceof AccountAwareStorageBackend<Environment> aware) {
+            aware.getForAccountMigratingLegacyKeys(accountId, key, List.of(environment.getName()),
+                    candidate -> accountId.equals(environmentAccount(candidate))
+                            && environmentRegion(environment).equals(environmentRegion(candidate)),
+                    isDefaultScope(accountId, environmentRegion(environment)));
             aware.putForAccount(accountId, key, environment);
         } else {
             storage.put(key, environment);
@@ -580,9 +592,42 @@ public class MwaaService implements TagHandler {
         if (storage instanceof AccountAwareStorageBackend<Environment> aware) {
             return aware.getForAccountMigratingLegacyKeys(accountId, key, List.of(name),
                     environment -> accountId.equals(environmentAccount(environment))
-                            && region.equals(environmentRegion(environment)));
+                            && region.equals(environmentRegion(environment)),
+                    isDefaultScope(accountId, region));
         }
         return storage.get(key);
+    }
+
+    private void migrateLegacyEnvironments(AccountAwareStorageBackend<Environment> aware,
+                                           String accountId, String region) {
+        for (Environment legacy : aware.scanUnscopedLegacy(environment ->
+                accountId.equals(environmentAccount(environment))
+                        && region.equals(environmentRegion(environment)))) {
+            migrateLegacyEnvironment(aware, accountId, region, legacy);
+        }
+        for (String legacyKey : aware.keysForAccount(accountId)) {
+            if (legacyKey.contains("/")) {
+                continue;
+            }
+            aware.getForAccount(accountId, legacyKey)
+                    .filter(environment -> accountId.equals(environmentAccount(environment))
+                            && region.equals(environmentRegion(environment)))
+                    .ifPresent(environment -> migrateLegacyEnvironment(aware, accountId, region, environment));
+        }
+    }
+
+    private void migrateLegacyEnvironment(AccountAwareStorageBackend<Environment> aware,
+                                          String accountId, String region, Environment environment) {
+        String key = environmentKey(region, environment.getName());
+        aware.getForAccountMigratingLegacyKeys(accountId, key, List.of(environment.getName()),
+                candidate -> accountId.equals(environmentAccount(candidate))
+                        && region.equals(environmentRegion(candidate)),
+                isDefaultScope(accountId, region)).ifPresent(value -> aware.putForAccount(accountId, key, value));
+    }
+
+    private boolean isDefaultScope(String accountId, String region) {
+        return accountId.equals(regionResolver.getDefaultAccountId())
+                && region.equals(regionResolver.getDefaultRegion());
     }
 
     private static String environmentKey(String region, String name) {
@@ -594,22 +639,11 @@ public class MwaaService implements TagHandler {
     }
 
     private static String environmentAccount(Environment environment) {
-        if (environment.getAccountId() != null) {
-            return environment.getAccountId();
-        }
-        try {
-            return AwsArnUtils.parse(environment.getArn()).accountId();
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+        return MwaaEnvironmentManager.environmentAccount(environment);
     }
 
     private static String environmentRegion(Environment environment) {
-        try {
-            return AwsArnUtils.parse(environment.getArn()).region();
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+        return MwaaEnvironmentManager.environmentRegion(environment);
     }
 
 }

--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaService.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -91,7 +92,7 @@ public class MwaaService implements TagHandler {
         dagSyncPoller.shutdownNow();
         if (!config.services().mwaa().mock() && !config.services().mwaa().keepRunningOnShutdown()) {
             for (Environment environment : allEnvironments()) {
-                proxyManager.stopProxy(environment.getName());
+                proxyManager.stopProxy(environmentIdentity(environment));
                 environmentManager.stopEnvironment(environment);
             }
         }
@@ -101,7 +102,9 @@ public class MwaaService implements TagHandler {
         if (name == null || name.isBlank()) {
             throw new AwsException("ValidationException", "Environment name is required", 400);
         }
-        if (storage.get(name).isPresent()) {
+        String accountId = regionResolver.getAccountId();
+        String region = regionResolver.getRegion();
+        if (getStoredEnvironment(accountId, region, name).isPresent()) {
             // CreateEnvironment's botocore model declares only ServiceUnavailableException,
             // ValidationException, and InternalServerException — no "already exists" shape — so an
             // SDK client can't map a ResourceAlreadyExistsException here.
@@ -111,8 +114,6 @@ public class MwaaService implements TagHandler {
 
         String version = resolveAirflowVersion(request.getAirflowVersion());
 
-        String region = config.defaultRegion();
-        String accountId = regionResolver.getAccountId();
         String arn = AwsArnUtils.Arn.of("airflow", region, accountId, "environment/" + name).toString();
 
         Environment environment = new Environment();
@@ -158,7 +159,7 @@ public class MwaaService implements TagHandler {
                 environment.setProxyPort(proxyPort);
                 environment.setWebserverUrl(buildWebserverUrl(proxyPort));
                 String airflowContainerId = environment.getAirflowContainerId();
-                proxyManager.startProxy(name, proxyPort,
+                proxyManager.startProxy(environmentIdentity(environment), proxyPort,
                         environment.getAirflowInternalHost(), environment.getAirflowInternalPort(),
                         this::isValidCliToken,
                         cliCommand -> environmentManager.runAirflowCli(airflowContainerId, cliCommand));
@@ -173,7 +174,7 @@ public class MwaaService implements TagHandler {
             }
         }
 
-        storage.put(name, environment);
+        putEnvironment(environment);
         return environment;
     }
 
@@ -187,7 +188,7 @@ public class MwaaService implements TagHandler {
      */
     private void rollbackFailedCreate(Environment environment, int proxyPort) {
         try {
-            proxyManager.stopProxy(environment.getName());
+            proxyManager.stopProxy(environmentIdentity(environment));
         } catch (Exception e) {
             LOG.warnv("Error stopping proxy while rolling back failed MWAA environment {0}: {1}",
                     environment.getName(), e.getMessage());
@@ -205,13 +206,19 @@ public class MwaaService implements TagHandler {
     }
 
     public Environment getEnvironment(String name) {
-        return storage.get(name)
+        return getStoredEnvironment(regionResolver.getAccountId(), regionResolver.getRegion(), name)
                 .orElseThrow(() -> new AwsException("ResourceNotFoundException",
                         "No environment found for name: " + name, 404));
     }
 
     public List<String> listEnvironments() {
-        return storage.scan(k -> true).stream()
+        String accountId = regionResolver.getAccountId();
+        String region = regionResolver.getRegion();
+        List<Environment> environments = storage instanceof AccountAwareStorageBackend<Environment> aware
+                ? aware.scanForAccount(accountId, k -> true)
+                : storage.scan(k -> true);
+        return environments.stream()
+                .filter(environment -> region.equals(environmentRegion(environment)))
                 .map(Environment::getName)
                 .collect(Collectors.toList());
     }
@@ -287,17 +294,18 @@ public class MwaaService implements TagHandler {
         Environment environment = getEnvironment(name);
         environment.setStatus(EnvironmentStatus.DELETING);
         if (!config.services().mwaa().mock()) {
-            proxyManager.stopProxy(name);
+            proxyManager.stopProxy(environmentIdentity(environment));
             environmentManager.stopEnvironment(environment);
             // Mirrors how Lambda/MSK/EC2/ECR release their allocated ports on cleanup — otherwise
             // repeated create/delete cycles exhaust the configured proxy port range even though no
             // MWAA proxy is actually running anymore.
             portAllocator.release(environment.getProxyPort());
         }
-        cliTokensByEnvironment.remove(name);
-        dagSyncState.remove(name);
-        requirementsEtagByEnvironment.remove(name);
-        storage.delete(name);
+        String environmentIdentity = environmentIdentity(environment);
+        cliTokensByEnvironment.remove(environmentIdentity);
+        dagSyncState.remove(environmentIdentity);
+        requirementsEtagByEnvironment.remove(environmentIdentity);
+        deleteEnvironment(environment);
         return environment;
     }
 
@@ -314,14 +322,14 @@ public class MwaaService implements TagHandler {
     public Map<String, Object> createCliToken(String name) {
         Environment environment = getEnvironment(name);
         String token = generateToken();
-        cliTokensByEnvironment.computeIfAbsent(name, k -> ConcurrentHashMap.newKeySet()).add(token);
+        cliTokensByEnvironment.computeIfAbsent(environmentIdentity(environment), k -> ConcurrentHashMap.newKeySet()).add(token);
         return Map.of(
                 "CliToken", token,
                 "WebServerHostname", hostnameFromUrl(environment.getWebserverUrl()));
     }
 
-    boolean isValidCliToken(String environmentName, String token) {
-        Set<String> tokens = cliTokensByEnvironment.get(environmentName);
+    boolean isValidCliToken(String environmentIdentity, String token) {
+        Set<String> tokens = cliTokensByEnvironment.get(environmentIdentity);
         return tokens != null && tokens.contains(token);
     }
 
@@ -392,11 +400,24 @@ public class MwaaService implements TagHandler {
     }
 
     private Environment findByArn(String resourceArn) {
-        int idx = resourceArn.lastIndexOf('/');
-        if (idx < 0 || idx == resourceArn.length() - 1) {
+        if (resourceArn == null) {
             throw new AwsException("ValidationException", "Invalid resource ARN: " + resourceArn, 400);
         }
-        return getEnvironment(resourceArn.substring(idx + 1));
+        try {
+            AwsArnUtils.Arn arn = AwsArnUtils.parse(resourceArn);
+            String name = arn.resource().startsWith("environment/")
+                    ? arn.resource().substring("environment/".length())
+                    : "";
+            if (name.isBlank() || arn.region().isBlank() || arn.accountId().isBlank()
+                    || !"airflow".equals(arn.service())) {
+                throw new IllegalArgumentException("not an MWAA environment ARN");
+            }
+            return getStoredEnvironment(arn.accountId(), arn.region(), name)
+                    .orElseThrow(() -> new AwsException("ResourceNotFoundException",
+                            "No environment found for name: " + name, 404));
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ValidationException", "Invalid resource ARN: " + resourceArn, 400);
+        }
     }
 
     private void startReadinessPoller() {
@@ -457,7 +478,8 @@ public class MwaaService implements TagHandler {
             currentByKey.put(relative, obj.getETag());
         }
 
-        Map<String, String> previous = dagSyncState.computeIfAbsent(environment.getName(), k -> new HashMap<>());
+        String environmentIdentity = environmentIdentity(environment);
+        Map<String, String> previous = dagSyncState.computeIfAbsent(environmentIdentity, k -> new HashMap<>());
         for (Map.Entry<String, String> entry : currentByKey.entrySet()) {
             String relative = entry.getKey();
             String etag = entry.getValue();
@@ -492,10 +514,11 @@ public class MwaaService implements TagHandler {
         }
         try {
             S3Object requirements = s3Service.getObject(bucket, environment.getRequirementsS3Path());
-            String lastEtag = requirementsEtagByEnvironment.get(environment.getName());
+            String environmentIdentity = environmentIdentity(environment);
+            String lastEtag = requirementsEtagByEnvironment.get(environmentIdentity);
             if (!requirements.getETag().equals(lastEtag)) {
                 environmentManager.installRequirements(environment, requirements.getData());
-                requirementsEtagByEnvironment.put(environment.getName(), requirements.getETag());
+                requirementsEtagByEnvironment.put(environmentIdentity, requirements.getETag());
             }
         } catch (Exception e) {
             LOG.warnv("Could not sync requirements.txt for environment {0}: {1}",
@@ -533,10 +556,60 @@ public class MwaaService implements TagHandler {
     }
 
     private void putEnvironment(Environment environment) {
-        if (environment.getAccountId() != null && storage instanceof AccountAwareStorageBackend<Environment> aware) {
-            aware.putForAccount(environment.getAccountId(), environment.getName(), environment);
+        String key = environmentKey(environmentRegion(environment), environment.getName());
+        String accountId = environmentAccount(environment);
+        if (accountId != null && storage instanceof AccountAwareStorageBackend<Environment> aware) {
+            aware.putForAccount(accountId, key, environment);
         } else {
-            storage.put(environment.getName(), environment);
+            storage.put(key, environment);
         }
     }
+
+    private void deleteEnvironment(Environment environment) {
+        String key = environmentKey(environmentRegion(environment), environment.getName());
+        String accountId = environmentAccount(environment);
+        if (accountId != null && storage instanceof AccountAwareStorageBackend<Environment> aware) {
+            aware.deleteForAccount(accountId, key);
+        } else {
+            storage.delete(key);
+        }
+    }
+
+    private Optional<Environment> getStoredEnvironment(String accountId, String region, String name) {
+        String key = environmentKey(region, name);
+        if (storage instanceof AccountAwareStorageBackend<Environment> aware) {
+            return aware.getForAccountMigratingLegacyKeys(accountId, key, List.of(name),
+                    environment -> accountId.equals(environmentAccount(environment))
+                            && region.equals(environmentRegion(environment)));
+        }
+        return storage.get(key);
+    }
+
+    private static String environmentKey(String region, String name) {
+        return region + "/" + name;
+    }
+
+    static String environmentIdentity(Environment environment) {
+        return environmentAccount(environment) + "/" + environmentRegion(environment) + "/" + environment.getName();
+    }
+
+    private static String environmentAccount(Environment environment) {
+        if (environment.getAccountId() != null) {
+            return environment.getAccountId();
+        }
+        try {
+            return AwsArnUtils.parse(environment.getArn()).accountId();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String environmentRegion(Environment environment) {
+        try {
+            return AwsArnUtils.parse(environment.getArn()).region();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
 }

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManagerTest.java
@@ -234,22 +234,21 @@ class MwaaEnvironmentManagerTest {
     }
 
     @Test
-    void containerNamingMatchesThePlan() {
-        assertEquals("floci-mwaa-my-env-db", MwaaEnvironmentManager.dbContainerName(null, "my-env"));
-        assertEquals("floci-mwaa-my-env-airflow", MwaaEnvironmentManager.airflowContainerName(null, "my-env"));
-    }
-
-    @Test
     void containerNamingAppliesTheConfiguredResourceNamespace() {
         EmulatorConfig.DockerConfig dockerConfig = Mockito.mock(EmulatorConfig.DockerConfig.class);
         when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("ns1"));
         EmulatorConfig namespacedConfig = Mockito.mock(EmulatorConfig.class);
         when(namespacedConfig.docker()).thenReturn(dockerConfig);
 
-        assertEquals("floci-ns1-mwaa-my-env-db",
-                MwaaEnvironmentManager.dbContainerName(namespacedConfig, "my-env"));
-        assertEquals("floci-ns1-mwaa-my-env-airflow",
-                MwaaEnvironmentManager.airflowContainerName(namespacedConfig, "my-env"));
+        Environment environment = new Environment();
+        environment.setName("my-env");
+        environment.setAccountId("000000000000");
+        environment.setArn("arn:aws:airflow:us-east-1:000000000000:environment/my-env");
+
+        assertEquals("floci-ns1-mwaa-000000000000.us-east-1.my-env-db",
+                MwaaEnvironmentManager.dbContainerName(namespacedConfig, environment));
+        assertEquals("floci-ns1-mwaa-000000000000.us-east-1.my-env-airflow",
+                MwaaEnvironmentManager.airflowContainerName(namespacedConfig, environment));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManagerTest.java
@@ -1,7 +1,6 @@
 package io.github.hectorvent.floci.services.mwaa;
 
 import io.github.hectorvent.floci.config.EmulatorConfig;
-import io.github.hectorvent.floci.core.common.RegionResolver;
 import io.github.hectorvent.floci.core.common.docker.ContainerBuilder;
 import io.github.hectorvent.floci.core.common.docker.ContainerDetector;
 import io.github.hectorvent.floci.core.common.docker.ContainerLifecycleManager;
@@ -27,6 +26,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,7 +41,6 @@ class MwaaEnvironmentManagerTest {
 
     private ContainerLifecycleManager lifecycleManager;
     private ContainerDetector containerDetector;
-    private RegionResolver regionResolver;
     private MwaaEnvironmentManager manager;
 
     @BeforeEach
@@ -78,13 +77,14 @@ class MwaaEnvironmentManagerTest {
                 "AWS_ACCESS_KEY_ID=test",
                 "AWS_SECRET_ACCESS_KEY=test",
                 "AWS_ENDPOINT_URL=http://localhost:4566"));
-
-        regionResolver = Mockito.mock(RegionResolver.class);
-        when(regionResolver.getAccountId()).thenReturn("000000000000");
-        when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
+        when(awsEnv.sdkBaselineEnv(eq("eu-west-1"), any())).thenReturn(List.of(
+                "AWS_DEFAULT_REGION=eu-west-1",
+                "AWS_ACCESS_KEY_ID=test",
+                "AWS_SECRET_ACCESS_KEY=test",
+                "AWS_ENDPOINT_URL=http://localhost:4566"));
 
         manager = new MwaaEnvironmentManager(containerBuilder, lifecycleManager, containerDetector, config,
-                awsEnv, regionResolver);
+                awsEnv);
     }
 
     @SuppressWarnings("unchecked")
@@ -155,6 +155,24 @@ class MwaaEnvironmentManagerTest {
         assertTrue(spec.env().contains("AWS_ENDPOINT_URL=http://localhost:4566"),
                 "DAG code's own boto3 calls must target Floci, not real AWS");
         assertTrue(spec.env().contains("AWS_DEFAULT_REGION=us-east-1"));
+    }
+
+    @Test
+    void airflowContainerUsesTheEnvironmentRegionForItsOwnAwsSdkCalls() {
+        when(containerDetector.isRunningInContainer()).thenReturn(false);
+        when(lifecycleManager.create(any())).thenReturn("airflow-container-id");
+        when(lifecycleManager.startCreated(eq("airflow-container-id"), any())).thenReturn(
+                new ContainerInfo("airflow-container-id", Map.of(8080, new EndpointInfo("172.18.0.5", 8080))));
+
+        Environment environment = new Environment();
+        environment.setName("my-env");
+        environment.setArn("arn:aws:airflow:eu-west-1:111111111111:environment/my-env");
+
+        manager.startAirflowContainer(environment, "2.10.5", "172.18.0.9", "db-secret-pw", null);
+
+        ArgumentCaptor<ContainerSpec> captor = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(lifecycleManager).create(captor.capture());
+        assertTrue(captor.getValue().env().contains("AWS_DEFAULT_REGION=eu-west-1"));
     }
 
     @Test
@@ -232,6 +250,24 @@ class MwaaEnvironmentManagerTest {
                 MwaaEnvironmentManager.dbContainerName(namespacedConfig, "my-env"));
         assertEquals("floci-ns1-mwaa-my-env-airflow",
                 MwaaEnvironmentManager.airflowContainerName(namespacedConfig, "my-env"));
+    }
+
+    @Test
+    void scopedContainerNamesDifferForSameNameEnvironments() {
+        Environment eastEnvironment = new Environment();
+        eastEnvironment.setName("shared-name");
+        eastEnvironment.setAccountId("111111111111");
+        eastEnvironment.setArn("arn:aws:airflow:us-east-1:111111111111:environment/shared-name");
+
+        Environment westEnvironment = new Environment();
+        westEnvironment.setName("shared-name");
+        westEnvironment.setAccountId("222222222222");
+        westEnvironment.setArn("arn:aws:airflow:eu-west-1:222222222222:environment/shared-name");
+
+        assertNotEquals(MwaaEnvironmentManager.dbContainerName(null, eastEnvironment),
+                MwaaEnvironmentManager.dbContainerName(null, westEnvironment));
+        assertNotEquals(MwaaEnvironmentManager.airflowContainerName(null, eastEnvironment),
+                MwaaEnvironmentManager.airflowContainerName(null, westEnvironment));
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,6 +42,9 @@ import static org.mockito.Mockito.when;
 class MwaaServiceTest {
 
     private MwaaService mwaaService;
+    private AccountAwareStorageBackend<Environment> environmentStorage;
+    private String currentAccount;
+    private String currentRegion;
 
     @BeforeEach
     void setUp() {
@@ -48,14 +52,99 @@ class MwaaServiceTest {
             @Override
             public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
                     TypeReference<Map<String, V>> typeReference) {
-                return AccountAwareStorageBackend.inMemory("000000000000");
+                environmentStorage = AccountAwareStorageBackend.<Environment>inMemory("000000000000");
+                return (AccountAwareStorageBackend<V>) (AccountAwareStorageBackend<?>) environmentStorage;
             }
         };
 
         EmulatorConfig config = testConfig();
-        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        currentAccount = "000000000000";
+        currentRegion = "us-east-1";
+        RegionResolver regionResolver = Mockito.mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenAnswer(invocation -> currentAccount);
+        when(regionResolver.getRegion()).thenAnswer(invocation -> currentRegion);
         S3Service s3Service = Mockito.mock(S3Service.class);
         mwaaService = new MwaaService(storageFactory, config, regionResolver, null, null, null, s3Service);
+    }
+
+    @Test
+    void sameNameEnvironmentsAreIsolatedByAccountAndRegion() {
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        Environment eastEnvironment = mwaaService.createEnvironment("shared-name",
+                createRequest("arn:aws:s3:::east-bucket", "dags"));
+
+        currentAccount = "222222222222";
+        currentRegion = "eu-west-1";
+        Environment westEnvironment = mwaaService.createEnvironment("shared-name",
+                createRequest("arn:aws:s3:::west-bucket", "dags"));
+
+        assertNotEquals(eastEnvironment.getArn(), westEnvironment.getArn());
+        assertEquals(westEnvironment.getArn(), mwaaService.getEnvironment("shared-name").getArn());
+        assertEquals(List.of("shared-name"), mwaaService.listEnvironments());
+
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        assertEquals(eastEnvironment.getArn(), mwaaService.getEnvironment("shared-name").getArn());
+        assertEquals(List.of("shared-name"), mwaaService.listEnvironments());
+    }
+
+    @Test
+    void deletingOneScopedEnvironmentDoesNotDeleteAnotherWithTheSameName() {
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        Environment eastEnvironment = mwaaService.createEnvironment("shared-name",
+                createRequest("arn:aws:s3:::east-bucket", "dags"));
+
+        currentAccount = "222222222222";
+        currentRegion = "eu-west-1";
+        mwaaService.createEnvironment("shared-name", createRequest("arn:aws:s3:::west-bucket", "dags"));
+        mwaaService.deleteEnvironment("shared-name");
+
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        assertEquals(eastEnvironment.getArn(), mwaaService.getEnvironment("shared-name").getArn());
+    }
+
+    @Test
+    void cliTokensAreIsolatedForSameNameEnvironments() {
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        Environment eastEnvironment = mwaaService.createEnvironment("shared-name",
+                createRequest("arn:aws:s3:::east-bucket", "dags"));
+        String eastToken = (String) mwaaService.createCliToken("shared-name").get("CliToken");
+
+        currentAccount = "222222222222";
+        currentRegion = "eu-west-1";
+        Environment westEnvironment = mwaaService.createEnvironment("shared-name",
+                createRequest("arn:aws:s3:::west-bucket", "dags"));
+        String westToken = (String) mwaaService.createCliToken("shared-name").get("CliToken");
+
+        assertTrue(mwaaService.isValidCliToken(MwaaService.environmentIdentity(westEnvironment), westToken));
+        assertFalse(mwaaService.isValidCliToken(MwaaService.environmentIdentity(westEnvironment), eastToken));
+        assertTrue(mwaaService.isValidCliToken(MwaaService.environmentIdentity(eastEnvironment), eastToken));
+        assertFalse(mwaaService.isValidCliToken(MwaaService.environmentIdentity(eastEnvironment), westToken));
+    }
+
+    @Test
+    void legacyEnvironmentIsMigratedOnlyWhenItsAccountAndRegionMatch() {
+        Environment legacy = new Environment();
+        legacy.setName("legacy-env");
+        legacy.setArn("arn:aws:airflow:us-east-1:111111111111:environment/legacy-env");
+        environmentStorage.putForAccount("111111111111", "legacy-env", legacy);
+
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        assertEquals(legacy, mwaaService.getEnvironment("legacy-env"));
+
+        Environment wrongRegion = new Environment();
+        wrongRegion.setName("foreign-env");
+        wrongRegion.setArn("arn:aws:airflow:eu-west-1:222222222222:environment/foreign-env");
+        environmentStorage.putForAccount("222222222222", "foreign-env", wrongRegion);
+
+        currentAccount = "222222222222";
+        currentRegion = "us-east-1";
+        assertThrows(AwsException.class, () -> mwaaService.getEnvironment("foreign-env"));
     }
 
     private EmulatorConfig testConfig() {
@@ -290,6 +379,24 @@ class MwaaServiceTest {
     }
 
     @Test
+    void taggingUsesTheAccountAndRegionInTheResourceArn() {
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        Environment first = mwaaService.createEnvironment("shared-name",
+                createRequest("arn:aws:s3:::first-bucket", "dags"));
+
+        currentAccount = "222222222222";
+        currentRegion = "eu-west-1";
+        mwaaService.createEnvironment("shared-name", createRequest("arn:aws:s3:::second-bucket", "dags"));
+
+        mwaaService.tagResource(null, first.getArn(), Map.of("owner", "first"));
+
+        assertEquals(Map.of("owner", "first"), mwaaService.listTags(null, first.getArn()));
+        assertTrue(mwaaService.listTags(null,
+                "arn:aws:airflow:eu-west-1:222222222222:environment/shared-name").isEmpty());
+    }
+
+    @Test
     void tagHandlerServiceKeyIsAirflow() {
         assertEquals("airflow", mwaaService.serviceKey());
         assertEquals("Tags", mwaaService.tagsBodyKey());
@@ -311,8 +418,10 @@ class MwaaServiceTest {
         Map<String, Object> response = mwaaService.createCliToken("cli-token-env");
         String token = (String) response.get("CliToken");
         assertNotNull(token);
-        assertTrue(mwaaService.isValidCliToken("cli-token-env", token));
-        assertFalse(mwaaService.isValidCliToken("cli-token-env", "not-a-real-token"));
+        assertTrue(mwaaService.isValidCliToken(MwaaService.environmentIdentity(
+                mwaaService.getEnvironment("cli-token-env")), token));
+        assertFalse(mwaaService.isValidCliToken(MwaaService.environmentIdentity(
+                mwaaService.getEnvironment("cli-token-env")), "not-a-real-token"));
         assertFalse(mwaaService.isValidCliToken("other-env", token));
     }
 
@@ -399,7 +508,7 @@ class MwaaServiceTest {
             assertEquals(EnvironmentStatus.CREATE_FAILED, environment.getStatus());
             verify(portAllocator).release(8701);
             verify(environmentManager).stopEnvironment(environment);
-            verify(proxyManager).stopProxy("failed-proxy-env");
+            verify(proxyManager).stopProxy(MwaaService.environmentIdentity(environment));
         }
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/mwaa/MwaaServiceTest.java
@@ -147,6 +147,38 @@ class MwaaServiceTest {
         assertThrows(AwsException.class, () -> mwaaService.getEnvironment("foreign-env"));
     }
 
+    @Test
+    void listMigratesMatchingLegacyEnvironmentAndRemovesTheOldKey() {
+        Environment legacy = new Environment();
+        legacy.setName("legacy-list-env");
+        legacy.setArn("arn:aws:airflow:us-east-1:111111111111:environment/legacy-list-env");
+        environmentStorage.putForAccount("111111111111", "legacy-list-env", legacy);
+
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+
+        assertEquals(List.of("legacy-list-env"), mwaaService.listEnvironments());
+        assertTrue(environmentStorage.getForAccount("111111111111", "legacy-list-env").isEmpty());
+        assertTrue(environmentStorage.getForAccount("111111111111", "us-east-1/legacy-list-env").isPresent());
+    }
+
+    @Test
+    void promotionDoesNotLeaveASecondLegacyEnvironmentEntry() {
+        Environment legacy = new Environment();
+        legacy.setName("promoted-env");
+        legacy.setArn("arn:aws:airflow:us-east-1:111111111111:environment/promoted-env");
+        legacy.setStatus(EnvironmentStatus.CREATING);
+        environmentStorage.putForAccount("111111111111", "promoted-env", legacy);
+
+        currentAccount = "111111111111";
+        currentRegion = "us-east-1";
+        legacy.setStatus(EnvironmentStatus.AVAILABLE);
+        mwaaService.putEnvironment(legacy);
+
+        assertEquals(List.of("promoted-env"), mwaaService.listEnvironments());
+        assertTrue(environmentStorage.getForAccount("111111111111", "promoted-env").isEmpty());
+    }
+
     private EmulatorConfig testConfig() {
         EmulatorConfig.MwaaServiceConfig mwaaConfig = proxy(EmulatorConfig.MwaaServiceConfig.class,
                 (proxy, method, args) -> switch (method.getName()) {
@@ -379,7 +411,7 @@ class MwaaServiceTest {
     }
 
     @Test
-    void taggingUsesTheAccountAndRegionInTheResourceArn() {
+    void taggingRejectsAResourceArnOutsideTheRequestScope() {
         currentAccount = "111111111111";
         currentRegion = "us-east-1";
         Environment first = mwaaService.createEnvironment("shared-name",
@@ -389,11 +421,9 @@ class MwaaServiceTest {
         currentRegion = "eu-west-1";
         mwaaService.createEnvironment("shared-name", createRequest("arn:aws:s3:::second-bucket", "dags"));
 
-        mwaaService.tagResource(null, first.getArn(), Map.of("owner", "first"));
-
-        assertEquals(Map.of("owner", "first"), mwaaService.listTags(null, first.getArn()));
-        assertTrue(mwaaService.listTags(null,
-                "arn:aws:airflow:eu-west-1:222222222222:environment/shared-name").isEmpty());
+        AwsException exception = assertThrows(AwsException.class,
+                () -> mwaaService.tagResource(null, first.getArn(), Map.of("owner", "first")));
+        assertEquals("ResourceNotFoundException", exception.getErrorCode());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Isolate MWAA environments by AWS account and Region so same-named environments do not share persisted state or runtime resources.

The change scopes environment storage, container and proxy identities, CLI tokens, and DAG or requirements state. Legacy entries are migrated only when their stored ARN matches the requested account and Region.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

MWAA environment ARNs contain the owning Region and account. Floci now uses those same identity components for storage and runtime lookups, preventing a request in one account or Region from reading or modifying another environment with the same name.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
