### PR TITLE
fix(neptune): isolate resources by account and region

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -114,29 +114,19 @@ public class NeptuneQueryHandler {
     /**
      * The rows the list form of DescribeDBClusters would return for the region a request is signed
      * for, for the RDS-family listing {@code RdsQueryHandler} assembles: a live account lists
-     * Neptune clusters from the RDS endpoint too. The Neptune store is not keyed by region, so the
-     * region is read off each record's ARN.
+     * Neptune clusters from the RDS endpoint too. The service storage is scoped by account and
+     * region before the rows are rendered.
      */
     public List<String> clusterRowsXml(String filterId, String region) {
         return service.listDbClusters(filterId).stream()
-                .filter(c -> inRegion(c.getDbClusterArn(), region))
                 .map(this::clusterInnerXml)
                 .toList();
     }
 
     public List<String> instanceRowsXml(String filterId, String region) {
         return service.listDbInstances(filterId).stream()
-                .filter(i -> inRegion(i.getDbInstanceArn(), region))
                 .map(this::instanceInnerXml)
                 .toList();
-    }
-
-    private static boolean inRegion(String arn, String region) {
-        if (region == null || region.isBlank()) {
-            return true;
-        }
-        String[] parts = arn == null ? new String[0] : arn.split(":", -1);
-        return parts.length >= 4 && region.equals(parts[3]);
     }
 
     private Response handleDeleteDbCluster(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneQueryHandler.java
@@ -119,14 +119,24 @@ public class NeptuneQueryHandler {
      */
     public List<String> clusterRowsXml(String filterId, String region) {
         return service.listDbClusters(filterId).stream()
+                .filter(c -> inRegion(c.getDbClusterArn(), region))
                 .map(this::clusterInnerXml)
                 .toList();
     }
 
     public List<String> instanceRowsXml(String filterId, String region) {
         return service.listDbInstances(filterId).stream()
+                .filter(i -> inRegion(i.getDbInstanceArn(), region))
                 .map(this::instanceInnerXml)
                 .toList();
+    }
+
+    private static boolean inRegion(String arn, String region) {
+        if (region == null || region.isBlank()) {
+            return true;
+        }
+        String[] parts = arn == null ? new String[0] : arn.split(":", -1);
+        return parts.length >= 4 && region.equals(parts[3]);
     }
 
     private Response handleDeleteDbCluster(MultivaluedMap<String, String> params) {

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -5,6 +5,7 @@ import io.github.hectorvent.floci.config.EmulatorConfig;
 import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.neptune.container.NeptuneContainerHandle;
@@ -70,7 +71,7 @@ public class NeptuneService {
     public NeptuneCluster createDbCluster(String id, String engineVersion, boolean iamEnabled,
                                           NeptuneClusterSettings settings, Map<String, String> tags) {
         settings.validate();
-        if (clusters.get(id).isPresent()) {
+        if (getStoredCluster(id).isPresent()) {
             throw new AwsException("DBClusterAlreadyExistsFault",
                     "Neptune cluster " + id + " already exists.", 400);
         }
@@ -97,10 +98,11 @@ public class NeptuneService {
             // A cluster record is metadata: its identifier, ARN, endpoint host and proxy port
             // are derived from configuration and need no Docker, so the cluster is created and
             // reaches 'available' even when no daemon is reachable. Only connecting to the
+            String region = currentRegion();
+            String accountId = currentAccount();
+            String identity = resourceIdentity(accountId, region, id);
             // graph database needs the container.
-            handle = containerManager.tryStart(id, image, dbType);
-
-            String region = regionResolver.getDefaultRegion();
+            handle = containerManager.tryStart(id, image, dbType, accountId, region);
             String endpointHost = resolveEndpointHost();
 
             NeptuneCluster cluster = new NeptuneCluster();
@@ -127,14 +129,14 @@ public class NeptuneService {
                 cluster.setContainerHost(handle.getHost());
                 cluster.setContainerPort(handle.getPort());
 
-                proxyManager.startProxy(id, proxyPort, handle.getHost(), handle.getPort());
+                proxyManager.startProxy(identity, proxyPort, handle.getHost(), handle.getPort());
             } else {
                 LOG.warnv("Neptune cluster {0} created without a backing graph database container: "
                         + "no Docker daemon is reachable. Metadata operations work; connections to "
                         + "the cluster do not until a daemon appears.", id);
             }
 
-            clusters.put(id, cluster);
+            putCluster(cluster);
             provisioned = true;
             LOG.infov("Neptune cluster {0} created ({1}), endpoint={2}:{3}",
                     id, dbType, endpointHost, String.valueOf(proxyPort));
@@ -147,30 +149,30 @@ public class NeptuneService {
             // catch (RuntimeException) would miss — so a failed create never leaks the
             // reserved port or leaves a container behind. Idempotent and a no-op on success.
             if (!provisioned) {
-                rollbackDbCluster(id, handle, proxyPort);
+                rollbackDbCluster(resourceIdentity(currentAccount(), currentRegion(), id), handle, proxyPort);
             }
         }
     }
 
-    private void rollbackDbCluster(String id, NeptuneContainerHandle handle, int proxyPort) {
+    private void rollbackDbCluster(String identity, NeptuneContainerHandle handle, int proxyPort) {
         try {
             try {
                 // The proxy only starts after the container is ready, so a null handle means it
                 // never started — nothing to stop.
                 if (handle != null) {
-                    proxyManager.stopProxy(id);
+                    proxyManager.stopProxy(identity);
                 }
             } catch (RuntimeException e) {
-                LOG.warnv("Error stopping proxy for Neptune cluster {0}: {1}", id, e.getMessage());
+                LOG.warnv("Error stopping proxy for Neptune cluster {0}: {1}", identity, e.getMessage());
             }
             try {
                 // Stop by id, not handle: a readiness timeout in containerManager.start() throws
                 // after the container was created and registered but before the handle is returned,
                 // so cleaning up by handle here would miss (and orphan) it. stopByClusterId is
                 // idempotent, so it's safe when the container never started.
-                containerManager.stopByClusterId(id);
+                containerManager.stopByClusterId(identity);
             } catch (RuntimeException e) {
-                LOG.warnv("Error stopping container for Neptune cluster {0}: {1}", id, e.getMessage());
+                LOG.warnv("Error stopping container for Neptune cluster {0}: {1}", identity, e.getMessage());
             }
         } finally {
             // Always release the port — even if a cleanup step throws a non-RuntimeException
@@ -180,7 +182,7 @@ public class NeptuneService {
     }
 
     public NeptuneCluster getDbCluster(String id) {
-        return clusters.get(id).orElseThrow(() ->
+        return getStoredCluster(id).orElseThrow(() ->
                 new AwsException("DBClusterNotFoundFault",
                         "Neptune cluster " + id + " not found.", 404));
     }
@@ -189,23 +191,23 @@ public class NeptuneService {
         if (id == null || id.isBlank()) {
             return false;
         }
-        return clusters.get(id).isPresent();
+        return getStoredCluster(id).isPresent();
     }
 
     public boolean hasInstance(String id) {
         if (id == null || id.isBlank()) {
             return false;
         }
-        return instances.get(id).isPresent();
+        return getStoredInstance(id).isPresent();
     }
 
     public boolean hasResourceWithArn(String arn) {
         if (arn == null || !arn.startsWith("arn:")) {
             return false;
         }
-        return clusters.scan(k -> true).stream()
+        return scanClusters().stream()
                         .anyMatch(c -> arn.equalsIgnoreCase(c.getDbClusterArn()))
-                || instances.scan(k -> true).stream()
+                || scanInstances().stream()
                         .anyMatch(i -> arn.equalsIgnoreCase(i.getDbInstanceArn()));
     }
 
@@ -216,13 +218,13 @@ public class NeptuneService {
             // the bare identifier, so a cross-account or cross-region ARN does not
             // resolve a same-named local cluster.
             if (filterId.startsWith("arn:")) {
-                return clusters.scan(k -> true).stream()
+                return scanClusters().stream()
                         .filter(c -> filterId.equalsIgnoreCase(c.getDbClusterArn()))
                         .toList();
             }
-            return clusters.scan(k -> k.equalsIgnoreCase(filterId));
+            return scanClusters().stream().filter(c -> c.getDbClusterIdentifier().equalsIgnoreCase(filterId)).toList();
         }
-        return clusters.scan(k -> true);
+        return scanClusters();
     }
 
     public NeptuneCluster modifyDbCluster(String id, String engineVersion, Boolean iamEnabled) {
@@ -240,13 +242,13 @@ public class NeptuneService {
             cluster.setIamDatabaseAuthenticationEnabled(iamEnabled);
         }
         settings.applyTo(cluster);
-        clusters.put(id, cluster);
+        putCluster(cluster);
         LOG.infov("Neptune cluster {0} modified", id);
         return cluster;
     }
 
     public void deleteDbCluster(String id) {
-        NeptuneCluster cluster = clusters.get(id).orElseThrow(() ->
+        NeptuneCluster cluster = getStoredCluster(id).orElseThrow(() ->
                 new AwsException("DBClusterNotFoundFault",
                         "Neptune cluster " + id + " not found.", 404));
 
@@ -260,18 +262,19 @@ public class NeptuneService {
         }
 
         cluster.setStatus("deleting");
-        clusters.put(id, cluster);
+        putCluster(cluster);
 
-        proxyManager.stopProxy(id);
+        String identity = resourceIdentity(cluster);
+        proxyManager.stopProxy(identity);
 
         if (cluster.getContainerId() != null) {
             containerManager.stop(new NeptuneContainerHandle(
-                    cluster.getContainerId(), id,
+                    cluster.getContainerId(), identity,
                     cluster.getContainerHost(), cluster.getContainerPort()));
         }
 
         releaseProxyPort(cluster.getProxyPort());
-        clusters.delete(id);
+        deleteCluster(cluster);
         LOG.infov("Neptune cluster {0} deleted", id);
     }
 
@@ -285,7 +288,7 @@ public class NeptuneService {
                     "Role ARN " + roleArn + " is already associated with Neptune cluster " + id + ".", 400);
         }
         cluster.getAssociatedRoleArns().add(roleArn);
-        clusters.put(id, cluster);
+        putCluster(cluster);
         LOG.infov("Role {0} added to Neptune cluster {1}", roleArn, id);
         return cluster;
     }
@@ -296,7 +299,7 @@ public class NeptuneService {
             throw new AwsException("DBClusterRoleNotFound",
                     "Role ARN " + roleArn + " is not associated with Neptune cluster " + id + ".", 404);
         }
-        clusters.put(id, cluster);
+        putCluster(cluster);
         LOG.infov("Role {0} removed from Neptune cluster {1}", roleArn, id);
         return cluster;
     }
@@ -338,13 +341,13 @@ public class NeptuneService {
                                             boolean iamEnabled, NeptuneInstanceSettings settings,
                                             Map<String, String> tags) {
         settings.validate();
-        if (instances.get(id).isPresent()) {
+        if (getStoredInstance(id).isPresent()) {
             throw new AwsException("DBInstanceAlreadyExists",
                     "Neptune instance " + id + " already exists.", 400);
         }
 
         NeptuneCluster cluster = getDbCluster(dbClusterIdentifier);
-        String region = regionResolver.getDefaultRegion();
+        String region = currentRegion();
 
         NeptuneInstance instance = new NeptuneInstance();
         instance.setDbInstanceIdentifier(id);
@@ -365,19 +368,19 @@ public class NeptuneService {
         }
 
         cluster.getDbClusterMembers().add(id);
-        clusters.put(dbClusterIdentifier, cluster);
+        putCluster(cluster);
 
-        instances.put(id, instance);
+        putInstance(instance);
         LOG.infov("Neptune instance {0} created in cluster {1}", id, dbClusterIdentifier);
         return instance;
     }
 
     public Optional<NeptuneCluster> findDbCluster(String id) {
-        return id == null ? Optional.empty() : clusters.get(id);
+        return id == null ? Optional.empty() : getStoredCluster(id);
     }
 
     public NeptuneInstance getDbInstance(String id) {
-        return instances.get(id).orElseThrow(() ->
+        return getStoredInstance(id).orElseThrow(() ->
                 new AwsException("DBInstanceNotFound",
                         "Neptune instance " + id + " not found.", 404));
     }
@@ -387,13 +390,13 @@ public class NeptuneService {
             // The db-instance-id filter accepts ARNs as well as identifiers; see
             // listDbClusters for why the match is against the stored ARN.
             if (filterId.startsWith("arn:")) {
-                return instances.scan(k -> true).stream()
+                return scanInstances().stream()
                         .filter(i -> filterId.equalsIgnoreCase(i.getDbInstanceArn()))
                         .toList();
             }
-            return instances.scan(k -> k.equalsIgnoreCase(filterId));
+            return scanInstances().stream().filter(i -> i.getDbInstanceIdentifier().equalsIgnoreCase(filterId)).toList();
         }
-        return instances.scan(k -> true);
+        return scanInstances();
     }
 
     public NeptuneInstance modifyDbInstance(String id, String dbInstanceClass, Boolean iamEnabled) {
@@ -411,24 +414,24 @@ public class NeptuneService {
             instance.setIamDatabaseAuthenticationEnabled(iamEnabled);
         }
         settings.applyTo(instance);
-        instances.put(id, instance);
+        putInstance(instance);
         LOG.infov("Neptune instance {0} modified", id);
         return instance;
     }
 
     public void deleteDbInstance(String id) {
-        NeptuneInstance instance = instances.get(id).orElseThrow(() ->
+        NeptuneInstance instance = getStoredInstance(id).orElseThrow(() ->
                 new AwsException("DBInstanceNotFound",
                         "Neptune instance " + id + " not found.", 404));
 
         String clusterId = instance.getDbClusterIdentifier();
-        NeptuneCluster cluster = clusters.get(clusterId).orElse(null);
+        NeptuneCluster cluster = getStoredCluster(clusterId).orElse(null);
         if (cluster != null) {
             cluster.getDbClusterMembers().remove(id);
-            clusters.put(clusterId, cluster);
+            putCluster(cluster);
         }
 
-        instances.delete(id);
+        deleteInstance(instance);
         LOG.infov("Neptune instance {0} deleted", id);
     }
 
@@ -474,25 +477,25 @@ public class NeptuneService {
         String id = resource.substring(separator + 1);
         return switch (type) {
             case "cluster" -> {
-                NeptuneCluster cluster = clusters.scan(k -> true).stream()
+                NeptuneCluster cluster = scanClusters().stream()
                         .filter(c -> resourceName.equalsIgnoreCase(c.getDbClusterArn()))
                         .findFirst()
                         .orElseThrow(() -> new AwsException("DBClusterNotFoundFault",
                                 "Neptune cluster " + id + " not found.", 404));
                 yield new TagTarget(cluster.getTags(), updated -> {
                     cluster.setTags(updated);
-                    clusters.put(cluster.getDbClusterIdentifier(), cluster);
+                    putCluster(cluster);
                 });
             }
             case "db" -> {
-                NeptuneInstance instance = instances.scan(k -> true).stream()
+                NeptuneInstance instance = scanInstances().stream()
                         .filter(i -> resourceName.equalsIgnoreCase(i.getDbInstanceArn()))
                         .findFirst()
                         .orElseThrow(() -> new AwsException("DBInstanceNotFound",
                                 "Neptune instance " + id + " not found.", 404));
                 yield new TagTarget(instance.getTags(), updated -> {
                     instance.setTags(updated);
-                    instances.put(instance.getDbInstanceIdentifier(), instance);
+                    putInstance(instance);
                 });
             }
             default -> throw new AwsException("InvalidParameterValue",
@@ -501,6 +504,169 @@ public class NeptuneService {
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private String currentAccount() {
+        String account = regionResolver.getAccountId();
+        return account != null ? account : regionResolver.getDefaultAccountId();
+    }
+
+    private String currentRegion() {
+        String region = regionResolver.getRegion();
+        return region != null ? region : regionResolver.getDefaultRegion();
+    }
+
+    private String clusterKey(String region, String id) {
+        return region + "/" + id;
+    }
+
+    private String instanceKey(String region, String id) {
+        return region + "/" + id;
+    }
+
+    private Optional<NeptuneCluster> getStoredCluster(String id) {
+        String account = currentAccount();
+        String region = currentRegion();
+        String key = clusterKey(region, id);
+        if (clusters instanceof AccountAwareStorageBackend<NeptuneCluster> aware) {
+            return aware.getForAccountMigratingLegacyKeys(account, key, java.util.List.of(id),
+                    value -> belongsTo(value.getDbClusterArn(), account, region));
+        }
+        return clusters.get(key);
+    }
+
+    private Optional<NeptuneInstance> getStoredInstance(String id) {
+        String account = currentAccount();
+        String region = currentRegion();
+        String key = instanceKey(region, id);
+        if (instances instanceof AccountAwareStorageBackend<NeptuneInstance> aware) {
+            return aware.getForAccountMigratingLegacyKeys(account, key, java.util.List.of(id),
+                    value -> belongsTo(value.getDbInstanceArn(), account, region));
+        }
+        return instances.get(key);
+    }
+
+    private Collection<NeptuneCluster> scanClusters() {
+        String account = currentAccount();
+        String region = currentRegion();
+        if (clusters instanceof AccountAwareStorageBackend<NeptuneCluster> aware) {
+            migrateLegacyClusters(aware, account, region);
+            return aware.scanForAccount(account, key -> key.startsWith(region + "/"));
+        }
+        return clusters.scan(key -> key.startsWith(region + "/"));
+    }
+
+    private Collection<NeptuneInstance> scanInstances() {
+        String account = currentAccount();
+        String region = currentRegion();
+        if (instances instanceof AccountAwareStorageBackend<NeptuneInstance> aware) {
+            migrateLegacyInstances(aware, account, region);
+            return aware.scanForAccount(account, key -> key.startsWith(region + "/"));
+        }
+        return instances.scan(key -> key.startsWith(region + "/"));
+    }
+
+    private void migrateLegacyClusters(AccountAwareStorageBackend<NeptuneCluster> aware,
+                                       String account, String region) {
+        for (AccountAwareStorageBackend.AccountEntry<NeptuneCluster> entry
+                : aware.scanAllAccountEntries(key -> !key.contains("/"))) {
+            NeptuneCluster cluster = entry.value();
+            if (!account.equals(entry.accountId())
+                    || !belongsTo(cluster.getDbClusterArn(), account, region)) {
+                continue;
+            }
+            String key = clusterKey(region, cluster.getDbClusterIdentifier());
+            aware.putForAccount(account, key, cluster);
+            aware.deleteForAccount(account, entry.key());
+        }
+    }
+
+    private void migrateLegacyInstances(AccountAwareStorageBackend<NeptuneInstance> aware,
+                                        String account, String region) {
+        for (AccountAwareStorageBackend.AccountEntry<NeptuneInstance> entry
+                : aware.scanAllAccountEntries(key -> !key.contains("/"))) {
+            NeptuneInstance instance = entry.value();
+            if (!account.equals(entry.accountId())
+                    || !belongsTo(instance.getDbInstanceArn(), account, region)) {
+                continue;
+            }
+            String key = instanceKey(region, instance.getDbInstanceIdentifier());
+            aware.putForAccount(account, key, instance);
+            aware.deleteForAccount(account, entry.key());
+        }
+    }
+
+    private void putCluster(NeptuneCluster cluster) {
+        String account = arnAccount(cluster.getDbClusterArn());
+        String region = arnRegion(cluster.getDbClusterArn());
+        String key = clusterKey(region, cluster.getDbClusterIdentifier());
+        if (clusters instanceof AccountAwareStorageBackend<NeptuneCluster> aware) {
+            aware.putForAccount(account, key, cluster);
+        } else {
+            clusters.put(key, cluster);
+        }
+    }
+
+    private void deleteCluster(NeptuneCluster cluster) {
+        String account = arnAccount(cluster.getDbClusterArn());
+        String region = arnRegion(cluster.getDbClusterArn());
+        String key = clusterKey(region, cluster.getDbClusterIdentifier());
+        if (clusters instanceof AccountAwareStorageBackend<NeptuneCluster> aware) {
+            aware.deleteForAccount(account, key);
+        } else {
+            clusters.delete(key);
+        }
+    }
+
+    private void putInstance(NeptuneInstance instance) {
+        String account = arnAccount(instance.getDbInstanceArn());
+        String region = arnRegion(instance.getDbInstanceArn());
+        String key = instanceKey(region, instance.getDbInstanceIdentifier());
+        if (instances instanceof AccountAwareStorageBackend<NeptuneInstance> aware) {
+            aware.putForAccount(account, key, instance);
+        } else {
+            instances.put(key, instance);
+        }
+    }
+
+    private void deleteInstance(NeptuneInstance instance) {
+        String account = arnAccount(instance.getDbInstanceArn());
+        String region = arnRegion(instance.getDbInstanceArn());
+        String key = instanceKey(region, instance.getDbInstanceIdentifier());
+        if (instances instanceof AccountAwareStorageBackend<NeptuneInstance> aware) {
+            aware.deleteForAccount(account, key);
+        } else {
+            instances.delete(key);
+        }
+    }
+
+    private static boolean belongsTo(String arn, String account, String region) {
+        return account.equals(arnAccount(arn)) && region.equals(arnRegion(arn));
+    }
+
+    private static String arnAccount(String arn) {
+        try {
+            return AwsArnUtils.parse(arn).accountId();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String arnRegion(String arn) {
+        try {
+            return AwsArnUtils.parse(arn).region();
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String resourceIdentity(String account, String region, String id) {
+        return account + "-" + region + "-" + id;
+    }
+
+    private static String resourceIdentity(NeptuneCluster cluster) {
+        return resourceIdentity(arnAccount(cluster.getDbClusterArn()), arnRegion(cluster.getDbClusterArn()),
+                cluster.getDbClusterIdentifier());
+    }
 
     private String resolveEndpointHost() {
         return config.hostname().orElse("localhost");

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/NeptuneService.java
@@ -222,7 +222,7 @@ public class NeptuneService {
                         .filter(c -> filterId.equalsIgnoreCase(c.getDbClusterArn()))
                         .toList();
             }
-            return scanClusters().stream().filter(c -> c.getDbClusterIdentifier().equalsIgnoreCase(filterId)).toList();
+            return scanClusters().stream().filter(c -> filterId.equalsIgnoreCase(c.getDbClusterIdentifier())).toList();
         }
         return scanClusters();
     }
@@ -394,7 +394,7 @@ public class NeptuneService {
                         .filter(i -> filterId.equalsIgnoreCase(i.getDbInstanceArn()))
                         .toList();
             }
-            return scanInstances().stream().filter(i -> i.getDbInstanceIdentifier().equalsIgnoreCase(filterId)).toList();
+            return scanInstances().stream().filter(i -> filterId.equalsIgnoreCase(i.getDbInstanceIdentifier())).toList();
         }
         return scanInstances();
     }
@@ -567,32 +567,56 @@ public class NeptuneService {
 
     private void migrateLegacyClusters(AccountAwareStorageBackend<NeptuneCluster> aware,
                                        String account, String region) {
-        for (AccountAwareStorageBackend.AccountEntry<NeptuneCluster> entry
-                : aware.scanAllAccountEntries(key -> !key.contains("/"))) {
-            NeptuneCluster cluster = entry.value();
-            if (!account.equals(entry.accountId())
-                    || !belongsTo(cluster.getDbClusterArn(), account, region)) {
+        if (account.equals(regionResolver.getDefaultAccountId())) {
+            for (NeptuneCluster cluster : aware.scanUnscopedLegacy(value -> belongsTo(
+                    value.getDbClusterArn(), account, region))) {
+                migrateLegacyCluster(aware, account, region, cluster);
+            }
+        }
+        for (String legacyKey : aware.keysForAccount(account)) {
+            if (legacyKey.contains("/")) {
                 continue;
             }
-            String key = clusterKey(region, cluster.getDbClusterIdentifier());
-            aware.putForAccount(account, key, cluster);
-            aware.deleteForAccount(account, entry.key());
+            aware.getForAccount(account, legacyKey)
+                    .filter(value -> belongsTo(value.getDbClusterArn(), account, region))
+                    .ifPresent(value -> migrateLegacyCluster(aware, account, region, value));
         }
     }
 
     private void migrateLegacyInstances(AccountAwareStorageBackend<NeptuneInstance> aware,
                                         String account, String region) {
-        for (AccountAwareStorageBackend.AccountEntry<NeptuneInstance> entry
-                : aware.scanAllAccountEntries(key -> !key.contains("/"))) {
-            NeptuneInstance instance = entry.value();
-            if (!account.equals(entry.accountId())
-                    || !belongsTo(instance.getDbInstanceArn(), account, region)) {
+        if (account.equals(regionResolver.getDefaultAccountId())) {
+            for (NeptuneInstance instance : aware.scanUnscopedLegacy(value -> belongsTo(
+                    value.getDbInstanceArn(), account, region))) {
+                migrateLegacyInstance(aware, account, region, instance);
+            }
+        }
+        for (String legacyKey : aware.keysForAccount(account)) {
+            if (legacyKey.contains("/")) {
                 continue;
             }
-            String key = instanceKey(region, instance.getDbInstanceIdentifier());
-            aware.putForAccount(account, key, instance);
-            aware.deleteForAccount(account, entry.key());
+            aware.getForAccount(account, legacyKey)
+                    .filter(value -> belongsTo(value.getDbInstanceArn(), account, region))
+                    .ifPresent(value -> migrateLegacyInstance(aware, account, region, value));
         }
+    }
+
+    private void migrateLegacyCluster(AccountAwareStorageBackend<NeptuneCluster> aware,
+                                      String account, String region, NeptuneCluster cluster) {
+        String key = clusterKey(region, cluster.getDbClusterIdentifier());
+        aware.getForAccountMigratingLegacyKeys(account, key,
+                java.util.List.of(cluster.getDbClusterIdentifier()),
+                value -> belongsTo(value.getDbClusterArn(), account, region))
+                .ifPresent(value -> aware.putForAccount(account, key, value));
+    }
+
+    private void migrateLegacyInstance(AccountAwareStorageBackend<NeptuneInstance> aware,
+                                       String account, String region, NeptuneInstance instance) {
+        String key = instanceKey(region, instance.getDbInstanceIdentifier());
+        aware.getForAccountMigratingLegacyKeys(account, key,
+                java.util.List.of(instance.getDbInstanceIdentifier()),
+                value -> belongsTo(value.getDbInstanceArn(), account, region))
+                .ifPresent(value -> aware.putForAccount(account, key, value));
     }
 
     private void putCluster(NeptuneCluster cluster) {
@@ -647,7 +671,7 @@ public class NeptuneService {
         try {
             return AwsArnUtils.parse(arn).accountId();
         } catch (IllegalArgumentException e) {
-            return null;
+            return "";
         }
     }
 
@@ -655,7 +679,7 @@ public class NeptuneService {
         try {
             return AwsArnUtils.parse(arn).region();
         } catch (IllegalArgumentException e) {
-            return null;
+            return "";
         }
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManager.java
@@ -72,10 +72,6 @@ public class NeptuneContainerManager {
      *
      * @return the container handle, or {@code null} when no Docker daemon is reachable
      */
-    public NeptuneContainerHandle tryStart(String clusterId, String image, NeptuneDbType dbType) {
-        return tryStart(clusterId, image, dbType, regionResolver.getAccountId(), regionResolver.getDefaultRegion());
-    }
-
     public NeptuneContainerHandle tryStart(String clusterId, String image, NeptuneDbType dbType,
                                            String accountId, String region) {
         try {
@@ -109,10 +105,6 @@ public class NeptuneContainerManager {
             LOG.debugv("Docker daemon is not reachable: {0}", e.getMessage());
             return false;
         }
-    }
-
-    public NeptuneContainerHandle start(String clusterId, String image, NeptuneDbType dbType) {
-        return start(clusterId, image, dbType, regionResolver.getAccountId(), regionResolver.getDefaultRegion());
     }
 
     public NeptuneContainerHandle start(String clusterId, String image, NeptuneDbType dbType,

--- a/src/main/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManager.java
@@ -73,8 +73,13 @@ public class NeptuneContainerManager {
      * @return the container handle, or {@code null} when no Docker daemon is reachable
      */
     public NeptuneContainerHandle tryStart(String clusterId, String image, NeptuneDbType dbType) {
+        return tryStart(clusterId, image, dbType, regionResolver.getAccountId(), regionResolver.getDefaultRegion());
+    }
+
+    public NeptuneContainerHandle tryStart(String clusterId, String image, NeptuneDbType dbType,
+                                           String accountId, String region) {
         try {
-            NeptuneContainerHandle handle = start(clusterId, image, dbType);
+            NeptuneContainerHandle handle = start(clusterId, image, dbType, accountId, region);
             dockerUnavailableLogged = false;
             return handle;
         } catch (RuntimeException e) {
@@ -107,10 +112,16 @@ public class NeptuneContainerManager {
     }
 
     public NeptuneContainerHandle start(String clusterId, String image, NeptuneDbType dbType) {
+        return start(clusterId, image, dbType, regionResolver.getAccountId(), regionResolver.getDefaultRegion());
+    }
+
+    public NeptuneContainerHandle start(String clusterId, String image, NeptuneDbType dbType,
+                                        String accountId, String region) {
         LOG.infov("Starting Neptune backend container ({0}) for cluster: {1}", dbType, clusterId);
 
         int backendPort = dbType.backendPort();
-        String containerName = containerName(clusterId);
+        String identity = resourceIdentity(accountId, region, clusterId);
+        String containerName = containerName(identity);
         lifecycleManager.removeIfExists(containerName);
 
         ContainerBuilder.Builder specBuilder = containerBuilder.newContainer(image)
@@ -119,7 +130,7 @@ public class NeptuneContainerManager {
                 .withDockerNetwork(config.services().neptune().dockerNetwork())
                 .withLogRotation()
                 .withLabels(ContainerStorageHelper.resourceIdentityLabels(
-                        "neptune", clusterId, regionResolver.getAccountId(), regionResolver.getDefaultRegion()));
+                        "neptune", clusterId, accountId, region));
 
         if (!containerDetector.isRunningInContainer()) {
             specBuilder.withDynamicPort(backendPort);
@@ -134,18 +145,17 @@ public class NeptuneContainerManager {
         LOG.infov("Neptune {0} backend for cluster {1}: {2}", dbType, clusterId, endpoint);
 
         NeptuneContainerHandle handle = new NeptuneContainerHandle(
-                info.containerId(), clusterId, endpoint.host(), endpoint.port());
-        activeContainers.put(clusterId, handle);
+                info.containerId(), identity, endpoint.host(), endpoint.port());
+        activeContainers.put(identity, handle);
 
         String shortId = info.containerId().length() >= 8
                 ? info.containerId().substring(0, 8)
                 : info.containerId();
-        String logGroup = "/aws/neptune/cluster/" + clusterId + "/" + dbType.name().toLowerCase() + "-log";
+        String logGroup = "/aws/neptune/cluster/" + identity + "/" + dbType.name().toLowerCase() + "-log";
         String logStream = logStreamer.generateLogStreamName(shortId);
-        String region = regionResolver.getDefaultRegion();
 
         Closeable logHandle = logStreamer.attach(
-                info.containerId(), logGroup, logStream, region, "neptune:" + clusterId);
+                info.containerId(), logGroup, logStream, region, "neptune:" + identity);
         handle.setLogStream(logHandle);
 
         waitForBackendReady(clusterId, dbType, endpoint.host(), endpoint.port());
@@ -190,6 +200,10 @@ public class NeptuneContainerManager {
             return;
         }
         lifecycleManager.removeIfExists(containerName(clusterId));
+    }
+
+    private static String resourceIdentity(String accountId, String region, String clusterId) {
+        return accountId + "-" + region + "-" + clusterId;
     }
 
     private String containerName(String clusterId) {

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -60,6 +60,7 @@ class NeptuneServiceTest {
         when(regionResolver.getAccountId()).thenAnswer(invocation -> currentAccount);
         when(regionResolver.getRegion()).thenAnswer(invocation -> currentRegion);
         when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
+        when(regionResolver.getDefaultAccountId()).thenReturn("000000000000");
         when(regionResolver.buildArn(anyString(), anyString(), anyString()))
                 .thenAnswer(invocation -> "arn:aws:" + invocation.getArgument(0)
                         + ":" + invocation.getArgument(1) + ":" + currentAccount

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/NeptuneServiceTest.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -42,6 +43,10 @@ class NeptuneServiceTest {
     private NeptuneContainerManager containerManager;
     private NeptuneProxyManager proxyManager;
     private EmulatorConfig.NeptuneServiceConfig neptuneConfig;
+    private RegionResolver regionResolver;
+    private String currentAccount;
+    private String currentRegion;
+    private AccountAwareStorageBackend<NeptuneCluster> clusterStorage;
 
     @BeforeEach
     void setUp() {
@@ -49,7 +54,16 @@ class NeptuneServiceTest {
         proxyManager = mock(NeptuneProxyManager.class);
         StorageFactory storageFactory = mock(StorageFactory.class);
         EmulatorConfig config = mock(EmulatorConfig.class);
-        RegionResolver regionResolver = new RegionResolver("us-east-1", "000000000000");
+        currentAccount = "000000000000";
+        currentRegion = "us-east-1";
+        regionResolver = mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenAnswer(invocation -> currentAccount);
+        when(regionResolver.getRegion()).thenAnswer(invocation -> currentRegion);
+        when(regionResolver.getDefaultRegion()).thenReturn("us-east-1");
+        when(regionResolver.buildArn(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> "arn:aws:" + invocation.getArgument(0)
+                        + ":" + invocation.getArgument(1) + ":" + currentAccount
+                        + ":" + invocation.getArgument(2));
 
         EmulatorConfig.ServicesConfig servicesConfig = mock(EmulatorConfig.ServicesConfig.class);
         neptuneConfig = mock(EmulatorConfig.NeptuneServiceConfig.class);
@@ -63,8 +77,14 @@ class NeptuneServiceTest {
         when(config.hostname()).thenReturn(Optional.of("localhost"));
 
         when(storageFactory.create(anyString(), anyString(), any()))
-                .thenAnswer(inv -> AccountAwareStorageBackend.inMemory("000000000000"));
-        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class)))
+                .thenAnswer(inv -> {
+                    AccountAwareStorageBackend<?> store = AccountAwareStorageBackend.inMemory("000000000000");
+                    if ("neptune-clusters.json".equals(inv.getArgument(1))) {
+                        clusterStorage = (AccountAwareStorageBackend<NeptuneCluster>) store;
+                    }
+                    return store;
+                });
+        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class), anyString(), anyString()))
                 .thenReturn(new NeptuneContainerHandle("cid", "c", "localhost", 8182));
         doNothing().when(proxyManager).startProxy(anyString(), anyInt(), anyString(), anyInt());
 
@@ -72,22 +92,63 @@ class NeptuneServiceTest {
     }
 
     @Test
+    void sameNameClustersAreIsolatedByAccountAndRegion() {
+        NeptuneCluster first = service.createDbCluster("shared", "1.3.2.1", false);
+        NeptuneInstance firstInstance = service.createDbInstance(
+                "shared-instance", "shared", "db.r5.large", null, false);
+
+        currentAccount = "111111111111";
+        currentRegion = "eu-west-1";
+        NeptuneCluster second = service.createDbCluster("shared", "1.3.2.1", false);
+        NeptuneInstance secondInstance = service.createDbInstance(
+                "shared-instance", "shared", "db.r5.large", null, false);
+
+        assertNotEquals(first.getDbClusterArn(), second.getDbClusterArn());
+        assertNotEquals(firstInstance.getDbInstanceArn(), secondInstance.getDbInstanceArn());
+        assertEquals(second.getDbClusterArn(), service.getDbCluster("shared").getDbClusterArn());
+        assertEquals(secondInstance.getDbInstanceArn(), service.getDbInstance("shared-instance").getDbInstanceArn());
+        assertEquals(1, service.listDbClusters(null).size());
+        assertEquals(1, service.listDbInstances(null).size());
+
+        currentAccount = "000000000000";
+        currentRegion = "us-east-1";
+        assertEquals(first.getDbClusterArn(), service.getDbCluster("shared").getDbClusterArn());
+        assertEquals(firstInstance.getDbInstanceArn(), service.getDbInstance("shared-instance").getDbInstanceArn());
+        assertEquals(1, service.listDbClusters(null).size());
+        assertEquals(1, service.listDbInstances(null).size());
+    }
+
+    @Test
+    void legacyClusterIsMigratedOnlyWhenItsArnMatchesTheRequestedScope() {
+        NeptuneCluster legacy = new NeptuneCluster();
+        legacy.setDbClusterIdentifier("legacy");
+        legacy.setDbClusterArn("arn:aws:neptune:us-east-1:000000000000:cluster:legacy");
+        clusterStorage.putForAccount("000000000000", "legacy", legacy);
+
+        assertEquals("legacy", service.getDbCluster("legacy").getDbClusterIdentifier());
+
+        currentRegion = "eu-west-1";
+        assertEquals("DBClusterNotFoundFault",
+                assertThrows(AwsException.class, () -> service.getDbCluster("legacy")).getErrorCode());
+    }
+
+    @Test
     void failedProvisioningRollsBackContainerAndReleasesProxyPort() {
         NeptuneContainerHandle handle = new NeptuneContainerHandle("cid", "c", "localhost", 8182);
-        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class)))
+        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class), anyString(), anyString()))
                 .thenReturn(handle);
 
         // Proxy startup blows up after the port is reserved and the container is started.
         doThrow(new RuntimeException("proxy boom"))
-                .when(proxyManager).startProxy(eq("c"), anyInt(), anyString(), anyInt());
+                .when(proxyManager).startProxy(eq("000000000000-us-east-1-c"), anyInt(), anyString(), anyInt());
 
         // The original failure must propagate to the caller (we clean up, then rethrow).
         assertThrows(RuntimeException.class,
                 () -> service.createDbCluster("c", "1.3.2.1", false));
 
         // Rollback stopped the proxy and the already-started container (by id).
-        verify(proxyManager).stopProxy("c");
-        verify(containerManager).stopByClusterId("c");
+        verify(proxyManager).stopProxy("000000000000-us-east-1-c");
+        verify(containerManager).stopByClusterId("000000000000-us-east-1-c");
 
         // The reserved proxy port was released: a subsequent successful create reuses the base port
         // instead of skipping to the next one (which is what a leak would cause).
@@ -100,20 +161,20 @@ class NeptuneServiceTest {
     @Test
     void jvmErrorDuringProvisioningStillRollsBack() {
         NeptuneContainerHandle handle = new NeptuneContainerHandle("cid", "c", "localhost", 8182);
-        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class)))
+        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class), anyString(), anyString()))
                 .thenReturn(handle);
 
         // A JVM Error (not a RuntimeException) escapes provisioning — a catch (RuntimeException)
         // would miss it, so rollback must run from a finally instead.
         doThrow(new StackOverflowError("boom"))
-                .when(proxyManager).startProxy(eq("c"), anyInt(), anyString(), anyInt());
+                .when(proxyManager).startProxy(eq("000000000000-us-east-1-c"), anyInt(), anyString(), anyInt());
 
         assertThrows(StackOverflowError.class,
                 () -> service.createDbCluster("c", "1.3.2.1", false));
 
         // Rollback still fired despite the Error: proxy and container stopped, port released.
-        verify(proxyManager).stopProxy("c");
-        verify(containerManager).stopByClusterId("c");
+        verify(proxyManager).stopProxy("000000000000-us-east-1-c");
+        verify(containerManager).stopByClusterId("000000000000-us-east-1-c");
 
         doNothing().when(proxyManager).startProxy(anyString(), anyInt(), anyString(), anyInt());
         NeptuneCluster recovered = service.createDbCluster("c2", "1.3.2.1", false);
@@ -127,7 +188,7 @@ class NeptuneServiceTest {
         // and (crucially) a readiness timeout, where start() created + registered the container
         // before throwing, so no handle ever reaches the service.
         doThrow(new RuntimeException("readiness boom"))
-                .when(containerManager).tryStart(eq("c"), anyString(), any(NeptuneDbType.class));
+                .when(containerManager).tryStart(eq("c"), anyString(), any(NeptuneDbType.class), anyString(), anyString());
 
         // The original failure must propagate to the caller (we clean up, then rethrow).
         assertThrows(RuntimeException.class,
@@ -137,10 +198,10 @@ class NeptuneServiceTest {
         verify(proxyManager, never()).stopProxy(anyString());
         // ...but the container must still be cleaned up by id, since start() may have created and
         // registered it before failing. Cleaning up by handle here would orphan it.
-        verify(containerManager).stopByClusterId("c");
+        verify(containerManager).stopByClusterId("000000000000-us-east-1-c");
 
         // The reserved proxy port was still released: a subsequent successful create reuses the base port.
-        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class)))
+        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class), anyString(), anyString()))
                 .thenReturn(new NeptuneContainerHandle("cid", "c2", "localhost", 8182));
         NeptuneCluster recovered = service.createDbCluster("c2", "1.3.2.1", false);
         assertEquals(18182, recovered.getProxyPort(),
@@ -192,7 +253,7 @@ class NeptuneServiceTest {
         // tryStart() returns null when no Docker daemon is reachable. The cluster record is
         // metadata, so the create still succeeds, the cluster reaches 'available' on the first
         // describe (what SDK/Terraform waiters poll), and no proxy is started.
-        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class))).thenReturn(null);
+        when(containerManager.tryStart(anyString(), anyString(), any(NeptuneDbType.class), anyString(), anyString())).thenReturn(null);
 
         NeptuneCluster created = service.createDbCluster("no-docker-cluster", "1.3.2.1", false);
 

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManagerTest.java
@@ -62,7 +62,8 @@ class NeptuneContainerManagerTest {
         NeptuneContainerManager manager = newManager(lifecycleManager);
 
         for (int attempt = 0; attempt < 3; attempt++) {
-            assertNull(manager.tryStart("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN),
+            assertNull(manager.tryStart("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN,
+                    "000000000000", "us-east-1"),
                     "attempt " + attempt + " should report unavailable");
         }
         assertFalse(manager.isDockerReachable());
@@ -81,7 +82,8 @@ class NeptuneContainerManagerTest {
         NeptuneContainerManager manager = newManager(lifecycleManager);
 
         RuntimeException failure = assertThrows(RuntimeException.class,
-                () -> manager.tryStart("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN));
+                () -> manager.tryStart("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN,
+                        "000000000000", "us-east-1"));
         assertEquals("no such image: tinkerpop/gremlin-server:3.7.3", failure.getMessage());
     }
 
@@ -112,7 +114,8 @@ class NeptuneContainerManagerTest {
             NeptuneContainerManager manager = newManager(lifecycleManager);
 
             NeptuneContainerHandle handle =
-                    manager.tryStart("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN);
+                    manager.tryStart("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN,
+                            "000000000000", "us-east-1");
 
             assertEquals("container-id", handle.getContainerId());
             assertEquals(serverSocket.getLocalPort(), handle.getPort());

--- a/src/test/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManagerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/neptune/container/NeptuneContainerManagerTest.java
@@ -157,14 +157,16 @@ class NeptuneContainerManagerTest {
                     mock(ContainerLogStreamer.class), mock(ContainerDetector.class), config,
                     new RegionResolver("us-east-1", "000000000000"));
 
-            manager.start("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN);
+            manager.start("cluster1", "tinkerpop/gremlin-server:3.7.3", NeptuneDbType.GREMLIN,
+                    "111111111111", "eu-west-1");
 
             verify(builder).withLabels(Map.of(
                     "io.floci", "aws",
                     "io.floci.service", "neptune",
                     "io.floci.resource-id", "cluster1",
-                    "io.floci.account", "000000000000",
-                    "io.floci.region", "us-east-1"));
+                    "io.floci.account", "111111111111",
+                    "io.floci.region", "eu-west-1"));
+            verify(builder).withName("floci-neptune-111111111111-eu-west-1-cluster1");
         }
     }
 


### PR DESCRIPTION
## Summary

Isolate Neptune clusters and instances by AWS account and Region so identical identifiers cannot share metadata or runtime resources.

The change scopes storage, proxy identities, Docker container identities, log identities, and tag operations. Legacy records are migrated only when their stored ARN proves the requested account and Region.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Neptune administrative resources are regional and account-owned. Floci now applies the request account and Region consistently to cluster and instance lookups, runtime resources, and tags while preserving the existing response shapes and handler interfaces.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
