### PR TITLE
fix(transfer): isolate servers and users by account and region

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/transfer/TransferService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transfer/TransferService.java
@@ -2,9 +2,10 @@ package io.github.hectorvent.floci.services.transfer;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.RegionResolver;
-import io.github.hectorvent.floci.core.storage.StorageBackend;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
 import io.github.hectorvent.floci.core.storage.StorageFactory;
 import io.github.hectorvent.floci.services.transfer.model.HomeDirectoryMapping;
 import io.github.hectorvent.floci.services.transfer.model.Server;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -25,9 +27,9 @@ public class TransferService {
 
     private static final String CHARS = "abcdefghijklmnopqrstuvwxyz0123456789";
 
-    private final StorageBackend<String, Server> serverStore;
-    private final StorageBackend<String, User> userStore;
-    private final StorageBackend<String, Map<String, String>> tagStore;
+    private final AccountAwareStorageBackend<Server> serverStore;
+    private final AccountAwareStorageBackend<User> userStore;
+    private final AccountAwareStorageBackend<Map<String, String>> tagStore;
     private final RegionResolver regionResolver;
 
     @Inject
@@ -72,17 +74,17 @@ public class TransferService {
         server.setTags(tags != null ? tags : new HashMap<>());
         server.setCreationTime(Instant.now());
 
-        serverStore.put(serverId, server);
+        putServer(server);
 
         if (tags != null && !tags.isEmpty()) {
-            tagStore.put("server/" + serverId, new HashMap<>(tags));
+            putTags("server/" + serverId, tags);
         }
 
         return server;
     }
 
     public Server getServer(String serverId) {
-        return serverStore.get(serverId).orElseThrow(() ->
+        return findServer(serverId).orElseThrow(() ->
                 new AwsException("ResourceNotFoundException",
                         "Server " + serverId + " does not exist.", 404));
     }
@@ -90,17 +92,20 @@ public class TransferService {
     public synchronized void deleteServer(String serverId) {
         // AWS deletes a server in any state: the DeleteServer API defines no
         // state precondition (and no ConflictException at all).
-        getServer(serverId);
-        serverStore.delete(serverId);
-        tagStore.delete("server/" + serverId);
-        for (User user : userStore.scan(k -> k.startsWith(serverId + "/"))) {
-            userStore.delete(serverId + "/" + user.getUserName());
-            tagStore.delete("user/" + serverId + "/" + user.getUserName());
+        Server server = getServer(serverId);
+        deleteServerRecord(server);
+        for (User user : userStore.scanForAccount(currentAccount(),
+                k -> k.startsWith(scopedKey(currentRegion(), serverId) + "/"))) {
+            deleteUserRecord(user);
         }
     }
 
     public List<Server> listServers(String nextToken, int maxResults) {
-        List<Server> all = new ArrayList<>(serverStore.scan(k -> true));
+        List<Server> all = new ArrayList<>(serverStore.scanForAccount(currentAccount(),
+                k -> k.startsWith(currentRegion() + "/")));
+        for (Server legacy : serverStore.scanUnscopedLegacy(s -> owns(s, currentAccount(), currentRegion()))) {
+            findServer(legacy.getServerId()).ifPresent(all::add);
+        }
         all.sort((a, b) -> a.getServerId().compareTo(b.getServerId()));
         if (nextToken != null && !nextToken.isEmpty()) {
             int idx = 0;
@@ -125,7 +130,7 @@ public class TransferService {
                     "Server is not in OFFLINE state.", 409);
         }
         server.setState("ONLINE");
-        serverStore.put(serverId, server);
+        putServer(server);
         return server;
     }
 
@@ -136,7 +141,7 @@ public class TransferService {
                     "Server is not in ONLINE state.", 409);
         }
         server.setState("OFFLINE");
-        serverStore.put(serverId, server);
+        putServer(server);
         return server;
     }
 
@@ -163,7 +168,7 @@ public class TransferService {
         if (securityPolicyName != null) {
             server.setSecurityPolicyName(securityPolicyName);
         }
-        serverStore.put(serverId, server);
+        putServer(server);
         return server;
     }
 
@@ -174,8 +179,8 @@ public class TransferService {
                            List<HomeDirectoryMapping> homeDirectoryMappings,
                            Map<String, String> tags) {
         getServer(serverId);
-        String key = serverId + "/" + userName;
-        if (userStore.get(key).isPresent()) {
+        String key = userKey(serverId, userName);
+        if (findUser(serverId, userName).isPresent()) {
             throw new AwsException("ResourceExistsException",
                     "User " + userName + " already exists on server " + serverId + ".", 400);
         }
@@ -191,10 +196,10 @@ public class TransferService {
         user.setSshPublicKeys(new ArrayList<>());
         user.setTags(tags != null ? tags : new HashMap<>());
 
-        userStore.put(key, user);
+        putUser(user);
 
         if (tags != null && !tags.isEmpty()) {
-            tagStore.put("user/" + key, new HashMap<>(tags));
+            putTags("user/" + key, tags);
         }
 
         return user;
@@ -202,21 +207,23 @@ public class TransferService {
 
     public User getUser(String serverId, String userName) {
         getServer(serverId);
-        return userStore.get(serverId + "/" + userName).orElseThrow(() ->
+        return findUser(serverId, userName).orElseThrow(() ->
                 new AwsException("ResourceNotFoundException",
                         "User " + userName + " does not exist on server " + serverId + ".", 404));
     }
 
     public void deleteUser(String serverId, String userName) {
-        getUser(serverId, userName);
-        String key = serverId + "/" + userName;
-        userStore.delete(key);
-        tagStore.delete("user/" + key);
+        deleteUserRecord(getUser(serverId, userName));
     }
 
     public List<User> listUsers(String serverId, String nextToken, int maxResults) {
         getServer(serverId);
-        List<User> all = new ArrayList<>(userStore.scan(k -> k.startsWith(serverId + "/")));
+        List<User> all = new ArrayList<>(userStore.scanForAccount(currentAccount(),
+                k -> k.startsWith(scopedKey(currentRegion(), serverId) + "/")));
+        for (User legacy : userStore.scanUnscopedLegacy(u -> owns(u, currentAccount(), currentRegion())
+                && u.getArn().contains("/" + serverId + "/"))) {
+            findUser(serverId, legacy.getUserName()).ifPresent(all::add);
+        }
         all.sort((a, b) -> a.getUserName().compareTo(b.getUserName()));
         if (nextToken != null && !nextToken.isEmpty()) {
             int idx = 0;
@@ -242,7 +249,7 @@ public class TransferService {
         if (homeDirectory != null) user.setHomeDirectory(homeDirectory);
         if (homeDirectoryType != null) user.setHomeDirectoryType(homeDirectoryType);
         if (homeDirectoryMappings != null) user.setHomeDirectoryMappings(homeDirectoryMappings);
-        userStore.put(serverId + "/" + userName, user);
+        putUser(user);
         return user;
     }
 
@@ -255,7 +262,7 @@ public class TransferService {
         List<SshPublicKey> keys = new ArrayList<>(user.getSshPublicKeys() != null ? user.getSshPublicKeys() : List.of());
         keys.add(key);
         user.setSshPublicKeys(keys);
-        userStore.put(serverId + "/" + userName, user);
+        putUser(user);
         return key;
     }
 
@@ -268,21 +275,22 @@ public class TransferService {
                     "SSH public key " + sshPublicKeyId + " does not exist.", 404);
         }
         user.setSshPublicKeys(keys);
-        userStore.put(serverId + "/" + userName, user);
+        putUser(user);
     }
 
     // ── Tags ──────────────────────────────────────────────────────────────────
 
     public Map<String, String> listTagsForResource(String arn) {
         String key = arnToTagKey(arn);
-        return tagStore.get(key).orElse(new HashMap<>());
+        return tagStore.getForAccount(currentAccount(), scopedKey(currentRegion(), key)).orElse(new HashMap<>());
     }
 
     public void tagResource(String arn, Map<String, String> tags) {
         String key = arnToTagKey(arn);
-        Map<String, String> existing = new HashMap<>(tagStore.get(key).orElse(new HashMap<>()));
+        Map<String, String> existing = new HashMap<>(tagStore.getForAccount(currentAccount(), scopedKey(currentRegion(), key))
+                .orElse(new HashMap<>()));
         existing.putAll(tags);
-        tagStore.put(key, existing);
+        putTags(key, existing);
 
         // Also sync tags into the resource object
         syncTagsToResource(arn, existing);
@@ -290,9 +298,10 @@ public class TransferService {
 
     public void untagResource(String arn, List<String> tagKeys) {
         String key = arnToTagKey(arn);
-        Map<String, String> existing = new HashMap<>(tagStore.get(key).orElse(new HashMap<>()));
+        Map<String, String> existing = new HashMap<>(tagStore.getForAccount(currentAccount(), scopedKey(currentRegion(), key))
+                .orElse(new HashMap<>()));
         tagKeys.forEach(existing::remove);
-        tagStore.put(key, existing);
+        putTags(key, existing);
         syncTagsToResource(arn, existing);
     }
 
@@ -306,30 +315,134 @@ public class TransferService {
     }
 
     private String arnToTagKey(String arn) {
-        // arn:aws:transfer:region:account:server/s-xxx  → server/s-xxx
-        // arn:aws:transfer:region:account:user/s-xxx/alice → user/s-xxx/alice
-        int idx = arn.lastIndexOf(':');
-        return idx >= 0 ? arn.substring(idx + 1) : arn;
+        AwsArnUtils.Arn parsed;
+        try {
+            parsed = AwsArnUtils.parse(arn);
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ResourceNotFoundException", "Resource " + arn + " does not exist.", 404);
+        }
+        if (!"transfer".equals(parsed.service())
+                || !currentAccount().equals(parsed.accountId())
+                || !currentRegion().equals(parsed.region())) {
+            throw new AwsException("ResourceNotFoundException", "Resource " + arn + " does not exist.", 404);
+        }
+        String resource = parsed.resource();
+        if (resource.startsWith("server/")) {
+            getServer(resource.substring("server/".length()));
+        } else if (resource.startsWith("user/")) {
+            String[] parts = resource.substring("user/".length()).split("/", 2);
+            if (parts.length != 2) {
+                throw new AwsException("ResourceNotFoundException", "Resource " + arn + " does not exist.", 404);
+            }
+            getUser(parts[0], parts[1]);
+        } else {
+            throw new AwsException("ResourceNotFoundException", "Resource " + arn + " does not exist.", 404);
+        }
+        return resource;
     }
 
     private void syncTagsToResource(String arn, Map<String, String> tags) {
         String key = arnToTagKey(arn);
         if (key.startsWith("server/")) {
             String serverId = key.substring("server/".length());
-            serverStore.get(serverId).ifPresent(s -> {
+            serverStore.getForAccount(currentAccount(), scopedKey(currentRegion(), serverId)).ifPresent(s -> {
                 s.setTags(tags);
-                serverStore.put(serverId, s);
+                putServer(s);
             });
         } else if (key.startsWith("user/")) {
             String userKey = key.substring("user/".length());
-            userStore.get(userKey).ifPresent(u -> {
+            userStore.getForAccount(currentAccount(), scopedKey(currentRegion(), userKey)).ifPresent(u -> {
                 u.setTags(tags);
-                userStore.put(userKey, u);
+                putUser(u);
             });
         }
     }
 
     public int countUsers(String serverId) {
-        return (int) userStore.scan(k -> k.startsWith(serverId + "/")).stream().count();
+        return (int) userStore.scanForAccount(currentAccount(),
+                k -> k.startsWith(scopedKey(currentRegion(), serverId) + "/")).stream().count();
+    }
+
+    private Optional<Server> findServer(String serverId) {
+        String accountId = currentAccount();
+        String region = currentRegion();
+        return serverStore.getForAccountMigratingLegacyKeys(accountId, scopedKey(region, serverId),
+                List.of(serverId), server -> owns(server, accountId, region));
+    }
+
+    private Optional<User> findUser(String serverId, String userName) {
+        String accountId = currentAccount();
+        String region = currentRegion();
+        String key = userKey(serverId, userName);
+        return userStore.getForAccountMigratingLegacyKeys(accountId, scopedKey(region, key),
+                List.of(key), user -> owns(user, accountId, region));
+    }
+
+    private void putServer(Server server) {
+        serverStore.putForAccount(currentAccount(), scopedKey(regionOf(server), server.getServerId()), server);
+    }
+
+    private void deleteServerRecord(Server server) {
+        serverStore.deleteForAccount(currentAccount(), scopedKey(regionOf(server), server.getServerId()));
+        tagStore.deleteForAccount(currentAccount(), scopedKey(regionOf(server), "server/" + server.getServerId()));
+    }
+
+    private void putUser(User user) {
+        String[] resource = AwsArnUtils.parse(user.getArn()).resource().substring("user/".length()).split("/", 2);
+        userStore.putForAccount(currentAccount(), scopedKey(regionOf(user), userKey(resource[0], resource[1])), user);
+    }
+
+    private void deleteUserRecord(User user) {
+        String[] resource = AwsArnUtils.parse(user.getArn()).resource().substring("user/".length()).split("/", 2);
+        String key = userKey(resource[0], resource[1]);
+        userStore.deleteForAccount(currentAccount(), scopedKey(regionOf(user), key));
+        tagStore.deleteForAccount(currentAccount(), scopedKey(regionOf(user), "user/" + key));
+    }
+
+    private void putTags(String key, Map<String, String> tags) {
+        tagStore.putForAccount(currentAccount(), scopedKey(currentRegion(), key), new HashMap<>(tags));
+    }
+
+    private String currentAccount() {
+        return regionResolver.getAccountId();
+    }
+
+    private String currentRegion() {
+        return regionResolver.getRegion();
+    }
+
+    private static String scopedKey(String region, String key) {
+        return region + "/" + key;
+    }
+
+    private static String userKey(String serverId, String userName) {
+        return serverId + "/" + userName;
+    }
+
+    private static boolean owns(Server server, String accountId, String region) {
+        return ownsArn(server.getArn(), accountId, region);
+    }
+
+    private static boolean owns(User user, String accountId, String region) {
+        return ownsArn(user.getArn(), accountId, region);
+    }
+
+    private static boolean ownsArn(String arn, String accountId, String region) {
+        try {
+            AwsArnUtils.Arn parsed = AwsArnUtils.parse(arn);
+            return "transfer".equals(parsed.service())
+                    && accountId.equals(parsed.accountId())
+                    && region.equals(parsed.region());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private static String regionOf(Server server) {
+        return AwsArnUtils.parse(server.getArn()).region();
+    }
+
+    private static String regionOf(User user) {
+        return AwsArnUtils.parse(user.getArn()).region();
     }
 }

--- a/src/main/java/io/github/hectorvent/floci/services/transfer/TransferService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/transfer/TransferService.java
@@ -56,6 +56,7 @@ public class TransferService {
                                String securityPolicyName,
                                Map<String, String> tags) {
         String serverId = generateServerId();
+        region = currentRegion();
         String arn = regionResolver.buildArn("transfer", region, "server/" + serverId);
 
         Server server = new Server();
@@ -94,6 +95,7 @@ public class TransferService {
         // state precondition (and no ConflictException at all).
         Server server = getServer(serverId);
         deleteServerRecord(server);
+        migrateLegacyUsers(currentAccount(), currentRegion(), serverId);
         for (User user : userStore.scanForAccount(currentAccount(),
                 k -> k.startsWith(scopedKey(currentRegion(), serverId) + "/"))) {
             deleteUserRecord(user);
@@ -101,11 +103,9 @@ public class TransferService {
     }
 
     public List<Server> listServers(String nextToken, int maxResults) {
+        migrateLegacyServers(currentAccount(), currentRegion());
         List<Server> all = new ArrayList<>(serverStore.scanForAccount(currentAccount(),
                 k -> k.startsWith(currentRegion() + "/")));
-        for (Server legacy : serverStore.scanUnscopedLegacy(s -> owns(s, currentAccount(), currentRegion()))) {
-            findServer(legacy.getServerId()).ifPresent(all::add);
-        }
         all.sort((a, b) -> a.getServerId().compareTo(b.getServerId()));
         if (nextToken != null && !nextToken.isEmpty()) {
             int idx = 0;
@@ -185,6 +185,7 @@ public class TransferService {
                     "User " + userName + " already exists on server " + serverId + ".", 400);
         }
 
+        region = currentRegion();
         String arn = regionResolver.buildArn("transfer", region, "user/" + serverId + "/" + userName);
         User user = new User();
         user.setUserName(userName);
@@ -218,12 +219,9 @@ public class TransferService {
 
     public List<User> listUsers(String serverId, String nextToken, int maxResults) {
         getServer(serverId);
+        migrateLegacyUsers(currentAccount(), currentRegion(), serverId);
         List<User> all = new ArrayList<>(userStore.scanForAccount(currentAccount(),
                 k -> k.startsWith(scopedKey(currentRegion(), serverId) + "/")));
-        for (User legacy : userStore.scanUnscopedLegacy(u -> owns(u, currentAccount(), currentRegion())
-                && u.getArn().contains("/" + serverId + "/"))) {
-            findUser(serverId, legacy.getUserName()).ifPresent(all::add);
-        }
         all.sort((a, b) -> a.getUserName().compareTo(b.getUserName()));
         if (nextToken != null && !nextToken.isEmpty()) {
             int idx = 0;
@@ -282,13 +280,13 @@ public class TransferService {
 
     public Map<String, String> listTagsForResource(String arn) {
         String key = arnToTagKey(arn);
-        return tagStore.getForAccount(currentAccount(), scopedKey(currentRegion(), key)).orElse(new HashMap<>());
+        return storedTags(key);
     }
 
     public void tagResource(String arn, Map<String, String> tags) {
         String key = arnToTagKey(arn);
-        Map<String, String> existing = new HashMap<>(tagStore.getForAccount(currentAccount(), scopedKey(currentRegion(), key))
-                .orElse(new HashMap<>()));
+        Map<String, String> existing = new HashMap<>(storedTags(key));
+        resourceTags(arn).ifPresent(resource -> existing.putAll(resource));
         existing.putAll(tags);
         putTags(key, existing);
 
@@ -298,8 +296,7 @@ public class TransferService {
 
     public void untagResource(String arn, List<String> tagKeys) {
         String key = arnToTagKey(arn);
-        Map<String, String> existing = new HashMap<>(tagStore.getForAccount(currentAccount(), scopedKey(currentRegion(), key))
-                .orElse(new HashMap<>()));
+        Map<String, String> existing = new HashMap<>(storedTags(key));
         tagKeys.forEach(existing::remove);
         putTags(key, existing);
         syncTagsToResource(arn, existing);
@@ -359,6 +356,7 @@ public class TransferService {
     }
 
     public int countUsers(String serverId) {
+        migrateLegacyUsers(currentAccount(), currentRegion(), serverId);
         return (int) userStore.scanForAccount(currentAccount(),
                 k -> k.startsWith(scopedKey(currentRegion(), serverId) + "/")).stream().count();
     }
@@ -378,25 +376,102 @@ public class TransferService {
                 List.of(key), user -> owns(user, accountId, region));
     }
 
+    private void migrateLegacyServers(String account, String region) {
+        for (Server server : serverStore.scanUnscopedLegacy(value -> owns(value, account, region))) {
+            migrateServer(server, account, region);
+        }
+        for (String key : serverStore.keysForAccount(account)) {
+            if (key.contains("/")) {
+                continue;
+            }
+            serverStore.getForAccount(account, key)
+                    .filter(value -> owns(value, account, region))
+                    .ifPresent(value -> migrateServer(value, account, region));
+        }
+    }
+
+    private void migrateServer(Server server, String account, String region) {
+        String key = server.getServerId();
+        serverStore.getForAccountMigratingLegacyKeys(account, scopedKey(region, key), List.of(key),
+                value -> owns(value, account, region)).ifPresent(value ->
+                serverStore.putForAccount(account, scopedKey(region, key), value));
+    }
+
+    private void migrateLegacyUsers(String account, String region, String serverId) {
+        for (User user : userStore.scanUnscopedLegacy(value -> owns(value, account, region)
+                && userMatchesServer(value, serverId))) {
+            migrateUser(user, account, region, serverId);
+        }
+        for (String key : userStore.keysForAccount(account)) {
+            if (key.contains("/") && key.startsWith(region + "/")) {
+                continue;
+            }
+            userStore.getForAccount(account, key)
+                    .filter(value -> owns(value, account, region) && userMatchesServer(value, serverId))
+                    .ifPresent(value -> migrateUser(value, account, region, serverId));
+        }
+    }
+
+    private void migrateUser(User user, String account, String region, String serverId) {
+        String key = userKey(serverId, user.getUserName());
+        userStore.getForAccountMigratingLegacyKeys(account, scopedKey(region, key), List.of(key),
+                value -> owns(value, account, region)).ifPresent(value ->
+                userStore.putForAccount(account, scopedKey(region, key), value));
+    }
+
+    private static boolean userMatchesServer(User user, String serverId) {
+        try {
+            return AwsArnUtils.parse(user.getArn()).resource().equals("user/" + serverId + "/" + user.getUserName());
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private Map<String, String> storedTags(String key) {
+        String account = currentAccount();
+        String scoped = scopedKey(currentRegion(), key);
+        Map<String, String> merged = new HashMap<>(tagStore.getForAccount(account, scoped)
+                .orElseGet(HashMap::new));
+        tagStore.getForAccount(account, key).ifPresent(merged::putAll);
+        if (!merged.isEmpty()) {
+            tagStore.putForAccount(account, scoped, merged);
+        }
+        return tagStore.getForAccountMigratingLegacyKeys(account, scoped, List.of(key), ignored -> true)
+                .orElseGet(HashMap::new);
+    }
+
+    private Optional<Map<String, String>> resourceTags(String arn) {
+        String resource = AwsArnUtils.parse(arn).resource();
+        if (resource.startsWith("server/")) {
+            return Optional.ofNullable(getServer(resource.substring("server/".length())).getTags());
+        }
+        String[] parts = resource.substring("user/".length()).split("/", 2);
+        return Optional.ofNullable(getUser(parts[0], parts[1]).getTags());
+    }
+
     private void putServer(Server server) {
         serverStore.putForAccount(currentAccount(), scopedKey(regionOf(server), server.getServerId()), server);
     }
 
     private void deleteServerRecord(Server server) {
-        serverStore.deleteForAccount(currentAccount(), scopedKey(regionOf(server), server.getServerId()));
-        tagStore.deleteForAccount(currentAccount(), scopedKey(regionOf(server), "server/" + server.getServerId()));
+        String serverId = server.getServerId();
+        serverStore.deleteForAccount(currentAccount(), scopedKey(regionOf(server), serverId));
+        tagStore.deleteForAccount(currentAccount(), scopedKey(regionOf(server), "server/" + serverId));
+        tagStore.deleteForAccount(currentAccount(), "server/" + serverId);
     }
 
     private void putUser(User user) {
-        String[] resource = AwsArnUtils.parse(user.getArn()).resource().substring("user/".length()).split("/", 2);
+        String[] resource = userResourceParts(user);
         userStore.putForAccount(currentAccount(), scopedKey(regionOf(user), userKey(resource[0], resource[1])), user);
     }
 
     private void deleteUserRecord(User user) {
-        String[] resource = AwsArnUtils.parse(user.getArn()).resource().substring("user/".length()).split("/", 2);
+        String[] resource = userResourceParts(user);
         String key = userKey(resource[0], resource[1]);
         userStore.deleteForAccount(currentAccount(), scopedKey(regionOf(user), key));
         tagStore.deleteForAccount(currentAccount(), scopedKey(regionOf(user), "user/" + key));
+        userStore.deleteForAccount(currentAccount(), key);
+        tagStore.deleteForAccount(currentAccount(), "user/" + key);
     }
 
     private void putTags(String key, Map<String, String> tags) {
@@ -439,10 +514,33 @@ public class TransferService {
     }
 
     private static String regionOf(Server server) {
-        return AwsArnUtils.parse(server.getArn()).region();
+        return parseRegion(server.getArn());
     }
 
     private static String regionOf(User user) {
-        return AwsArnUtils.parse(user.getArn()).region();
+        return parseRegion(user.getArn());
+    }
+
+    private static String parseRegion(String arn) {
+        try {
+            return AwsArnUtils.parse(arn).region();
+        } catch (IllegalArgumentException e) {
+            throw new AwsException("ResourceNotFoundException", "Persisted Transfer resource has an invalid ARN.", 404);
+        }
+    }
+
+    private static String[] userResourceParts(User user) {
+        try {
+            String resource = AwsArnUtils.parse(user.getArn()).resource();
+            String[] parts = resource.startsWith("user/")
+                    ? resource.substring("user/".length()).split("/", 2)
+                    : new String[0];
+            if (parts.length == 2) {
+                return parts;
+            }
+        } catch (IllegalArgumentException ignored) {
+            // Convert corrupt persisted records into the AWS resource error below.
+        }
+        throw new AwsException("ResourceNotFoundException", "Persisted Transfer user has an invalid ARN.", 404);
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/transfer/TransferServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/transfer/TransferServiceTest.java
@@ -32,6 +32,7 @@ class TransferServiceTest {
     private AccountAwareStorageBackend<Server> serverStore;
     private AccountAwareStorageBackend<User> userStore;
     private InMemoryStorage<String, Server> serverDelegate;
+    private AccountAwareStorageBackend<Map<String, String>> tagStore;
     private TransferService service;
     private RegionResolver regionResolver;
     private RequestContext requestContext;
@@ -49,7 +50,7 @@ class TransferServiceTest {
                 "111111111111");
         userStore = new AccountAwareStorageBackend<>(new InMemoryStorage<>(), requestContextInstance,
                 "111111111111");
-        AccountAwareStorageBackend<Map<String, String>> tagStore = new AccountAwareStorageBackend<>(
+        tagStore = new AccountAwareStorageBackend<>(
                 new InMemoryStorage<>(), requestContextInstance, "111111111111");
         StorageFactory factory = new StorageFactory(null, null) {
             @Override
@@ -153,5 +154,41 @@ class TransferServiceTest {
         when(regionResolver.getAccountId()).thenReturn("222222222222");
         when(regionResolver.getRegion()).thenReturn("eu-west-1");
         assertThrows(AwsException.class, () -> service.getServer("s-legacy"));
+    }
+
+    @Test
+    void listMigratesAccountPrefixedLegacyServerAndUserRecords() {
+        Server server = new Server();
+        server.setServerId("s-legacy");
+        server.setArn("arn:aws:transfer:us-east-1:111111111111:server/s-legacy");
+        serverStore.putForAccount("111111111111", "s-legacy", server);
+
+        User user = new User();
+        user.setUserName("alice");
+        user.setArn("arn:aws:transfer:us-east-1:111111111111:user/s-legacy/alice");
+        userStore.putForAccount("111111111111", "s-legacy/alice", user);
+
+        assertEquals(1, service.listServers(null, 100).size());
+        assertEquals(1, service.listUsers("s-legacy", null, 100).size());
+        assertTrue(serverStore.getForAccount("111111111111", "s-legacy").isEmpty());
+        assertTrue(userStore.getForAccount("111111111111", "s-legacy/alice").isEmpty());
+        assertTrue(serverStore.getForAccount("111111111111", "us-east-1/s-legacy").isPresent());
+        assertTrue(userStore.getForAccount("111111111111", "us-east-1/s-legacy/alice").isPresent());
+        assertEquals(1, service.countUsers("s-legacy"));
+    }
+
+    @Test
+    void legacyTagsAreMigratedWithoutDroppingResourceTags() {
+        Server server = service.createServer("us-east-1", null, null, null, null,
+                null, null, null, null, Map.of("resource", "tag"));
+        tagStore.putForAccount("111111111111", "server/" + server.getServerId(),
+                new java.util.HashMap<>(Map.of("legacy", "tag")));
+
+        service.tagResource(server.getArn(), Map.of("new", "tag"));
+
+        assertEquals(Map.of("legacy", "tag", "resource", "tag", "new", "tag"),
+                service.listTagsForResource(server.getArn()));
+        assertTrue(tagStore.getForAccount("111111111111", "server/" + server.getServerId()).isEmpty());
+        assertTrue(tagStore.getForAccount("111111111111", "us-east-1/server/" + server.getServerId()).isPresent());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/transfer/TransferServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/transfer/TransferServiceTest.java
@@ -33,6 +33,7 @@ class TransferServiceTest {
     private AccountAwareStorageBackend<User> userStore;
     private InMemoryStorage<String, Server> serverDelegate;
     private AccountAwareStorageBackend<Map<String, String>> tagStore;
+    private InMemoryStorage<String, Map<String, String>> tagDelegate;
     private TransferService service;
     private RegionResolver regionResolver;
     private RequestContext requestContext;
@@ -50,8 +51,9 @@ class TransferServiceTest {
                 "111111111111");
         userStore = new AccountAwareStorageBackend<>(new InMemoryStorage<>(), requestContextInstance,
                 "111111111111");
+        tagDelegate = new InMemoryStorage<>();
         tagStore = new AccountAwareStorageBackend<>(
-                new InMemoryStorage<>(), requestContextInstance, "111111111111");
+                tagDelegate, requestContextInstance, "111111111111");
         StorageFactory factory = new StorageFactory(null, null) {
             @Override
             public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
@@ -190,5 +192,31 @@ class TransferServiceTest {
                 service.listTagsForResource(server.getArn()));
         assertTrue(tagStore.getForAccount("111111111111", "server/" + server.getServerId()).isEmpty());
         assertTrue(tagStore.getForAccount("111111111111", "us-east-1/server/" + server.getServerId()).isPresent());
+    }
+
+    @Test
+    void fullyUnscopedLegacyTagsAreMigratedToTheScopedKey() {
+        Server server = service.createServer("us-east-1", null, null, null, null,
+                null, null, null, null, null);
+        String legacyKey = "server/" + server.getServerId();
+        tagDelegate.put(legacyKey, Map.of("legacy", "tag"));
+
+        assertEquals(Map.of("legacy", "tag"), service.listTagsForResource(server.getArn()));
+        assertTrue(tagDelegate.get(legacyKey).isEmpty());
+        assertEquals(Map.of("legacy", "tag"),
+                tagStore.getForAccount("111111111111", "us-east-1/" + legacyKey).orElseThrow());
+    }
+
+    @Test
+    void scopedTagsWinOverFullyUnscopedLegacyDuplicates() {
+        Server server = service.createServer("us-east-1", null, null, null, null,
+                null, null, null, null, null);
+        String legacyKey = "server/" + server.getServerId();
+        tagDelegate.put(legacyKey, Map.of("legacy", "tag"));
+        tagStore.putForAccount("111111111111", "us-east-1/" + legacyKey,
+                Map.of("current", "tag"));
+
+        assertEquals(Map.of("current", "tag"), service.listTagsForResource(server.getArn()));
+        assertTrue(tagDelegate.get(legacyKey).isEmpty());
     }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/transfer/TransferServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/transfer/TransferServiceTest.java
@@ -1,0 +1,157 @@
+package io.github.hectorvent.floci.services.transfer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsException;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
+import io.github.hectorvent.floci.core.common.RequestContext;
+import io.github.hectorvent.floci.core.common.RegionResolver;
+import io.github.hectorvent.floci.core.storage.AccountAwareStorageBackend;
+import io.github.hectorvent.floci.core.storage.InMemoryStorage;
+import io.github.hectorvent.floci.core.storage.StorageFactory;
+import jakarta.enterprise.inject.Instance;
+import io.github.hectorvent.floci.services.transfer.model.Server;
+import io.github.hectorvent.floci.services.transfer.model.SshPublicKey;
+import io.github.hectorvent.floci.services.transfer.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+
+class TransferServiceTest {
+
+    private AccountAwareStorageBackend<Server> serverStore;
+    private AccountAwareStorageBackend<User> userStore;
+    private InMemoryStorage<String, Server> serverDelegate;
+    private TransferService service;
+    private RegionResolver regionResolver;
+    private RequestContext requestContext;
+
+    @BeforeEach
+    void setUp() {
+        requestContext = new RequestContext();
+        requestContext.setAccountId("111111111111");
+        requestContext.setRegion("us-east-1");
+        @SuppressWarnings("unchecked")
+        Instance<RequestContext> requestContextInstance = Mockito.mock(Instance.class);
+        when(requestContextInstance.get()).thenReturn(requestContext);
+        serverDelegate = new InMemoryStorage<>();
+        serverStore = new AccountAwareStorageBackend<>(serverDelegate, requestContextInstance,
+                "111111111111");
+        userStore = new AccountAwareStorageBackend<>(new InMemoryStorage<>(), requestContextInstance,
+                "111111111111");
+        AccountAwareStorageBackend<Map<String, String>> tagStore = new AccountAwareStorageBackend<>(
+                new InMemoryStorage<>(), requestContextInstance, "111111111111");
+        StorageFactory factory = new StorageFactory(null, null) {
+            @Override
+            public <V> AccountAwareStorageBackend<V> create(String serviceName, String fileName,
+                    TypeReference<Map<String, V>> typeReference) {
+                AccountAwareStorageBackend<?> store = switch (fileName) {
+                    case "transfer-servers.json" -> serverStore;
+                    case "transfer-users.json" -> userStore;
+                    case "transfer-tags.json" -> tagStore;
+                    default -> throw new IllegalArgumentException(fileName);
+                };
+                @SuppressWarnings("unchecked")
+                AccountAwareStorageBackend<V> typed = (AccountAwareStorageBackend<V>) store;
+                return typed;
+            }
+        };
+        regionResolver = Mockito.mock(RegionResolver.class);
+        when(regionResolver.getAccountId()).thenAnswer(invocation -> requestContext.getAccountId());
+        when(regionResolver.getRegion()).thenAnswer(invocation -> requestContext.getRegion());
+        when(regionResolver.buildArn(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> AwsArnUtils.Arn.of(invocation.getArgument(0),
+                        invocation.getArgument(1), requestContext.getAccountId(), invocation.getArgument(2)).toString());
+        service = new TransferService(factory, null, regionResolver);
+    }
+
+    @Test
+    void serversAndUsersAreIsolatedByAccountAndRegion() {
+        Server first = service.createServer("us-east-1", null, null, null, null,
+                null, null, null, null, null);
+        User firstUser = service.createUser(first.getServerId(), "us-east-1", "alice", "role", null,
+                null, null, null);
+
+        requestContext.setAccountId("222222222222");
+        requestContext.setRegion("eu-west-1");
+        Server second = service.createServer("eu-west-1", null, null, null, null,
+                null, null, null, null, null);
+        User secondUser = service.createUser(second.getServerId(), "eu-west-1", "alice", "role", null,
+                null, null, null);
+
+        assertEquals(List.of(second.getServerId()), service.listServers(null, 100).stream()
+                .map(Server::getServerId).toList());
+        assertEquals(secondUser.getArn(), service.getUser(second.getServerId(), "alice").getArn());
+        assertThrows(AwsException.class, () -> service.getServer(first.getServerId()));
+        assertThrows(AwsException.class, () -> service.getUser(first.getServerId(), "alice"));
+
+        requestContext.setAccountId("111111111111");
+        requestContext.setRegion("us-east-1");
+        assertEquals(firstUser.getArn(), service.getUser(first.getServerId(), "alice").getArn());
+    }
+
+    @Test
+    void deletingServerCascadesOnlyWithinItsScope() {
+        Server first = service.createServer("us-east-1", null, null, null, null,
+                null, null, null, null, null);
+        service.createUser(first.getServerId(), "us-east-1", "alice", "role", null,
+                null, null, null);
+        service.importSshPublicKey(first.getServerId(), "alice", "ssh-rsa AAAA");
+
+        requestContext.setAccountId("222222222222");
+        requestContext.setRegion("eu-west-1");
+        Server second = service.createServer("eu-west-1", null, null, null, null,
+                null, null, null, null, null);
+        service.createUser(second.getServerId(), "eu-west-1", "alice", "role", null,
+                null, null, null);
+
+        service.deleteServer(second.getServerId());
+        requestContext.setAccountId("111111111111");
+        requestContext.setRegion("us-east-1");
+        service.importSshPublicKey(first.getServerId(), "alice", "ssh-rsa BBBB");
+        assertEquals(2, service.getUser(first.getServerId(), "alice").getSshPublicKeys().size(),
+                "the first scope must remain available");
+        assertThrows(AwsException.class, () -> service.getUser(second.getServerId(), "alice"));
+    }
+
+    @Test
+    void taggingForeignArnIsRejected() {
+        Server first = service.createServer("us-east-1", null, null, null, null,
+                null, null, null, null, null);
+        service.tagResource(first.getArn(), Map.of("owner", "first"));
+
+        requestContext.setAccountId("222222222222");
+        requestContext.setRegion("eu-west-1");
+        AwsException error = assertThrows(AwsException.class,
+                () -> service.tagResource(first.getArn(), Map.of("owner", "foreign")));
+
+        assertEquals(404, error.getHttpStatus());
+        requestContext.setAccountId("111111111111");
+        requestContext.setRegion("us-east-1");
+        assertEquals(Map.of("owner", "first"), service.listTagsForResource(first.getArn()));
+    }
+
+    @Test
+    void legacyServerIsMigratedOnlyWhenArnMatchesScope() {
+        Server legacy = new Server();
+        legacy.setServerId("s-legacy");
+        legacy.setArn("arn:aws:transfer:us-east-1:111111111111:server/s-legacy");
+        serverDelegate.put("s-legacy", legacy);
+
+        assertEquals("s-legacy", service.getServer("s-legacy").getServerId());
+
+        when(regionResolver.getAccountId()).thenReturn("222222222222");
+        when(regionResolver.getRegion()).thenReturn("eu-west-1");
+        assertThrows(AwsException.class, () -> service.getServer("s-legacy"));
+    }
+}


### PR DESCRIPTION
## Summary

Isolate AWS Transfer Family servers and users by account and Region so identical identifiers cannot expose or modify another scope.

The change scopes server, user, tag, cascade-delete, and SSH-key state. Legacy records are migrated only when their stored ARN proves ownership by the requested account and Region.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

AWS Transfer Family server and user ARNs include Region and account ID. Floci now validates those components for lookups and tag operations while preserving the existing API response shapes and handler interfaces.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
