### PR TITLE
fix(rds): wait for the final PostgreSQL server before reporting the instance ready

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/RdsService.java
@@ -734,6 +734,7 @@ public class RdsService implements Resettable, ResourceProvider {
             try {
                 sqlDump = containerManager.createPostgresSnapshot(instance.getContainerId(), instance.getMasterUsername());
             } catch (Exception e) {
+                LOG.warnv(e, "Failed to create snapshot {0} of DB instance {1}", snapshotId, instanceId);
                 throw new AwsException("InvalidDBInstanceState", "Failed to create snapshot: " + e.getMessage(), 400);
             }
         }

--- a/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManager.java
@@ -480,10 +480,16 @@ public class RdsContainerManager {
                 """;
     }
 
+    /**
+     * Connects over TCP loopback on purpose. The official image runs first-boot init against a
+     * temporary server that listens only on the Unix socket, so a socket connection can succeed
+     * before the final server is up. Loopback is trusted by the generated pg_hba.conf.
+     */
     private void initializePostgresIamRole(String containerName, String containerId, String masterUsername) {
         String effectiveUser = (masterUsername != null && !masterUsername.isBlank()) ? masterUsername : "postgres";
         String[] cmd = {
                 "psql",
+                "-h", "127.0.0.1",
                 "-v", "ON_ERROR_STOP=1",
                 "-U", effectiveUser,
                 "-d", "postgres",

--- a/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerPostgresTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/rds/container/RdsContainerManagerPostgresTest.java
@@ -154,7 +154,7 @@ class RdsContainerManagerPostgresTest {
     }
 
     private void waitForPostgresReady(String containerId, String user, String dbName, int maxSeconds) {
-        String[] cmd = {"psql", "-U", user, "-d", dbName, "-c", "SELECT 1"};
+        String[] cmd = {"psql", "-h", "127.0.0.1", "-U", user, "-d", dbName, "-c", "SELECT 1"};
         for (int i = 0; i < maxSeconds; i++) {
             try {
                 ExecResult result = exec(containerId, cmd, 5);


### PR DESCRIPTION
## Summary

Closes #3384

The official postgres image serves first-boot init through a temporary server that listens only on the Unix socket, then restarts it. The readiness probe ran psql over that socket, so it passed against the temporary server and CreateDBInstance returned while the container was still restarting. A CreateDBSnapshot sent right after then failed pg_dumpall and returned InvalidDBInstanceState.

Run the rds_iam role setup over TCP loopback instead, as the Redshift readiness check already does. The temporary server never listens on TCP, so the command only succeeds once the final server is up. Loopback connections are trusted by the generated pg_hba.conf, so no password is needed. Log the cause when a snapshot fails. The round-trip container test waits the same way.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No changes

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
