### PR TITLE
fix(mwaa): probe the metadata database over TCP before starting Airflow

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
+++ b/src/main/java/io/github/hectorvent/floci/services/mwaa/MwaaEnvironmentManager.java
@@ -425,11 +425,17 @@ public class MwaaEnvironmentManager {
                 + "exec airflow webserver";
     }
 
+    /**
+     * Probes over TCP loopback on purpose. The official image runs first-boot init against a
+     * temporary server that listens only on the Unix socket, so a socket probe can pass before
+     * the final server accepts the Airflow container's TCP connections.
+     */
     private void waitForPostgresReady(String containerId) {
         Exception last = null;
         for (int attempt = 1; attempt <= 60; attempt++) {
             try {
-                ExecResult result = execInContainer(containerId, new String[]{"pg_isready", "-U", "airflow"});
+                ExecResult result = execInContainer(containerId,
+                        new String[]{"pg_isready", "-h", "127.0.0.1", "-U", "airflow"});
                 if (result.exitCode() == 0) {
                     return;
                 }


### PR DESCRIPTION
## Summary

Same fix as in #3405

The official postgres image serves first-boot init through a temporary server that listens only on the Unix socket, then restarts it. The readiness probe ran pg_isready over that socket, so it could pass against the temporary server before the final server accepted TCP connections from the Airflow container. Probe TCP loopback instead.


## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

No changes

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<!-- First PR here? Your CI checks wait for a maintainer to approve them before they run — that's GitHub's gate on first-time contributors, not a problem with your PR. -->
<!-- Questions, or want feedback on an approach before going further? Join us on Slack: https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw -->

