### PR TITLE
fix(storage): migrate legacy entries by exact key

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackend.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -161,6 +162,47 @@ public class AccountAwareStorageBackend<V> implements StorageBackend<String, V> 
                     result.add(new AccountEntry<>(accountId, logicalKey, value)));
         }
         return result;
+    }
+
+    /**
+     * Migrates legacy entries owned by {@code accountId} to account-relative destination keys.
+     * The source key is deleted exactly, including for unprefixed gen-0 entries.
+     */
+    public synchronized void migrateLegacyEntries(
+            String accountId,
+            Predicate<String> legacyKeyFilter,
+            Function<V, String> destinationKey,
+            Predicate<V> legacyOwner) {
+        for (String rawKey : new ArrayList<>(delegate.keys())) {
+            boolean prefixed = hasAccountPrefix(rawKey);
+            String owner = prefixed ? rawKey.substring(0, 12) : defaultAccountId;
+            if (!accountId.equals(owner)) {
+                continue;
+            }
+
+            String logicalKey = prefixed ? rawKey.substring(13) : rawKey;
+            if (!legacyKeyFilter.test(logicalKey)) {
+                continue;
+            }
+
+            Optional<V> value = delegate.get(rawKey);
+            if (value.isEmpty() || !legacyOwner.test(value.get())) {
+                continue;
+            }
+
+            String newLogicalKey = destinationKey.apply(value.get());
+            if (newLogicalKey == null) {
+                continue;
+            }
+
+            String destination = accountId + "/" + newLogicalKey;
+            if (!destination.equals(rawKey) && delegate.get(destination).isEmpty()) {
+                delegate.put(destination, value.get());
+            }
+            if (!destination.equals(rawKey)) {
+                delegate.delete(rawKey);
+            }
+        }
     }
 
     /**

--- a/src/main/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackend.java
+++ b/src/main/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackend.java
@@ -3,6 +3,7 @@ package io.github.hectorvent.floci.core.storage;
 import io.github.hectorvent.floci.core.common.RequestContext;
 import jakarta.enterprise.context.ContextNotActiveException;
 import jakarta.enterprise.inject.Instance;
+import org.jboss.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -11,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -31,6 +33,8 @@ import java.util.stream.Collectors;
  * created before multi-account support was added.
  */
 public class AccountAwareStorageBackend<V> implements StorageBackend<String, V> {
+
+    private static final Logger LOG = Logger.getLogger(AccountAwareStorageBackend.class);
 
     /** A stored value together with its owning AWS account and account-relative key. */
     public record AccountEntry<T>(String accountId, String key, T value) {}
@@ -173,6 +177,15 @@ public class AccountAwareStorageBackend<V> implements StorageBackend<String, V> 
             Predicate<String> legacyKeyFilter,
             Function<V, String> destinationKey,
             Predicate<V> legacyOwner) {
+        migrateLegacyEntries(accountId, legacyKeyFilter,
+                (ignored, value) -> destinationKey.apply(value), legacyOwner);
+    }
+
+    private synchronized void migrateLegacyEntries(
+            String accountId,
+            Predicate<String> legacyKeyFilter,
+            BiFunction<String, V, String> destinationKey,
+            Predicate<V> legacyOwner) {
         for (String rawKey : new ArrayList<>(delegate.keys())) {
             boolean prefixed = hasAccountPrefix(rawKey);
             String owner = prefixed ? rawKey.substring(0, 12) : defaultAccountId;
@@ -190,16 +203,19 @@ public class AccountAwareStorageBackend<V> implements StorageBackend<String, V> 
                 continue;
             }
 
-            String newLogicalKey = destinationKey.apply(value.get());
+            String newLogicalKey = destinationKey.apply(logicalKey, value.get());
             if (newLogicalKey == null) {
                 continue;
             }
 
             String destination = accountId + "/" + newLogicalKey;
-            if (!destination.equals(rawKey) && delegate.get(destination).isEmpty()) {
-                delegate.put(destination, value.get());
-            }
             if (!destination.equals(rawKey)) {
+                if (delegate.get(destination).isEmpty()) {
+                    delegate.put(destination, value.get());
+                } else {
+                    LOG.warnv("Legacy storage migration skipped stale value at {0}; destination {1} already exists",
+                            rawKey, destination);
+                }
                 delegate.delete(rawKey);
             }
         }
@@ -236,25 +252,17 @@ public class AccountAwareStorageBackend<V> implements StorageBackend<String, V> 
      */
     public Map<String, V> scanAllAccountsRaw() {
         Map<String, V> result = new LinkedHashMap<>();
-        List<String> legacyKeys = new ArrayList<>();
         for (String rawKey : delegate.keys()) {
-            if (rawKey.indexOf('/') < 0) {
-                legacyKeys.add(rawKey);
-                continue;
+            if (rawKey.indexOf('/') >= 0) {
+                delegate.get(rawKey).ifPresent(v -> result.put(rawKey, v));
             }
-            delegate.get(rawKey).ifPresent(v -> result.put(rawKey, v));
         }
-        for (String rawKey : legacyKeys) {
-            String effectiveKey = defaultAccountId + "/" + rawKey;
-            if (result.containsKey(effectiveKey)) {
-                delegate.delete(rawKey);
-                continue;
+        migrateLegacyEntries(defaultAccountId, key -> key.indexOf('/') < 0,
+                (key, value) -> key, value -> true);
+        for (String rawKey : delegate.keys()) {
+            if (rawKey.indexOf('/') >= 0) {
+                delegate.get(rawKey).ifPresent(v -> result.put(rawKey, v));
             }
-            delegate.get(rawKey).ifPresent(v -> {
-                delegate.put(effectiveKey, v);
-                delegate.delete(rawKey);
-                result.put(effectiveKey, v);
-            });
         }
         return result;
     }

--- a/src/test/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackendTest.java
+++ b/src/test/java/io/github/hectorvent/floci/core/storage/AccountAwareStorageBackendTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -217,6 +218,78 @@ class AccountAwareStorageBackendTest {
                 new AccountAwareStorageBackend.AccountEntry<>("123456789012", "us-east-1::api-a", "account-a"),
                 new AccountAwareStorageBackend.AccountEntry<>("000000000000", "us-east-1::legacy", "legacy")),
                 Set.copyOf(storage.scanAllAccountEntries(key -> key.startsWith("us-east-1::"))));
+    }
+
+    @Test
+    void migrateLegacyEntriesMovesGen0KeyAndDeletesExactSource() {
+        InMemoryStorage<String, String> raw = new InMemoryStorage<>();
+        raw.put("legacy", "owned");
+        AccountAwareStorageBackend<String> storage =
+                new AccountAwareStorageBackend<>(raw, null, "111111111111");
+
+        storage.migrateLegacyEntries("111111111111", "legacy"::equals,
+                value -> "us-east-1/" + value, "owned"::equals);
+
+        assertEquals("owned", raw.get("111111111111/us-east-1/owned").orElseThrow());
+        assertFalse(raw.get("legacy").isPresent());
+    }
+
+    @Test
+    void migrateLegacyEntriesMovesGen1KeyAndDeletesExactSource() {
+        InMemoryStorage<String, String> raw = new InMemoryStorage<>();
+        raw.put("111111111111/legacy", "owned");
+        AccountAwareStorageBackend<String> storage =
+                new AccountAwareStorageBackend<>(raw, null, "000000000000");
+
+        storage.migrateLegacyEntries("111111111111", "legacy"::equals,
+                value -> "us-east-1/" + value, "owned"::equals);
+
+        assertEquals("owned", raw.get("111111111111/us-east-1/owned").orElseThrow());
+        assertFalse(raw.get("111111111111/legacy").isPresent());
+    }
+
+    @Test
+    void migrateLegacyEntriesIsIdempotent() {
+        InMemoryStorage<String, String> raw = new InMemoryStorage<>();
+        raw.put("legacy", "owned");
+        AccountAwareStorageBackend<String> storage =
+                new AccountAwareStorageBackend<>(raw, null, "111111111111");
+
+        storage.migrateLegacyEntries("111111111111", "legacy"::equals,
+                value -> "us-east-1/" + value, "owned"::equals);
+        storage.migrateLegacyEntries("111111111111", "legacy"::equals,
+                value -> "us-east-1/" + value, "owned"::equals);
+
+        assertEquals(Set.of("111111111111/us-east-1/owned"), raw.keys());
+    }
+
+    @Test
+    void migrateLegacyEntriesLeavesNonOwnerUntouched() {
+        InMemoryStorage<String, String> raw = new InMemoryStorage<>();
+        raw.put("legacy", "foreign");
+        AccountAwareStorageBackend<String> storage =
+                new AccountAwareStorageBackend<>(raw, null, "111111111111");
+
+        storage.migrateLegacyEntries("111111111111", "legacy"::equals,
+                value -> "us-east-1/" + value, "owned"::equals);
+
+        assertEquals("foreign", raw.get("legacy").orElseThrow());
+        assertTrue(raw.get("111111111111/us-east-1/foreign").isEmpty());
+    }
+
+    @Test
+    void migrateLegacyEntriesDeletesSourceWhenDestinationAlreadyExists() {
+        InMemoryStorage<String, String> raw = new InMemoryStorage<>();
+        raw.put("111111111111/legacy", "stale");
+        raw.put("111111111111/us-east-1/current", "current");
+        AccountAwareStorageBackend<String> storage =
+                new AccountAwareStorageBackend<>(raw, null, "000000000000");
+
+        storage.migrateLegacyEntries("111111111111", "legacy"::equals,
+                value -> "us-east-1/current", "stale"::equals);
+
+        assertEquals("current", raw.get("111111111111/us-east-1/current").orElseThrow());
+        assertFalse(raw.get("111111111111/legacy").isPresent());
     }
 
     /**


### PR DESCRIPTION
## Summary

Migrate legacy account-prefixed and unscoped storage entries to their new account-relative keys while deleting the exact legacy source key.

The shared migrator is now used by `scanAllAccountsRaw`, so this behavior is exercised by a production storage path. Service-specific region migrations remain isolated in their respective service PRs, including Neptune PR 3401.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Legacy entries could be copied to the new key while the original key remained. Repeated reads or scans could therefore rediscover and migrate the same data again.

The migration is idempotent, does not overwrite an existing destination, removes the exact source key for both unscoped and account-prefixed legacy data, and leaves non-owner values untouched. When a destination already exists, the legacy value is discarded only after a warning is logged.

Verified with focused `AccountAwareStorageBackendTest` coverage for both legacy formats, idempotence, ownership checks, destination conflicts, and bulk scans. The service-specific Neptune caller remains in PR 3401 to keep the changes isolated.

## Checklist

- [ ] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)