### PR TITLE
fix(dynamodb): match AWS wording and order for Select rejections

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidator.java
@@ -55,11 +55,12 @@ final class DynamoDbAccessPathValidator {
     static void validateSelection(TableDefinition table, DynamoDbAccessPath accessPath,
                                   String select, String projectionExpression,
                                   JsonNode attributesToGet, JsonNode expressionAttributeNames) {
-        if ("ALL_PROJECTED_ATTRIBUTES".equals(select) && !accessPath.isIndex()) {
-            throw validationException("Select type ALL_PROJECTED_ATTRIBUTES is not supported for query on a table");
-        }
         if (projectionExpression != null && select != null && !"SPECIFIC_ATTRIBUTES".equals(select)) {
-            throw validationException("Cannot use both Select and ProjectionExpression unless Select is SPECIFIC_ATTRIBUTES");
+            throw validationException("Cannot specify the ProjectionExpression when choosing to get "
+                    + ("COUNT".equals(select) ? "only the Count" : select));
+        }
+        if ("ALL_PROJECTED_ATTRIBUTES".equals(select) && !accessPath.isIndex()) {
+            throw validationException("ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName");
         }
         if (attributesToGet != null && select != null && !"SPECIFIC_ATTRIBUTES".equals(select)) {
             throw validationException("Cannot use both Select and AttributesToGet unless Select is SPECIFIC_ATTRIBUTES");

--- a/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbJsonHandler.java
@@ -838,6 +838,9 @@ public class DynamoDbJsonHandler {
     private static final Set<String> VALID_SELECT = Set.of(
             "ALL_ATTRIBUTES", "ALL_PROJECTED_ATTRIBUTES", "SPECIFIC_ATTRIBUTES", "COUNT");
 
+    private static final String SELECT_NEEDS_PROJECTION =
+            "Must specify the AttributesToGet or ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES";
+
     private Response handleQuery(JsonNode request, String region) {
         String tableName = request.path("TableName").asText();
         DynamoDbTableNames.resolve(tableName); // validate tableName first
@@ -921,8 +924,9 @@ public class DynamoDbJsonHandler {
 
         boolean hasAttributesToGet = attributesToGet != null && attributesToGet.size() > 0;
         if ("SPECIFIC_ATTRIBUTES".equals(select) && projectionExpression == null && !hasAttributesToGet) {
+            // Query prefixes the count here, Scan does not.
             throw new AwsException("ValidationException",
-                    "Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided.", 400);
+                    "1 validation error detected: " + SELECT_NEEDS_PROJECTION, 400);
         }
 
         TableDefinition queryTable = dynamoDbService.describeTable(tableName, region);
@@ -1096,8 +1100,7 @@ public class DynamoDbJsonHandler {
         boolean hasAttributesToGetScan = attributesToGetScan != null && attributesToGetScan.size() > 0;
         if ("SPECIFIC_ATTRIBUTES".equals(select)
                 && projectionExpressionScan == null && !hasAttributesToGetScan) {
-            throw new AwsException("ValidationException",
-                    "Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided.", 400);
+            throw new AwsException("ValidationException", SELECT_NEEDS_PROJECTION, 400);
         }
 
         TableDefinition scanTable = dynamoDbService.describeTable(tableName, region);

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbAccessPathValidatorTest.java
@@ -387,6 +387,36 @@ class DynamoDbAccessPathValidatorTest {
         assertEquals("Query key condition not supported", error.getMessage());
     }
 
+    @Test
+    void namesTheSelectValueWhenRejectingAProjectionExpression() {
+        AwsException allAttributes = assertThrows(AwsException.class,
+                () -> DynamoDbAccessPathValidator.validateSelection(
+                        table, tablePath, "ALL_ATTRIBUTES", "sk", null, null));
+        assertEquals("Cannot specify the ProjectionExpression when choosing to get ALL_ATTRIBUTES",
+                allAttributes.getMessage());
+
+        AwsException count = assertThrows(AwsException.class,
+                () -> DynamoDbAccessPathValidator.validateSelection(
+                        table, tablePath, "COUNT", "sk", null, null));
+        assertEquals("Cannot specify the ProjectionExpression when choosing to get only the Count",
+                count.getMessage());
+    }
+
+    @Test
+    void reportsTheProjectionExpressionConflictBeforeTheMissingIndex() {
+        AwsException both = assertThrows(AwsException.class,
+                () -> DynamoDbAccessPathValidator.validateSelection(
+                        table, tablePath, "ALL_PROJECTED_ATTRIBUTES", "sk", null, null));
+        assertEquals("Cannot specify the ProjectionExpression when choosing to get ALL_PROJECTED_ATTRIBUTES",
+                both.getMessage());
+
+        AwsException indexOnly = assertThrows(AwsException.class,
+                () -> DynamoDbAccessPathValidator.validateSelection(
+                        table, tablePath, "ALL_PROJECTED_ATTRIBUTES", null, null, null));
+        assertEquals("ALL_PROJECTED_ATTRIBUTES can be used only when Querying using an IndexName",
+                indexOnly.getMessage());
+    }
+
     private void validateExpression(DynamoDbAccessPath accessPath, String expression) {
         DynamoDbAccessPathValidator.validateQuery(
                 table, accessPath, null, expression, null, null, null,

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -810,6 +810,27 @@ class DynamoDbIntegrationTest {
 
     @Test
     @Order(10)
+    void scanWithSelectSpecificAttributesRequiresProjectionParameters() {
+        given()
+            .header("X-Amz-Target", "DynamoDB_20120810.Scan")
+            .contentType(DYNAMODB_CONTENT_TYPE)
+            .body("""
+                {
+                    "TableName": "TestTable",
+                    "Select": "SPECIFIC_ATTRIBUTES"
+                }
+                """)
+        .when()
+            .post("/")
+        .then()
+            .statusCode(400)
+            .body("__type", equalTo("ValidationException"))
+            .body("message", equalTo("Must specify the AttributesToGet or "
+                    + "ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES"));
+    }
+
+    @Test
+    @Order(10)
     void queryWithProjectionExpressionAndAttributesToGetFails() {
         given()
             .header("X-Amz-Target", "DynamoDB_20120810.Query")

--- a/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/dynamodb/DynamoDbIntegrationTest.java
@@ -804,7 +804,8 @@ class DynamoDbIntegrationTest {
         .then()
             .statusCode(400)
             .body("__type", equalTo("ValidationException"))
-            .body("message", equalTo("Select type SPECIFIC_ATTRIBUTES requires the ProjectionExpression to be provided."));
+            .body("message", equalTo("1 validation error detected: Must specify the AttributesToGet or "
+                    + "ProjectionExpression when choosing to get SPECIFIC_ATTRIBUTES"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes 8 TIER 1 and 2 TIER 3 cases in the [dynamodb-conformance](https://github.com/paritysuite/dynamodb-conformance) suite.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Query and Scan share one Select validator. It reported Floci wording and checked the rules in the wrong order, so a request breaking both the ProjectionExpression rule and the IndexName rule named the wrong one.

The ProjectionExpression conflict is now reported first, and each message names the Select value the way AWS does. The SPECIFIC_ATTRIBUTES message without a projection also matches AWS, which prefixes the error count on Query but not on Scan.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

