### PR TITLE
fix(lambda): recover a DynamoDB Streams ESM from a trimmed checkpoint

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePoller.java
@@ -31,6 +31,9 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(DynamoDbStreamsEventSourcePoller.class);
 
+    /** Raised by the stream when a stored checkpoint has aged out of the retained window. */
+    private static final String TRIMMED_DATA_ACCESS_EXCEPTION = "TrimmedDataAccessException";
+
     private final Vertx vertx;
     private final DynamoDbStreamService streamService;
     private final LambdaExecutorService executorService;
@@ -154,11 +157,28 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                 String shardId = DynamoDbStreamService.SHARD_ID;
                 String lastSeq = esm.getShardSequenceNumbers().get(shardId);
 
-                String iterator = lastSeq == null
-                        ? streamService.getShardIterator(streamArn, shardId, "TRIM_HORIZON", null)
-                        : streamService.getShardIterator(streamArn, shardId, "AFTER_SEQUENCE_NUMBER", lastSeq);
-
-                DynamoDbStreamService.GetRecordsResult result = streamService.getRecords(iterator, esm.getBatchSize());
+                DynamoDbStreamService.GetRecordsResult result;
+                try {
+                    String iterator = lastSeq == null
+                            ? streamService.getShardIterator(streamArn, shardId, "TRIM_HORIZON", null)
+                            : streamService.getShardIterator(streamArn, shardId, "AFTER_SEQUENCE_NUMBER", lastSeq);
+                    result = streamService.getRecords(iterator, esm.getBatchSize());
+                } catch (AwsException e) {
+                    if (!TRIMMED_DATA_ACCESS_EXCEPTION.equals(e.getErrorCode())) {
+                        throw e;
+                    }
+                    // The checkpoint fell outside the retained window, so the cursor it names can
+                    // never succeed again. Retrying it wedges the ESM permanently: every later
+                    // write reaches the stream and none is ever delivered. Resume from the oldest
+                    // record still held instead, which is what AWS does when a consumer is
+                    // overtaken by the trim horizon. Records written between the lost checkpoint
+                    // and that record are gone from the stream and are not delivered.
+                    LOG.warnv("DynamoDB Streams ESM {0}: checkpoint {1} was trimmed, resuming from the "
+                                    + "trim horizon; records between were dropped from the stream",
+                            esm.getUuid(), lastSeq);
+                    String horizon = streamService.getShardIterator(streamArn, shardId, "TRIM_HORIZON", null);
+                    result = streamService.getRecords(horizon, esm.getBatchSize());
+                }
                 List<DynamoDbStreamRecord> records = result.records();
 
                 if (records.isEmpty()) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
@@ -332,6 +332,67 @@ class DynamoDbStreamsEventSourcePollerTest {
         assertEquals("s2", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
     }
 
+    /**
+     * A checkpoint that has aged out of the retained window names a cursor that can never succeed.
+     * Retrying it wedges the ESM for good: later writes keep reaching the stream and none is ever
+     * delivered. The poller must resume from the trim horizon instead.
+     */
+    @Test
+    void trimmedCheckpointResumesFromTrimHorizonInsteadOfWedging() {
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("fn");
+        when(functionStore.getForAccount(ACCOUNT_ID, "us-east-1", "fn")).thenReturn(Optional.of(fn));
+
+        when(streamService.getShardIterator(eq(STREAM_ARN), eq(DynamoDbStreamService.SHARD_ID),
+                eq("AFTER_SEQUENCE_NUMBER"), any())).thenReturn("it-trimmed");
+        when(streamService.getShardIterator(eq(STREAM_ARN), eq(DynamoDbStreamService.SHARD_ID),
+                eq("TRIM_HORIZON"), any())).thenReturn("it-horizon");
+        when(streamService.getRecords("it-trimmed", 10)).thenThrow(
+                new AwsException("TrimmedDataAccessException",
+                        "The requested sequence number has been trimmed", 400));
+        when(streamService.getRecords("it-horizon", 10)).thenReturn(
+                new DynamoDbStreamService.GetRecordsResult(
+                        List.of(ddbRecord("s9", "INSERT", "{\"status\":{\"S\":\"active\"}}")), "it-horizon"));
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(new InvokeResult());
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.getShardSequenceNumbers().put(DynamoDbStreamService.SHARD_ID, STALE_CHECKPOINT);
+
+        pollerWith(store).pollAndInvoke(esm);
+
+        ArgumentCaptor<byte[]> payload = ArgumentCaptor.forClass(byte[].class);
+        verify(executorService, timeout(2000)).invoke(any(), payload.capture(), eq(InvocationType.RequestResponse));
+        assertEquals(1, readRecords(payload.getValue()).size());
+        verify(store, timeout(2000)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s9", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+    }
+
+    /** Only a trimmed checkpoint resets the cursor; any other stream failure retries the same window. */
+    @Test
+    void nonTrimmedStreamErrorLeavesTheCheckpointAlone() {
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("fn");
+        when(functionStore.getForAccount(ACCOUNT_ID, "us-east-1", "fn")).thenReturn(Optional.of(fn));
+
+        when(streamService.getShardIterator(eq(STREAM_ARN), eq(DynamoDbStreamService.SHARD_ID),
+                anyString(), any())).thenReturn("it");
+        when(streamService.getRecords("it", 10)).thenThrow(
+                new AwsException("InternalServerError", "boom", 500));
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.getShardSequenceNumbers().put(DynamoDbStreamService.SHARD_ID, STALE_CHECKPOINT);
+
+        pollerWith(store).pollAndInvoke(esm);
+        awaitPollCompletedViaSecondFetch(pollerWith(store), esm);
+
+        verify(executorService, never()).invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse));
+        verify(store, never()).saveForAccount(anyString(), any());
+        assertEquals(STALE_CHECKPOINT, esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+    }
+
     private JsonNode readRecords(byte[] payload) {
         try {
             return OBJECT_MAPPER.readTree(payload).path("Records");


### PR DESCRIPTION
## Summary

A DynamoDB Streams ESM that falls behind the trim horizon wedges permanently, and silently.

The poller stores the sequence number of the last record it delivered and resumes with `AFTER_SEQUENCE_NUMBER`:

```java
String lastSeq = esm.getShardSequenceNumbers().get(shardId);
String iterator = lastSeq == null
        ? streamService.getShardIterator(streamArn, shardId, "TRIM_HORIZON", null)
        : streamService.getShardIterator(streamArn, shardId, "AFTER_SEQUENCE_NUMBER", lastSeq);
DynamoDbStreamService.GetRecordsResult result = streamService.getRecords(iterator, esm.getBatchSize());
```

The stream retains a bounded window (`DynamoDbStreamService.MAX_RECORDS = 1000`), so a burst of writes that outruns the consumer pushes that checkpoint out of the window. `getRecords` then raises `TrimmedDataAccessException`, which reached only the catch-all at the bottom of the poll loop:

```java
} catch (Exception e) {
    LOG.warnv("DynamoDB Streams ESM {0} poll error: {1}", esm.getUuid(), e.getMessage());
} finally {
    activePolls.remove(esm.getUuid());
}
```

It logs and leaves the checkpoint untouched, so the next poll re-derives the same cursor and fails identically — forever. Every later write still reaches the stream and none is ever delivered.

This change treats a trimmed checkpoint as what it is, a cursor that can never succeed, and resumes from the oldest record the stream still holds — what AWS does when a consumer is overtaken by the trim horizon. Records between the lost checkpoint and the trim horizon are gone from the stream and are not delivered; the warning says so. Any other stream failure keeps the current behaviour and retries the same window.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** once the ESM's checkpoint ages out of the retained window, the mapping stops delivering and never resumes. Nothing surfaces to the client: the mapping still reports `State: Enabled`, `StateTransitionReason: None`, the stream keeps accepting writes, and the only signal is a warning line repeating once per poll interval.

On AWS a consumer overtaken by the trim horizon does not stall — it resumes from the oldest retained record, losing the records in between. `LastProcessingResult` also reflects the failure rather than staying `None`.

Observed on a real stack. A bulk import burst outran the consumer, and from that moment the pipeline was dead:

```
06:42:04  INFO  Published DynamoDB stream records to sync FIFO queues
                { "streamRecordCount": 100, "queueCount": 1, "messageCount": 100 }
06:42:05  WARN  [DynamoDbStreamsEventSourcePoller] ESM a132b871-… poll error:
                The requested sequence number has been trimmed
```

Nearly four hours later that warning had repeated **4,023 times** and was still firing once per second. Meanwhile:

| | |
|---|---|
| Stream records available, newest | seconds old — capture was fine |
| ESM state / `EventSourceArn` | `Enabled`, matching the table's `LatestStreamArn` |
| Last Lambda invocation | 06:42:04, ~4h earlier |
| Records in DynamoDB vs search index | **8 vs 1** |

Seven records never propagated, and every downstream consumer behind the FIFO queues — search sync, audit log, utilization counters — was stalled with no error anywhere.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Two cases added to `DynamoDbStreamsEventSourcePollerTest`:

| Case | Asserts |
|---|---|
| `trimmedCheckpointResumesFromTrimHorizonInsteadOfWedging` | a trimmed cursor re-reads from the horizon, the Lambda is invoked, and the checkpoint advances |
| `nonTrimmedStreamErrorLeavesTheCheckpointAlone` | any other stream failure still retries the same window and does not reset |

The first fails on `main` (no invoke ever happens) and passes with the change. Ran the poller and stream suites together — `DynamoDbStreamsEventSourcePollerTest`, `DynamoDbStreamServiceTest`, `DynamoDbStreamViewTypeDurabilityTest`, `PipesPollerTest`, `EmulatorLifecycleTest` — 59 tests, all passing.

**On end-to-end verification, so the claim is not overstated:** the stall is a race between write burst and consumer, and I could not re-trigger it on demand. Re-running the same bulk import against an image built from this branch produced zero trim errors and a healthy pipeline, which shows no regression but does not by itself exercise the recovery path. The evidence for the fix is the unit coverage above plus the captured incident; I have not watched a wedged ESM recover in a live run. If you would like the recovery pinned at integration level — writing past `MAX_RECORDS` with a deliberately lagging consumer — I am happy to add that.
