### PR TITLE
fix(athena): project the column names the Glue table declares

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/athena/GlueViewDdlBuilder.java
+++ b/src/main/java/io/github/hectorvent/floci/services/athena/GlueViewDdlBuilder.java
@@ -1,14 +1,18 @@
 package io.github.hectorvent.floci.services.athena;
 
 import io.github.hectorvent.floci.services.glue.GlueService;
+import io.github.hectorvent.floci.services.glue.model.Column;
 import io.github.hectorvent.floci.services.glue.model.Database;
 import io.github.hectorvent.floci.services.glue.model.Table;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 @ApplicationScoped
 public class GlueViewDdlBuilder {
@@ -88,13 +92,67 @@ public class GlueViewDdlBuilder {
                         : quote(t.getName());
                 sb.append("CREATE OR REPLACE VIEW ")
                   .append(target)
-                  .append(" AS SELECT * FROM ")
+                  .append(" AS SELECT ")
+                  .append(buildProjection(t))
+                  .append(" FROM ")
                   .append(readExpression(readFn, normalizedLocation))
                   .append(";\n");
             } catch (Exception e) {
                 LOG.debugv("skip Glue table {0}.{1}: {2}", schemaOrNull, t != null ? t.getName() : "unknown", e.getMessage());
             }
         }
+    }
+
+    /**
+     * Projects the columns the catalog declares, rather than whatever the underlying files spell.
+     *
+     * <p>Athena reports a table's declared column names: a JSON body written with {@code tenantId}
+     * surfaces as {@code tenantid} when the table declares it that way, because the catalog owns the
+     * schema and the SerDe maps onto it. Inference sees only the data, so without this the view
+     * exposes the file's spelling and a client reading the declared name finds nothing. Identifier
+     * resolution is case-insensitive here, so a declared name still binds to an inferred one that
+     * differs from it only by case.
+     *
+     * <p>Partition keys are part of the table's schema and are what partition predicates filter on,
+     * so they are projected too. A table that declares no columns keeps {@code *}, leaving inference
+     * in charge.
+     */
+    static String buildProjection(Table table) {
+        List<Column> declared = new ArrayList<>();
+        if (table != null) {
+            if (table.getStorageDescriptor() != null && table.getStorageDescriptor().getColumns() != null) {
+                declared.addAll(table.getStorageDescriptor().getColumns());
+            }
+            if (table.getPartitionKeys() != null) {
+                declared.addAll(table.getPartitionKeys());
+            }
+        }
+
+        List<String> names = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (Column c : declared) {
+            if (c == null || c.getName() == null || c.getName().isBlank()) {
+                continue;
+            }
+            String name = c.getName();
+            // A partition key repeating a data column would bind twice and make the view ambiguous.
+            if (seen.add(name.toLowerCase(Locale.ROOT))) {
+                names.add(name);
+            }
+        }
+
+        if (names.isEmpty()) {
+            return "*";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < names.size(); i++) {
+            if (i > 0) {
+                sb.append(", ");
+            }
+            sb.append(quote(names.get(i))).append(" AS ").append(quote(names.get(i)));
+        }
+        return sb.toString();
     }
 
     static String inferReadFunction(Table table) {

--- a/src/test/java/io/github/hectorvent/floci/services/athena/GlueViewDdlBuilderTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/athena/GlueViewDdlBuilderTest.java
@@ -2,6 +2,7 @@ package io.github.hectorvent.floci.services.athena;
 
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.services.glue.GlueService;
+import io.github.hectorvent.floci.services.glue.model.Column;
 import io.github.hectorvent.floci.services.glue.model.Database;
 import io.github.hectorvent.floci.services.glue.model.StorageDescriptor;
 import io.github.hectorvent.floci.services.glue.model.Table;
@@ -48,6 +49,82 @@ class GlueViewDdlBuilderTest {
             table.setStorageDescriptor(sd);
         }
         return table;
+    }
+
+    private static Column column(String name) {
+        Column c = new Column();
+        c.setName(name);
+        c.setType("string");
+        return c;
+    }
+
+    private Table tableWithColumns(String name, String location, List<Column> columns, List<Column> partitionKeys) {
+        Table table = createTable(name, location, "org.openx.data.jsonserde.JsonSerDe", null);
+        table.getStorageDescriptor().setColumns(columns);
+        table.setPartitionKeys(partitionKeys);
+        return table;
+    }
+
+    private String ddlFor(Table table) {
+        Database db = createDatabase("audit");
+        when(glueService.getDatabases()).thenReturn(List.of(db));
+        when(glueService.getTables("audit")).thenReturn(List.of(table));
+        return builder.build(null);
+    }
+
+    /**
+     * Athena reports the column names the catalog declares. The files here spell them camelCase, so a
+     * view built by inference alone would expose the file's spelling and a client reading the declared
+     * name would find nothing.
+     */
+    @Test
+    void testDeclaredColumnsAreProjectedInsteadOfStar() {
+        String ddl = ddlFor(tableWithColumns("audit_events", "s3://audit/",
+                List.of(column("eventid"), column("tenantid")),
+                List.of(column("tenant"), column("year"))));
+
+        assertTrue(ddl.contains("\"eventid\" AS \"eventid\""), ddl);
+        assertTrue(ddl.contains("\"tenantid\" AS \"tenantid\""), ddl);
+        assertFalse(ddl.contains("SELECT * FROM"), ddl);
+    }
+
+    /** Partition keys are part of the schema and are what partition predicates filter on. */
+    @Test
+    void testPartitionKeysAreProjectedAlongsideDataColumns() {
+        String ddl = ddlFor(tableWithColumns("audit_events", "s3://audit/",
+                List.of(column("eventid")),
+                List.of(column("tenant"), column("year"), column("month"), column("day"))));
+
+        for (String name : List.of("eventid", "tenant", "year", "month", "day")) {
+            assertTrue(ddl.contains("\"" + name + "\" AS \"" + name + "\""), name + " missing from: " + ddl);
+        }
+    }
+
+    /** A partition key repeating a data column would bind twice and make the view ambiguous. */
+    @Test
+    void testDuplicateColumnAndPartitionKeyIsProjectedOnce() {
+        String ddl = ddlFor(tableWithColumns("t", "s3://b/",
+                List.of(column("tenant")), List.of(column("TENANT"))));
+
+        int first = ddl.indexOf("AS \"tenant\"");
+        assertTrue(first >= 0, ddl);
+        assertEquals(-1, ddl.indexOf("AS \"tenant\"", first + 1), "projected twice: " + ddl);
+    }
+
+    /** A table that declares no columns leaves inference in charge, as before. */
+    @Test
+    void testTableWithoutDeclaredColumnsStillUsesStar() {
+        String ddl = ddlFor(tableWithColumns("t", "s3://b/", null, null));
+
+        assertTrue(ddl.contains("SELECT * FROM"), ddl);
+    }
+
+    /** Column identifiers go through the same quoting as table and schema names. */
+    @Test
+    void testColumnIdentifierQuotingEscapesDoubleQuotes() {
+        String ddl = ddlFor(tableWithColumns("t", "s3://b/", List.of(column("we\"ird")), null));
+
+        assertTrue(ddl.contains("\"we\"\"ird\" AS \"we\"\"ird\""), ddl);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Views built from the Glue catalog select `*`, so the column names come from whatever the underlying files happen to spell rather than from the table:

```java
sb.append("CREATE OR REPLACE VIEW ").append(target)
  .append(" AS SELECT * FROM ").append(readExpression(readFn, normalizedLocation));
```

`GlueViewDdlBuilder` reads the table for its name, `StorageDescriptor.Location` and the input format, but never for `StorageDescriptor.Columns`. For a JSON table whose bodies use camelCase keys, a view over a table declaring lowercase columns still reports camelCase.

This projects the declared columns explicitly instead. Identifier resolution is case-insensitive here, so a declared name still binds to an inferred one differing from it only by case. Partition keys are projected alongside the data columns — they are part of the table's schema and are what partition predicates filter on — and a partition key repeating a data column is projected once, since binding it twice would make the view ambiguous.

A table that declares no columns keeps `*`, so catalogs that never declared a schema are unaffected.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

**Incorrect behavior:** for a Glue table declaring `eventid, rootentityid, tenantid, …` over JSON objects whose keys are `eventId, rootEntityId, tenantId, …`:

| | Column names returned by `SELECT *` |
|---|---|
| Athena | `eventid`, `rootentityid`, `tenantid` — the declared names |
| floci before | `eventId`, `rootEntityId`, `tenantId` — the file's keys |

Athena reports a table's declared column names: the catalog owns the schema and the SerDe maps the data onto it. The [Athena naming guidance](https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html) puts it as *"Athena accepts mixed case in DDL and DML queries, but lower cases the names when it executes the query"*, and column names *"should be in lower case"* — so a catalog written through the Glue API with lowercase columns, as here, is read back lowercase.

Worth being precise about what this change is **not**: it does not lowercase anything. Glue's API stores the names it is given, so forcing case would break a catalog that legitimately declared mixed case. The rule applied is only that the view exposes the names the catalog declares.

**Why it is easy to miss.** Nothing fails. The query succeeds, the rows are there, and every mapped field is blank, because a client reading the declared names matches nothing. Found in an application whose audit log had silently returned zero events: Athena reported 699 rows for the query the application itself issued, while the application rendered an empty list, having mapped 698 events to blank attributes and then dropped them all on a tenant-scope check comparing an empty string.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Five cases added to `GlueViewDdlBuilderTest`:

| Case | Asserts |
|---|---|
| declared columns projected | the declared names appear as aliases, and the view is no longer `SELECT *` |
| partition keys projected | `tenant`, `year`, `month`, `day` are projected with the data columns |
| duplicate column / partition key | projected once, not twice |
| table without declared columns | still `SELECT *` — the backward-compatible path |
| identifier quoting | column names go through the same escaping as table and schema names |

Four of the five fail on `main`; the backward-compatibility one passes on both, by design. All 12 pre-existing tests in that class pass unchanged, since none of them declare columns.

Ran the Athena suites together — `GlueViewDdlBuilderTest` and `AthenaIntegrationTest`, 32 tests, all passing.

End to end, on an image built from this branch: an audit-log endpoint backed by this catalog went from `{"data": [], "meta": {"status": "SUCCEEDED"}}` to 139 fully populated events, actor and tenant and action intact, with no application change.
