### PR TITLE
feat(glue): support GetPartitionIndexes

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
+++ b/src/main/java/io/github/hectorvent/floci/services/glue/GlueJsonHandler.java
@@ -84,6 +84,16 @@ public class GlueJsonHandler {
                 Table table = glueService.getTable(dbName, tableName);
                 yield Response.ok(Map.of("Table", table)).build();
             }
+            case "GetPartitionIndexes" -> {
+                String dbName = request.get("DatabaseName").asText();
+                String tableName = request.get("TableName").asText();
+                // Resolve the table so a missing one is reported as such rather than as an empty
+                // index list. No index can exist until CreatePartitionIndex is supported, so the
+                // list is empty for every table that does resolve - which is the answer a client
+                // reading a table's indexes needs, rather than an unsupported-action failure.
+                glueService.getTable(dbName, tableName);
+                yield Response.ok(Map.of("PartitionIndexDescriptorList", List.of())).build();
+            }
             case "GetTables" -> {
                 String dbName = request.get("DatabaseName").asText();
                 yield Response.ok(Map.of("TableList", glueService.getTables(dbName))).build();

--- a/src/test/java/io/github/hectorvent/floci/services/glue/GlueJsonHandlerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/glue/GlueJsonHandlerTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class GlueJsonHandlerTest {
@@ -38,6 +39,51 @@ class GlueJsonHandlerTest {
         GlueService glueService = new GlueService(
                 storageFactory, schemaRegistryService, regionResolver, new ResourceGroupsTaggingService(storageFactory));
         handler = new GlueJsonHandler(glueService, schemaRegistryService, mapper);
+    }
+
+    private void createDatabaseAndTable(String dbName, String tableName) throws Exception {
+        ObjectNode createDb = mapper.createObjectNode();
+        createDb.putObject("DatabaseInput").put("Name", dbName);
+        assertEquals(200, handler.handle("CreateDatabase", createDb, REGION).getStatus());
+
+        ObjectNode createTable = mapper.createObjectNode();
+        createTable.put("DatabaseName", dbName);
+        createTable.putObject("TableInput").put("Name", tableName);
+        assertEquals(200, handler.handle("CreateTable", createTable, REGION).getStatus());
+    }
+
+    /**
+     * A client reading a table's partition indexes needs an answer, not an unsupported-action
+     * failure: the Terraform AWS provider reads them after creating a table and on every refresh,
+     * so without this a Glue table cannot be managed as a resource at all.
+     */
+    @Test
+    void getPartitionIndexesReturnsAnEmptyListForAnExistingTable() throws Exception {
+        createDatabaseAndTable("indexes_db", "events");
+
+        ObjectNode request = mapper.createObjectNode();
+        request.put("DatabaseName", "indexes_db");
+        request.put("TableName", "events");
+
+        Response response = handler.handle("GetPartitionIndexes", request, REGION);
+
+        assertEquals(200, response.getStatus());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> body = (Map<String, Object>) response.getEntity();
+        assertTrue(body.containsKey("PartitionIndexDescriptorList"));
+        assertTrue(((java.util.List<?>) body.get("PartitionIndexDescriptorList")).isEmpty());
+    }
+
+    /** A missing table is reported as missing, not as a table that happens to have no indexes. */
+    @Test
+    void getPartitionIndexesOnAMissingTableFails() throws Exception {
+        createDatabaseAndTable("indexes_db2", "events");
+
+        ObjectNode request = mapper.createObjectNode();
+        request.put("DatabaseName", "indexes_db2");
+        request.put("TableName", "absent");
+
+        assertThrows(Exception.class, () -> handler.handle("GetPartitionIndexes", request, REGION));
     }
 
     @Test


### PR DESCRIPTION
## Summary

`GetPartitionIndexes` was not handled, so reading a table's partition indexes failed as an unsupported action. That makes a Glue table unmanageable as infrastructure rather than merely missing a feature: the Terraform AWS provider reads the indexes immediately after creating a table and again on **every** refresh, so the create reports an error and every later `plan` fails on the same call.

```
Error: reading Glue Catalog Table (000000000000:keystone_audit:audit_events) partition indexes:
operation error Glue: GetPartitionIndexes, https response error StatusCode: 400,
api error InvalidAction: Action GetPartitionIndexes is not supported
```

The table itself is created correctly — only the read of its indexes is missing — so the resource lands in state and then cannot be planned, which is an awkward place to be stuck.

This returns an empty descriptor list. No index can exist while `CreatePartitionIndex` is unsupported, so empty is the accurate answer rather than a placeholder, and it is what a client reading a table's indexes needs. The table is resolved first so a missing one is reported as missing rather than as a table that happens to have no indexes.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

`GetPartitionIndexes` returns `PartitionIndexDescriptorList`, and an optional `NextToken` when the list is paged. A table with no indexes returns the empty list — Glue does not treat "no indexes" as an error — and a table that does not exist returns `EntityNotFoundException`. Both are matched here; `NextToken` is omitted, which is correct for a single empty page.

Verified against the Terraform AWS provider v5 rather than by inspection alone: `aws_glue_catalog_table` calls this on create and on refresh, and treats a non-empty list as configured partition indexes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Two cases added to `GlueJsonHandlerTest`:

| Case | Asserts |
|---|---|
| existing table | `200` with an empty `PartitionIndexDescriptorList` |
| missing table | fails, rather than reporting an empty list |

58 tests across `GlueJsonHandlerTest`, `GlueJsonHandlerEmptyListTest` and `GlueServiceTest` pass. `make docs-check` is clean.

End to end, on an image built from this branch, a Glue database and a partition-projected table previously provisioned by shelling out to the CLI now manage cleanly as `aws_glue_catalog_database` / `aws_glue_catalog_table`:

- `tofu apply` creates both, and a second `plan` is clean with no error on the index read
- deleting the catalog out of band is detected on the next refresh and recreated, which a `local-exec` provisioner cannot do
- the audit-log endpoint backed by that table returns rows with no manual catalog step
