### PR TITLE
feat(ses): support v2 dedicated IP (IP-level) and scaling/warmup APIs

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesDedicatedIpPoolTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/com/floci/test/SesDedicatedIpPoolTest.java
@@ -13,10 +13,17 @@ import software.amazon.awssdk.services.sesv2.model.AlreadyExistsException;
 import software.amazon.awssdk.services.sesv2.model.BadRequestException;
 import software.amazon.awssdk.services.sesv2.model.CreateDedicatedIpPoolRequest;
 import software.amazon.awssdk.services.sesv2.model.DeleteDedicatedIpPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.GetAccountRequest;
 import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpPoolRequest;
 import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpPoolResponse;
+import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpRequest;
+import software.amazon.awssdk.services.sesv2.model.GetDedicatedIpsRequest;
 import software.amazon.awssdk.services.sesv2.model.ListDedicatedIpPoolsResponse;
 import software.amazon.awssdk.services.sesv2.model.NotFoundException;
+import software.amazon.awssdk.services.sesv2.model.PutAccountDedicatedIpWarmupAttributesRequest;
+import software.amazon.awssdk.services.sesv2.model.PutDedicatedIpInPoolRequest;
+import software.amazon.awssdk.services.sesv2.model.PutDedicatedIpPoolScalingAttributesRequest;
+import software.amazon.awssdk.services.sesv2.model.PutDedicatedIpWarmupAttributesRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -129,5 +136,99 @@ class SesDedicatedIpPoolTest {
         assertThatThrownBy(() -> sesV2.deleteDedicatedIpPool(
                 DeleteDedicatedIpPoolRequest.builder().poolName("compat-pool-ghost").build()))
                 .isInstanceOf(NotFoundException.class);
+    }
+
+    // ─────────────── IP-level / scaling / account warmup ───────────────
+
+    private static final String TEST_IP = "192.0.2.1";
+
+    @Test
+    @Order(9)
+    void getDedicatedIps_empty() {
+        assertThat(sesV2.getDedicatedIps(GetDedicatedIpsRequest.builder().build()).dedicatedIps())
+                .isEmpty();
+    }
+
+    @Test
+    @Order(10)
+    void getDedicatedIp_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.getDedicatedIp(
+                GetDedicatedIpRequest.builder().ip(TEST_IP).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(11)
+    void putDedicatedIpInPool_throwsNotFound() {
+        String pool = "compat-pool-scaling";
+        // Pre-clean like the class-level pools: an interrupted earlier run may have left it behind.
+        deletePoolQuietly(pool);
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder().poolName(pool).build());
+        try {
+            assertThatThrownBy(() -> sesV2.putDedicatedIpInPool(PutDedicatedIpInPoolRequest.builder()
+                    .ip(TEST_IP).destinationPoolName(pool).build()))
+                    .isInstanceOf(NotFoundException.class);
+
+            // Switching the pool's scaling mode is the only IP-level operation that
+            // mutates state (no IPs exist to manage).
+            sesV2.putDedicatedIpPoolScalingAttributes(PutDedicatedIpPoolScalingAttributesRequest.builder()
+                    .poolName(pool).scalingMode("MANAGED").build());
+            assertThat(sesV2.getDedicatedIpPool(GetDedicatedIpPoolRequest.builder().poolName(pool).build())
+                    .dedicatedIpPool().scalingModeAsString()).isEqualTo("MANAGED");
+        } finally {
+            sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(pool).build());
+        }
+    }
+
+    @Test
+    @Order(12)
+    void putDedicatedIpWarmupAttributes_throwsNotFound() {
+        assertThatThrownBy(() -> sesV2.putDedicatedIpWarmupAttributes(
+                PutDedicatedIpWarmupAttributesRequest.builder().ip(TEST_IP).warmupPercentage(50).build()))
+                .isInstanceOf(NotFoundException.class);
+    }
+
+    @Test
+    @Order(13)
+    void putDedicatedIpPoolScalingAttributes_managedToStandard_throwsBadRequest() {
+        String pool = "compat-pool-downgrade";
+        deletePoolQuietly(pool);
+        sesV2.createDedicatedIpPool(CreateDedicatedIpPoolRequest.builder().poolName(pool).build());
+        try {
+            sesV2.putDedicatedIpPoolScalingAttributes(PutDedicatedIpPoolScalingAttributesRequest.builder()
+                    .poolName(pool).scalingMode("MANAGED").build());
+            assertThatThrownBy(() -> sesV2.putDedicatedIpPoolScalingAttributes(
+                    PutDedicatedIpPoolScalingAttributesRequest.builder()
+                            .poolName(pool).scalingMode("STANDARD").build()))
+                    .isInstanceOf(BadRequestException.class);
+        } finally {
+            sesV2.deleteDedicatedIpPool(DeleteDedicatedIpPoolRequest.builder().poolName(pool).build());
+        }
+    }
+
+    @Test
+    @Order(14)
+    void putDedicatedIpWarmupAttributes_outOfRange_throwsBadRequest() {
+        // Range is enforced before the IP lookup, so an out-of-range value is a BadRequestException
+        // rather than the IP NotFoundException.
+        assertThatThrownBy(() -> sesV2.putDedicatedIpWarmupAttributes(
+                PutDedicatedIpWarmupAttributesRequest.builder().ip(TEST_IP).warmupPercentage(150).build()))
+                .isInstanceOf(BadRequestException.class);
+    }
+
+    @Test
+    @Order(15)
+    void accountDedicatedIpAutoWarmup_togglable() {
+        boolean original = sesV2.getAccount(GetAccountRequest.builder().build())
+                .dedicatedIpAutoWarmupEnabled();
+        try {
+            sesV2.putAccountDedicatedIpWarmupAttributes(PutAccountDedicatedIpWarmupAttributesRequest.builder()
+                    .autoWarmupEnabled(false).build());
+            assertThat(sesV2.getAccount(GetAccountRequest.builder().build()).dedicatedIpAutoWarmupEnabled())
+                    .isFalse();
+        } finally {
+            sesV2.putAccountDedicatedIpWarmupAttributes(PutAccountDedicatedIpWarmupAttributesRequest.builder()
+                    .autoWarmupEnabled(original).build());
+        }
     }
 }

--- a/docs/services/ses.md
+++ b/docs/services/ses.md
@@ -260,6 +260,12 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `GET` | `/v2/email/dedicated-ip-pools` | `ListDedicatedIpPools` |
 | `GET` | `/v2/email/dedicated-ip-pools/{PoolName}` | `GetDedicatedIpPool` |
 | `DELETE` | `/v2/email/dedicated-ip-pools/{PoolName}` | `DeleteDedicatedIpPool` |
+| `PUT` | `/v2/email/dedicated-ip-pools/{PoolName}/scaling` | `PutDedicatedIpPoolScalingAttributes` |
+| `GET` | `/v2/email/dedicated-ips` | `GetDedicatedIps` |
+| `GET` | `/v2/email/dedicated-ips/{IP}` | `GetDedicatedIp` |
+| `PUT` | `/v2/email/dedicated-ips/{IP}/pool` | `PutDedicatedIpInPool` |
+| `PUT` | `/v2/email/dedicated-ips/{IP}/warmup` | `PutDedicatedIpWarmupAttributes` |
+| `PUT` | `/v2/email/account/dedicated-ips/warmup` | `PutAccountDedicatedIpWarmupAttributes` |
 | `POST` | `/v2/email/contact-lists` | `CreateContactList` |
 | `GET` | `/v2/email/contact-lists` | `ListContactLists` |
 | `GET` | `/v2/email/contact-lists/{ContactListName}` | `GetContactList` |
@@ -277,6 +283,8 @@ Alongside the classic Query API, Floci implements a subset of the SES v2 REST JS
 | `POST` | `/v2/email/tags` | `TagResource` |
 | `DELETE` | `/v2/email/tags?ResourceArn=...&TagKeys=...` | `UntagResource` |
 | `GET` | `/v2/email/tags?ResourceArn=...` | `ListTagsForResource` |
+
+Floci models no leased dedicated IPs: `GetDedicatedIps` is empty and IP-targeted operations return `NotFoundException`, as real AWS does for an account with no leased IPs, with required request members validated first (`BadRequestException`). `PutDedicatedIpPoolScalingAttributes` rejects downgrading a `MANAGED` pool to `STANDARD`, and `PutAccountDedicatedIpWarmupAttributes` stores the flag behind `GetAccount.DedicatedIpAutoWarmupEnabled` (default `true`).
 
 Configuration set event destinations are stored as configuration. The target is not validated for existence; missing targets cause Floci to log a warning and skip that destination. Each event destination must specify exactly one destination type and at least one matching event type. A CloudWatch destination requires a non-empty dimension configuration list, and a Pinpoint destination requires an application ARN.
 

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesAccountService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesAccountService.java
@@ -64,6 +64,14 @@ public class SesAccountService {
         LOG.infov("Updated account sending enabled for region {0}: {1}", region, enabled);
     }
 
+    public boolean isDedicatedIpAutoWarmupEnabled(String region) {
+        return accountSettingsStore.get("dedicatedIpAutoWarmup::" + region).orElse(true);
+    }
+
+    public void setDedicatedIpAutoWarmup(String region, boolean enabled) {
+        accountSettingsStore.put("dedicatedIpAutoWarmup::" + region, enabled);
+    }
+
     // VDM (Virtual Deliverability Manager) is opt-in and per region: GetAccount omits VdmAttributes
     // entirely until PutAccountVdmAttributes is called for the region, so this returns empty when the
     // region was never configured. The whole tuple is stored under one region key so GetAccount never

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesController.java
@@ -1881,6 +1881,36 @@ public class SesController {
         return Response.ok(result).build();
     }
 
+    @PUT
+    @Path("/dedicated-ip-pools/{poolName}/scaling")
+    public Response putDedicatedIpPoolScalingAttributes(@Context HttpHeaders headers,
+                                                        @PathParam("poolName") String poolName,
+                                                        String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            String scalingMode = parseOptionString(request.path("ScalingMode"), "ScalingMode");
+            sesService.putDedicatedIpPoolScalingAttributes(poolName, scalingMode, region);
+            LOG.infov("SES V2 PutDedicatedIpPoolScalingAttributes on {0}", poolName);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    // ──────────────────────── Dedicated IPs (IP-level) ────────────────────────
+
+    @GET
+    @Path("/dedicated-ips")
+    public Response getDedicatedIps(@Context HttpHeaders headers) {
+        regionResolver.resolveRegion(headers);
+        // Floci does not model leased dedicated IPs, so the account has none.
+        ObjectNode result = objectMapper.createObjectNode();
+        result.putArray("DedicatedIps");
+        result.putNull("NextToken");
+        return Response.ok(result).build();
+    }
+
     @GET
     @Path("/contact-lists/{contactListName}")
     public Response getContactList(@Context HttpHeaders headers,
@@ -2160,6 +2190,59 @@ public class SesController {
         return result;
     }
 
+    @GET
+    @Path("/dedicated-ips/{ip}")
+    public Response getDedicatedIp(@Context HttpHeaders headers, @PathParam("ip") String ip) {
+        String region = regionResolver.resolveRegion(headers);
+        sesService.getDedicatedIp(ip, region);
+        return Response.ok(objectMapper.createObjectNode()).build();
+    }
+
+    @PUT
+    @Path("/dedicated-ips/{ip}/pool")
+    public Response putDedicatedIpInPool(@Context HttpHeaders headers,
+                                         @PathParam("ip") String ip, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            String destinationPoolName = parseOptionString(
+                    request.path("DestinationPoolName"), "DestinationPoolName");
+            sesService.putDedicatedIpInPool(ip, destinationPoolName, region);
+            LOG.infov("SES V2 PutDedicatedIpInPool: {0}", ip);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    @PUT
+    @Path("/dedicated-ips/{ip}/warmup")
+    public Response putDedicatedIpWarmupAttributes(@Context HttpHeaders headers,
+                                                   @PathParam("ip") String ip, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            sesService.putDedicatedIpWarmupAttributes(ip,
+                    parseWarmupPercentage(request.path("WarmupPercentage")), region);
+            LOG.infov("SES V2 PutDedicatedIpWarmupAttributes: {0}", ip);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
+    }
+
+    // JSON-layer concern only: a non-integer WarmupPercentage is a SerializationException,
+    // matching AWS. Required/range validation lives in the service.
+    private static Integer parseWarmupPercentage(JsonNode node) {
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (!node.isInt()) {
+            throw new AwsException("SerializationException", null, 400);
+        }
+        return node.intValue();
+    }
+
     // ──────────────────────────── Account ────────────────────────────
 
     @GET
@@ -2171,7 +2254,7 @@ public class SesController {
         AccountSuppressionAttributes suppression = sesService.getAccountSuppressionAttributes(region);
 
         ObjectNode result = objectMapper.createObjectNode();
-        result.put("DedicatedIpAutoWarmupEnabled", false);
+        result.put("DedicatedIpAutoWarmupEnabled", sesService.isAccountDedicatedIpAutoWarmupEnabled(region));
         result.put("EnforcementStatus", "HEALTHY");
         result.put("ProductionAccessEnabled", true);
         result.put("SendingEnabled", sendingEnabled);
@@ -2371,6 +2454,25 @@ public class SesController {
                 "1 validation error detected: Value at '" + path
                         + "' failed to satisfy constraint: Member must satisfy enum value set: [ENABLED, DISABLED]",
                 400);
+    }
+
+    @PUT
+    @Path("/account/dedicated-ips/warmup")
+    public Response putAccountDedicatedIpWarmupAttributes(@Context HttpHeaders headers, String body) {
+        String region = regionResolver.resolveRegion(headers);
+        try {
+            JsonNode request = readOptionBody(body);
+            JsonNode enabledNode = request.path("AutoWarmupEnabled");
+            // AutoWarmupEnabled has a default of false: the SDK omits it when false, so a missing
+            // member is treated as false rather than rejected. A present value goes through the
+            // shared SES v2 boolean coercion (string→true, null/number/container→SerializationException).
+            boolean enabled = enabledNode.isMissingNode() ? false : coerceBoolean(enabledNode);
+            sesService.setAccountDedicatedIpAutoWarmup(region, enabled);
+            LOG.infov("SES V2 PutAccountDedicatedIpWarmupAttributes: {0}", enabled);
+            return Response.ok(objectMapper.createObjectNode()).build();
+        } catch (AwsException e) {
+            throw remapV1Exception(e);
+        }
     }
 
     @PUT

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpService.java
@@ -30,8 +30,9 @@ public class SesDedicatedIpService {
     private static final Set<String> SCALING_MODES = Set.of("STANDARD", "MANAGED");
 
     private final StorageBackend<String, DedicatedIpPool> dedicatedIpPoolStore;
-    // Serializes pool check-then-write mutations (create/delete/tag) so concurrent creates for the
-    // same name can't both succeed and tagging can't resurrect a concurrently deleted pool.
+    // Serializes pool check-then-write mutations (create/delete/tag/scaling) so concurrent creates
+    // for the same name can't both succeed and tagging or scaling can't resurrect a concurrently
+    // deleted pool.
     private final Object poolMutationLock = new Object();
 
     @Inject
@@ -139,6 +140,69 @@ public class SesDedicatedIpService {
         // (probe-confirmed), unlike the CRUD "The requested pool <X> does not exist."
         return new AwsException("NotFoundException",
                 "No DedicatedIpPool present with name: " + poolName, 404);
+    }
+
+    // ──────────────────────── Dedicated IPs (IP-level) ────────────────────────
+    //
+    // SES has no API to create a dedicated IP: they are leased out-of-band
+    // (STANDARD) or auto-provisioned by AWS (MANAGED). Floci does not model that,
+    // so an account has no dedicated IPs: GetDedicatedIps is empty and any
+    // IP-targeted operation reports the IP as not found, matching real AWS for an
+    // account with no leased IPs (verified 2026-06-21).
+
+    private AwsException dedicatedIpNotFound(String ip) {
+        return new AwsException("NotFoundException",
+                "Could not find dedicated IP <" + ip + "> under this account.", 404);
+    }
+
+    public void getDedicatedIp(String ip, String region) {
+        // Unconditional, hence void: the account holds no dedicated IPs (see the section note
+        // above), so the lookup can only fail, the way real AWS answers with no leased IPs.
+        throw dedicatedIpNotFound(ip);
+    }
+
+    public void putDedicatedIpInPool(String ip, String destinationPoolName, String region) {
+        // AWS validates the required DestinationPoolName before it checks the IP.
+        if (destinationPoolName == null || destinationPoolName.isBlank()) {
+            throw new AwsException("BadRequestException", "Pool name can't be blank.", 400);
+        }
+        // AWS checks the IP before the destination pool.
+        throw dedicatedIpNotFound(ip);
+    }
+
+    // WarmupPercentage is a required integer in 0..100 (AWS returns -1 only in responses, for
+    // managed pools). AWS validates it before it looks up the IP; a non-integer value is a
+    // SerializationException raised at the controller's JSON layer before reaching here.
+    public void putDedicatedIpWarmupAttributes(String ip, Integer warmupPercentage, String region) {
+        if (warmupPercentage == null) {
+            throw new AwsException("BadRequestException", "Warmup Percentage can't be null.", 400);
+        }
+        if (warmupPercentage < 0 || warmupPercentage > 100) {
+            throw new AwsException("BadRequestException",
+                    "Warmup Percentage must be between 0 and 100.", 400);
+        }
+        throw dedicatedIpNotFound(ip);
+    }
+
+    public void putDedicatedIpPoolScalingAttributes(String poolName, String scalingMode, String region) {
+        // AWS validates ScalingMode before it checks that the pool exists.
+        if (scalingMode == null || !SCALING_MODES.contains(scalingMode)) {
+            throw new AwsException("BadRequestException", "The ScalingMode parameter is invalid.", 400);
+        }
+        String key = dedicatedIpPoolKey(region, poolName);
+        synchronized (poolMutationLock) {
+            DedicatedIpPool pool = dedicatedIpPoolStore.get(key)
+                    .orElseThrow(() -> new AwsException("NotFoundException",
+                            "The requested pool <" + poolName + "> does not exist.", 404));
+            // AWS rejects downgrading a MANAGED pool back to STANDARD.
+            if ("MANAGED".equals(pool.getScalingMode()) && "STANDARD".equals(scalingMode)) {
+                throw new AwsException("BadRequestException", "The ScalingMode parameter is invalid.", 400);
+            }
+            pool.setScalingMode(scalingMode);
+            dedicatedIpPoolStore.put(key, pool);
+        }
+        LOG.infov("Updated ScalingMode on dedicated IP pool {0} in region {1}: {2}",
+                poolName, region, scalingMode);
     }
 
     private static String dedicatedIpPoolKey(String region, String name) {

--- a/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/ses/SesService.java
@@ -1338,6 +1338,34 @@ public class SesService {
 
 
 
+    // Dedicated IPs (IP-level) and pool scaling live in SesDedicatedIpService; the facade forwards.
+
+    public void getDedicatedIp(String ip, String region) {
+        dedicatedIpService.getDedicatedIp(ip, region);
+    }
+
+    public void putDedicatedIpInPool(String ip, String destinationPoolName, String region) {
+        dedicatedIpService.putDedicatedIpInPool(ip, destinationPoolName, region);
+    }
+
+    public void putDedicatedIpWarmupAttributes(String ip, Integer warmupPercentage, String region) {
+        dedicatedIpService.putDedicatedIpWarmupAttributes(ip, warmupPercentage, region);
+    }
+
+    public void putDedicatedIpPoolScalingAttributes(String poolName, String scalingMode, String region) {
+        dedicatedIpService.putDedicatedIpPoolScalingAttributes(poolName, scalingMode, region);
+    }
+
+    // Dedicated-IP auto-warmup is an account-level setting owned by SesAccountService.
+
+    public boolean isAccountDedicatedIpAutoWarmupEnabled(String region) {
+        return accountService.isDedicatedIpAutoWarmupEnabled(region);
+    }
+
+    public void setAccountDedicatedIpAutoWarmup(String region, boolean enabled) {
+        accountService.setDedicatedIpAutoWarmup(region, enabled);
+    }
+
     public void createConfigurationSetEventDestination(String configSetName, String eventDestinationName,
                                                        EventDestination dest, String region) {
         configSetService.createEventDestination(configSetName, eventDestinationName, dest, region);

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesAccountServiceTest.java
@@ -90,4 +90,13 @@ class SesAccountServiceTest {
         assertThrows(AwsException.class, () -> service.putAccountDetails(REGION, null,
                 null, null, null, null, false));
     }
+
+    @Test
+    void dedicatedIpAutoWarmup_defaultsTrue_thenRoundTrips() {
+        assertTrue(service.isDedicatedIpAutoWarmupEnabled(REGION));
+
+        service.setDedicatedIpAutoWarmup(REGION, false);
+        assertFalse(service.isDedicatedIpAutoWarmupEnabled(REGION));
+        assertTrue(service.isDedicatedIpAutoWarmupEnabled("eu-west-1"));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpServiceTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpServiceTest.java
@@ -118,4 +118,53 @@ class SesDedicatedIpServiceTest {
     void delete_missingThrows() {
         assertThrows(AwsException.class, () -> service.deleteDedicatedIpPool("ghost", REGION));
     }
+
+    @Test
+    void ipLevelOperations_reportIpNotFound() {
+        // Floci models no leased dedicated IPs, so every IP-targeted op reports not-found.
+        assertThrows(AwsException.class, () -> service.getDedicatedIp("1.2.3.4", REGION));
+        assertThrows(AwsException.class, () -> service.putDedicatedIpInPool("1.2.3.4", "pool-a", REGION));
+        assertThrows(AwsException.class, () -> service.putDedicatedIpWarmupAttributes("1.2.3.4", 50, REGION));
+    }
+
+    @Test
+    void putWarmupAttributes_validatesPercentageBeforeIp() {
+        // Required and range checks fire before the IP lookup, matching AWS precedence.
+        AwsException missing = assertThrows(AwsException.class,
+                () -> service.putDedicatedIpWarmupAttributes("1.2.3.4", null, REGION));
+        assertEquals("Warmup Percentage can't be null.", missing.getMessage());
+
+        AwsException outOfRange = assertThrows(AwsException.class,
+                () -> service.putDedicatedIpWarmupAttributes("1.2.3.4", 101, REGION));
+        assertEquals("Warmup Percentage must be between 0 and 100.", outOfRange.getMessage());
+    }
+
+    @Test
+    void putDedicatedIpInPool_validatesBlankDestinationBeforeIp() {
+        assertThrows(AwsException.class, () -> service.putDedicatedIpInPool("1.2.3.4", " ", REGION));
+    }
+
+    @Test
+    void putScalingAttributes_rejectsInvalidMode() {
+        service.createDedicatedIpPool("pool-a", "STANDARD", null, REGION);
+        assertThrows(AwsException.class,
+                () -> service.putDedicatedIpPoolScalingAttributes("pool-a", "TURBO", REGION));
+    }
+
+    @Test
+    void putScalingAttributes_missingPoolThrows() {
+        assertThrows(AwsException.class,
+                () -> service.putDedicatedIpPoolScalingAttributes("ghost", "MANAGED", REGION));
+    }
+
+    @Test
+    void putScalingAttributes_upgradesStandardToManaged_thenRejectsDowngrade() {
+        service.createDedicatedIpPool("pool-a", "STANDARD", null, REGION);
+
+        service.putDedicatedIpPoolScalingAttributes("pool-a", "MANAGED", REGION);
+        assertEquals("MANAGED", service.getDedicatedIpPool("pool-a", REGION).getScalingMode());
+
+        assertThrows(AwsException.class,
+                () -> service.putDedicatedIpPoolScalingAttributes("pool-a", "STANDARD", REGION));
+    }
 }

--- a/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/ses/SesDedicatedIpV2IntegrationTest.java
@@ -1,0 +1,232 @@
+package io.github.hectorvent.floci.services.ses;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/**
+ * Integration tests for the SES V2 dedicated-IP (IP-level) endpoints. Floci does
+ * not model leased dedicated IPs, so an account has none: GetDedicatedIps is
+ * empty and any IP-targeted operation reports the IP as not found, matching real
+ * AWS for an account with no leased IPs.
+ */
+@QuarkusTest
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SesDedicatedIpV2IntegrationTest {
+
+    private static final String AUTH_HEADER =
+            "AWS4-HMAC-SHA256 Credential=AKID/20260101/us-east-1/ses/aws4_request";
+    private static final String TEST_IP = "192.0.2.1";
+
+    @Test
+    @Order(1)
+    void getDedicatedIps_empty() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ips")
+        .then().statusCode(200)
+            .body("DedicatedIps", hasSize(0));
+    }
+
+    @Test
+    @Order(2)
+    void getDedicatedIp_notFound() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ips/" + TEST_IP)
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("Could not find dedicated IP <" + TEST_IP + "> under this account."));
+    }
+
+    @Test
+    @Order(3)
+    void putDedicatedIpInPool_ipNotFound() {
+        // Even with an existing destination pool, the IP is checked first.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"PoolName\": \"dip-scaling-pool\"}")
+        .when().post("/v2/email/dedicated-ip-pools").then().statusCode(200);
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"DestinationPoolName\": \"dip-scaling-pool\"}")
+        .when().put("/v2/email/dedicated-ips/" + TEST_IP + "/pool")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("Could not find dedicated IP <" + TEST_IP + "> under this account."));
+    }
+
+    @Test
+    @Order(4)
+    void putDedicatedIpWarmupAttributes_ipNotFound() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"WarmupPercentage\": 50}")
+        .when().put("/v2/email/dedicated-ips/" + TEST_IP + "/warmup")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("Could not find dedicated IP <" + TEST_IP + "> under this account."));
+    }
+
+    @Test
+    @Order(5)
+    void putDedicatedIpPoolScalingAttributes_updatesPool() {
+        // The pool from Order 3 starts STANDARD; switch it to MANAGED.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ScalingMode\": \"MANAGED\"}")
+        .when().put("/v2/email/dedicated-ip-pools/dip-scaling-pool/scaling")
+        .then().statusCode(200);
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/dedicated-ip-pools/dip-scaling-pool")
+        .then().statusCode(200)
+            .body("DedicatedIpPool.ScalingMode", equalTo("MANAGED"));
+    }
+
+    @Test
+    @Order(6)
+    void putDedicatedIpPoolScalingAttributes_invalidMode_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ScalingMode\": \"NONSENSE\"}")
+        .when().put("/v2/email/dedicated-ip-pools/dip-scaling-pool/scaling")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+
+    @Test
+    @Order(7)
+    void putDedicatedIpPoolScalingAttributes_unknownPool_returns404() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ScalingMode\": \"STANDARD\"}")
+        .when().put("/v2/email/dedicated-ip-pools/dip-ghost-pool/scaling")
+        .then().statusCode(404)
+            .body("__type", equalTo("NotFoundException"))
+            .body("message", equalTo("The requested pool <dip-ghost-pool> does not exist."));
+    }
+
+    @Test
+    @Order(8)
+    void accountDedicatedIpAutoWarmup_defaultsTrue_andTogglable() {
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/account")
+        .then().statusCode(200)
+            .body("DedicatedIpAutoWarmupEnabled", equalTo(true));
+
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"AutoWarmupEnabled\": false}")
+        .when().put("/v2/email/account/dedicated-ips/warmup")
+        .then().statusCode(200);
+
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/account")
+        .then().statusCode(200)
+            .body("DedicatedIpAutoWarmupEnabled", equalTo(false));
+    }
+
+    @Test
+    @Order(9)
+    void putDedicatedIpInPool_missingDestinationPoolName_returns400() {
+        // A missing required member is validated before the IP lookup.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/dedicated-ips/" + TEST_IP + "/pool")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Pool name can't be blank."));
+    }
+
+    @Test
+    @Order(10)
+    void putDedicatedIpPoolScalingAttributes_missingModeUnknownPool_returns400() {
+        // ScalingMode is validated before the pool-existence check, so a missing mode on an
+        // unknown pool is a BadRequestException, not NotFoundException.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/dedicated-ip-pools/dip-ghost-pool/scaling")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+
+    @Test
+    @Order(11)
+    void putDedicatedIpPoolScalingAttributes_managedToStandard_returns400() {
+        // dip-scaling-pool was switched to MANAGED in Order 5; AWS forbids downgrading to STANDARD.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"ScalingMode\": \"STANDARD\"}")
+        .when().put("/v2/email/dedicated-ip-pools/dip-scaling-pool/scaling")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("The ScalingMode parameter is invalid."));
+    }
+
+    @Test
+    @Order(12)
+    void putDedicatedIpWarmupAttributes_missingPercentage_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{}")
+        .when().put("/v2/email/dedicated-ips/" + TEST_IP + "/warmup")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Warmup Percentage can't be null."));
+    }
+
+    @Test
+    @Order(13)
+    void putDedicatedIpWarmupAttributes_outOfRange_returns400() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"WarmupPercentage\": 150}")
+        .when().put("/v2/email/dedicated-ips/" + TEST_IP + "/warmup")
+        .then().statusCode(400)
+            .body("__type", equalTo("BadRequestException"))
+            .body("message", equalTo("Warmup Percentage must be between 0 and 100."));
+    }
+
+    @Test
+    @Order(14)
+    void putDedicatedIpWarmupAttributes_nonInteger_returnsSerializationException() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"WarmupPercentage\": \"abc\"}")
+        .when().put("/v2/email/dedicated-ips/" + TEST_IP + "/warmup")
+        .then().statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(15)
+    void putAccountAutoWarmup_stringCoercesToTrue() {
+        // AWS's Jackson layer coerces a JSON string to true for SES v2 booleans.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"AutoWarmupEnabled\": \"nonsense\"}")
+        .when().put("/v2/email/account/dedicated-ips/warmup")
+        .then().statusCode(200);
+
+        given().header("Authorization", AUTH_HEADER)
+        .when().get("/v2/email/account")
+        .then().statusCode(200)
+            .body("DedicatedIpAutoWarmupEnabled", equalTo(true));
+    }
+
+    @Test
+    @Order(16)
+    void putAccountAutoWarmup_explicitNull_returnsSerializationException() {
+        // Only an omitted member falls back to the @default(false); an explicit null does not.
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"AutoWarmupEnabled\": null}")
+        .when().put("/v2/email/account/dedicated-ips/warmup")
+        .then().statusCode(400)
+            .body("__type", equalTo("SerializationException"));
+    }
+
+    @Test
+    @Order(17)
+    void putAccountAutoWarmup_number_returnsSerializationException() {
+        given().contentType("application/json").header("Authorization", AUTH_HEADER)
+            .body("{\"AutoWarmupEnabled\": 1}")
+        .when().put("/v2/email/account/dedicated-ips/warmup")
+        .then().statusCode(400)
+            .body("__type", equalTo("SerializationException"))
+            .body("message", equalTo("NUMBER_VALUE can not be converted to a Boolean"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds the remaining SES v2 dedicated-IP operations on top of the existing pool management: `GetDedicatedIps`, `GetDedicatedIp`, `PutDedicatedIpInPool`, `PutDedicatedIpWarmupAttributes`, `PutDedicatedIpPoolScalingAttributes`, and `PutAccountDedicatedIpWarmupAttributes`.

SES has no API to create a dedicated IP: they are leased out-of-band (`STANDARD`) or auto-provisioned by AWS (`MANAGED`). Floci does not model that, so an account holds no dedicated IPs and the IP-level operations behave the way real AWS does for an account with none:

- `GetDedicatedIps` returns an empty list, and every IP-targeted operation reports `NotFoundException` ("Could not find dedicated IP <ip> under this account.").
- Required request members are validated before that lookup, matching AWS precedence: a missing `ScalingMode`, `DestinationPoolName`, or `WarmupPercentage` (or a `WarmupPercentage` outside 0 to 100) is a `BadRequestException`, not `NotFoundException`.
- `PutDedicatedIpPoolScalingAttributes` sets a pool's scaling mode but rejects downgrading a `MANAGED` pool back to `STANDARD`.
- `PutAccountDedicatedIpWarmupAttributes` stores the account-level auto-warmup flag, now surfaced by `GetAccount.DedicatedIpAutoWarmupEnabled` (default `true`). Its `AutoWarmupEnabled` member goes through the controller's shared SES v2 boolean coercion, so the SDK's `@default(false)` omission and AWS's string and number handling both hold.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

Wire behavior probed against real AWS SES v2 in us-east-2: the empty `DedicatedIps` list, the `NotFoundException` message and its precedence against required-member validation (the IP is checked before the destination pool), an invalid `ScalingMode` as `BadRequestException`, the `MANAGED` to `STANDARD` rejection, and `DedicatedIpAutoWarmupEnabled` defaulting to `true`. Verified with AWS SDK for Java v2 through `SesDedicatedIpPoolTest` in `compatibility-tests/sdk-test-java`, which also covers the REST paths and the `@default(false)` omission of `AutoWarmupEnabled`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
