### PR TITLE
fix(lambda): honor MaximumRetryAttempts and DestinationConfig.OnFailure for DynamoDB Streams ESM (#3263)

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePoller.java
@@ -1,6 +1,11 @@
 package io.github.hectorvent.floci.services.lambda;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.hectorvent.floci.config.EmulatorConfig;
+import io.github.hectorvent.floci.core.common.AwsArnUtils;
 import io.github.hectorvent.floci.core.common.AwsException;
 import io.github.hectorvent.floci.core.common.Resettable;
 import io.github.hectorvent.floci.services.dynamodb.DynamoDbStreamService;
@@ -10,16 +15,16 @@ import io.github.hectorvent.floci.services.lambda.model.InvocationType;
 import io.github.hectorvent.floci.services.lambda.model.InvokeResult;
 import io.github.hectorvent.floci.services.lambda.model.LambdaFunction;
 import io.github.hectorvent.floci.services.pipes.PipesFilterMatcher;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.github.hectorvent.floci.services.sns.SnsService;
+import io.github.hectorvent.floci.services.sqs.SqsService;
 import io.vertx.core.Vertx;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,9 +50,13 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
     private final EsmStore esmStore;
     private final ObjectMapper objectMapper;
     private final PipesFilterMatcher filterMatcher;
+    private final SqsService sqsService;
+    private final SnsService snsService;
+    private final String baseUrl;
     private final long pollIntervalMs;
     private final ConcurrentHashMap<String, Long> timerIds = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, Boolean> activePolls = new ConcurrentHashMap<>();
+    final ConcurrentHashMap<String, Boolean> activePolls = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Integer> retryCounts = new ConcurrentHashMap<>();
     private final ExecutorService pollExecutor = Executors.newCachedThreadPool(r -> {
         Thread t = new Thread(r, "dynamodb-streams-esm-poller");
         t.setDaemon(true);
@@ -61,7 +70,9 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                                             EsmStore esmStore,
                                             ObjectMapper objectMapper,
                                             EmulatorConfig config,
-                                            PipesFilterMatcher filterMatcher) {
+                                            PipesFilterMatcher filterMatcher,
+                                            SqsService sqsService,
+                                            SnsService snsService) {
         this.vertx = vertx;
         this.streamService = streamService;
         this.executorService = executorService;
@@ -69,7 +80,10 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
         this.esmStore = esmStore;
         this.objectMapper = objectMapper;
         this.pollIntervalMs = config.services().lambda().pollIntervalMs();
+        this.baseUrl = config.effectiveBaseUrl();
         this.filterMatcher = filterMatcher;
+        this.sqsService = sqsService;
+        this.snsService = snsService;
     }
 
     public void startPersistedPollers() {
@@ -118,6 +132,7 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
         timerIds.values().forEach(vertx::cancelTimer);
         timerIds.clear();
         activePolls.clear();
+        retryCounts.clear();
     }
 
     public void startPolling(EventSourceMapping esm) {
@@ -142,7 +157,9 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
             vertx.cancelTimer(timerId);
             LOG.debugv("Stopped DynamoDB Streams polling for ESM {0}", uuid);
         }
+        retryCounts.keySet().removeIf(k -> k.startsWith(uuid + ":"));
     }
+
 
     void pollAndInvoke(EventSourceMapping esm) {
         if (activePolls.putIfAbsent(esm.getUuid(), Boolean.TRUE) != null) {
@@ -161,6 +178,7 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                 String shardId = DynamoDbStreamService.SHARD_ID;
                 String lastSeq = esm.getShardSequenceNumbers().get(shardId);
 
+                boolean checkpointTrimmed = false;
                 DynamoDbStreamService.GetRecordsResult result;
                 try {
                     String iterator = lastSeq == null
@@ -171,6 +189,7 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                     if (!TRIMMED_DATA_ACCESS_EXCEPTION.equals(e.getErrorCode())) {
                         throw e;
                     }
+                    checkpointTrimmed = true;
                     // The checkpoint fell outside the retained window, so the cursor it names can
                     // never succeed again. Retrying it wedges the ESM permanently: every later
                     // write reaches the stream and none is ever delivered. Resume from the oldest
@@ -226,15 +245,28 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                     throw e;
                 }
 
+                String checkpointSeq = (lastSeq == null || checkpointTrimmed) ? "TRIM_HORIZON" : lastSeq;
+                String batchKey = esm.getUuid() + ":" + shardId + ":" + checkpointSeq;
                 if (invokeResult.getFunctionError() == null) {
+                    retryCounts.remove(batchKey);
                     String checkpoint = successfulInvocationCheckpoint(
                             esm, invokeResult, lastSeq, records, matched);
                     if (checkpoint != null && !checkpoint.equals(lastSeq)) {
                         advanceCheckpoint(esm, shardId, checkpoint);
                     }
                 } else {
-                    LOG.warnv("DynamoDB Streams ESM {0}: Lambda returned error [{1}], records will be retried",
-                            esm.getUuid(), invokeResult.getFunctionError());
+                    Integer maxRetries = esm.getMaximumRetryAttempts();
+                    int currentRetries = retryCounts.merge(batchKey, 1, Integer::sum);
+                    if (maxRetries != null && maxRetries >= 0 && currentRetries > maxRetries) {
+                        LOG.warnv("DynamoDB Streams ESM {0}: maximum retry attempts ({1}) exhausted for batch ending at {2}",
+                                esm.getUuid(), maxRetries, newestFetchedSeq);
+                        sendToOnFailureDestination(esm, shardId, matched, invokeResult, currentRetries);
+                        retryCounts.remove(batchKey);
+                        advanceCheckpoint(esm, shardId, newestFetchedSeq);
+                    } else {
+                        LOG.warnv("DynamoDB Streams ESM {0}: Lambda returned error [{1}], retry {2}, records will be retried",
+                                esm.getUuid(), invokeResult.getFunctionError(), currentRetries);
+                    }
                 }
             } catch (Exception e) {
                 LOG.warnv("DynamoDB Streams ESM {0} poll error: {1}", esm.getUuid(), e.getMessage());
@@ -311,6 +343,86 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                         + "retrying the whole batch",
                 esm.getUuid(), reason);
         return previousCheckpoint;
+    }
+
+    private void sendToOnFailureDestination(EventSourceMapping esm, String shardId,
+                                           List<DynamoDbStreamRecord> records,
+                                           InvokeResult invokeResult,
+                                           int invokeCount) {
+        if (esm.getDestinationConfig() == null || esm.getDestinationConfig().getOnFailure() == null) {
+            return;
+        }
+        String destinationArn = esm.getDestinationConfig().getOnFailure().getDestination();
+        if (destinationArn == null || destinationArn.isBlank()) {
+            return;
+        }
+
+        try {
+            String payload = buildOnFailurePayload(esm, shardId, records, invokeResult, invokeCount);
+            String region = AwsArnUtils.regionOrDefault(destinationArn, esm.getRegion());
+
+            if (destinationArn.contains(":sqs:")) {
+                String queueUrl = AwsArnUtils.arnToQueueUrl(destinationArn, baseUrl);
+                sqsService.sendMessage(queueUrl, payload, 0, region);
+                LOG.infov("DynamoDB Streams ESM {0}: sent failed batch to SQS DLQ {1}", esm.getUuid(), destinationArn);
+            } else if (destinationArn.contains(":sns:")) {
+                snsService.publish(destinationArn, null, payload, "ESM OnFailure", region);
+                LOG.infov("DynamoDB Streams ESM {0}: sent failed batch to SNS DLQ {1}", esm.getUuid(), destinationArn);
+            } else {
+                LOG.warnv("DynamoDB Streams ESM {0}: unsupported OnFailure destination ARN {1}",
+                        esm.getUuid(), destinationArn);
+            }
+        } catch (Exception e) {
+            LOG.errorv("DynamoDB Streams ESM {0}: failed to send to OnFailure destination {1}: {2}",
+                    esm.getUuid(), destinationArn, e.getMessage());
+        }
+    }
+
+    private String buildOnFailurePayload(EventSourceMapping esm, String shardId,
+                                         List<DynamoDbStreamRecord> records,
+                                         InvokeResult invokeResult,
+                                         int invokeCount) {
+        try {
+            ObjectNode root = objectMapper.createObjectNode();
+            root.put("version", "1.0");
+            root.put("timestamp", DateTimeFormatter.ISO_INSTANT.format(Instant.now()));
+
+            ObjectNode requestContext = root.putObject("requestContext");
+            requestContext.put("requestId", invokeResult.getRequestId() != null ? invokeResult.getRequestId() : "");
+            requestContext.put("functionArn", esm.getFunctionArn() != null ? esm.getFunctionArn() : "");
+            requestContext.put("condition", "RetryAttemptsExhausted");
+            requestContext.put("approximateInvokeCount", invokeCount);
+
+            ObjectNode responseContext = root.putObject("responseContext");
+            responseContext.put("statusCode", invokeResult.getStatusCode() != 0 ? invokeResult.getStatusCode() : 200);
+            responseContext.put("executedVersion", invokeResult.getExecutedVersion() != null ? invokeResult.getExecutedVersion() : "$LATEST");
+            if (invokeResult.getFunctionError() != null) {
+                responseContext.put("functionError", invokeResult.getFunctionError());
+            }
+
+            ObjectNode batchInfo = root.putObject("DDBStreamBatchInfo");
+            batchInfo.put("shardId", shardId);
+            String startSeq = records.isEmpty() ? "" : records.get(0).getSequenceNumber();
+            String endSeq = records.isEmpty() ? "" : records.get(records.size() - 1).getSequenceNumber();
+            batchInfo.put("startSequenceNumber", startSeq);
+            batchInfo.put("endSequenceNumber", endSeq);
+
+            if (!records.isEmpty()) {
+                long firstArrival = records.get(0).getApproximateCreationDateTime();
+                long lastArrival = records.get(records.size() - 1).getApproximateCreationDateTime();
+                batchInfo.put("approximateArrivalOfFirstRecord",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(firstArrival)));
+                batchInfo.put("approximateArrivalOfLastRecord",
+                        DateTimeFormatter.ISO_INSTANT.format(Instant.ofEpochSecond(lastArrival)));
+            }
+            batchInfo.put("batchSize", records.size());
+            batchInfo.put("streamArn", esm.getEventSourceArn());
+
+            return objectMapper.writeValueAsString(root);
+        } catch (Exception e) {
+            LOG.warnv("Failed to serialize OnFailure payload: {0}", e.getMessage());
+            return "{}";
+        }
     }
 
     private String buildDynamoDbEvent(List<DynamoDbStreamRecord> records, EventSourceMapping esm) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePoller.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePoller.java
@@ -247,13 +247,13 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
 
                 String checkpointSeq = (lastSeq == null || checkpointTrimmed) ? "TRIM_HORIZON" : lastSeq;
                 String batchKey = esm.getUuid() + ":" + shardId + ":" + checkpointSeq;
-                if (invokeResult.getFunctionError() == null) {
+                String checkpoint = invokeResult.getFunctionError() == null
+                        ? successfulInvocationCheckpoint(esm, invokeResult, lastSeq, records, matched)
+                        : null;
+
+                if (checkpoint != null && !checkpoint.equals(lastSeq)) {
                     retryCounts.remove(batchKey);
-                    String checkpoint = successfulInvocationCheckpoint(
-                            esm, invokeResult, lastSeq, records, matched);
-                    if (checkpoint != null && !checkpoint.equals(lastSeq)) {
-                        advanceCheckpoint(esm, shardId, checkpoint);
-                    }
+                    advanceCheckpoint(esm, shardId, checkpoint);
                 } else {
                     Integer maxRetries = esm.getMaximumRetryAttempts();
                     int currentRetries = retryCounts.merge(batchKey, 1, Integer::sum);
@@ -264,8 +264,11 @@ public class DynamoDbStreamsEventSourcePoller implements Resettable {
                         retryCounts.remove(batchKey);
                         advanceCheckpoint(esm, shardId, newestFetchedSeq);
                     } else {
+                        String error = invokeResult.getFunctionError() != null
+                                ? invokeResult.getFunctionError()
+                                : "batchItemFailures";
                         LOG.warnv("DynamoDB Streams ESM {0}: Lambda returned error [{1}], retry {2}, records will be retried",
-                                esm.getUuid(), invokeResult.getFunctionError(), currentRetries);
+                                esm.getUuid(), error, currentRetries);
                     }
                 }
             } catch (Exception e) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaController.java
@@ -369,6 +369,10 @@ public class LambdaController {
             node.put("BisectBatchOnFunctionError", esm.getBisectBatchOnFunctionError());
         }
 
+        if (esm.getMaximumRetryAttempts() != null) {
+            node.put("MaximumRetryAttempts", esm.getMaximumRetryAttempts());
+        }
+
         if (esm.getDestinationConfig() != null && esm.getDestinationConfig().getOnFailure() != null) {
             ObjectNode destinationConfig = node.putObject("DestinationConfig");
             ObjectNode onFailure = destinationConfig.putObject("OnFailure");

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/LambdaService.java
@@ -1290,6 +1290,8 @@ public class LambdaService implements ResourceProvider {
                 ? b
                 : null;
 
+        Integer maximumRetryAttempts = parseMaximumRetryAttempts(request);
+
         EventSourceMapping.DestinationConfig destinationConfig = parseDestinationConfig(request);
 
         EventSourceMapping.FilterCriteria filterCriteria = parseFilterCriteria(request, objectMapper);
@@ -1315,6 +1317,7 @@ public class LambdaService implements ResourceProvider {
         esm.setScalingConfig(scalingConfig);
         esm.setFunctionResponseTypes(functionResponseTypes);
         esm.setBisectBatchOnFunctionError(bisectBatchOnFunctionError);
+        esm.setMaximumRetryAttempts(maximumRetryAttempts);
         esm.setDestinationConfig(destinationConfig);
         esm.setFilterCriteria(filterCriteria);
         esm.setStartingPosition(startingPosition.position());
@@ -1698,6 +1701,28 @@ public class LambdaService implements ResourceProvider {
         return (int) value;
     }
 
+    private Integer parseMaximumRetryAttempts(Map<String, Object> request) {
+        Object raw = request.get("MaximumRetryAttempts");
+        if (raw == null) {
+            return null;
+        }
+        if (!(raw instanceof Number)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "MaximumRetryAttempts must be a numeric value", 400);
+        }
+        double d = ((Number) raw).doubleValue();
+        if (Double.isNaN(d) || Double.isInfinite(d) || d != Math.floor(d)) {
+            throw new AwsException("InvalidParameterValueException",
+                    "MaximumRetryAttempts must be an integer", 400);
+        }
+        long value = ((Number) raw).longValue();
+        if (value < -1 || value > 10000) {
+            throw new AwsException("InvalidParameterValueException",
+                    "MaximumRetryAttempts must be between -1 and 10000 (got " + value + ")", 400);
+        }
+        return (int) value;
+    }
+
     private void startPollingHelper(EventSourceMapping esm) {
         if (esm.getEventSourceArn() == null) {
             return;
@@ -1767,6 +1792,10 @@ public class LambdaService implements ResourceProvider {
         if (request.containsKey("BisectBatchOnFunctionError")) {
             Object raw = request.get("BisectBatchOnFunctionError");
             esm.setBisectBatchOnFunctionError(raw instanceof Boolean b ? b : null);
+        }
+
+        if (request.containsKey("MaximumRetryAttempts")) {
+            esm.setMaximumRetryAttempts(parseMaximumRetryAttempts(request));
         }
 
         if (request.containsKey("DestinationConfig")) {

--- a/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
+++ b/src/main/java/io/github/hectorvent/floci/services/lambda/model/EventSourceMapping.java
@@ -31,6 +31,7 @@ public class EventSourceMapping {
     private Map<String, String> shardSequenceNumbers = new HashMap<>();
     private ScalingConfig scalingConfig;
     private Boolean bisectBatchOnFunctionError;
+    private Integer maximumRetryAttempts;
     private DestinationConfig destinationConfig;
     private FilterCriteria filterCriteria;
     private Map<String, Object> selfManagedEventSource;
@@ -116,6 +117,14 @@ public class EventSourceMapping {
 
     public void setBisectBatchOnFunctionError(Boolean bisectBatchOnFunctionError) {
         this.bisectBatchOnFunctionError = bisectBatchOnFunctionError;
+    }
+
+    public Integer getMaximumRetryAttempts() {
+        return maximumRetryAttempts;
+    }
+
+    public void setMaximumRetryAttempts(Integer maximumRetryAttempts) {
+        this.maximumRetryAttempts = maximumRetryAttempts;
     }
 
     public DestinationConfig getDestinationConfig() {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
@@ -684,6 +684,143 @@ class DynamoDbStreamsEventSourcePollerTest {
         assertFalse(dlqPayload.has("hasBeenTruncated"));
     }
 
+    @Test
+    void reportBatchItemFailuresExhaustsRetriesAndDeliversToOnFailureDestination() throws Exception {
+        stubTrimHorizon(List.of(ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}")));
+        InvokeResult result = new InvokeResult();
+        result.setStatusCode(200);
+        result.setRequestId("req-batch-fail");
+        result.setPayload("{\"batchItemFailures\":[{\"itemIdentifier\":\"s1\"}]}".getBytes());
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(result);
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.setFunctionResponseTypes(List.of("ReportBatchItemFailures"));
+        esm.setMaximumRetryAttempts(1); // 1 retry attempt allowed, 2nd error exhausts retries
+
+        String sqsArn = "arn:aws:sqs:us-east-1:000000000000:my-dlq";
+        EventSourceMapping.DestinationConfig destConfig = new EventSourceMapping.DestinationConfig();
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(sqsArn);
+        destConfig.setOnFailure(onFailure);
+        esm.setDestinationConfig(destConfig);
+
+        DynamoDbStreamsEventSourcePoller p = pollerWith(store);
+
+        // First poll: attempt 1 (initial partial failure, retries left)
+        p.pollAndInvoke(esm);
+        verify(executorService, timeout(2000)).invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse));
+
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            if (p.activePolls.isEmpty()) {
+                break;
+            }
+            Thread.sleep(25);
+        }
+
+        // After 1st failure: checkpoint not advanced, no DLQ delivery
+        verify(store, never()).saveForAccount(anyString(), any());
+        verify(sqsService, never()).sendMessage(anyString(), anyString(), anyInt(), anyString());
+
+        // Second poll: attempt 2 (retry 1, which exceeds maxRetryAttempts=1 -> exhausted!)
+        p.pollAndInvoke(esm);
+
+        // Checkpoint advanced to "s1"
+        verify(store, timeout(2000)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s1", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+
+        // SQS delivery invoked
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        String expectedQueueUrl = "http://localhost:4566/000000000000/my-dlq";
+        verify(sqsService, timeout(2000)).sendMessage(eq(expectedQueueUrl), bodyCaptor.capture(), eq(0), eq("us-east-1"));
+
+        JsonNode dlqPayload = OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+        assertEquals("1.0", dlqPayload.path("version").asText());
+        assertEquals("RetryAttemptsExhausted", dlqPayload.path("requestContext").path("condition").asText());
+        assertEquals(2, dlqPayload.path("requestContext").path("approximateInvokeCount").asInt());
+        assertEquals("req-batch-fail", dlqPayload.path("requestContext").path("requestId").asText());
+        assertEquals(200, dlqPayload.path("responseContext").path("statusCode").asInt());
+        assertFalse(dlqPayload.path("responseContext").has("functionError"));
+        assertEquals(DynamoDbStreamService.SHARD_ID, dlqPayload.path("DDBStreamBatchInfo").path("shardId").asText());
+        assertEquals("s1", dlqPayload.path("DDBStreamBatchInfo").path("startSequenceNumber").asText());
+        assertEquals("s1", dlqPayload.path("DDBStreamBatchInfo").path("endSequenceNumber").asText());
+        assertEquals(1, dlqPayload.path("DDBStreamBatchInfo").path("batchSize").asInt());
+        assertEquals(STREAM_ARN, dlqPayload.path("DDBStreamBatchInfo").path("streamArn").asText());
+        assertFalse(dlqPayload.has("hasBeenTruncated"));
+    }
+
+    @Test
+    void reportBatchItemFailuresPartialSuccessAdvancesCheckpointAndRetriesFailingItem() throws Exception {
+        when(streamService.getShardIterator(eq(STREAM_ARN), eq(DynamoDbStreamService.SHARD_ID),
+                eq("TRIM_HORIZON"), any())).thenReturn("it-1");
+        when(streamService.getShardIterator(eq(STREAM_ARN), eq(DynamoDbStreamService.SHARD_ID),
+                eq("AFTER_SEQUENCE_NUMBER"), eq("s1"))).thenReturn("it-2");
+        when(streamService.getRecords(eq("it-1"), anyInt())).thenReturn(
+                new DynamoDbStreamService.GetRecordsResult(
+                        List.of(ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}"),
+                                ddbRecord("s2", "INSERT", "{\"status\":{\"S\":\"active\"}}")), "it-1"));
+        when(streamService.getRecords(eq("it-2"), anyInt())).thenReturn(
+                new DynamoDbStreamService.GetRecordsResult(
+                        List.of(ddbRecord("s2", "INSERT", "{\"status\":{\"S\":\"active\"}}")), "it-2"));
+
+        InvokeResult partialFailure = new InvokeResult();
+        partialFailure.setStatusCode(200);
+        partialFailure.setPayload("{\"batchItemFailures\":[{\"itemIdentifier\":\"s2\"}]}".getBytes());
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(partialFailure);
+
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("fn");
+        when(functionStore.getForAccount(ACCOUNT_ID, "us-east-1", "fn")).thenReturn(Optional.of(fn));
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.setFunctionResponseTypes(List.of("ReportBatchItemFailures"));
+        esm.setMaximumRetryAttempts(0); // exhausts on first failure of s2 standalone
+
+        String sqsArn = "arn:aws:sqs:us-east-1:000000000000:my-dlq";
+        EventSourceMapping.DestinationConfig destConfig = new EventSourceMapping.DestinationConfig();
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(sqsArn);
+        destConfig.setOnFailure(onFailure);
+        esm.setDestinationConfig(destConfig);
+
+        DynamoDbStreamsEventSourcePoller p = pollerWith(store);
+
+        // First poll: s1 succeeds, s2 fails -> checkpoint advances to s1
+        p.pollAndInvoke(esm);
+        verify(store, timeout(2000)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s1", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+        verify(sqsService, never()).sendMessage(anyString(), anyString(), anyInt(), anyString());
+
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            if (p.activePolls.isEmpty()) {
+                break;
+            }
+            Thread.sleep(25);
+        }
+
+        // Second poll: fetches [s2], s2 fails again -> maxRetries=0 exhausts
+        p.pollAndInvoke(esm);
+
+        verify(store, timeout(2000).times(2)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s2", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        String expectedQueueUrl = "http://localhost:4566/000000000000/my-dlq";
+        verify(sqsService, timeout(2000)).sendMessage(eq(expectedQueueUrl), bodyCaptor.capture(), eq(0), eq("us-east-1"));
+
+        JsonNode dlqPayload = OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+        assertEquals("1.0", dlqPayload.path("version").asText());
+        assertEquals(1, dlqPayload.path("requestContext").path("approximateInvokeCount").asInt());
+        assertEquals("s2", dlqPayload.path("DDBStreamBatchInfo").path("startSequenceNumber").asText());
+        assertEquals("s2", dlqPayload.path("DDBStreamBatchInfo").path("endSequenceNumber").asText());
+        assertEquals(1, dlqPayload.path("DDBStreamBatchInfo").path("batchSize").asInt());
+    }
+
     private JsonNode readRecords(byte[] payload) {
         try {
             return OBJECT_MAPPER.readTree(payload).path("Records");

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -550,6 +551,46 @@ class DynamoDbStreamsEventSourcePollerTest {
         assertTrue(dlqPayload.path("DDBStreamBatchInfo").has("approximateArrivalOfFirstRecord"));
         assertTrue(dlqPayload.path("DDBStreamBatchInfo").has("approximateArrivalOfLastRecord"));
         assertFalse(dlqPayload.has("hasBeenTruncated"));
+    }
+
+    @Test
+    void onFailurePayloadUsesEpochSecondsNotMillisForArrivalTimestamps() throws Exception {
+        // Chosen so the seconds/millis interpretations land 46+ years apart: a millis bug cannot
+        // accidentally parse back to this epoch-seconds value.
+        long knownEpochSeconds = 1_700_000_000L;
+        DynamoDbStreamRecord rec = ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}");
+        rec.setApproximateCreationDateTime(knownEpochSeconds);
+        stubTrimHorizon(List.of(rec));
+
+        InvokeResult err = new InvokeResult();
+        err.setFunctionError("Unhandled");
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(err);
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.setMaximumRetryAttempts(0); // exhausts on the first failure
+
+        String sqsArn = "arn:aws:sqs:us-east-1:000000000000:my-dlq";
+        EventSourceMapping.DestinationConfig destConfig = new EventSourceMapping.DestinationConfig();
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(sqsArn);
+        destConfig.setOnFailure(onFailure);
+        esm.setDestinationConfig(destConfig);
+
+        DynamoDbStreamsEventSourcePoller p = pollerWith(store);
+        p.pollAndInvoke(esm);
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(sqsService, timeout(2000)).sendMessage(anyString(), bodyCaptor.capture(), anyInt(), anyString());
+
+        JsonNode dlqPayload = OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+        Instant first = Instant.parse(
+                dlqPayload.path("DDBStreamBatchInfo").path("approximateArrivalOfFirstRecord").asText());
+        Instant last = Instant.parse(
+                dlqPayload.path("DDBStreamBatchInfo").path("approximateArrivalOfLastRecord").asText());
+        assertEquals(knownEpochSeconds, first.getEpochSecond());
+        assertEquals(knownEpochSeconds, last.getEpochSecond());
     }
 
     @Test

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/DynamoDbStreamsEventSourcePollerTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -58,6 +59,8 @@ class DynamoDbStreamsEventSourcePollerTest {
     private EsmStore esmStore;
     private EmulatorConfig config;
     private PipesFilterMatcher filterMatcher;
+    private io.github.hectorvent.floci.services.sqs.SqsService sqsService;
+    private io.github.hectorvent.floci.services.sns.SnsService snsService;
 
     @BeforeEach
     void setUp() {
@@ -67,18 +70,21 @@ class DynamoDbStreamsEventSourcePollerTest {
         when(config.services()).thenReturn(services);
         when(services.lambda()).thenReturn(lambdaConfig);
         when(lambdaConfig.pollIntervalMs()).thenReturn(1000L);
+        when(config.effectiveBaseUrl()).thenReturn("http://localhost:4566");
 
         streamService = mock(DynamoDbStreamService.class);
         executorService = mock(LambdaExecutorService.class);
         functionStore = mock(LambdaFunctionStore.class);
         esmStore = new EsmStore(new AccountAwareStorageBackend<>(new InMemoryStorage<>(), null, ACCOUNT_ID));
         filterMatcher = new PipesFilterMatcher(OBJECT_MAPPER);
+        sqsService = mock(io.github.hectorvent.floci.services.sqs.SqsService.class);
+        snsService = mock(io.github.hectorvent.floci.services.sns.SnsService.class);
 
         // A mocked Vertx makes setPeriodic a no-op, so startPolling registers no live timer and
         // the tests drive pollAndInvoke deterministically.
         poller = new DynamoDbStreamsEventSourcePoller(
                 mock(Vertx.class), streamService, executorService, functionStore,
-                esmStore, OBJECT_MAPPER, config, filterMatcher);
+                esmStore, OBJECT_MAPPER, config, filterMatcher, sqsService, snsService);
     }
 
     private EventSourceMapping persistedStreamsEsmWithStaleCheckpoint() {
@@ -152,7 +158,7 @@ class DynamoDbStreamsEventSourcePollerTest {
     private DynamoDbStreamsEventSourcePoller pollerWith(EsmStore store) {
         return new DynamoDbStreamsEventSourcePoller(
                 mock(Vertx.class), streamService, executorService, functionStore,
-                store, OBJECT_MAPPER, config, filterMatcher);
+                store, OBJECT_MAPPER, config, filterMatcher, sqsService, snsService);
     }
 
     /**
@@ -476,6 +482,165 @@ class DynamoDbStreamsEventSourcePollerTest {
         verify(executorService, never()).invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse));
         verify(store, never()).saveForAccount(anyString(), any());
         assertEquals(STALE_CHECKPOINT, esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+    }
+
+    @Test
+    void maxRetryAttemptsExhaustedDeliversToSqsOnFailureDestinationAndAdvancesCheckpoint() throws Exception {
+        stubTrimHorizon(List.of(ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}")));
+        InvokeResult err = new InvokeResult();
+        err.setFunctionError("Unhandled");
+        err.setStatusCode(200);
+        err.setRequestId("req-123");
+        err.setExecutedVersion("$LATEST");
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(err);
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.setMaximumRetryAttempts(1); // 1 retry attempt allowed, 2nd error exhausts retries
+
+        String sqsArn = "arn:aws:sqs:us-east-1:000000000000:my-dlq";
+        EventSourceMapping.DestinationConfig destConfig = new EventSourceMapping.DestinationConfig();
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(sqsArn);
+        destConfig.setOnFailure(onFailure);
+        esm.setDestinationConfig(destConfig);
+
+        DynamoDbStreamsEventSourcePoller p = pollerWith(store);
+
+        // First poll: attempt 1 (initial failure, retries left)
+        p.pollAndInvoke(esm);
+        // Verify invoke was called for attempt 1
+        verify(executorService, timeout(2000)).invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse));
+        // Wait for poll 1 to finish by ensuring activePolls is released
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            if (p.activePolls.isEmpty()) {
+                break;
+            }
+            Thread.sleep(25);
+        }
+        // After 1st failure: checkpoint not advanced, no DLQ delivery
+        verify(store, never()).saveForAccount(anyString(), any());
+        verify(sqsService, never()).sendMessage(anyString(), anyString(), anyInt(), anyString());
+
+        // Second poll: attempt 2 (retry 1, which exceeds maxRetryAttempts=1 -> exhausted!)
+        p.pollAndInvoke(esm);
+
+        // Checkpoint advanced to "s1"
+        verify(store, timeout(2000)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s1", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+
+        // SQS delivery invoked
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        String expectedQueueUrl = "http://localhost:4566/000000000000/my-dlq";
+        verify(sqsService, timeout(2000)).sendMessage(eq(expectedQueueUrl), bodyCaptor.capture(), eq(0), eq("us-east-1"));
+
+        JsonNode dlqPayload = OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+        assertEquals("1.0", dlqPayload.path("version").asText());
+        assertEquals("RetryAttemptsExhausted", dlqPayload.path("requestContext").path("condition").asText());
+        assertEquals(2, dlqPayload.path("requestContext").path("approximateInvokeCount").asInt());
+        assertEquals("req-123", dlqPayload.path("requestContext").path("requestId").asText());
+        assertEquals("Unhandled", dlqPayload.path("responseContext").path("functionError").asText());
+        assertEquals(DynamoDbStreamService.SHARD_ID, dlqPayload.path("DDBStreamBatchInfo").path("shardId").asText());
+        assertEquals("s1", dlqPayload.path("DDBStreamBatchInfo").path("startSequenceNumber").asText());
+        assertEquals("s1", dlqPayload.path("DDBStreamBatchInfo").path("endSequenceNumber").asText());
+        assertEquals(1, dlqPayload.path("DDBStreamBatchInfo").path("batchSize").asInt());
+        assertEquals(STREAM_ARN, dlqPayload.path("DDBStreamBatchInfo").path("streamArn").asText());
+        assertTrue(dlqPayload.path("DDBStreamBatchInfo").has("approximateArrivalOfFirstRecord"));
+        assertTrue(dlqPayload.path("DDBStreamBatchInfo").has("approximateArrivalOfLastRecord"));
+        assertFalse(dlqPayload.has("hasBeenTruncated"));
+    }
+
+    @Test
+    void maxRetryAttemptsExhaustedDeliversToSnsOnFailureDestination() {
+        stubTrimHorizon(List.of(ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}")));
+        InvokeResult err = new InvokeResult();
+        err.setFunctionError("Handled");
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(err);
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.setMaximumRetryAttempts(0); // 0 retries allowed, 1st error exhausts immediately
+
+        String snsArn = "arn:aws:sns:us-east-1:000000000000:my-dlq-topic";
+        EventSourceMapping.DestinationConfig destConfig = new EventSourceMapping.DestinationConfig();
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(snsArn);
+        destConfig.setOnFailure(onFailure);
+        esm.setDestinationConfig(destConfig);
+
+        DynamoDbStreamsEventSourcePoller p = pollerWith(store);
+
+        p.pollAndInvoke(esm);
+
+        verify(store, timeout(2000)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s1", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+
+        verify(snsService, timeout(2000)).publish(eq(snsArn), any(), anyString(), eq("ESM OnFailure"), eq("us-east-1"));
+    }
+
+    @Test
+    void maxRetryAttemptsExhaustedTracksRetriesAcrossExpandingBatchWindow() throws Exception {
+        when(streamService.getShardIterator(eq(STREAM_ARN), eq(DynamoDbStreamService.SHARD_ID),
+                eq("TRIM_HORIZON"), any())).thenReturn("it-1", "it-2");
+        when(streamService.getRecords(eq("it-1"), anyInt())).thenReturn(
+                new DynamoDbStreamService.GetRecordsResult(
+                        List.of(ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}")), "it-1"));
+        when(streamService.getRecords(eq("it-2"), anyInt())).thenReturn(
+                new DynamoDbStreamService.GetRecordsResult(
+                        List.of(ddbRecord("s1", "INSERT", "{\"status\":{\"S\":\"active\"}}"),
+                                ddbRecord("s2", "INSERT", "{\"status\":{\"S\":\"active\"}}")), "it-2"));
+
+        InvokeResult err = new InvokeResult();
+        err.setFunctionError("Unhandled");
+        when(executorService.invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse)))
+                .thenReturn(err);
+        LambdaFunction fn = new LambdaFunction();
+        fn.setFunctionName("fn");
+        when(functionStore.getForAccount(ACCOUNT_ID, "us-east-1", "fn")).thenReturn(Optional.of(fn));
+
+        EsmStore store = mock(EsmStore.class);
+        EventSourceMapping esm = filterEsm();
+        esm.setMaximumRetryAttempts(1); // 1 retry allowed, 2nd error exhausts
+
+        String sqsArn = "arn:aws:sqs:us-east-1:000000000000:my-dlq";
+        EventSourceMapping.DestinationConfig destConfig = new EventSourceMapping.DestinationConfig();
+        EventSourceMapping.OnFailure onFailure = new EventSourceMapping.OnFailure();
+        onFailure.setDestination(sqsArn);
+        destConfig.setOnFailure(onFailure);
+        esm.setDestinationConfig(destConfig);
+
+        DynamoDbStreamsEventSourcePoller p = pollerWith(store);
+
+        p.pollAndInvoke(esm);
+        verify(executorService, timeout(2000)).invoke(any(), any(byte[].class), eq(InvocationType.RequestResponse));
+
+        long deadline = System.currentTimeMillis() + 3000;
+        while (System.currentTimeMillis() < deadline) {
+            if (p.activePolls.isEmpty()) {
+                break;
+            }
+            Thread.sleep(25);
+        }
+
+        p.pollAndInvoke(esm);
+
+        verify(store, timeout(2000)).saveForAccount(eq(ACCOUNT_ID), any());
+        assertEquals("s2", esm.getShardSequenceNumbers().get(DynamoDbStreamService.SHARD_ID));
+
+        ArgumentCaptor<String> bodyCaptor = ArgumentCaptor.forClass(String.class);
+        String expectedQueueUrl = "http://localhost:4566/000000000000/my-dlq";
+        verify(sqsService, timeout(2000)).sendMessage(eq(expectedQueueUrl), bodyCaptor.capture(), eq(0), eq("us-east-1"));
+
+        JsonNode dlqPayload = OBJECT_MAPPER.readTree(bodyCaptor.getValue());
+        assertEquals("1.0", dlqPayload.path("version").asText());
+        assertEquals(2, dlqPayload.path("requestContext").path("approximateInvokeCount").asInt());
+        assertEquals("s1", dlqPayload.path("DDBStreamBatchInfo").path("startSequenceNumber").asText());
+        assertEquals("s2", dlqPayload.path("DDBStreamBatchInfo").path("endSequenceNumber").asText());
+        assertEquals(2, dlqPayload.path("DDBStreamBatchInfo").path("batchSize").asInt());
+        assertFalse(dlqPayload.has("hasBeenTruncated"));
     }
 
     private JsonNode readRecords(byte[] payload) {

--- a/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/lambda/EsmIntegrationTest.java
@@ -223,6 +223,7 @@ class EsmIntegrationTest {
                 .body("""
                         {
                           "BisectBatchOnFunctionError": true,
+                          "MaximumRetryAttempts": 3,
                           "DestinationConfig": {
                             "OnFailure": {
                               "Destination": "%s"
@@ -235,6 +236,7 @@ class EsmIntegrationTest {
                 .then()
                 .statusCode(202)
                 .body("BisectBatchOnFunctionError", equalTo(true))
+                .body("MaximumRetryAttempts", equalTo(3))
                 .body("DestinationConfig.OnFailure.Destination", equalTo(destinationArn));
 
         given()
@@ -243,6 +245,7 @@ class EsmIntegrationTest {
                 .then()
                 .statusCode(200)
                 .body("BisectBatchOnFunctionError", equalTo(true))
+                .body("MaximumRetryAttempts", equalTo(3))
                 .body("DestinationConfig.OnFailure.Destination", equalTo(destinationArn));
 
         given()
@@ -266,6 +269,7 @@ class EsmIntegrationTest {
                 .then()
                 .statusCode(202)
                 .body("$", not(hasKey("BisectBatchOnFunctionError")))
+                .body("$", not(hasKey("MaximumRetryAttempts")))
                 .body("$", not(hasKey("DestinationConfig")))
                 .extract()
                 .path("UUID");


### PR DESCRIPTION
## Summary

Honor `MaximumRetryAttempts` and `DestinationConfig.OnFailure` for DynamoDB Streams Event Source Mapping (ESM).
When a batch fails and retry attempts exceed the configured maximum, deliver an invocation record to the configured OnFailure destination (SQS queue or SNS topic) and advance the shard checkpoint so the shard is not blocked indefinitely.

Closes #3263

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## AWS Compatibility

When `MaximumRetryAttempts` is reached for a batch in DynamoDB Streams ESM:
- AWS delivers an event with standard schema (`version`, `timestamp`, `requestContext`, `responseContext`, `hasBeenTruncated`, and `DDBStreamBatchInfo`) to `DestinationConfig.OnFailure` (SQS or SNS).
- Previously, Floci omitted `MaximumRetryAttempts` validation/storage, ignored retry limits, and retried the failing batch indefinitely without delivering to the DLQ or advancing the checkpoint.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
