### PR TITLE
fix(apigateway): allow idempotent custom-id tags

### DIFF
--- a/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
+++ b/src/main/java/io/github/hectorvent/floci/core/common/ReservedTags.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.function.TriFunction;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 @RegisterForReflection
 public final class ReservedTags {
@@ -90,11 +91,27 @@ public final class ReservedTags {
      * error code rather than the {@code ValidationException} the shared guard uses.
      */
     public static void rejectApiGatewayReservedTagsOnUpdate(Map<String, String> tags) {
+        rejectApiGatewayReservedTagsOnUpdate(tags, null);
+    }
+
+    /**
+     * API Gateway resource update guard with an idempotent exception for its two id-override keys.
+     * Infrastructure tools resend the complete tag set, so an override equal to the resource's
+     * existing id is a no-op. A different value would attempt to rename the resource and remains
+     * invalid after creation.
+     */
+    public static void rejectApiGatewayReservedTagsOnUpdate(Map<String, String> tags, String resourceId) {
         if (tags == null) {
             return;
         }
-        for (String key : tags.keySet()) {
+        for (Map.Entry<String, String> tag : tags.entrySet()) {
+            String key = tag.getKey();
             if (isReserved(key) || DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY.equals(key)) {
+                boolean idOverride = OVERRIDE_ID_KEY.equals(key)
+                        || DEPRECATED_API_GATEWAY_CUSTOM_ID_KEY.equals(key);
+                if (idOverride && resourceId != null && Objects.equals(tag.getValue(), resourceId)) {
+                    continue;
+                }
                 throw new AwsException(
                         BAD_REQUEST_EXCEPTION,
                         "Reserved tag key " + key + " can only be supplied during resource creation.",

--- a/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayService.java
@@ -2000,9 +2000,9 @@ public class ApiGatewayService {
     }
 
     public void tagResource(String region, String apiId, Map<String, String> tags) {
-        ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags);
         RestApi api = getRestApi(region, apiId);
-        api.getTags().putAll(tags);
+        ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags, apiId);
+        api.getTags().putAll(ReservedTags.stripApiGatewayReservedTags(tags));
         apiStore.put(apiKey(region, apiId), api);
     }
 

--- a/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
+++ b/src/main/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2Service.java
@@ -1168,9 +1168,9 @@ public class ApiGatewayV2Service {
     }
 
     public void tagResource(String resourceArn, Map<String, String> tags) {
-        ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags);
         TaggedResource target = parseArn(resourceArn);
         if (target.isStage()) {
+            ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags);
             Stage stage = getStage(target.region(), target.apiId(), target.stageName());
             if (tags != null && !tags.isEmpty()) {
                 if (stage.getTags() == null) {
@@ -1182,11 +1182,12 @@ public class ApiGatewayV2Service {
             return;
         }
         Api api = getApi(target.region(), target.apiId());
+        ReservedTags.rejectApiGatewayReservedTagsOnUpdate(tags, target.apiId());
         if (tags != null && !tags.isEmpty()) {
             if (api.getTags() == null) {
                 api.setTags(new java.util.HashMap<>());
             }
-            api.getTags().putAll(tags);
+            api.getTags().putAll(ReservedTags.stripApiGatewayReservedTags(tags));
         }
         apiStore.put(apiKey(target.region(), target.apiId()), api);
     }

--- a/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigateway/ApiGatewayIntegrationTest.java
@@ -395,6 +395,36 @@ class ApiGatewayIntegrationTest {
     }
 
     @Test @Order(51)
+    void tagRestApi_customIdTag_isIdempotent() {
+        String arn = "arn:aws:apigateway:us-east-1::/restapis/MYCUSTOMNAME";
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"_custom_id_":"MYCUSTOMNAME","repeat":"accepted"}}
+                        """)
+                .when().put("/tags/" + arn)
+                .then()
+                .statusCode(204);
+
+        given()
+                .when().get("/restapis/MYCUSTOMNAME")
+                .then()
+                .statusCode(200)
+                .body("tags._custom_id_", nullValue())
+                .body("tags.repeat", equalTo("accepted"));
+
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"_custom_id_":"DIFFERENT"}}
+                        """)
+                .when().put("/tags/" + arn)
+                .then()
+                .statusCode(400)
+                .body("message", containsString("can only be supplied during resource creation"));
+    }
+
+    @Test @Order(52)
     void getRestApi_customId_resolvesById() {
         given()
                 .when().get("/restapis/MYCUSTOMNAME")
@@ -406,7 +436,7 @@ class ApiGatewayIntegrationTest {
 
     // ──────────────────────────── floci:override-id tag ────────────────────────────
 
-    @Test @Order(52)
+    @Test @Order(53)
     void createRestApi_flociOverrideIdTag_usesTagValueAsApiId() {
         String body = """
                 {"name":"override-id-api","tags":{"floci:override-id":"MYOVERRIDEID"}}
@@ -422,7 +452,7 @@ class ApiGatewayIntegrationTest {
                 .body("tags.'floci:override-id'", nullValue());
     }
 
-    @Test @Order(53)
+    @Test @Order(54)
     void createRestApi_bothOverrideKeys_prefersFlociOverrideId() {
         String body = """
                 {"name":"both-keys-api","tags":{"floci:override-id":"WINNER","_custom_id_":"LOSER"}}
@@ -436,7 +466,7 @@ class ApiGatewayIntegrationTest {
                 .body("id", equalTo("WINNER"));
     }
 
-    @Test @Order(54)
+    @Test @Order(55)
     void createRestApi_blankOverrideId_isRejected() {
         String body = """
                 {"name":"blank-override-api","tags":{"floci:override-id":"   "}}
@@ -450,7 +480,7 @@ class ApiGatewayIntegrationTest {
                 .body("message", containsString("must not be blank"));
     }
 
-    @Test @Order(55)
+    @Test @Order(56)
     void createRestApi_overrideIdWithPathSeparator_isRejected() {
         String body = """
                 {"name":"bad-override-api","tags":{"floci:override-id":"has/slash"}}

--- a/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
+++ b/src/test/java/io/github/hectorvent/floci/services/apigatewayv2/ApiGatewayV2IntegrationTest.java
@@ -504,7 +504,45 @@ class ApiGatewayV2IntegrationTest {
     }
 
     @Test @Order(105)
-    void tagApi_withOverrideKey_isRejectedAfterCreation() {
+    void tagApi_withOverrideKey_isIdempotent() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"floci:override-id":"MYV2OVERRIDE","repeat":"accepted"}}
+                        """)
+                .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2OVERRIDE")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2OVERRIDE")
+                .then()
+                .statusCode(200)
+                .body("tags.'floci:override-id'", nullValue())
+                .body("tags.repeat", equalTo("accepted"));
+    }
+
+    @Test @Order(106)
+    void tagApi_withDeprecatedCustomIdKey_isIdempotent() {
+        given()
+                .contentType(ContentType.JSON)
+                .body("""
+                        {"tags":{"_custom_id_":"MYV2CUSTOM","repeat":"accepted"}}
+                        """)
+                .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2CUSTOM")
+                .then()
+                .statusCode(201);
+
+        given()
+                .when().get("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2CUSTOM")
+                .then()
+                .statusCode(200)
+                .body("tags._custom_id_", nullValue())
+                .body("tags.repeat", equalTo("accepted"));
+    }
+
+    @Test @Order(107)
+    void tagApi_withChangedOverrideId_isRejected() {
         given()
                 .contentType(ContentType.JSON)
                 .body("""
@@ -513,21 +551,18 @@ class ApiGatewayV2IntegrationTest {
                 .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2OVERRIDE")
                 .then()
                 .statusCode(400);
-    }
 
-    @Test @Order(106)
-    void tagApi_withDeprecatedCustomIdKey_isRejectedAfterCreation() {
         given()
                 .contentType(ContentType.JSON)
                 .body("""
                         {"tags":{"_custom_id_":"TOOLATE"}}
                         """)
-                .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2OVERRIDE")
+                .when().post("/v2/tags/arn:aws:apigateway:us-east-1::/apis/MYV2CUSTOM")
                 .then()
                 .statusCode(400);
     }
 
-    @Test @Order(107)
+    @Test @Order(108)
     void deleteApis_customAndOverrideId() {
         given().when().delete("/v2/apis/MYV2CUSTOM").then().statusCode(204);
         given().when().delete("/v2/apis/MYV2OVERRIDE").then().statusCode(204);


### PR DESCRIPTION
## Summary

Allow API Gateway v1 and v2 TagResource requests to repeat _custom_id_ or floci:override-id when the supplied value matches the existing API ID. The override remains creation-only for changed values and is stripped before tags are persisted.

Closes #3417

## Type of change

- [x] Bug fix (fix:)
- [ ] New feature (feat:)
- [ ] Breaking change (feat!: or fix!:)
- [ ] Docs / chore

## AWS Compatibility

Previously, repeat Terraform applies failed with BadRequestException because the complete tag set included the unchanged creation-time ID override. REST APIs and HTTP/WebSocket APIs now treat an unchanged override as an idempotent no-op while still rejecting attempts to change the resource ID. API Gateway v2 stage tagging retains the strict creation-only validation.

## Checklist

- [ ] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits